### PR TITLE
Documentation cleanup.

### DIFF
--- a/advanced/neo4j-advanced/pom.xml
+++ b/advanced/neo4j-advanced/pom.xml
@@ -135,6 +135,23 @@
               <goal>javadoc</goal>
             </goals>
             <configuration>
+              <additionnalDependencies>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-classic</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-core</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>1.6.4</version>
+                </additionnalDependency>
+              </additionnalDependencies>
               <outputDirectory>${project.build.directory}/site/apidocs</outputDirectory>
               <sourcepath>${project.build.directory}/javadoc-sources</sourcepath>
               <header>${project.name}</header>
@@ -142,7 +159,7 @@
               <skip>${javadoc.skip}</skip>
               <windowtitle>${project.name} ${project.version} API</windowtitle>
               <excludePackageNames>
-                *.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
               </excludePackageNames>
               <groups>
                 <group>
@@ -219,11 +236,28 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <additionnalDependencies>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.6.4</version>
+            </additionnalDependency>
+          </additionnalDependencies>
           <header>${project.name}</header>
           <doctitle>${project.name} ${project.version} API</doctitle>
           <windowtitle>${project.name} ${project.version} API</windowtitle>
           <excludePackageNames>
-            *.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
           </excludePackageNames>
           <groups>
             <group>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -259,6 +259,23 @@ public class ComponentVersion extends Version
             <plugin>
               <artifactId>maven-javadoc-plugin</artifactId>
               <configuration>
+                <additionnalDependencies>
+                  <additionnalDependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <version>1.0.0</version>
+                  </additionnalDependency>
+                  <additionnalDependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                    <version>1.0.0</version>
+                  </additionnalDependency>
+                  <additionnalDependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                    <version>1.6.4</version>
+                  </additionnalDependency>
+                </additionnalDependencies>
                 <detectJavaApiLink>true</detectJavaApiLink>
                 <detectLinks>true</detectLinks>
                 <quiet>true</quiet>
@@ -298,6 +315,23 @@ public class ComponentVersion extends Version
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <additionnalDependencies>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.6.4</version>
+            </additionnalDependency>
+          </additionnalDependencies>
           <groups>
             <group>
               <title>Graph database</title>
@@ -411,6 +445,23 @@ public class ComponentVersion extends Version
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <additionnalDependencies>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.6.4</version>
+            </additionnalDependency>
+          </additionnalDependencies>
           <detectJavaApiLink>true</detectJavaApiLink>
           <detectLinks>true</detectLinks>
           <quiet>true</quiet>

--- a/community/kernel/src/docs/ops/performance-guide.asciidoc
+++ b/community/kernel/src/docs/ops/performance-guide.asciidoc
@@ -111,27 +111,7 @@ and when a transaction is committed changes to the logical log will be forced
 (+fdatasync+) down to disk. The store files are however not flushed to disk and 
 writes to them are not append-only either. They will be written to in a more or
 less random pattern (depending on graph layout) and writes will not be forced to 
-disk until the log is rotated or the Neo4j kernel is shut down. It may be a good 
-idea to increase the logical log target size for rotation or turn off log rotation 
-if you experience problems with writes that can be linked to the actual rotation 
-of the log. Here is some example code demonstrating how to change log rotation 
-settings at runtime:
-
-[source,java]
-----
-    GraphDatabaseService graphDb; // ... 
-
-    // get the XaDataSource for the native store
-    TxModule txModule = ((EmbeddedGraphDatabase) graphDb).getConfig().getTxModule();
-    XaDataSourceManager xaDsMgr = txModule.getXaDataSourceManager();
-    XaDataSource xaDs = xaDsMgr.getXaDataSource( "nioneodb" );
-  
-    // turn off log rotation
-    xaDs.setAutoRotate( false );
-
-    // or to increase log target size to 100MB (default 10MB)
-    xaDs.setLogicalLogTargetSize( 100 * 1024 * 1024L );
-----
+disk until the log is rotated or the Neo4j kernel is shut down.
 
 Since random writes to memory mapped regions for the store files may 
 happen it is very important that the data does not get written out to disk unless 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Node.java
@@ -20,6 +20,7 @@
 package org.neo4j.graphdb;
 
 import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.kernel.Traversal;
 
 /**
  * A node in the graph with properties and relationships to other entities.
@@ -316,12 +317,12 @@ public interface Node extends PropertyContainer
      *            <code>relationshipType</code> will be traversed
      * @return a new traverser, configured as above
      * @deprecated because of an unnatural and too tight coupling with
-     * {@link Node}. Also because of the introduction of a new traversal
-     * framework. The new way of doing traversals is by creating a
-     * new {@link TraversalDescription} from
-     * {@link Traversal#traversal()}, add rules and
-     * behaviours to it and then calling
-     * {@link TraversalDescription#traverse(Node...)}
+     *             {@link Node}. Also because of the introduction of a new
+     *             traversal framework. The new way of doing traversals is by
+     *             creating a new {@link TraversalDescription} from
+     *             {@link Traversal#traversal()}, add rules and behaviors to it
+     *             and then calling
+     *             {@link TraversalDescription#traverse(Node...)}
      */
     public Traverser traverse( Traverser.Order traversalOrder,
             StopEvaluator stopEvaluator,

--- a/community/kernel/src/main/java/org/neo4j/graphdb/ReturnableEvaluator.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/ReturnableEvaluator.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.graphdb;
 
+import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.helpers.Predicate;
+import org.neo4j.kernel.Traversal;
 
 /**
  * A client hook for evaluating whether a specific node should be returned from

--- a/community/kernel/src/main/java/org/neo4j/graphdb/StopEvaluator.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/StopEvaluator.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.graphdb;
 
+import org.neo4j.graphdb.traversal.Evaluator;
+import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.kernel.Traversal;
+
 
 /**
  * A client hook for evaluating whether the traverser should traverse beyond a

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Traverser.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Traverser.java
@@ -22,6 +22,9 @@ package org.neo4j.graphdb;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.kernel.Traversal;
+
 /**
  * A traversal in the node space. A Traverser is an {@link Iterable} that
  * encapsulates a number of traversal parameters (defined at traverser creation)

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/AutoIndexer.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/AutoIndexer.java
@@ -51,7 +51,7 @@ public interface AutoIndexer<T extends PropertyContainer>
      * 
      * @return true iff this auto indexer is enabled
      * 
-     * @see setEnabled(boolean)
+     * @see #setEnabled(boolean)
      */
     boolean isEnabled();
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/BatchInserterIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/BatchInserterIndexProvider.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.batchinsert.BatchInserter;
  * @author Mattias Persson
  * 
  * @deprecated this interface has been moved to
- *             {@link org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider.java}
+ *             {@link org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider}
  *             as of version 1.7.
  */
 public interface BatchInserterIndexProvider

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/ReadableIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/ReadableIndex.java
@@ -42,15 +42,15 @@ public interface ReadableIndex<T extends PropertyContainer>
     Class<T> getEntityType();
 
     /**
-     * Returns exact matches from this index, given the key/value pair.
-     * Matches will be for key/value pairs just as they were added by the
-     * {@link #add(PropertyContainer, String, Object)} method.
-     *
+     * Returns exact matches from this index, given the key/value pair. Matches
+     * will be for key/value pairs just as they were added by the
+     * {@link Index#add(PropertyContainer, String, Object)} method.
+     * 
      * @param key the key in the key/value pair to match.
      * @param value the value in the key/value pair to match.
      * @return the result wrapped in an {@link IndexHits} object. If the entire
-     * result set isn't looped through, {@link IndexHits#close()} must be
-     * called before disposing of the result.
+     *         result set isn't looped through, {@link IndexHits#close()} must
+     *         be called before disposing of the result.
      */
     IndexHits<T> get( String key, Object value );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/ReadableRelationshipIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/ReadableRelationshipIndex.java
@@ -38,8 +38,8 @@ public interface ReadableRelationshipIndex extends ReadableIndex<Relationship>
     /**
      * Returns exact matches from this index, given the key/value pair. Matches
      * will be for key/value pairs just as they were added by the
-     * {@link #add(PropertyContainer, String, Object)} method.
-     *
+     * {@link Index#add(PropertyContainer, String, Object)} method.
+     * 
      * @param key the key in the key/value pair to match.
      * @param valueOrNull the value in the key/value pair to match.
      * @param startNodeOrNull filter so that only {@link Relationship}s with

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluation.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluation.java
@@ -101,10 +101,10 @@ public enum Evaluation
      * traversal. The returned evaluation will always return true for
      * {@link Evaluation#includes()}.
      * 
-     * @param includes whether or not to continue further down a
-     * {@link TraversalBranch} in the traversal.
+     * @param continues whether or not to continue further down a
+     *            {@link TraversalBranch} in the traversal.
      * @return an {@link Evaluation} representing whether or not to continue
-     * further down a {@link TraversalBranch} in the traversal.
+     *         further down a {@link TraversalBranch} in the traversal.
      */
     public static Evaluation ofContinues( boolean continues )
     {

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
@@ -305,7 +305,7 @@ public abstract class Evaluators
     }
 
     /**
-     * @deprecated use {@link #includeWhereEndNodeIs(Node...)
+     * @deprecated use {@link #includeWhereEndNodeIs(Node...)}
      */
     public static Evaluator returnWhereEndNodeIs( Node... nodes )
     {
@@ -314,9 +314,11 @@ public abstract class Evaluators
 
     /**
      * @param nodes end nodes for paths to be included in the result.
-     * @see #endNodeIs(Evaluation, Evaluation, Node...),
-     *      uses {@link Evaluation#INCLUDE_AND_CONTINUE} for {@code evaluationIfMatch}
-     *      and {@link Evaluation#EXCLUDE_AND_CONTINUE} for {@code evaluationIfNoMatch}.
+     * @see this#endNodeIs(Evaluation, Evaluation, Node...), uses
+     *      {@link Evaluation#INCLUDE_AND_CONTINUE} for
+     *      {@code evaluationIfMatch} and
+     *      {@link Evaluation#EXCLUDE_AND_CONTINUE} for
+     *      {@code evaluationIfNoMatch}.
      */
     @SuppressWarnings( "rawtypes" )
     public static PathEvaluator includeWhereEndNodeIs( Node... nodes )

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/TraversalBranch.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/TraversalBranch.java
@@ -56,7 +56,8 @@ public interface TraversalBranch extends Path
     
     /**
      * Explicitly tell this branch to be pruned so that consecutive calls to
-     * {@link #next()} is guaranteed to return {@code null}.
+     * {@link #next(PathExpander, TraversalContext)} is guaranteed to return
+     * {@code null}.
      */
     void prune();
     

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/TraversalDescription.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/TraversalDescription.java
@@ -263,5 +263,5 @@ public interface TraversalDescription
      * @return a {@link Traverser} used to step through the graph and to get
      * results from.
      */
-    Traverser traverse( Node... startNode );
+    Traverser traverse( Node... startNodes );
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/MapUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/MapUtil.java
@@ -326,8 +326,9 @@ public abstract class MapUtil
     /**
      * Stores the data in {@code config} into {@code writer} in a standard java
      * {@link Properties} format.
+     * 
      * @param config the data to store in the properties file.
-     * @param stream the {@link Writer} to store the properties in.
+     * @param writer the {@link Writer} to store the properties in.
      * @throws IOException IO error.
      */
     public static void store( Map<String, String> config, Writer writer ) throws IOException
@@ -339,10 +340,11 @@ public abstract class MapUtil
     
     /**
      * Stores the data in {@code config} into {@code writer} in a standard java
-     * {@link Properties} format. Any {@link IOException} is wrapped and thrown as a
-     * {@link RuntimeException} instead.
+     * {@link Properties} format. Any {@link IOException} is wrapped and thrown
+     * as a {@link RuntimeException} instead.
+     * 
      * @param config the data to store in the properties file.
-     * @param stream the {@link Writer} to store the properties in.
+     * @param writer the {@link Writer} to store the properties in.
      * @throws IOException IO error.
      */
     public static void storeStrictly( Map<String, String> config, Writer writer )

--- a/community/kernel/src/main/java/org/neo4j/kernel/LegacyIndexIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/LegacyIndexIterable.java
@@ -26,7 +26,9 @@ import org.neo4j.graphdb.index.IndexProvider;
 import org.neo4j.helpers.Service;
 
 /**
- * Provides {@link IndexProvider} objects based on {@link Service#load()} static method. 
+ * Provides {@link IndexProvider} objects based on {@link Service#load} static
+ * method.
+ * 
  * @author ceefour
  */
 public class LegacyIndexIterable implements IndexIterable {

--- a/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
@@ -328,10 +328,11 @@ public class Traversal
      * {@link TraversalBranch} representing a path from the start node of the
      * <code>source</code> {@link TraversalBranch} to the start node of the
      * <code>target</code> {@link TraversalBranch}. The resulting
-     * {@link TraversalBranch} will not {@link TraversalBranch#next() expand
-     * further}, and does not provide a {@link TraversalBranch#parent() parent}
-     * {@link TraversalBranch}.
-     *
+     * {@link TraversalBranch} will not
+     * {@link TraversalBranch#next(PathExpander, org.neo4j.graphdb.traversal.TraversalContext)
+     * ) expand further}, and does not provide a
+     * {@link TraversalBranch#parent() parent} {@link TraversalBranch}.
+     * 
      * @param source the {@link TraversalBranch} where the resulting path starts
      * @param target the {@link TraversalBranch} where the resulting path ends
      * @throws IllegalArgumentException if the {@link TraversalBranch#endNode()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
@@ -73,9 +73,9 @@ public interface BatchInserter
     public void setNodeProperties( long node, Map<String,Object> properties );
 
     /**
-     * Returns true iff the node with id {@value node} has a property with name
-     * {@value propertyName}.
-     *
+     * Returns true iff the node with id {@code node} has a property with name
+     * {@code propertyName}.
+     * 
      * @param node The node id of the node to check.
      * @param propertyName The property name to check for
      * @return True if the node has the named property - false otherwise.
@@ -83,9 +83,9 @@ public interface BatchInserter
     public boolean nodeHasProperty( long node, String propertyName );
 
     /**
-     * Returns true iff the relationship with id {@value relationship} has a
-     * property with name {@value propertyName}.
-     *
+     * Returns true iff the relationship with id {@code relationship} has a
+     * property with name {@code propertyName}.
+     * 
      * @param relationship The relationship id of the relationship to check.
      * @param propertyName The property name to check for
      * @return True if the relationship has the named property - false
@@ -95,10 +95,10 @@ public interface BatchInserter
             String propertyName );
 
     /**
-     * Sets the property with name {@value propertyName} of node with id
-     * {@value node} to the value {@propertyValue}. If the property exists it is
-     * updated, otherwise created.
-     *
+     * Sets the property with name {@code propertyName} of node with id
+     * {@code node} to the value {@code propertyValue}. If the property exists
+     * it is updated, otherwise created.
+     * 
      * @param node The node id of the node whose property is to be set
      * @param propertyName The name of the property to set
      * @param propertyValue The value of the property to set
@@ -107,11 +107,10 @@ public interface BatchInserter
             Object propertyValue );
 
     /**
-     * Sets the property with name {@value propertyName} of relationship with id
-     * {@value relationship} to the value {@value propertyValue}. If the
-     * property
+     * Sets the property with name {@code propertyName} of relationship with id
+     * {@code relationship} to the value {@code propertyValue}. If the property
      * exists it is updated, otherwise created.
-     *
+     * 
      * @param relationship The node id of the relationship whose property is to
      *            be set
      * @param propertyName The name of the property to set
@@ -138,9 +137,9 @@ public interface BatchInserter
     public Iterable<Long> getRelationshipIds( long nodeId );
 
     /**
-     * Returns an iterable of {@link BatchRelationsip relationships} connected
+     * Returns an iterable of {@link BatchRelationship relationships} connected
      * to the node with supplied id.
-     *
+     * 
      * @param nodeId the id of the node.
      * @return iterable over the relationships connected to the node.
      */
@@ -203,18 +202,18 @@ public interface BatchInserter
     public Map<String,Object> getRelationshipProperties( long relId );
 
     /**
-     * Removes the property named {@value property} from the node with id
-     * {@value id}, if present.
-     *
+     * Removes the property named {@code property} from the node with id
+     * {@code id}, if present.
+     * 
      * @param node The id of the node from which to remove the property
      * @param property The name of the property
      */
     public void removeNodeProperty( long node, String property );
 
     /**
-     * Removes the property named {@value property} from the relationship with
-     * id {@value id}, if present.
-     *
+     * Removes the property named {@code property} from the relationship with id
+     * {@code id}, if present.
+     * 
      * @param relationship The id of the relationship from which to remove the
      *            property
      * @param property The name of the property

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterIndexProvider.java
@@ -42,27 +42,29 @@ public interface BatchInserterIndexProvider
      * {@link Map} can contain any provider-implementation-specific data that
      * can control how an index behaves.
      * 
-     * @param indexName the name of the index. It will be created if it
-     * doesn't exist.
+     * @param indexName the name of the index. It will be created if it doesn't
+     *            exist.
      * @param config a {@link Map} of configuration parameters to use with the
-     * index if it doesn't exist. Parameters can be anything and are
-     * implementation-specific.
-     * @return the {@link Index} corresponding to the {@code indexName}.
+     *            index if it doesn't exist. Parameters can be anything and are
+     *            implementation-specific.
+     * @return the {@link BatchInserterIndex} corresponding to the
+     *         {@code indexName}.
      */
     BatchInserterIndex nodeIndex( String indexName, Map<String, String> config );
     
     /**
-     * Returns a {@link BatchInserterIndex} for {@link Relationship}s for the name
-     * {@code indexName} with the given {@code config}. The {@code config}
+     * Returns a {@link BatchInserterIndex} for {@link Relationship}s for the
+     * name {@code indexName} with the given {@code config}. The {@code config}
      * {@link Map} can contain any provider-implementation-specific data that
      * can control how an index behaves.
      * 
-     * @param indexName the name of the index. It will be created if it
-     * doesn't exist.
+     * @param indexName the name of the index. It will be created if it doesn't
+     *            exist.
      * @param config a {@link Map} of configuration parameters to use with the
-     * index if it doesn't exist. Parameters can be anything and are
-     * implementation-specific.
-     * @return the {@link Index} corresponding to the {@code indexName}.
+     *            index if it doesn't exist. Parameters can be anything and are
+     *            implementation-specific.
+     * @return the {@link BatchInserterIndex} corresponding to the
+     *         {@code indexName}.
      */
     BatchInserterIndex relationshipIndex( String indexName, Map<String, String> config );
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/QueryContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/QueryContext.java
@@ -164,8 +164,8 @@ public class QueryContext
     /**
      * Returns the default operator used between terms in compound queries.
      * 
-     * @return the default {@link Operator} specified with {@link #defaultOperator(Operator)}
-     * or "OR" if none specified.
+     * @return the default {@link Operator} specified with
+     *         {@link #defaultOperator} or "OR" if none specified.
      */
     public Operator getDefaultOperator()
     {

--- a/community/neo4j-community/pom.xml
+++ b/community/neo4j-community/pom.xml
@@ -162,13 +162,32 @@ the relevant Commercial Agreement.
               <goal>javadoc</goal>
             </goals>
             <configuration>
+              <additionnalDependencies>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-classic</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-core</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>1.6.4</version>
+                </additionnalDependency>
+              </additionnalDependencies>
               <outputDirectory>${project.build.directory}/site/apidocs</outputDirectory>
               <sourcepath>${project.build.directory}/javadoc-sources</sourcepath>
               <header>${project.name}</header>
               <doctitle>${project.name} ${project.version} API</doctitle>
               <skip>${javadoc.skip}</skip>
               <windowtitle>${project.name} ${project.version} API</windowtitle>
-               <excludePackageNames>*.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index</excludePackageNames>
+               <excludePackageNames>
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
+               </excludePackageNames>
               <groups>
                 <group>
                   <title>Graph database</title>
@@ -245,10 +264,29 @@ the relevant Commercial Agreement.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <additionnalDependencies>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.6.4</version>
+            </additionnalDependency>
+          </additionnalDependencies>
           <header>${project.name}</header>
           <doctitle>${project.name} ${project.version} API</doctitle>
           <windowtitle>${project.name} ${project.version} API</windowtitle>
-           <excludePackageNames>*.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index</excludePackageNames>
+          <excludePackageNames>
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
+          </excludePackageNames>
           <groups>
             <group>
               <title>Graph database</title>

--- a/community/neo4j/pom.xml
+++ b/community/neo4j/pom.xml
@@ -176,13 +176,32 @@ the relevant Commercial Agreement.
               <goal>javadoc</goal>
             </goals>
             <configuration>
+              <additionnalDependencies>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-classic</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>ch.qos.logback</groupId>
+                  <artifactId>logback-core</artifactId>
+                  <version>1.0.0</version>
+                </additionnalDependency>
+                <additionnalDependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>1.6.4</version>
+                </additionnalDependency>
+              </additionnalDependencies>
               <outputDirectory>${project.build.directory}/site/apidocs</outputDirectory>
               <sourcepath>${project.build.directory}/javadoc-sources</sourcepath>
               <header>${project.name}</header>
               <doctitle>${project.name} ${project.version} API</doctitle>
               <skip>${javadoc.skip}</skip>
               <windowtitle>${project.name} ${project.version} API</windowtitle>
-               <excludePackageNames>*.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index</excludePackageNames>
+               <excludePackageNames>
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
+               </excludePackageNames>
               <groups>
                 <group>
                   <title>Graph database</title>
@@ -259,11 +278,28 @@ the relevant Commercial Agreement.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <additionnalDependencies>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.0.0</version>
+            </additionnalDependency>
+            <additionnalDependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.6.4</version>
+            </additionnalDependency>
+          </additionnalDependencies>
           <header>${project.name}</header>
           <doctitle>${project.name} API</doctitle>
           <skip>${javadoc.skip}</skip>
           <windowtitle>${project.name} API</windowtitle>
-           <excludePackageNames>*.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index</excludePackageNames>
+           <excludePackageNames>*.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.consistency:org.neo4j.consistency.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging</excludePackageNames>
           <groups>
             <group>
               <title>Graph database</title>

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterMonitor.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterMonitor.java
@@ -24,14 +24,13 @@ import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.heartbeat.Heartbeat;
 
 /**
- * Bundles up different ways of listening in on events going on
- * in a cluster.
+ * Bundles up different ways of listening in on events going on in a cluster.
  * 
- * {@link Binding} for notifications about which URI is used
- * for sending events of the network.
- * {@link Heartbeat} for notifications about failed/alive members.
- * {@link #addClusterListener(ClusterListener)}, {@link #removeClusterListener(ClusterListener)
- * for getting notified about cluster membership events.
+ * {@link BindingNotifier} for notifications about which URI is used for sending
+ * events of the network. {@link Heartbeat} for notifications about failed/alive
+ * members. {@link #addClusterListener(ClusterListener)},
+ * {@link #removeClusterListener(ClusterListener)} for getting notified about
+ * cluster membership events.
  * 
  * @author Mattias Persson
  */

--- a/enterprise/neo4j-enterprise/pom.xml
+++ b/enterprise/neo4j-enterprise/pom.xml
@@ -169,7 +169,7 @@
               <doctitle>${project.name} ${project.version} API</doctitle>
               <windowtitle>${project.name} ${project.version} API</windowtitle>
               <excludePackageNames>
-                *.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.consistency:org.neo4j.consistency.*
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
               </excludePackageNames>
               <groups>
                 <group>
@@ -246,7 +246,7 @@
           <doctitle>${project.name} ${project.version} API</doctitle>
           <windowtitle>${project.name} ${project.version} API</windowtitle>
           <excludePackageNames>
-*.impl.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.consistency:org.neo4j.consistency.*
+                *.impl.*:*.internal.*:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha.*:org.neo4j.com:org.neo4j.com.*:org.apache.lucene.index:org.neo4j.cluster.*:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging
           </excludePackageNames>
           <groups>
             <group>


### PR DESCRIPTION
The list of packages to exclude from javadoc looks like this (in this PR):

_.impl._:_.internal._:org.neo4j.ext.udc:org.neo4j.kernel.ha:org.neo4j.kernel.ha._:org.neo4j.com:org.neo4j.com._:org.apache.lucene.index:org.neo4j.cluster._:org.neo4j.consistency:org.neo4j.consistency._:org.neo4j.helpers.progress:org.neo4j.kernel.configuration:org.neo4j.kernel.guard:org.neo4j.kernel.info:org.neo4j.kernel.logging

I'm not sure this is correct, so please verify there's no package in there we actually should have in the public javadocs. Too see what javadocs we currently publish, have a look at http://components.neo4j.org/neo4j-enterprise/snapshot/apidocs/index.html
