### PR TITLE
Ensuring that Nodes cannot be created twice with explicit properties or labels

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
@@ -108,11 +108,11 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService) extends PatternGraphBuil
       case AllRelationships(varName: String)                                    => varName -> RelationshipType()
       case CreateRelationshipStartItem(CreateRelationship(varName, _, _, _, _)) => varName -> RelationshipType()
 
-      case NodeByIndex(varName: String, _, _, _)          => varName -> NodeType()
-      case NodeByIndexQuery(varName: String, _, _)        => varName -> NodeType()
-      case NodeById(varName: String, _)                   => varName -> NodeType()
-      case AllNodes(varName: String)                      => varName -> NodeType()
-      case CreateNodeStartItem(CreateNode(varName, _, _)) => varName -> RelationshipType()
+      case NodeByIndex(varName: String, _, _, _)             => varName -> NodeType()
+      case NodeByIndexQuery(varName: String, _, _)           => varName -> NodeType()
+      case NodeById(varName: String, _)                      => varName -> NodeType()
+      case AllNodes(varName: String)                         => varName -> NodeType()
+      case CreateNodeStartItem(CreateNode(varName, _, _, _)) => varName -> RelationshipType()
     }.toMap
 
     val symbols = new SymbolTable(startMap)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/CreateNode.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/CreateNode.scala
@@ -27,7 +27,7 @@ import collection.Map
 import org.neo4j.cypher.internal.ExecutionContext
 import collection.JavaConverters._
 
-case class CreateNode(key: String, properties: Map[String, Expression], labels: Expression = Literal(Seq.empty))
+case class CreateNode(key: String, properties: Map[String, Expression], labels: Expression, bare: Boolean = true)
   extends UpdateAction
   with GraphElementPropertyFunctions
   with CollectionSupport
@@ -89,7 +89,8 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
 
   override def children = properties.map(_._2).toSeq :+ labels
 
-  override def rewrite(f: (Expression) => Expression): CreateNode = CreateNode(key, properties.rewrite(f), labels.rewrite(f))
+  override def rewrite(f: (Expression) => Expression): CreateNode =
+    CreateNode(key, properties.rewrite(f), labels.rewrite(f), bare)
 
   override def throwIfSymbolsMissing(symbols: SymbolTable) {
     properties throwIfSymbolsMissing symbols

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/CreateRelationship.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/CreateRelationship.scala
@@ -26,10 +26,10 @@ import org.neo4j.graphdb.Node
 import org.neo4j.cypher.internal.symbols.{SymbolTable, RelationshipType}
 import org.neo4j.cypher.internal.ExecutionContext
 
-case class RelationshipEndpoint(node: Expression, props: Map[String, Expression], labels: Expression)
+case class RelationshipEndpoint(node: Expression, props: Map[String, Expression], labels: Expression, bare: Boolean)
   extends GraphElementPropertyFunctions {
   def rewrite(f: (Expression) => Expression): RelationshipEndpoint =
-    RelationshipEndpoint(node.rewrite(f), props.mapValues(_.rewrite(f)), labels.rewrite(f))
+    RelationshipEndpoint(node.rewrite(f), props.mapValues(_.rewrite(f)), labels.rewrite(f), bare)
 
   def throwIfSymbolsMissing(symbols: SymbolTable) {
     props.throwIfSymbolsMissing(symbols)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/NamedExpectation.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/NamedExpectation.scala
@@ -28,13 +28,20 @@ import org.neo4j.cypher.internal.spi.QueryContext
 import org.neo4j.cypher.internal.ExecutionContext
 
 object NamedExpectation {
-  def apply(name: String): NamedExpectation = NamedExpectation(name, Map.empty)
+  def apply(name: String, bare: Boolean): NamedExpectation = NamedExpectation(name, Map.empty, bare)
 
-  def apply(name: String, properties: Map[String, Expression]): NamedExpectation =
-    new NamedExpectation(name, Identifier(name), properties)
+  def apply(name: String, properties: Map[String, Expression], bare: Boolean): NamedExpectation =
+    NamedExpectation(name, properties, Literal(Seq.empty), bare)
+
+  def apply(name: String, e: Expression, properties: Map[String, Expression], bare: Boolean): NamedExpectation =
+    new NamedExpectation(name, e, properties, Literal(Seq.empty), bare)
+
+  def apply(name: String, properties: Map[String, Expression], labels: Expression, bare: Boolean): NamedExpectation =
+    new NamedExpectation(name, Identifier(name), properties, labels, bare)
 }
 
-case class NamedExpectation(name: String, e: Expression, properties: Map[String, Expression])
+case class NamedExpectation(name: String, e: Expression, properties: Map[String, Expression],
+                            labels: Expression, bare: Boolean)
   extends GraphElementPropertyFunctions
   with CollectionSupport
   with TypeSafe {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/CreateUnique.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/CreateUnique.scala
@@ -62,9 +62,9 @@ trait CreateUnique extends Base with ParserPattern {
       ParsedEntity(startName, startExp, startProps, True()),
       ParsedEntity(endName, endExp, endProps, True()), typ, dir, map, True()) if typ.size == 1 =>
         val link = UniqueLink(
-          start = NamedExpectation(startName, startExp, startProps),
-          end = NamedExpectation(endName, endExp, endProps),
-          rel = NamedExpectation(name, props),
+          start = NamedExpectation(startName, startExp, startProps, true),
+          end = NamedExpectation(endName, endExp, endProps, true),
+          rel = NamedExpectation(name, props, true),
           relType = typ.head,
           dir = dir
         )

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/StartClause.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/StartClause.scala
@@ -79,14 +79,14 @@ trait StartClause extends Base with Expressions with CreateUnique {
                        else
                          (b, a)
 
-      Yes(Seq(CreateRelationshipStartItem(CreateRelationship(name, RelationshipEndpoint(from, startProps,Literal(Seq.empty)), RelationshipEndpoint(to, endProps, Literal(Seq.empty)), relType.head, props))))
+      Yes(Seq(CreateRelationshipStartItem(CreateRelationship(name, RelationshipEndpoint(from, startProps, Literal(Seq.empty), true), RelationshipEndpoint(to, endProps, Literal(Seq.empty), true), relType.head, props))))
 
 
     case ParsedEntity(_, Identifier(name), props, True()) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(name, props))))
+      Yes(Seq(CreateNodeStartItem(CreateNode(name, props, Literal(Seq.empty)))))
 
     case ParsedEntity(_, p: ParameterExpression, _, True()) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p)))))
+      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p), Literal(Seq.empty)))))
 
     case _ => No(Seq(""))
   }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/CreateUnique.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/CreateUnique.scala
@@ -62,9 +62,9 @@ trait CreateUnique extends Base with ParserPattern {
       ParsedEntity(startName, startExp, startProps, True()),
       ParsedEntity(endName, endExp, endProps, True()), typ, dir, map, True()) if typ.size == 1 =>
         val link = UniqueLink(
-          start = NamedExpectation(startName, startExp, startProps),
-          end = NamedExpectation(endName, endExp, endProps),
-          rel = NamedExpectation(name, props),
+          start = NamedExpectation(startName, startExp, startProps, true),
+          end = NamedExpectation(endName, endExp, endProps, true),
+          rel = NamedExpectation(name, props, true),
           relType = typ.head,
           dir = dir
         )

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/StartClause.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/StartClause.scala
@@ -79,13 +79,13 @@ trait StartClause extends Base with Expressions with CreateUnique {
                        else
                          (b, a)
 
-      Yes(Seq(CreateRelationshipStartItem(CreateRelationship(name, RelationshipEndpoint(from, startProps, Literal(Seq.empty)), RelationshipEndpoint(to, endProps, Literal(Seq.empty)), relType.head, props))))
+      Yes(Seq(CreateRelationshipStartItem(CreateRelationship(name, RelationshipEndpoint(from, startProps, Literal(Seq.empty), true), RelationshipEndpoint(to, endProps, Literal(Seq.empty), true), relType.head, props))))
 
     case ParsedEntity(_, Identifier(name), props, True()) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(name, props))))
+      Yes(Seq(CreateNodeStartItem(CreateNode(name, props, Literal(Seq.empty)))))
 
     case ParsedEntity(_, p: ParameterExpression, _, True()) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p)))))
+      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p), Literal(Seq.empty)))))
 
     case _ => No(Seq(""))
   }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/AbstractPattern.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/AbstractPattern.scala
@@ -47,7 +47,8 @@ case class ParsedEntity(name: String,
                         expression: Expression,
                         props: Map[String, Expression],
                         predicate: Predicate,
-                        labels: Expression = Literal(Seq.empty)) extends AbstractPattern{
+                        labels: Expression,
+                        bare: Boolean) extends AbstractPattern {
   def makeOutgoing = this
 }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/CreateUnique.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/CreateUnique.scala
@@ -58,13 +58,14 @@ trait CreateUnique extends Base with ParserPattern {
           })
         }
 
+      // TODO labels -> NamedExpectation
       case ParsedRelation(name, props,
-      ParsedEntity(startName, startExp, startProps, True(), _),
-      ParsedEntity(endName, endExp, endProps, True(), _), typ, dir, map, True()) if typ.size == 1 =>
+      ParsedEntity(startName, startExp, startProps, True(), startLabels, startBare),
+      ParsedEntity(endName, endExp, endProps, True(), endLabels, endBare), typ, dir, map, True()) if typ.size == 1 =>
         val link = UniqueLink(
-          start = NamedExpectation(startName, startExp, startProps),
-          end = NamedExpectation(endName, endExp, endProps),
-          rel = NamedExpectation(name, props),
+          start = NamedExpectation(startName, startExp, startProps, startLabels, startBare),
+          end = NamedExpectation(endName, endExp, endProps, endLabels, endBare),
+          rel = NamedExpectation(name, props, true),
           relType = typ.head,
           dir = dir
         )

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/LabelParsing.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/LabelParsing.scala
@@ -25,10 +25,7 @@ import org.neo4j.cypher.internal.commands.values.LabelValue
 trait LabelParsing {
   self: Base =>
 
-  def optLabelSeq = opt(labelSeq) ^^ {
-    case Some(labels) => labels
-    case _            => Literal(Seq.empty)
-  }
+  def optLabelSeq = opt(labelSeq)
 
   def labelSeq = longLabelSeq | shortLabelSeq
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/StartAndCreateClause.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/StartAndCreateClause.scala
@@ -76,7 +76,7 @@ trait StartAndCreateClause extends Base with Expressions with CreateUnique {
     case ParsedRelation(name, props, a, b, relType, dir, map, True()) if relType.size == 1 =>
 
       def translate(in: ParsedEntity) =
-        RelationshipEndpoint(in.expression, in.props, in.labels)
+        RelationshipEndpoint(in.expression, in.props, in.labels, in.bare)
 
       val (from, to) = if (dir != Direction.INCOMING)
         (a, b)
@@ -85,11 +85,11 @@ trait StartAndCreateClause extends Base with Expressions with CreateUnique {
 
       Yes(Seq(CreateRelationshipStartItem(CreateRelationship(name, translate(from), translate(to), relType.head, props))))
 
-    case ParsedEntity(_, Identifier(name), props, True(), labels) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(name, props, labels))))
+    case ParsedEntity(_, Identifier(name), props, True(), labels, bare) =>
+      Yes(Seq(CreateNodeStartItem(CreateNode(name, props, labels, bare))))
 
-    case ParsedEntity(_, p: ParameterExpression, _, True(), labels) =>
-      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p), labels))))
+    case ParsedEntity(_, p: ParameterExpression, _, True(), labels, bare) =>
+      Yes(Seq(CreateNodeStartItem(CreateNode(namer.name(None), Map[String, Expression]("*" -> p), labels, bare))))
 
     case _ => No(Seq(""))
   }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Updates.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Updates.scala
@@ -41,8 +41,9 @@ trait Updates extends Base with Expressions with StartAndCreateClause {
   override def longLabelSeq: Parser[Expression]  = ignoreCase("LABEL") ~> (labelLitSeq | expression)
 
   private def add: Parser[UpdateAction] = ignoreCase("add") ~> identity ~ optLabelSeq  ^^ {
-      case entity ~ labelSetExpr =>
-        LabelAction(Identifier(entity), LabelAdd, labelSetExpr)
+      case entity ~ optLabels =>
+        val labelsVal = optLabels.getOrElse(Literal(Seq.empty))
+        LabelAction(Identifier(entity), LabelAdd, labelsVal)
     }
 
   private def delete: Parser[Seq[UpdateAction]] = ignoreCase("delete") ~> commaList(expression) ^^ {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/ExecuteUpdateCommandsPipe.scala
@@ -63,27 +63,38 @@ class ExecuteUpdateCommandsPipe(source: Pipe, db: GraphDatabaseService, commands
   }
 
 
-  private def extractEntitiesWithProperties(action: UpdateAction): Seq[NamedExpectation] = action match {
-    case CreateNode(key, props, _)                   => Seq(NamedExpectation(key, props))
-    case CreateRelationship(key, from, to, _, props) => Seq(NamedExpectation(key, props)) ++ extractIfEntity(from) ++ extractIfEntity(to)
-    case CreateUniqueAction(links@_*)                => links.flatMap(l => Seq(l.start, l.end, l.rel))
-    case _                                           => Seq()
+  private def extractEntities(action: UpdateAction): Seq[NamedExpectation] = action match
+  {
+    case CreateNode(key, props, labels, bare) =>
+      Seq(NamedExpectation(key, props, labels, bare))
+    case CreateRelationship(key, from, to, _, props) =>
+      Seq(NamedExpectation(key, props, true)) ++ extractIfEntity(from) ++ extractIfEntity(to)
+    case CreateUniqueAction(links@_*) =>
+      links.flatMap(l => Seq(l.start, l.end, l.rel))
+    case _ =>
+      Seq()
   }
 
 
   def extractIfEntity(from: RelationshipEndpoint): Option[NamedExpectation] = {
     from match {
-      case RelationshipEndpoint(Identifier(key), props, _) => Some(NamedExpectation(key, props))
-      case _                                               => None
+      case RelationshipEndpoint(Identifier(key), props, labels, bare) => Some(NamedExpectation(key, props, labels, bare))
+      case _                                                          => None
     }
   }
 
   private def assertNothingIsCreatedWhenItShouldNot() {
-    val entitiesAndProps: Seq[NamedExpectation] = commands.flatMap(cmd => extractEntitiesWithProperties(cmd))
-    val entitiesWithProps = entitiesAndProps.filter(_.properties.nonEmpty)
+    val entities: Seq[NamedExpectation] = commands.flatMap(cmd => extractEntities(cmd))
 
+    val entitiesWithProps = entities.filter(_.properties.nonEmpty)
     entitiesWithProps.foreach(l => if (source.symbols.keys.contains(l.name))
       throw new SyntaxException("Can't create `%s` with properties here. It already exists in this context".format(l.name))
+    )
+
+    // lush is the opposite of bare
+    val lushEntities = entities.filter(! _.bare)
+    lushEntities.foreach(l => if (source.symbols.keys.contains(l.name))
+      throw new SyntaxException("Can't create `%s` with properties or labels here. It already exists in this context".format(l.name))
     )
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -1248,7 +1248,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
   @Test def read_first_and_update_next() {
     val secondQ = Query.
-      start(CreateNodeStartItem(CreateNode("b", Map("age" -> Multiply(Property(Identifier("a"), "age"), Literal(2.0)))))).
+      start(CreateNodeStartItem(CreateNode("b", Map("age" -> Multiply(Property(Identifier("a"), "age"), Literal(2.0))), Literal(Seq.empty)))).
       returns(ReturnItem(Identifier("b"), "b"))
 
     val q = Query.
@@ -1288,7 +1288,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node() {
     testAll("create a",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map()))).
+        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq.empty)))).
         returns()
     )
   }
@@ -1296,7 +1296,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_with_a_property() {
     testAll("create (a {name : 'Andres'})",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres"))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq.empty)))).
         returns()
     )
   }
@@ -1304,7 +1304,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_with_a_property2() {
     testAll("create a={name : 'Andres'}",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres"))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq.empty)))).
         returns()
     )
   }
@@ -1312,7 +1312,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_using_the_VALUES_keyword() {
     testFrom_2_0("create a VALUES {name : 'Andres'}",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres"))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq.empty), false))).
         returns()
     )
   }
@@ -1320,7 +1320,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_using_LABEL_keyword_and_EQ() {
     testFrom_2_0("create a:fii = {name : 'Andres'}",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii"))), false))).
         returns()
     )
   }
@@ -1328,7 +1328,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_using_LABEL_and_VALUES_keyword() {
     testFrom_2_0("create a :fii VALUES {name : 'Andres'}",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii"))), false))).
         returns()
     )
   }
@@ -1336,14 +1336,14 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_using_LABEL_and_VALUES_keyword2() {
     testFrom_2_0("create a:fii VALUES {name : 'Andres'}",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq(LabelName("fii"))), false))).
         returns()
     )
   }
   @Test def create_node_with_a_property_and_return_it() {
     testAll("create (a {name : 'Andres'}) return a",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres"))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq.empty)))).
         returns (ReturnItem(Identifier("a"), "a"))
     )
   }
@@ -1351,8 +1351,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_two_nodes_with_a_property_and_return_it() {
     testAll("create (a {name : 'Andres'}), b return a,b",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")))),
-        CreateNodeStartItem(CreateNode("b", Map()))).
+        start(CreateNodeStartItem(CreateNode("a", Map("name" -> Literal("Andres")), Literal(Seq.empty))),
+        CreateNodeStartItem(CreateNode("b", Map(), Literal(Seq.empty)))).
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"))
     )
   }
@@ -1360,7 +1360,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_from_map_expression() {
     testAll("create (a {param})",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map("*" -> ParameterExpression("param"))))).
+        start(CreateNodeStartItem(CreateNode("a", Map("*" -> ParameterExpression("param")), Literal(Seq.empty)))).
         returns()
     )
   }
@@ -1368,7 +1368,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_with_a_label() {
     testFrom_2_0("create a label :FOO",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO"))), false))).
         returns()
     )
   }
@@ -1376,7 +1376,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_with_multiple_labels() {
     testFrom_2_0("create a label :FOO:BAR",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO"), LabelName("BAR")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO"), LabelName("BAR"))), false))).
         returns()
     )
   }
@@ -1384,7 +1384,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_node_with_multiple_labels_with_spaces() {
     testFrom_2_0("create a label :FOO :BAR",
       Query.
-        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO"), LabelName("BAR")))))).
+        start(CreateNodeStartItem(CreateNode("a", Map(), Literal(Seq(LabelName("FOO"), LabelName("BAR"))), false))).
         returns()
     )
   }
@@ -1393,8 +1393,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
     testFrom_2_0("CREATE (n:Person:Husband)-[:FOO]->x:Person",
       Query.
         start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED1",
-        RelationshipEndpoint(Identifier("n"),Map(), Literal(Seq(LabelName("Person"), LabelName("Husband")))),
-        RelationshipEndpoint(Identifier("x"),Map(), Literal(Seq(LabelName("Person")))), "FOO", Map()))).
+        RelationshipEndpoint(Identifier("n"),Map(), Literal(Seq(LabelName("Person"), LabelName("Husband"))), false),
+        RelationshipEndpoint(Identifier("x"),Map(), Literal(Seq(LabelName("Person"))), false), "FOO", Map()))).
         returns()
     )
   }
@@ -1402,8 +1402,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def start_with_two_nodes_and_create_relationship() {
     val secondQ = Query.
       start(CreateRelationshipStartItem(CreateRelationship("r",
-      RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)),
-      RelationshipEndpoint(Identifier("b"),Map(), Literal(Seq.empty)), "REL", Map()))).
+      RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+      RelationshipEndpoint(Identifier("b"),Map(), Literal(Seq.empty), true), "REL", Map()))).
       returns()
 
     val q = Query.
@@ -1417,7 +1417,9 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
   @Test def start_with_two_nodes_and_create_relationship_using_alternative_with_syntax() {
     val secondQ = Query.
-      start(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("a"),Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"),Map(), Literal(Seq.empty)), "REL", Map()))).
+      start(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("a"),Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("b"),Map(), Literal(Seq.empty), true), "REL", Map()))).
       returns()
 
     val q = Query.
@@ -1436,8 +1438,8 @@ create a-[r:REL]->b
   @Test def create_relationship_with_properties() {
     val secondQ = Query.
       start(CreateRelationshipStartItem(CreateRelationship("r",
-      RelationshipEndpoint(Identifier("a"),Map(),Literal(Seq.empty)),
-      RelationshipEndpoint(Identifier("b"),Map(),Literal(Seq.empty)), "REL", Map("why" -> Literal(42), "foo" -> Literal("bar"))))).
+      RelationshipEndpoint(Identifier("a"),Map(),Literal(Seq.empty), true),
+      RelationshipEndpoint(Identifier("b"),Map(),Literal(Seq.empty), true), "REL", Map("why" -> Literal(42), "foo" -> Literal("bar"))))).
       returns()
 
     val q = Query.
@@ -1452,21 +1454,28 @@ create a-[r:REL]->b
   @Test def create_relationship_without_identifier() {
     testAll("create ({a})-[:REL]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3", RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), "REL", Map()))).
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3",
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true),
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true), "REL", Map()))).
         returns())
   }
 
   @Test def create_relationship_with_properties_from_map() {
     testAll("create ({a})-[:REL {param}]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3", RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), "REL", Map("*" -> ParameterExpression("param"))))).
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3",
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true),
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true),
+        "REL", Map("*" -> ParameterExpression("param"))))).
         returns())
   }
 
   @Test def create_relationship_without_identifier2() {
     testAll("create ({a})-[:REL]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3", RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty)), "REL", Map()))).
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED3",
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true),
+          RelationshipEndpoint(ParameterExpression("a"),Map(),Literal(Seq.empty), true), "REL", Map()))).
         returns())
   }
 
@@ -1526,7 +1535,7 @@ create a-[r:REL]->b
 
   @Test def simple_read_first_and_update_next() {
     val secondQ = Query.
-      start(CreateNodeStartItem(CreateNode("b", Map("age" -> Multiply(Property(Identifier("a"), "age"), Literal(2.0)))))).
+      start(CreateNodeStartItem(CreateNode("b", Map("age" -> Multiply(Property(Identifier("a"), "age"), Literal(2.0))), Literal(Seq.empty)))).
       returns(ReturnItem(Identifier("b"), "b"))
 
     val q = Query.
@@ -1540,7 +1549,9 @@ create a-[r:REL]->b
 
   @Test def simple_start_with_two_nodes_and_create_relationship() {
     val secondQ = Query.
-      start(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), "REL", Map()))).
+      start(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+      RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true), "REL", Map()))).
       returns()
 
     val q = Query.
@@ -1554,7 +1565,9 @@ create a-[r:REL]->b
 
   @Test def simple_create_relationship_with_properties() {
     val secondQ = Query.
-      start(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), "REL",
+      start(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true), "REL",
       Map("why" -> Literal(42), "foo" -> Literal("bar"))
     ))).
       returns()
@@ -1682,7 +1695,10 @@ create a-[r:REL]->b
   @Test def relate_with_initial_values_for_node() {
     val secondQ = Query.
       unique(
-      UniqueLink(NamedExpectation("a"), NamedExpectation("b", Map[String, Expression]("name" -> Literal("Andres"))), NamedExpectation("  UNNAMED1"), "X", Direction.OUTGOING)).
+      UniqueLink(
+        NamedExpectation("a", true),
+        NamedExpectation("b", Map[String, Expression]("name" -> Literal("Andres")), true),
+        NamedExpectation("  UNNAMED1", true), "X", Direction.OUTGOING)).
       returns()
 
     val q = Query.
@@ -1695,7 +1711,10 @@ create a-[r:REL]->b
   @Test def relate_with_initial_values_for_rel() {
     val secondQ = Query.
       unique(
-      UniqueLink(NamedExpectation("a"), NamedExpectation("b"), NamedExpectation("  UNNAMED1", Map[String, Expression]("name" -> Literal("Andres"))), "X", Direction.OUTGOING)).
+      UniqueLink(
+        NamedExpectation("a", true),
+        NamedExpectation("b", true),
+        NamedExpectation("  UNNAMED1", Map[String, Expression]("name" -> Literal("Andres")), true), "X", Direction.OUTGOING)).
       returns()
 
     val q = Query.
@@ -1708,13 +1727,13 @@ create a-[r:REL]->b
   @Test def foreach_with_literal_collection() {
 
     val q2 = Query.updates(
-      ForeachAction(Collection(Literal(1.0), Literal(2.0), Literal(3.0)), "x", Seq(CreateNode("a", Map("number" -> Identifier("x")))))
+      ForeachAction(Collection(Literal(1.0), Literal(2.0), Literal(3.0)), "x", Seq(CreateNode("a", Map("number" -> Identifier("x")), Literal(Seq.empty))))
     ).returns()
 
     testAll(
       "create root foreach(x in [1,2,3] : create (a {number:x}))",
       Query.
-        start(CreateNodeStartItem(CreateNode("root", Map.empty))).
+        start(CreateNodeStartItem(CreateNode("root", Map.empty, Literal(Seq.empty)))).
         tail(q2).
         returns(AllIdentifiers())
     )
@@ -1725,8 +1744,8 @@ create a-[r:REL]->b
       "create (tag1 {name:'tag2'}), (tag2 {name:'tag1'})",
       Query.
         start(
-        CreateNodeStartItem(CreateNode("tag1", Map("name"->Literal("tag2")))),
-        CreateNodeStartItem(CreateNode("tag2", Map("name"->Literal("tag1"))))
+        CreateNodeStartItem(CreateNode("tag1", Map("name"->Literal("tag2")), Literal(Seq.empty))),
+        CreateNodeStartItem(CreateNode("tag2", Map("name"->Literal("tag1")), Literal(Seq.empty)))
       ).returns()
     )
   }
@@ -1778,8 +1797,12 @@ create a-[r:REL]->b
   @Test def full_path_in_create() {
     val secondQ = Query.
       start(
-      CreateRelationshipStartItem(CreateRelationship("r1", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), "KNOWS", Map())),
-      CreateRelationshipStartItem(CreateRelationship("r2", RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), "LOVES", Map()))).
+      CreateRelationshipStartItem(CreateRelationship("r1",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true), "KNOWS", Map())),
+      CreateRelationshipStartItem(CreateRelationship("r2",
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true), "LOVES", Map()))).
       returns()
     val q = Query.
       start(NodeById("a", 1), NodeById("b", 2)).
@@ -1795,7 +1818,9 @@ create a-[r:REL]->b
     testAll(
       "create p = a-[r:KNOWS]->() return p",
       Query.
-      start(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), "KNOWS", Map()))).
+      start(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true), "KNOWS", Map()))).
       namedPaths(NamedPath("p", RelatedTo("a", "  UNNAMED1", "r", "KNOWS", Direction.OUTGOING, optional = false, predicate = True()))).
       returns(ReturnItem(Identifier("p"), "p")))
   }
@@ -1804,7 +1829,9 @@ create a-[r:REL]->b
     testAll(
       "create (a {name:'A'})-[:KNOWS]-(b {name:'B'})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED1", RelationshipEndpoint(Identifier("a"), Map("name" -> Literal("A")), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"), Map("name" -> Literal("B")), Literal(Seq.empty)), "KNOWS", Map()))).
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED1",
+          RelationshipEndpoint(Identifier("a"), Map("name" -> Literal("A")), Literal(Seq.empty), true),
+          RelationshipEndpoint(Identifier("b"), Map("name" -> Literal("B")), Literal(Seq.empty), true), "KNOWS", Map()))).
         returns())
   }
 
@@ -1830,7 +1857,9 @@ foreach(x in [1,2,3] :
   foreach( i in p :
     set i.touched = true))""",
       Query.
-      start(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), "KNOWS", Map()))).
+      start(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true), "KNOWS", Map()))).
       namedPaths(NamedPath("p", RelatedTo("a", "  UNNAMED1", "r", "KNOWS", Direction.OUTGOING, optional = false, predicate = True()))).
       returns(ReturnItem(Identifier("p"), "p")))
   }
@@ -1846,9 +1875,9 @@ foreach(x in [1,2,3] :
   }
 
   @Test def create_unique_should_support_parameter_maps() {
-    val start = NamedExpectation("n")
-    val rel = NamedExpectation("  UNNAMED2")
-    val end = NamedExpectation("  UNNAMED1", ParameterExpression("param"), Map.empty)
+    val start = NamedExpectation("n", true)
+    val rel = NamedExpectation("  UNNAMED2", true)
+    val end = new NamedExpectation("  UNNAMED1", ParameterExpression("param"), Map.empty, Literal(Seq.empty), true)
 
     val secondQ = Query.
                   unique(UniqueLink(start, end, rel, "foo", Direction.OUTGOING)).

--- a/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
@@ -24,7 +24,6 @@ import org.scalatest.Assertions
 import org.neo4j.test.ImpermanentGraphDatabase
 import org.neo4j.graphdb.Node
 
-@Ignore
 class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker with Assertions {
 
   @Test def `Adding single literal label`() {
@@ -40,6 +39,7 @@ class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker 
     assertThat("create n = {} add n :FOO:BAR", List("FOO", "BAR"))
   }
 
+  @Ignore
   @Test def `Adding labels using an expression`() {
     createLabeledNode("FOO", "BAR")
     assertThat("start x=node(1) create n = {} add n label labels(x)", List("FOO", "BAR"))
@@ -47,17 +47,25 @@ class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker 
   }
 
   @Test def `Creating nodes with literal labels`() {
-    assertThat("CREATE node LABEL [:BAR, :FOO] VALUES {name='Jacob'}", List("BAR", "FOO"))
-    assertThat("CREATE node :FOO:BAR {name='Stefan'}", List("FOO", "BAR"))
-    assertThat("CREATE node:FOO:BAR VALUES {name='Mattias'}", List("FOO", "BAR"))
+    assertThat("CREATE node LABEL [:BAR, :FOO] VALUES {name: 'Jacob'}", List("BAR", "FOO"))
+    assertThat("CREATE node :FOO:BAR {name: 'Stefan'}", List("FOO", "BAR"))
+    assertThat("CREATE node:FOO:BAR VALUES {name: 'Mattias'}", List("FOO", "BAR"))
     assertThat("CREATE (n:Person)-[:OWNS]->(x:Dog)", List("Person"))
-    assertDoesNotWork("CREATE n:FOO CREATE (n:Person)-[:OWNS]->(x:Dog)")
   }
 
+  @Test def `Recreating and labelling the same node twice is forbidden`() {
+    assertDoesNotWork("CREATE (n: FOO)-[:test]->b, (n: BAR)-[:test2]->c")
+    assertDoesNotWork("CREATE (n LABEL :Bar)-[:OWNS]->(n LABEL :Car)")
+    assertDoesNotWork("CREATE n :Foo CREATE (n :Bar)-[:OWNS]->(x:Dog)")
+    assertDoesNotWork("CREATE n {} CREATE (n :Bar)-[:OWNS]->(x:Dog)")
+    assertDoesNotWork("CREATE n :Foo CREATE (n {})-[:OWNS]->(x:Dog)")
+  }
+
+  @Ignore
   @Test def `Creating nodes with labels from expressions`() {
     assertThat("START n=node(0) WITH [:FOO,:BAR] as lbls CREATE node LABEL lbls", List("FOO", "BAR"))
     assertThat("CREATE (n LABEL <expr> VALUES <expr>)-[:FOO]->x:Person", List("FOO", "BAR"))
-    assertThat("CREATE node LABEL [:name, strlabel(“comic')] = {name=’susi’}", List("FOO", "BAR"))
+    assertThat("CREATE node LABEL [:name, strlabel(“comic')] = {name: ’susi’}", List("FOO", "BAR"))
   }
 
   @Test def `Add labels to nodes in a foreach`() {

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/CreateNodesAndRelationshipsBuilderTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/CreateNodesAndRelationshipsBuilderTest.scala
@@ -41,7 +41,7 @@ class CreateNodesAndRelationshipsBuilderTest extends BuilderTest {
   @Test
   def does_offer_to_solve_queries_without_start_items() {
     val q = PartiallySolvedQuery().
-      copy(start = Seq(Unsolved(CreateNodeStartItem(CreateNode("r", Map())))))
+      copy(start = Seq(Unsolved(CreateNodeStartItem(CreateNode("r", Map(), Literal(Seq.empty))))))
 
     assertTrue("Should be able to build on this", builder.canWorkWith(plan(q)))
   }
@@ -49,8 +49,12 @@ class CreateNodesAndRelationshipsBuilderTest extends BuilderTest {
   @Test
   def full_path() {
     val q = PartiallySolvedQuery().copy(start = Seq(
-      Unsolved(CreateRelationshipStartItem(CreateRelationship("r1", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), "KNOWS", Map()))),
-      Unsolved(CreateRelationshipStartItem(CreateRelationship("r2", RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty)), "LOVES", Map())))))
+      Unsolved(CreateRelationshipStartItem(CreateRelationship("r1",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true), "KNOWS", Map()))),
+      Unsolved(CreateRelationshipStartItem(CreateRelationship("r2",
+        RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("  UNNAMED1"), Map(), Literal(Seq.empty), true), "LOVES", Map())))))
 
 
     val startPipe = createPipe(Seq("a", "b"))
@@ -61,7 +65,9 @@ class CreateNodesAndRelationshipsBuilderTest extends BuilderTest {
   @Test
   def single_relationship_missing_nodes() {
     val q = PartiallySolvedQuery().copy(start = Seq(
-      Unsolved(CreateRelationshipStartItem(CreateRelationship("r", RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), "LOVES", Map())))))
+      Unsolved(CreateRelationshipStartItem(CreateRelationship("r",
+        RelationshipEndpoint(Identifier("a"), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true), "LOVES", Map())))))
 
     assertTrue("Should be able to build on this", builder.canWorkWith(plan(q)))
   }
@@ -69,7 +75,9 @@ class CreateNodesAndRelationshipsBuilderTest extends BuilderTest {
   @Test
   def single_relationship_missing_nodes_with_expression() {
     val q = PartiallySolvedQuery().copy(updates = Seq(
-      Unsolved(CreateRelationship("r", RelationshipEndpoint(HeadFunction(Identifier("p")), Map(), Literal(Seq.empty)), RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty)), "LOVES", Map()))))
+      Unsolved(CreateRelationship("r",
+        RelationshipEndpoint(HeadFunction(Identifier("p")), Map(), Literal(Seq.empty), true),
+        RelationshipEndpoint(Identifier("b"), Map(), Literal(Seq.empty), true), "LOVES", Map()))))
 
     assertFalse("Should not be able to build on this", builder.canWorkWith(plan(q)))
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/mutation/CreateNodeActionTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/mutation/CreateNodeActionTest.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.ExecutionContext
 class CreateNodeActionTest extends ExecutionEngineHelper with Assertions {
 
   @Test def mixed_types_are_not_ok() {
-    val action = CreateNode("id", Map("*" -> Literal(Map("name" -> "Andres", "age" -> 37))))
+    val action = CreateNode("id", Map("*" -> Literal(Map("name" -> "Andres", "age" -> 37))), Literal(Seq.empty))
 
     val tx = graph.beginTx()
     action.exec(ExecutionContext.empty, new QueryState(graph, new TransactionBoundQueryContext(graph), Map.empty))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/MutationTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/MutationTest.scala
@@ -44,7 +44,7 @@ class MutationTest extends ExecutionEngineHelper with Assertions {
   @Test
   def create_node() {
     val start = new NullPipe
-    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")))))
+    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")), Literal(Seq.empty))))
 
     val queryState = createQueryState
     createNode.createResults(queryState).toList
@@ -59,7 +59,7 @@ class MutationTest extends ExecutionEngineHelper with Assertions {
   def join_existing_transaction_and_rollback() {
     val tx = graph.beginTx()
     val start = new NullPipe
-    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")))))
+    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")), Literal(Seq.empty))))
 
     createNode.createResults(createQueryState).toList
 
@@ -73,7 +73,7 @@ class MutationTest extends ExecutionEngineHelper with Assertions {
   def join_existing_transaction_and_commit() {
     val tx = graph.beginTx()
     val start = new NullPipe
-    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")))))
+    val createNode = new ExecuteUpdateCommandsPipe(start, graph, Seq(CreateNode("n", Map("name" -> Literal("Andres")), Literal(Seq.empty))))
 
     createNode.createResults(createQueryState).toList
 
@@ -91,7 +91,9 @@ class MutationTest extends ExecutionEngineHelper with Assertions {
     val a = createNode()
     val b = createNode()
 
-    val createRel = CreateRelationship("r", RelationshipEndpoint(getNode("a", a), Map(), Literal(Seq.empty)), RelationshipEndpoint(getNode("b", b), Map(), Literal(Seq.empty)), "REL", Map("I" -> Literal("was here")))
+    val createRel = CreateRelationship("r",
+      RelationshipEndpoint(getNode("a", a), Map(), Literal(Seq.empty), true),
+      RelationshipEndpoint(getNode("b", b), Map(), Literal(Seq.empty), true), "REL", Map("I" -> Literal("was here")))
 
     val startPipe = new NullPipe
     val createNodePipe = new ExecuteUpdateCommandsPipe(startPipe, graph, Seq(createRel))


### PR DESCRIPTION
Adds bare flag and labels to CreateNode, RelationshipEndpoint, and NamedExpectation

bare is true by default everywhere except in the 2.0 parser

Works for now but the handling around NamedExpectation needs more cleanup in general
