### PR TITLE
Removes RagManager dependency on TxManager

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -777,7 +777,7 @@ public abstract class InternalAbstractGraphDatabase
 
     protected LockManager createLockManager()
     {
-        return new LockManagerImpl( new RagManager( txManager ) );
+        return new LockManagerImpl( new RagManager() );
     }
 
     protected Logging createLogging()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LockElement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LockElement.java
@@ -30,11 +30,15 @@ public class LockElement implements Lock
     private Object resource;
     private final LockType lockType;
     private final LockManager lockManager;
+    private final Transaction tx;
 
-    public LockElement( Object resource, LockType type, LockManager lockManager )
+    public LockElement( Object resource, Transaction tx, LockType type, LockManager lockManager )
     {
         if ( resource == null )
             throw new IllegalArgumentException( "Null resource" );
+        if ( tx == null )
+            throw new IllegalArgumentException( "Null tx" );
+        this.tx = tx;
         this.resource = resource;
         this.lockType = type;
         this.lockManager = lockManager;
@@ -46,13 +50,6 @@ public class LockElement implements Lock
     }
 
     public boolean releaseIfAcquired()
-    {
-        // Assume that we are in a tx context, and will be able 
-        // to figure out the tx when we actually end up needing it. 
-        return releaseIfAcquired( null );
-    }
-
-    public boolean releaseIfAcquired( Transaction tx )
     {
         if ( released() )
             return false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
@@ -258,8 +258,8 @@ public class WritableTransactionState implements TransactionState
     @Override
     public LockElement acquireWriteLock( Object resource )
     {
-        lockManager.getWriteLock( resource );
-        LockElement lock = new LockElement( resource, LockType.WRITE, lockManager );
+        lockManager.getWriteLock( resource, tx );
+        LockElement lock = new LockElement( resource, tx, LockType.WRITE, lockManager );
         addLockToTransaction( lock );
         return lock;
     }
@@ -267,8 +267,8 @@ public class WritableTransactionState implements TransactionState
     @Override
     public LockElement acquireReadLock( Object resource )
     {
-        lockManager.getReadLock( resource );
-        LockElement lock = new LockElement( resource, LockType.READ, lockManager );
+        lockManager.getReadLock( resource, tx );
+        LockElement lock = new LockElement( resource, tx, LockType.READ, lockManager );
         addLockToTransaction( lock );
         return lock;
     }
@@ -376,7 +376,7 @@ public class WritableTransactionState implements TransactionState
             {
                 try
                 {
-                    lockElement.releaseIfAcquired( tx );
+                    lockElement.releaseIfAcquired();
                 }
                 catch ( Exception e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockManager.java
@@ -29,14 +29,8 @@ import org.neo4j.kernel.logging.Logging;
 
 public interface LockManager
 {
-    void getReadLock( Object resource )
-            throws DeadlockDetectedException, IllegalResourceException;
-
     void getReadLock( Object resource, Transaction tx )
                 throws DeadlockDetectedException, IllegalResourceException;
-
-    void getWriteLock( Object resource )
-                        throws DeadlockDetectedException, IllegalResourceException;
 
     void getWriteLock( Object resource, Transaction tx )
                             throws DeadlockDetectedException, IllegalResourceException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNode.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNode.java
@@ -19,11 +19,18 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.Exceptions.launderedException;
+
 import java.lang.Thread.State;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.junit.Test;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
@@ -31,8 +38,6 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
-
-import static org.junit.Assert.*;
 
 public class TestNode extends AbstractNeo4jTestCase
 {
@@ -385,14 +390,14 @@ public class TestNode extends AbstractNeo4jTestCase
                 Transaction tx = getGraphDb().beginTx();
                 try
                 {
-                    getEmbeddedGraphDb().getLockManager().getWriteLock( entity );
+                    getEmbeddedGraphDb().getLockManager().getWriteLock( entity, getEmbeddedGraphDb().getTxManager().getTransaction() );
                     gotTheLock.set( true );
                     tx.success();
                 }
-                catch ( RuntimeException e )
+                catch ( Exception e )
                 {
                     e.printStackTrace();
-                    throw e;
+                    throw launderedException( e );
                 }
                 finally
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LockWorker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LockWorker.java
@@ -50,7 +50,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state )
             {
                 state.doing( "+R " + resource + ", wait:" + wait );
-                state.grabber.getReadLock( resource );
+                state.grabber.getReadLock( resource, state.tx );
                 state.done();
             }
         }, wait );
@@ -64,7 +64,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state )
             {
                 state.doing( "+W " + resource + ", wait:" + wait );
-                state.grabber.getWriteLock( resource );
+                state.grabber.getWriteLock( resource, state.tx );
                 state.done();
             }
         }, wait );
@@ -78,7 +78,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state )
             {
                 state.doing( "-R " + resource );
-                state.grabber.releaseReadLock( resource, null );
+                state.grabber.releaseReadLock( resource, state.tx );
                 state.done();
             }
         }, true );
@@ -92,7 +92,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state )
             {
                 state.doing( "-W " + resource );
-                state.grabber.releaseWriteLock( resource, null );
+                state.grabber.releaseWriteLock( resource, state.tx );
                 state.done();
             }
         }, true );
@@ -129,6 +129,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             this.name = name;
         }
 
+        @Override
         public String toString()
         {
             return this.name;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LockWorkerState.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LockWorkerState.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.transaction.Transaction;
 
 class LockWorkerState
 {
@@ -28,6 +32,7 @@ class LockWorkerState
     volatile boolean deadlockOnLastWait;
     final List<String> completedOperations = new ArrayList<String>();
     String doing;
+    final Transaction tx = mock( Transaction.class );
     
     public LockWorkerState( LockManager grabber )
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -66,7 +66,7 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
     @Override
     protected LockManager getMasterImpl()
     {
-        return new LockManagerImpl( new RagManager( txManager ) );
+        return new LockManagerImpl( new RagManager() );
     }
 
     @Override
@@ -81,7 +81,7 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
             }
         };
 
-        return new SlaveLockManager(txManager, txHook, switchBlock, slaveConfig, new RagManager( txManager ),
+        return new SlaveLockManager(txManager, txHook, switchBlock, slaveConfig, new RagManager(),
                 requestContextFactory, master, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -81,15 +81,6 @@ public class SlaveLockManager implements LockManager
     }
 
     @Override
-    public void getReadLock( Object resource ) throws DeadlockDetectedException, IllegalResourceException
-    {
-        if ( getReadLockOnMaster( resource ) )
-        {
-            local.getReadLock( resource );
-        }
-    }
-
-    @Override
     public void getReadLock( Object resource, Transaction tx ) throws DeadlockDetectedException, IllegalResourceException
     {
         if ( getReadLockOnMaster( resource ) )
@@ -145,15 +136,6 @@ public class SlaveLockManager implements LockManager
         }
 
         return true;
-    }
-
-    @Override
-    public void getWriteLock( Object resource ) throws DeadlockDetectedException, IllegalResourceException
-    {
-        if ( getWriteLockOnMaster( resource ) )
-        {
-            local.getWriteLock( resource );
-        }
     }
 
     @Override


### PR DESCRIPTION
since all lock requests now needs to pass in the transaction explicitly. There's now no such thing as trying to figure out the transaction late by using the transaction manager.

This makes things more explicit, less entangled and easier to reason about.
