### PR TITLE
Include only documentation tests in the -DdocsBuild.

### DIFF
--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -193,6 +193,35 @@
       </plugin>
     </plugins>
   </build>
+  
+  <profiles>
+    <profile>
+      <id>neo-docs-build</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>docsBuild</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <includes>
+                  <include>**/DocTest*.java</include>
+                  <include>**/*DocTest.java</include>
+                  <include>**/docgen/**</include>
+                </includes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 
   <distributionManagement>
     <site>

--- a/community/cypher/src/docs/dev/general/parameters.asciidoc
+++ b/community/cypher/src/docs/dev/general/parameters.asciidoc
@@ -18,7 +18,7 @@ Here follows a few examples of how you can use parameters from Java.
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParameterForNodeId
 classifier=test-sources
 ----
@@ -27,7 +27,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParameterForNodeObject
 classifier=test-sources
 ----
@@ -36,7 +36,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParameterForMultipleNodeIds
 classifier=test-sources
 ----
@@ -45,7 +45,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithStringLiteralAsParameter
 classifier=test-sources
 ----
@@ -54,7 +54,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParametersForIndexKeyAndValue
 classifier=test-sources
 ----
@@ -63,7 +63,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParametersForQuery
 classifier=test-sources
 ----
@@ -72,7 +72,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParameterForSkipLimit
 classifier=test-sources
 ----
@@ -81,7 +81,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=exampleWithParameterRegularExpression
 classifier=test-sources
 ----
@@ -90,7 +90,7 @@ classifier=test-sources
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=set_properties_on_a_node_from_a_map
 classifier=test-sources
 ----

--- a/community/cypher/src/docs/dev/ql/create/index.asciidoc
+++ b/community/cypher/src/docs/dev/ql/create/index.asciidoc
@@ -39,7 +39,7 @@ This query can be used in the following fashion:
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=create_node_from_map
 classifier=test-sources
 ----
@@ -60,7 +60,7 @@ This query can be used in the following fashion:
 [snippet,java]
 ----
 component=neo4j-cypher
-source=org/neo4j/cypher/javacompat/JavaExecutionEngineTest.java
+source=org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
 tag=create_multiple_nodes_from_map
 classifier=test-sources
 ----

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createCypherSnippet;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createQueryResultSnippet;
 
-public class IntroExamplesTest implements GraphHolder
+public class IntroDocTest implements GraphHolder
 {
     private static final String DOCS_TARGET = "target/docs/dev/general/";
     public @Rule

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
@@ -48,7 +48,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-public class JavaExecutionEngineTest
+public class JavaExecutionEngineDocTest
 {
 
     private GraphDatabaseService db;

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQueryDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQueryDocTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.neo4j.test.JavaDocsGenerator;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
-public class JavaQueryTest
+public class JavaQueryDocTest
 {
     @Test
     public void test()

--- a/community/embedded-examples/src/docs/dev/graph-algo.asciidoc
+++ b/community/embedded-examples/src/docs/dev/graph-algo.asciidoc
@@ -4,7 +4,7 @@ Graph Algorithm examples
 
 [TIP]
 The source code used in the example is found here:
-https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingExamplesTest.java[PathFindingExamplesTest.java]
+https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java[PathFindingDocTest.java]
 
 
 Calculating the shortest path (least number of relationships) between two nodes:
@@ -12,7 +12,7 @@ Calculating the shortest path (least number of relationships) between two nodes:
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/PathFindingExamplesTest.java
+source=org/neo4j/examples/PathFindingDocTest.java
 tag=shortestPathUsage
 ----
 
@@ -21,7 +21,7 @@ Using http://en.wikipedia.org/wiki/Dijkstra%27s_algorithm[Dijkstra's algorithm] 
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/PathFindingExamplesTest.java
+source=org/neo4j/examples/PathFindingDocTest.java
 tag=dijkstraUsage
 ----
 
@@ -33,7 +33,7 @@ image::graphalgo-astar.png[scaledwidth="50%", alt="A* algorithm example graph"]
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/PathFindingExamplesTest.java
+source=org/neo4j/examples/PathFindingDocTest.java
 tag=astarUsage
 ----
 

--- a/community/embedded-examples/src/docs/dev/management.asciidoc
+++ b/community/embedded-examples/src/docs/dev/management.asciidoc
@@ -9,14 +9,14 @@ want to use the approach outlined here.
 
 [TIP]
 The source code of the example is found here:
-https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/JmxTest.java[JmxTest.java]
+https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/JmxDocTest.java[JmxDocTest.java]
 
 This example shows how to get the start time of a database:
 	
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/JmxTest.java
+source=org/neo4j/examples/JmxDocTest.java
 tag=getStartTime
 ----
 

--- a/community/embedded-examples/src/docs/dev/setup.asciidoc
+++ b/community/embedded-examples/src/docs/dev/setup.asciidoc
@@ -155,7 +155,7 @@ To start Neo4j with configuration settings, a Neo4j properties file can be loade
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/StartWithConfigurationTest.java
+source=org/neo4j/examples/StartWithConfigurationDocTest.java
 classifier=test-sources
 tag=startDbWithConfig
 ----
@@ -165,7 +165,7 @@ Or you could of course create you own +Map<String, String>+ programmatically and
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/StartWithConfigurationTest.java
+source=org/neo4j/examples/StartWithConfigurationDocTest.java
 classifier=test-sources
 tag=startDbWithMapConfig
 ----
@@ -180,7 +180,7 @@ If you want a _read-only view_ of the database, create an instance this way:
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/ReadOnlyTest.java
+source=org/neo4j/examples/ReadOnlyDocTest.java
 classifier=test-sources
 tag=createReadOnlyInstance
 ----

--- a/community/embedded-examples/src/docs/dev/unit-testing.asciidoc
+++ b/community/embedded-examples/src/docs/dev/unit-testing.asciidoc
@@ -47,7 +47,7 @@ With that in place, we're ready to code our tests.
 
 [TIP]
 For the full source code of this example see:
-https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicTest.java[Neo4jBasicTest.java]
+https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java[Neo4jBasicDocTest.java]
 
 
 Before each test, create a fresh database:
@@ -55,7 +55,7 @@ Before each test, create a fresh database:
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/Neo4jBasicTest.java
+source=org/neo4j/examples/Neo4jBasicDocTest.java
 classifier=test-sources
 tag=beforeTest
 ----
@@ -65,7 +65,7 @@ After the test has executed, the database should be shut down:
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/Neo4jBasicTest.java
+source=org/neo4j/examples/Neo4jBasicDocTest.java
 classifier=test-sources
 tag=afterTest
 ----
@@ -75,7 +75,7 @@ During a test, create nodes and check to see that they are there, while enclosin
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/Neo4jBasicTest.java
+source=org/neo4j/examples/Neo4jBasicDocTest.java
 classifier=test-sources
 tag=unitTest
 ----
@@ -85,7 +85,7 @@ If you want to set configuration parameters at database creation, it's done like
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/Neo4jBasicTest.java
+source=org/neo4j/examples/Neo4jBasicDocTest.java
 classifier=test-sources
 tag=startDbWithConfig
 ----

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.GraphDescription.Graph;
 
-public class AclExampleTest extends AbstractJavaDocTestbase
+public class AclExampleDocTest extends AbstractJavaDocTestbase
 {
     
     /**

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/CypherSqlDocIT.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/CypherSqlDocIT.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.TestData.Title;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-public class CypherSqlIT extends AbstractJavaDocTestbase
+public class CypherSqlDocIT extends AbstractJavaDocTestbase
 {
     private static CypherSql cyperSql;
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/DocumentationDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/DocumentationDocTest.java
@@ -26,7 +26,7 @@ import org.neo4j.test.GraphDescription.Graph;
 
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.*;
 
-public class DocumentationTest extends AbstractJavaDocTestbase
+public class DocumentationDocTest extends AbstractJavaDocTestbase
 {
     /**
      * This is a sample documentation test, demonstrating different ways of

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/EmbeddedNeo4jDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/EmbeddedNeo4jDocTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.neo4j.test.JavaDocsGenerator;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
-public class EmbeddedNeo4jTest
+public class EmbeddedNeo4jDocTest
 {
     private static EmbeddedNeo4j hello;
     private static JavaDocsGenerator gen;

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.UniqueFactory;
 
-public class GetOrCreateIT extends AbstractJavaDocTestbase
+public class GetOrCreateDocIT extends AbstractJavaDocTestbase
 {
     interface GetOrCreate
     {
@@ -93,7 +93,7 @@ public class GetOrCreateIT extends AbstractJavaDocTestbase
             final AtomicReference<RuntimeException> failure = new AtomicReference<RuntimeException>();
             for ( int i = 0; i < Runtime.getRuntime().availableProcessors()*2; i++ )
             {
-                threads.add( new Thread( GetOrCreateIT.class.getSimpleName() + " thread " + i )
+                threads.add( new Thread( GetOrCreateDocIT.class.getSimpleName() + " thread " + i )
                 {
                     @Override
                     public void run()

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/JmxDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/JmxDocTest.java
@@ -31,7 +31,7 @@ import org.neo4j.jmx.JmxUtils;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-public class JmxTest
+public class JmxDocTest
 {
     @Test
     public void readJmxProperties()

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/MatrixDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/MatrixDocTest.java
@@ -25,7 +25,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.test.JavaDocsGenerator;
 
-public class MatrixTest
+public class MatrixDocTest
 {
     private static JavaDocsGenerator gen;
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.*;
 /**
  * An example of unit testing with Neo4j.
  */
-public class Neo4jBasicTest
+public class Neo4jBasicDocTest
 {
     protected GraphDatabaseService graphDb;
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
@@ -45,7 +45,7 @@ import org.neo4j.kernel.Traversal;
 
 import static org.junit.Assert.*;
 
-public class PathFindingExamplesTest
+public class PathFindingDocTest
 {
     @ClassRule
     public static TemporaryFolder temp = new TemporaryFolder();

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.util.FileUtils;
 /**
  * How to get a read-only Neo4j instance.
  */
-public class ReadOnlyTest
+public class ReadOnlyDocTest
 {
     protected GraphDatabaseService graphDb;
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/RolesDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/RolesDocTest.java
@@ -36,7 +36,7 @@ import org.neo4j.kernel.Traversal;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.GraphDescription.Graph;
 
-public class RolesTest extends AbstractJavaDocTestbase
+public class RolesDocTest extends AbstractJavaDocTestbase
 {
     private static final String NAME = "name";
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 
 import static org.junit.Assert.*;
 
-public class StartWithConfigurationTest
+public class StartWithConfigurationDocTest
 {
     @Test
     public void loadFromFile()

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/TraversalDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/TraversalDocTest.java
@@ -27,7 +27,7 @@ import org.neo4j.test.GraphDescription.Graph;
 
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.*;
 
-public class TraversalTest extends AbstractJavaDocTestbase
+public class TraversalDocTest extends AbstractJavaDocTestbase
 {
     /**
      * A

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/UniquenessOfPathsDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/UniquenessOfPathsDocTest.java
@@ -33,7 +33,7 @@ import org.neo4j.test.GraphDescription.Graph;
 import static org.junit.Assert.*;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.*;
 
-public class UniquenessOfPathsTest extends AbstractJavaDocTestbase
+public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
 {    
     /**
      * Uniqueness of Paths in traversals.

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
@@ -37,7 +37,7 @@ import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.JavaDocsGenerator;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
-public class OrderedPathTest
+public class OrderedPathDocTest
 {
     private static OrderedPath orderedPath;
     private static JavaDocsGenerator gen;

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/osgi/OSGiDocIT.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/osgi/OSGiDocIT.java
@@ -45,7 +45,7 @@ import org.ops4j.pax.exam.testforge.WaitForService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 
-public class OSGiIT
+public class OSGiDocIT
 {
 
     public static final String NEO4J_VERSION = GraphDatabaseService.class.getPackage()
@@ -110,7 +110,7 @@ public class OSGiIT
     {
         // create a proper ExamSystem with your options. Focus on
         // "createServerSystem"
-        OSGiIT instance = new OSGiIT();
+        OSGiDocIT instance = new OSGiDocIT();
         ArrayList<Option> ops = new ArrayList<Option>();
         ops.addAll( Arrays.asList( instance.testOptions() ) );
         ops.addAll( Arrays.asList( instance.gogoShellOptions() ) );

--- a/community/kernel/src/docs/dev/batchinsert.asciidoc
+++ b/community/kernel/src/docs/dev/batchinsert.asciidoc
@@ -24,14 +24,14 @@ As we have already pointed out, you can't have multiple threads using the batch 
 
 [TIP]
 The source code of the examples is found here:
-https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/kernel/src/test/java/examples/BatchInsertExampleTest.java[BatchInsertExampleTest.java]
+https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/kernel/src/test/java/examples/BatchInsertDocTest.java[BatchInsertDocTest.java]
 
 To get hold of a +BatchInseter+, use http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/unsafe/batchinsert/BatchInserters.html[+BatchInserters+] and then go from there:
 
 [snippet,java]
 ----
 component=neo4j-kernel
-source=examples/BatchInsertExampleTest.java
+source=examples/BatchInsertDocTest.java
 tag=insert
 ----
 
@@ -42,7 +42,7 @@ This is how to start a batch inserter with configuration options:
 [snippet,java]
 ----
 component=neo4j-kernel
-source=examples/BatchInsertExampleTest.java
+source=examples/BatchInsertDocTest.java
 tag=configuredInsert
 ----
 
@@ -51,7 +51,7 @@ In case you have stored the configuration in a file, you can load it like this:
 [snippet,java]
 ----
 component=neo4j-kernel
-source=examples/BatchInsertExampleTest.java
+source=examples/BatchInsertDocTest.java
 tag=configFileInsert
 ----
 
@@ -76,11 +76,11 @@ With these precautions in mind, this is how to do it:
 [snippet,java]
 ----
 component=neo4j-kernel
-source=examples/BatchInsertExampleTest.java
+source=examples/BatchInsertDocTest.java
 tag=batchDb
 ----
 
 [TIP]
 The source code of the example is found here:
-https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/kernel/src/test/java/examples/BatchInsertExampleTest.java[BatchInsertExampleTest.java]
+https://github.com/neo4j/neo4j/blob/{neo4j-git-tag}/community/kernel/src/test/java/examples/BatchInsertDocTest.java[BatchInsertDocTest.java]
 

--- a/community/kernel/src/docs/dev/transactions.asciidoc
+++ b/community/kernel/src/docs/dev/transactions.asciidoc
@@ -129,7 +129,7 @@ To get the more high-level +get-or-create+ functionality make use of http://comp
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/GetOrCreateIT.java
+source=org/neo4j/examples/GetOrCreateDocIT.java
 classifier=test-sources
 tag=getOrCreate
 ----
@@ -150,7 +150,7 @@ Also, a solution using manual synchronization doesn't ensure uniqueness in an HA
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/GetOrCreateIT.java
+source=org/neo4j/examples/GetOrCreateDocIT.java
 classifier=test-sources
 tag=pessimisticLocking
 ----

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -43,7 +43,7 @@ import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 
-public class BatchInsertExampleTest
+public class BatchInsertDocTest
 {
     @Test
     public void insert() throws IOException

--- a/community/lucene-index/src/docs/dev/batchinsertindex.asciidoc
+++ b/community/lucene-index/src/docs/dev/batchinsertindex.asciidoc
@@ -10,7 +10,7 @@ An example:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=batchInsert
 ----
 

--- a/community/lucene-index/src/docs/dev/index.asciidoc
+++ b/community/lucene-index/src/docs/dev/index.asciidoc
@@ -40,7 +40,7 @@ To set the stage for our examples, let's create some indexes to begin with:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=createIndexes
 ----
 
@@ -54,7 +54,7 @@ You can also check if an index exists like this:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=checkIfExists
 ----
 
@@ -69,7 +69,7 @@ A new index can be created with the same name at a later point in time.
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=delete
 ----
 
@@ -86,7 +86,7 @@ To begin with, let's add a few nodes to the indexes:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=createNodes
 ----
 
@@ -97,7 +97,7 @@ Next up, we'll create relationships and index them as well:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=createRelationships
 ----
 
@@ -117,7 +117,7 @@ http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/inde
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=removeNodeFromIndex
 ----
 
@@ -138,7 +138,7 @@ Here's a code example that demonstrates how it's done:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=update
 ----
 
@@ -158,7 +158,7 @@ This is how to search for a single exact match:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=getSingleNode
 ----
 
@@ -169,7 +169,7 @@ Here's how to get a single relationship by exact matching and retrieve its start
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=getSingleRelationship
 ----
 
@@ -178,7 +178,7 @@ Finally, we can iterate over all exact matches from a relationship index:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=getRelationships
 ----
 
@@ -195,7 +195,7 @@ Here's an example using the key-query option:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=actorsQuery
 ----
 
@@ -204,7 +204,7 @@ In the following example the query uses multiple keys:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=matrixQuery
 ----
 
@@ -225,7 +225,7 @@ Example of querying a relationship index:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=queryForRelationships
 ----
 
@@ -234,7 +234,7 @@ And here's an example for the special case of searching for a specific relations
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=queryForRelationshipType
 ----
 
@@ -252,7 +252,7 @@ See <<indexing-lucene-sort>> for how to sort by score.
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=queryWithScore
 ----
 
@@ -266,7 +266,7 @@ For example to create a Lucene fulltext index:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=fulltext
 ----
 
@@ -311,7 +311,7 @@ To mark a value so that it is indexed as a numeric value, we can make use of the
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=numericRange
 ----
 
@@ -325,7 +325,7 @@ In the following example we are doing that, and have added sorting to the query 
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=sortedNumericRange
 ----
 
@@ -334,7 +334,7 @@ From/to in the ranges defaults to be _inclusive_, but you can change this behavi
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=exclusiveRange
 ----
 
@@ -348,7 +348,7 @@ Lucene performs sorting very well, and that is also exposed in the index backend
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=sortedResult
 ----
 
@@ -357,7 +357,7 @@ We sort the results by relevance (score) like this:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=queryWithRelevance
 ----
 
@@ -369,7 +369,7 @@ Instead of passing in Lucene query syntax queries, you can instantiate such quer
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=termQuery
 ----
 
@@ -380,7 +380,7 @@ This is how to perform _wildcard_ searches using Lucene Query Objects:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=wildcardTermQuery
 ----
 
@@ -394,7 +394,7 @@ Lucene supports querying for multiple terms in the same query, like so:
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=compoundQueries
 ----
 
@@ -408,7 +408,7 @@ The default operator (that is whether +AND+ or +OR+ is used in between different
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=defaultOperator
 ----
 
@@ -422,7 +422,7 @@ You can control the size of the cache (the maximum number of results) per index 
 [snippet,java]
 ----
 component=neo4j-lucene-index
-source=examples/ImdbExampleTest.java
+source=examples/ImdbDocTest.java
 tag=cache
 ----
 

--- a/community/lucene-index/src/test/java/examples/ImdbDocTest.java
+++ b/community/lucene-index/src/test/java/examples/ImdbDocTest.java
@@ -68,7 +68,7 @@ import org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
-public class ImdbExampleTest
+public class ImdbDocTest
 {
     private static GraphDatabaseService graphDb;
     private Transaction tx;

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -870,6 +870,31 @@
                 </repository>
             </repositories>
         </profile>
+
+        <profile>
+          <id>neo-docs-build</id>
+          <activation>
+            <activeByDefault>false</activeByDefault>
+            <property>
+              <name>docsBuild</name>
+            </property>
+          </activation>
+          <build>
+            <pluginManagement>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                    <includes>
+                       <include>**/*FunctionalTest.java</include>
+                     </includes>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </pluginManagement>
+          </build>
+        </profile>
     </profiles>
 
     <reporting>

--- a/community/server/src/docs/dev/server-embedded.asciidoc
+++ b/community/server/src/docs/dev/server-embedded.asciidoc
@@ -90,7 +90,7 @@ the web interface that comes with the server.
 [snippet,java]
 ----
 component=neo4j-server
-source=org/neo4j/server/WrappingNeoServerBootstrapperTest.java
+source=org/neo4j/server/WrappingNeoServerBootstrapperDocTest.java
 tag=usingWrappingNeoServerBootstrapper
 classifier=test-sources
 ----
@@ -109,7 +109,7 @@ the underlying database, such as database location and database configuration pa
 [snippet,java]
 ----
 component=neo4j-server
-source=org/neo4j/server/WrappingNeoServerBootstrapperTest.java
+source=org/neo4j/server/WrappingNeoServerBootstrapperDocTest.java
 tag=customConfiguredWrappingNeoServerBootstrapper
 classifier=test-sources
 ----

--- a/community/server/src/functionaltest/java/org/neo4j/server/WrappingNeoServerBootstrapperDocTest.java
+++ b/community/server/src/functionaltest/java/org/neo4j/server/WrappingNeoServerBootstrapperDocTest.java
@@ -48,7 +48,7 @@ import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
-public class WrappingNeoServerBootstrapperTest extends ExclusiveServerTestBase
+public class WrappingNeoServerBootstrapperDocTest extends ExclusiveServerTestBase
 {
     public
     @Rule

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -34,7 +34,7 @@ import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-public class ShellTest
+public class ShellDocTest
 {
     private AppCommandParser parse( final String line ) throws Exception
     {

--- a/enterprise/ha/src/test/java/jmx/JmxDocTest.java
+++ b/enterprise/ha/src/test/java/jmx/JmxDocTest.java
@@ -55,7 +55,7 @@ import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.test.AsciiDocGenerator;
 import org.neo4j.test.TargetDirectory;
 
-public class JmxDocsTest
+public class JmxDocTest
 {
     private static final String IFDEF_HTMLOUTPUT = "ifndef::nonhtmloutput[]\n";
     private static final String IFDEF_NONHTMLOUTPUT = "ifdef::nonhtmloutput[]\n";
@@ -79,7 +79,7 @@ public class JmxDocsTest
             put( "java.util.Date", "Date (java.util.Date)" );
         }
     };
-    private static final TargetDirectory dir = TargetDirectory.forTest( JmxDocsTest.class );
+    private static final TargetDirectory dir = TargetDirectory.forTest( JmxDocTest.class );
     private static GraphDatabaseService db;
 
     @BeforeClass

--- a/manual/src/community/docs.asciidoc
+++ b/manual/src/community/docs.asciidoc
@@ -383,7 +383,7 @@ This is how to define a code snippet inclusion:
  [snippet,java]
  ----
  component=neo4j-examples
- source=org/neo4j/examples/JmxTest.java
+ source=org/neo4j/examples/JmxDocTest.java
  classifier=test-sources
  tag=getStartTime
  ----
@@ -394,7 +394,7 @@ This is how it renders:
 [snippet,java]
 ----
 component=neo4j-examples
-source=org/neo4j/examples/JmxTest.java
+source=org/neo4j/examples/JmxDocTest.java
 classifier=test-sources
 tag=getStartTime
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,35 @@
         <attach-docs-phase>verify</attach-docs-phase>
         <integration-test-phase>integration-test</integration-test-phase>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <includes>
+                  <include>**/DocTest*.java</include>
+                  <include>**/*DocTest.java</include>
+                  <include>**/*DocTests.java</include>
+                  <include>**/*DocTestCase.java</include>
+                </includes>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <includes>
+                 <include>**/DocIT*.java</include>
+                 <include>**/*DocIT.java</include>
+                 <include>**/*DocITCase.java</include>
+                </includes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>neo-minimal-build</id>


### PR DESCRIPTION
Makes it possible to run documentation related tests only, speeding up work on documentation a lot.

The tests executed in a -DdocsBuild matches one of:
- named *DocTest,
- named *DocIT,
- named *FunctionalTest and located in community/server,
- located in the docgen package of the Cypher module.
  (and a few more variations with no current matches)
