### PR TITLE
Use jgit to get git describe for the kernel version

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -153,6 +153,13 @@ the relevant Commercial Agreement.
         </executions>
       </plugin>
       <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <configuration>
+          <dotGitDirectory>${project.build.directory}../../.git</dotGitDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
@@ -162,16 +169,7 @@ the relevant Commercial Agreement.
               <property environment="env" />
               <target>
                 <mkdir dir="target/generated-sources/version/org/neo4j/kernel/impl/" />
-                <exec executable="${git.executable}" failifexecutionfails="false" failonerror="false">
-                  <arg value="fetch" />
-                  <arg value="--tags" />
-                </exec>
-                <exec executable="${git.executable}" outputproperty="git.describe" errorproperty="git.describe.error" failifexecutionfails="false" failonerror="false">
-                  <arg value="describe" />
-                  <arg value="--dirty" />
-                  <arg value="--always" />
-                </exec>
-                <property name="git.describe" value="" />
+                <property name="git.describe" value="${git.commit.id.describe}" />
                 <echo file="target/generated-sources/version/org/neo4j/${short-name}/impl/ComponentVersion.java">package org.neo4j.${short-name}.impl;
 
 import org.neo4j.kernel.Version;

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,36 @@
     <module>enterprise</module>
     <module>cypher-plugin</module>
   </modules>
-
+  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>2.1.4</version>
+          <executions>
+            <execution>
+              <id>generate-git-hash</id>
+              <goals>
+                <goal>revision</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <skipPoms>false</skipPoms>
+            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+            <gitDescribe>
+              <dirty>-dirty</dirty>
+              <abbrev>7</abbrev>
+              <forceLongFormat>true</forceLongFormat>
+            </gitDescribe>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  
   <profiles>
     <profile>
       <id>neo-full-build</id>


### PR DESCRIPTION
Build-time wise this equals having ant call out to CLI git, but I think using JGit will prove more stable. (that call gets stuck a lot on my Ubuntu boxes.) Also, we'll get -dirty appended to the revision string when building from a dirty repo. (couldn't do that previously, as we didn't know what git version would be in use)

Here's the generated class from the PR build 118:

``` java
package org.neo4j.kernel.impl;

import org.neo4j.kernel.Version;
import org.neo4j.helpers.Service;

@Service.Implementation(Version.class)
public class ComponentVersion extends Version
{
    public ComponentVersion()
    {
        super("neo4j-kernel", "1.9-SNAPSHOT");
    }

    @Override
    public String getRevision()
    {
        return "1.9.M02-237-g072d5cd";
    }
}
```
