### PR TITLE
Creating and populating schema indexes in the batch inserter

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -32,14 +32,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
-import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
-import org.neo4j.kernel.impl.api.index.IndexingService.StoreScan;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 
@@ -51,7 +49,7 @@ import org.neo4j.kernel.logging.Logging;
  */
 public class IndexPopulationJob implements Runnable
 {
-    private final IndexingService.IndexStoreView storeView;
+    private final IndexStoreView storeView;
 
     // NOTE: unbounded queue expected here
     private final Queue<NodePropertyUpdate> queue = new ConcurrentLinkedQueue<NodePropertyUpdate>();
@@ -69,7 +67,7 @@ public class IndexPopulationJob implements Runnable
 
     public IndexPopulationJob( IndexDescriptor descriptor, SchemaIndexProvider.Descriptor providerDescriptor,
                                IndexPopulator populator, FlippableIndexProxy flipper,
-                               IndexingService.IndexStoreView storeView, UpdateableSchemaState updateableSchemaState,
+                               IndexStoreView storeView, UpdateableSchemaState updateableSchemaState,
                                Logging logging )
     {
         this.descriptor = descriptor;
@@ -153,13 +151,13 @@ public class IndexPopulationJob implements Runnable
 
     private void indexAllNodes()
     {
-        storeScan = storeView.visitNodesWithPropertyAndLabel( descriptor, new Visitor<Pair<Long, Object>>()
+        storeScan = storeView.visitNodesWithPropertyAndLabel( descriptor, new Visitor<NodePropertyUpdate>()
         {
             @Override
-            public boolean visit( Pair<Long, Object> element )
+            public boolean visit( NodePropertyUpdate update )
             {
-                populator.add( element.first(), element.other() );
-                populateFromQueueIfAvailable( element.first() );
+                populator.add( update.getNodeId(), update.getValueAfter() );
+                populateFromQueueIfAvailable( update.getNodeId() );
 
                 return false;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+
+/** The indexing services view of the universe. */
+public interface IndexStoreView
+{
+    /**
+     * Get properties of a node, if those properties exist.
+     */
+    Iterator<Pair<Integer, Object>> getNodeProperties( long nodeId, Iterator<Long> propertyKeys );
+
+    /**
+     * Retrieve all nodes in the database with a given label and property, as pairs of node id and property value.
+     *
+     * @return a {@link StoreScan} to start and to stop the scan.
+     */
+    StoreScan visitNodesWithPropertyAndLabel( IndexDescriptor descriptor, Visitor<NodePropertyUpdate> visitor );
+
+    /**
+     * Retrieve all nodes in the database which has got one or more of the given labels AND
+     * one or more of the given property key ids.
+     *
+     * @return a {@link StoreScan} to start and to stop the scan.
+     */
+    StoreScan visitNodes( long[] labelIds, long[] propertyKeyIds, Visitor<NodePropertyUpdate> visitor );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -475,28 +474,5 @@ public class IndexingService extends LifecycleAdapter
                 return proxy;
             }
         };
-    }
-
-    public interface StoreScan
-    {
-        void run();
-
-        void stop();
-    }
-
-    /** The indexing services view of the universe. */
-    public interface IndexStoreView
-    {
-        /**
-         * Get properties of a node, if those properties exist.
-         */
-        Iterator<Pair<Integer, Object>> getNodeProperties( long nodeId, Iterator<Long> propertyKeys );
-
-        /**
-         * Retrieve all nodes in the database with a given label and property, as pairs of node id and property value.
-         *
-         * @return a {@link StoreScan} to start and to stop the scan.
-         */
-        StoreScan visitNodesWithPropertyAndLabel( IndexDescriptor descriptor, Visitor<Pair<Long, Object>> visitor );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -29,7 +29,6 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
-import org.neo4j.kernel.impl.api.index.IndexingService.IndexStoreView;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.logging.Logging;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+public interface StoreScan
+{
+    void run();
+
+    void stop();
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchIndexDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchIndexDefinition.java
@@ -26,12 +26,12 @@ import java.util.Collections;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.schema.IndexDefinition;
 
-public class BatchIndexDefinitionImpl implements IndexDefinition
+public class BatchIndexDefinition implements IndexDefinition
 {
     private final Label label;
     private final Collection<String> propertyKeys;
 
-    public BatchIndexDefinitionImpl( Label label, String... propertyKeys )
+    public BatchIndexDefinition( Label label, String... propertyKeys )
     {
         this.label = label;
         this.propertyKeys = new ArrayList<String>( );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.batchinsert;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.neo4j.graphdb.Label;
@@ -282,10 +283,11 @@ public interface BatchInserter
      *
      * Note that you can call this method multiple times, each time will only populate the
      * indexes that were created since the previous call.
+     * @throws IOException 
      *
      * @see #createDeferredSchemaIndex(Label)
      */
-    public void ensureSchemaIndexesOnline();
+    public void ensureSchemaIndexesOnline() throws IOException;
 
     /**
      * Returns all nodes having the label, and the wanted property value. If an online

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -49,7 +49,7 @@ public class IndexingServiceTest
         IndexingService indexingService = new IndexingService(
                 mock( JobScheduler.class ),
                 providerMap,
-                mock( IndexingService.IndexStoreView.class ),
+                mock( IndexStoreView.class ),
                 mock( UpdateableSchemaState.class ),
                 mockLogging( logger ) );
 
@@ -83,7 +83,7 @@ public class IndexingServiceTest
         IndexingService indexingService = new IndexingService(
                 mock( JobScheduler.class ),
                 providerMap,
-                mock( IndexingService.IndexStoreView.class ),
+                mock( IndexStoreView.class ),
                 mock( UpdateableSchemaState.class ),
                 mockLogging( logger ) );
 


### PR DESCRIPTION
- Schema indexes can be created as deferred, which means they will be
  created later using #ensureSchemaIndexesOnline
- All indexes that are not online yet can be made online in a single store
  scan using #ensureSchemaIndexesOnline
