### PR TITLE
Adding a way to get the current timestamp in Cypher.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Expressions.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Expressions.scala
@@ -52,6 +52,7 @@ trait Expressions extends Base with ParserPattern with Predicates with StringLit
   (ignoreCase("true") ^^^ Literal(true)
       | ignoreCase("false") ^^^ Literal(false)
       | ignoreCase("null") ^^^ Literal(null)
+      | ignoreCase("gettimestamp") ^^^ Literal(System.currentTimeMillis) 
       | pathExpression
       | extract
       | reduce

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -2451,4 +2451,16 @@ RETURN x0.name?
     // THEN PASS
     println(result.executionPlanDescription())
   }
+
+  @Test
+  def shouldBeAbleToCallGetTimestamp() {
+    val result = engine.execute("START n=node(*) RETURN gettimestamp")
+
+    val ts:Long = result.toList.head("gettimestamp") match {
+      case x:Long => x
+      case _ => 0L
+    }
+    assert(ts != 0L)
+    assert(ts <= System.currentTimeMillis)
+  }
 }


### PR DESCRIPTION
```
neo4j-sh (?)$ create (n {ts:gettimestamp});
+-------------------+
| No data returned. |
+-------------------+
Nodes created: 1
Properties set: 1
3 ms

neo4j-sh (?)$ start n=node(*) return (getTimestamp - n.ts) / 1000;
+------------------------------+
| (getTimestamp - n.ts) / 1000 |
+------------------------------+
| 29                           |
+------------------------------+
1 row
16 ms
```

Willing to accept feedback... especially on the name.
