### PR TITLE
Fix for problems when using patterns with multiple unnamed nodes

### DIFF
--- a/community/cypher/CHANGES.txt
+++ b/community/cypher/CHANGES.txt
@@ -6,6 +6,7 @@ o Made Cypher better at keeping a numeric type. Adding two integers now returns 
 o Major refactoring to make certain Cypher is more lazy
 o When asking for the top x rows by some value, Cypher will now only keep a list the size of x
 o Fix so identifiers created inside a foreach can be used by other statements in the foreach
+o Fix for problems when using patterns with multiple unnamed nodes
 
 1.9.M01 (2012-10-23)
 --------------------

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PathExpression.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PathExpression.scala
@@ -23,7 +23,6 @@ import expressions.Expression
 import expressions.Identifier._
 import org.neo4j.cypher.internal.symbols._
 import org.neo4j.cypher.internal.pipes.matching.MatchingContext
-import collection.Map
 import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.graphdb.Path
 import org.neo4j.cypher.internal.executionplan.builders.PatternGraphBuilder
@@ -77,4 +76,6 @@ case class PathExpression(pathPattern: Seq[Pattern])
     val startPointDependencies = pathPattern.flatMap(_.possibleStartPoints).map(_._1).filter(isNamed).toSet
     patternDependencies ++ startPointDependencies
   }
+
+  override def toString() = pathPattern.mkString
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Pattern.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Pattern.scala
@@ -36,7 +36,6 @@ trait Pattern extends TypeSafe {
   protected def rightArrow(dir: Direction) = if (dir == Direction.OUTGOING) "->" else "-"
 
   def rewrite( f : Expression => Expression) : Pattern
-  def equalOrUnnamed(name1: String, name2: String) = name1 == name2 || (notNamed(name1) && notNamed(name2))
   protected def filtered(x:Seq[String]): Seq[String] =x.filter(isNamed)
 
   def nodes:Seq[String]
@@ -68,18 +67,6 @@ case class RelatedTo(left: String,
 
   def rewrite(f: (Expression) => Expression) =
     new RelatedTo(left, right, relName, relTypes, direction, optional, predicate.rewrite(f))
-  override def equals(p1: Any): Boolean = p1 match {
-    case null => false
-    case other: RelatedTo =>
-      equalOrUnnamed(other.left, left) &&
-        equalOrUnnamed(other.right, right) &&
-        equalOrUnnamed(other.relName, relName) &&
-        other.relTypes  == relTypes &&
-        other.direction == direction &&
-        other.optional == optional &&
-        other.predicate == predicate
-    case _ => false
-  }
 
   def nodes = Seq(left,right)
 
@@ -143,22 +130,6 @@ case class VarLengthRelatedTo(pathName: String,
 
   def rewrite(f: (Expression) => Expression) = new VarLengthRelatedTo(pathName,start,end, minHops,maxHops,relTypes,direction,relIterator,optional,predicate.rewrite(f))
   lazy val possibleStartPoints: Seq[(String, AnyType)] = Seq(start -> NodeType(), end -> NodeType(), pathName -> PathType())
-
-  override def equals(p1: Any): Boolean = p1 match {
-    case null => false
-    case other: VarLengthRelatedTo =>
-      equalOrUnnamed(other.pathName, pathName) &&
-        equalOrUnnamed(other.start, start) &&
-        equalOrUnnamed(other.end, end) &&
-        other.minHops == minHops &&
-        other.maxHops == maxHops &&
-        other.relTypes == relTypes &&
-        other.direction == direction &&
-        other.relIterator == relIterator &&
-        other.optional == optional &&
-        other.predicate == predicate
-    case _ => false
-  }
 
   def nodes = Seq(start,end)
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Predicate.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Predicate.scala
@@ -276,7 +276,7 @@ case class NonEmpty(collection:Expression) extends Predicate with CollectionSupp
   }
 
   def atoms: Seq[Predicate] = Seq(this)
-  override def toString(): String = "nonEmpty(" + collection + ")"
+  override def toString(): String = "nonEmpty(" + collection.toString() + ")"
   def containsIsNull = false
   def rewrite(f: (Expression) => Expression) = NonEmpty(collection.rewrite(f))
   def filter(f: (Expression) => Boolean) = collection.filter(f)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/MatchBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/MatchBuilder.scala
@@ -57,16 +57,13 @@ class MatchBuilder extends PlanBuilder with PatternGraphBuilder {
 
   def canWorkWith(plan: ExecutionPlanInProgress) = {
     val q = plan.query
-    q.patterns.filter(yesOrNo(_, plan.pipe, q.start)).nonEmpty
+    q.patterns.exists(yesOrNo(_, plan.pipe, q.start))
   }
 
   private def yesOrNo(q: QueryToken[_], p: Pipe, start: Seq[QueryToken[StartItem]]) = q match {
     case Unsolved(x: ShortestPath) => false
     case Unsolved(x: Pattern) => {
-      val patternIdentifiers = x.possibleStartPoints.map(_._1)
-      val startItems = start.map(_.token.identifierName)
-
-      startItems.exists( patternIdentifiers.contains )
+      val patternIdentifiers: Seq[String] = x.possibleStartPoints.map(_._1)
 
       val apa = start.map(si => patternIdentifiers.find(_ == si.token.identifierName) match {
         case Some(_) => si.solved
@@ -74,7 +71,6 @@ class MatchBuilder extends PlanBuilder with PatternGraphBuilder {
       })
 
       val resolvedStartPoints =  apa.foldLeft(true)(_ && _)
-
       val pipeSatisfied = x.predicate.checkTypes(p.symbols)
 
       resolvedStartPoints && pipeSatisfied

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternGraph.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternGraph.scala
@@ -211,22 +211,24 @@ class PatternGraph(val patternNodes: Map[String, PatternNode],
     var visited = Seq[PatternElement]()
     var loop = false
 
-    val follow = (element: PatternElement) => element match {
+    def follow(element: PatternElement) = element match {
       case n: PatternNode         => true
       case r: PatternRelationship => !visited.contains(r)
     }
 
-    val vNode = (n: PatternNode, x: Unit) => {
+    def visit_node(n: PatternNode, x: Unit) {
       if (visited.contains(n))
         loop = true
       visited = visited :+ n
     }
 
-    val vRel = (r: PatternRelationship, x: Unit) => visited :+= r
+    def visit_relationship(r: PatternRelationship, x: Unit) {
+      visited :+= r
+    }
 
     boundPatternElements.foreach {
-      case pr: PatternRelationship => pr.startNode.traverse(follow, vNode, vRel, (), Seq())
-      case pn: PatternNode         => pn.traverse(follow, vNode, vRel, (), Seq())
+      case pr: PatternRelationship => pr.startNode.traverse(follow, visit_node, visit_relationship, (), Seq())
+      case pn: PatternNode         => pn.traverse(follow, visit_node, visit_relationship, (), Seq())
     }
 
     val notVisitedElements = allPatternElements.filterNot(visited contains)

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -385,8 +385,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def relatedTo() {
-    testAll(
+  @Test def relatedTo17() {
+    test_1_7(
       "start a = NODE(1) match a -[:KNOWS]-> (b) return a, b",
       Query.
         start(NodeById("a", 1)).
@@ -394,12 +394,30 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
   }
 
-  @Test def relatedToWithoutRelType() {
-    testAll(
+  @Test def relatedTo() {
+    testFrom_1_8(
+      "start a = NODE(1) match a -[:KNOWS]-> (b) return a, b",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq("KNOWS"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
+  }
+
+  @Test def relatedToWithoutRelType17() {
+    test_1_7(
       "start a = NODE(1) match a --> (b) return a, b",
       Query.
         start(NodeById("a", 1)).
         matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
+  }
+
+  @Test def relatedToWithoutRelType() {
+    testFrom_1_8(
+      "start a = NODE(1) match a --> (b) return a, b",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
   }
 
@@ -458,17 +476,26 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("rel"), "rel")))
   }
 
-  @Test def relatedToWithoutEndName() {
-    testAll(
-      "start a = NODE(1) match a -[:MARRIED]-> () return a",
+  @Test def relatedToWithoutEndName17() {
+    test_1_7(
+      "start a = NODE(1) match a -[r:MARRIED]-> () return a",
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "  UNNAMED1", "  UNNAMED2", Seq("MARRIED"), Direction.OUTGOING, false, True())).
+        matches(RelatedTo("a", "  UNNAMED1", "r", Seq("MARRIED"), Direction.OUTGOING, false, True())).
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def relatedInTwoSteps() {
-    testAll(
+  @Test def relatedToWithoutEndName() {
+    testFrom_1_8(
+      "start a = NODE(1) match a -[r:MARRIED]-> () return a",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "  UNNAMED3", "r", Seq("MARRIED"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("a"), "a")))
+  }
+
+  @Test def relatedInTwoSteps1_7() {
+    test_1_7(
       "start a = NODE(1) match a -[:KNOWS]-> b -[:FRIEND]-> (c) return c",
       Query.
         start(NodeById("a", 1)).
@@ -479,21 +506,44 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def djangoRelationshipType() {
-    testAll(
-      "start a = NODE(1) match a -[:`<<KNOWS>>`]-> b return c",
+  @Test def relatedInTwoSteps() {
+    testFrom_1_8(
+      "start a = NODE(1) match a -[:KNOWS]-> b -[:FRIEND]-> (c) return c",
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "b", "  UNNAMED1", Seq("<<KNOWS>>"), Direction.OUTGOING, false, True())).
+        matches(
+        RelatedTo("a", "b", "  UNNAMED5", Seq("KNOWS"), Direction.OUTGOING, false, True()),
+        RelatedTo("b", "c", "  UNNAMED6", Seq("FRIEND"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("c"), "c"))
+    )
+  }
+
+  @Test def djangoRelationshipType() {
+    testAll(
+      "start a = NODE(1) match a -[r:`<<KNOWS>>`]-> b return c",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "r", Seq("<<KNOWS>>"), Direction.OUTGOING, false, True())).
         returns(ReturnItem(Identifier("c"), "c")))
   }
 
-  @Test def countTheNumberOfHits() {
-    testAll(
+  @Test def countTheNumberOfHits1_7() {
+    test_1_7(
       "start a = NODE(1) match a --> b return a, b, count(*)",
       Query.
         start(NodeById("a", 1)).
         matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
+        aggregation(CountStar()).
+        columns("a", "b", "count(*)").
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(CountStar(), "count(*)")))
+  }
+
+  @Test def countTheNumberOfHits() {
+    testFrom_1_8(
+      "start a = NODE(1) match a --> b return a, b, count(*)",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
         aggregation(CountStar()).
         columns("a", "b", "count(*)").
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(CountStar(), "count(*)")))
@@ -510,8 +560,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(CountStar(), "count(*)")))
   }
 
-  @Test def distinct() {
-    testAll(
+  @Test def distinct1_7() {
+    test_1_7(
       "start a = NODE(1) match a --> b return distinct a, b",
       Query.
         start(NodeById("a", 1)).
@@ -520,19 +570,40 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
   }
 
-  @Test def sumTheAgesOfPeople() {
-    testAll(
-      "start a = NODE(1) match a --> b return a, b, sum(a.age)",
+  @Test def distinct() {
+    testFrom_1_8(
+      "start a = NODE(1) match a -[r]-> b return distinct a, b",
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
+        matches(RelatedTo("a", "b", "r", Seq(), Direction.OUTGOING, false, True())).
+        aggregation().
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b")))
+  }
+
+  @Test def sumTheAgesOfPeople() {
+    testAll(
+      "start a = NODE(1) match a -[r]-> b return a, b, sum(a.age)",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "r", Seq(), Direction.OUTGOING, false, True())).
         aggregation(Sum(Property("a", "age"))).
         columns("a", "b", "sum(a.age)").
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Sum(Property("a", "age")), "sum(a.age)")))
   }
 
   @Test def avgTheAgesOfPeople() {
-    testAll(
+    testFrom_1_8(
+      "start a = NODE(1) match a --> b return a, b, avg(a.age)",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
+        aggregation(Avg(Property("a", "age"))).
+        columns("a", "b", "avg(a.age)").
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Avg(Property("a", "age")), "avg(a.age)")))
+  }
+
+  @Test def avgTheAgesOfPeople1_7() {
+    test_1_7(
       "start a = NODE(1) match a --> b return a, b, avg(a.age)",
       Query.
         start(NodeById("a", 1)).
@@ -542,8 +613,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Avg(Property("a", "age")), "avg(a.age)")))
   }
 
-  @Test def minTheAgesOfPeople() {
-    testAll(
+  @Test def minTheAgesOfPeople1_7() {
+    test_1_7(
       "start a = NODE(1) match (a) --> b return a, b, min(a.age)",
       Query.
         start(NodeById("a", 1)).
@@ -553,8 +624,34 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Min(Property("a", "age")), "min(a.age)")))
   }
 
+  @Test def minTheAgesOfPeople() {
+    testFrom_1_8(
+      "start a = NODE(1) match (a) --> b return a, b, min(a.age)",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
+        aggregation(Min(Property("a", "age"))).
+        columns("a", "b", "min(a.age)").
+        returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Min(Property("a", "age")), "min(a.age)")))
+  }
+
   @Test def maxTheAgesOfPeople() {
-    testAll(
+    testFrom_1_8(
+      "start a = NODE(1) match a --> b return a, b, max(a.age)",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
+        aggregation(Max((Property("a", "age")))).
+        columns("a", "b", "max(a.age)").
+        returns(
+        ReturnItem(Identifier("a"), "a"),
+        ReturnItem(Identifier("b"), "b"),
+        ReturnItem(Max((Property("a", "age"))), "max(a.age)")
+      ))
+  }
+
+  @Test def maxTheAgesOfPeople1_7() {
+    test_1_7(
       "start a = NODE(1) match a --> b return a, b, max(a.age)",
       Query.
         start(NodeById("a", 1)).
@@ -692,11 +789,11 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
   @Test def pathLength() {
     testAll(
-      "start n=NODE(1) match p=(n-->x) where LENGTH(p) = 10 return p",
+      "start n=NODE(1) match p=(n-[r]->x) where LENGTH(p) = 10 return p",
       Query.
         start(NodeById("n", 1)).
-        matches(RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
-        namedPaths(NamedPath("p", RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        matches(RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True()))).
         where(Equals(LengthFunction(Identifier("p")), Literal(10.0))).
         returns(ReturnItem(Identifier("p"), "p")))
   }
@@ -723,23 +820,23 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
   @Test def relationshipsFromPathOutput() {
     testAll(
-      "start n=NODE(1) match p=n-->x return RELATIONSHIPS(p)",
+      "start n=NODE(1) match p=n-[r]->x return RELATIONSHIPS(p)",
 
       Query.
         start(NodeById("n", 1)).
-        matches(RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
-        namedPaths(NamedPath("p", RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        matches(RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True()))).
         returns(ReturnItem(RelationshipFunction(Identifier("p")), "RELATIONSHIPS(p)")))
   }
 
   @Test def relationshipsFromPathInWhere() {
     testAll(
-      "start n=NODE(1) match p=n-->x where length(rels(p))=1 return p",
+      "start n=NODE(1) match p=n-[r]->x where length(rels(p))=1 return p",
 
       Query.
         start(NodeById("n", 1)).
-        matches(RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
-        namedPaths(NamedPath("p", RelatedTo("n", "x", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        matches(RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("n", "x", "r", Seq(), Direction.OUTGOING, false, True()))).
         where(Equals(LengthFunction(RelationshipFunction(Identifier("p"))), Literal(1))).
         returns (ReturnItem(Identifier("p"), "p")))
   }
@@ -779,42 +876,52 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def simplePathExample() {
-    testAll(
+  @Test def simplePathExample17() {
+    test_1_7(
       "start a = node(0) match p = a-->b return a",
       Query.
         start(NodeById("a", 0)).
         matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
         namedPaths(NamedPath("p", RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        returns(ReturnItem(Identifier("a"), "a")))
+  }
+
+  @Test def simplePathExample() {
+    testFrom_1_8(
+      "start a = node(0) match p = a-->b return a",
+      Query.
+        start(NodeById("a", 0)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, false, True()))).
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
   @Test def threeStepsPath() {
     testAll(
-      "start a = node(0) match p = ( a-->b-->c ) return a",
+      "start a = node(0) match p = ( a-[r1]->b-[r2]->c ) return a",
       Query.
         start(NodeById("a", 0)).
         matches(
-          RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()),
-          RelatedTo("b", "c", "  UNNAMED2", Seq(), Direction.OUTGOING, false, True())).
+          RelatedTo("a", "b", "r1", Seq(), Direction.OUTGOING, false, True()),
+          RelatedTo("b", "c", "r2", Seq(), Direction.OUTGOING, false, True())).
         namedPaths(NamedPath("p",
-          RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()),
-          RelatedTo("b", "c", "  UNNAMED2", Seq(), Direction.OUTGOING, false, True()))).
+          RelatedTo("a", "b", "r1", Seq(), Direction.OUTGOING, false, True()),
+          RelatedTo("b", "c", "r2", Seq(), Direction.OUTGOING, false, True()))).
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
   @Test def pathsShouldBePossibleWithoutParenthesis() {
     testAll(
-      "start a = node(0) match p = a-->b return a",
+      "start a = node(0) match p = a-[r]->b return a",
       Query.
         start(NodeById("a", 0)).
-        matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
-        namedPaths(NamedPath("p", RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        matches(RelatedTo("a", "b", "r", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("a", "b", "r", Seq(), Direction.OUTGOING, false, True()))).
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def variableLengthPath() {
-    testAll("start a=node(0) match a -[:knows*1..3]-> x return x",
+  @Test def variableLengthPath17() {
+    test_1_7("start a=node(0) match a -[:knows*1..3]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(1), Some(3), "knows", Direction.OUTGOING)).
@@ -822,8 +929,17 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def variableLengthPathWithRelsIterable() {
-    testAll("start a=node(0) match a -[r:knows*1..3]-> x return x",
+  @Test def variableLengthPath() {
+    testFrom_1_8("start a=node(0) match a -[:knows*1..3]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(1), Some(3), "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def variableLengthPathWithRelsIterable17() {
+    test_1_7("start a=node(0) match a -[r:knows*1..3]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(1), Some(3), Seq("knows"), Direction.OUTGOING, Some("r"), false, True())).
@@ -831,8 +947,17 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def fixedVarLengthPath() {
-    testAll("start a=node(0) match a -[*3]-> x return x",
+  @Test def variableLengthPathWithRelsIterable() {
+    testFrom_1_8("start a=node(0) match a -[r:knows*1..3]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(1), Some(3), Seq("knows"), Direction.OUTGOING, Some("r"), false, True())).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def fixedVarLengthPath1_7() {
+    test_1_7("start a=node(0) match a -[*3]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(3), Some(3), Seq(), Direction.OUTGOING, None, false, True())).
@@ -840,17 +965,35 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def variableLengthPathWithoutMinDepth() {
-    testAll("start a=node(0) match a -[:knows*..3]-> x return x",
+  @Test def fixedVarLengthPath() {
+    testFrom_1_8("start a=node(0) match a -[*3]-> x return x",
       Query.
         start(NodeById("a", 0)).
-        matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", None, Some(3), "knows", Direction.OUTGOING)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(3), Some(3), Seq(), Direction.OUTGOING, None, false, True())).
         returns(ReturnItem(Identifier("x"), "x"))
     )
   }
 
-  @Test def variableLengthPathWithRelationshipIdentifier() {
-    testAll("start a=node(0) match a -[r:knows*2..]-> x return x",
+  @Test def variableLengthPathWithoutMinDepth17() {
+    test_1_7("start a=node(0) match p = a -[:knows*..3]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("p", "a", "x", None, Some(3), "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def variableLengthPathWithoutMinDepth() {
+    testFrom_1_8("start a=node(0) match a -[:knows*..3]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", None, Some(3), "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def variableLengthPathWithRelationshipIdentifier17() {
+    test_1_7("start a=node(0) match a -[r:knows*2..]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(2), None, Seq("knows"), Direction.OUTGOING, Some("r"), false, True())).
@@ -858,17 +1001,35 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def variableLengthPathWithoutMaxDepth() {
-    testAll("start a=node(0) match a -[:knows*2..]-> x return x",
+  @Test def variableLengthPathWithRelationshipIdentifier() {
+    testFrom_1_8("start a=node(0) match a -[r:knows*2..]-> x return x",
       Query.
         start(NodeById("a", 0)).
-        matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(2), None, "knows", Direction.OUTGOING)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(2), None, Seq("knows"), Direction.OUTGOING, Some("r"), false, True())).
         returns(ReturnItem(Identifier("x"), "x"))
     )
   }
 
-  @Test def unboundVariableLengthPath() {
-    testAll("start a=node(0) match a -[:knows*]-> x return x",
+  @Test def variableLengthPathWithoutMaxDepth17() {
+    test_1_7("start a=node(0) match p = a -[:knows*2..]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("p", "a", "x", Some(2), None, "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def variableLengthPathWithoutMaxDepth() {
+    testFrom_1_8("start a=node(0) match a -[:knows*2..]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(2), None, "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def unboundVariableLengthPath17() {
+    test_1_7("start a=node(0) match a -[:knows*]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", None, None, "knows", Direction.OUTGOING)).
@@ -876,12 +1037,30 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
-  @Test def optionalRelationship() {
-    testAll(
+  @Test def unboundVariableLengthPath() {
+    testFrom_1_8("start a=node(0) match a -[:knows*]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", None, None, "knows", Direction.OUTGOING)).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def optionalRelationship17() {
+    test_1_7(
       "start a = node(1) match a -[?]-> (b) return b",
       Query.
         start(NodeById("a", 1)).
         matches(RelatedTo("a", "b", "  UNNAMED1", Seq(), Direction.OUTGOING, true, True())).
+        returns(ReturnItem(Identifier("b"), "b")))
+  }
+
+  @Test def optionalRelationship() {
+    testFrom_1_8(
+      "start a = node(1) match a -[?]-> (b) return b",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, true, True())).
         returns(ReturnItem(Identifier("b"), "b")))
   }
 
@@ -903,12 +1082,21 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def optionalTypedRelationship() {
-    testAll(
+  @Test def optionalTypedRelationship17() {
+    test_1_7(
       "start a = node(1) match a -[?:KNOWS]-> (b) return b",
       Query.
         start(NodeById("a", 1)).
         matches(RelatedTo("a", "b", "  UNNAMED1", Seq("KNOWS"), Direction.OUTGOING, true, True())).
+        returns(ReturnItem(Identifier("b"), "b")))
+  }
+
+  @Test def optionalTypedRelationship() {
+    testFrom_1_8(
+      "start a = node(1) match a -[?:KNOWS]-> (b) return b",
+      Query.
+        start(NodeById("a", 1)).
+        matches(RelatedTo("a", "b", "  UNNAMED3", Seq("KNOWS"), Direction.OUTGOING, true, True())).
         returns(ReturnItem(Identifier("b"), "b")))
   }
 
@@ -1086,7 +1274,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where a-->b return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(NonEmpty(PathExpression(Seq(RelatedTo("a", "b", "  UNNAMED3", Seq(), Direction.OUTGOING, optional = false, predicate = True()))))).
+        where(NonEmpty(PathExpression(Seq(RelatedTo("a", "b", "  UNNAMED39", Seq(), Direction.OUTGOING, optional = false, predicate = True()))))).
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1104,7 +1292,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where not(a-->()) return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(Not(NonEmpty(PathExpression(Seq(RelatedTo("a", "  UNNAMED1", "  UNNAMED6", Seq(), Direction.OUTGOING, optional = false, predicate = True())))))).
+        where(Not(NonEmpty(PathExpression(Seq(RelatedTo("a", "  UNNAMED143", "  UNNAMED144", Seq(), Direction.OUTGOING, optional = false, predicate = True())))))).
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1182,8 +1370,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def first_last_and_rest() {
-    val p1 = RelatedTo("x", "z", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())
-    testAll("start x = NODE(1) match p=x-->z return head(nodes(p)), last(nodes(p)), tail(nodes(p))",
+    val p1 = RelatedTo("x", "z", "r", Seq(), Direction.OUTGOING, false, True())
+    testAll("start x = NODE(1) match p=x-[r]->z return head(nodes(p)), last(nodes(p)), tail(nodes(p))",
       Query.
         start(NodeById("x", 1)).
         matches(p1).
@@ -1196,11 +1384,11 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def filter() {
-    testAll("start x = NODE(1) match p=x-->z return filter(x in p : x.prop = 123)",
+    testAll("start x = NODE(1) match p=x-[r]->z return filter(x in p : x.prop = 123)",
       Query.
         start(NodeById("x", 1)).
-        matches(RelatedTo("x", "z", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True())).
-        namedPaths(NamedPath("p", RelatedTo("x", "z", "  UNNAMED1", Seq(), Direction.OUTGOING, false, True()))).
+        matches(RelatedTo("x", "z", "r", Seq(), Direction.OUTGOING, false, True())).
+        namedPaths(NamedPath("p", RelatedTo("x", "z", "r", Seq(), Direction.OUTGOING, false, True()))).
         returns(
         ReturnItem(FilterFunction(Identifier("p"), "x", Equals(Property("x", "prop"), Literal(123))), "filter(x in p : x.prop = 123)")
       ))
@@ -1247,8 +1435,26 @@ class CypherParserTest extends JUnitSuite with Assertions {
     )
   }
 
+  @Test def mutliple_relationship_type_in_match17() {
+    test_1_7("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+      Query.
+        start(NodeById("x", 1)).
+        matches(RelatedTo("x", "z", "  UNNAMED1", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
   @Test def mutliple_relationship_type_in_match() {
-    testAll("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+    testFrom_1_8("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+      Query.
+        start(NodeById("x", 1)).
+        matches(RelatedTo("x", "z", "  UNNAMED3", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def mutliple_relationship_type_in_varlength_rel17() {
+    test_1_7("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
       Query.
         start(NodeById("x", 1)).
         matches(RelatedTo("x", "z", "  UNNAMED1", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
@@ -1257,7 +1463,16 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def mutliple_relationship_type_in_varlength_rel() {
-    testAll("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+    testFrom_1_8("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+      Query.
+        start(NodeById("x", 1)).
+        matches(RelatedTo("x", "z", "  UNNAMED3", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def mutliple_relationship_type_in_shortest_path17() {
+    test_1_7("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
       Query.
         start(NodeById("x", 1)).
         matches(RelatedTo("x", "z", "  UNNAMED1", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
@@ -1266,10 +1481,10 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def mutliple_relationship_type_in_shortest_path() {
-    testAll("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
+    testFrom_1_8("start x = NODE(1) match x-[:REL1|REL2|REL3]->z return x",
       Query.
         start(NodeById("x", 1)).
-        matches(RelatedTo("x", "z", "  UNNAMED1", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
+        matches(RelatedTo("x", "z", "  UNNAMED3", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false, True())).
         returns(ReturnItem(Identifier("x"), "x"))
     )
   }
@@ -1288,7 +1503,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where a-[:KNOWS|BLOCKS]-b return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(NonEmpty(PathExpression(Seq(RelatedTo("a", "b", "  UNNAMED3", Seq("KNOWS","BLOCKS"), Direction.BOTH, optional = false, predicate = True())))))
+        where(NonEmpty(PathExpression(Seq(RelatedTo("a", "b", "  UNNAMED39", Seq("KNOWS","BLOCKS"), Direction.BOTH, optional = false, predicate = True())))))
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1322,11 +1537,20 @@ class CypherParserTest extends JUnitSuite with Assertions {
     testFrom_1_8("start a = node(1) with a create (b {age : a.age * 2}) return b", q)
   }
 
-  @Test def variable_length_path_with_collection_for_relationships() {
-    testAll("start a=node(0) match a -[r?*1..3]-> x return x",
+  @Test def variable_length_path_with_collection_for_relationships17() {
+    test_1_7("start a=node(0) match a -[r?*1..3]-> x return x",
       Query.
         start(NodeById("a", 0)).
         matches(VarLengthRelatedTo("  UNNAMED1", "a", "x", Some(1), Some(3), Seq(), Direction.OUTGOING, Some("r"), true, True())).
+        returns(ReturnItem(Identifier("x"), "x"))
+    )
+  }
+
+  @Test def variable_length_path_with_collection_for_relationships() {
+    testFrom_1_8("start a=node(0) match a -[r?*1..3]-> x return x",
+      Query.
+        start(NodeById("a", 0)).
+        matches(VarLengthRelatedTo("  UNNAMED3", "a", "x", Some(1), Some(3), Seq(), Direction.OUTGOING, Some("r"), true, True())).
         returns(ReturnItem(Identifier("x"), "x"))
     )
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -245,15 +245,6 @@ class ExecutionEngineTest extends ExecutionEngineHelper {
 
     val result = parseAndExecute("start n=node(1) match n-->a-->b RETURN b").toList
 
-//    val query = Query.
-//      start(NodeById("start", n1.getId)).
-//      matches(
-//      RelatedTo("start", "a", "rel", "KNOWS", Direction.OUTGOING),
-//      RelatedTo("a", "b", "rel2", "FRIEND", Direction.OUTGOING)).
-//      returns(ReturnItem(Identifier("b"), "b"))
-//
-//    val result = execute(query)
-
     assertEquals(List(Map("b" -> n3)), result.toList)
   }
 
@@ -2282,6 +2273,14 @@ RETURN x0.name?
   @Test
   def can_use_identifiers_created_inside_the_foreach() {
     val result = parseAndExecute("start n=node(0) foreach (x in [1,2,3] : create a= { name: 'foo'}  set a.id = x)")
+
+    assert(result.toList === List())
+  }
+
+  @Test
+  def can_handle_paths_with_multiple_unnamed_nodes() {
+    val a = createNode()
+    val result = parseAndExecute("START a=node(0) MATCH a<--()<--b-->()-->c RETURN c")
 
     assert(result.toList === List())
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/TrailBuilderTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/TrailBuilderTest.scala
@@ -29,7 +29,6 @@ import org.neo4j.cypher.GraphDatabaseTestBase
 import org.neo4j.cypher.internal.pipes.matching._
 import org.neo4j.cypher.internal.pipes.matching.EndPoint
 import org.neo4j.cypher.internal.commands.Equals
-import scala.Some
 import org.neo4j.cypher.internal.pipes.matching.SingleStepTrail
 import org.neo4j.cypher.internal.commands.True
 
@@ -196,7 +195,7 @@ class TrailBuilderTest extends GraphDatabaseTestBase with Assertions with Builde
 
     val endPoint = EndPoint("e")
     val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
-    val trail  = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
+    val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
 
     val expected = Some(LongestTrail("a", None, trail))
 
@@ -215,7 +214,7 @@ class TrailBuilderTest extends GraphDatabaseTestBase with Assertions with Builde
 
     val endPoint = EndPoint("e")
     val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
-    val trail  = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
+    val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
 
     val expected = Some(LongestTrail("a", None, trail))
 
@@ -234,7 +233,7 @@ class TrailBuilderTest extends GraphDatabaseTestBase with Assertions with Builde
 
     val endPoint = EndPoint("e")
     val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
-    val trail  = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
+    val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
 
     val expected = Some(LongestTrail("a", None, trail))
 
@@ -256,7 +255,7 @@ class TrailBuilderTest extends GraphDatabaseTestBase with Assertions with Builde
 
     val endPoint = EndPoint("e")
     val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
-    val trail  = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
+    val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", None, None, AtoB)
 
     val expected = Some(LongestTrail("a", None, trail))
 
@@ -281,6 +280,29 @@ class TrailBuilderTest extends GraphDatabaseTestBase with Assertions with Builde
     val result = TrailBuilder.findLongestTrail(Seq(AtoB, BtoC, AtoX, XtoC), Seq("a", "c"), Seq.empty)
     println(result)
     val expected = Some(LongestTrail("a", Some("c"), trail))
+
+    assert(result === expected)
+  }
+
+  @Test def should_handle_long_paths_with_unnamed_nodes() {
+    // GIVEN
+    // a<-[15]- (13)<-[16]- b-[17]-> (14)-[18]-> c
+
+    val s1 = RelatedTo("  UNNAMED13", "a", "  UNNAMED15", Seq(), Direction.OUTGOING, optional = false, predicate = True())
+    val s2 = RelatedTo("b", "  UNNAMED13", "  UNNAMED16", Seq(), Direction.OUTGOING, optional = false, predicate = True())
+    val s3 = RelatedTo("b", "  UNNAMED14", "  UNNAMED17", Seq(), Direction.OUTGOING, optional = false, predicate = True())
+    val s4 = RelatedTo("  UNNAMED14", "c", "  UNNAMED18", Seq(), Direction.OUTGOING, optional = false, predicate = True())
+
+
+    val fifth = EndPoint("c")
+    val fourth = SingleStepTrail(fifth , Direction.OUTGOING, "  UNNAMED18", Seq(), "  UNNAMED14", None, None, s4)
+    val third  = SingleStepTrail(fourth, Direction.OUTGOING, "  UNNAMED17", Seq(), "b", None, None, s3)
+    val second = SingleStepTrail(third , Direction.INCOMING, "  UNNAMED16", Seq(), "  UNNAMED13", None, None, s2)
+    val first  = SingleStepTrail(second, Direction.INCOMING, "  UNNAMED15", Seq(), "a", None, None, s1)
+
+    val result = TrailBuilder.findLongestTrail(Seq(s1, s2, s3, s4), Seq("a"), Seq.empty)
+    println(result)
+    val expected = Some(LongestTrail("a", None, first))
 
     assert(result === expected)
   }


### PR DESCRIPTION
To not have to use the same unnamed-numbering between parser versions, Pattern classes had a custom equals() method that ignored unnamed numbering.
This lead to a bug where patterns with multiple unnamed pattern relationships where dropped, and the user got a un-connected pattern exception.

The fix is to not ignore unnamed-numbers when doing equality checks. Unfortunately, this leads to having to have tests for the specific parsers, which is why
so many new tests where added to CypherParserTest
