### PR TITLE
Small changes to produce more effective execution plans

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
@@ -54,7 +54,6 @@ object PartiallySolvedQuery {
     )
   }
 
-
   def apply() = new PartiallySolvedQuery(
     returns = Seq(),
     start = Seq(),

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/ExtractBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/ExtractBuilder.scala
@@ -60,7 +60,7 @@ object ExtractBuilder {
       }
       ))
 
-      val resultPipe = new ExtractPipe(pipe, expressions)
+      val resultPipe = ExtractPipe(pipe, expressions)
       val resultQuery = newPsq.copy(extracted = true)
       plan.copy(pipe = resultPipe, query = resultQuery)
     } else {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/ExtractPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/ExtractPipe.scala
@@ -22,6 +22,13 @@ package org.neo4j.cypher.internal.pipes
 import org.neo4j.cypher.internal.symbols._
 import org.neo4j.cypher.internal.commands.expressions.Expression
 
+object ExtractPipe {
+  def apply(source: Pipe, expressions: Map[String, Expression]): ExtractPipe = source match {
+    case p: ExtractPipe => new ExtractPipe(p.source, p.expressions ++ expressions)
+    case _              => new ExtractPipe(source, expressions)
+  }
+}
+
 class ExtractPipe(source: Pipe, val expressions: Map[String, Expression]) extends PipeWithSource(source) {
   val symbols: SymbolTable = {
     val newIdentifiers = expressions.map {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/TraversalMatchPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/TraversalMatchPipe.scala
@@ -42,7 +42,7 @@ class TraversalMatchPipe(source: Pipe, matcher: TraversalMatcher, trail: Trail) 
 
   def symbols = trail.symbols(source.symbols)
 
-  def executionPlanDescription() = "TraversalMatcher()"
+  def executionPlanDescription() = source.executionPlanDescription() + "\nTraversalMatcher(" + trail+")"
 
   def throwIfSymbolsMissing(symbols: SymbolTable) {
   }


### PR DESCRIPTION
- Collapses ExtractPipes into a single instance
- Does not produce FilterPipes when not needed
