### PR TITLE
Removed cypher-plugin from manual

### DIFF
--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -193,13 +193,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.neo4j.server.plugin</groupId>
-      <artifactId>neo4j-cypher-plugin</artifactId>
-      <version>${neo4j.version}</version>
-      <classifier>docs</classifier>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.neo4j.drivers</groupId>
       <artifactId>neo4j-python-embedded</artifactId>
       <version>${neo4j.version}</version>

--- a/manual/src/main/resources/reference/index.asciidoc
+++ b/manual/src/main/resources/reference/index.asciidoc
@@ -41,10 +41,6 @@ include::{importdir}/neo4j-server-docs-jar/dev/rest-api/index.asciidoc[]
 
 :leveloffset: 2
 
-include::{importdir}/neo4j-cypher-plugin-docs-jar/dev/cypher-plugin-api/index.asciidoc[]
-
-:leveloffset: 2
-
 include::{importdir}/neo4j-gremlin-plugin-docs-jar/dev/rest-api/index.asciidoc[]
 
 :leveloffset: 1


### PR DESCRIPTION
ping @nawroth - I wasn't able to build this locally, hopefully the PR bot will tell us it's all good :) 

On topic: Cypher Plugin has been deprecated since 1.6, time to kill it for the 1.9 release, IMHO.
