### PR TITLE
Creating and populating schema indexes in the batch inserter

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,10 +1,12 @@
 2.0.0-M02
 ---------
 o BREAKING CHANGE: Replaced protected fields from org.neo4j.graphdb.factory.GraphDatabaseFactory with a single
-org.neo4j.graphdb.factory.GraphDatabaseFactoryState instance to avoid race conditions when creating multiple,
-lazily instantiated builders
+  org.neo4j.graphdb.factory.GraphDatabaseFactoryState instance to avoid race conditions when creating multiple,
+  lazily instantiated builders
 o BREAKING CHANGE: org.neo4j.graphdb.index.BatchInserterIndex and org.neo4j.graphdb.index.BatchInserterIndexProvider
   has been removed in favor of the same interfaces available in org.neo4j.unsafe.batchinsert
+o BREAKING CHANGE: The BatchInserter and the BatchGraphDatabase are not binary compatible with 1.9 due to some methods
+  now taking a varargs array of labels as last argument.  Please recompile any code that depends on the BatchInserter.
 
 2.0.M01
 -------

--- a/community/kernel/src/docs/dev/batchinsert.asciidoc
+++ b/community/kernel/src/docs/dev/batchinsert.asciidoc
@@ -5,13 +5,15 @@ Batch Insertion
 Neo4j has a batch insertion facility intended for initial imports, which bypasses transactions and other checks in favor of performance.
 This is useful when you have a big dataset that needs to be loaded once.
 
-Batch insertion is inlcuded in the http://search.maven.org/#search|ga|1|neo4j-kernel[neo4j-kernel] component, which is part of all Neo4j distributions and editions.
+Batch insertion is included in the http://search.maven.org/#search|ga|1|neo4j-kernel[neo4j-kernel] component, which is part of all Neo4j distributions and editions.
 
 Be aware of the following points when using batch insertion:
 
 * The intended use is for initial import of data.
 * Batch insertion is _not thread safe._
 * Batch insertion is _non-transactional._
+* Batch insertion will re-populate all existing schema indexes and schema indexes created during batch insertion
+  on shutdown.
 * Unless +shutdown+ is successfully invoked at the end of the import, the database files _will_ be corrupt.
 
 WARNING: Always perform batch insertion in a _single thread_ (or use synchronization to make only one thread at a time access the batch inserter) and invoke +shutdown+ when finished.

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -20,6 +20,7 @@
 package org.neo4j.helpers.collection;
 
 import static java.util.Arrays.asList;
+import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -33,6 +34,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Predicate;
 
@@ -637,6 +641,18 @@ public final class Iterables
 
         List<T> list = toList( iterable );
         return list.toArray( (T[]) Array.newInstance( componentType, list.size() ) );
+    }
+
+    public static <T> ResourceIterable<T> asResourceIterable( final Iterable<T> labels )
+    {
+        return new ResourceIterable<T>()
+        {
+            @Override
+            public ResourceIterator<T> iterator()
+            {
+                return asResourceIterator( labels.iterator() );
+            }
+        };
     }
 
     private static class MapIterable<FROM, TO>

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -51,7 +51,10 @@ public interface IndexPopulator
      * @param updates
      */
     void update( Iterable<NodePropertyUpdate> updates );
-    
+
+    // TODO instead of this flag, we should store if population fails and mark indexes as failed internally
+    // Rationale: Users should be required to explicitly drop failed indexes
+
     /**
      * Close this populator and releases any resources related to it.
      * If {@code populationCompletedSuccessfully} is {@code true} then it must mark this index

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaCache.java
@@ -41,9 +41,9 @@ import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
  */
 public class SchemaCache
 {
-    private final Map<Long, Map<Long,SchemaRule>> rulesMap = new HashMap<Long, Map<Long,SchemaRule>>();
+    private final Map<Long, Map<Long,SchemaRule>> rulesByLabelMap = new HashMap<Long, Map<Long,SchemaRule>>();
     private final Map<Long, SchemaRule> ruleByIdMap = new HashMap<Long, SchemaRule>();
-    
+
     public SchemaCache( Iterable<SchemaRule> initialRules )
     {
         splitUpInitialRules( initialRules );
@@ -57,18 +57,18 @@ public class SchemaCache
 
     private Map<Long,SchemaRule> getOrCreateSchemaRulesMapForLabel( Long label )
     {
-        Map<Long,SchemaRule> rulesForLabel = rulesMap.get( label );
+        Map<Long,SchemaRule> rulesForLabel = rulesByLabelMap.get( label );
         if ( rulesForLabel == null )
         {
             rulesForLabel = new HashMap<Long, SchemaRule>();
-            rulesMap.put( label, rulesForLabel );
+            rulesByLabelMap.put( label, rulesForLabel );
         }
         return rulesForLabel;
     }
     
     public Iterable<SchemaRule> getSchemaRules()
     {
-        return new NestingIterable<SchemaRule, Map<Long,SchemaRule>>( rulesMap.values() )
+        return new NestingIterable<SchemaRule, Map<Long,SchemaRule>>( rulesByLabelMap.values() )
         {
             @Override
             protected Iterator<SchemaRule> createNestedIterator( Map<Long,SchemaRule> item )
@@ -80,7 +80,7 @@ public class SchemaCache
     
     public Collection<SchemaRule> getSchemaRulesForLabel( long label )
     {
-        Map<Long,SchemaRule> rulesForLabel = rulesMap.get( label );
+        Map<Long,SchemaRule> rulesForLabel = rulesByLabelMap.get( label );
         return rulesForLabel != null ? unmodifiableCollection( rulesForLabel.values() ) :
             Collections.<SchemaRule>emptyList();
     }
@@ -97,9 +97,9 @@ public class SchemaCache
         if ( rule == null )
             return;
         
-        Map<Long, SchemaRule> rules = rulesMap.get( rule.getLabel() );
+        Map<Long, SchemaRule> rules = rulesByLabelMap.get( rule.getLabel() );
         if ( rules.remove( id ) != null )
             if ( rules.isEmpty() )
-                rulesMap.remove( rule.getLabel() );
+                rulesByLabelMap.remove( rule.getLabel() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+
+/** The indexing services view of the universe. */
+public interface IndexStoreView
+{
+    /**
+     * Get properties of a node, if those properties exist.
+     */
+    Iterator<Pair<Integer, Object>> getNodeProperties( long nodeId, Iterator<Long> propertyKeys );
+
+    /**
+     * Retrieve all nodes in the database with a given label and property, as pairs of node id and property value.
+     *
+     * @return a {@link StoreScan} to start and to stop the scan.
+     */
+    StoreScan visitNodesWithPropertyAndLabel( IndexDescriptor descriptor, Visitor<NodePropertyUpdate> visitor );
+
+    /**
+     * Retrieve all nodes in the database which has got one or more of the given labels AND
+     * one or more of the given property key ids.
+     *
+     * @return a {@link StoreScan} to start and to stop the scan.
+     */
+    StoreScan visitNodes( long[] labelIds, long[] propertyKeyIds, Visitor<NodePropertyUpdate> visitor );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -475,28 +474,5 @@ public class IndexingService extends LifecycleAdapter
                 return proxy;
             }
         };
-    }
-
-    public interface StoreScan
-    {
-        void run();
-
-        void stop();
-    }
-
-    /** The indexing services view of the universe. */
-    public interface IndexStoreView
-    {
-        /**
-         * Get properties of a node, if those properties exist.
-         */
-        Iterator<Pair<Integer, Object>> getNodeProperties( long nodeId, Iterator<Long> propertyKeys );
-
-        /**
-         * Retrieve all nodes in the database with a given label and property, as pairs of node id and property value.
-         *
-         * @return a {@link StoreScan} to start and to stop the scan.
-         */
-        StoreScan visitNodesWithPropertyAndLabel( IndexDescriptor descriptor, Visitor<Pair<Long, Object>> visitor );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -29,7 +29,6 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
-import org.neo4j.kernel.impl.api.index.IndexingService.IndexStoreView;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.logging.Logging;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+public interface StoreScan
+{
+    void run();
+
+    void stop();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -110,7 +110,6 @@ public class StoreUpgrader
                 throw new UnableToUpgradeException( e );
             }
         }
-
         fileSystem.mkdir( upgradeDirectory );
 
         File upgradeFileName = new File( upgradeDirectory, NeoStore.DEFAULT_NAME );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchIndexDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchIndexDefinition.java
@@ -26,12 +26,12 @@ import java.util.Collections;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.schema.IndexDefinition;
 
-public class BatchIndexDefinitionImpl implements IndexDefinition
+public class BatchIndexDefinition implements IndexDefinition
 {
     private final Label label;
     private final Collection<String> propertyKeys;
 
-    public BatchIndexDefinitionImpl( Label label, String... propertyKeys )
+    public BatchIndexDefinition( Label label, String... propertyKeys )
     {
         this.label = label;
         this.propertyKeys = new ArrayList<String>( );

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -32,8 +32,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.helpers.collection.MapUtil;
@@ -50,11 +52,13 @@ public class BatchInsertDocTest
     {
         // START SNIPPET: insert
         BatchInserter inserter = BatchInserters.inserter( "target/batchinserter-example", fileSystem );
+        Label personLabel = DynamicLabel.label( "Person" );
+        inserter.createDeferredSchemaIndex( personLabel ).on( "name" );
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put( "name", "Mattias" );
-        long mattiasNode = inserter.createNode( properties );
+        long mattiasNode = inserter.createNode( properties, personLabel );
         properties.put( "name", "Chris" );
-        long chrisNode = inserter.createNode( properties );
+        long chrisNode = inserter.createNode( properties, personLabel );
         RelationshipType knows = DynamicRelationshipType.withName( "KNOWS" );
         // To set properties on the relationship, use a properties map
         // instead of null as the last parameter.
@@ -115,10 +119,12 @@ public class BatchInsertDocTest
         // START SNIPPET: batchDb
         GraphDatabaseService batchDb =
                 BatchInserters.batchDatabase( "target/batchdb-example", fileSystem );
-        Node mattiasNode = batchDb.createNode();
+        Label personLabel = DynamicLabel.label( "Person" );
+        Node mattiasNode = batchDb.createNode( personLabel );
         mattiasNode.setProperty( "name", "Mattias" );
         Node chrisNode = batchDb.createNode();
         chrisNode.setProperty( "name", "Chris" );
+        chrisNode.addLabel( personLabel );
         RelationshipType knows = DynamicRelationshipType.withName( "KNOWS" );
         mattiasNode.createRelationshipTo( chrisNode, knows );
         // END SNIPPET: batchDb

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -49,7 +49,7 @@ public class IndexingServiceTest
         IndexingService indexingService = new IndexingService(
                 mock( JobScheduler.class ),
                 providerMap,
-                mock( IndexingService.IndexStoreView.class ),
+                mock( IndexStoreView.class ),
                 mock( UpdateableSchemaState.class ),
                 mockLogging( logger ) );
 
@@ -83,7 +83,7 @@ public class IndexingServiceTest
         IndexingService indexingService = new IndexingService(
                 mock( JobScheduler.class ),
                 providerMap,
-                mock( IndexingService.IndexStoreView.class ),
+                mock( IndexStoreView.class ),
                 mock( UpdateableSchemaState.class ),
                 mockLogging( logger ) );
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInserterImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInserterImplTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.test.ReflectionUtil;
 import org.neo4j.test.TargetDirectory;
@@ -65,7 +66,7 @@ public class BatchInserterImplTest
         Boolean memoryMappingConfig = createInserterAndGetMemoryMappingConfig( stringMap() );
         assertFalse( "memory mapped config is active", memoryMappingConfig );
     }
-
+    
     private Boolean createInserterAndGetMemoryMappingConfig( Map<String, String> initialConfig ) throws Exception
     {
         BatchInserter inserter = BatchInserters.inserter(

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchDatabase.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+public class TestBatchDatabase
+{
+    private final String storeDir = "/tmp/dblala";
+
+    private EphemeralFileSystemAbstraction fs;
+
+    @Test
+    public void shouldCreateLabeledNodes()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+
+        // when
+        long nodeId = gdb.createNode( luluLabel ).getId();
+
+        // and
+        gdb = turnIntoRealGraphDatabase( gdb );
+
+        // then
+        assertEquals( asSet( luluLabel ), asSet( gdb.getNodeById( nodeId ).getLabels() ) );
+
+        gdb.shutdown();
+    }
+
+    @Test
+    public void shouldCreateAndSeeLabeledNodes()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+
+        // when
+        long nodeId = gdb.createNode( luluLabel ).getId();
+
+        // then
+        assertEquals( asSet( luluLabel ), asSet( gdb.getNodeById( nodeId ).getLabels() ) );
+    }
+
+    @Test
+    public void shouldCreateAndTestLabeledNodes()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+
+        // when
+        long nodeId = gdb.createNode( luluLabel ).getId();
+
+        // then
+        assertEquals( asSet( luluLabel ), asSet( gdb.getNodeById( nodeId ).getLabels() ) );
+    }
+
+    @Test
+    public void shouldAddLabelToNode()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+        Node node = gdb.createNode();
+
+        // when
+        node.addLabel( luluLabel );
+
+        // then
+        assertEquals( asSet( luluLabel ), asSet( gdb.getNodeById( node.getId() ).getLabels() ) );
+    }
+
+    @Test
+    public void shouldAddLabelTwiceToNode()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+        Node node = gdb.createNode();
+
+        // when
+        node.addLabel( luluLabel );
+        node.addLabel( luluLabel );
+
+        // then
+        assertEquals( asSet( luluLabel ), asSet( gdb.getNodeById( node.getId() ).getLabels() ) );
+    }
+
+    @Test
+    public void removingNonExistantLabelFromNodeShouldBeNoOp()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+        Node node = gdb.createNode();
+
+        // when
+        node.removeLabel( luluLabel );
+
+        // then
+        assertFalse( gdb.getNodeById( node.getId() ).hasLabel( luluLabel ) );
+        assertTrue( asSet( gdb.getNodeById( node.getId() ).getLabels() ).isEmpty() );
+    }
+
+    @Test
+    public void shouldRemoveLabelFromNode()
+    {
+        // given
+
+        GraphDatabaseService gdb = BatchInserters.batchDatabase( storeDir, fs );
+        Label luluLabel = label( "lulu" );
+        Label lalaLabel = label( "lala" );
+        Node node = gdb.createNode();
+        node.addLabel( lalaLabel );
+        node.addLabel( luluLabel );
+
+        // when
+        node.removeLabel( luluLabel );
+
+        // then
+        assertEquals( asSet( lalaLabel ), asSet( gdb.getNodeById( node.getId() ).getLabels() ) );
+    }
+
+    private GraphDatabaseService turnIntoRealGraphDatabase( GraphDatabaseService gdb )
+    {
+        gdb.shutdown();
+
+        TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
+        factory.setFileSystem( fs );
+        return factory.newImpermanentDatabase( storeDir );
+    }
+
+    @Before
+    public void before()
+    {
+        fs = new EphemeralFileSystemAbstraction();
+    }
+
+    @After
+    public void after()
+    {
+        fs.shutdown();
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/TransactionTimeoutDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/TransactionTimeoutDocIT.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.server.configuration.Configurator.TRANSACTION_TIMEOUT;
 import static org.neo4j.server.helpers.ServerBuilder.server;
+import static org.neo4j.server.rest.transactional.TimeoutEvictingTransactionRegistry.TX_NOT_FOUND_ERR_MSG;
 import static org.neo4j.server.rest.transactional.error.Neo4jError.Code.INVALID_TRANSACTION_ID;
 
 import java.util.List;
@@ -60,8 +61,7 @@ public class TransactionTimeoutDocIT extends ExclusiveServerTestBase
 
         // Then
         List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get( "errors" );
-        assertThat( (String) errors.get( 0 ).get( "message" ), equalTo( "The transaction you asked for cannot be " +
-                "found. This could also be because the transaction has timed out and has been rolled back." ) );
+        assertThat( (String) errors.get( 0 ).get( "message" ), equalTo( TX_NOT_FOUND_ERR_MSG ) );
 
         assertThat( ((Number) errors.get( 0 ).get( "code" )).longValue(), equalTo( INVALID_TRANSACTION_ID.getCode() ) );
     }


### PR DESCRIPTION
- Schema indexes can be created as deferred, which means they will be
  created later using #ensureSchemaIndexesOnline
- All indexes that are not online yet can be made online in a single store
  scan using #ensureSchemaIndexesOnline
