### PR TITLE
Exposes and fixes lucene recovery issue

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -41,6 +41,14 @@ public interface IndexAccessor
     void updateAndCommit( Iterable<NodePropertyUpdate> updates ) throws IOException;
 
     /**
+     * Apply a set of changes to this index. This method will be called instead of
+     * {@link #updateAndCommit(Iterable)} during recovery of the database when starting up after
+     * a crash or similar. Updates given here may have already been applied to this index, so
+     * additional checks must be in place so that data doesn't get duplicated, but is idempotent.
+     */
+    void recover( Iterable<NodePropertyUpdate> updates ) throws IOException;
+    
+    /**
      * Forces this index to disk. Called at certain points from within Neo4j for example when
      * rotating the logical log. After completion of this call there cannot be any essential state that
      * hasn't been forced to disk.
@@ -72,6 +80,11 @@ public interface IndexAccessor
 
         @Override
         public void updateAndCommit( Iterable<NodePropertyUpdate> updates )
+        {
+        }
+        
+        @Override
+        public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -42,6 +42,12 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     {
         getDelegate().update( updates );
     }
+    
+    @Override
+    public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        getDelegate().recover( updates );
+    }
 
     @Override
     public Future<Void> drop() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.index;
 
 import static org.neo4j.helpers.FutureAdapter.VOID;
 
+import java.io.IOException;
 import java.util.concurrent.Future;
 
 import org.neo4j.kernel.api.index.IndexReader;
@@ -46,6 +47,12 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
 
     @Override
     public void update( Iterable<NodePropertyUpdate> updates )
+    {
+        // intentionally swallow updates, we're failed and nothing but re-population or dropIndex will solve this
+    }
+    
+    @Override
+    public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
     {
         // intentionally swallow updates, we're failed and nothing but re-population or dropIndex will solve this
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -96,6 +96,21 @@ public class FlippableIndexProxy implements IndexProxy
     }
     
     @Override
+    public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        // TODO Shouldn't need the lock
+        lock.readLock().lock();
+        try
+        {
+            delegate.recover( updates );
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+    
+    @Override
     public Future<Void> drop() throws IOException
     {
         lock.readLock().lock();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -54,6 +54,8 @@ public interface IndexProxy
     
     void update( Iterable<NodePropertyUpdate> updates ) throws IOException;
     
+    void recover( Iterable<NodePropertyUpdate> updates ) throws IOException;
+    
     /**
      * Initiates dropping this index context. The returned {@link Future} can be used to await
      * its completion.
@@ -91,6 +93,11 @@ public interface IndexProxy
 
         @Override
         public void update( Iterable<NodePropertyUpdate> updates )
+        {
+        }
+        
+        @Override
+        public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -252,15 +252,32 @@ public class IndexingService extends LifecycleAdapter
 
     public void updateIndexes( Iterable<NodePropertyUpdate> updates )
     {
-        for ( IndexProxy index : indexes.values() )
+        if ( serviceRunning )
         {
-            try
+            for ( IndexProxy index : indexes.values() )
             {
-                index.update( updates );
+                try
+                {
+                    index.update( updates );
+                }
+                catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( "Unable to update " + index, e );
+                }
             }
-            catch ( IOException e )
+        }
+        else
+        {
+            for ( IndexProxy index : indexes.values() )
             {
-                throw new UnderlyingStorageException( "Unable to update " + index, e );
+                try
+                {
+                    index.recover( updates );
+                }
+                catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( "Unable to update " + index, e );
+                }
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -50,6 +50,12 @@ public class OnlineIndexProxy implements IndexProxy
     {
         accessor.updateAndCommit( updates );
     }
+    
+    @Override
+    public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        accessor.recover( updates );
+    }
 
     @Override
     public Future<Void> drop() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.IOException;
 import java.util.concurrent.Future;
 
 import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
@@ -54,6 +55,12 @@ public class PopulatingIndexProxy implements IndexProxy
     public void update( Iterable<NodePropertyUpdate> updates )
     {
         job.update( updates );
+    }
+    
+    @Override
+    public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        throw new UnsupportedOperationException( "Recovered updates shouldn't reach this place" );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/InMemoryIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/InMemoryIndexProvider.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -108,6 +109,12 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
         
         @Override
         public void updateAndCommit( Iterable<NodePropertyUpdate> updates )
+        {
+            update( updates );
+        }
+        
+        @Override
+        public void recover( Iterable<NodePropertyUpdate> updates ) throws IOException
         {
             update( updates );
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
@@ -128,11 +128,11 @@ class LuceneIndexPopulator implements IndexPopulator
                 writer.addDocument( documentLogic.newDocument( nodeId, update.getValueAfter() ) );
                 break;
             case CHANGED:
-                writer.updateDocument( documentLogic.newQueryForChangeOrRemove( nodeId, update.getValueBefore() ),
+                writer.updateDocument( documentLogic.newQueryForChangeOrRemove( nodeId ),
                         documentLogic.newDocument( nodeId, update.getValueAfter() ) );
                 break;
             case REMOVED:
-                writer.deleteDocuments( documentLogic.newQueryForChangeOrRemove( nodeId, update.getValueBefore() ) );
+                writer.deleteDocuments( documentLogic.newQueryForChangeOrRemove( nodeId ) );
                 break;
             }
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
@@ -137,7 +137,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
             throw new UnsupportedOperationException( value.toString() + ", " + value.getClass() );
         }
         
-        public Term newQueryForChangeOrRemove( long nodeId, Object value )
+        public Term newQueryForChangeOrRemove( long nodeId )
         {
             return new Term( NODE_ID_KEY, "" + nodeId );
         }


### PR DESCRIPTION
- Changed the LuceneIndexRecoveryIT to expose the problem where recovery would insert data so that it got duplicated in a lucene index.
- Fixed so that IndexAccessor gets a separate call when doing recovery
  instead of update()
