### PR TITLE
Fixes a problem with recovering a creatIndex command where the index

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/IndexDefinitionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/IndexDefinitionImpl.java
@@ -20,9 +20,6 @@
 package org.neo4j.kernel;
 
 import static java.util.Arrays.asList;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
-
-import java.util.Collection;
 
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Label;
@@ -37,14 +34,14 @@ import org.neo4j.kernel.api.StatementContext;
 class IndexDefinitionImpl implements IndexDefinition
 {
     private final Label label;
-    private final Collection<String> propertyKey;
+    private final String propertyKey;
     private final ThreadToStatementContextBridge ctxProvider;
 
     public IndexDefinitionImpl( ThreadToStatementContextBridge ctxProvider, Label label, String propertyKey )
     {
         this.ctxProvider = ctxProvider;
         this.label = label;
-        this.propertyKey = asList( propertyKey );
+        this.propertyKey = propertyKey;
     }
 
     @Override
@@ -56,7 +53,7 @@ class IndexDefinitionImpl implements IndexDefinition
     @Override
     public Iterable<String> getPropertyKeys()
     {
-        return propertyKey;
+        return asList( propertyKey );
     }
 
     @Override
@@ -67,11 +64,12 @@ class IndexDefinitionImpl implements IndexDefinition
         {
             context.dropIndexRule(
                     context.getIndexRule( context.getLabelId( label.name() ),
-                    context.getPropertyKeyId( single( propertyKey ) ) ) );
+                    context.getPropertyKeyId( propertyKey ) ) );
         }
         catch ( ConstraintViolationKernelException e )
         {
-            throw new ConstraintViolationException(String.format("Unable to drop index on label `%s` for property %s.", label.name(), propertyKey), e );
+            throw new ConstraintViolationException( String.format(
+                    "Unable to drop index on label `%s` for property %s.", label.name(), propertyKey ), e );
         }
         catch ( LabelNotFoundKernelException e )
         {
@@ -83,7 +81,8 @@ class IndexDefinitionImpl implements IndexDefinition
         }
         catch ( SchemaRuleNotFoundException e )
         {
-            throw new ConstraintViolationException(String.format("Unable to drop index on label `%s` for property %s.", label.name(), propertyKey), e );
+            throw new ConstraintViolationException( String.format(
+                    "Unable to drop index on label `%s` for property %s.", label.name(), propertyKey ), e );
         }
     }
     
@@ -112,5 +111,11 @@ class IndexDefinitionImpl implements IndexDefinition
         if ( !propertyKey.equals( other.propertyKey ) )
             return false;
         return true;
+    }
+    
+    @Override
+    public String toString()
+    {
+        return "IndexDefinition[label:" + label + ", on:" + propertyKey + "]";
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementContext.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.KeyNotFoundException;
-import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyIndexManager;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -32,9 +32,9 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     protected abstract IndexProxy getDelegate();
 
     @Override
-    public void create() throws IOException
+    public void start() throws IOException
     {
-        getDelegate().create();
+        getDelegate().start();
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -38,9 +38,9 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
     }
 
     @Override
-    public void create()
+    public void start()
     {
-        String message = "Unable to create index, it is in a " + getState().name() + " state.";
+        String message = "Unable to start index, it is in a " + getState().name() + " state.";
         throw new UnsupportedOperationException( message, cause );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -68,12 +68,12 @@ public class FlippableIndexProxy implements IndexProxy
     }
     
     @Override
-    public void create() throws IOException
+    public void start() throws IOException
     {
         lock.readLock().lock();
         try
         {
-            delegate.create();
+            delegate.start();
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -62,11 +62,11 @@ public class IndexPopulationJob implements Runnable
     private volatile StoreScan storeScan;
     private volatile boolean cancelled;
 
-    public IndexPopulationJob( IndexDescriptor descriptor, IndexPopulator writer, FlippableIndexProxy flipper,
+    public IndexPopulationJob( IndexDescriptor descriptor, IndexPopulator populator, FlippableIndexProxy flipper,
                                IndexingService.IndexStoreView storeView, Logging logging )
     {
         this.descriptor = descriptor;
-        this.populator = writer;
+        this.populator = populator;
         this.flipper = flipper;
         this.storeView = storeView;
         this.log = logging.getLogger( getClass() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -50,7 +50,7 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
  */
 public interface IndexProxy
 {
-    void create() throws IOException;
+    void start() throws IOException;
     
     void update( Iterable<NodePropertyUpdate> updates ) throws IOException;
     
@@ -85,7 +85,7 @@ public interface IndexProxy
         public static final Adapter EMPTY = new Adapter();
 
         @Override
-        public void create()
+        public void start()
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -41,9 +41,8 @@ public class OnlineIndexProxy implements IndexProxy
     }
     
     @Override
-    public void create()
+    public void start()
     {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -45,7 +45,7 @@ public class PopulatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public void create()
+    public void start()
     {
         scheduler.submit( job );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicRecord.java
@@ -25,7 +25,6 @@ public class DynamicRecord extends Abstract64BitRecord
     private byte[] data = null;
     private int length;
     private long nextBlock = Record.NO_NEXT_BLOCK.intValue();
-    private boolean isLight = true;
     private int type;
     private boolean startRecord = true;
 
@@ -54,14 +53,9 @@ public class DynamicRecord extends Abstract64BitRecord
         this.type = type;
     }
 
-    void setIsLight( boolean status )
-    {
-        this.isLight = status;
-    }
-
     public boolean isLight()
     {
-        return isLight;
+        return data == null;
     }
 
     public void setLength( int length )
@@ -87,7 +81,6 @@ public class DynamicRecord extends Abstract64BitRecord
 
     public void setData( byte[] data )
     {
-        isLight = false;
         this.length = data.length;
         this.data = data;
     }
@@ -119,7 +112,7 @@ public class DynamicRecord extends Abstract64BitRecord
         buf.append( "DynamicRecord[" )
                 .append( getId() )
                 .append( ",used=" ).append(inUse() ).append( "," )
-                .append( "light=" ).append( isLight )
+                .append( "light=" ).append( isLight() )
                 .append("(" ).append( length ).append( "),type=" );
         PropertyType type = PropertyType.getPropertyType( this.type << 24, true );
         if ( type == null ) buf.append( this.type ); else buf.append( type.name() );
@@ -167,7 +160,6 @@ public class DynamicRecord extends Abstract64BitRecord
             result.data = data.clone();
         result.setInUse( inUse() );
         result.length = length;
-        result.isLight = isLight;
         result.nextBlock = nextBlock;
         result.type = type;
         result.startRecord = startRecord;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -34,11 +34,11 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.create();
-        outer.create();
+        outer.start();
+        outer.start();
     }
 
     @Test( expected = /* THEN */ IllegalStateException.class )
@@ -46,7 +46,7 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         outer.close();
@@ -58,7 +58,7 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         outer.drop();
@@ -70,7 +70,7 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         outer.close();
@@ -83,10 +83,10 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.create();
+        outer.start();
 
         // PASS
         outer.drop();
@@ -98,10 +98,10 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.create();
+        outer.start();
 
         // PASS
         outer.close();
@@ -113,7 +113,7 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         outer.update( null );
@@ -124,10 +124,10 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.create();
+        outer.start();
         outer.close();
         outer.update( null );
     }
@@ -137,7 +137,7 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         outer.force();
@@ -148,10 +148,10 @@ public class ContractCheckingIndexProxyTest
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
-        IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
-        outer.create();
+        outer.start();
         outer.close();
         outer.force();
     }
@@ -164,12 +164,12 @@ public class ContractCheckingIndexProxyTest
         final IndexProxy inner = new IndexProxy.Adapter()
         {
             @Override
-            public void create()
+            public void start()
             {
                 latch.startAndAwaitFinish();
             }
         };
-        final IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        final IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         runInSeparateThread( new ThrowingRunnable()
@@ -177,7 +177,7 @@ public class ContractCheckingIndexProxyTest
             @Override
             public void run() throws IOException
             {
-                outer.create();
+                outer.start();
             }
         } );
 
@@ -200,12 +200,12 @@ public class ContractCheckingIndexProxyTest
         final IndexProxy inner = new IndexProxy.Adapter()
         {
             @Override
-            public void create()
+            public void start()
             {
                 latch.startAndAwaitFinish();
             }
         };
-        final IndexProxy outer = new ContractCheckingIndexProxy( inner );
+        final IndexProxy outer = newContractCheckingIndexProxy( inner );
 
         // WHEN
         runInSeparateThread( new ThrowingRunnable()
@@ -213,7 +213,7 @@ public class ContractCheckingIndexProxyTest
             @Override
             public void run() throws IOException
             {
-                outer.create();
+                outer.start();
             }
         } );
 
@@ -242,8 +242,8 @@ public class ContractCheckingIndexProxyTest
                 latch.startAndAwaitFinish();
             }
         };
-        final IndexProxy outer = new ContractCheckingIndexProxy( inner );
-        outer.create();
+        final IndexProxy outer = newContractCheckingIndexProxy( inner );
+        outer.start();
 
         // WHEN
         runInSeparateThread( new ThrowingRunnable()
@@ -279,8 +279,8 @@ public class ContractCheckingIndexProxyTest
                 latch.startAndAwaitFinish();
             }
         };
-        final IndexProxy outer = new ContractCheckingIndexProxy( inner );
-        outer.create();
+        final IndexProxy outer = newContractCheckingIndexProxy( inner );
+        outer.start();
 
         // WHEN
         runInSeparateThread( new ThrowingRunnable()
@@ -325,5 +325,10 @@ public class ContractCheckingIndexProxyTest
                 }
             }
         } ).start();
+    }
+
+    private ContractCheckingIndexProxy newContractCheckingIndexProxy( IndexProxy inner )
+    {
+        return new ContractCheckingIndexProxy( inner, false );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/InMemoryIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/InMemoryIndexProvider.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.util.CopyOnWriteHashMap;
 
 public class InMemoryIndexProvider extends SchemaIndexProvider
 {
-    private final Map<Long, InMemoryIndexWriter> indexes = new CopyOnWriteHashMap<Long, InMemoryIndexWriter>();
+    private final Map<Long, InMemoryIndex> indexes = new CopyOnWriteHashMap<Long, InMemoryIndex>();
 
     public InMemoryIndexProvider()
     {
@@ -45,7 +45,7 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
     @Override
     public IndexAccessor getOnlineAccessor( long indexId )
     {
-        InMemoryIndexWriter index = indexes.get( indexId );
+        InMemoryIndex index = indexes.get( indexId );
         if ( index == null || index.state != InternalIndexState.ONLINE )
             throw new IllegalStateException( "Index " + indexId + " not online yet" );
         return index;
@@ -54,19 +54,19 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
     @Override
     public InternalIndexState getInitialState( long indexId )
     {
-        InMemoryIndexWriter index = indexes.get( indexId );
+        InMemoryIndex index = indexes.get( indexId );
         return index != null ? index.state : InternalIndexState.POPULATING;
     }
 
     @Override
     public IndexPopulator getPopulator( long indexId )
     {
-        InMemoryIndexWriter populator = new InMemoryIndexWriter();
+        InMemoryIndex populator = new InMemoryIndex();
         indexes.put( indexId, populator );
         return populator;
     }
     
-    private static class InMemoryIndexWriter extends IndexAccessor.Adapter implements IndexPopulator
+    public static class InMemoryIndex extends IndexAccessor.Adapter implements IndexPopulator
     {
         private final Map<Object, Set<Long>> indexData = new HashMap<Object, Set<Long>>();
         private InternalIndexState state = InternalIndexState.POPULATING;

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -25,6 +25,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.logging.SingleLoggingService;
 
 /**
  * Test factory for graph databases
@@ -32,6 +35,8 @@ import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 public class TestGraphDatabaseFactory
     extends GraphDatabaseFactory
 {
+    private boolean systemOutLogging;
+
     public GraphDatabaseService newImpermanentDatabase()
     {
         return newImpermanentDatabaseBuilder().newGraphDatabase();
@@ -65,6 +70,15 @@ public class TestGraphDatabaseFactory
                         else
                             return super.createFileSystemAbstraction();
                     }
+                    
+                    @Override
+                    protected Logging createLogging()
+                    {
+                        if ( TestGraphDatabaseFactory.this.systemOutLogging )
+                            return new SingleLoggingService( StringLogger.SYSTEM );
+                        else
+                            return super.createLogging();
+                    }
                 };
             }
         } );
@@ -73,6 +87,12 @@ public class TestGraphDatabaseFactory
     public TestGraphDatabaseFactory setFileSystem( FileSystemAbstraction fileSystem )
     {
         this.fileSystem = fileSystem;
+        return this;
+    }
+    
+    public TestGraphDatabaseFactory useSystemOutLogging()
+    {
+        systemOutLogging = true;
         return this;
     }
 }


### PR DESCRIPTION
didn't already exist when doing initIndexes (either because that record
hadn't yet found its way to disk, or that it had been dropped later in the
same logical log.
