### PR TITLE
fixes #697 passing arrays as properties to unique node creation

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -1043,10 +1043,18 @@ public class DatabaseActions
                 }
                 Node node = node(nodeOrNull);
                 result = graphDb.index().forNodes( indexName ).putIfAbsent( node, key, value );
-                if ( ( created = ( result == null ) ) == true ) result = node;
+                created = result == null;
+                if (created) result = node;
             }
             else
             {
+                if ( properties != null )
+                {
+                    for ( Map.Entry<String, Object> entry : properties.entrySet() )
+                    {
+                        entry.setValue( property( entry.getValue() ));
+                    }
+                }
                 UniqueNodeFactory factory = new UniqueNodeFactory( indexName, properties );
                 result = factory.getOrCreate( key, value );
                 created = factory.created;

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -769,7 +769,7 @@ public class RestfulGraphDatabase
                 Map<String, Object> entityBody = input.readMap( postBody, "key", "value" );
                 Pair<IndexedEntityRepresentation, Boolean> result = actions( force ).getOrCreateIndexedNode( indexName, String.valueOf( entityBody.get( "key" ) ),
                        String.valueOf( entityBody.get( "value" ) ), extractNodeIdOrNull( getStringOrNull( entityBody, "uri" ) ), getMapOrNull( entityBody, "properties" ) );
-                return result.other().booleanValue() ? output.created( result.first() ) : output.ok( result.first() );
+                return result.other() ? output.created( result.first() ) : output.ok( result.first() );
             }
             else
             {


### PR DESCRIPTION
by making sure all the collections in the supplied properties are converted into arrays like in other places
in the REST API

make sure to forward merge into 1.9 and 2.x
