### PR TITLE
Preparing to move gremlin plugin to it's own documentation

### DIFF
--- a/community/cypher/src/docs/dev/introduction.asciidoc
+++ b/community/cypher/src/docs/dev/introduction.asciidoc
@@ -14,7 +14,7 @@ borrows expression approaches from http://en.wikipedia.org/wiki/SPARQL[SPARQL].
 
 Being a declarative language, Cypher focuses on the clarity of expressing _what_ to retrieve from a graph, not _how_
 to do it, in contrast to imperative languages like Java, and scripting languages like
-http://gremlin.tinkerpop.com[Gremlin] (supported via the <<gremlin-plugin>>) and
+http://gremlin.tinkerpop.com[Gremlin] and
 http://neo4j.rubyforge.org/[the JRuby Neo4j bindings]. This makes the concern of how to optimize queries an
 implementation detail not exposed to the user.
 

--- a/community/embedded-examples/src/docs/dev/traversal-framework.asciidoc
+++ b/community/embedded-examples/src/docs/dev/traversal-framework.asciidoc
@@ -6,7 +6,7 @@ The Traversal Framework
 The http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/package-summary.html[Neo4j Traversal API] is a callback based, lazily executed way of specifying desired movements through a graph in Java.
 Some traversal examples are collected under <<tutorials-java-embedded-traversal>>. 
 
-Other options to traverse or query graphs in Neo4j are <<cypher-query-lang,Cypher>> and <<gremlin-plugin,Gremlin>>.
+You can also use <<cypher-query-lang, The Cypher Query Language>> as a powerful declarative way to query the graph.
 
 [[tutorial-traversal-concepts]]
 == Main concepts ==

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -186,13 +186,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.neo4j.server.plugin</groupId>
-      <artifactId>neo4j-gremlin-plugin</artifactId>
-      <version>${neo4j.version}</version>
-      <classifier>docs</classifier>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.neo4j.drivers</groupId>
       <artifactId>neo4j-python-embedded</artifactId>
       <version>${neo4j.version}</version>

--- a/manual/src/main/dot/artifacts.dot
+++ b/manual/src/main/dot/artifacts.dot
@@ -60,13 +60,6 @@ subgraph cluster_enterprise {
  "server-enterprise" -> "shell" 
 }
 
-subgraph cluster_serverplugins {
- label="Server plugins"
- "gremlin-plugin" -> "server-api"
- "gremlin-plugin" -> "server"
- "gremlin-plugin" -> "neo4j"
-}
-
 subgraph cluster_langs {
  label="Language bindings"
  "neo4js"
@@ -93,7 +86,6 @@ subgraph cluster_packaging {
  "standalone" -> "server-advanced"
  "standalone" -> "neo4j-enterprise"
  "standalone" -> "server-enterprise"
- "standalone" -> "gremlin-plugin"
  "standalone" -> "windows-wrapper"
  "standalone" -> "manual"
  "neo4j-enterprise-windows" -> "standalone" [arrowhead="none"]

--- a/manual/src/main/resources/community/embedded-drivers.asciidoc
+++ b/manual/src/main/resources/community/embedded-drivers.asciidoc
@@ -7,7 +7,7 @@
 | Neo4j.rb | JRuby | https://github.com/andreasronge/neo4j
 | Neo4django | Python, Django | https://github.com/scholrly/neo4django
 | Neo4js | JavaScript | https://github.com/neo4j/neo4js
-| Gremlin | Java, Groovy | <<gremlin-plugin>>, https://github.com/tinkerpop/gremlin/wiki
+| Gremlin | Java, Groovy | https://github.com/tinkerpop/gremlin/wiki
 | Neo4j-Scala | Scala | https://github.com/FaKod/neo4j-scala
 | Borneo | Clojure | https://github.com/wagjo/borneo
 |===============================================================================

--- a/manual/src/main/resources/introduction/the-neo4j-graphdb.asciidoc
+++ b/manual/src/main/resources/introduction/the-neo4j-graphdb.asciidoc
@@ -252,6 +252,6 @@ At a basic level there's a choice between traversing breadth- or depth-first.
 For an in-depth introduction to the traversal framework, see <<tutorial-traversal>>.
 For Java code examples see <<tutorials-java-embedded-traversal>>.
 
-Other options to traverse or query graphs in Neo4j are <<cypher-query-lang, Cypher>> and <<gremlin-plugin, Gremlin>>.
+You can also use <<cypher-query-lang, The Cypher Query Language>> as a powerful declarative way to query the graph.
 
 

--- a/manual/src/main/resources/reference/import/import.asciidoc
+++ b/manual/src/main/resources/reference/import/import.asciidoc
@@ -4,7 +4,7 @@ Data Import
 
 For high-performance data import, the batch insert facilities described in this chapter are recommended.
 
-Other ways to import data into Neo4j include using Gremlin graph import (see <<rest-api-load-a-sample-graph>>) or using the Geoff notation (see http://geoff.nigelsmall.net/).
+Other ways to import data into Neo4j include using Gremlin graph import or using the Geoff notation (see http://geoff.nigelsmall.net/).
 
 
 :leveloffset: 2

--- a/manual/src/main/resources/reference/index.asciidoc
+++ b/manual/src/main/resources/reference/index.asciidoc
@@ -39,10 +39,6 @@ include::{importdir}/neo4j-server-docs-jar/dev/index.asciidoc[]
 
 include::{importdir}/neo4j-server-docs-jar/dev/rest-api/index.asciidoc[]
 
-:leveloffset: 2
-
-include::{importdir}/neo4j-gremlin-plugin-docs-jar/dev/rest-api/index.asciidoc[]
-
 :leveloffset: 1
 
 include::{importdir}/neo4j-python-embedded-docs-jar/dev/index.asciidoc[]

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -92,12 +92,6 @@ terms of the relevant Commercial Agreement.
           <type>pom</type>
         </dependency>
         <dependency>
-          <groupId>org.neo4j.server.plugin</groupId>
-          <artifactId>neo4j-gremlin-plugin</artifactId>
-          <version>${project.version}</version>
-          <type>pom</type>
-        </dependency>
-        <dependency>
           <groupId>org.neo4j.doc</groupId>
           <artifactId>neo4j-manual</artifactId>
           <version>${project.version}</version>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -319,11 +319,6 @@ terms of the relevant Commercial Agreement.
       <classifier>upgrade</classifier>
       <type>zip</type>
     </dependency>
-    <dependency>
-      <groupId>org.neo4j.server.plugin</groupId>
-      <artifactId>neo4j-gremlin-plugin</artifactId>
-      <version>${neo4j.version}</version>
-    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/python-embedded/pom.xml
+++ b/python-embedded/pom.xml
@@ -45,7 +45,6 @@
 		<build.number>0</build.number>
 
 		<neo4j.version>2.0-SNAPSHOT</neo4j.version>
-		<gremlin.version>1.2</gremlin.version>
 		<docs.url>http://docs.neo4j.org/chunked/${project.version}/python-embedded.html</docs.url>
 	</properties>
 


### PR DESCRIPTION
Moving gremlin-plugin documentation out of the Neo4j manual, as both it and the python-embedded projects will have their own manuals for the 2.0 release.
