### PR TITLE
misc text updates

### DIFF
--- a/community/server/src/main/coffeescript/neo4j/webadmin/modules/baseui/base.haml
+++ b/community/server/src/main/coffeescript/neo4j/webadmin/modules/baseui/base.haml
@@ -12,18 +12,23 @@
   
 
 #footer
-  %p.copyright Copyright (c) 2002-2012
-    \ 
-    %a(href="http://neotechnology.com") Neo Technology
-    \.
-    \ This is free software, available under the 
-    \ 
-    %a(href="http://www.gnu.org/licenses/gpl.html") GNU General Public License
-    \ version 3 or greater.
-    \ Icons by
-    \ 
-    %a(href="http://glyphish.com/") Glyphish
-    \ &amp;
-    \ 
-    %a(href="http://tango.freedesktop.org/Tango_Icon_Library") Tango
-    \.
+  %p.copyright Copyright &copy; 2002-2013 
+    %span 
+      %a(href="http://neotechnology.com") Neo Technology
+      \.
+      \ &nbsp;
+    %span License: 
+      %a(href="http://www.gnu.org/licenses/gpl.html") GPLv3 
+      \ or 
+      %a(href="http://www.gnu.org/licenses/agpl-3.0.html") AGPL
+      \ for Open Source, and 
+      %a(href="http://neotechnology.com") NTCL 
+      \ for Commercial.
+      \ &nbsp;
+    %span Icons by
+      \ 
+      %a(href="http://glyphish.com/") Glyphish
+      \ &amp;
+      \ 
+      %a(href="http://tango.freedesktop.org/Tango_Icon_Library") Tango
+      \.

--- a/community/server/src/main/coffeescript/neo4j/webadmin/modules/dashboard/views/base.haml
+++ b/community/server/src/main/coffeescript/neo4j/webadmin/modules/dashboard/views/base.haml
@@ -1,5 +1,5 @@
 .sidebar
-  %h1.pad Neo4j web administration
+  %h1.pad 
   %ul.info_list
     %li
       %h3 Server url
@@ -8,7 +8,7 @@
       %h3 Kernel version
       %p= server.version
 
-  %p.pad For more information, help and examples, please visit <a href="http://neo4j.org">the Neo4j community site</a>.
+  %p.pad For more information, help and examples, please visit <a href="http://neo4j.org">neo4j.org</a>.
 
   .foldout
     %h2

--- a/community/server/src/main/coffeescript/neo4j/webadmin/modules/splash/splash.haml
+++ b/community/server/src/main/coffeescript/neo4j/webadmin/modules/splash/splash.haml
@@ -1,4 +1,4 @@
 .overlay
   #splash
     %img#splash-logo(src="img/logo.png")
-    %h1(style="background: url('@@splash.icon@@') no-repeat scroll center top transparent") @@neo4j.version@@ @@neo4j.codename@@
+    %h1 no-repeat scroll center top transparent") @@neo4j.version@@

--- a/community/server/src/main/resources/webadmin-html/index.html
+++ b/community/server/src/main/resources/webadmin-html/index.html
@@ -10,7 +10,7 @@
 		
 		<link rel="stylesheet" href="css/style.css" type="text/css" />
 		
-		<title>Neo4j Monitoring and Management Tool</title>
+		<title>Neo4j - @@neo4j.version@@</title>
 		
 	</head>
 	


### PR DESCRIPTION
Text changes to Neo4j's web UI:
- removed codename
- removed versioned splash icon
- clarified licensing in footer
- revised page title to include version number (convenient when talking to multiple Neo4j instances)
