### PR TITLE
Changed so index queries and all-node queries use Iterator instead of Iterable

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/GetGraphElements.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/GetGraphElements.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.ParameterWrongTypeException
 import collection.JavaConverters._
 
 object GetGraphElements {
-  def getElements[T: Manifest](data: Any, name: String, getElement: Long => T): Iterable[T] = {
+  def getElements[T: Manifest](data: Any, name: String, getElement: Long => T): Iterator[T] = {
     def castElement(x: Any): T = x match {
       case i: Int    => getElement(i)
       case i: Long   => getElement(i)
@@ -33,11 +33,12 @@ object GetGraphElements {
     }
 
     data match {
-      case result: Int                   => Iterable(getElement(result))
-      case result: Long                  => Iterable(getElement(result))
-      case result: java.lang.Iterable[_] => result.asScala.view.map(castElement)
-      case result: Seq[_]                => result.view.map(castElement)
-      case element: PropertyContainer    => Iterable(element.asInstanceOf[T])
+      case result: Int                   => Iterator(getElement(result))
+      case result: Long                  => Iterator(getElement(result))
+      case result: java.util.Iterator[_] => result.asScala.map(castElement)
+      case result: java.lang.Iterable[_] => result.asScala.view.map(castElement).iterator
+      case result: Seq[_]                => result.view.map(castElement).iterator
+      case element: PropertyContainer    => Iterator(element.asInstanceOf[T])
       case x                             => throw new ParameterWrongTypeException("Expected a propertycontainer or number here, but got: " + x.toString)
     }
   }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/IndexQueryBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/IndexQueryBuilder.scala
@@ -73,16 +73,14 @@ object IndexQueryBuilder {
         (m, state) => {
           val keyVal = key(m)(state).toString
           val valueVal = value(m)(state)
-          // TODO memory waste
-          state.query.nodeOps.indexGet(idxName,keyVal, valueVal).toList
+          state.query.nodeOps.indexGet(idxName,keyVal, valueVal)
         }
 
       case NodeByIndexQuery(varName, idxName, query) =>
         checkNodeIndex(idxName, graph)
         (m, state) => {
           val queryText = query(m)(state)
-          // TODO memory waste
-          state.query.nodeOps.indexQuery(idxName, queryText).toList
+          state.query.nodeOps.indexQuery(idxName, queryText)
         }
 
       case NodeById(varName, ids) =>
@@ -98,16 +96,14 @@ object IndexQueryBuilder {
         (m, state) => {
           val keyVal = key(m)(state).toString
           val valueVal = value(m)(state)
-          // TODO memory waste
-          state.query.relationshipOps.indexGet(idxName, keyVal, valueVal).toList
+          state.query.relationshipOps.indexGet(idxName, keyVal, valueVal)
         }
 
       case RelationshipByIndexQuery(varName, idxName, query) =>
         checkRelIndex(idxName, graph)
         (m, state) => {
           val queryText = query(m)(state)
-          // TODO memory waste
-          state.query.relationshipOps.indexQuery(idxName, queryText).toList
+          state.query.relationshipOps.indexQuery(idxName, queryText)
         }
     }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/StartPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/StartPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.symbols._
 import org.neo4j.cypher.internal.ExecutionContext
 
 abstract class StartPipe[T <: PropertyContainer](source: Pipe, name: String, createSource: EntityProducer[T]) extends PipeWithSource(source) {
-  def this(inner: Pipe, name: String, sourceIterable: Iterable[T]) = this (inner, name, (a,b) => sourceIterable)
+  def this(inner: Pipe, name: String, sourceIterable: Iterator[T]) = this (inner, name, (a,b) => sourceIterable)
 
   def identifierType: CypherType
 
@@ -33,7 +33,7 @@ abstract class StartPipe[T <: PropertyContainer](source: Pipe, name: String, cre
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
     input.flatMap(ctx => {
-      val source: Iterable[T] = createSource(ctx, state)
+      val source = createSource(ctx, state)
       source.map(x => {
         ctx.newWith(name -> x)
       })
@@ -47,14 +47,14 @@ abstract class StartPipe[T <: PropertyContainer](source: Pipe, name: String, cre
   def throwIfSymbolsMissing(symbols: SymbolTable) {}
 }
 
-class NodeStartPipe(source: Pipe, name: String, createSource: (ExecutionContext, QueryState) => Iterable[Node])
+class NodeStartPipe(source: Pipe, name: String, createSource: (ExecutionContext, QueryState) => Iterator[Node])
   extends StartPipe[Node](source, name, createSource) {
   def identifierType = NodeType()
 
   def visibleName = "Nodes"
 }
 
-class RelationshipStartPipe(source: Pipe, name: String, createSource: (ExecutionContext, QueryState) => Iterable[Relationship])
+class RelationshipStartPipe(source: Pipe, name: String, createSource: (ExecutionContext, QueryState) => Iterator[Relationship])
   extends StartPipe[Relationship](source, name, createSource) {
   def identifierType = RelationshipType()
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/package.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/package.scala
@@ -22,5 +22,5 @@ package org.neo4j.cypher.internal
 import org.neo4j.graphdb.PropertyContainer
 
 package object pipes {
-  type EntityProducer[T <: PropertyContainer] = (ExecutionContext, QueryState) => Iterable[T]
+  type EntityProducer[T <: PropertyContainer] = (ExecutionContext, QueryState) => Iterator[T]
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/profiler/Profiler.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/profiler/Profiler.scala
@@ -120,13 +120,13 @@ class ProfilingQueryContext(val inner: QueryContext, val p: Pipe) extends Delega
       inner.setProperty(obj, propertyKey, value)
     }
 
-    override def indexGet(name: String, key: String, value: Any): Iterable[T] = countItems(inner.indexGet(name, key, value))
+    override def indexGet(name: String, key: String, value: Any): Iterator[T] = countItems(inner.indexGet(name, key, value))
 
-    override def indexQuery(name: String, query: Any): Iterable[T] = countItems(inner.indexQuery(name, query))
+    override def indexQuery(name: String, query: Any): Iterator[T] = countItems(inner.indexQuery(name, query))
 
-    override def all: Iterable[T] = countItems(inner.all)
+    override def all: Iterator[T] = countItems(inner.all)
 
-    private def countItems(in: Iterable[T]): Iterable[T] = in.view.map {
+    private def countItems(in: Iterator[T]): Iterator[T] = in.map {
       t =>
         increment()
         t

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/DelegatingQueryContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/DelegatingQueryContext.scala
@@ -60,9 +60,9 @@ class DelegatingOperations[T <: PropertyContainer](protected val inner: Operatio
     inner.removeProperty(obj, propertyKey)
   }
 
-  def indexGet(name: String, key: String, value: Any): Iterable[T] = inner.indexGet(name, key, value)
+  def indexGet(name: String, key: String, value: Any): Iterator[T] = inner.indexGet(name, key, value)
 
-  def indexQuery(name: String, query: Any): Iterable[T] = inner.indexQuery(name, query)
+  def indexQuery(name: String, query: Any): Iterator[T] = inner.indexQuery(name, query)
 
-  def all: Iterable[T] = inner.all
+  def all: Iterator[T] = inner.all
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/QueryContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/QueryContext.scala
@@ -51,9 +51,9 @@ trait Operations[T <: PropertyContainer] {
 
   def getById(id: Long): T
 
-  def indexGet(name: String, key: String, value: Any): Iterable[T]
+  def indexGet(name: String, key: String, value: Any): Iterator[T]
 
-  def indexQuery(name: String, query: Any): Iterable[T]
+  def indexQuery(name: String, query: Any): Iterator[T]
 
-  def all : Iterable[T]
+  def all : Iterator[T]
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/GDSBackedQueryContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/GDSBackedQueryContext.scala
@@ -76,13 +76,14 @@ class GDSBackedQueryContext(graph: GraphDatabaseService) extends QueryContext {
         graph.getNodeById(id)
       }
 
-      def indexGet(name: String, key: String, value: Any): Iterable[Node] =
-        graph.index.forNodes(name).get(key, value).asInstanceOf[JIterable[Node]].asScala
+      def indexGet(name: String, key: String, value: Any): Iterator[Node] =
+        graph.index.forNodes(name).get(key, value).iterator().asScala
 
-      def indexQuery(name: String, query: Any): Iterable[Node] =
-        graph.index.forNodes(name).query(name, query).asInstanceOf[JIterable[Node]].asScala
+      def indexQuery(name: String, query: Any): Iterator[Node] =
+        graph.index.forNodes(name).query(name, query).iterator().asScala
 
-      def all: Iterable[Node] = GlobalGraphOperations.at(graph).getAllNodes.asScala
+      def all: Iterator[Node] =
+        GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
     }
   }
 
@@ -112,13 +113,14 @@ class GDSBackedQueryContext(graph: GraphDatabaseService) extends QueryContext {
       def getById(id: Long): Relationship =
         graph.getRelationshipById(id)
 
-      def indexGet(name: String, key: String, value: Any): Iterable[Relationship] =
-        graph.index.forRelationships(name).get(key, value).asInstanceOf[JIterable[Relationship]].asScala
+      def indexGet(name: String, key: String, value: Any): Iterator[Relationship] =
+        graph.index.forRelationships(name).get(key, value).iterator().asScala
 
-      def indexQuery(name: String, query: Any): Iterable[Relationship] =
-        graph.index.forRelationships(name).query(query).asInstanceOf[JIterable[Relationship]].asScala
+      def indexQuery(name: String, query: Any): Iterator[Relationship] =
+        graph.index.forRelationships(name).query(query).iterator().asScala
 
-      def all: Iterable[Relationship] = GlobalGraphOperations.at(graph).getAllRelationships.asScala
+      def all: Iterator[Relationship] =
+        GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
     }
   }
 }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
@@ -26,6 +26,7 @@ import collection.Map
 import org.neo4j.graphdb._
 import org.neo4j.test.ImpermanentGraphDatabase
 import org.neo4j.kernel.GraphDatabaseAPI
+import org.neo4j.kernel.impl.core.NodeManager
 
 class GraphDatabaseTestBase extends JUnitSuite {
   var graph: GraphDatabaseAPI with Snitch = null
@@ -142,8 +143,10 @@ class GraphDatabaseTestBase extends JUnitSuite {
   }
 }
 
-trait Snitch extends GraphDatabaseService {
+trait Snitch extends GraphDatabaseAPI {
   val createdNodes = collection.mutable.Queue[Node]()
+  val fetchedNodes = collection.mutable.Queue[Long]()
+  var seenNodes = 0
 
   abstract override def createNode(): Node = {
     val n = super.createNode()

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/TraversalMatcherTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/TraversalMatcherTest.scala
@@ -61,7 +61,7 @@ class TraversalMatcherTest extends GraphDatabaseTestBase {
     assert(result.head.lastRelationship() === r2)
   }
 
-  private def produce(x: Node*) = (_: ExecutionContext, _: QueryState) => x
+  private def produce(x: Node*) = (_: ExecutionContext, _: QueryState) => x.iterator
 
   @Test def tree() {
     /*Data nodes and rels


### PR DESCRIPTION
This makes index queries and all-nodes queries lazy and less memory intensive
