### PR TITLE
Ensure that log rotation does not read excessively from the log.

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -384,6 +384,10 @@ public class ComponentVersion extends Version
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.2.2</version>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -1379,10 +1379,10 @@ public class XaLogicalLog implements LogLoader
 //        System.out.println( " ---- Performing rotate on " + currentLogFile + " -----" );
 //        DumpLogicalLog.main( new String[] { currentLogFile } );
 //        System.out.println( " ----- end ----" );
+        long endPosition = writeBuffer.getFileChannelPosition();
         msgLog.logMessage( "Rotating [" + currentLogFile + "] @ version=" +
                 currentVersion + " to " + newLogFile + " from position " +
-                writeBuffer.getFileChannelPosition(), true );
-        long endPosition = writeBuffer.getFileChannelPosition();
+                endPosition, true );
         writeBuffer.force();
         FileChannel newLog = fileSystem.open( newLogFile, "rw" );
         long lastTx = xaTf.getLastCommittedTx();
@@ -1392,10 +1392,9 @@ public class XaLogicalLog implements LogLoader
         {
             throw new IOException( "Unable to write log version to new" );
         }
-        long pos = fileChannel.position();
         fileChannel.position( 0 );
         readAndAssertLogHeader( sharedBuffer, fileChannel, currentVersion );
-        fileChannel.position( pos );
+        fileChannel.position( endPosition );
         if ( xidIdentMap.size() > 0 )
         {
             long firstEntryPosition = getFirstStartEntry( endPosition );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+import java.io.File;
+import java.nio.channels.FileChannel;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.listeners.InvocationListener;
+import org.mockito.listeners.MethodInvocationReport;
+import org.mockito.stubbing.Answer;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
+import org.neo4j.kernel.impl.transaction.XidImpl;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.SingleLoggingService;
+import org.neo4j.test.FailureOutput;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+public class XaLogicalLogTest
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.forTest( XaLogicalLogTest.class ).cleanTestDirectory();
+    @Rule
+    public final FailureOutput output = new FailureOutput();
+    private static final byte[] RESOURCE_ID = new byte[]{0x00, (byte) 0x99, (byte) 0xcc};
+    private long version;
+    private int reads;
+
+    @Test
+    public void shouldNotReadExcessivelyFromTheFileChannelWhenRotatingLogWithNoOpenTransactions() throws Exception
+    {
+        // given
+        XaTransactionFactory xaTf = mock( XaTransactionFactory.class );
+        when( xaTf.getAndSetNewVersion() ).thenAnswer( new TxVersion( TxVersion.UPDATE_AND_GET ) );
+        when( xaTf.getCurrentVersion() ).thenAnswer( new TxVersion( TxVersion.GET ) );
+        // spy on the file system abstraction so that we can spy on the file channel for the logical log
+        FileSystemAbstraction fs = spy( new EphemeralFileSystemAbstraction() );
+        // -- when opening the logical log, spy on the file channel we return and count invocations to channel.read(*)
+        when( fs.open( new File( dir.directory(), "logical.log.1" ), "rw" ) ).thenAnswer( new Answer<FileChannel>()
+        {
+            @Override
+            public FileChannel answer( InvocationOnMock invocation ) throws Throwable
+            {
+                FileChannel channel = (FileChannel) invocation.callRealMethod();
+                return mock( channel.getClass(), withSettings()
+                        .spiedInstance( channel )
+                        .name( "channel" )
+                        .defaultAnswer( CALLS_REAL_METHODS )
+                        .invocationListeners( new InvocationListener()
+                        {
+                            @Override
+                            public void reportInvocation( MethodInvocationReport methodInvocationReport )
+                            {
+                                if ( methodInvocationReport.getInvocation().toString().startsWith( "channel.read(" ) )
+                                {
+                                    reads++;
+                                }
+                            }
+                        } ) );
+            }
+        } );
+        XaLogicalLog xaLogicalLog = new XaLogicalLog( new File( dir.directory(), "logical.log" ),
+                                                      mock( XaResourceManager.class ),
+                                                      mock( XaCommandFactory.class ),
+                                                      xaTf,
+                                                      new DefaultLogBufferFactory(),
+                                                      fs,
+                                                      new SingleLoggingService( StringLogger.wrap( output.writer() ) ),
+                                                      LogPruneStrategies.NO_PRUNING,
+                                                      mock( TransactionStateFactory.class ) );
+        xaLogicalLog.open();
+        // -- set the log up with 10 transactions (with no commands, just start and commit)
+        for ( int txId = 1; txId <= 10; txId++ )
+        {
+            int identifier = xaLogicalLog.start( new XidImpl( XidImpl.getNewGlobalId(), RESOURCE_ID ), -1, 0 );
+            xaLogicalLog.writeStartEntry( identifier );
+            xaLogicalLog.commitOnePhase( identifier, txId, ForceMode.forced );
+            xaLogicalLog.done( identifier );
+        }
+
+        // when
+        xaLogicalLog.rotate();
+
+        // then
+        assertThat( "should not read excessively from the logical log file channel", reads, lessThan( 10 ) );
+    }
+
+    private class TxVersion implements Answer<Object>
+    {
+        private final boolean update;
+        public static final boolean UPDATE_AND_GET = true, GET = false;
+
+        TxVersion( boolean update )
+        {
+            this.update = update;
+        }
+
+        @Override
+        public Object answer( InvocationOnMock invocation ) throws Throwable
+        {
+            synchronized ( XaLogicalLogTest.this )
+            {
+                if ( update )
+                {
+                    version++;
+                }
+                return version;
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/FailureOutput.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FailureOutput.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Utility for capturing output and printing it on test failure only.
+ */
+public class FailureOutput implements TestRule
+{
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private final PrintStream stream = new PrintStream( output );
+    private final PrintStream target;
+
+    public FailureOutput()
+    {
+        this( System.out );
+    }
+
+    public FailureOutput( PrintStream target )
+    {
+        this.target = target;
+    }
+
+    @Override
+    public Statement apply( final Statement base, Description description )
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                try
+                {
+                    base.evaluate();
+                }
+                catch ( Throwable failure )
+                {
+                    printOutput();
+                    throw failure;
+                }
+            }
+        };
+    }
+
+    private void printOutput() throws IOException
+    {
+        target.write( output.toByteArray() );
+        target.flush();
+    }
+
+    public PrintStream stream()
+    {
+        return stream;
+    }
+
+    public PrintWriter writer()
+    {
+        return new PrintWriter( stream );
+    }
+}


### PR DESCRIPTION
Rotating the logical log should not read more transactions from the log than necessary when copying transactions from the old log to the new log. Even if there are no open transactions...
