### PR TITLE
Explicitly marks the start entry as written to avoid duplicate entries

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -242,6 +242,7 @@ public class XaResourceManager
         private boolean prepared = false;
         private boolean commitStarted = false;
         private boolean rollback = false;
+        private boolean startWritten = false;
         private final XaTransaction xaTransaction;
 
         TransactionStatus( XaTransaction xaTransaction )
@@ -279,9 +280,14 @@ public class XaResourceManager
             return commitStarted;
         }
 
-        boolean started()
+        boolean startWritten()
         {
-            return prepared || commitStarted || rollback;
+            return startWritten;
+        }
+        
+        void markStartWritten()
+        {
+            this.startWritten = true;
         }
 
         XaTransaction getTransaction()
@@ -301,9 +307,10 @@ public class XaResourceManager
     private void checkStartWritten( TransactionStatus status, XaTransaction tx )
             throws XAException
     {
-        if ( !status.started() && !tx.isRecovered() )
+        if ( !status.startWritten() && !tx.isRecovered() )
         {
             log.writeStartEntry( tx.getIdentifier() );
+            status.markStartWritten();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DummyXaDataSource.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DummyXaDataSource.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAResource;
+
+import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+
+/**
+ * Is one-phase commit always performed when only one (or many isSameRM)
+ * resource(s) are present in the transaction?
+ * 
+ * If so it could be tested...
+ */
+// public void test1PhaseCommit()
+// {
+//	
+// }
+public class DummyXaDataSource extends XaDataSource
+{
+    private XAResource xaResource = null;
+
+    public DummyXaDataSource( String name, byte[] branchId, XAResource xaResource )
+        throws InstantiationException
+    {
+        super( branchId, name );
+        this.xaResource = xaResource;
+    }
+
+    public XaConnection getXaConnection()
+    {
+        return new DummyXaConnection( xaResource );
+    }
+
+    @Override
+    public long getLastCommittedTxId()
+    {
+        return 0;
+    }
+
+    public void init()
+    {
+    }
+
+    public void start()
+    {
+    }
+
+    public void stop()
+    {
+    }
+
+    public void shutdown()
+    {
+    }
+
+    static class DummyXaConnection implements XaConnection
+    {
+        private XAResource xaResource = null;
+
+        public DummyXaConnection( XAResource xaResource )
+        {
+            this.xaResource = xaResource;
+        }
+
+        public XAResource getXaResource()
+        {
+            return xaResource;
+        }
+
+        public void destroy()
+        {
+        }
+
+        @Override
+        public boolean enlistResource( Transaction javaxTx )
+            throws SystemException, RollbackException
+        {
+            return javaxTx.enlistResource( xaResource );
+        }
+
+        @Override
+        public boolean delistResource( Transaction tx, int tmsuccess )
+            throws IllegalStateException, SystemException
+        {
+            return tx.delistResource( xaResource, tmsuccess );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.transaction.xa.Xid;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.kernel.EmbeddedGraphDatabase;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+import org.neo4j.test.LogTestUtils.LogHookAdapter;
+import org.neo4j.test.TargetDirectory;
+
+public class TestInjectMultipleStartEntries
+{
+    @Test
+    public void fail_prepare_two_phase_transaction_should_not_yield_two_start_log_entries() throws Exception
+    {
+        // GIVEN
+        // -- a database with one additional data source and some initial data
+        GraphDatabaseAPI db = new EmbeddedGraphDatabase( storeDir );
+        XaDataSourceManager xaDs = db.getXaDataSourceManager();
+        XaDataSource additionalDs = new DummyXaDataSource( "dummy", "dummy".getBytes(), new FakeXAResource( "dummy" ) );
+        xaDs.registerDataSource( additionalDs );
+        Node node = createNodeWithOneRelationshipToIt( db );
+
+        // WHEN
+        // -- doing a transaction involving both data sources and fails in prepare phase
+        //    due to invalid transaction data
+        deleteNodeButNotItsRelationshipsInATwoPhaseTransaction( db, additionalDs, node );
+        db.shutdown();
+
+        // THEN
+        // -- the logical log should only contain unique start entries after this transaction
+        filterNeostoreLogicalLog( new File( storeDir, LOGICAL_LOG_DEFAULT_NAME + ".v0" ), new VerificationLogHook() );
+    }
+    
+    private final String storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath();
+    
+    private static class VerificationLogHook extends LogHookAdapter<LogEntry>
+    {
+        private final Set<Xid> startXids = new HashSet<Xid>();
+        
+        @Override
+        public boolean accept( LogEntry item )
+        {
+            if ( item instanceof LogEntry.Start )
+                assertTrue( startXids.add( ((LogEntry.Start) item).getXid() ) );
+            return true;
+        }
+    }
+
+    private void deleteNodeButNotItsRelationshipsInATwoPhaseTransaction( GraphDatabaseAPI db,
+            XaDataSource additionalDs, Node node ) throws Exception
+    {
+        Transaction tx = db.beginTx();
+        additionalDs.getXaConnection().enlistResource( db.getTxManager().getTransaction() );
+        node.delete();
+        tx.success();
+        try
+        {
+            tx.finish();
+            fail( "This transaction shouldn't be successful" );
+        }
+        catch ( TransactionFailureException e )
+        {
+            // Good
+        }
+    }
+
+    private Node createNodeWithOneRelationshipToIt( GraphDatabaseService db )
+    {
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node node = db.createNode();
+            node.createRelationshipTo( db.createNode(), MyRelTypes.TEST );
+            tx.success();
+            return node;
+        }
+        finally
+        {
+            tx.finish();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestJtaCompliance.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestJtaCompliance.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -37,8 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
-import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
-import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 
 public class TestJtaCompliance extends AbstractNeo4jTestCase
 {
@@ -58,8 +55,8 @@ public class TestJtaCompliance extends AbstractNeo4jTestCase
         map2.put( "store_dir", "target/var" );
         try
         {
-            xaDsMgr.registerDataSource( new DummyXaDataSource( map1, "fakeRes1", UTF8.encode( "0xDDDDDE" ), new FakeXAResource( "XAResource1" ) ));
-            xaDsMgr.registerDataSource( new DummyXaDataSource( map2, "fakeRes2", UTF8.encode( "0xDDDDDF" ), new FakeXAResource( "XAResource2" ) ));
+            xaDsMgr.registerDataSource( new DummyXaDataSource( "fakeRes1", UTF8.encode( "0xDDDDDE" ), new FakeXAResource( "XAResource1" ) ));
+            xaDsMgr.registerDataSource( new DummyXaDataSource( "fakeRes2", UTF8.encode( "0xDDDDDF" ), new FakeXAResource( "XAResource2" ) ));
         }
         catch ( Exception e )
         {
@@ -694,87 +691,5 @@ public class TestJtaCompliance extends AbstractNeo4jTestCase
         assertTrue( tm.getStatus() == Status.STATUS_MARKED_ROLLBACK );
         tm.rollback();
         assertTrue( tm.getStatus() == Status.STATUS_NO_TRANSACTION );
-    }
-
-    /**
-     * Is one-phase commit always performed when only one (or many isSameRM)
-     * resource(s) are present in the transaction?
-     * 
-     * If so it could be tested...
-     */
-    // public void test1PhaseCommit()
-    // {
-    //	
-    // }
-    public static class DummyXaDataSource extends XaDataSource
-    {
-        private XAResource xaResource = null;
-
-        public DummyXaDataSource( java.util.Map<String,String> map, String name, byte[] branchId, XAResource xaResource )
-            throws InstantiationException
-        {
-            super( branchId, name );
-            this.xaResource = xaResource;
-        }
-
-        public XaConnection getXaConnection()
-        {
-            return new DummyXaConnection( xaResource );
-        }
-
-        @Override
-        public long getLastCommittedTxId()
-        {
-            return 0;
-        }
-
-        public void init()
-        {
-        }
-
-        public void start()
-        {
-        }
-
-        public void stop()
-        {
-        }
-
-        public void shutdown()
-        {
-        }
-    }
-
-    private static class DummyXaConnection implements XaConnection
-    {
-        private XAResource xaResource = null;
-
-        public DummyXaConnection( XAResource xaResource )
-        {
-            this.xaResource = xaResource;
-        }
-
-        public XAResource getXaResource()
-        {
-            return xaResource;
-        }
-
-        public void destroy()
-        {
-        }
-
-        @Override
-        public boolean enlistResource( Transaction javaxTx )
-            throws SystemException, RollbackException
-        {
-            return javaxTx.enlistResource( xaResource );
-        }
-
-        @Override
-        public boolean delistResource( Transaction tx, int tmsuccess )
-            throws IllegalStateException, SystemException
-        {
-            return tx.delistResource( xaResource, tmsuccess );
-        }
     }
 }


### PR DESCRIPTION
Removes a class of potential bugs regarding this. We've had several over the course of the product.
