### PR TITLE
IndexManager and Index instances from an HAGD survives internal restarts...

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -329,7 +329,7 @@ public class LuceneDataSource extends LogBackedXaDataSource
             LuceneIndex index = indexes.get( identifier );
             if ( index == null )
             {
-                index = new LuceneIndex.NodeIndex( luceneIndexImplementation, graphDb, identifier );
+                index = new LuceneIndex.NodeIndex( luceneIndexImplementation, identifier );
                 indexes.put( identifier, index );
             }
             return index;
@@ -348,7 +348,7 @@ public class LuceneDataSource extends LogBackedXaDataSource
             LuceneIndex index = indexes.get( identifier );
             if ( index == null )
             {
-                index = new LuceneIndex.RelationshipIndex( luceneIndexImplementation, gdb, identifier );
+                index = new LuceneIndex.RelationshipIndex( luceneIndexImplementation, identifier );
                 indexes.put( identifier, index );
             }
             return (RelationshipIndex) index;

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
@@ -429,20 +429,16 @@ public abstract class LuceneIndex<T extends PropertyContainer> implements Index<
 
     static class NodeIndex extends LuceneIndex<Node>
     {
-        private GraphDatabaseService gdb;
-
         NodeIndex( LuceneIndexImplementation service,
-                   GraphDatabaseService gdb,
                 IndexIdentifier identifier )
         {
             super( service, identifier );
-            this.gdb = gdb;
         }
 
         @Override
         protected Node getById( long id )
         {
-            return gdb.getNodeById(id);
+            return service.graphDb().getNodeById(id);
         }
 
         @Override
@@ -474,20 +470,15 @@ public abstract class LuceneIndex<T extends PropertyContainer> implements Index<
     static class RelationshipIndex extends LuceneIndex<Relationship>
             implements org.neo4j.graphdb.index.RelationshipIndex
     {
-        private GraphDatabaseService gdb;
-
-        RelationshipIndex( LuceneIndexImplementation service,
-                           GraphDatabaseService gdb,
-                IndexIdentifier identifier )
+        RelationshipIndex( LuceneIndexImplementation service, IndexIdentifier identifier )
         {
             super( service, identifier );
-            this.gdb = gdb;
         }
 
         @Override
         protected Relationship getById( long id )
         {
-            return gdb.getRelationshipById(id);
+            return service.graphDb().getRelationshipById(id);
         }
 
         @Override

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndexImplementation.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndexImplementation.java
@@ -22,6 +22,7 @@ package org.neo4j.index.impl.lucene;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.index.Index;
@@ -50,7 +51,7 @@ public class LuceneIndexImplementation implements IndexImplementation
 
     public static final int DEFAULT_LAZY_THRESHOLD = 100;
 
-    private final GraphDatabaseService graphDb;
+    private GraphDatabaseService graphDb;
     private IndexConnectionBroker<LuceneXaConnection> broker;
     private LuceneDataSource dataSource;
     final int lazynessThreshold;
@@ -159,8 +160,9 @@ public class LuceneIndexImplementation implements IndexImplementation
         return this.graphDb.equals(gdb);
     }
 
-    public void reset( LuceneDataSource dataSource, IndexConnectionBroker<LuceneXaConnection> broker)
+    public void reset( GraphDatabaseService graphDb, LuceneDataSource dataSource, IndexConnectionBroker<LuceneXaConnection> broker)
     {
+        this.graphDb = graphDb;
         this.broker = broker;
         this.dataSource = dataSource;
     }

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneIndexProvider.java
@@ -85,7 +85,7 @@ public class LuceneIndexProvider extends IndexProvider
             if (indexImplementation == null)
                 iterator.remove();
             else if ( indexImplementation.matches( gdb ) )
-                indexImplementation.reset( luceneDataSource, broker );
+                indexImplementation.reset( gdb, luceneDataSource, broker );
         }
         
         LuceneIndexImplementation indexImplementation = new LuceneIndexImplementation( gdb, luceneDataSource, broker );

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -27,9 +27,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
-import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.cypher.javacompat.ExecutionResult;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.rest.repr.BadInputException;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -49,7 +49,6 @@ import org.neo4j.com.TransactionStream;
 import org.neo4j.com.TxExtractor;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
-import org.neo4j.consistency.checking.full.FullCheck;
 import org.neo4j.graphdb.factory.GraphDatabaseSetting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.ProgressIndicator;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.neo4j.com.ComException;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/HighlyAvailableGraphDatabase.java
@@ -159,6 +159,7 @@ public class HighlyAvailableGraphDatabase
     private final SlaveUpdateMode slaveUpdateMode;
     private final Caches caches;
     private final MasterClientResolver masterClientResolver;
+    private final ProxyIndexManager indexManager;
 
     // This lock is used to safeguard access to internal database
     // Users will acquire readlock, and upon master/slave switch
@@ -282,6 +283,8 @@ public class HighlyAvailableGraphDatabase
 
         this.broker = createBroker();
         this.pullUpdates = false;
+        
+        this.indexManager = new ProxyIndexManager();
 
         start();
     }
@@ -378,7 +381,7 @@ public class HighlyAvailableGraphDatabase
     @Override
     public IndexManager index()
     {
-        return localGraph().index();
+        return indexManager;
     }
 
     @Override
@@ -1074,6 +1077,7 @@ public class HighlyAvailableGraphDatabase
         {
             newDb.registerKernelEventHandler( handler );
         }
+        indexManager.setDelegate( newDb.index() );
     }
 
     private void logHaInfo( String started )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ProxyIndexManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ProxyIndexManager.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.index.AutoIndexer;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.graphdb.index.RelationshipAutoIndexer;
+import org.neo4j.graphdb.index.RelationshipIndex;
+
+public class ProxyIndexManager implements IndexManager
+{
+    private IndexManager indexManager;
+    
+    void setDelegate( IndexManager indexManager )
+    {
+        this.indexManager = indexManager;
+    }
+
+    public boolean existsForNodes( String indexName )
+    {
+        return indexManager.existsForNodes( indexName );
+    }
+
+    public Index<Node> forNodes( String indexName )
+    {
+        return indexManager.forNodes( indexName );
+    }
+
+    public Index<Node> forNodes( String indexName, Map<String, String> customConfiguration )
+    {
+        return indexManager.forNodes( indexName, customConfiguration );
+    }
+
+    public String[] nodeIndexNames()
+    {
+        return indexManager.nodeIndexNames();
+    }
+
+    public boolean existsForRelationships( String indexName )
+    {
+        return indexManager.existsForRelationships( indexName );
+    }
+
+    public RelationshipIndex forRelationships( String indexName )
+    {
+        return indexManager.forRelationships( indexName );
+    }
+
+    public RelationshipIndex forRelationships( String indexName, Map<String, String> customConfiguration )
+    {
+        return indexManager.forRelationships( indexName, customConfiguration );
+    }
+
+    public String[] relationshipIndexNames()
+    {
+        return indexManager.relationshipIndexNames();
+    }
+
+    public Map<String, String> getConfiguration( Index<? extends PropertyContainer> index )
+    {
+        return indexManager.getConfiguration( index );
+    }
+
+    public String setConfiguration( Index<? extends PropertyContainer> index, String key, String value )
+    {
+        return indexManager.setConfiguration( index, key, value );
+    }
+
+    public String removeConfiguration( Index<? extends PropertyContainer> index, String key )
+    {
+        return indexManager.removeConfiguration( index, key );
+    }
+
+    public AutoIndexer<Node> getNodeAutoIndexer()
+    {
+        return indexManager.getNodeAutoIndexer();
+    }
+
+    public RelationshipAutoIndexer getRelationshipAutoIndexer()
+    {
+        return indexManager.getRelationshipAutoIndexer();
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestIndexReuse.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestIndexReuse.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.TargetDirectory.forTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.kernel.HighlyAvailableGraphDatabase;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.ha.LocalhostZooKeeperCluster;
+
+public class TestIndexReuse
+{
+    @Test
+    public void testIndexCanBeReusedAfterInternalRestart() throws Exception
+    {
+        String indexName = "indexTEST", key = "testkey", value = "datest";
+        IndexManager indexManager = slave.index();
+        Index<Node> nodeIndex = indexManager.forNodes( indexName );
+        Node node = createIndexedNode( slave, nodeIndex, key, value );
+        
+        switchMaster();
+
+        // Use the index manager again
+        assertTrue( indexManager.existsForNodes( indexName ) );
+        assertNotNull( indexManager.forNodes( "new index" ) );
+        
+        // Use the index again
+        assertEquals( node, nodeIndex.get( key, value ).next() );
+    }
+
+    private final TargetDirectory dir = forTest( getClass() );
+    private LocalhostZooKeeperCluster zoo;
+    private HighlyAvailableGraphDatabase master, slave;
+    
+    @Before
+    public void before() throws Exception
+    {
+        zoo = LocalhostZooKeeperCluster.singleton().clearDataAndVerifyConnection();
+
+        master = new HighlyAvailableGraphDatabase( dir.directory( "master", true ).getAbsolutePath(), stringMap(
+                HaSettings.server_id.name(), "0", HaSettings.server.name(), "localhost:" + 6666,
+                HaSettings.coordinators.name(), zoo.getConnectionString(), HaSettings.pull_interval.name(),
+                0 + "ms", HaSettings.tx_push_strategy.name(), HaSettings.TxPushStrategySetting.fixed , HaSettings.tx_push_factor.name(), "1") );
+        
+        createNode( master );
+        Thread.sleep( 5000 );
+        
+        slave = new HighlyAvailableGraphDatabase( dir.directory( "slave", true ).getAbsolutePath(), stringMap(
+                HaSettings.server_id.name(), "1", HaSettings.server.name(), "localhost:" + 6667,
+                HaSettings.coordinators.name(), zoo.getConnectionString(), HaSettings.pull_interval.name(),
+                0 + "ms", HaSettings.tx_push_strategy.name(), HaSettings.TxPushStrategySetting.fixed , HaSettings.tx_push_factor.name(), "1") );
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        if ( slave != null )
+            slave.shutdown();
+        if ( master != null )
+            master.shutdown();
+    }
+    
+    private Node createIndexedNode( HighlyAvailableGraphDatabase db, Index<Node> nodeIndex, String key, Object value )
+    {
+        Transaction tx = db.beginTx();
+        Node node = null;
+        try
+        {
+            node = db.createNode();
+            nodeIndex.add( node, key, value );
+            tx.success();
+        }
+        finally
+        {
+            tx.finish();
+        }
+        return node;
+    }
+
+    private void switchMaster()
+            throws InterruptedException
+    {
+        // kill master so we get a role switch (internal restart) on slave 
+        master.shutdown();
+        master = null;
+        int count = 0;
+        boolean success = false;
+        do
+        {
+            try
+            {
+                createNode( slave );
+                success = true;
+            }
+            catch ( Throwable t )
+            {
+                t.printStackTrace();
+                Thread.sleep( 1000 );
+            }
+        } while ( !success && ++count < 10 );
+        assertTrue( count < 10 );
+    }
+
+    private void createNode( HighlyAvailableGraphDatabase db )
+    {
+        Transaction masterTx = db.beginTx();
+        try
+        {
+            db.createNode();
+            masterTx.success();
+        }
+        finally
+        {
+            masterTx.finish();
+        }
+    }
+}


### PR DESCRIPTION
IndexManager instances solved by having a proxy HA IndexManager that delegates to a mutable actual IndexManager, injected on each internal restart.

Index instances already had support for this by the old little hack in LuceneIndexProvider (comments will mark which part of the code that is). It just didn't include the graphDb itself, but now it does.
