### PR TITLE
Adding nth(n, coll) support.

### DIFF
--- a/community/cypher/src/docs/dev/ql/functions/index.asciidoc
+++ b/community/cypher/src/docs/dev/ql/functions/index.asciidoc
@@ -60,6 +60,8 @@ include::filter.asciidoc[]
 
 include::tail.asciidoc[]
 
+include::nth.asciidoc[]
+
 include::range.asciidoc[]
 
 include::reduce.asciidoc[]

--- a/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -27,6 +27,8 @@ abstract class CypherException(message: String, cause: Throwable) extends Runtim
 
 class UniquePathNotUniqueException(message:String) extends CypherException(message)
 
+class CollectionIndexOutOfRange(message:String) extends CypherException(message)
+
 class EntityNotFoundException(message:String, cause:Throwable=null) extends CypherException(message, cause)
 
 class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(message, cause)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/NthFunction.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/NthFunction.scala
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.commands.expressions
+import org.neo4j.cypher.internal.symbols._
+import org.neo4j.cypher.internal.helpers.CollectionSupport
+import org.neo4j.cypher.internal.ExecutionContext
+import org.neo4j.cypher.CollectionIndexOutOfRange
+
+case class NthFunction(n: Expression, collection: Expression)
+  extends NullInNullOutExpression(collection) with CollectionSupport with NumericHelper {
+  def compute(value: Any, m: ExecutionContext) = {
+    val nval = asInt(n(m))
+    val coll = makeTraversable(value)
+    if(nval >= coll.size) throw new CollectionIndexOutOfRange("n out of range for nth")
+    coll.drop(nval).head
+  }
+                    
+  def rewrite(f: (Expression) => Expression) =
+    f(NthFunction(n.rewrite(f), collection.rewrite(f)))
+
+  def children = Seq(n, collection)
+
+  def identifierDependencies(expectedType: CypherType) = AnyType
+
+  def calculateType(symbols: SymbolTable) = collection.evaluateType(AnyCollectionType(), symbols).iteratedType
+
+  def symbolTableDependencies = (collection.symbolTableDependencies ++ n.symbolTableDependencies)
+}

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Expressions.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Expressions.scala
@@ -151,6 +151,7 @@ trait Expressions extends Base with ParserPattern with Predicates with StringLit
     "head" -> func(1, args => HeadFunction(args.head)),
     "last" -> func(1, args => LastFunction(args.head)),
     "tail" -> func(1, args => TailFunction(args.head)),
+    "nth" -> func(2, args => NthFunction(args(0), args(1))),
     "replace" -> func(3, args => ReplaceFunction(args(0), args(1), args(2))),
     "left" -> func(2, args => LeftFunction(args(0), args(1))),
     "right" -> func(2, args => RightFunction(args(0), args(1))),

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -188,6 +188,22 @@ class FunctionsTest extends DocumentingTestBase {
       })
   }
 
+  @Test def nth() {
+    testThis(
+      title = "NTH",
+      syntax = "NTH( n, collection)",
+      arguments = List(
+        "n" -> "This expression should return an integer.",
+        "collection" -> "This expression should return a collection of some kind."),
+      text = "`NTH` returns the nth (zero-based) element in a collection.",
+      queryText = """start a=node(%E%) return a.array, nth(1, a.array)""",
+      returns = "This returns the nth element in a collection.",
+      assertions = (p) => {
+        val toList = p.columnAs[String]("nth(1, a.array)").toList.head
+        assert(toList === "two")
+      })
+  }
+
   @Test def filter() {
     testThis(
       title = "FILTER",

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/commands/NthTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/commands/NthTest.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.commands
+
+import expressions.{NthFunction, Identifier, LengthFunction, Add, Literal}
+import org.neo4j.cypher.internal.symbols.{SymbolTable, StringType, NumberType, AnyCollectionType, IntegerType}
+import org.scalatest.Assertions
+import org.junit.Test
+import org.neo4j.cypher.internal.ExecutionContext
+
+class NthTest extends Assertions {
+  @Test def canReturnSomethingFromAnIterable() {
+    val l = Seq("x", "xxx", "xx")
+    val collection = Identifier("l")
+    val m = ExecutionContext.from("l" -> l)
+
+    val nth = NthFunction(Literal(1), collection)
+
+    assert(nth(m) === "xxx")
+  }
+
+  @Test def returns_null_from_null_collection() {
+    val collection = Literal(null)
+    val m = ExecutionContext.empty
+
+    val nth = NthFunction(Literal(0), collection)
+
+    assert(nth(m) === null)
+  }
+}


### PR DESCRIPTION
Now you can do this:

```
neo4j-sh (0)$ start n=node(0) return nth(1, [1,2,3]); 
+-----------------+
| nth(1, [1,2,3]) |
+-----------------+
| 2               |
+-----------------+
1 row
9 ms
```

Feedback welcome.
