### PR TITLE
Adding XOR Predicate

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_7/Expressions.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_7/Expressions.scala
@@ -165,7 +165,11 @@ trait Expressions extends Base {
     case head ~ rest => rest.foldLeft(head)((a,b) => And(a,b))
   }
 
-  def predicateLvl2: Parser[Predicate] = (
+  def predicateLvl2: Parser[Predicate] = predicateLvl3 ~ rep( ignoreCase("xor") ~> predicateLvl3 ) ^^{
+    case head ~ rest => rest.foldLeft(head)((a,b) => Xor(a,b))
+  }
+
+  def predicateLvl3: Parser[Predicate] = (
     expressionOrEntity <~ ignoreCase("is null") ^^ (x => IsNull(x))
       | expressionOrEntity <~ ignoreCase("is not null") ^^ (x => Not(IsNull(x)))
       | operators

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/Predicates.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_8/Predicates.scala
@@ -32,7 +32,11 @@ trait Predicates extends Base with ParserPattern with StringLiteral {
     case head ~ rest => rest.foldLeft(head)((a,b) => And(a,b))
   }
 
-  def predicateLvl2: Parser[Predicate] = (
+  def predicateLvl2: Parser[Predicate] = predicateLvl3 ~ rep( ignoreCase("xor") ~> predicateLvl3 ) ^^{
+    case head ~ rest => rest.foldLeft(head)((a,b) => Xor(a,b))
+  }
+
+  def predicateLvl3: Parser[Predicate] = (
     expressionOrEntity <~ ignoreCase("is null") ^^ (x => IsNull(x))
       | expressionOrEntity <~ ignoreCase("is not null") ^^ (x => Not(IsNull(x)))
       | operators

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Predicates.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Predicates.scala
@@ -32,7 +32,11 @@ trait Predicates extends Base with ParserPattern with StringLiteral {
     case head ~ rest => rest.foldLeft(head)((a,b) => And(a,b))
   }
 
-  def predicateLvl2: Parser[Predicate] = (
+  def predicateLvl2: Parser[Predicate] = predicateLvl3 ~ rep( ignoreCase("xor") ~> predicateLvl3 ) ^^{
+    case head ~ rest => rest.foldLeft(head)((a,b) => Xor(a,b))
+  }
+
+  def predicateLvl3: Parser[Predicate] = (
     expressionOrEntity <~ ignoreCase("is null") ^^ (x => IsNull(x))
       | expressionOrEntity <~ ignoreCase("is not null") ^^ (x => Not(IsNull(x)))
       | operators

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -327,6 +327,21 @@ class ExecutionEngineTest extends ExecutionEngineHelper {
     assertEquals(List(n1, n2), result.columnAs[Node]("n").toList)
   }
 
+  @Test def shouldHandleXorFilters() {
+    val n1 = createNode(Map("name" -> "boy"))
+    val n2 = createNode(Map("name" -> "girl"))
+
+    val query = Query.
+      start(NodeById("n", n1.getId, n2.getId)).
+      where(Xor(
+      Equals(Property(Identifier("n"), "name"), Literal("boy")),
+      Equals(Property(Identifier("n"), "name"), Literal("girl")))).
+      returns(ReturnItem(Identifier("n"), "n"))
+
+    val result = execute(query)
+
+    assertEquals(List(n1, n2), result.columnAs[Node]("n").toList)
+  }
 
   @Test def shouldHandleNestedAndOrFilters() {
     val n1 = createNode(Map("animal" -> "monkey", "food" -> "banana"))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -47,7 +47,7 @@ class WhereTest extends DocumentingTestBase {
     testQuery(
       title = "Boolean operations",
       text = "You can use the expected boolean operators `AND` and `OR`, and also the boolean function `NOT()`.",
-      queryText = """start n=node(%Andres%, %Tobias%) where (n.age < 30 and n.name = "Tobias") or not(n.name = "Tobias")  return n""",
+      queryText = """start n=node(%Andres%, %Tobias%) where n.name = "Peter" xor (n.age < 30 and n.name = "Tobias") or not(n.name = "Tobias")  return n""",
       returns = """This will return both nodes in the start clause.""",
       assertions = (p) => assertEquals(List(node("Andres"), node("Tobias")), p.columnAs[Node]("n").toList))
   }


### PR DESCRIPTION
My attempt at adding the XOR Predicate to cypher.

Use case => https://github.com/maxdemarzi/neo_love/blob/master/neolove.rb#L64
I want to be able to do this:
me.orientation = person.orientation AND
 (me.gender <> person.gender XOR me.orientation = "gay")

Instead of having to do this:

me.orientation = person.orientation AND
 ((me.gender <> person.gender OR me.orientation = "straight") OR
  (me.gender = person.gender AND me.orientation = "gay")) 
