### PR TITLE
Make naming of "unnamed" relationships consistent

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ParserPattern.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ParserPattern.scala
@@ -136,8 +136,8 @@ trait ParserPattern extends Base with Labels {
       case head ~ tails =>
         var start = head
         val links = tails.map {
-          case Tail(_, dir, relName, relProps, end, None, types, optional) =>
-            val t = ParsedRelation(relName, relProps, start, end, types, dir, optional)
+          case Tail(pathName, dir, relName, relProps, end, None, types, optional) =>
+            val t = ParsedRelation(if (Identifier.isNamed(relName)) relName else pathName, relProps, start, end, types, dir, optional)
             start = end
             t
           case Tail(pathName, dir, relName, relProps, end, Some((min, max)), types, optional) =>
@@ -172,8 +172,8 @@ trait ParserPattern extends Base with Labels {
   }
 
 
-  private def tailWithRelData: Parser[Tail] = generatedName ~ opt("<") ~ "-" ~ "[" ~ optionalName ~ opt("?") ~ opt(":" ~> rep1sep(opt(":") ~> escapableString, "|")) ~ variable_length ~ props ~ "]" ~ "-" ~ opt(">") ~ node ^^ {
-    case pathName ~ l ~ "-" ~ "[" ~ rel ~ optional ~ typez ~ varLength ~ properties ~ "]" ~ "-" ~ r ~ end => Tail(pathName, direction(l, r), rel, properties, end, varLength, typez.toSeq.flatten.distinct, optional.isDefined)
+  private def tailWithRelData: Parser[Tail] = "" ~ generatedName ~ opt("<") ~ "-" ~ "[" ~ optionalName ~ opt("?") ~ opt(":" ~> rep1sep(opt(":") ~> escapableString, "|")) ~ variable_length ~ props ~ "]" ~ "-" ~ opt(">") ~ node ^^ {
+    case _ ~ pathName ~ l ~ "-" ~ "[" ~ rel ~ optional ~ typez ~ varLength ~ properties ~ "]" ~ "-" ~ r ~ end => Tail(pathName, direction(l, r), rel, properties, end, varLength, typez.toSeq.flatten.distinct, optional.isDefined)
   } | linkErrorMessages
 
   private def linkErrorMessages: Parser[Tail] =
@@ -190,8 +190,8 @@ trait ParserPattern extends Base with Labels {
     case _ => throw new ThisShouldNotHappenError("Stefan/Andres", "This non-exhaustive match would have been a RuntimeException in the past")
   }
 
-  private def tailWithNoRelData = generatedName ~ opt("<") ~ "-" ~ generatedName ~ "-" ~ opt(">") ~ node ^^ {
-    case pathName ~ l ~ "-" ~ name ~ "-" ~ r ~ end => Tail(pathName, direction(l, r), name, Map(), end, None, Seq(), optional = false)
+  private def tailWithNoRelData = "" ~ generatedName ~ opt("<") ~ "-" ~ generatedName ~ "-" ~ opt(">") ~ node ^^ {
+    case _ ~ pathName ~ l ~ "-" ~ name ~ "-" ~ r ~ end => Tail(pathName, direction(l, r), name, Map(), end, None, Seq(), optional = false)
   }
 
   private def tail: Parser[Tail] = tailWithRelData | tailWithNoRelData

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -360,7 +360,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED28" -> testFrom2_0
+      "  UNNAMED26" -> testFrom2_0
     )
   }
 
@@ -375,7 +375,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED27" -> testFrom2_0)
+      "  UNNAMED26" -> testFrom2_0)
   }
 
   @Test def relatedToWithoutRelTypeButWithRelVariable() {
@@ -398,7 +398,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED29" -> testFrom2_0)
+      "  UNNAMED26" -> testFrom2_0)
   }
 
   @Test def shouldOutputVariables() {
@@ -457,7 +457,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       ("  UNNAMED5", "  UNNAMED6") -> testPre2_0,
-      ("  UNNAMED28", "  UNNAMED42") -> testFrom2_0
+      ("  UNNAMED26", "  UNNAMED40") -> testFrom2_0
     )
   }
 
@@ -486,7 +486,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       "start a = NODE(1) match a --> b return a, b, count(*)",
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "b", "  UNNAMED27", Seq(), Direction.OUTGOING, false)).
+        matches(RelatedTo("a", "b", "  UNNAMED26", Seq(), Direction.OUTGOING, false)).
         aggregation(CountStar()).
         columns("a", "b", "count(*)").
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(CountStar(), "count(*)")))
@@ -540,7 +540,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       "start a = NODE(1) match a --> b return a, b, avg(a.age)",
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "b", "  UNNAMED27", Seq(), Direction.OUTGOING, false)).
+        matches(RelatedTo("a", "b", "  UNNAMED26", Seq(), Direction.OUTGOING, false)).
         aggregation(Avg(Property(Identifier("a"), "age"))).
         columns("a", "b", "avg(a.age)").
         returns(ReturnItem(Identifier("a"), "a"), ReturnItem(Identifier("b"), "b"), ReturnItem(Avg(Property(Identifier("a"), "age")), "avg(a.age)")))
@@ -559,7 +559,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED29"-> testFrom2_0
+      "  UNNAMED28"-> testFrom2_0
     )
   }
 
@@ -578,7 +578,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       query,
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo("a", "b", "  UNNAMED27", Seq(), Direction.OUTGOING, false)).
+        matches(RelatedTo("a", "b", "  UNNAMED26", Seq(), Direction.OUTGOING, false)).
         aggregation(Max((Property(Identifier("a"), "age")))).
         columns("a", "b", "max(a.age)").
         returns(
@@ -823,7 +823,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED30" -> testFrom2_0)
+      "  UNNAMED29" -> testFrom2_0)
   }
 
   @Test def threeStepsPath() {
@@ -861,7 +861,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED23" -> testFrom2_0)
+      "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def variableLengthPathWithRelsIterable() {
@@ -875,7 +875,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
     "  UNNAMED3" -> testPre2_0,
-    "  UNNAMED23" -> testFrom2_0)
+    "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def fixedVarLengthPath() {
@@ -890,7 +890,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     testPre2_0(string, queryWith("  UNNAMED3"))
 
-    testFrom2_0(string, queryWith("  UNNAMED23"))
+    testFrom2_0(string, queryWith("  UNNAMED24"))
   }
 
   @Test def variableLengthPathWithoutMinDepth() {
@@ -902,7 +902,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("x"), "x"))
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED23" -> testFrom2_0)
+      "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def variableLengthPathWithRelationshipIdentifier() {
@@ -914,7 +914,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("x"), "x"))
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED23" -> testFrom2_0)
+      "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def variableLengthPathWithoutMaxDepth() {
@@ -927,7 +927,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED23" -> testFrom2_0)
+      "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def unboundVariableLengthPath_Old() {
@@ -943,7 +943,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
     testFrom2_0("start a=node(0) match a -[:knows*]-> x return x",
       Query.
         start(NodeById("a", 0)).
-        matches(VarLengthRelatedTo("  UNNAMED23", "a", "x", None, None, "knows", Direction.OUTGOING)).
+        matches(VarLengthRelatedTo("  UNNAMED24", "a", "x", None, None, "knows", Direction.OUTGOING)).
         returns(ReturnItem(Identifier("x"), "x"))
     )
   }
@@ -959,7 +959,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED28" -> testFrom2_0)
+      "  UNNAMED26" -> testFrom2_0)
   }
 
   @Test def questionMarkOperator() {
@@ -991,7 +991,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED28" -> testFrom2_0)
+      "  UNNAMED26" -> testFrom2_0)
   }
 
   @Test def optionalTypedAndNamedRelationship() {
@@ -1169,7 +1169,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where a-->b return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(PatternPredicate(Seq(RelatedTo("a", "b", "  UNNAMED35", Seq(), Direction.OUTGOING, optional = false)))).
+        where(PatternPredicate(Seq(RelatedTo("a", "b", "  UNNAMED34", Seq(), Direction.OUTGOING, optional = false)))).
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1187,7 +1187,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where not(a-->()) return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(Not(PatternPredicate(Seq(RelatedTo("a", "  UNNAMED42", "  UNNAMED39", Seq(), Direction.OUTGOING, optional = false))))).
+        where(Not(PatternPredicate(Seq(RelatedTo("a", "  UNNAMED42", "  UNNAMED38", Seq(), Direction.OUTGOING, optional = false))))).
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1336,7 +1336,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
     val query = {
       Query.
         start(NodeById("x", 1)).
-        matches(RelatedTo("x", "z", "  UNNAMED27", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
+        matches(RelatedTo("x", "z", "  UNNAMED25", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("x"), "x"))
     }
 
@@ -1358,7 +1358,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
     val q=
       Query.
         start(NodeById("x", 1)).
-        matches(RelatedTo("x", "z", "  UNNAMED27", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
+        matches(RelatedTo("x", "z", "  UNNAMED25", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("x"), "x"))
 
     testFrom2_0("start x = NODE(1) match x-[:REL1|:REL2|:REL3]->z return x", q)
@@ -1378,7 +1378,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
     def q =
       Query.
         start(NodeById("x", 1)).
-        matches(RelatedTo("x", "z", "  UNNAMED27", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
+        matches(RelatedTo("x", "z", "  UNNAMED25", Seq("REL1", "REL2", "REL3"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("x"), "x"))
 
     testFrom2_0("start x = NODE(1) match x-[:REL1|:REL2|:REL3]->z return x", q)
@@ -1398,7 +1398,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
       """start a=node(0), b=node(1) where a-[:KNOWS|:BLOCKS]-b return a""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        where(PatternPredicate(Seq(RelatedTo("a", "b", "  UNNAMED36", Seq("KNOWS","BLOCKS"), Direction.BOTH, optional = false))))
+        where(PatternPredicate(Seq(RelatedTo("a", "b", "  UNNAMED34", Seq("KNOWS","BLOCKS"), Direction.BOTH, optional = false))))
         returns (ReturnItem(Identifier("a"), "a")))
   }
 
@@ -1447,7 +1447,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
     tests(string, query,
       "  UNNAMED3" -> testPre2_0,
-      "  UNNAMED23" -> testFrom2_0)
+      "  UNNAMED24" -> testFrom2_0)
   }
 
   @Test def binary_precedence() {
@@ -1592,7 +1592,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   @Test def create_nodes_with_labels_and_a_rel() {
     testFrom2_0("CREATE (n:Person:Husband)-[:FOO]->x:Person",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED27",
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED25",
         RelationshipEndpoint(Identifier("n"),Map(), LabelSupport.labelCollection("Person", "Husband"), false),
         RelationshipEndpoint(Identifier("x"),Map(), LabelSupport.labelCollection("Person"), false), "FOO", Map()))).
         returns()
@@ -1663,7 +1663,7 @@ create a-[r:REL]->b
   @Test def create_relationship_without_identifier() {
     testFrom2_0("create ({a})-[:REL]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED14",
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED12",
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true),
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true), "REL", Map()))).
         returns())
@@ -1682,7 +1682,7 @@ create a-[r:REL]->b
   @Test def create_relationship_with_properties_from_map() {
     testFrom2_0("create ({a})-[:REL {param}]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED14",
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED12",
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true),
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true),
         "REL", Map("*" -> ParameterExpression("param"))))).
@@ -1701,7 +1701,7 @@ create a-[r:REL]->b
   @Test def create_relationship_without_identifier2() {
     testFrom2_0("create ({a})-[:REL]->({a})",
       Query.
-        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED14",
+        start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED12",
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true),
         RelationshipEndpoint(ParameterExpression("a"), Map(), Seq.empty, true), "REL", Map()))).
         returns())
@@ -1909,7 +1909,7 @@ create a-[r:REL]->b
 
     tests(string, query,
       "  UNNAMED1" -> testPre2_0,
-      "  UNNAMED46" -> testFrom2_0)
+      "  UNNAMED44" -> testFrom2_0)
   }
 
   @Test def single_create_unique_with_rel() {
@@ -1940,7 +1940,7 @@ create a-[r:REL]->b
 
     tests(string, query,
       ("  UNNAMED1", "  UNNAMED2")->testPre2_0,
-      ("  UNNAMED58", "  UNNAMED46")->testFrom2_0)
+      ("  UNNAMED58", "  UNNAMED44")->testFrom2_0)
   }
 
   @Test def two_relates() {
@@ -1960,7 +1960,7 @@ create a-[r:REL]->b
 
     tests(string, query,
       ("  UNNAMED1", "  UNNAMED2") -> testPre2_0,
-      ("  UNNAMED35", "  UNNAMED44") -> testFrom2_0)
+      ("  UNNAMED33", "  UNNAMED41") -> testFrom2_0)
   }
 
   @Test def relate_with_initial_values_for_node() {
@@ -1982,7 +1982,7 @@ create a-[r:REL]->b
 
     tests(string, query,
       ("  UNNAMED1", true) -> testPre2_0,
-      ("  UNNAMED35", false) -> testFrom2_0)
+      ("  UNNAMED33", false) -> testFrom2_0)
   }
 
   @Test def relate_with_initial_values_for_rel() {
@@ -2003,7 +2003,7 @@ create a-[r:REL]->b
     }
     tests(string, query,
       "  UNNAMED1" -> testPre2_0,
-      "  UNNAMED35" -> testFrom2_0)
+      "  UNNAMED33" -> testFrom2_0)
   }
 
   @Test def foreach_with_literal_collectionOld() {
@@ -2084,7 +2084,7 @@ create a-[r:REL]->b
     testFrom2_0("start a  = node(1) return a-->()",
       Query.
         start(NodeById("a", 1)).
-        returns(ReturnItem(PatternPredicate(Seq(RelatedTo("a", "  UNNAMED31", "  UNNAMED28", Seq(), Direction.OUTGOING, optional = false))), "a-->()"))
+        returns(ReturnItem(PatternPredicate(Seq(RelatedTo("a", "  UNNAMED31", "  UNNAMED27", Seq(), Direction.OUTGOING, optional = false))), "a-->()"))
     )
   }
 
@@ -2154,7 +2154,7 @@ create a-[r:REL]->b
 
     tests(string, query,
       ("  UNNAMED1", true) -> testPre2_0,
-      ("  UNNAMED23", false) -> testFrom2_0)
+      ("  UNNAMED21", false) -> testFrom2_0)
   }
 
   @Test def relate_and_assign_to_path_identifier() {
@@ -2188,7 +2188,7 @@ create a-[r:REL]->b
 
   @Test def create_unique_should_support_parameter_maps() {
     val start = NamedExpectation("n", true)
-    val rel = NamedExpectation("  UNNAMED33", true)
+    val rel = NamedExpectation("  UNNAMED31", true)
     val end = new NamedExpectation("  UNNAMED41", ParameterExpression("param"), Map.empty, Seq.empty, true)
 
     val secondQ = Query.
@@ -2536,7 +2536,7 @@ create a-[r:REL]->b
     testFrom2_0("START n=node(0) MATCH n:On-[:WHERE]->() RETURN n",
       Query.
         start(NodeById("n", 0)).
-        matches(RelatedTo("n", "  UNNAMED38", "  UNNAMED28", Seq("WHERE"), Direction.OUTGOING, false)).
+        matches(RelatedTo("n", "  UNNAMED38", "  UNNAMED26", Seq("WHERE"), Direction.OUTGOING, false)).
         where(HasLabel(Identifier("n"), Seq(LabelName("On")))).
         returns(ReturnItem(Identifier("n"), "n"))
     )
@@ -2549,7 +2549,7 @@ create a-[r:REL]->b
 
   @Test def simple_query_with_index_hint() {
     testFrom2_0("match n:Person-->() using index n:Person(name) where n.name = 'Andres' return n",
-      Query.matches(RelatedTo("n", "  UNNAMED18", "  UNNAMED15", Seq(), Direction.OUTGOING, optional = false)).
+      Query.matches(RelatedTo("n", "  UNNAMED18", "  UNNAMED14", Seq(), Direction.OUTGOING, optional = false)).
         where(And(Equals(Property(Identifier("n"), "name"), Literal("Andres")), HasLabel(Identifier("n"), Seq(LabelName("Person"))))).
         usingIndex(SchemaIndex("n", "Person", "name", None)).
         returns(ReturnItem(Identifier("n"), "n", renamed = false)))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/CreateUniqueTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/CreateUniqueTest.scala
@@ -34,7 +34,7 @@ class CreateUniqueTest extends CreateUnique with MatchClause with ParserTest wit
 
     val aLink = NamedExpectation("a", Identifier("a"), Map.empty, LabelSupport.labelCollection("Foo"), bare = false)
     val bLink = NamedExpectation("b", Identifier("b"), Map.empty, Seq.empty, bare = true)
-    val relLink = NamedExpectation("  UNNAMED7", Identifier("  UNNAMED7"), Map.empty, Seq.empty, bare = true)
+    val relLink = NamedExpectation("  UNNAMED5", Identifier("  UNNAMED5"), Map.empty, Seq.empty, bare = true)
 
     parsing("a:Foo-[:x]->b") shouldGive
       Seq(PathAndRelateLink(None, Seq(UniqueLink(aLink, bLink, relLink, "x", Direction.OUTGOING))))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/MatchClauseTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/MatchClauseTest.scala
@@ -33,7 +33,7 @@ class MatchClauseTest extends MatchClause with Expressions with ParserTest {
 
     parsing("MATCH a-[:FOO|BAR]->b") or
     parsing("MATCH a-[:FOO|:BAR]->b") shouldGive
-      RelatedTo("a", "b", "  UNNAMED9", Seq("FOO", "BAR"), Direction.OUTGOING, false)
+      RelatedTo("a", "b", "  UNNAMED7", Seq("FOO", "BAR"), Direction.OUTGOING, false)
   }
 
   implicit def a(p: Pattern): (Seq[Pattern], Seq[NamedPath], Predicate) = (Seq(p), Seq.empty, True())

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/PredicatesTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/PredicatesTest.scala
@@ -34,17 +34,17 @@ class PredicatesTest extends Predicates with MatchClause with ParserTest with Ex
     implicit val parserToTest = patternPredicate
 
     parsing("a-->(:Foo)") shouldGive
-      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED2", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("  UNNAMED5"), Seq(LabelName("Foo"))))
+      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED1", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("  UNNAMED5"), Seq(LabelName("Foo"))))
 
     parsing("a-->(n:Foo)") shouldGive
-      PatternPredicate(Seq(RelatedTo("a", "n", "  UNNAMED2", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("n"), Seq(LabelName("Foo"))))
+      PatternPredicate(Seq(RelatedTo("a", "n", "  UNNAMED1", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("n"), Seq(LabelName("Foo"))))
 
     parsing("a-->(:Bar:Foo)") shouldGive
-      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED2", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("  UNNAMED5"), Seq(LabelName("Bar"), LabelName("Foo"))))
+      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED1", Seq.empty, Direction.OUTGOING, false)), HasLabel(Identifier("  UNNAMED5"), Seq(LabelName("Bar"), LabelName("Foo"))))
 
     val patterns = Seq(
-      RelatedTo("a", "  UNNAMED5", "  UNNAMED2", Seq.empty, Direction.OUTGOING, false),
-      RelatedTo("  UNNAMED5", "  UNNAMED16", "  UNNAMED13", Seq.empty, Direction.OUTGOING, false))
+      RelatedTo("a", "  UNNAMED5", "  UNNAMED1", Seq.empty, Direction.OUTGOING, false),
+      RelatedTo("  UNNAMED5", "  UNNAMED16", "  UNNAMED12", Seq.empty, Direction.OUTGOING, false))
 
     val predicate = And(
       HasLabel(Identifier("  UNNAMED5"), Seq(LabelName("First"))),
@@ -59,7 +59,7 @@ class PredicatesTest extends Predicates with MatchClause with ParserTest with Ex
     )
 
     parsing("a-->(:Bar|:Foo)") shouldGive
-      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED2", Seq.empty, Direction.OUTGOING, false)), orPred)
+      PatternPredicate(Seq(RelatedTo("a", "  UNNAMED5", "  UNNAMED1", Seq.empty, Direction.OUTGOING, false)), orPred)
   }
 
   @Test


### PR DESCRIPTION
Previously anonymous relationships were named as `UNNAMED<n>`, such that `<n>` was:
- For single length relationships with data: the character index immediately after the `[`;
- For single length relationships without data: the character index immediately after the first `-`; or
- For varlength relationships: the character index immediately after the end of the preceeding node (either the identifier or the closing brace).

This commit makes `<n>` consistently refer to the first character in the relationship declaration, being either `<` or `-`.
