### PR TITLE
Transaction manager now forwards original cause of crashes to subsequent...

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -71,6 +71,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     private final Map<RecoveredBranchInfo, Boolean> branches = new HashMap<RecoveredBranchInfo, Boolean>();
     private volatile TxLog txLog = null;
     private boolean tmOk = false;
+    private Throwable tmNotOkCause;
     private boolean blocked = false;
 
     private final KernelPanicEventGenerator kpe;
@@ -82,7 +83,6 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
 
     private final StringLogger log;
 
-//    final TxHook finishHook;
     private XaDataSourceManager xaDataSourceManager;
     private final FileSystemAbstraction fileSystem;
     private TxManager.TxManagerDataSourceRegistrationListener dataSourceRegistrationListener;
@@ -93,7 +93,6 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     public TxManager( File txLogDir,
                       XaDataSourceManager xaDataSourceManager,
                       KernelPanicEventGenerator kpe,
-//                      TxHook finishHook,
                       StringLogger log,
                       FileSystemAbstraction fileSystem,
                       TransactionStateFactory stateFactory
@@ -104,7 +103,6 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         this.fileSystem = fileSystem;
         this.log = log;
         this.kpe = kpe;
-//        this.finishHook = finishHook;
         this.stateFactory = stateFactory;
     }
 
@@ -250,6 +248,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
             return;
         
         tmOk = false;
+        tmNotOkCause = cause;
         log.logMessage( "setting TM not OK", cause );
         kpe.generateEvent( ErrorState.TX_MANAGER_NOT_OK );
     }
@@ -329,8 +328,14 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     {
         if ( !tmOk )
         {
-            throw new SystemException( "TM has encountered some problem, "
+            SystemException ex = new SystemException( "TM has encountered some problem, "
                     + "please perform neccesary action (tx recovery/restart)" );
+            if(tmNotOkCause != null)
+            {
+                ex = Exceptions.withCause( ex, tmNotOkCause );
+            }
+
+            throw ex;
         }
     }
 
@@ -813,26 +818,23 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         try
         {
             // Assuming here that the last datasource to register is the Neo one
-//            if ( !tmOk )
-            {
-                // Do recovery on start - all Resources should be registered by now
-                Iterable<List<TxLog.Record>> knownDanglingRecordList = txLog.getDanglingRecords();
-                if ( knownDanglingRecordList.iterator().hasNext() )
-                    log.info( "Unresolved transactions found, " +
-                            "recovery started ... " + txLogDir );
+            // Do recovery on start - all Resources should be registered by now
+            Iterable<List<TxLog.Record>> knownDanglingRecordList = txLog.getDanglingRecords();
+            if ( knownDanglingRecordList.iterator().hasNext() )
+                log.info( "Unresolved transactions found, " +
+                        "recovery started ... " + txLogDir );
 
-                log.logMessage( "TM non resolved transactions found in " + txLog.getName(), true );
+            log.logMessage( "TM non resolved transactions found in " + txLog.getName(), true );
 
-                // Recover DataSources
-                xaDataSourceManager.recover( knownDanglingRecordList.iterator() );
+            // Recover DataSources
+            xaDataSourceManager.recover( knownDanglingRecordList.iterator() );
 
-                log.logMessage( "Recovery completed, all transactions have been " +
-                        "resolved to a consistent state." );
-                
-                getTxLog().truncate();
-                recovered = true;
-                tmOk = true;
-            }
+            log.logMessage( "Recovery completed, all transactions have been " +
+                    "resolved to a consistent state." );
+
+            getTxLog().truncate();
+            recovered = true;
+            tmOk = true;
         }
         catch ( Throwable t )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+
+import javax.transaction.SystemException;
+
+import org.junit.Test;
+import org.neo4j.kernel.KernelEventHandlers;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+public class TxManagerTest
+{
+
+    @Test
+    public void settingTmNotOkShouldAttachCauseToSubsequentErrors() throws Exception
+    {
+        // Given
+        XaDataSourceManager mockXaManager = mock(XaDataSourceManager.class);
+        TxManager txm = new TxManager( new File("/dev/null"), mockXaManager,
+                                       new KernelPanicEventGenerator( new KernelEventHandlers() ),
+                                       StringLogger.DEV_NULL, new EphemeralFileSystemAbstraction(), null );
+        txm.doRecovery(); // Make the txm move to an ok state
+
+        String msg = "These kinds of throwables, breaking our transaction managers, are why we can't have nice things.";
+
+        // When
+        txm.setTmNotOk( new Throwable( msg ) );
+
+        // Then
+        try {
+            txm.begin();
+            fail("Should have thrown SystemException.");
+        } catch(SystemException topLevelException)
+        {
+            assertThat( "TM should forward a cause.", topLevelException.getCause(), is(Throwable.class) );
+            assertThat( "Cause should be the original cause", topLevelException.getCause().getMessage(), is( msg ) );
+        }
+
+    }
+
+
+
+
+}


### PR DESCRIPTION
... calls, by adding the original error as a cause to the SystemExceptions it throws.

This helps debugging basic crashes, and makes it easier to understand what is going on when the transaction manager shuts down.
