### PR TITLE
Fixed manual build for newer macs

### DIFF
--- a/manual/README.asciidoc
+++ b/manual/README.asciidoc
@@ -25,9 +25,13 @@ Note that this profile can't be used together with the `package` goal.
 
 === With brew on OSX ===
 
+Install libraries
+
   brew install docbook asciidoc w3m fop graphviz libtool
 
-  sudo docbook-register
+Register the docbook xml DTD
+
+  sudo src/build/osx-register-docbook
 
 === With apt-get on Ubuntu ===
 

--- a/manual/src/build/osx-register-docbook
+++ b/manual/src/build/osx-register-docbook
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+ 
+# Make sure Homebrew and DocBook are present
+which -s brew
+docbook="$(brew --prefix docbook)"
+test -d "$docbook"
+ 
+# Make sure the XML catalog is present
+test -d /etc/xml || mkdir /etc/xml
+test -f /etc/xml/catalog || xmlcatalog --noout --create /etc/xml/catalog
+ 
+# Register DocBook in the global XML catalog
+for catalog in "$docbook"/docbook/{xml,xsl}/*/catalog.xml; do
+	xmlcatalog --noout --del "file://$catalog" /etc/xml/catalog
+	xmlcatalog --noout --add "nextCatalog" "" "file://$catalog" /etc/xml/catalog
+done


### PR DESCRIPTION
Now the manual builds on my mac again :)

Added a little shell script to register docbook DTD on os x, updated manual with new instructions.

/cc @nawroth
