### PR TITLE
Fixes issue where batch insertion on existing db would delete indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexStore.java
@@ -109,7 +109,7 @@ public class IndexStore extends LifecycleAdapter
     }
     
     @Override
-    public void start() throws Throwable
+    public void start()
     {
         read();
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -139,6 +139,7 @@ public class BatchInserterImpl implements BatchInserter
         NameData[] types = getRelationshipTypeStore().getNames( Integer.MAX_VALUE );
         typeHolder = new RelationshipTypeHolder( types );
         indexStore = new IndexStore( this.storeDir, fileSystem );
+        indexStore.start();
     }
 
     private Map<String, String> getDefaultParams()
@@ -967,6 +968,7 @@ public class BatchInserterImpl implements BatchInserter
     /**
      * @deprecated as of Neo4j 1.7
      */
+    @Deprecated
     public GraphDatabaseService getBatchGraphDbService()
     {
         return new BatchGraphDatabaseImpl( this );


### PR DESCRIPTION
When doing batch insertion on an existing database containing indexes,
those indexes, or rather the configuration for them (as well as the
existence of them from the dbs POV) would be deleted if not used in this
second batch insertion. I.e. any index configuration would be overwritten
with whatever this second batch insertion did.

Fixes #527
