### PR TITLE
added missing file.encoding argument to the startup script

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -260,6 +260,7 @@ console() {
         -Dorg.neo4j.server.properties="${NEO4J_CONFIG}/neo4j-server.properties" \
         -Djava.util.logging.config.file="${NEO4J_CONFIG}/logging.properties" \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
+        -Dfile.encoding=UTF-8 \
         org.neo4j.server.Bootstrapper
 
   else


### PR DESCRIPTION
I found my local development database to not correctly handle UTF-8 content in properties. In my development environment (OS X 10.8) Neo4j runs under my local user account. 
I located the source of that problem in the startup script. On [line 189](https://github.com/neo4j/neo4j/blob/22da14fd09d604af4f53827f48a25fe40e225d01/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j#L189) the command used when starting with changing users contains the argument `-Dfile.encoding=UTF-8`. Just below, in the else branch, is the statement to start Neo4j under the current user, which lacks that file.encoding argument. 
For some weird reasons Java seems to pick Mac Roman as default charset, when the file encoding isn't specified explicitly. 
