### PR TITLE
Uses suspend/resume instead of spawning a separate thread for keys

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -641,7 +641,7 @@ class TransactionImpl implements Transaction
      * However, in the spirit of baby steps, we hook into the current tx infrastructure at a few
      * points to not have to do the full move in one step.
      */
-    public void setTranscationContext( TransactionContext transactionContext )
+    public void setTransactionContext( TransactionContext transactionContext )
     {
         this.transactionContext = transactionContext;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -326,7 +326,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         startedTxCount.incrementAndGet();
         // start record written on resource enlistment
 
-        tx.setTranscationContext(kernel.newTransactionContext() );
+        tx.setTransactionContext(kernel.newTransactionContext() );
     }
 
     private void assertTmOk( String source ) throws SystemException


### PR DESCRIPTION
i.e. relationship types and property keys
