### PR TITLE
Allow server to be deployed painlessly in behind-the-proxy use-cases.

### DIFF
--- a/community/server/src/docs/dev/server-configuration.asciidoc
+++ b/community/server/src/docs/dev/server-configuration.asciidoc
@@ -136,7 +136,7 @@ By default the HTTP logger uses +http://en.wikipedia.org/wiki/Common_Log_Format[
 meaning that most Web server tooling can automtically consume such logs. In general users should only enable HTTP logging,
 select an output directory, and if necessary alter the rollover and retention policies.
 
-To enable HTTP logging, edit the 'conf/neo4j-server.properties' file resemble the following:
+To enable HTTP logging, edit the 'conf/neo4j-server.properties' file to resemble the following:
 
 [source]
 ----
@@ -153,6 +153,21 @@ rotation and +http://en.wikipedia.org/wiki/Common_Log_Format[Common Log Format]+
 If logging is set up to use log files then the server will check that the log file directory exists and is writable. If
 this check fails, then the server will not startup and wil report the failure another available channel like standard out.
 
+== Using X-Forwarded-Proto and X-Forwarded-Host to parameterize the base URI for REST responses ==
+
+There are occasions, for example when you want to host Neo4j server behind a proxy (e.g. one that handles HTTPS traffic),
+and still have Neo4j respect the base URI of that externally visible proxy.
+
+Ordinarily Neo4j uses the `HOST` header of the HTTP request to construct URIs in its responses. Where a proxy is involved
+however, this is often undesirable. Instead Neo4j, uses the
+`X-Forwarded-Host` and `X-Forwarded-Proto` headers provided by proxies to parameterize the URIs in the responses from
+the databases's REST API. From the outside it looks as if the proxy generated that payload. If an `X-Forwarded-Host`
+header value contains more than one address (`X-Forwarded-Host` allows comma-and-space separated lists of addresses),
+Neo4j picks the first, which represents the client request.
+
+In order to take advantage of this functionality, your proxy server must be configured to transmit these headers to the
+Neo4j server. Failure to transmit both `X-Forwarded-Host` and `X-Forwarded-Proto` headers will result in the original
+base URI being used.
 
 == Other configuration options ==
 

--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -117,22 +117,3 @@ BalancerMember http://192.168.1.51:80
 ProxyPass /test balancer://mycluster
 --------------
 
-== Rewriting URLs with a Proxy installation ==
-
-When installing Neo4j Server behind proxies, you need to enable rewriting of the JSON calls, 
-otherwise they will point back to the servers own base URL (normally http://localhost:7474).
-
-To do this, you can use http://httpd.apache.org/docs/2.2/mod/mod_substitute.html[Apache mod_substitute].
-
-[source]
-----
-ProxyPass / http://localhost:7474/
-ProxyPassReverse / http://localhost:7474/
-<Location />
-    AddOutputFilterByType SUBSTITUTE application/json
-    AddOutputFilterByType SUBSTITUTE text/html
-    Substitute s/localhost:7474/myproxy.example.com/n
-    Substitute s/http/https/n
-</Location>
-----
-

--- a/community/server/src/functionaltest/java/org/neo4j/server/rest/ConfigureBaseUriFunctionalTest.java
+++ b/community/server/src/functionaltest/java/org/neo4j/server/rest/ConfigureBaseUriFunctionalTest.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.server.rest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.server.helpers.FunctionalTestHelper;
+
+public class ConfigureBaseUriFunctionalTest extends AbstractRestFunctionalTestBase
+{
+    private static FunctionalTestHelper functionalTestHelper;
+
+    @BeforeClass
+    public static void setupServer() throws IOException
+    {
+        functionalTestHelper = new FunctionalTestHelper( server() );
+    }
+
+    @Before
+    public void setupTheDatabase()
+    {
+        cleanDatabase();
+    }
+
+    @Test
+    public void shouldForwardHttpAndHost() throws Exception
+    {
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+            httpget.setHeader( "X-Forwarded-Host", "foobar.com" );
+            httpget.setHeader( "X-Forwarded-Proto", "http" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertTrue( responseEntityBody.contains( "http://foobar.com" ) );
+            assertFalse( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+
+    }
+
+    @Test
+    public void shouldForwardHttpsAndHost() throws Exception
+    {
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+            httpget.setHeader( "X-Forwarded-Host", "foobar.com" );
+            httpget.setHeader( "X-Forwarded-Proto", "https" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertTrue( responseEntityBody.contains( "https://foobar.com" ) );
+            assertFalse( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void shouldForwardHttpAndHostOnDifferentPort() throws Exception
+    {
+
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+            httpget.setHeader( "X-Forwarded-Host", "foobar.com:9999" );
+            httpget.setHeader( "X-Forwarded-Proto", "http" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertTrue( responseEntityBody.contains( "http://foobar.com:9999" ) );
+            assertFalse( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void shouldForwardHttpAndFirstHost() throws Exception
+    {
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+            httpget.setHeader( "X-Forwarded-Host", "foobar.com, bazbar.com" );
+            httpget.setHeader( "X-Forwarded-Proto", "http" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertTrue( responseEntityBody.contains( "http://foobar.com" ) );
+            assertFalse( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+
+    }
+
+    @Test
+    public void shouldForwardHttpsAndHostOnDifferentPort() throws Exception
+    {
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+            httpget.setHeader( "X-Forwarded-Host", "foobar.com:9999" );
+            httpget.setHeader( "X-Forwarded-Proto", "https" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertTrue( responseEntityBody.contains( "https://foobar.com:9999" ) );
+            assertFalse( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+
+
+    @Test
+    public void shouldUseRequestUriWhenNoXForwardHeadersPresent() throws Exception
+    {
+        URI rootUri = functionalTestHelper.baseUri();
+
+        HttpClient httpclient = new DefaultHttpClient();
+        try
+        {
+            HttpGet httpget = new HttpGet( rootUri );
+
+            httpget.setHeader( "Accept", "application/json" );
+
+            HttpResponse response = httpclient.execute( httpget );
+
+            String length = response.getHeaders( "CONTENT-LENGTH" )[0].getValue();
+            byte[] data = new byte[Integer.valueOf( length )];
+            response.getEntity().getContent().read( data );
+
+            String responseEntityBody = new String( data );
+
+            assertFalse( responseEntityBody.contains( "https://foobar.com" ) );
+            assertTrue( responseEntityBody.contains( "localhost" ) );
+        }
+        finally
+        {
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/community/server/src/functionaltest/java/org/neo4j/server/rest/DisableWADLFunctionalTest.java
+++ b/community/server/src/functionaltest/java/org/neo4j/server/rest/DisableWADLFunctionalTest.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.server.rest;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URI;
@@ -36,8 +36,6 @@ import org.neo4j.server.rest.domain.GraphDbHelper;
 
 public class DisableWADLFunctionalTest extends AbstractRestFunctionalTestBase
 {
-
-
     private static FunctionalTestHelper functionalTestHelper;
     private static GraphDbHelper helper;
 
@@ -58,7 +56,7 @@ public class DisableWADLFunctionalTest extends AbstractRestFunctionalTestBase
     public void should404OnAnyUriEndinginWADL() throws Exception
     {
         URI nodeUri = new URI( "http://localhost:7474/db/data/application.wadl" );
-        
+
         HttpClient httpclient = new DefaultHttpClient();
         try
         {
@@ -66,13 +64,13 @@ public class DisableWADLFunctionalTest extends AbstractRestFunctionalTestBase
 
             httpget.setHeader( "Accept", "*/*" );
             HttpResponse response = httpclient.execute( httpget );
-            
-            assertEquals(404, response.getStatusLine().getStatusCode());
 
-        } finally
+            assertEquals( 404, response.getStatusLine().getStatusCode() );
+
+        }
+        finally
         {
             httpclient.getConnectionManager().shutdown();
         }
     }
-
 }

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -44,7 +44,6 @@ import org.neo4j.server.modules.RESTApiModule;
 import org.neo4j.server.modules.ServerModule;
 import org.neo4j.server.plugins.PluginInvocatorProvider;
 import org.neo4j.server.plugins.PluginManager;
-import org.neo4j.server.plugins.TypedInjectable;
 import org.neo4j.server.preflight.PreFlightTasks;
 import org.neo4j.server.preflight.PreflightFailedException;
 import org.neo4j.server.rest.paging.LeaseManager;
@@ -58,7 +57,6 @@ import org.neo4j.server.security.KeyStoreFactory;
 import org.neo4j.server.security.KeyStoreInformation;
 import org.neo4j.server.security.SslCertificateFactory;
 import org.neo4j.server.statistic.StatisticCollector;
-import org.neo4j.server.web.InjectableWrapper;
 import org.neo4j.server.web.SimpleUriBuilder;
 import org.neo4j.server.web.WebServer;
 import org.neo4j.server.web.WebServerProvider;
@@ -307,8 +305,8 @@ public abstract class AbstractNeoServer implements NeoServer
         webServer.setEnableHttps( sslEnabled );
         webServer.setHttpsPort( sslPort );
 
-        webServer.setWadlEnabled( Boolean.valueOf( String.valueOf( getConfiguration().getProperty( Configurator
-                .WADL_ENABLED ) ) ) );
+        webServer.setWadlEnabled(
+                Boolean.valueOf( String.valueOf( getConfiguration().getProperty( Configurator.WADL_ENABLED ) ) ) );
         webServer.setDefaultInjectables( createDefaultInjectables() );
 
         if ( sslEnabled )
@@ -373,12 +371,7 @@ public abstract class AbstractNeoServer implements NeoServer
     private boolean configLocated()
     {
         final Object property = getConfiguration().getProperty( Configurator.HTTP_LOG_CONFIG_LOCATION );
-        if ( property == null )
-        {
-            return false;
-        }
-
-        return new File( String.valueOf( property ) ).exists();
+        return property != null && new File( String.valueOf( property ) ).exists();
     }
 
     private boolean loggingEnabled()
@@ -574,11 +567,6 @@ public abstract class AbstractNeoServer implements NeoServer
         singletons.add( new OutputFormatProvider( repository ) );
         singletons.add( new CypherExecutorProvider( cypherExecutor ) );
         return singletons;
-    }
-
-    private InjectableWrapper toInjectableProvider( Object service )
-    {
-        return new InjectableWrapper( TypedInjectable.injectable( service ) );
     }
 
     private boolean hasModule( Class<? extends ServerModule> clazz )

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormatProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormatProvider.java
@@ -19,15 +19,17 @@
  */
 package org.neo4j.server.rest.repr;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.Provider;
 
-import com.sun.jersey.api.core.HttpRequestContext;
-import org.neo4j.server.database.InjectableProvider;
-
 import com.sun.jersey.api.core.HttpContext;
+import org.neo4j.server.database.InjectableProvider;
 
 @Provider
 public final class OutputFormatProvider extends InjectableProvider<OutputFormat>
@@ -45,15 +47,128 @@ public final class OutputFormatProvider extends InjectableProvider<OutputFormat>
     {
         try
         {
-            HttpRequestContext request = context.getRequest();
-            return repository.outputFormat( request
-                    .getAcceptableMediaTypes(), request.getBaseUri(), request.getRequestHeaders() );
+            return repository.outputFormat( context.getRequest()
+                    .getAcceptableMediaTypes(), getBaseUri( context ), context.getRequest().getRequestHeaders() );
         }
         catch ( MediaTypeNotSupportedException e )
         {
             throw new WebApplicationException( Response.status( Status.NOT_ACCEPTABLE )
                     .entity( e.getMessage() )
                     .build() );
+        }
+        catch ( URISyntaxException e )
+        {
+            throw new WebApplicationException( Response.status( Status.INTERNAL_SERVER_ERROR )
+                    .entity( e.getMessage() )
+                    .build() );
+        }
+    }
+
+    private URI getBaseUri( HttpContext context ) throws URISyntaxException
+    {
+        UriBuilder builder = UriBuilder.fromUri( context.getRequest().getBaseUri() );
+
+        ForwardedHost forwardedHost = new ForwardedHost( context.getRequest().getHeaderValue( "X-Forwarded-Host" ) );
+        ForwardedProto xForwardedProto = new ForwardedProto(
+                context.getRequest().getHeaderValue( "X-Forwarded-Proto" ) );
+
+
+        if ( forwardedHost.isValid() )
+        {
+            builder.host( forwardedHost.getHost() ).port( forwardedHost.getPort() );
+        }
+
+        if ( xForwardedProto.isValid() )
+        {
+            builder.scheme( xForwardedProto.getScheme() );
+        }
+
+        return builder.build();
+    }
+
+    private class ForwardedHost
+    {
+        private String host;
+        private int port;
+        private boolean isValid = false;
+
+        public ForwardedHost( String headerValue )
+        {
+            if ( headerValue == null )
+            {
+                this.isValid = false;
+                return;
+            }
+
+            String firstAddress = headerValue.split( "," )[0].trim();
+
+            try
+            {
+                UriBuilder.fromUri( firstAddress ).build();
+            }
+            catch ( IllegalArgumentException ex )
+            {
+                this.isValid = false;
+                return;
+            }
+
+            String[] strings = firstAddress.split( ":" );
+            if ( strings.length > 0 )
+            {
+                this.host = strings[0];
+                isValid = true;
+            }
+            if ( strings.length > 1 )
+            {
+                this.port = Integer.valueOf( strings[1] );
+                isValid = true;
+            }
+            if ( strings.length > 2 )
+            {
+                this.isValid = true;
+            }
+        }
+
+        public boolean isValid()
+        {
+            return isValid && port >= 0;
+        }
+
+        public String getHost()
+        {
+            return host;
+        }
+
+        public int getPort()
+        {
+            return port;
+        }
+    }
+
+    private class ForwardedProto
+    {
+        private final String headerValue;
+
+        public ForwardedProto( String headerValue )
+        {
+            if ( headerValue != null )
+            {
+                this.headerValue = headerValue;
+            }
+            else
+            {
+                this.headerValue = "";
+            }
+        }
+
+        public boolean isValid()
+        {
+            return headerValue.toLowerCase().equals( "http" ) || headerValue.toLowerCase().equals( "https" );
+        }
+
+        public String getScheme()
+        {
+            return headerValue;
         }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -157,7 +157,7 @@ public class RestfulGraphDatabase
     private Long extractNodeIdOrNull( String uri ) throws BadInputException
     {
         if ( uri == null ) return null;
-        return Long.valueOf( extractNodeId( uri ) );
+        return extractNodeId( uri );
     }
 
     private long extractNodeId( String uri ) throws BadInputException
@@ -790,13 +790,13 @@ public class RestfulGraphDatabase
 	        		entityBody = input.readMap( postBody, "key", "value" );
 	                result = actions( force ).getOrCreateIndexedNode( indexName, String.valueOf( entityBody.get( "key" ) ),
 	                       String.valueOf( entityBody.get( "value" ) ), extractNodeIdOrNull( getStringOrNull( entityBody, "uri" ) ), getMapOrNull( entityBody, "properties" ) );
-	                return result.other().booleanValue() ? output.created( result.first() ) : output.okIncludeLocation( result.first() );
+	                return result.other() ? output.created( result.first() ) : output.okIncludeLocation( result.first() );
 	
 	        	case CreateOrFail:
 	        		entityBody = input.readMap( postBody, "key", "value" );
 	                result = actions( force ).getOrCreateIndexedNode( indexName, String.valueOf( entityBody.get( "key" ) ),
 	                       String.valueOf( entityBody.get( "value" ) ), extractNodeIdOrNull( getStringOrNull( entityBody, "uri" ) ), getMapOrNull( entityBody, "properties" ) );
-	                return result.other().booleanValue() ? output.created( result.first() ) : output.conflict( result.first() );
+	                return result.other() ? output.created( result.first() ) : output.conflict( result.first() );
 	
 	            default:
 	            	entityBody = input.readMap( postBody, "key", "value", "uri" );
@@ -845,7 +845,7 @@ public class RestfulGraphDatabase
 	                       String.valueOf( entityBody.get( "value" ) ), extractRelationshipIdOrNull( getStringOrNull( entityBody, "uri" ) ),
 	                       extractNodeIdOrNull( getStringOrNull( entityBody, "start" ) ), getStringOrNull( entityBody, "type" ), extractNodeIdOrNull( getStringOrNull( entityBody, "end" ) ),
 	                       getMapOrNull( entityBody, "properties" ) );
-	                return result.other().booleanValue() ? output.created( result.first() ) : output.ok( result.first() );
+	                return result.other() ? output.created( result.first() ) : output.ok( result.first() );
 	
 	        	case CreateOrFail:
 	                entityBody = input.readMap( postBody, "key", "value" );
@@ -853,7 +853,7 @@ public class RestfulGraphDatabase
 	                       String.valueOf( entityBody.get( "value" ) ), extractRelationshipIdOrNull( getStringOrNull( entityBody, "uri" ) ),
 	                       extractNodeIdOrNull( getStringOrNull( entityBody, "start" ) ), getStringOrNull( entityBody, "type" ), extractNodeIdOrNull( getStringOrNull( entityBody, "end" ) ),
 	                       getMapOrNull( entityBody, "properties" ) );
-	                return result.other().booleanValue() ? output.created( result.first() ) : output.conflict( result.first() );
+	                return result.other() ? output.created( result.first() ) : output.conflict( result.first() );
 
                 default:
                     entityBody = input.readMap( postBody, "key", "value", "uri" );
@@ -885,7 +885,7 @@ public class RestfulGraphDatabase
     	UniqueIndexType unique = UniqueIndexType.None;
         if ( uniquenessParam == null || uniquenessParam.equals("") ){
         	// Backward compatibility check
-        	if(unique != null && ("".equals( uniqueParam ) || Boolean.parseBoolean( uniqueParam ))){
+        	if( "".equals( uniqueParam ) || Boolean.parseBoolean( uniqueParam ) ){
         		unique = UniqueIndexType.GetOrCreate;
         	}
         	
@@ -911,6 +911,7 @@ public class RestfulGraphDatabase
         throw new BadInputException( "\"" + key + "\" should be a string" );
     }
 
+    @SuppressWarnings("unchecked")
     private static Map<String, Object> getMapOrNull( Map<String, Object> data, String key ) throws BadInputException
     {
         Object object = data.get( key );
@@ -1312,7 +1313,7 @@ public class RestfulGraphDatabase
             ListRepresentation result = actions.pagedTraverse( traverserId, returnType );
 
             return Response.ok(uriInfo.getRequestUri())
-                    .entity( output.format( result ) )
+                    .entity( output.assemble( result ) )
                     .build();
         }
         catch ( EvaluationException e)
@@ -1340,7 +1341,7 @@ public class RestfulGraphDatabase
             String traverserId = actions.createPagedTraverser( startNode, input.readMap( body ), pageSize,
                     leaseTimeInSeconds );
 
-            String responseBody = output.format( actions.pagedTraverse( traverserId, returnType ) );
+            String responseBody = output.assemble( actions.pagedTraverse( traverserId, returnType ) );
 
             URI uri = new URI( uriInfo.getBaseUri()
                     .toString() + "node/" + startNode + "/paged/traverse/" + returnType + "/" + traverserId );

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerBuilder.java
@@ -93,13 +93,13 @@ public class ServerBuilder
             this.dbDir = createTempDir().getAbsolutePath();
         }
         File configFile = createPropertiesFiles();
-        
+
         if ( preflightTasks == null )
         {
             preflightTasks = new PreFlightTasks()
             {
                 @Override
-				public boolean run()
+                public boolean run()
                 {
                     return true;
                 }
@@ -108,21 +108,21 @@ public class ServerBuilder
 
         return new CommunityNeoServer( new PropertyFileConfigurator( new Validator(
                 new DatabaseLocationMustBeSpecifiedRule() ), configFile ) )
-	    {
-        	@Override
-        	protected PreFlightTasks createPreflightTasks()
+        {
+            @Override
+            protected PreFlightTasks createPreflightTasks()
             {
-        		return preflightTasks;
-        	}
+                return preflightTasks;
+            }
 
-        	@Override
-        	protected Database createDatabase()
+            @Override
+            protected Database createDatabase()
             {
-        		return persistent ? 
-        				new CommunityDatabase(configurator.configuration()) :
-    					new EphemeralDatabase(configurator.configuration());
-        		
-        	}
+                return persistent ?
+                        new CommunityDatabase( configurator.configuration() ) :
+                        new EphemeralDatabase( configurator.configuration() );
+
+            }
 
             @Override
             protected DatabaseActions createDatabaseActions()
@@ -131,13 +131,13 @@ public class ServerBuilder
 
                 return new DatabaseActions(
                         database,
-                        new LeaseManager(clockToUse),
+                        new LeaseManager( clockToUse ),
                         ForceMode.forced,
                         configurator.configuration().getBoolean(
                                 Configurator.SCRIPT_SANDBOXING_ENABLED_KEY,
                                 Configurator.DEFAULT_SCRIPT_SANDBOXING_ENABLED ) );
             }
-	    };
+        };
     }
 
     public File createPropertiesFiles() throws IOException
@@ -159,9 +159,9 @@ public class ServerBuilder
     private void createPropertiesFile( File temporaryConfigFile )
     {
         Map<String, String> properties = MapUtil.stringMap(
-            Configurator.DATABASE_LOCATION_PROPERTY_KEY, dbDir,
-            Configurator.MANAGEMENT_PATH_PROPERTY_KEY, webAdminUri,
-            Configurator.REST_API_PATH_PROPERTY_KEY, webAdminDataUri );
+                Configurator.DATABASE_LOCATION_PROPERTY_KEY, dbDir,
+                Configurator.MANAGEMENT_PATH_PROPERTY_KEY, webAdminUri,
+                Configurator.REST_API_PATH_PROPERTY_KEY, webAdminDataUri );
         if ( portNo != null )
         {
             properties.put( Configurator.WEBSERVER_PORT_PROPERTY_KEY, portNo );
@@ -226,25 +226,25 @@ public class ServerBuilder
         {
             File databaseTuningPropertyFile = createTempPropertyFile();
             Map<String, String> properties = MapUtil.stringMap(
-                "neostore.nodestore.db.mapped_memory", "25M",
-                "neostore.relationshipstore.db.mapped_memory", "50M",
-                "neostore.propertystore.db.mapped_memory", "90M",
-                "neostore.propertystore.db.strings.mapped_memory", "130M",
-                "neostore.propertystore.db.arrays.mapped_memory", "130M" );
+                    "neostore.nodestore.db.mapped_memory", "25M",
+                    "neostore.relationshipstore.db.mapped_memory", "50M",
+                    "neostore.propertystore.db.mapped_memory", "90M",
+                    "neostore.propertystore.db.strings.mapped_memory", "130M",
+                    "neostore.propertystore.db.arrays.mapped_memory", "130M" );
             writePropertiesToFile( properties, databaseTuningPropertyFile );
             writePropertyToFile( Configurator.DB_TUNING_PROPERTY_FILE_KEY,
-                databaseTuningPropertyFile.getAbsolutePath(), temporaryConfigFile );
+                    databaseTuningPropertyFile.getAbsolutePath(), temporaryConfigFile );
         }
         else if ( action == WhatToDo.CREATE_DANGLING_TUNING_FILE_PROPERTY )
         {
             writePropertyToFile( Configurator.DB_TUNING_PROPERTY_FILE_KEY, createTempPropertyFile().getAbsolutePath(),
-                temporaryConfigFile );
+                    temporaryConfigFile );
         }
         else if ( action == WhatToDo.CREATE_CORRUPT_TUNING_FILE )
         {
             File corruptTuningFile = trashFile();
             writePropertyToFile( Configurator.DB_TUNING_PROPERTY_FILE_KEY, corruptTuningFile.getAbsolutePath(),
-                temporaryConfigFile );
+                    temporaryConfigFile );
         }
     }
 
@@ -345,25 +345,25 @@ public class ServerBuilder
         preflightTasks = new PreFlightTasks()
         {
             @Override
-			public boolean run()
+            public boolean run()
             {
                 return false;
             }
 
             @Override
-			public PreflightTask failedTask()
+            public PreflightTask failedTask()
             {
                 return new PreflightTask()
                 {
 
                     @Override
-					public String getFailureMessage()
+                    public String getFailureMessage()
                     {
                         return "mockFailure";
                     }
 
                     @Override
-					public boolean run()
+                    public boolean run()
                     {
                         return false;
                     }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/CypherResultRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/CypherResultRepresentationTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.server.rest.repr;
 
 import static java.util.Arrays.asList;
+import static org.apache.commons.collections.IteratorUtils.emptyIterator;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -34,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.junit.Test;
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.cypher.javacompat.PlanDescription;
@@ -47,6 +47,7 @@ public class CypherResultRepresentationTest
 {
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldSerializeProfilingResult() throws Exception
     {
         // Given
@@ -64,7 +65,7 @@ public class CypherResultRepresentationTest
         when( plan.getProfilerStatistics() ).thenReturn( stats );
 
         ExecutionResult result = mock(ExecutionResult.class);
-        when(result.iterator()).thenReturn(IteratorUtils.emptyIterator());
+        when(result.iterator()).thenReturn( emptyIterator());
         when(result.columns()).thenReturn(new ArrayList<String>());
         when( result.executionPlanDescription() ).thenReturn( plan );
 
@@ -85,11 +86,12 @@ public class CypherResultRepresentationTest
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldNotIncludePlanUnlessAskedFor() throws Exception
     {
         // Given
         ExecutionResult result = mock(ExecutionResult.class);
-        when(result.iterator()).thenReturn(IteratorUtils.emptyIterator());
+        when(result.iterator()).thenReturn( emptyIterator());
         when(result.columns()).thenReturn(new ArrayList<String>());
 
         // When
@@ -110,7 +112,7 @@ public class CypherResultRepresentationTest
     private Map<String, Object> serialize( CypherResultRepresentation repr ) throws URISyntaxException, JsonParseException
     {
         OutputFormat format = new OutputFormat( new JsonFormat(), new URI( "http://localhost/" ), null );
-        return jsonToMap( format.format( repr ) );
+        return jsonToMap( format.assemble( repr ) );
     }
 
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
@@ -37,7 +37,7 @@ public class MapRepresentationTest
         Map map = MapUtil.map( "name","John","age",23 );
         MapRepresentation rep = new MapRepresentation( map  );
         OutputFormat format = new OutputFormat( new JsonFormat(), new URI( "http://localhost/" ), null );
-        assertTrue(format.format( rep ).contains( "\"age\" : 23" ));
+        assertTrue(format.assemble( rep ).contains( "\"age\" : 23" ));
     }
 
 

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/OutputFormatProviderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/OutputFormatProviderTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.server.rest.repr;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.core.HttpRequestContext;
+import org.junit.Test;
+import org.neo4j.server.AbstractNeoServer;
+
+public class OutputFormatProviderTest
+{
+    @Test
+    public void shouldUseXForwardedHostHeaderWhenPresent() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( "foobar.com:9999" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://foobar.com:9999" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldUseXForwardedProtoHeaderWhenPresent() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "https://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Proto" ) ).thenReturn( "http" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://localhost:37465" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldPickFirstXForwardedHostHeaderValueFromCommaAndSpaceSeparatedList() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( "foobar.com:9999, " +
+                "bazbar.org:8888, barbar.me:7777" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://foobar.com:9999" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldPickFirstXForwardedHostHeaderValueFromCommaSeparatedList() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( "foobar.com:9999," +
+                "bazbar.org:8888,barbar.me:7777" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://foobar.com:9999" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldUseBaseUriOnBadXForwardedHostHeader() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( ":5543:foobar.com:9999" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://localhost:37465" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldUseBaseUriIfFirstAddressInXForwardedHostHeaderIsBad() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( ":5543:foobar.com:9999, " +
+                "bazbar.com:8888" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://localhost:37465" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldUseBaseUriOnBadXForwardedProtoHeader() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Proto" ) ).thenReturn( "%%%DEFINITELY-NOT-A-PROTO!" );
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "http://localhost:37465" ) ),
+                any( ExtensionInjector.class ) );
+    }
+
+    @Test
+    public void shouldUseXForwardedHostAndXForwardedProtoHeadersWhenPresent() throws Exception
+    {
+        // given
+        OutputFormatProvider provider = new OutputFormatProvider( new RepresentationFormatRepository(
+                mock( AbstractNeoServer.class ) ) );
+
+        HttpRequestContext httpRequestContext = mock( HttpRequestContext.class );
+        HttpContext httpContext = mock( HttpContext.class );
+        when( httpContext.getRequest() ).thenReturn( httpRequestContext );
+        when( httpRequestContext.getBaseUri() ).thenReturn( new URI( "http://localhost:37465" ) );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Host" ) ).thenReturn( "foobar.com:9999" );
+        when( httpRequestContext.getHeaderValue( "X-Forwarded-Proto" ) ).thenReturn( "https" );
+
+
+        Representation representation = mock( Representation.class );
+        OutputFormat outputFormat = provider.getValue( httpContext );
+
+        // when
+        outputFormat.assemble( representation );
+
+        // then
+        verify( representation ).serialize( any( RepresentationFormat.class ),
+                eq( new URI( "https://foobar.com:9999" ) ),
+                any( ExtensionInjector.class ) );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
@@ -20,7 +20,10 @@
 package org.neo4j.server.rest.repr;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -28,16 +31,20 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
-import javax.ws.rs.core.*;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.io.ByteArrayOutputStream;
-import java.net.URI;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class RepresentationFormatRepositoryTest
 {
@@ -68,7 +75,7 @@ public class RepresentationFormatRepositoryTest
     {
         OutputFormat format = repository.outputFormat(asList(MediaType.APPLICATION_JSON_TYPE), null, null);
         assertNotNull(format);
-        assertEquals("\"test\"", format.format(ValueRepresentation.string("test")));
+        assertEquals("\"test\"", format.assemble( ValueRepresentation.string( "test" ) ));
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/CompactJsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/CompactJsonFormatTest.java
@@ -47,14 +47,14 @@ public class CompactJsonFormatTest
     @Test
     public void canFormatString() throws Exception
     {
-        String entity = json.format( ValueRepresentation.string( "expected value" ) );
+        String entity = json.assemble( ValueRepresentation.string( "expected value" ) );
         assertEquals( entity, "\"expected value\"" );
     }
 
     @Test
     public void canFormatListOfStrings() throws Exception
     {
-        String entity = json.format( ListRepresentation.strings( "hello", "world" ) );
+        String entity = json.assemble( ListRepresentation.strings( "hello", "world" ) );
         String expectedString = JsonHelper.createJsonFrom( Arrays.asList( "hello", "world" ) );
         assertEquals( expectedString, entity );
     }
@@ -62,14 +62,14 @@ public class CompactJsonFormatTest
     @Test
     public void canFormatInteger() throws Exception
     {
-        String entity = json.format( ValueRepresentation.number( 10 ) );
+        String entity = json.assemble( ValueRepresentation.number( 10 ) );
         assertEquals( "10", entity );
     }
 
     @Test
     public void canFormatObjectWithStringField() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "string" )
+        String entity = json.assemble( new MappingRepresentation( "string" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/JsonFormatTest.java
@@ -28,8 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.server.rest.domain.JsonHelper;
@@ -55,14 +53,14 @@ public class JsonFormatTest
     @Test
     public void canFormatString() throws Exception
     {
-        String entity = json.format( ValueRepresentation.string( "expected value" ) );
+        String entity = json.assemble( ValueRepresentation.string( "expected value" ) );
         assertEquals( entity, "\"expected value\"" );
     }
 
     @Test
     public void canFormatListOfStrings() throws Exception
     {
-        String entity = json.format( ListRepresentation.strings( "hello", "world" ) );
+        String entity = json.assemble( ListRepresentation.strings( "hello", "world" ) );
         String expectedString = JsonHelper.createJsonFrom( Arrays.asList( "hello", "world" ) );
         assertEquals( expectedString, entity );
     }
@@ -70,14 +68,14 @@ public class JsonFormatTest
     @Test
     public void canFormatInteger() throws Exception
     {
-        String entity = json.format( ValueRepresentation.number( 10 ) );
+        String entity = json.assemble( ValueRepresentation.number( 10 ) );
         assertEquals( "10", entity );
     }
 
     @Test
     public void canFormatEmptyObject() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "empty" )
+        String entity = json.assemble( new MappingRepresentation( "empty" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -90,7 +88,7 @@ public class JsonFormatTest
     @Test
     public void canFormatObjectWithStringField() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "string" )
+        String entity = json.assemble( new MappingRepresentation( "string" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -104,7 +102,7 @@ public class JsonFormatTest
     @Test
     public void canFormatObjectWithUriField() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "uri" )
+        String entity = json.assemble( new MappingRepresentation( "uri" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -120,7 +118,7 @@ public class JsonFormatTest
     @Test
     public void canFormatObjectWithNestedObject() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "nesting" )
+        String entity = json.assemble( new MappingRepresentation( "nesting" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -143,24 +141,26 @@ public class JsonFormatTest
     @Test
     public void canFormatNestedMapsAndLists() throws Exception
     {
-        String entity = json.format( new MappingRepresentation( "test" )
+        String entity = json.assemble( new MappingRepresentation( "test" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
             {
                 ArrayList<Representation> maps = new ArrayList<Representation>();
-                maps.add(new MappingRepresentation("map") {
-					
-					@Override
-					protected void serialize(MappingSerializer serializer) {
-						serializer.putString( "foo", "bar" );
-						
-					}
-				});
-				serializer.putList("foo", new ServerListRepresentation(RepresentationType.MAP, maps ));
+                maps.add( new MappingRepresentation( "map" )
+                {
+
+                    @Override
+                    protected void serialize( MappingSerializer serializer )
+                    {
+                        serializer.putString( "foo", "bar" );
+
+                    }
+                } );
+                serializer.putList( "foo", new ServerListRepresentation( RepresentationType.MAP, maps ) );
             }
         } );
 
-        Assert.assertEquals( "bar",((Map)((List)((Map)JsonHelper.jsonToMap(entity)).get("foo")).get(0)).get("foo") );
+        assertEquals( "bar",((Map)((List)((Map)JsonHelper.jsonToMap(entity)).get("foo")).get(0)).get("foo") );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
@@ -55,21 +55,21 @@ public class StreamingJsonFormatTest
     public void canFormatNode() throws Exception
     {
         final Node refNode = new ImpermanentGraphDatabase().getReferenceNode();
-        json.format(new NodeRepresentation(refNode));
+        json.assemble( new NodeRepresentation( refNode ) );
         assertTrue(stream.toString().contains("\"self\" : \"http://localhost/node/0\","));
     }
 
     @Test
     public void canFormatString() throws Exception
     {
-        json.format( ValueRepresentation.string( "expected value" ) );
+        json.assemble( ValueRepresentation.string( "expected value" ) );
         assertEquals( stream.toString(), "\"expected value\"" );
     }
 
     @Test
     public void canFormatListOfStrings() throws Exception
     {
-        json.format( ListRepresentation.strings( "hello", "world" ) );
+        json.assemble( ListRepresentation.strings( "hello", "world" ) );
         String expectedString = JsonHelper.createJsonFrom( Arrays.asList( "hello", "world" ) );
         assertEquals( expectedString, stream.toString() );
     }
@@ -77,14 +77,14 @@ public class StreamingJsonFormatTest
     @Test
     public void canFormatInteger() throws Exception
     {
-        json.format( ValueRepresentation.number( 10 ) );
+        json.assemble( ValueRepresentation.number( 10 ) );
         assertEquals( "10", stream.toString() );
     }
 
     @Test
     public void canFormatEmptyObject() throws Exception
     {
-        json.format( new MappingRepresentation( "empty" )
+        json.assemble( new MappingRepresentation( "empty" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -97,7 +97,7 @@ public class StreamingJsonFormatTest
     @Test
     public void canFormatObjectWithStringField() throws Exception
     {
-        json.format( new MappingRepresentation( "string" )
+        json.assemble( new MappingRepresentation( "string" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -111,7 +111,7 @@ public class StreamingJsonFormatTest
     @Test
     public void canFormatObjectWithUriField() throws Exception
     {
-        json.format( new MappingRepresentation( "uri" )
+        json.assemble( new MappingRepresentation( "uri" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )
@@ -127,7 +127,7 @@ public class StreamingJsonFormatTest
     @Test
     public void canFormatObjectWithNestedObject() throws Exception
     {
-        json.format( new MappingRepresentation( "nesting" )
+        json.assemble( new MappingRepresentation( "nesting" )
         {
             @Override
             protected void serialize( MappingSerializer serializer )

--- a/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
@@ -31,19 +31,10 @@ public class SharedServerTestBase
 	private static boolean useExternal = Boolean.valueOf(System.getProperty("neo-server.external","false"));
 	private static String externalURL = System.getProperty("neo-server.external.url","http://localhost:7474");
 
-    protected static final NeoServer server()
+    protected static NeoServer server()
     {
         return server;
     }
-
-    /*
-    protected static final void restartServer() throws IOException
-    {
-        releaseServer();
-        ServerHolder.ensureNotRunning();
-        allocateServer();
-    }
-    */
 
     protected final void cleanDatabase()
     {
@@ -78,7 +69,7 @@ public class SharedServerTestBase
     }
 
     @AfterClass
-    public static final void releaseServer()
+    public static void releaseServer()
     {
     	if(!useExternal) 
     	{

--- a/cypher-plugin/src/test/java/org/neo4j/server/plugin/cypher/CypherPluginTest.java
+++ b/cypher-plugin/src/test/java/org/neo4j/server/plugin/cypher/CypherPluginTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.server.plugin.cypher;
 
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -35,11 +40,6 @@ import org.neo4j.test.GraphDescription.PROP;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestData;
-
-import java.net.URI;
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
 
 public class CypherPluginTest implements GraphHolder
 {
@@ -67,7 +67,7 @@ public class CypherPluginTest implements GraphHolder
         Node i = data.get().get( "I" );
         Representation result = testQuery( "start n=node(" + i.getId()
                                            + ") return n" );
-        assertTrue( json.format( result ).contains( "I" ) );
+        assertTrue( json.assemble( result ).contains( "I" ) );
     }
 
     @Test
@@ -82,7 +82,7 @@ public class CypherPluginTest implements GraphHolder
         Representation result = testQuery( "start x =node("
                                            + i.getId()
                                            + ") match (x) -- (n) return n, n.name?, n.bool?, n.int?" );
-        String formatted = json.format( result );
+        String formatted = json.assemble( result );
         System.out.println( formatted );
         assertTrue( formatted.contains( "columns" ) );
         assertTrue( formatted.contains( "name" ) );


### PR DESCRIPTION
... a base URI for the data we return as part of our RESTful representations. Useful for neo4j-behind-proxy scenarios.

Removed/simplified/etc code as IntelliJ pointed out how silly/unused/always true it was.
