### PR TITLE
Improvements around master election, giving preference to current master

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityMemberInfoProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityMemberInfoProvider.java
@@ -17,28 +17,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cluster.protocol.election;
+package org.neo4j.kernel.ha;
 
-import org.neo4j.kernel.impl.core.LastTxIdGetter;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
 
 /**
- * ElectionCredentialsProvider that provides the server URI and latest tx id as credentials for elections
+ * Interface that decouples information about a database instance from the instance itself.
  */
-public class DefaultElectionCredentialsProvider
-    implements ElectionCredentialsProvider
+public interface HighAvailabilityMemberInfoProvider
 {
-    private final int serverId;
-    private final LastTxIdGetter lastTxIdGetter;
-
-    public DefaultElectionCredentialsProvider( int serverId, LastTxIdGetter lastTxIdGetter )
-    {
-        this.serverId = serverId;
-        this.lastTxIdGetter = lastTxIdGetter;
-    }
-
-    @Override
-    public DefaultElectionCredentials getCredentials( String role )
-    {
-        return new DefaultElectionCredentials( serverId, lastTxIdGetter.getLastTxId() );
-    }
+    HighAvailabilityMemberState getHighAvailabilityMemberState();
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentialsProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultElectionCredentialsProvider.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
+import org.neo4j.kernel.ha.HighAvailabilityMemberInfoProvider;
+import org.neo4j.kernel.impl.core.LastTxIdGetter;
+
+/**
+ * ElectionCredentialsProvider that provides the server id, latest txId and current role status as credentials for
+ * elections.
+ */
+public class DefaultElectionCredentialsProvider
+    implements ElectionCredentialsProvider
+{
+    private final int serverId;
+    private final LastTxIdGetter lastTxIdGetter;
+    private final HighAvailabilityMemberInfoProvider masterInfo;
+
+    public DefaultElectionCredentialsProvider( int serverId, LastTxIdGetter lastTxIdGetter,
+                                               HighAvailabilityMemberInfoProvider masterInfo )
+    {
+        this.serverId = serverId;
+        this.lastTxIdGetter = lastTxIdGetter;
+        this.masterInfo = masterInfo;
+    }
+
+    @Override
+    public DefaultElectionCredentials getCredentials( String role )
+    {
+        return new DefaultElectionCredentials( serverId, lastTxIdGetter.getLastTxId(), isMasterOrToMaster() );
+    }
+
+    private boolean isMasterOrToMaster()
+    {
+        return masterInfo.getHighAvailabilityMemberState() == HighAvailabilityMemberState.MASTER ||
+                masterInfo.getHighAvailabilityMemberState() == HighAvailabilityMemberState.TO_MASTER;
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -118,8 +118,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                         } );
                 context.setAvailableHaMasterId( null );
                 accessGuard.setState( state );
-                logger.debug( "Got masterIsElected(" + masterUri + "), moved to " + state + " from " +
-                        oldState + ". Previous elected master is " + previousElected );
+                logger.debug( "Got masterIsElected(" + masterUri + "), changed " + oldState + " -> " +
+                        state + ". Previous elected master is " + previousElected );
             }
             catch ( Throwable t )
             {

--- a/enterprise/ha/src/test/java/org/neo4j/ha/DefaultElectionCredentialsTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/DefaultElectionCredentialsTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cluster.protocol.election;
+package org.neo4j.ha;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+import org.neo4j.cluster.protocol.election.ElectionCredentials;
+import org.neo4j.kernel.ha.cluster.DefaultElectionCredentials;
 
 public class DefaultElectionCredentialsTest
 {
@@ -34,13 +36,13 @@ public class DefaultElectionCredentialsTest
     public void testCompareToDifferentTxId() throws Exception
     {
         DefaultElectionCredentials highTxId =
-                new DefaultElectionCredentials( 3, 12 );
+                new DefaultElectionCredentials( 3, 12, false );
 
         DefaultElectionCredentials mediumTxId =
-                new DefaultElectionCredentials( 1, 11 );
+                new DefaultElectionCredentials( 1, 11, false );
 
         DefaultElectionCredentials lowTxId =
-                new DefaultElectionCredentials( 2, 10 );
+                new DefaultElectionCredentials( 2, 10, false );
 
         List<ElectionCredentials> toSort = new ArrayList<ElectionCredentials>( 2 );
         toSort.add( mediumTxId);
@@ -56,9 +58,9 @@ public class DefaultElectionCredentialsTest
     public void testCompareToSameTxId() throws Exception
     {
         // Lower id means higher priority
-        DefaultElectionCredentials highSameTxId = new DefaultElectionCredentials( 1, 10 );
+        DefaultElectionCredentials highSameTxId = new DefaultElectionCredentials( 1, 10, false );
 
-        DefaultElectionCredentials lowSameTxId = new DefaultElectionCredentials( 2, 10 );
+        DefaultElectionCredentials lowSameTxId = new DefaultElectionCredentials( 2, 10, false );
 
         List<ElectionCredentials> toSort = new ArrayList<ElectionCredentials>( 2 );
         toSort.add( highSameTxId );
@@ -69,32 +71,77 @@ public class DefaultElectionCredentialsTest
     }
 
     @Test
+    public void testExistingMasterLosesWhenComparedToHigherTxIdHigherId()
+    {
+        DefaultElectionCredentials currentMaster = new DefaultElectionCredentials( 1, 10, true );
+        DefaultElectionCredentials incoming = new DefaultElectionCredentials( 2, 11, false );
+
+        List<ElectionCredentials> toSort = new ArrayList<ElectionCredentials>( 2 );
+        toSort.add( currentMaster );
+        toSort.add( incoming );
+        Collections.sort( toSort );
+
+        assertEquals( toSort.get( 0 ), currentMaster );
+        assertEquals( toSort.get( 1 ), incoming );
+    }
+
+    @Test
+    public void testExistingMasterWinsWhenComparedToLowerIdSameTxId()
+    {
+        DefaultElectionCredentials currentMaster = new DefaultElectionCredentials( 2, 10, true );
+        DefaultElectionCredentials incoming = new DefaultElectionCredentials( 1, 10, false );
+
+        List<ElectionCredentials> toSort = new ArrayList<ElectionCredentials>( 2 );
+        toSort.add( currentMaster );
+        toSort.add( incoming );
+        Collections.sort( toSort );
+
+        assertEquals( toSort.get( 0 ), incoming );
+        assertEquals( toSort.get( 1 ), currentMaster );
+    }
+
+    @Test
+    public void testExistingMasterWinsWhenComparedToHigherIdLowerTxId()
+    {
+        DefaultElectionCredentials currentMaster = new DefaultElectionCredentials( 1, 10, true );
+        DefaultElectionCredentials incoming = new DefaultElectionCredentials( 2, 9, false );
+
+        List<ElectionCredentials> toSort = new ArrayList<ElectionCredentials>( 2 );
+        toSort.add( currentMaster );
+        toSort.add( incoming );
+        Collections.sort( toSort );
+
+        assertEquals( toSort.get( 0 ), incoming );
+        assertEquals( toSort.get( 1 ), currentMaster );
+    }
+
+    @Test
     public void testEquals() throws Exception
     {
         DefaultElectionCredentials sameAsNext =
-                new DefaultElectionCredentials( 1, 10 );
+                new DefaultElectionCredentials( 1, 10, false );
 
         DefaultElectionCredentials sameAsPrevious =
-                new DefaultElectionCredentials( 1, 10 );
+                new DefaultElectionCredentials( 1, 10, false );
 
         assertEquals( sameAsNext, sameAsPrevious );
         assertEquals( sameAsNext, sameAsNext );
 
 
         DefaultElectionCredentials differentTxIdFromNext =
-                new DefaultElectionCredentials( 1, 11 );
+                new DefaultElectionCredentials( 1, 11, false );
 
         DefaultElectionCredentials differentTxIdFromPrevious =
-                new DefaultElectionCredentials( 1, 10 );
+                new DefaultElectionCredentials( 1, 10, false );
 
         assertFalse( differentTxIdFromNext.equals( differentTxIdFromPrevious ) );
         assertFalse( differentTxIdFromPrevious.equals( differentTxIdFromNext ) );
 
         DefaultElectionCredentials differentURIFromNext =
-                new DefaultElectionCredentials( 1, 11 );
+                new DefaultElectionCredentials( 1, 11, false );
 
         DefaultElectionCredentials differentURIFromPrevious =
-                new DefaultElectionCredentials( 2, 11 );
+                new DefaultElectionCredentials( 2, 11, false );
 
         assertFalse( differentTxIdFromNext.equals( differentURIFromPrevious ) );
         assertFalse( differentTxIdFromPrevious.equals( differentURIFromNext ) );


### PR DESCRIPTION
Gives preference for electing as master the existing master if txIds match

Moves DefaultElectionCredentialsProvider and friends to ha from cluster, since it is
 HA specific
Introduces HighAvailabilityMemberInfoProvider to decouple instance state info from HAGD
DefaultElectionCredentialsProvider now also provides info on current member status
ElectionState now asks the current master last for its election credentials, ensuring
 that its credentials are the most up to date
Whitespace and some cleanup in ElectionState
