### PR TITLE
Labels are stored on the node record itself

### DIFF
--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQueryTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQueryTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.neo4j.test.JavaDocsGenerator;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
 public class JavaQueryTest
@@ -30,7 +31,7 @@ public class JavaQueryTest
     @Test
     public void test()
     {
-        JavaDocsGenerator gen = new JavaDocsGenerator( "java-cypher-queries", "dev/java" );
+        JavaDocsGenerator gen = new JavaDocsGenerator( "java-cypher-queries", storeDir );
 
         JavaQuery jq = new JavaQuery();
         jq.run();
@@ -48,4 +49,6 @@ public class JavaQueryTest
         gen.saveToFile( "node", AsciidocHelper.createOutputSnippet( jq.nodeResult ) );
         gen.saveToFile( "rows", AsciidocHelper.createOutputSnippet( jq.rows ) );
     }
+    
+    private final String storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath();
 }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfiguration.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfiguration.java
@@ -18,14 +18,15 @@
  */
 package org.neo4j.examples;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-
-import static org.junit.Assert.*;
+import org.neo4j.test.TargetDirectory;
 
 public class StartWithConfiguration
 {
@@ -35,7 +36,7 @@ public class StartWithConfiguration
         String pathToConfig = "src/test/resources/";
         // START SNIPPET: startDbWithConfig
         GraphDatabaseService graphDb = new GraphDatabaseFactory()
-            .newEmbeddedDatabaseBuilder( "target/database/location" )
+            .newEmbeddedDatabaseBuilder( storeDir )
             .loadPropertiesFromFile( pathToConfig + "neo4j.properties" )
             .newGraphDatabase();
         // END SNIPPET: startDbWithConfig
@@ -52,11 +53,13 @@ public class StartWithConfiguration
         config.put( "string_block_size", "60" );
         config.put( "array_block_size", "300" );
         GraphDatabaseService graphDb = new GraphDatabaseFactory()
-            .newEmbeddedDatabaseBuilder( "target/database/location" )
+            .newEmbeddedDatabaseBuilder( storeDir )
             .setConfig( config )
             .newGraphDatabase();
         // END SNIPPET: startDbWithConfigInMap
         assertNotNull( graphDb );
         graphDb.shutdown();
     }
+    
+    private final String storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath();
 }

--- a/community/graph-matching/src/test/java/matching/TestMatchingOfCircularPattern.java
+++ b/community/graph-matching/src/test/java/matching/TestMatchingOfCircularPattern.java
@@ -47,6 +47,7 @@ import org.neo4j.graphmatching.PatternMatch;
 import org.neo4j.graphmatching.PatternMatcher;
 import org.neo4j.graphmatching.PatternNode;
 import org.neo4j.helpers.collection.IteratorWrapper;
+import org.neo4j.test.TargetDirectory;
 
 public class TestMatchingOfCircularPattern
 {
@@ -70,6 +71,7 @@ public class TestMatchingOfCircularPattern
             message.createRelationshipTo( start, withName( "IS_VISIBLE_BY" ) );
         }
 
+        @Override
         public Iterator<Node> iterator()
         {
             Iterable<PatternMatch> matches = PatternMatcher.getMatcher().match(
@@ -221,6 +223,7 @@ public class TestMatchingOfCircularPattern
         return startNode.traverse( Order.BREADTH_FIRST, stopAtDepth( 2 ),
                 new ReturnableEvaluator()
                 {
+                    @Override
                     public boolean isReturnableNode( TraversalPosition pos )
                     {
                         Node node = pos.currentNode();
@@ -235,6 +238,7 @@ public class TestMatchingOfCircularPattern
     {
         return new StopEvaluator()
         {
+            @Override
             public boolean isStopNode( TraversalPosition currentPos )
             {
                 return currentPos.depth() >= depth;
@@ -265,7 +269,7 @@ public class TestMatchingOfCircularPattern
     @BeforeClass
     public static void setUpDb()
     {
-        graphdb = new GraphDatabaseFactory().newEmbeddedDatabase( "target/var/db" );
+        graphdb = new GraphDatabaseFactory().newEmbeddedDatabase( TargetDirectory.forTest( TestMatchingOfCircularPattern.class ).graphDbDir( true ).getAbsolutePath() );
         Transaction tx = graphdb.beginTx();
         try
         {

--- a/community/graph-matching/src/test/java/matching/TestPatternMatching.java
+++ b/community/graph-matching/src/test/java/matching/TestPatternMatching.java
@@ -19,6 +19,11 @@
  */
 package matching;
 
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -48,10 +54,8 @@ import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.ProcessStreamHandler;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestData;
-
-import static java.util.Arrays.*;
-import static org.junit.Assert.*;
 
 public class TestPatternMatching implements GraphHolder
 {
@@ -87,7 +91,7 @@ public class TestPatternMatching implements GraphHolder
     @BeforeClass
     public static void setUpDb()
     {
-        graphDb = new EmbeddedGraphDatabase( "target/var/db" );
+        graphDb = new EmbeddedGraphDatabase( TargetDirectory.forTest( TestPatternMatching.class ).graphDbDir( true ).getAbsolutePath() );
     }
 
     @Before

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -290,6 +290,13 @@ public abstract class GraphDatabaseSettings
     public static final IntegerSetting array_block_size =
             new IntegerSetting( setting("array_block_size", INTEGER, "120",min(1)));
 
+    @Description("Specifies the block size for storing labels exceeding in-lined space in node record. " +
+    		"This parameter is only honored when the store is created, otherwise it is ignored. " +
+            "The default block size is 60 bytes, and the overhead of each block is the same as for string blocks, " +
+            "i.e., 8 bytes.")
+    public static final IntegerSetting label_block_size =
+            new IntegerSetting( setting("label_block_size", INTEGER, "60",min(1)));
+
     @Description("Mark this database as a backup slave.")
     public static final BooleanSetting backup_slave = new BooleanSetting( setting("backup_slave", BOOLEAN, FALSE ));
 

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -572,4 +572,32 @@ public abstract class IteratorUtil
             }
         }
     }
+    
+    public static Iterable<Long> asIterable( final long... array )
+    {
+        return new Iterable<Long>()
+        {
+            @Override
+            public Iterator<Long> iterator()
+            {
+                return new PrefetchingIterator<Long>()
+                {
+                    private int index;
+                    
+                    @Override
+                    protected Long fetchNextOrNull()
+                    {
+                        try
+                        {
+                            return index < array.length ? array[index] : null;
+                        }
+                        finally
+                        {
+                            index++;
+                        }
+                    }
+                };
+            }
+        };
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/IdType.java
@@ -31,7 +31,8 @@ public enum IdType
     RELATIONSHIP_TYPE( 16, false ),
     RELATIONSHIP_TYPE_BLOCK( false ),
     NEOSTORE_BLOCK( false ),
-    SCHEMA( 35, true );
+    SCHEMA( 35, true ),
+    NODE_LABELS( 35, true );
 
     private final long max;
     private final boolean allowAggressiveReuse;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -73,7 +73,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
         this.persistenceManager = persistenceManager;
         this.dataSourceManager = dataSourceManager;
         this.lockManager = lockManager;
-        this.persistenceCache = new PersistenceCache( new TemporaryLabelAsPropertyLoader( persistenceManager ) );
+        this.persistenceCache = new PersistenceCache( new NodeCacheLoader( persistenceManager ) );
         this.schemaCache = schemaCache;
     }
     
@@ -138,7 +138,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     public StatementContext newReadOnlyStatementContext()
     {
         // I/O
-        StatementContext result = new TemporaryLabelAsPropertyStatementContext( propertyIndexManager,
+        StatementContext result = new StoreStatementContext( propertyIndexManager,
                 persistenceManager, neoStore );
         // + Cache
         result = new CachingStatementContext( result, persistenceCache, schemaCache );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TemporaryLabelAsPropertyTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TemporaryLabelAsPropertyTransactionContext.java
@@ -42,7 +42,7 @@ public class TemporaryLabelAsPropertyTransactionContext implements TransactionCo
     @Override
     public StatementContext newStatementContext()
     {
-        return new TemporaryLabelAsPropertyStatementContext( propertyIndexManager, persistenceManager, neoStore );
+        return new StoreStatementContext( propertyIndexManager, persistenceManager, neoStore );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyIndexManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyIndexManager.java
@@ -23,7 +23,6 @@ import static java.lang.System.arraycopy;
 
 import java.util.Map;
 
-import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.kernel.impl.persistence.EntityIdGenerator;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
@@ -67,32 +66,7 @@ public class PropertyIndexManager extends KeyHolder<PropertyIndex>
         return existing;
     }
     
-    @Override
-    public PropertyIndex getKeyByIdOrNull( int id )
-    {
-        PropertyIndex index = super.getKeyByIdOrNull( id );
-        if ( index != null )
-            return index;
-        
-        // Try load it
-        String keyName = persistenceManager.loadIndex( id );
-        if ( keyName == null )
-            throw new NotFoundException( "Index not found [" + id + "]" );
-        
-        index = new PropertyIndex( keyName, id );
-        addKeyEntry( keyName, id );
-        return index;
-    }
-    
-    @Override
-    protected PropertyIndex newKey( String key, int id )
-    {
-        return new PropertyIndex( key, id );
-    }
-
     /*
-     * Need synchronization here so we don't create multiple lists.
-     * 
      * TODO Since legacy databases can have multiple ids for any given property key
      * this legacy method is left behind and used specifically for property indexes
      * until migration has been added to dedup them.
@@ -117,6 +91,12 @@ public class PropertyIndexManager extends KeyHolder<PropertyIndex>
         indexMap.put( name, list );
     }
 
+    @Override
+    protected PropertyIndex newKey( String key, int id )
+    {
+        return new PropertyIndex( key, id );
+    }
+    
     @Override
     protected String nameOf( PropertyIndex key )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractBaseRecord.java
@@ -51,4 +51,30 @@ public abstract class AbstractBaseRecord
     {
         return created;
     }
+
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        long id = getLongId();
+        result = prime * result + (int) (id ^ (id >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        AbstractBaseRecord other = (AbstractBaseRecord) obj;
+        if ( getLongId() != other.getLongId() )
+            return false;
+        return true;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
@@ -228,9 +228,9 @@ public abstract class AbstractNameStore<T extends AbstractNameRecord> extends Ab
         return forceGetRecord( id );
     }
 
-    public Collection<DynamicRecord> allocateNameRecords( int nameId, byte[] chars )
+    public Collection<DynamicRecord> allocateNameRecords( byte[] chars )
     {
-        return nameStore.allocateRecords( nameId, chars );
+        return nameStore.allocateRecordsFromBytes( chars );
     }
 
     public T getLightRecord( int id )
@@ -382,8 +382,8 @@ public abstract class AbstractNameStore<T extends AbstractNameRecord> extends Ab
                 records = nameRecord.getNameRecords().iterator();
             }
         }
-        return (String) PropertyStore.getStringFor( PropertyStore.readFullByteArray(
-                nameRecord.getNameId(), relevantRecords, nameStore, PropertyType.STRING ).other() );
+        return (String) PropertyStore.getStringFor( nameStore.readFullByteArray(
+                relevantRecords, PropertyType.STRING ).other() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -57,7 +57,7 @@ public abstract class CommonAbstractStore
         public static final GraphDatabaseSetting.BooleanSetting use_memory_mapped_buffers = GraphDatabaseSettings.use_memory_mapped_buffers;
     }
 
-    public static final String ALL_STORES_VERSION = "v0.A.0";
+    public static final String ALL_STORES_VERSION = "v0.A.1";
     public static final String UNKNOWN_VERSION = "Uknown";
 
     protected Config configuration;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicRecord.java
@@ -48,7 +48,6 @@ public class DynamicRecord extends Abstract64BitRecord
     {
         return type;
     }
-    
 
     public void setType( int type )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -19,21 +19,19 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.api.LabelAsProperty;
 import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
 import org.neo4j.kernel.impl.util.StringLogger;
 
@@ -89,7 +87,7 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
         return stringPropertyStore;
     }
 
-    DynamicArrayStore getArrayStore()
+    public DynamicArrayStore getArrayStore()
     {
         return arrayPropertyStore;
     }
@@ -517,15 +515,14 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
         this.updateHighId();
     }
 
-    private Collection<DynamicRecord> allocateStringRecords( long valueBlockId, byte[] chars )
+    private Collection<DynamicRecord> allocateStringRecords( byte[] chars )
     {
-        return stringPropertyStore.allocateRecords( valueBlockId, chars );
+        return stringPropertyStore.allocateRecordsFromBytes( chars );
     }
 
-    private Collection<DynamicRecord> allocateArrayRecords( long valueBlockId,
-        Object array )
+    private Collection<DynamicRecord> allocateArrayRecords( Object array )
     {
-        return arrayPropertyStore.allocateRecords( valueBlockId, array );
+        return arrayPropertyStore.allocateRecords( array );
     }
 
     public void encodeValue( PropertyBlock block, int keyId, Object value )
@@ -537,10 +534,9 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
                     PropertyType.getPayloadSize() ) ) return;
 
             // Fall back to dynamic string store
-            long stringBlockId = nextStringBlockId();
-            setSingleBlockValue( block, keyId, PropertyType.STRING, stringBlockId );
             byte[] encodedString = encodeString( string );
-            Collection<DynamicRecord> valueRecords = allocateStringRecords( stringBlockId, encodedString );
+            Collection<DynamicRecord> valueRecords = allocateStringRecords( encodedString );
+            setSingleBlockValue( block, keyId, PropertyType.STRING, first( valueRecords ).getId() );
             for ( DynamicRecord valueRecord : valueRecords )
             {
                 valueRecord.setType( PropertyType.STRING.intValue() );
@@ -571,20 +567,19 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
             if ( ShortArray.encode( keyId, value, block, PropertyType.getPayloadSize() ) ) return;
 
             // Fall back to dynamic array store
-            long arrayBlockId = nextArrayBlockId();
-            setSingleBlockValue( block, keyId, PropertyType.ARRAY, arrayBlockId );
-            Collection<DynamicRecord> arrayRecords = allocateArrayRecords( arrayBlockId, value );
+            Collection<DynamicRecord> arrayRecords = allocateArrayRecords( value );
+            setSingleBlockValue( block, keyId, PropertyType.ARRAY, first( arrayRecords ).getId() );
             for ( DynamicRecord valueRecord : arrayRecords )
             {
                 valueRecord.setType( PropertyType.ARRAY.intValue() );
                 block.addValueRecord( valueRecord );
             }
         }
-        else if ( value instanceof LabelAsProperty )
-        {
-            long keyAndType = keyId | (((long) PropertyType.LABEL.intValue()) << 24);
-            block.setValueBlocks( new long[]{keyAndType, ((LabelAsProperty) value).getNodeId()} );
-        }
+//        else if ( value instanceof LabelAsProperty )
+//        {
+//            long keyAndType = keyId | (((long) PropertyType.LABEL.intValue()) << 24);
+//            block.setValueBlocks( new long[]{keyAndType, ((LabelAsProperty) value).getNodeId()} );
+//        }
         else
         {
             throw new IllegalArgumentException( "Unknown property type on: "
@@ -615,7 +610,7 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
 
     public static Object getStringFor( AbstractDynamicStore store, long startRecord, Collection<DynamicRecord> dynamicRecords )
     {
-        Pair<byte[], byte[]> source = readFullByteArray( startRecord, dynamicRecords, store, PropertyType.STRING );
+        Pair<byte[], byte[]> source = store.readFullByteArray( dynamicRecords, PropertyType.STRING );
         // A string doesn't have a header in the data array
         return getStringFor( source.other() );
     }
@@ -628,58 +623,13 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
     public Object getArrayFor( PropertyBlock propertyBlock )
     {
         assert !propertyBlock.isLight();
-        return getArrayFor( propertyBlock.getSingleValueLong(), propertyBlock.getValueRecords(), arrayPropertyStore );
+        return getArrayFor( propertyBlock.getValueRecords() );
     }
 
-    public static Object getArrayFor( long startRecord, Iterable<DynamicRecord> records,
-            DynamicArrayStore arrayPropertyStore )
+    public Object getArrayFor( Iterable<DynamicRecord> records )
     {
         return arrayPropertyStore.getRightArray(
-                readFullByteArray( startRecord, records, arrayPropertyStore, PropertyType.ARRAY ) );
-    }
-
-    public static Pair<byte[]/*header in the first record*/,byte[]/*all other bytes*/> readFullByteArray(
-            long startRecord, Iterable<DynamicRecord> records, AbstractDynamicStore store, PropertyType propertyType )
-    {
-        long recordToFind = startRecord;
-        Map<Long,DynamicRecord> recordsMap = new HashMap<Long,DynamicRecord>();
-        for ( DynamicRecord record : records )
-        {
-            recordsMap.put( record.getId(), record );
-        }
-        byte[] header = null;
-        List<byte[]> byteList = new LinkedList<byte[]>();
-        int totalSize = 0;
-        while ( recordToFind != Record.NO_NEXT_BLOCK.intValue() )
-        {
-            DynamicRecord record = recordsMap.get( recordToFind );
-            if ( record.isLight() )
-            {
-                store.makeHeavy( record );
-            }
-            
-            int offset = 0;
-            if ( recordToFind == startRecord )
-            {   // This is the first one, read out the header separately
-                header = propertyType.readDynamicRecordHeader( record.getData() );
-                offset = header.length;
-            }
-            
-            byteList.add( record.getData() );
-            totalSize += (record.getData().length-offset);
-            recordToFind = record.getNextBlock();
-        }
-        byte[] bArray = new byte[totalSize];
-        int sourceOffset = header.length;
-        int offset = 0;
-        for ( byte[] currentArray : byteList )
-        {
-            System.arraycopy( currentArray, sourceOffset, bArray, offset,
-                currentArray.length-sourceOffset );
-            offset += (currentArray.length-sourceOffset);
-            sourceOffset = 0;
-        }
-        return Pair.of( header, bArray );
+                arrayPropertyStore.readFullByteArray( records, PropertyType.ARRAY ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/SchemaStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/SchemaStore.java
@@ -59,11 +59,11 @@ public class SchemaStore extends AbstractDynamicStore
         return TYPE_DESCRIPTOR;
     }
     
-    public Collection<DynamicRecord> allocateFrom( long startBlock, SchemaRule rule )
+    public Collection<DynamicRecord> allocateFrom( SchemaRule rule )
     {
         RecordSerializer serializer = new RecordSerializer();
         serializer = serializer.append( rule );
-        return allocateRecords( startBlock, serializer.serialize() );
+        return allocateRecordsFromBytes( serializer.serialize() );
     }
     
     public Iterable<SchemaRule> loadAll()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -49,6 +49,7 @@ public class StoreFactory
     {
         public static final GraphDatabaseSetting.IntegerSetting string_block_size = GraphDatabaseSettings.string_block_size;
         public static final GraphDatabaseSetting.IntegerSetting array_block_size = GraphDatabaseSettings.array_block_size;
+        public static final GraphDatabaseSetting.IntegerSetting label_block_size = GraphDatabaseSettings.label_block_size;
     }
     
     private final Config config;
@@ -57,7 +58,25 @@ public class StoreFactory
     private final FileSystemAbstraction fileSystemAbstraction;
     private final StringLogger stringLogger;
     private final TxHook txHook;
-
+    
+    public static final String NODE_STORE_NAME = ".nodestore.db";
+    public static final String LABELS_PART = ".labels";
+    public static final String NODE_LABELS_STORE_NAME = NODE_STORE_NAME + LABELS_PART;
+    public static final String RELATIONSHIP_STORE_NAME = ".relationshipstore.db";
+    public static final String RELATIONSHIP_TYPE_STORE_NAME = ".relationshiptypestore.db";
+    public static final String NAMES_PART = ".names";
+    public static final String RELATIONSHIP_TYPE_NAMES_STORE_NAME = RELATIONSHIP_TYPE_STORE_NAME + NAMES_PART;
+    public static final String PROPERTY_STORE_NAME = ".propertystore.db";
+    public static final String INDEX_PART = ".index";
+    public static final String KEYS_PART = ".keys";
+    public static final String ARRAYS_PART = ".arrays";
+    public static final String STRINGS_PART = ".strings";
+    public static final String PROPERTY_INDEX_STORE_NAME = PROPERTY_STORE_NAME + INDEX_PART;
+    public static final String PROPERTY_INDEX_KEYS_STORE_NAME = PROPERTY_STORE_NAME + INDEX_PART + KEYS_PART;
+    public static final String PROPERTY_STRINGS_STORE_NAME = PROPERTY_STORE_NAME + STRINGS_PART;
+    public static final String PROPERTY_ARRAYS_STORE_NAME = PROPERTY_STORE_NAME + ARRAYS_PART;
+    public static final String SCHEMA_STORE_NAME = ".schemastore.db";
+    
     public StoreFactory( Config config, IdGeneratorFactory idGeneratorFactory, WindowPoolFactory windowPoolFactory,
                          FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger, TxHook txHook )
     {
@@ -102,12 +121,12 @@ public class StoreFactory
     {
         return new NeoStore( fileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction,
                 stringLogger, txHook,
-                newRelationshipTypeStore(new File(fileName.getPath() + ".relationshiptypestore.db")),
-                newPropertyStore(new File( fileName.getPath() + ".propertystore.db")),
-                newRelationshipStore(new File( fileName.getPath() + ".relationshipstore.db")),
-                newNodeStore(new File( fileName.getPath() + ".nodestore.db")),
+                newRelationshipTypeStore(new File(fileName.getPath() + RELATIONSHIP_TYPE_STORE_NAME)),
+                newPropertyStore(new File( fileName.getPath() + PROPERTY_STORE_NAME)),
+                newRelationshipStore(new File( fileName.getPath() + RELATIONSHIP_STORE_NAME)),
+                newNodeStore(new File( fileName.getPath() + NODE_STORE_NAME)),
                 // We don't need any particular upgrade when we add the schema store
-                newOrCreateSchemaStore(new File( fileName.getPath() + ".schemastore.db")));
+                newOrCreateSchemaStore(new File( fileName.getPath() + SCHEMA_STORE_NAME)));
     }
 
     private void tryToUpgradeStores( File fileName )
@@ -138,23 +157,23 @@ public class StoreFactory
 
     private RelationshipTypeStore newRelationshipTypeStore(File baseFileName)
     {
-        DynamicStringStore nameStore = newDynamicStringStore( new File( baseFileName.getPath() + ".names"), IdType.RELATIONSHIP_TYPE_BLOCK );
+        DynamicStringStore nameStore = newDynamicStringStore( new File( baseFileName.getPath() + NAMES_PART), IdType.RELATIONSHIP_TYPE_BLOCK );
         return new RelationshipTypeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger, nameStore );
     }
 
     private PropertyStore newPropertyStore(File baseFileName)
     {
-        DynamicStringStore stringPropertyStore = newDynamicStringStore(new File( baseFileName.getPath() + ".strings"), IdType.STRING_BLOCK);
-        PropertyIndexStore propertyIndexStore = newPropertyIndexStore(new File( baseFileName.getPath() + ".index"));
-        DynamicArrayStore arrayPropertyStore = newDynamicArrayStore( new File( baseFileName.getPath() + ".arrays" ));
+        DynamicStringStore stringPropertyStore = newDynamicStringStore(new File( baseFileName.getPath() + STRINGS_PART), IdType.STRING_BLOCK);
+        PropertyIndexStore propertyIndexStore = newPropertyIndexStore(new File( baseFileName.getPath() + INDEX_PART));
+        DynamicArrayStore arrayPropertyStore = newDynamicArrayStore( new File( baseFileName.getPath() + ARRAYS_PART ));
         return new PropertyStore( baseFileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction, stringLogger,
                 stringPropertyStore, propertyIndexStore, arrayPropertyStore);
     }
 
     private PropertyIndexStore newPropertyIndexStore(File baseFileName)
     {
-        DynamicStringStore nameStore = newDynamicStringStore(new File( baseFileName.getPath() + ".keys"), IdType.PROPERTY_INDEX_BLOCK);
+        DynamicStringStore nameStore = newDynamicStringStore(new File( baseFileName.getPath() + KEYS_PART), IdType.PROPERTY_INDEX_BLOCK);
         return new PropertyIndexStore( baseFileName, config, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger, nameStore );
     }
@@ -165,15 +184,22 @@ public class StoreFactory
                 fileSystemAbstraction, stringLogger);
     }
 
-    private DynamicArrayStore newDynamicArrayStore(File baseFileName)
+    public DynamicArrayStore newDynamicArrayStore(File baseFileName)
     {
         return new DynamicArrayStore( baseFileName, config, IdType.ARRAY_BLOCK, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger);
     }
 
-    private NodeStore newNodeStore(File baseFileName)
+    public NodeStore newNodeStore(File baseFileName)
     {
-        return new NodeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction, stringLogger );
+        File labelsFileName = new File( baseFileName.getPath() + LABELS_PART );
+        if ( !fileSystemAbstraction.fileExists( labelsFileName ) )
+            createNodeLabelsStore( labelsFileName );
+        
+        DynamicArrayStore dynamicLabelStore = new DynamicArrayStore( labelsFileName,
+                config, IdType.NODE_LABELS, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction, stringLogger);
+        return new NodeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction,
+                stringLogger, dynamicLabelStore );
     }
 
     public NeoStore createNeoStore(File fileName)
@@ -184,20 +210,12 @@ public class StoreFactory
     public NeoStore createNeoStore(File fileName, StoreId storeId)
     {
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( NeoStore.TYPE_DESCRIPTOR ) );
-        createNodeStore(new File( fileName.getPath() + ".nodestore.db"));
-        createRelationshipStore(new File( fileName.getPath() + ".relationshipstore.db"));
-        createPropertyStore(new File( fileName.getPath() + ".propertystore.db"));
-        createRelationshipTypeStore(new File( fileName.getPath() + ".relationshiptypestore.db"));
-        createSchemaStore(new File( fileName.getPath() + ".schemastore.db"));
-/*
-        if ( !config.containsKey( "neo_store" ) )
-        {
-            // TODO Ugly
-            Map<String, Object> newConfig = new HashMap<String, Object>( config );
-            newConfig.put( "neo_store", fileName );
-            config = newConfig;
-        }
-*/
+        createNodeStore(new File( fileName.getPath() + NODE_STORE_NAME));
+        createRelationshipStore(new File( fileName.getPath() + RELATIONSHIP_STORE_NAME));
+        createPropertyStore(new File( fileName.getPath() + PROPERTY_STORE_NAME));
+        createRelationshipTypeStore(new File( fileName.getPath() + RELATIONSHIP_TYPE_STORE_NAME));
+        createSchemaStore(new File( fileName.getPath() + SCHEMA_STORE_NAME));
+        
         NeoStore neoStore = newNeoStore( fileName );
         /*
         *  created time | random long | backup version | tx id | store version | next prop
@@ -220,14 +238,23 @@ public class StoreFactory
      * @param fileName
      *            File name of the new node store
      */
-    private void createNodeStore( File fileName )
+    public void createNodeStore( File fileName )
     {
+        createNodeLabelsStore( new File( fileName.getPath() + LABELS_PART ) );
+        
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( NodeStore.TYPE_DESCRIPTOR ) );
         NodeStore store = newNodeStore( fileName );
         NodeRecord nodeRecord = new NodeRecord( store.nextId(), Record.NO_NEXT_RELATIONSHIP.intValue(), Record.NO_NEXT_PROPERTY.intValue() );
         nodeRecord.setInUse( true );
         store.updateRecord( nodeRecord );
         store.close();
+    }
+
+    private void createNodeLabelsStore( File fileName )
+    {
+        int labelStoreBlockSize = config.get( Configuration.label_block_size );
+        createEmptyDynamicStore(fileName, labelStoreBlockSize,
+                DynamicArrayStore.VERSION, IdType.NODE_LABELS );
     }
 
     /**
@@ -261,9 +288,9 @@ public class StoreFactory
         int stringStoreBlockSize = config.get( Configuration.string_block_size );
         int arrayStoreBlockSize = config.get( Configuration.array_block_size );
 
-        createDynamicStringStore(new File( fileName.getPath() + ".strings"), stringStoreBlockSize, IdType.STRING_BLOCK);
-        createPropertyIndexStore(new File( fileName.getPath() + ".index"));
-        createDynamicArrayStore(new File( fileName.getPath() + ".arrays"), arrayStoreBlockSize);
+        createDynamicStringStore(new File( fileName.getPath() + STRINGS_PART), stringStoreBlockSize, IdType.STRING_BLOCK);
+        createPropertyIndexStore(new File( fileName.getPath() + INDEX_PART));
+        createDynamicArrayStore(new File( fileName.getPath() + ARRAYS_PART), arrayStoreBlockSize);
     }
 
     /**
@@ -279,7 +306,7 @@ public class StoreFactory
     private void createRelationshipTypeStore( File fileName )
     {
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( RelationshipTypeStore.TYPE_DESCRIPTOR ));
-        createDynamicStringStore( new File( fileName.getPath() + ".names"), AbstractNameStore.NAME_STORE_BLOCK_SIZE, IdType.RELATIONSHIP_TYPE_BLOCK);
+        createDynamicStringStore( new File( fileName.getPath() + NAMES_PART), AbstractNameStore.NAME_STORE_BLOCK_SIZE, IdType.RELATIONSHIP_TYPE_BLOCK);
         RelationshipTypeStore store = newRelationshipTypeStore( fileName );
         store.close();
     }
@@ -292,7 +319,7 @@ public class StoreFactory
     private void createPropertyIndexStore( File fileName)
     {
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( PropertyIndexStore.TYPE_DESCRIPTOR ));
-        createDynamicStringStore(new File( fileName.getPath() + ".keys"), PropertyIndexStore.NAME_STORE_BLOCK_SIZE, IdType.PROPERTY_INDEX_BLOCK);
+        createDynamicStringStore(new File( fileName.getPath() + KEYS_PART), PropertyIndexStore.NAME_STORE_BLOCK_SIZE, IdType.PROPERTY_INDEX_BLOCK);
     }
 
     public void createDynamicArrayStore( File fileName, int blockSize)
@@ -375,7 +402,7 @@ public class StoreFactory
         // TODO highestIdInUse = 0 works now, but not when slave can create store files.
         IdGenerator idGenerator = idGeneratorFactory.open(fileSystemAbstraction, new File( fileName.getPath() + ".id"),
                 idType.getGrabSize(), idType, 0 );
-        idGenerator.nextId(); // reserv first for blockSize
+        idGenerator.nextId(); // reserve first for blockSize
         idGenerator.close();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogic.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogic.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import static java.lang.Long.highestOneBit;
+import static java.lang.System.arraycopy;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.util.Bits.bits;
+import static org.neo4j.kernel.impl.util.Bits.bitsFromLongs;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeStore;
+import org.neo4j.kernel.impl.util.Bits;
+
+/**
+ * Logic for parsing and constructing {@link NodeRecord#getLabelField()} and dynamic label
+ * records in {@link NodeRecord#getDynamicLabelRecords()} from label ids.
+ * 
+ * Each node has a label field of 5 bytes, where labels will be stored, if sufficient space
+ * (max bits required for storing each label id is considered). If not then the field will
+ * point to a dynamic record where the labels will be stored in the format of an array property.
+ * 
+ * [hhhh,bbbb][bbbb,bbbb][bbbb,bbbb][bbbb,bbbb][bbbb,bbbb]
+ * h: header
+ *    - 0x0<=h<=0x7 (leaving high bit reserved): number of in-lined labels in the body
+ *    - 0x8: body will be a pointer to first dynamic record in node-labels dynamic store
+ * b: body
+ *    - 0x0<=h<=0x7 (leaving high bit reserved): bits of this many in-lined label ids
+ *    - 0x8: pointer to node-labels store
+ */
+public class NodeLabelRecordLogic
+{
+    private static final int LABEL_BITS = 36;
+    private final NodeRecord node;
+    private final NodeStore nodeStore;
+
+    public NodeLabelRecordLogic( NodeRecord node, NodeStore nodeStore )
+    {
+        this.node = node;
+        this.nodeStore = nodeStore;
+    }
+
+    public Iterable<DynamicRecord> add( long labelId )
+    {
+        long existingLabelsField = node.getLabelField();
+        byte header = getHeader( existingLabelsField );
+        long existingLabelsBits = parseLabelsBody( existingLabelsField );
+        Collection<DynamicRecord> changedDynamicRecords = Collections.emptyList();
+        if ( !highHeaderBitSet( header ) )
+        {   // There's in-lined or no labels
+            long[] newLabelIds = header == 0 ?
+                    new long[] {labelId} : concatAndSort( parseInlined( existingLabelsBits, header ), labelId );
+            if ( !tryInline( newLabelIds, changedDynamicRecords ) )
+            {
+                changedDynamicRecords = nodeStore.allocateRecordsForDynamicLabels( newLabelIds );
+                node.setLabelField( dynamicPointer( changedDynamicRecords ), changedDynamicRecords );
+            }
+        }
+        else
+        {   // The labels are in dynamic records
+            nodeStore.makeHeavy( node, existingLabelsBits );
+            Collection<DynamicRecord> existingRecords = node.getDynamicLabelRecords();
+            long[] existingLabelIds = nodeStore.getDynamicLabelsArray( existingRecords );
+            long[] newLabelIds = concatAndSort( existingLabelIds, labelId );
+            changedDynamicRecords = nodeStore.allocateRecordsForDynamicLabels( newLabelIds, existingRecords.iterator() );
+            node.setLabelField( dynamicPointer( changedDynamicRecords ), changedDynamicRecords );
+        }
+        return changedDynamicRecords;
+    }
+
+    private void assertNotContains( long[] existingLabels, long labelId )
+    {
+        if ( Arrays.binarySearch( existingLabels, labelId ) >= 0 )
+            throw new IllegalStateException( "Label " + labelId + " already exists on " + node );
+    }
+
+    public static boolean highHeaderBitSet( byte header )
+    {
+        return (header & 0x8) != 0;
+    }
+
+    public Iterable<DynamicRecord> remove( long labelId )
+    {
+        long existingLabelsField = node.getLabelField();
+        byte header = getHeader( existingLabelsField );
+        long existingLabelsBits = parseLabelsBody( existingLabelsField );
+        Collection<DynamicRecord> changedDynamicRecords = Collections.emptyList();
+        if ( header > 0 && !highHeaderBitSet( header ) )
+        {   // There's in-lined labels
+            long[] newLabelIds = filter( parseInlined( existingLabelsBits, header ), labelId );
+            boolean inlined = tryInline( newLabelIds, changedDynamicRecords );
+            assert inlined;
+        }
+        else
+        {   // The labels are in dynamic records
+            nodeStore.makeHeavy( node, existingLabelsBits );
+            Collection<DynamicRecord> existingRecords = node.getDynamicLabelRecords();
+            long[] existingLabelIds = nodeStore.getDynamicLabelsArray( existingRecords );
+            long[] newLabelIds = filter( existingLabelIds, labelId );
+            if ( tryInline( newLabelIds, existingRecords ) )
+            {
+                for ( DynamicRecord record : existingRecords )
+                    record.setInUse( false );
+            }
+            else
+            {
+                Collection<DynamicRecord> newRecords = nodeStore.allocateRecordsForDynamicLabels( newLabelIds,
+                        existingRecords.iterator() );
+                node.setLabelField( dynamicPointer( newRecords ), existingRecords );
+                if ( !newRecords.equals( existingRecords ) )
+                {   // One less dynamic record, mark that one as not in use
+                    for ( DynamicRecord record : existingRecords )
+                        if ( !newRecords.contains( record ) )
+                            record.setInUse( false );
+                }
+            }
+            changedDynamicRecords = existingRecords;
+        }
+        return changedDynamicRecords;
+    }
+
+    public static long parseLabelsBody( long labelsField )
+    {
+        return labelsField & 0xFFFFFFFFFL;
+    }
+
+    public static long dynamicPointer( Collection<DynamicRecord> newRecords )
+    {
+        return 0x8000000000L | first( newRecords ).getId();
+    }
+
+    private long[] filter( long[] ids, long excludeId )
+    {
+        boolean found = false;
+        for ( int i = 0; i < ids.length; i++ )
+        {
+            if ( ids[i] == excludeId )
+            {
+                found = true;
+                break;
+            }
+        }
+        if ( !found )
+            throw new IllegalStateException( "Label " + excludeId + " not found on " + node );
+        
+        long[] result = new long[ids.length-1];
+        int writerIndex = 0;
+        for ( int i = 0; i < ids.length; i++ )
+            if ( ids[i] != excludeId )
+                result[writerIndex++] = ids[i];
+        return result;
+    }
+
+    private boolean tryInline( long[] ids, Collection<DynamicRecord> changedDynamicRecords )
+    {
+        // We reserve the high header bit for future extensions of the format of the in-lined label bits
+        // i.e. the 0-valued high header bit can allow for 0-7 in-lined labels in the bit-packed format.
+        if ( ids.length > 7 )
+            return false;
+        
+        byte bitsPerLabel = (byte) (ids.length > 0 ? (LABEL_BITS/ids.length) : LABEL_BITS);
+        long limit = 1 << bitsPerLabel;
+        Bits bits = bits( 5 );
+        for ( long id : ids )
+        {
+            if ( highestOneBit( id ) < limit )
+                bits.put( id, bitsPerLabel );
+            else
+                return false;
+        }
+        node.setLabelField( putHeader( bits.getLongs()[0], (byte) ids.length ), changedDynamicRecords );
+        return true;
+    }
+
+    private long[] concatAndSort( long[] existing, long additional )
+    {
+        assertNotContains( existing, additional );
+        
+        long[] result = new long[existing.length+1];
+        arraycopy( existing, 0, result, 0, existing.length );
+        result[existing.length] = additional;
+        Arrays.sort( result );
+        return result;
+    }
+
+    public static long[] parseInlined( long existingLabelsField, byte numberOfLabels )
+    {
+        if ( numberOfLabels == 0 )
+            return new long[0];
+        
+        byte bitsPerLabel = (byte) (LABEL_BITS/numberOfLabels);
+        Bits bits = bitsFromLongs( new long[] { existingLabelsField } );
+        long[] result = new long[numberOfLabels];
+        for ( int i = 0; i < result.length; i++ )
+            result[i] = bits.getLong( bitsPerLabel );
+        return result;
+    }
+
+    public static byte getHeader( long labelField )
+    {
+        return (byte) ((labelField & 0xF000000000L) >>> 36);
+    }
+    
+    public static long putHeader( long labelBits, byte numberOfLabels )
+    {
+        return (((long)numberOfLabels << 36) | labelBits);
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -456,5 +458,24 @@ class ReadTransaction implements NeoStoreTransaction
     public void deleteSchemaRule( long id )
     {
         throw readOnlyException();
+    }
+
+    @Override
+    public void addLabelToNode( long labelId, long nodeId )
+    {
+        throw readOnlyException();
+    }
+
+    @Override
+    public void removeLabelFromNode( long labelId, long nodeId )
+    {
+        throw readOnlyException();
+    }
+    
+    @Override
+    public Iterable<Long> getLabelsForNode( long nodeId )
+    {
+        NodeRecord node = getNodeStore().getRecord( nodeId );
+        return asIterable( getNodeStore().getLabelsForNode( node ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
@@ -342,4 +342,10 @@ public interface NeoStoreTransaction
     void createSchemaRule( SchemaRule schemaRule );
     
     void deleteSchemaRule( long id );
+    
+    void addLabelToNode( long labelId, long nodeId );
+    
+    void removeLabelFromNode( long labelId, long nodeId );
+
+    Iterable<Long> getLabelsForNode( long nodeId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
@@ -406,4 +406,19 @@ public class PersistenceManager
     {
         getResource( true ).createSchemaRule( rule );
     }
+
+    public void addLabelToNode( long labelId, long nodeId )
+    {
+        getResource( true ).addLabelToNode( labelId, nodeId );
+    }
+    
+    public void removeLabelFromNode( long labelId, long nodeId )
+    {
+        getResource( true ).removeLabelFromNode( labelId, nodeId );
+    }
+    
+    public Iterable<Long> getLabelsForNode( long nodeId )
+    {
+        return getReadOnlyResourceIfPossible().getLabelsForNode( nodeId );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFiles.java
@@ -23,21 +23,22 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
 import org.neo4j.kernel.impl.util.FileUtils;
 
 public class StoreFiles
 {
     public static final String[] fileNames = {
             NeoStore.DEFAULT_NAME,
-            "neostore.nodestore.db",
-            "neostore.propertystore.db",
-            "neostore.propertystore.db.arrays",
-            "neostore.propertystore.db.index",
-            "neostore.propertystore.db.index.keys",
-            "neostore.propertystore.db.strings",
-            "neostore.relationshipstore.db",
-            "neostore.relationshiptypestore.db",
-            "neostore.relationshiptypestore.db.names",
+            neoStore( StoreFactory.NODE_STORE_NAME ),
+            neoStore( StoreFactory.PROPERTY_STORE_NAME ),
+            neoStore( StoreFactory.PROPERTY_ARRAYS_STORE_NAME ),
+            neoStore( StoreFactory.PROPERTY_INDEX_STORE_NAME ),
+            neoStore( StoreFactory.PROPERTY_INDEX_KEYS_STORE_NAME ),
+            neoStore( StoreFactory.PROPERTY_STRINGS_STORE_NAME ),
+            neoStore( StoreFactory.RELATIONSHIP_STORE_NAME ),
+            neoStore( StoreFactory.RELATIONSHIP_TYPE_STORE_NAME ),
+            neoStore( StoreFactory.RELATIONSHIP_TYPE_NAMES_STORE_NAME ),
     };
 
     /**
@@ -58,6 +59,11 @@ public class StoreFiles
             moveFile( fileName, fromDirectory, toDirectory );
             moveFile( fileName + ".id", fromDirectory, toDirectory );
         }
+    }
+
+    private static String neoStore( String part )
+    {
+        return NeoStore.DEFAULT_NAME + part;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationTool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationTool.java
@@ -38,6 +38,11 @@ import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+/**
+ * Stand alone tool for migrating/upgrading a neo4j database from one version to the next.
+ * 
+ * @see StoreMigrator
+ */
 public class StoreMigrationTool
 {
     public static void main( String[] args ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.DefaultWindowPoolFactory;
@@ -33,16 +34,24 @@ import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 import org.neo4j.kernel.impl.util.FileUtils;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+/**
+ * Uses {@link StoreMigrator} to upgrade automatically when starting up a database, given the right source database,
+ * environment and configuration for doing so. The migration will happen to a separate, isolated directory
+ * so that an incomplete migration will not affect the original database. Only when a successful migration
+ * has taken place the migrated store will replace the original database.
+ * 
+ * @see StoreMigrator
+ */
 public class StoreUpgrader
 {
-    private Config originalConfig;
-    private UpgradeConfiguration upgradeConfiguration;
-    private UpgradableDatabase upgradableDatabase;
-    private StoreMigrator storeMigrator;
-    private DatabaseFiles databaseFiles;
-    private StringLogger msgLog;
-    private IdGeneratorFactory idGeneratorFactory;
-    private FileSystemAbstraction fileSystemAbstraction;
+    private final Config originalConfig;
+    private final UpgradeConfiguration upgradeConfiguration;
+    private final UpgradableDatabase upgradableDatabase;
+    private final StoreMigrator storeMigrator;
+    private final DatabaseFiles databaseFiles;
+    private final StringLogger msgLog;
+    private final IdGeneratorFactory idGeneratorFactory;
+    private final FileSystemAbstraction fileSystemAbstraction;
 
     public StoreUpgrader( Config originalConfig, StringLogger msgLog, UpgradeConfiguration upgradeConfiguration,
                           UpgradableDatabase upgradableDatabase, StoreMigrator storeMigrator,
@@ -79,8 +88,8 @@ public class StoreUpgrader
     {
         try
         {
-            FileUtils.copyFile( new File( workingDirectory, "messages.log" ),
-                    new File( backupDirectory, "messages.log" ) );
+            FileUtils.copyFile( new File( workingDirectory, StringLogger.DEFAULT_NAME ),
+                    new File( backupDirectory, StringLogger.DEFAULT_NAME ) );
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
@@ -38,6 +38,10 @@ import org.neo4j.kernel.impl.storemigration.legacystore.LegacyRelationshipStoreR
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyRelationshipTypeStoreReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 
+/**
+ * Logic to check whether a database version is upgradable to the current version. It looks at the
+ * version information found in the store files themselves.
+ */
 public class UpgradableDatabase
 {
     /*

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyDynamicStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyDynamicStoreReader.java
@@ -38,11 +38,11 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 public class LegacyDynamicStoreReader
 {
-    public static final String FROM_VERSION_ARRAY = "ArrayPropertyStore v0.9.9";
-    public static final String FROM_VERSION_STRING = "StringPropertyStore v0.9.9";
+    public static final String FROM_VERSION_ARRAY = "ArrayPropertyStore " + LegacyStore.LEGACY_VERSION;
+    public static final String FROM_VERSION_STRING = "StringPropertyStore " + LegacyStore.LEGACY_VERSION;
 
-    private PersistenceWindowPool windowPool;
-    private int blockSize;
+    private final PersistenceWindowPool windowPool;
+    private final int blockSize;
 
     // in_use(byte)+prev_block(int)+nr_of_bytes(int)+next_block(int)
     protected static final int BLOCK_HEADER_SIZE = 1 + 4 + 4 + 4;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyNodeStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyNodeStoreReader.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.nioneo.store.Record;
 
 public class LegacyNodeStoreReader
 {
-    public static final String FROM_VERSION = "NodeStore v0.9.9";
+    public static final String FROM_VERSION = "NodeStore " + LegacyStore.LEGACY_VERSION;
     public static final int RECORD_LENGTH = 9;
 
     private final FileChannel fileChannel;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyPropertyIndexStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyPropertyIndexStoreReader.java
@@ -32,8 +32,8 @@ import org.neo4j.kernel.impl.nioneo.store.Record;
 
 public class LegacyPropertyIndexStoreReader
 {
-    public static final String FROM_VERSION = "PropertyIndex v0.9.9";
-    private File fileName;
+    public static final String FROM_VERSION = "PropertyIndex " + LegacyStore.LEGACY_VERSION;
+    private final File fileName;
 
     public LegacyPropertyIndexStoreReader( File fileName )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyPropertyStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyPropertyStoreReader.java
@@ -35,9 +35,9 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 public class LegacyPropertyStoreReader
 {
-    public static final String FROM_VERSION = "PropertyStore v0.9.9";
+    public static final String FROM_VERSION = "PropertyStore " + LegacyStore.LEGACY_VERSION;
     public static final int RECORD_LENGTH = 25;
-    private PersistenceWindowPool windowPool;
+    private final PersistenceWindowPool windowPool;
     private final FileChannel fileChannel;
 
     public LegacyPropertyStoreReader( File fileNamed ) throws FileNotFoundException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 
 public class LegacyRelationshipStoreReader
 {
-    public static final String FROM_VERSION = "RelationshipStore v0.9.9";
+    public static final String FROM_VERSION = "RelationshipStore " + LegacyStore.LEGACY_VERSION;
     public static final int RECORD_LENGTH = 33;
 
     private final FileChannel fileChannel;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipTypeStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipTypeStoreReader.java
@@ -32,8 +32,8 @@ import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeRecord;
 
 public class LegacyRelationshipTypeStoreReader
 {
-    public static final String FROM_VERSION = "RelationshipTypeStore v0.9.9";
-    private File fileName;
+    public static final String FROM_VERSION = "RelationshipTypeStore " + LegacyStore.LEGACY_VERSION;
+    private final File fileName;
 
     public LegacyRelationshipTypeStoreReader( File fileName )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyStore.java
@@ -24,13 +24,23 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.neo4j.kernel.impl.nioneo.store.IdGeneratorImpl;
+import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+/**
+ * Reader for a database in an older store format version. 
+ * 
+ * Since only one store migration is supported at any given version (migration from the previous store version)
+ * the reader code is specific for the current upgrade and changes with each store format version.
+ * 
+ * {@link #FROM_VERSION} marks which version it's able to read.
+ */
 public class LegacyStore
 {
-    public static final String FROM_VERSION = "NeoStore v0.9.9";
+    public static final String LEGACY_VERSION = "v0.9.9";
+    public static final String FROM_VERSION = "NeoStore " + LEGACY_VERSION;
 
-    private File storageFileName;
+    private final File storageFileName;
     private LegacyNeoStoreReader neoStoreReader;
     private LegacyPropertyStoreReader propertyStoreReader;
     private LegacyNodeStoreReader nodeStoreReader;
@@ -40,7 +50,7 @@ public class LegacyStore
     private LegacyRelationshipStoreReader relationshipStoreReader;
     private LegacyRelationshipTypeStoreReader relationshipTypeStoreReader;
     private LegacyDynamicStoreReader relationshipTypeNameStoreReader;
-    private StringLogger log;
+    private final StringLogger log;
 
     public LegacyStore( File storageFileName ) throws IOException
     {
@@ -57,16 +67,17 @@ public class LegacyStore
     protected void initStorage() throws IOException
     {
         neoStoreReader = new LegacyNeoStoreReader( getStorageFileName(), log );
-        propertyStoreReader = new LegacyPropertyStoreReader( new File( getStorageFileName().getPath() + ".propertystore.db"), log );
-        dynamicRecordFetcher = new LegacyDynamicRecordFetcher( new File( getStorageFileName().getPath() + ".propertystore.db.strings"), new File( getStorageFileName().getPath() + ".propertystore.db.arrays"), log );
-        nodeStoreReader = new LegacyNodeStoreReader( new File( getStorageFileName().getPath() + ".nodestore.db" ));
-        relationshipStoreReader = new LegacyRelationshipStoreReader( new File( getStorageFileName().getPath() + ".relationshipstore.db" ));
-        relationshipTypeStoreReader = new LegacyRelationshipTypeStoreReader( new File( getStorageFileName().getPath() + ".relationshiptypestore.db" ));
-        relationshipTypeNameStoreReader = new LegacyDynamicStoreReader( new File( getStorageFileName().getPath() + ".relationshiptypestore.db.names"), LegacyDynamicStoreReader.FROM_VERSION_STRING, log );
-        propertyIndexStoreReader = new LegacyPropertyIndexStoreReader( new File( getStorageFileName().getPath() + ".propertystore.db.index" ));
-        propertyIndexKeyStoreReader = new LegacyDynamicStoreReader( new File( getStorageFileName().getPath() + ".propertystore.db.index.keys"), LegacyDynamicStoreReader.FROM_VERSION_STRING, log );
+        propertyStoreReader = new LegacyPropertyStoreReader( new File( getStorageFileName().getPath() + StoreFactory.PROPERTY_STORE_NAME ), log );
+        dynamicRecordFetcher = new LegacyDynamicRecordFetcher( new File( getStorageFileName().getPath() + StoreFactory.PROPERTY_STRINGS_STORE_NAME ),
+                new File( getStorageFileName().getPath() + StoreFactory.PROPERTY_ARRAYS_STORE_NAME ), log );
+        nodeStoreReader = new LegacyNodeStoreReader( new File( getStorageFileName().getPath() + StoreFactory.NODE_STORE_NAME ));
+        relationshipStoreReader = new LegacyRelationshipStoreReader( new File( getStorageFileName().getPath() + StoreFactory.RELATIONSHIP_STORE_NAME ));
+        relationshipTypeStoreReader = new LegacyRelationshipTypeStoreReader( new File( getStorageFileName().getPath() + StoreFactory.RELATIONSHIP_TYPE_STORE_NAME ));
+        relationshipTypeNameStoreReader = new LegacyDynamicStoreReader( new File( getStorageFileName().getPath() + StoreFactory.RELATIONSHIP_TYPE_NAMES_STORE_NAME ), LegacyDynamicStoreReader.FROM_VERSION_STRING, log );
+        propertyIndexStoreReader = new LegacyPropertyIndexStoreReader( new File( getStorageFileName().getPath() + StoreFactory.PROPERTY_INDEX_STORE_NAME ));
+        propertyIndexKeyStoreReader = new LegacyDynamicStoreReader( new File( getStorageFileName().getPath() + StoreFactory.PROPERTY_INDEX_KEYS_STORE_NAME ), LegacyDynamicStoreReader.FROM_VERSION_STRING, log );
     }
-
+    
     public File getStorageFileName()
     {
         return storageFileName;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogEntry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogEntry.java
@@ -29,8 +29,9 @@ public abstract class LogEntry
 {
     /* version 1 as of 2011-02-22
      * version 2 as of 2011-10-17
+     * version 3 as of 2013-02-09: neo4j 2.0 Labels & Indexing
      */
-    static final byte CURRENT_VERSION = (byte) 2;
+    static final byte CURRENT_VERSION = (byte) 3;
     // empty record due to memory mapped file
     public static final byte EMPTY = (byte) 0;
     public static final byte TX_START = (byte) 1;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.batchinsert;
 
 import static java.lang.Boolean.parseBoolean;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.impl.nioneo.store.PropertyStore.encodeString;
 
 import java.io.File;
@@ -844,10 +845,9 @@ public class BatchInserterImpl implements BatchInserter
         PropertyIndexRecord record = new PropertyIndexRecord( keyId );
         record.setInUse( true );
         record.setCreated();
-        int nameId = idxStore.nextNameId();
-        record.setNameId( nameId );
         Collection<DynamicRecord> keyRecords =
-                idxStore.allocateNameRecords( nameId, encodeString( stringKey ) );
+                idxStore.allocateNameRecords( encodeString( stringKey ) );
+        record.setNameId( (int) first( keyRecords ).getId() );
         for ( DynamicRecord keyRecord : keyRecords )
         {
             record.addNameRecord( keyRecord );
@@ -864,9 +864,8 @@ public class BatchInserterImpl implements BatchInserter
         RelationshipTypeRecord record = new RelationshipTypeRecord( id );
         record.setInUse( true );
         record.setCreated();
-        int nameId = typeStore.nextNameId();
-        record.setNameId( nameId );
-        Collection<DynamicRecord> nameRecords = typeStore.allocateNameRecords( nameId, encodeString( name ) );
+        Collection<DynamicRecord> nameRecords = typeStore.allocateNameRecords( encodeString( name ) );
+        record.setNameId( (int) first( nameRecords ).getId() );
         for ( DynamicRecord typeRecord : nameRecords )
         {
             record.addNameRecord( typeRecord );
@@ -957,6 +956,7 @@ public class BatchInserterImpl implements BatchInserter
     /**
      * @deprecated as of Neo4j 1.7
      */
+    @Deprecated
     public GraphDatabaseService getBatchGraphDbService()
     {
         return new BatchGraphDatabaseImpl( this );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/SetCacheProvidersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/SetCacheProvidersTest.java
@@ -22,12 +22,14 @@ package org.neo4j.graphdb.factory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import org.junit.Test;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.cache.SoftCacheProvider;
+import org.neo4j.test.TargetDirectory;
 
 public class SetCacheProvidersTest
 {
@@ -39,7 +41,7 @@ public class SetCacheProvidersTest
         gdbf.setCacheProviders( cacheList );
         try
         {
-            gdbf.newEmbeddedDatabase( "target/db" );
+            gdbf.newEmbeddedDatabase( storeDir.getAbsolutePath() );
         }
         catch ( IllegalArgumentException iae )
         {
@@ -54,8 +56,10 @@ public class SetCacheProvidersTest
         GraphDatabaseFactory gdbf = new GraphDatabaseFactory();
         cacheList.add( new SoftCacheProvider() );
         gdbf.setCacheProviders( cacheList );
-        EmbeddedGraphDatabase db = (EmbeddedGraphDatabase) gdbf.newEmbeddedDatabase( "target/db" );
+        EmbeddedGraphDatabase db = (EmbeddedGraphDatabase) gdbf.newEmbeddedDatabase( storeDir.getAbsolutePath() );
         assertEquals( SoftCacheProvider.NAME,
                 db.getNodeManager().getCacheType().getName() );
     }
+    
+    private final File storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TemporaryLabelAsPropertyStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TemporaryLabelAsPropertyStatementContextTest.java
@@ -86,7 +86,8 @@ public class TemporaryLabelAsPropertyStatementContextTest
 
         // THEN
         Iterable<Long> readLabels = statement.getLabelsForNode( nodeId );
-        assertEquals( new HashSet<Long>( asList( labelId1, labelId2 ) ), addToCollection( readLabels, new HashSet<Long>() ) );
+        assertEquals( new HashSet<Long>( asList( labelId1, labelId2 ) ),
+                addToCollection( readLabels, new HashSet<Long>() ) );
     }
     
     @Test
@@ -326,7 +327,7 @@ public class TemporaryLabelAsPropertyStatementContextTest
     public void before()
     {
         db = new ImpermanentGraphDatabase();
-        statement = new TemporaryLabelAsPropertyStatementContext(
+        statement = new StoreStatementContext(
                 db.getDependencyResolver().resolveDependency( PropertyIndexManager.class ),
                 db.getDependencyResolver().resolveDependency( PersistenceManager.class ),
                 // Ooh, jucky

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
+import static org.neo4j.kernel.impl.nioneo.store.NodeStore.RECORD_SIZE;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class TestJumpingIdGenerator
         IdGenerator generator = factory.get( IdType.NODE );
         for ( int i = 0; i < sizePerJump/2; i++ )
         {
-            assertEquals( (long)i, generator.nextId() );
+            assertEquals( i, generator.nextId() );
         }
         
         for ( int i = 0; i < sizePerJump-1; i++ )
@@ -95,8 +96,8 @@ public class TestJumpingIdGenerator
 
     private byte readSomethingLikeNodeRecord( JumpingFileChannel channel, long id ) throws IOException
     {
-        ByteBuffer buffer = ByteBuffer.allocate( 9 );
-        channel.position( id*9 );
+        ByteBuffer buffer = ByteBuffer.allocate( RECORD_SIZE );
+        channel.position( id*RECORD_SIZE );
         channel.read( buffer );
         buffer.flip();
         buffer.getLong();
@@ -105,8 +106,8 @@ public class TestJumpingIdGenerator
 
     private void writeSomethingLikeNodeRecord( JumpingFileChannel channel, long id, int justAByte ) throws IOException
     {
-        channel.position( id*9 );
-        ByteBuffer buffer = ByteBuffer.allocate( 9 );
+        channel.position( id*RECORD_SIZE );
+        ByteBuffer buffer = ByteBuffer.allocate( RECORD_SIZE );
         buffer.putLong( 4321 );
         buffer.put( (byte) justAByte );
         buffer.flip();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/SchemaStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/SchemaStoreTest.java
@@ -23,6 +23,7 @@ import static java.nio.ByteBuffer.wrap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.StringLogger.SYSTEM;
 
@@ -53,11 +54,11 @@ public class SchemaStoreTest
         expected.put( Kind.INDEX_RULE.id() );
         expected.putShort( (short) 1 );
         expected.putLong( propertyKey );
-        long blockId = store.nextId();
-        SchemaRule indexRule = new IndexRule( blockId, labelId, new long[] {propertyKey} );
+        SchemaRule indexRule = new IndexRule( -1, labelId, new long[] {propertyKey} );
 
         // WHEN
-        Collection<DynamicRecord> records = store.allocateFrom( blockId, indexRule );
+        Collection<DynamicRecord> records = store.allocateFrom( indexRule );
+        long blockId = first( records ).getId();
         for ( DynamicRecord record : records )
             store.updateRecord( record );
         
@@ -130,11 +131,10 @@ public class SchemaStoreTest
 
     private long storeRule( SchemaRule rule )
     {
-        long id = store.nextId();
-        Collection<DynamicRecord> records = store.allocateFrom( id, rule );
+        Collection<DynamicRecord> records = store.allocateFrom( rule );
         for ( DynamicRecord record : records )
             store.updateRecord( record );
-        return id;
+        return first( records ).getId();
     }
 
     private Config config;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreVersionTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,7 +93,7 @@ public class StoreVersionTest
         try
         {
             new NodeStore( workingFile, config, new DefaultIdGeneratorFactory(),
-                    new DefaultWindowPoolFactory(), fileSystem, StringLogger.SYSTEM );
+                    new DefaultWindowPoolFactory(), fileSystem, StringLogger.SYSTEM, null );
             fail( "Should have thrown exception" );
         }
         catch ( NotCurrentStoreVersionException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestArrayStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestArrayStore.java
@@ -19,9 +19,8 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.helpers.collection.IteratorUtil.first;
 
 import java.io.File;
 import java.lang.reflect.Array;
@@ -103,7 +102,7 @@ public class TestArrayStore
     public void stringArrayGetsStoredAsUtf8() throws Exception
     {
         String[] array = new String[] { "first", "second" };
-        Collection<DynamicRecord> records = arrayStore.allocateRecords( arrayStore.nextId(), array );
+        Collection<DynamicRecord> records = arrayStore.allocateRecords( array );
         Pair<byte[], byte[]> loaded = loadArray( records );
         assertStringHeader( loaded.first(), array.length );
         ByteBuffer buffer = ByteBuffer.wrap( loaded.other() );
@@ -143,7 +142,7 @@ public class TestArrayStore
 
     private Collection<DynamicRecord> storeArray( Object array )
     {
-        Collection<DynamicRecord> records = arrayStore.allocateRecords( arrayStore.nextId(), array );
+        Collection<DynamicRecord> records = arrayStore.allocateRecords( array );
         for ( DynamicRecord record : records )
             arrayStore.updateRecord( record );
         return records;
@@ -151,6 +150,6 @@ public class TestArrayStore
     
     private Pair<byte[], byte[]> loadArray( Collection<DynamicRecord> records )
     {
-        return PropertyStore.readFullByteArray( first( records ).getId(), records, arrayStore, PropertyType.ARRAY );
+        return arrayStore.readFullByteArray( records, PropertyType.ARRAY );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGrowingFileMemoryMapping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGrowingFileMemoryMapping.java
@@ -63,7 +63,7 @@ public class TestGrowingFileMemoryMapping
                 NodeStore.TYPE_DESCRIPTOR ) );
 
         NodeStore nodeStore = new NodeStore( fileName, config, idGeneratorFactory, new DefaultWindowPoolFactory(),
-                new DefaultFileSystemAbstraction(), StringLogger.SYSTEM );
+                new DefaultFileSystemAbstraction(), StringLogger.SYSTEM, null );
 
         // when
         for ( int i = 0; i < 2 * NUMBER_OF_RECORDS; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -221,6 +221,10 @@ public class TestNeoStore extends AbstractNeo4jTestCase
         file.delete();
         file = file( "neo.nodestore.db.id" );
         file.delete();
+        file = file( "neo.nodestore.db.labels" );
+        file.delete();
+        file = file( "neo.nodestore.db.labels.id" );
+        file.delete();
         file = file( "neo.propertystore.db" );
         file.delete();
         file = file( "neo.propertystore.db.id" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
@@ -175,6 +175,16 @@ public class TestXa extends AbstractNeo4jTestCase
         {
             assertTrue( file.delete() );
         }
+        file = file( "neo.nodestore.db.labels" );
+        if ( file.exists() )
+        {
+            assertTrue( file.delete() );
+        }
+        file = file( "neo.nodestore.db.labels.id" );
+        if ( file.exists() )
+        {
+            assertTrue( file.delete() );
+        }
         file = file( "neo.propertystore.db" );
         if ( file.exists() )
         {
@@ -872,7 +882,7 @@ public class TestXa extends AbstractNeo4jTestCase
         ds.stop();
         deleteLogicalLogIfExist();
         renameCopiedLogicalLog( path() );
-        truncateLogicalLog( 264 );
+        truncateLogicalLog( 288 );
         ds = newNeoStore();
         xaCon = ds.getXaConnection();
         xaRes = xaCon.getXaResource();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogicTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogicTest.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+import static org.neo4j.kernel.impl.util.Bits.bits;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.DefaultTxHook;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.nioneo.store.DefaultWindowPoolFactory;
+import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeStore;
+import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
+import org.neo4j.kernel.impl.util.Bits;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+public class NodeLabelRecordLogicTest
+{
+    @Test
+    public void shouldInlineOneLabel() throws Exception
+    {
+        // GIVEN
+        long labelId = 10;
+        NodeRecord node = nodeRecordWithInlinedLabels();
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, null );
+        
+        // WHEN
+        manipulator.add( labelId );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId ), node.getLabelField() );
+    }
+
+    @Test
+    public void shouldInlineTwoSmallLabels() throws Exception
+    {
+        // GIVEN
+        long labelId1 = 10, labelId2 = 30;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, null );
+        
+        // WHEN
+        manipulator.add( labelId2 );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId1, labelId2 ), node.getLabelField() );
+    }
+
+    @Test
+    public void shouldInlineThreeSmallLabels() throws Exception
+    {
+        // GIVEN
+        long labelId1 = 10, labelId2 = 30, labelId3 = 4095;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1, labelId2 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, null );
+        
+        // WHEN
+        manipulator.add( labelId3 );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId1, labelId2, labelId3 ), node.getLabelField() );
+    }
+    
+    @Test
+    public void shouldInlineFourSmallLabels() throws Exception
+    {
+        // GIVEN
+        long labelId1 = 10, labelId2 = 30, labelId3 = 45, labelId4 = 60;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1, labelId2, labelId3 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, null );
+        
+        // WHEN
+        manipulator.add( labelId4 );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId1, labelId2, labelId3, labelId4 ), node.getLabelField() );
+    }
+    
+    @Test
+    public void shouldInlineFiveSmallLabels() throws Exception
+    {
+        // GIVEN
+        long labelId1 = 10, labelId2 = 30, labelId3 = 45, labelId4 = 60, labelId5 = 61;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1, labelId2, labelId3, labelId4 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, null );
+        
+        // WHEN
+        manipulator.add( labelId5 );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId1, labelId2, labelId3, labelId4, labelId5 ),
+                node.getLabelField() );
+    }
+    
+    @Test
+    public void shouldSpillOverToDynamicRecordIfExceedsInlinedSpace() throws Exception
+    {
+        // GIVEN -- the upper limit for a label ID for 3 labels would be 36b/3 - 1 = 12b - 1 = 4095
+        long labelId1 = 10, labelId2 = 30, labelId3 = 4096;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1, labelId2 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+        
+        // WHEN
+        Iterable<DynamicRecord> changedDynamicRecords = manipulator.add( labelId3 );
+
+        // THEN
+        assertEquals( 1, count( changedDynamicRecords ) );
+        assertEquals( dynamicLabelsLongRepresentation( changedDynamicRecords ), node.getLabelField() );
+        assertTrue( Arrays.equals( new long[] {labelId1, labelId2, labelId3},
+                nodeStore.getDynamicLabelsArray( changedDynamicRecords ) ) );
+    }
+
+    @Test
+    public void oneDynamicRecordShouldExtendIntoAnAdditionalIfTooManyLabels() throws Exception
+    {
+        // GIVEN
+        // will occupy 60B of data, i.e. one dynamic record
+        NodeRecord node = nodeRecordWithDynamicLabels( nodeStore, oneByteLongs( 57 ) );
+        Collection<DynamicRecord> initialRecords = node.getDynamicLabelRecords();
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        Set<DynamicRecord> changedDynamicRecords = asSet( manipulator.add( 1 ) );
+
+        // THEN
+        assertTrue( changedDynamicRecords.containsAll( initialRecords ) );
+        assertEquals( initialRecords.size()+1, changedDynamicRecords.size() );
+    }
+    
+    @Test
+    public void twoDynamicRecordsShouldShrinkToOneWhenRemoving() throws Exception
+    {
+        // GIVEN
+        // will occupy 61B of data, i.e. just two dynamic records
+        NodeRecord node = nodeRecordWithDynamicLabels( nodeStore, oneByteLongs( 58 ) );
+        Collection<DynamicRecord> initialRecords = node.getDynamicLabelRecords();
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        List<DynamicRecord> changedDynamicRecords = addToCollection(
+                manipulator.remove( 255 /*Initial labels go from 255 and down to 255-58*/ ),
+                new ArrayList<DynamicRecord>() );
+
+        // THEN
+        assertEquals( initialRecords, changedDynamicRecords );
+        assertTrue( changedDynamicRecords.get( 0 ).inUse() );
+        assertFalse( changedDynamicRecords.get( 1 ).inUse() );
+    }
+    
+    @Test
+    public void oneDynamicRecordShouldShrinkIntoInlinedWhenRemoving() throws Exception
+    {
+        // GIVEN
+        NodeRecord node = nodeRecordWithDynamicLabels( nodeStore, oneByteLongs( 5 ) );
+        Collection<DynamicRecord> initialRecords = node.getDynamicLabelRecords();
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        Collection<DynamicRecord> changedDynamicRecords = asCollection( manipulator.remove( 255 ) );
+
+        // THEN
+        assertEquals( initialRecords, changedDynamicRecords );
+        assertFalse( single( changedDynamicRecords ).inUse() );
+        assertEquals( inlinedLabelsLongRepresentation( 251, 252, 253, 254 ), node.getLabelField() );
+    }
+    
+    @Test
+    public void maximumOfEightInlinedLabels() throws Exception
+    {
+        // GIVEN
+        long[] labels = new long[] {0, 1, 2, 3, 4, 5, 6};
+        NodeRecord node = nodeRecordWithInlinedLabels( labels );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        Iterable<DynamicRecord> changedDynamicRecords = manipulator.add( 23 );
+
+        // THEN
+        assertEquals( dynamicLabelsLongRepresentation( changedDynamicRecords ), node.getLabelField() );
+        assertEquals( 1, count( changedDynamicRecords ) );
+    }
+    
+    @Test
+    public void addingAnAlreadyAddedLabelWhenLabelsAreInlinedShouldFail() throws Exception
+    {
+        // GIVEN
+        long labelId = 1;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        try
+        {
+            manipulator.add( labelId );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+    
+    @Test
+    public void addingAnAlreadyAddedLabelWhenLabelsAreInDynamicRecordsShouldFail() throws Exception
+    {
+        // GIVEN
+        long[] labels = oneByteLongs( 20 );
+        NodeRecord node = nodeRecordWithDynamicLabels( nodeStore, labels );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        try
+        {
+            manipulator.add( labels[0] );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+    
+    @Test
+    public void removingNonExistentInlinedLabelShouldFail() throws Exception
+    {
+        // GIVEN
+        long labelId1 = 1, labelId2 = 2;
+        NodeRecord node = nodeRecordWithInlinedLabels( labelId1 );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        try
+        {
+            manipulator.remove( labelId2 );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void removingNonExistentLabelInDynamicRecordsShouldFail() throws Exception
+    {
+        // GIVEN
+        long[] labels = oneByteLongs( 20 );
+        NodeRecord node = nodeRecordWithDynamicLabels( nodeStore, labels );
+        NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( node, nodeStore );
+
+        // WHEN
+        try
+        {
+            manipulator.remove( 123456L );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+    
+    private long dynamicLabelsLongRepresentation( Iterable<DynamicRecord> records )
+    {
+        return 0x8000000000L|first( records ).getId();
+    }
+
+    private long inlinedLabelsLongRepresentation( long... labelIds )
+    {
+        long header = (long)labelIds.length << 36;
+        byte bitsPerLabel = (byte) (36/labelIds.length);
+        Bits bits = bits( 5 );
+        for ( long labelId : labelIds )
+            bits.put( labelId, bitsPerLabel );
+        return header|bits.getLongs()[0];
+    }
+    
+    private EphemeralFileSystemAbstraction fs;
+    private NodeStore nodeStore;
+    
+    @Before
+    public void startUp()
+    {
+        StoreFactory storeFactory = new StoreFactory( new Config(), new DefaultIdGeneratorFactory(),
+                new DefaultWindowPoolFactory(), (fs = new EphemeralFileSystemAbstraction()), StringLogger.SYSTEM,
+                new DefaultTxHook() );
+        File storeFile = new File( "store" );
+        storeFactory.createNodeStore( storeFile );
+        nodeStore = storeFactory.newNodeStore( storeFile );
+    }
+    
+    @After
+    public void cleanUp()
+    {
+        if ( nodeStore != null )
+            nodeStore.close();
+        if ( fs != null )
+            fs.shutdown();
+    }
+
+    private NodeRecord nodeRecordWithInlinedLabels( long... labels )
+    {
+        NodeRecord node = new NodeRecord( 0, 0, 0 );
+        if ( labels.length > 0 )
+            node.setLabelField( inlinedLabelsLongRepresentation( labels ) );
+        return node;
+    }
+    
+    private NodeRecord nodeRecordWithDynamicLabels( NodeStore nodeStore, long... labels )
+    {
+        Collection<DynamicRecord> initialRecords = allocateAndApply( nodeStore, labels );
+        NodeRecord node = new NodeRecord( 0, 0, 0 );
+        node.setLabelField( dynamicLabelsLongRepresentation( initialRecords ), initialRecords );
+        return node;
+    }
+    
+    private Collection<DynamicRecord> allocateAndApply( NodeStore nodeStore, long[] longs )
+    {
+        Collection<DynamicRecord> records = nodeStore.allocateRecordsForDynamicLabels( longs );
+        nodeStore.updateDynamicLabelRecords( records );
+        return records;
+    }
+
+    private long[] oneByteLongs( int numberOfLongs )
+    {
+        long[] result = new long[numberOfLongs];
+        for ( int i = 0; i < numberOfLongs; i++ )
+            result[i] = 255-i;
+        Arrays.sort( result );
+        return result;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriterTest.java
@@ -19,12 +19,21 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,19 +43,12 @@ import org.junit.Test;
 import org.junit.internal.matchers.TypeSafeMatcher;
 import org.mockito.InOrder;
 import org.neo4j.kernel.impl.nioneo.store.AbstractBaseRecord;
+import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.transaction.xaframework.InMemoryLogBuffer;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionReader;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TransactionWriterTest
 {
@@ -58,6 +60,7 @@ public class TransactionWriterTest
         TransactionWriter writer = new TransactionWriter( buffer, 1 );
 
         NodeRecord node = new NodeRecord( 0, -1, -1 );
+        node.setLabelField( 0, Collections.<DynamicRecord>emptyList() );
         RelationshipRecord relationship = new RelationshipRecord( 0, 1, 1, 6 );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -73,11 +73,12 @@ public class WriteTransactionTest
     public void shouldRemoveSchemaRuleFromCacheWhenApplyingTransactionThatDeletesOne() throws Exception
     {
         // GIVEN
-        long ruleId = schemaStore.nextId(), labelId = 10;
-        long propertyKey = 10;
-        IndexRule rule = new IndexRule( ruleId, labelId, new long[] {propertyKey} );
-        for ( DynamicRecord record : schemaStore.allocateFrom( ruleId, rule ) )
+        long labelId = 10, propertyKey = 10;
+        IndexRule rule = new IndexRule( -1, labelId, new long[] {propertyKey} );
+        Collection<DynamicRecord> records = schemaStore.allocateFrom( rule );
+        for ( DynamicRecord record : records )
             schemaStore.updateRecord( record );
+        long ruleId = first( records ).getId();
         WriteTransaction writeTransaction = new WriteTransaction( 0, log, transactionState, neoStore,
                 cacheAccessBackDoor );
         writeTransaction.setCommitTxId( 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/NeoStoreVersionRecordUpgradeIssueIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/NeoStoreVersionRecordUpgradeIssueIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -32,6 +33,7 @@ import org.neo4j.kernel.impl.nioneo.store.ProduceUncleanStore;
 import org.neo4j.kernel.impl.util.FileUtils;
 import org.neo4j.test.TargetDirectory;
 
+@Ignore( "Only applicable between versions 1.5 and 1.6. Left here for informational reasons, if any." )
 public class NeoStoreVersionRecordUpgradeIssueIT
 {
     public final @Rule TestName testName = new TestName();

--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
@@ -47,26 +47,11 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.impl.nioneo.store.FileLock;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-public class EphemeralFileSystemAbstraction implements FileSystemAbstraction, Lifecycle
+public class EphemeralFileSystemAbstraction extends LifecycleAdapter implements FileSystemAbstraction
 {
     private final Map<File, EphemeralFileData> files = new HashMap<File, EphemeralFileData>();
-
-    @Override
-    public void init()
-    {
-    }
-
-    @Override
-    public void start()
-    {
-    }
-
-    @Override
-    public void stop()
-    {
-    }
 
     @Override
     public void shutdown()

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneThreeFiveUpgradeIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneThreeFiveUpgradeIT.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -42,6 +43,7 @@ import org.neo4j.test.TargetDirectory;
  * Tests upgrade from a neo4j 1.5 store (which had lucene version 3.1.0) to a
  * new neo4j version which has lucene version 3.5.0
  */
+@Ignore( "Not valid since 2.0 and forwards, since the store format was changed" )
 public class LuceneThreeFiveUpgradeIT
 {
     public final @Rule TestName testName = new TestName();

--- a/community/server/src/functionaltest/java/org/neo4j/server/WrappingNeoServerBootstrapperTest.java
+++ b/community/server/src/functionaltest/java/org/neo4j/server/WrappingNeoServerBootstrapperTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.server;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.ClientResponse.Status;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -45,8 +45,12 @@ import org.neo4j.server.rest.RESTDocsGenerator;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.shell.ShellSettings;
 import org.neo4j.test.ImpermanentGraphDatabase;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse.Status;
 
 public class WrappingNeoServerBootstrapperTest extends ExclusiveServerTestBase
 {
@@ -96,7 +100,7 @@ public class WrappingNeoServerBootstrapperTest extends ExclusiveServerTestBase
         // START SNIPPET: customConfiguredWrappingNeoServerBootstrapper
         // let the database accept remote neo4j-shell connections
         GraphDatabaseAPI graphdb = (GraphDatabaseAPI) new GraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( "target/configDb" )
+                .newEmbeddedDatabaseBuilder( TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath() )
                 .setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE )
                 .newGraphDatabase();
         ServerConfigurator config;

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/TestEnterpriseDatabase.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/TestEnterpriseDatabase.java
@@ -25,16 +25,18 @@ import static org.junit.Assert.assertThat;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Test;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
+import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.MapBasedConfiguration;
-
+import org.neo4j.test.TargetDirectory;
 
 public class TestEnterpriseDatabase
 {
-
     @Test
     public void shouldStartInSingleModeByDefault() throws Throwable
     {
         Configuration config = new MapBasedConfiguration();
+        config.getString( Configurator.DATABASE_LOCATION_PROPERTY_KEY,
+                TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath() );
         EnterpriseDatabase db = new EnterpriseDatabase( config );
 
         try


### PR DESCRIPTION
WARNING: This change increases the store format version as well as the logical log version, but migration isn't supported yet.

o Integrated and working solution for storing node labels on the node record
  itself. If the in-record space isn't enough it will spill over to a
  dymamic array store dedicated for node labels.
o Javadocs on store migration
o Can create the node label store lazily to allow for a bridge until real migration is in place
o Refactorings/cleanup in store classes w/ regards to allocating/reading arrays
