### PR TITLE
Fixes listener addition/removal

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
@@ -274,6 +274,12 @@ public class ClusterClient extends LifecycleAdapter implements ClusterMonitor, C
     }
 
     @Override
+    public void init() throws Throwable
+    {
+        life.init();
+    }
+
+    @Override
     public void start() throws Throwable
     {
         life.start();

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosNetworkTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosNetworkTest.java
@@ -54,6 +54,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.ConfigurationDefaults;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.LogbackService;
+import org.neo4j.test.TargetDirectory;
 
 /**
  * TODO
@@ -66,7 +67,8 @@ public class MultiPaxosNetworkTest
     {
         final LifeSupport life = new LifeSupport();
         Config config = new Config( new ConfigurationDefaults( GraphDatabaseSettings.class ).apply( MapUtil.stringMap
-                ( GraphDatabaseSettings.store_dir.name(), "test" ) ) );
+                ( GraphDatabaseSettings.store_dir.name(),
+                        TargetDirectory.forTest( getClass() ).directory( "cluster" ).getAbsolutePath() ) ) );
 
         final LoggerContext loggerContext = new LoggerContext();
         loggerContext.putProperty( "host", "none" );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.Map;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.com.NetworkInstance;
@@ -62,8 +63,6 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.ClassicLoggingService;
 import org.neo4j.kernel.logging.LogbackService;
 import org.neo4j.kernel.logging.Logging;
-
-import ch.qos.logback.classic.LoggerContext;
 
 public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
 {
@@ -105,13 +104,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         kernelEventHandlers.registerKernelEventHandler( new TxManagerCheckKernelEventHandler( xaDataSourceManager,
                 (TxManager) txManager ) );
         transactionSupport.setLockReleaser( lockReleaser );
-        life.add( memberStateMachine );
         life.add( updatePuller = new UpdatePuller( (HaXaDataSourceManager) xaDataSourceManager, master,
                 requestContextFactory, txManager, accessGuard, config, msgLog ) );
-
-        // Add this just before cluster join to ensure that it is up and running as late as possible
-        // and is shut down as early as possible
-        life.add( clusterClient );
 
         life.add( new StartupWaiter() );
 
@@ -173,16 +167,15 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         DefaultElectionCredentialsProvider electionCredentialsProvider = new DefaultElectionCredentialsProvider(
                 config.get( HaSettings.server_id ), new OnDiskLastTxIdGetter( new File( getStoreDir() ) ) );
         // Add if to lifecycle later, as late as possible really
-        clusterClient = new ClusterClient( ClusterClient.adapt( config, electionCredentialsProvider ), logging );
-
+        clusterClient = life.add( new ClusterClient( ClusterClient.adapt( config, electionCredentialsProvider ),
+                logging ) );
         clusterEvents = life.add( new PaxosHighAvailabilityEvents( PaxosHighAvailabilityEvents.adapt( config ),
-                clusterClient,
-                logging.getLogger( PaxosHighAvailabilityEvents.class ) ) );
+                clusterClient, logging.getLogger( PaxosHighAvailabilityEvents.class ) ) );
 
         memberContext = new HighAvailabilityMemberContext( clusterClient );
 
-        memberStateMachine = new HighAvailabilityMemberStateMachine( memberContext, accessGuard, clusterEvents,
-                logging.getLogger( HighAvailabilityMemberStateMachine.class ) );
+        memberStateMachine = life.add( new HighAvailabilityMemberStateMachine( memberContext, accessGuard, clusterEvents,
+                logging.getLogger( HighAvailabilityMemberStateMachine.class ) ) );
         life.add( new HighAvailabilityModeSwitcher( delegateInvocationHandler, clusterEvents, memberStateMachine, this,
                 config, logging.getLogger( HighAvailabilityModeSwitcher.class ) ) );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/AbstractModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/AbstractModeSwitcher.java
@@ -36,12 +36,15 @@ public abstract class AbstractModeSwitcher<T> implements Lifecycle
 {
     private final DelegateInvocationHandler<T> delegate;
     private LifeSupport life;
+    private final HighAvailability highAvailability;
+    private DelegateStateSwitcher delegateStateSwitcher;
 
     protected AbstractModeSwitcher( HighAvailability highAvailability, DelegateInvocationHandler<T> delegate )
     {
         this.delegate = delegate;
         this.life = new LifeSupport();
-        highAvailability.addHighAvailabilityMemberListener( new DelegateStateSwitcher() );
+        this.highAvailability = highAvailability;
+        highAvailability.addHighAvailabilityMemberListener( delegateStateSwitcher = new DelegateStateSwitcher() );
     }
 
     @Override
@@ -60,6 +63,7 @@ public abstract class AbstractModeSwitcher<T> implements Lifecycle
     public void stop() throws Throwable
     {
         life.stop();
+        highAvailability.removeHighAvailabilityMemberListener( delegateStateSwitcher );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/paxos/PaxosHighAvailabilityEvents.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/paxos/PaxosHighAvailabilityEvents.java
@@ -47,6 +47,10 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public class PaxosHighAvailabilityEvents implements HighAvailabilityEvents, Lifecycle
 {
+    private ClusterListener clusterListener;
+    private HeartbeatListener heartbeatListener;
+    private AtomicBroadcastListener atomicBroadcastListener;
+
     public interface Configuration
     {
         String getHaServer();
@@ -122,7 +126,7 @@ public class PaxosHighAvailabilityEvents implements HighAvailabilityEvents, Life
     {
         serializer = new AtomicBroadcastSerializer();
 
-        cluster.addClusterListener( new ClusterListener.Adapter()
+        cluster.addClusterListener( clusterListener = new ClusterListener.Adapter()
         {
             @Override
             public void joinedCluster( URI member )
@@ -155,7 +159,7 @@ public class PaxosHighAvailabilityEvents implements HighAvailabilityEvents, Life
             }
         } );
         
-        cluster.addHeartbeatListener( new HeartbeatListener.Adapter()
+        cluster.addHeartbeatListener( heartbeatListener = new HeartbeatListener.Adapter()
         {
             @Override
             public void alive( URI server )
@@ -164,7 +168,7 @@ public class PaxosHighAvailabilityEvents implements HighAvailabilityEvents, Life
             }
         } );
 
-        cluster.addAtomicBroadcastListener( new AtomicBroadcastListener()
+        cluster.addAtomicBroadcastListener( atomicBroadcastListener = new AtomicBroadcastListener()
         {
             @Override
             public void receive( Payload payload )
@@ -237,6 +241,9 @@ public class PaxosHighAvailabilityEvents implements HighAvailabilityEvents, Life
     public void stop()
             throws Throwable
     {
+        cluster.removeAtomicBroadcastListener( atomicBroadcastListener );
+        cluster.removeClusterListener( clusterListener );
+        cluster.removeHeartbeatListener( heartbeatListener );
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/MultipleClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/MultipleClusterTest.java
@@ -35,6 +35,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.test.LoggerRule;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 
@@ -49,7 +50,7 @@ public class MultipleClusterTest
     @Test
     public void runTwoClusters() throws Throwable
     {
-        File root = new File( "target/cluster" );
+        File root = TargetDirectory.forTest( getClass() ).directory( "cluster", true );
 
         ClusterManager clusterManager = new ClusterManager( fromXml( getClass().getResource( "/twoclustertest.xml" ).toURI() ),
                 root, MapUtil.stringMap() );


### PR DESCRIPTION
Tries to get listeners to events to register on init(), be removed on shutdown(). That makes some nasty bugs go away by ensuring events
  are not received when they no longer can be handled.
Fixes the ClusterClient life by adding an init() that was missing.
The above allow for the ClusterClient to be added to the life of HAGD as soon as it is created.
Touches up some tests.
