### PR TITLE
Fixes an issue with property being inconsistently light/heavy when writing to log

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
@@ -155,6 +155,7 @@ public class PropertyBlock implements Cloneable
     {
         StringBuilder result = new StringBuilder("PropertyBlock[");
         PropertyType type = getType();
+        result.append( "blocks=" + valueBlocks.length ).append( "," );
         result.append( type == null ? "<unknown type>" : type.name() ).append( ',' );
         result.append( "key=" ).append( valueBlocks == null ? "?" : Integer.toString( getKeyIndexId() ) );
         if ( type != null ) switch ( type )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -337,28 +337,6 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
         {
             releaseWindow( window );
         }
-        for ( PropertyBlock block : record.getPropertyBlocks() )
-        {
-            // assert block.inUse();
-            if ( block.getType() == PropertyType.STRING )
-            {
-                Collection<DynamicRecord> stringRecords = stringPropertyStore.getLightRecords( block.getSingleValueLong() );
-                for ( DynamicRecord stringRecord : stringRecords )
-                {
-                    stringRecord.setType( PropertyType.STRING.intValue() );
-                    block.addValueRecord( stringRecord );
-                }
-            }
-            else if ( block.getType() == PropertyType.ARRAY )
-            {
-                Collection<DynamicRecord> arrayRecords = arrayPropertyStore.getLightRecords( block.getSingleValueLong() );
-                for ( DynamicRecord arrayRecord : arrayRecords )
-                {
-                    arrayRecord.setType( PropertyType.ARRAY.intValue() );
-                    block.addValueRecord( arrayRecord );
-                }
-            }
-        }
         return record;
     }
 
@@ -584,7 +562,7 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
     
     public Object getStringFor( PropertyBlock propertyBlock )
     {
-        assert !propertyBlock.isLight();
+        ensureHeavy( propertyBlock );
         return getStringFor( propertyBlock.getSingleValueLong(), propertyBlock.getValueRecords() );
     }
 
@@ -597,7 +575,7 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
 
     public Object getArrayFor( PropertyBlock propertyBlock )
     {
-        assert !propertyBlock.isLight();
+        ensureHeavy( propertyBlock );
         return getArrayFor( propertyBlock.getValueRecords() );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChanges.java
@@ -143,7 +143,7 @@ public class RecordChanges<KEY,RECORD extends AbstractBaseRecord,ADDITIONAL>
         
         private RECORD prepareForChange()
         {
-            ensureBeforeInstantiated();
+            ensureHasBeforeRecordImage();
             if ( !this.changed )
             {
                 this.allChanges.put( key, this );
@@ -180,14 +180,14 @@ public class RecordChanges<KEY,RECORD extends AbstractBaseRecord,ADDITIONAL>
         
         public RECORD getBefore()
         {
-            ensureBeforeInstantiated();
+            ensureHasBeforeRecordImage();
             if ( !manageBeforeState )
                 throw new UnsupportedOperationException( "This RecordChanges instance doesn't manage before-state" );
             return before;
         }
 
         @SuppressWarnings( "unchecked" )
-        private void ensureBeforeInstantiated()
+        private void ensureHasBeforeRecordImage()
         {
             if ( manageBeforeState && this.before == null )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentPropertyAccessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentPropertyAccessIT.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Thread.interrupted;
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.neo4j.test.TargetDirectory.forTest;
+
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.Pair;
+
+@Ignore( "Good for driving out problems with loading/heaviness of property records" )
+public class ConcurrentPropertyAccessIT
+{
+    @Test
+    public void tryTriggerIssueWithConcurrentlySettingAndReadingProperties() throws Exception
+    {
+        // GIVEN
+        ExecutorService executor = newCachedThreadPool();
+        executor.submit( new SetPropertyWorker() );
+        executor.submit( new RemovePropertyWorker() );
+        executor.submit( new GetPropertyWorker() );
+        executor.submit( new ReplaceNodeWorker() );
+
+        waitIndefinitely();
+
+        // THEN
+    }
+    
+    private void waitIndefinitely()
+    {
+        while ( true )
+        {
+            try
+            {
+                sleep( MAX_VALUE );
+            }
+            catch ( InterruptedException e )
+            {
+                interrupted();
+                // meh
+            }
+        }
+    }
+
+    private GraphDatabaseService db;
+    private Node[] nodes;
+
+    protected Pair<Integer, Node> getNode( Random random, boolean takeOut )
+    {
+        synchronized ( nodes )
+        {
+            while ( true )
+            {
+                int index = random.nextInt( nodes.length );
+                Node node = nodes[index];
+                if ( null != node )
+                {
+                    if ( takeOut )
+                        nodes[index] = null;
+                    return Pair.of( index, node );
+                }
+            }
+        }
+    }
+
+    protected void setNode( int i, Node node )
+    {
+        synchronized ( nodes )
+        {
+            nodes[i] = node;
+        }
+    }
+
+    private abstract class Worker implements Runnable
+    {
+        protected final Random random = new Random();
+        
+        @Override
+        public void run()
+        {
+            while ( true )
+            {
+                Transaction tx = db.beginTx();
+                try
+                {
+                    doSomething();
+                    tx.success();
+                }
+                catch ( Throwable t )
+                {
+                    t.printStackTrace(System.err);
+                    System.err.flush();
+                    // throw Exceptions.launderedException( t );
+                }
+                finally
+                {
+                    tx.finish();
+                }
+            }
+        }
+
+        protected abstract void doSomething() throws Throwable;
+    }
+    
+    private class SetPropertyWorker extends Worker
+    {
+        @Override
+        protected void doSomething() throws Throwable
+        {
+            Pair<Integer, Node> pair = getNode( random, false );
+            Node node = pair.other();
+            node.setProperty( randomPropertyKey( random ), randomLongPropertyValue( random.nextInt( 8 ) + 2,  random ) );
+        }
+    }
+    
+    private class GetPropertyWorker extends Worker
+    {
+        @Override
+        protected void doSomething() throws Throwable
+        {
+            Pair<Integer, Node> pair = getNode( random, false );
+            Node node = pair.other();
+            node.getProperty( randomPropertyKey( random ), null );
+        }
+    }
+    
+    private class RemovePropertyWorker extends Worker
+    {
+        @Override
+        protected void doSomething() throws Throwable
+        {
+            Pair<Integer, Node> pair = getNode( random, false );
+            Node node = pair.other();
+            node.removeProperty( randomPropertyKey( random ) );
+        }
+    }
+
+    private class ReplaceNodeWorker extends Worker
+    {
+
+        @Override
+        protected void doSomething() throws Throwable
+        {
+            Pair<Integer, Node> pair = getNode( random, true );
+            int index = pair.first();
+            Node node = pair.other();
+            node.delete();
+            setNode( index, db.createNode() );
+        }
+    }
+    
+    private Object randomLongPropertyValue( int length, Random random )
+    {
+        String[] parts = new String[] { "bozo", "bimbo", "basil", "bongo" };
+        StringBuilder result = new StringBuilder( 4 * length );
+        for ( int i = 0; i < length; i ++ )
+        {
+            result.append( parts[ random.nextInt( parts.length )] );
+        }
+        return result.toString();
+    }
+    
+    private String randomPropertyKey( Random random )
+    {
+        return random.nextBoolean() ? "name" : "animals";
+    }
+
+    @Before
+    public void before() throws Exception
+    {
+        db =
+          new GraphDatabaseFactory().newEmbeddedDatabase( forTest( getClass() ).graphDbDir( true ).getAbsolutePath() );
+        nodes = createInitialNodes();
+    }
+
+    private Node[] createInitialNodes()
+    {
+        Node[] nodes = new Node[100];
+        Transaction tx = db.beginTx();
+        try
+        {
+            for ( int i = 0; i < nodes.length; i++ )
+            {
+                nodes[i] = db.createNode();
+            }
+            tx.success();
+        }
+        finally
+        {
+            tx.finish();
+        }
+        return nodes;
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        db.shutdown();
+    }
+}


### PR DESCRIPTION
When loading a property record for just changing linkage of it
(prev/next pointers) the value records were also loaded, but not made
heavy. This tripped up an assumption when writing that record to the
logical log during commit where it would see that the property block was
heavy but when it got the data to write it was null.

See WriteTransactionTest#shouldWriteProperPropertyRecordsWhenOnlyChangingLinkage for details.
