### PR TITLE
Fixed issues around migration

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
+import static java.lang.String.format;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -151,12 +153,10 @@ public class NeoStore extends AbstractStore
                 String foundVersion = versionLongToString( getStoreVersion(fileSystemAbstraction, configuration.get( Configuration.neo_store) ));
                 if ( !CommonAbstractStore.ALL_STORES_VERSION.equals( foundVersion ) )
                 {
-                    throw new IllegalStateException(
-                            String.format(
-                                    "Mismatching store version found (%s while expecting %s) and the store is not cleanly shutdown."
-                                            + " Recover the database with the previous database version and then attempt to upgrade",
-                                    foundVersion,
-                                    CommonAbstractStore.ALL_STORES_VERSION ) );
+                    throw new IllegalStateException( format(
+                            "Mismatching store version found (%s while expecting %s). The store cannot be automatically upgraded since it isn't cleanly shutdown." +
+                            " Recover by starting the database using the previous Neo4j version, followed by a clean shutdown. Then start with this version again.",
+                            foundVersion, CommonAbstractStore.ALL_STORES_VERSION ) );
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -126,7 +126,7 @@ public class StoreFactory
                 newRelationshipStore(new File( fileName.getPath() + RELATIONSHIP_STORE_NAME)),
                 newNodeStore(new File( fileName.getPath() + NODE_STORE_NAME)),
                 // We don't need any particular upgrade when we add the schema store
-                newOrCreateSchemaStore(new File( fileName.getPath() + SCHEMA_STORE_NAME)));
+                newSchemaStore(new File( fileName.getPath() + SCHEMA_STORE_NAME)));
     }
 
     private void tryToUpgradeStores( File fileName )
@@ -142,13 +142,6 @@ public class StoreFactory
     {
         return new SchemaStore( file, config, IdType.SCHEMA, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger );
-    }
-    
-    private SchemaStore newOrCreateSchemaStore( File file )
-    {
-        if ( !fileSystemAbstraction.fileExists( file ) )
-            createSchemaStore( file );
-        return newSchemaStore( file );
     }
     
     private DynamicStringStore newDynamicStringStore(File fileName, IdType nameIdType)
@@ -195,9 +188,6 @@ public class StoreFactory
     public NodeStore newNodeStore(File baseFileName)
     {
         File labelsFileName = new File( baseFileName.getPath() + LABELS_PART );
-        if ( !fileSystemAbstraction.fileExists( labelsFileName ) )
-            createNodeLabelsStore( labelsFileName );
-        
         DynamicArrayStore dynamicLabelStore = new DynamicArrayStore( labelsFileName,
                 config, IdType.NODE_LABELS, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction, stringLogger);
         return new NodeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseFiles.java
@@ -38,24 +38,24 @@ public class DatabaseFiles
         if ( fs.fileExists( backupDirectory ) )
         {
             throw new StoreUpgrader.UnableToUpgradeException( String.format( "Cannot proceed with upgrade " +
-                    "because there is an existing upgrade backup in the way at %s. If you do not need this " +
-                    "backup please delete it or move it out of the way before re-attempting upgrade.",
+                    "because there is an existing upgrade backup in the way at %s from a previous upgrade attempt. " +
+                    "If you do not need this backup please delete it or move it out of the way before re-attempting upgrade.",
                     backupDirectory.getAbsolutePath() ) );
         }
         fs.mkdir( backupDirectory );
-        move( workingDirectory, backupDirectory );
+        move( workingDirectory, backupDirectory, StoreFile.legacyStoreFiles() );
     }
 
     public void moveToWorkingDirectory( File upgradeDirectory, File workingDirectory )
     {
-        move( upgradeDirectory, workingDirectory );
+        move( upgradeDirectory, workingDirectory, StoreFile.currentStoreFiles() );
     }
 
-    private void move( File fromDirectory, File toDirectory )
+    private void move( File fromDirectory, File toDirectory, Iterable<StoreFile> storeFiles )
     {
         try
         {
-            StoreFile.move( fs, fromDirectory, toDirectory );
+            StoreFile.move( fs, fromDirectory, toDirectory, storeFiles );
             LogFiles.move( fs, fromDirectory, toDirectory );
         }
         catch ( IOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
@@ -59,7 +59,7 @@ public class UpgradableDatabase
     public void checkUpgradeable( File neoStoreFile )
     {
         File storeDirectory = neoStoreFile.getParentFile();
-        for ( StoreFile store : StoreFile.values() )
+        for ( StoreFile store : StoreFile.legacyStoreFiles() )
         {
             String expectedVersion = store.legacyVersion();
             FileChannel fileChannel = null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
@@ -19,13 +19,15 @@
  */
 package org.neo4j.kernel.impl.storemigration.monitoring;
 
+import static java.lang.String.format;
+
 import java.io.PrintStream;
 
 import org.neo4j.kernel.impl.util.StringLogger;
 
 public class VisibleMigrationProgressMonitor implements MigrationProgressMonitor
 {
-    private StringLogger logger;
+    private final StringLogger logger;
     private final PrintStream out;
 
     public VisibleMigrationProgressMonitor( StringLogger logger, PrintStream out )
@@ -34,28 +36,31 @@ public class VisibleMigrationProgressMonitor implements MigrationProgressMonitor
         this.out = out;
     }
 
+    @Override
     public void started()
     {
         String message = "Starting upgrade of database store files";
         out.println( message );
-        logger.info( message );
+        logger.logMessage( message, true );
     }
 
+    @Override
     public void percentComplete( int percent )
     {
         out.print( "." );
         out.flush();
         if (percent % 10 == 0)
         {
-            logger.info( String.format( "Store upgrade %d%% complete", percent ) );
+            logger.logMessage( format( "Store upgrade %d%% complete", percent ), true );
         }
     }
 
+    @Override
     public void finished()
     {
         String message = "Finished upgrade of database store files";
         out.println();
         out.println( message );
-        logger.info( message );
+        logger.logMessage( message, true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -126,7 +126,7 @@ public class MigrationTestUtils
     public static boolean allStoreFilesHaveVersion( FileSystemAbstraction fileSystem, File workingDirectory,
             String version ) throws IOException
     {
-        for ( StoreFile storeFile : StoreFile.values() )
+        for ( StoreFile storeFile : StoreFile.legacyStoreFiles() )
         {
             FileChannel channel = fileSystem.open( new File( workingDirectory, storeFile.storeFileName() ), "r" );
             int length = UTF8.encode( version ).length;
@@ -145,7 +145,7 @@ public class MigrationTestUtils
         return true;
     }
 
-    public static boolean containsAnyLogicalLogs( EphemeralFileSystemAbstraction fileSystem, File directory )
+    public static boolean containsAnyLogicalLogs( FileSystemAbstraction fileSystem, File directory )
     {
         boolean containsLogicalLog = false;
         for ( File workingFile : fileSystem.listFiles( directory ) )
@@ -158,6 +158,18 @@ public class MigrationTestUtils
         return containsLogicalLog;
     }
 
+    public static boolean containsAnyStoreFiles( FileSystemAbstraction fileSystem, File directory )
+    {
+        for ( StoreFile file : StoreFile.values() )
+        {
+            if ( fileSystem.fileExists( new File( directory, file.storeFileName() ) ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     public static void verifyFilesHaveSameContent( FileSystemAbstraction fileSystem, File original,
             File other ) throws IOException
     {
@@ -202,5 +214,10 @@ public class MigrationTestUtils
     public static UpgradeConfiguration alwaysAllowed()
     {
         return new AlwaysAllowedUpgradeConfiguration();
+    }
+
+    public static File isolatedMigrationDirectoryOf( File dbDirectory )
+    {
+        return new File( dbDirectory, "upgrade" );
     }
 }

--- a/community/neo4j/src/docs/ops/upgrades.asciidoc
+++ b/community/neo4j/src/docs/ops/upgrades.asciidoc
@@ -53,6 +53,7 @@ To perform a special upgrade (for significant changes to the database store):
 . start the database
 . the upgrade will happen during startup and the process is done when the database has been successfully started
 . "+allow_store_upgrade=true+" configuration parameter should be removed, set to "+false+" or commented out
+. information about the upgrade and progress indicator is printed in +messages.log+
 
 [[deployment-upgrading-one-nine]]
 == Upgrade 1.8 -> 1.9.M02 ==

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -297,7 +297,7 @@ public class BackupTool
             throw new IOException( "Trouble making target backup directory "
                     + backupDir.getAbsolutePath() );
         }
-        StoreFile.move( fs, toDir, backupDir );
+        StoreFile.move( fs, toDir, backupDir, StoreFile.legacyStoreFiles() );
         LogFiles.move( fs, toDir, backupDir );
     }
 


### PR DESCRIPTION
- New store files created during update gets moved over after upgrade
- No more lazy creation of schema/nodeLabel stores, since we've got
  proper migration
- Upgrade progress indication flushes the log

co-author: Stefan Plantikow
