### PR TITLE
Tell the user if they have a snapshot build.

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
@@ -41,6 +41,9 @@ if not "%javaHomeError%" == "" (
   goto:eof
 )
 
+rem Check classpath
+echo "%classpath%" | findstr "SNAPSHOT" > NUL && echo "WARNING! Latest Development Build. Not intended for general-pupose use. May be unstable."
+
 rem Unescape javaPath
 for /f "tokens=* delims=" %%P in (%javaPath%) do (
     set javaPath=%%P

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -178,6 +178,7 @@ startit() {
     printf "Starting $FRIENDLY_NAME..."
 
     buildclasspath
+    checkclasspath
     checkandrepairenv
 
     if [ $UID == 0 ] ; then

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
@@ -360,3 +360,8 @@ checkjvmcompatibility() {
     fi
   fi
 }
+
+checkclasspath() {
+  echo $CLASSPATH | grep -q SNAPSHOT && \
+  echo "\nWARNING! Latest Development Build. Not intended for general-pupose use. May be unstable."
+}


### PR DESCRIPTION
I discussed this with PR and MH while Europe slept.

Snapshot builds are convenient for people to test bugfixes against
but there's an inherent risk that people will use them, which is
very, very bad.  This commit looks for SNAPSHOT versions and
heroically warns the user.

This will also pick up stray snapshot versions at release time.
