### PR TITLE
Move all write operations out of StoreStatementContext

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NodeCacheLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NodeCacheLoader.java
@@ -19,20 +19,21 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-
 import org.neo4j.kernel.impl.api.PersistenceCache.CachedNodeEntity;
 import org.neo4j.kernel.impl.cache.LockStripedCache;
 import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
-import org.neo4j.kernel.impl.persistence.PersistenceManager;
+import org.neo4j.kernel.impl.nioneo.store.NodeStore;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 class NodeCacheLoader implements LockStripedCache.Loader<CachedNodeEntity>
 {
-    private final PersistenceManager persistenceManager;
+    private final NodeStore nodeStore;
 
-    NodeCacheLoader( PersistenceManager persistenceManager )
+    NodeCacheLoader( NodeStore nodeStore )
     {
-        this.persistenceManager = persistenceManager;
+        this.nodeStore = nodeStore;
     }
 
     @Override
@@ -40,9 +41,8 @@ class NodeCacheLoader implements LockStripedCache.Loader<CachedNodeEntity>
     {
         try
         {
-            Iterable<Long> labels = persistenceManager.getLabelsForNode( id );
             CachedNodeEntity result = new CachedNodeEntity( id );
-            result.addLabels( asSet( labels ) );
+            result.addLabels( asSet(asIterable(nodeStore.getLabelsForNode(nodeStore.getRecord(id))) ) );
             return result;
         }
         catch ( InvalidRecordException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.api.state.TxState.NodeState;
 import org.neo4j.kernel.impl.cache.EntityWithSize;
 import org.neo4j.kernel.impl.cache.LockStripedCache;
 import org.neo4j.kernel.impl.cache.SoftLruCache;
 
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 /**
  * This is a cache for data not cached by NodeImpl/RelationshipImpl. NodeImpl/RelationshipImpl
  * currently has the roles of caching, locking and transaction state merging. In the future
  * they might disappear and split up into {@link CachingStatementContext},
- * {@link LockingStatementContext} and {@link TransactionStateAwareStatementContext}.
+ * {@link LockingStatementContext} and {@link TransactionStateStatementContext}.
  * 
  * The point is that we need a cache and the implementation is a bit temporary, but might end
  * up being the cache to replace the data within NodeImpl/RelationshipImpl.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api;
 
 import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.api.TransactionContext;
-import org.neo4j.kernel.impl.api.state.OldTxStateBridgeImpl;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.core.TransactionState;
 
@@ -37,14 +36,14 @@ public class StateHandlingTransactionContext extends DelegatingTransactionContex
     @Deprecated
     private final TransactionState oldTransactionState;
 
-    public StateHandlingTransactionContext( TransactionContext actual, PersistenceCache persistenceCache,
-            TransactionState oldTransactionState, SchemaCache schemaCache )
+    public StateHandlingTransactionContext( TransactionContext actual, TxState state,
+            PersistenceCache persistenceCache, TransactionState oldTransactionState, SchemaCache schemaCache )
     {
         super(actual);
         this.persistenceCache = persistenceCache;
         this.oldTransactionState = oldTransactionState;
         this.schemaCache = schemaCache;
-        this.state = new TxState(new OldTxStateBridgeImpl( oldTransactionState ));
+        this.state = state;
     }
 
     @Override
@@ -55,7 +54,7 @@ public class StateHandlingTransactionContext extends DelegatingTransactionContex
         // + Caching
         result = new CachingStatementContext( result, persistenceCache, schemaCache );
         // + Transaction-local state awareness
-        result = new TransactionStateAwareStatementContext( result, state );
+        result = new TransactionStateStatementContext( result, state );
         // + Old transaction state bridge
         result = new OldBridgingTransactionStateStatementContext( result, oldTransactionState );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreTransactionContext.java
@@ -25,21 +25,18 @@ import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyIndexManager;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
-import org.neo4j.kernel.impl.persistence.PersistenceManager;
 
 public class StoreTransactionContext implements TransactionContext
 {
     private final PropertyIndexManager propertyIndexManager;
-    private final PersistenceManager persistenceManager;
     private final NeoStore neoStore;
     private final IndexingService indexingService;
     private final NodeManager nodeManager;
 
-    public StoreTransactionContext( PropertyIndexManager propertyIndexManager,
-            PersistenceManager persistenceManager, NodeManager nodeManager, NeoStore neoStore, IndexingService indexingService )
+    public StoreTransactionContext( PropertyIndexManager propertyIndexManager, NodeManager nodeManager,
+                                    NeoStore neoStore, IndexingService indexingService )
     {
         this.propertyIndexManager = propertyIndexManager;
-        this.persistenceManager = persistenceManager;
         this.nodeManager = nodeManager;
         this.neoStore = neoStore;
         this.indexingService = indexingService;
@@ -48,7 +45,7 @@ public class StoreTransactionContext implements TransactionContext
     @Override
     public StatementContext newStatementContext()
     {
-        return new StoreStatementContext( propertyIndexManager, persistenceManager, nodeManager, neoStore, indexingService,
+        return new StoreStatementContext( propertyIndexManager, nodeManager, neoStore, indexingService,
                 new IndexReaderFactory.Caching( indexingService ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
@@ -19,38 +19,17 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.impl.core.PropertyIndex;
-import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
-import org.neo4j.kernel.impl.nioneo.store.NameData;
-import org.neo4j.kernel.impl.nioneo.store.NeoStore;
-import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
-import org.neo4j.kernel.impl.nioneo.store.NodeStore;
-import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
-import org.neo4j.kernel.impl.nioneo.store.PropertyData;
-import org.neo4j.kernel.impl.nioneo.store.PropertyIndexRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyIndexStore;
-import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
-import org.neo4j.kernel.impl.nioneo.store.Record;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
-import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.kernel.impl.nioneo.store.*;
 import org.neo4j.kernel.impl.persistence.NeoStoreTransaction;
 import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import java.util.*;
 
 class ReadTransaction implements NeoStoreTransaction
 {
@@ -371,18 +350,6 @@ class ReadTransaction implements NeoStoreTransaction
     {
         throw readOnlyException();
     }
-    
-    @Override
-    public boolean isNodeCreated( long nodeId )
-    {
-        return false;
-    }
-
-    @Override
-    public boolean isRelationshipCreated( long relId )
-    {
-        return false;
-    }
 
     public static int getKeyIdForProperty( PropertyData property,
             PropertyStore store )
@@ -438,12 +405,5 @@ class ReadTransaction implements NeoStoreTransaction
     public void removeLabelFromNode( long labelId, long nodeId )
     {
         throw readOnlyException();
-    }
-    
-    @Override
-    public Iterable<Long> getLabelsForNode( long nodeId )
-    {
-        NodeRecord node = getNodeStore().getRecord( nodeId );
-        return asIterable( getNodeStore().getLabelsForNode( node ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
@@ -19,34 +19,7 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static java.util.Arrays.binarySearch;
-import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.kernel.impl.nioneo.store.PropertyStore.encodeString;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.CREATE;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.DELETE;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.UPDATE;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.xa.XAException;
-
-import org.neo4j.graphdb.ConstraintViolationException;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.*;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -54,29 +27,7 @@ import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.PropertyIndex;
 import org.neo4j.kernel.impl.core.TransactionState;
-import org.neo4j.kernel.impl.nioneo.store.AbstractDynamicStore;
-import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
-import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
-import org.neo4j.kernel.impl.nioneo.store.NameData;
-import org.neo4j.kernel.impl.nioneo.store.NeoStore;
-import org.neo4j.kernel.impl.nioneo.store.NeoStoreRecord;
-import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
-import org.neo4j.kernel.impl.nioneo.store.NodeStore;
-import org.neo4j.kernel.impl.nioneo.store.PrimitiveRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
-import org.neo4j.kernel.impl.nioneo.store.PropertyData;
-import org.neo4j.kernel.impl.nioneo.store.PropertyIndexRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyIndexStore;
-import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
-import org.neo4j.kernel.impl.nioneo.store.PropertyType;
-import org.neo4j.kernel.impl.nioneo.store.Record;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeRecord;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeStore;
-import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
-import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
+import org.neo4j.kernel.impl.nioneo.store.*;
 import org.neo4j.kernel.impl.nioneo.xa.Command.NodeCommand;
 import org.neo4j.kernel.impl.nioneo.xa.Command.PropertyCommand;
 import org.neo4j.kernel.impl.nioneo.xa.Command.SchemaRuleCommand;
@@ -88,6 +39,17 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
 import org.neo4j.kernel.impl.transaction.xaframework.XaTransaction;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAException;
+import java.io.Serializable;
+import java.util.*;
+
+import static java.util.Arrays.binarySearch;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.nioneo.store.PropertyStore.encodeString;
+import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.*;
 
 /**
  * Transaction containing {@link Command commands} reflecting the operations
@@ -1726,20 +1688,6 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
             return "Lockable relationship #" + this.getId();
         }
     }
-    
-    @Override
-    public boolean isNodeCreated( long nodeId )
-    {
-        RecordChange<Long, NodeRecord, Void> node = nodeRecords.getIfLoaded( nodeId );
-        return node != null ? node.isCreated() : false;
-    }
-
-    @Override
-    public boolean isRelationshipCreated( long relId )
-    {
-        RecordChange<Long, RelationshipRecord, Void> rel = relRecords.getIfLoaded( relId );
-        return rel != null ? rel.isCreated() : false;
-    }
 
     @Override
     public int getKeyIdForProperty( PropertyData property )
@@ -1922,13 +1870,5 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
         NodeLabelRecordLogic manipulator = new NodeLabelRecordLogic( nodeRecord,
                 getNodeStore() );
         manipulator.remove( labelId );
-    }
-    
-    @Override
-    public Iterable<Long> getLabelsForNode( long nodeId )
-    {
-        // Don't consider changes in this transaction
-        NodeRecord node = getNodeStore().getRecord( nodeId );
-        return asIterable( getNodeStore().getLabelsForNode( node ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
@@ -19,21 +19,16 @@
  */
 package org.neo4j.kernel.impl.persistence;
 
-import java.util.Map;
-
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.impl.core.PropertyIndex;
-import org.neo4j.kernel.impl.nioneo.store.NameData;
-import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
-import org.neo4j.kernel.impl.nioneo.store.PropertyData;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
-import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.kernel.impl.nioneo.store.*;
 import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import java.util.Map;
 
 /**
  * A connection to a {@link PersistenceSource}. <CODE>ResourceConnection</CODE>
@@ -296,24 +291,6 @@ public interface NeoStoreTransaction
      */
     Pair<Map<DirectionWrapper, Iterable<RelationshipRecord>>, Long> getMoreRelationships(
             long nodeId, long position );
-    
-    /**
-     * Check if the node with the given id was created in this transaction.
-     *
-     * @param nodeId The node id to check.
-     * @return True iff a node with the given id was created in this
-     *         transaction.
-     */
-    boolean isNodeCreated( long nodeId );
-
-    /**
-     * Check if the node with the given id was created in this transaction.
-     *
-     * @param relId The relationship id to check.
-     * @return True iff a node with the given id was created in this
-     *         transaction.
-     */
-    boolean isRelationshipCreated( long relId );
 
     /**
      * Returns the index key ids that are contained within the property record
@@ -336,5 +313,4 @@ public interface NeoStoreTransaction
     
     void removeLabelFromNode( long labelId, long nodeId );
 
-    Iterable<Long> getLabelsForNode( long nodeId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaTransaction.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import java.io.IOException;
-
-import javax.transaction.xa.XAException;
-
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.impl.core.TransactionState;
+
+import javax.transaction.xa.XAException;
+import java.io.IOException;
 
 /**
  * <CODE>XaTransaction</CODE> holds all the commands that participate in the
@@ -159,7 +158,7 @@ public abstract class XaTransaction
      * Commits the transaction, loop through all commands and invoke 
      * <CODE>execute()</CODE>.
      * 
-     * @throws XAEXception
+     * @throws XAException
      *             If unable to commit
      */
     protected abstract void doCommit() throws XAException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementContextTest.java
@@ -19,26 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import static java.util.Arrays.asList;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.neo4j.graphdb.DynamicLabel.label;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cache_type;
-import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
-import static org.neo4j.helpers.collection.MapUtil.map;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,19 +30,46 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.PropertyNotFoundException;
-import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyIndexManager;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
-import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cache_type;
+import static org.neo4j.helpers.collection.IteratorUtil.*;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
 public class StoreStatementContextTest
 {
+
+    @Test
+    public void shouldDeclineWriteOps() throws Exception
+    {
+        // When
+        try {
+            statement.addLabelToNode( 12, 12);
+            fail("Should have thrown unsupported operation.");
+        } catch(UnsupportedOperationException e)
+        {
+            // ok
+        }
+    }
+
     @Test
     public void should_be_able_to_read_a_node_property() throws Exception
     {
@@ -105,36 +112,16 @@ public class StoreStatementContextTest
         long propertyKeyId = statement.getPropertyKeyId( propertyKey );
         statement.getNodePropertyValue( nodeId, propertyKeyId );
     }
-
-    @Test
-    public void should_be_able_to_add_label_to_node() throws Exception
-    {
-        // GIVEN
-        Transaction tx = db.beginTx();
-        long nodeId = db.createNode().getId();
-        String labelName = label.name();
-        long labelId = statement.getOrCreateLabelId( labelName );
-
-        // WHEN
-        statement.addLabelToNode( labelId, nodeId );
-        tx.success();
-        tx.finish();
-
-        // THEN
-        assertTrue( "Label " + labelName + " wasn't set on " + nodeId, statement.isLabelSetOnNode( labelId, nodeId ) );
-    }
     
     @Test
     public void should_be_able_to_list_labels_for_node() throws Exception
     {
         // GIVEN
         Transaction tx = db.beginTx();
-        long nodeId = db.createNode().getId();
+        long nodeId = db.createNode(label, label2).getId();
         String labelName1 = label.name(), labelName2 = label2.name();
-        long labelId1 = statement.getOrCreateLabelId( labelName1 );
+        long labelId1 = statement.getLabelId( labelName1 );
         long labelId2 = statement.getOrCreateLabelId( labelName2 );
-        statement.addLabelToNode( labelId1, nodeId );
-        statement.addLabelToNode( labelId2, nodeId );
         tx.success();
         tx.finish();
 
@@ -158,28 +145,6 @@ public class StoreStatementContextTest
         assertEquals( labelName, readLabelName );
     }
 
-    @Test
-    public void should_be_able_to_remove_node_label() throws Exception
-    {
-        // GIVEN
-        Transaction tx = db.beginTx();
-        String labelName = label.name();
-        long labelId = statement.getOrCreateLabelId( labelName );
-        long node = db.createNode().getId();
-        statement.addLabelToNode( labelId, node );
-        tx.success();
-        tx.finish();
-
-        // WHEN
-        tx = db.beginTx();
-        statement.removeLabelFromNode( labelId, node );
-        tx.success();
-        tx.finish();
-
-        // THEN
-        assertFalse( statement.isLabelSetOnNode( labelId, node ) );
-    }
-
     /*
      * This test doesn't really belong here, but OTOH it does, as it has to do with this specific
      * store solution. It creates its own IGD with cache_type:none to try reproduce to trigger the problem.
@@ -198,103 +163,7 @@ public class StoreStatementContextTest
         // THEN
         assertEquals( asSet( "name" ), asSet( propertyKeys ) );
     }
-    
-    @Test
-    public void should_return_true_when_adding_new_label() throws Exception
-    {
-        // GIVEN
-        Node node = createLabeledNode( db, map() );
 
-        // WHEN
-        Transaction tx = db.beginTx();
-        boolean added = false;
-        try
-        {
-            long labelId = statement.getOrCreateLabelId( label.name() );
-            added = statement.addLabelToNode( labelId, node.getId() );
-            tx.success();
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // THEN
-        assertTrue( "Label should have been added", added );
-    }
-    
-    @Test
-    public void should_return_false_when_adding_existing_label() throws Exception
-    {
-        // GIVEN
-        Node node = createLabeledNode( db, map(), label );
-
-        // WHEN
-        Transaction tx = db.beginTx();
-        boolean added = false;
-        try
-        {
-            long labelId = statement.getOrCreateLabelId( label.name() );
-            added = statement.addLabelToNode( labelId, node.getId() );
-            tx.success();
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // THEN
-        assertFalse( "Label should not have been added", added );
-    }
-    
-    @Test
-    public void should_return_true_when_remove_existing_label() throws Exception
-    {
-        // GIVEN
-        Node node = createLabeledNode( db, map(), label );
-
-        // WHEN
-        Transaction tx = db.beginTx();
-        boolean removed = false;
-        try
-        {
-            long labelId = statement.getOrCreateLabelId( label.name() );
-            removed = statement.removeLabelFromNode( labelId, node.getId() );
-            tx.success();
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // THEN
-        assertTrue( "Label should have been removed", removed );
-    }
-    
-    @Test
-    public void should_return_false_when_removing_non_existent_label() throws Exception
-    {
-        // GIVEN
-        Node node = createLabeledNode( db, map() );
-
-        // WHEN
-        Transaction tx = db.beginTx();
-        boolean removed = false;
-        try
-        {
-            long labelId = statement.getOrCreateLabelId( label.name() );
-            removed = statement.addLabelToNode( labelId, node.getId() );
-            tx.success();
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // THEN
-        assertTrue( "Label should not have been removed", removed );
-    }
-    
     @Test
     public void should_return_all_nodes_with_label() throws Exception
     {
@@ -371,7 +240,7 @@ public class StoreStatementContextTest
         IndexingService mockIndexService = mock(IndexingService.class);
         when( mockIndexService.getIndexDescriptor( 1337l ) ).thenReturn( idxDesc );
 
-        StoreStatementContext ctx = new StoreStatementContext( null, null, null, mock( NeoStore.class ), mockIndexService, null);
+        StoreStatementContext ctx = new StoreStatementContext( null, null, mock( NeoStore.class ), mockIndexService, null);
 
         // WHEN
         IndexDescriptor idx = ctx.getIndexDescriptor( 1337l );
@@ -396,7 +265,7 @@ public class StoreStatementContextTest
     }
     
     private GraphDatabaseAPI db;
-    private StatementContext statement;
+    private StoreStatementContext statement;
     private final Label label = label( "first-label" ), label2 = label( "second-label" );
     private final String propertyKey = "name";
 
@@ -407,7 +276,6 @@ public class StoreStatementContextTest
         IndexingService indexingService = db.getDependencyResolver().resolveDependency( IndexingService.class );
         statement = new StoreStatementContext(
                 db.getDependencyResolver().resolveDependency( PropertyIndexManager.class ),
-                db.getDependencyResolver().resolveDependency( PersistenceManager.class ),
                 db.getDependencyResolver().resolveDependency( NodeManager.class ),
                 // Ooh, jucky
                 db.getDependencyResolver().resolveDependency( XaDataSourceManager.class )


### PR DESCRIPTION
This moves all write operations out of StoreStatementContext, and clarifies it's role as a read-only part of the stack.

Instead, writes are handed over to the old transaction infrastructure at the TransactionStateStatementContext, by it talking to TxState, which in turn delegates to PersistenceManager.

This is an initial step towards concentrating ownership of transaction state into one single place. Even though it still delegates back into the old infrastructure, combining it behind one abstraction will help refactoring further.
