### PR TITLE
Uses DEV_NULL instead of SYSTEM StringLogger in many places

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -127,12 +127,10 @@ public class StoreUpgrader
         }
         catch ( IOException e )
         {
-            e.printStackTrace();
             throw new UnableToUpgradeException( e );
         }
         catch ( Exception e )
         {
-            e.printStackTrace();
             throw Exceptions.launderedException( e );
         }
         finally

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -74,14 +74,7 @@ public class XaResourceManager
     public synchronized void setLogicalLog( XaLogicalLog log )
     {
         this.log = log;
-        if ( log != null )
-        {
-            this.msgLog = log.getStringLogger();
-        }
-        else
-        {
-            this.msgLog = StringLogger.SYSTEM;
-        }
+        this.msgLog = log.getStringLogger();
     }
 
     synchronized XaTransaction getXaTransaction( XAResource xaRes )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StringLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StringLogger.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
@@ -41,22 +42,28 @@ public abstract class StringLogger
 {
     public static final String DEFAULT_NAME = "messages.log";
     public static final String DEFAULT_ENCODING = "UTF-8";
-    public static final StringLogger SYSTEM;
+    public static final StringLogger SYSTEM, SYSTEM_ERR;
 
     static
+    {
+        SYSTEM = instantiateStringLoggerForPrintStream( System.out );
+        SYSTEM_ERR = instantiateStringLoggerForPrintStream( System.err );
+    }
+
+    private static ActualStringLogger instantiateStringLoggerForPrintStream( PrintStream stream )
     {
         PrintWriter writer;
 
         try
         {
-            writer = new PrintWriter( new OutputStreamWriter( System.out, DEFAULT_ENCODING ) );
+            writer = new PrintWriter( new OutputStreamWriter( stream, DEFAULT_ENCODING ) );
         }
         catch ( UnsupportedEncodingException e )
         {
             throw new RuntimeException( e );
         }
 
-        SYSTEM = new ActualStringLogger( writer )
+        return new ActualStringLogger( writer )
         {
             @Override
             public void close()

--- a/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -41,6 +41,17 @@ public class LifeSupport
     List<LifecycleInstance> instances = new ArrayList<LifecycleInstance>();
     LifecycleStatus status = LifecycleStatus.NONE;
     List<LifecycleListener> listeners = new ArrayList<LifecycleListener>();
+    private final StringLogger log;
+    
+    public LifeSupport()
+    {
+        this( StringLogger.SYSTEM_ERR );
+    }
+    
+    public LifeSupport( StringLogger log )
+    {
+        this.log = log;
+    }
 
     /**
      * Initialize all registered instances, transitioning from status NONE to STOPPED.
@@ -418,8 +429,8 @@ public class LifeSupport
             return exception;
         }
 
-        exception.printStackTrace();
-        chainedLifecycleException.printStackTrace();
+        log.error( "Lifecycle exception", exception );
+        log.error( "Chained lifecycle exception", chainedLifecycleException );
         
         Throwable current = exception;
         while ( current.getCause() != null )
@@ -512,7 +523,7 @@ public class LifeSupport
                 }
                 catch ( Throwable e )
                 {
-                    e.printStackTrace();
+                    log.error( "Exception when stopping " + instance, e );
                     throw new LifecycleException( instance, LifecycleStatus.STARTED, LifecycleStatus.STOPPED, e );
                 }
                 finally

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl;
 
 import java.util.concurrent.CountDownLatch;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,7 +80,7 @@ public class TestPropertyDataRace
                 {
                     for ( String key : one.getPropertyKeys() )
                     {
-                        System.out.println( getName() + " removed " + key + "=" + one.removeProperty( key ) );
+                        one.removeProperty( key );
                     }
                     clearCaches();
                     prepare.countDown();
@@ -126,7 +127,7 @@ public class TestPropertyDataRace
                     }
                     for ( String key : one.getPropertyKeys() )
                     {
-                        System.out.println( getName() + " removed " + key + "=" + one.removeProperty( key ) );
+                        one.removeProperty( key );
                     }
 
                     txn.success();
@@ -142,7 +143,7 @@ public class TestPropertyDataRace
         done.await();
         for ( String key : two.getPropertyKeys() )
         {
-            System.out.println( "should be untouched: " + key + "=" + two.getProperty( key ) );
+            two.getProperty( key );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestPropertyCachePoisoning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestPropertyCachePoisoning.java
@@ -74,7 +74,7 @@ public class TestPropertyCachePoisoning
                 removeProperty( first, "key" );
             }
         };
-        System.out.println( "key:" + first.getProperty( "key", null ) );
+        first.getProperty( "key", null );
         final Node second = new TX<Node>()
         {
             @Override
@@ -154,6 +154,7 @@ public class TestPropertyCachePoisoning
         {
             new Thread()
             {
+                @Override
                 public void run()
                 {
                     Transaction tx = graphdb.beginTx();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -158,7 +158,7 @@ public class IdGeneratorRebuildFailureEmulationTest
         config.put( GraphDatabaseSettings.rebuild_idgenerators_fast.name(), GraphDatabaseSetting.FALSE );
         config.put( GraphDatabaseSettings.store_dir.name(), prefix );
         factory = new StoreFactory( new Config( config, GraphDatabaseSettings.class ),
-                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs, StringLogger.SYSTEM, null );
+                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs, StringLogger.DEV_NULL, null );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/SchemaStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/SchemaStoreTest.java
@@ -25,7 +25,7 @@ import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.util.StringLogger.SYSTEM;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 import java.io.File;
 import java.util.Arrays;
@@ -140,7 +140,7 @@ public class SchemaStoreTest
         config = new Config( stringMap() );
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory();
         DefaultWindowPoolFactory windowPoolFactory = new DefaultWindowPoolFactory();
-        storeFactory = new StoreFactory( config, idGeneratorFactory, windowPoolFactory, fs.get(), SYSTEM,
+        storeFactory = new StoreFactory( config, idGeneratorFactory, windowPoolFactory, fs.get(), DEV_NULL,
                 new DefaultTxHook() );
         File file = new File( "schema-store" );
         storeFactory.createSchemaStore( file );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreVersionTest.java
@@ -56,7 +56,7 @@ public class StoreVersionTest
         config.put( GraphDatabaseSettings.store_dir.name(), outputDir.getPath());
         config.put( "neo_store", storeFileName.getPath() );
         StoreFactory sf = new StoreFactory( new Config( config, GraphDatabaseSettings.class ),
-                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs.get(), StringLogger.SYSTEM,
+                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs.get(), StringLogger.DEV_NULL,
                 null );
         NeoStore neoStore = sf.createNeoStore( storeFileName );
 
@@ -91,7 +91,7 @@ public class StoreVersionTest
         try
         {
             new NodeStore( workingFile, config, new DefaultIdGeneratorFactory(),
-                    new DefaultWindowPoolFactory(), fs.get(), StringLogger.SYSTEM, null );
+                    new DefaultWindowPoolFactory(), fs.get(), StringLogger.DEV_NULL, null );
             fail( "Should have thrown exception" );
         }
         catch ( NotCurrentStoreVersionException e )
@@ -114,7 +114,7 @@ public class StoreVersionTest
         config.put( GraphDatabaseSettings.store_dir.name(), outputDir.getPath() );
         config.put( "neo_store", storeFileName.getPath() );
         StoreFactory sf = new StoreFactory( new Config( config, GraphDatabaseSettings.class ),
-                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs.get(), StringLogger.SYSTEM,
+                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), fs.get(), StringLogger.DEV_NULL,
                 null );
         NeoStore neoStore = sf.createNeoStore( storeFileName );
         // The first checks the instance method, the other the public one

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestDynamicStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestDynamicStore.java
@@ -34,8 +34,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -120,13 +118,13 @@ public class TestDynamicStore
     private void createEmptyStore( File fileName, int blockSize )
     {
         new StoreFactory( config(), ID_GENERATOR_FACTORY, new DefaultWindowPoolFactory(), fs.get(),
-                StringLogger.SYSTEM, null ).createDynamicArrayStore( fileName, blockSize );
+                StringLogger.DEV_NULL, null ).createDynamicArrayStore( fileName, blockSize );
     }
 
     private DynamicArrayStore newStore()
     {
         return new DynamicArrayStore( dynamicStoreFile(), config(), IdType.ARRAY_BLOCK, ID_GENERATOR_FACTORY,
-                WINDOW_POOL_FACTORY, fs.get(), StringLogger.SYSTEM );
+                WINDOW_POOL_FACTORY, fs.get(), StringLogger.DEV_NULL );
     }
 
     private void deleteBothFiles()
@@ -146,11 +144,8 @@ public class TestDynamicStore
     @Test
     public void testStickyStore() throws IOException
     {
-        Logger log = Logger.getLogger( CommonAbstractStore.class.getName() );
-        Level level = log.getLevel();
         try
         {
-            log.setLevel( Level.OFF );
             createEmptyStore( dynamicStoreFile(), 30 );
             FileChannel fileChannel = fs.get().open( dynamicStoreFile(), "rw" );
             fileChannel.truncate( fileChannel.size() - 2 );
@@ -161,7 +156,6 @@ public class TestDynamicStore
         }
         finally
         {
-            log.setLevel( level );
             deleteBothFiles();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGrowingFileMemoryMapping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGrowingFileMemoryMapping.java
@@ -55,7 +55,7 @@ public class TestGrowingFileMemoryMapping
                 NodeStore.Configuration.store_dir.name(), storeDir.getPath() ), NodeStore.Configuration.class );
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory();
         StoreFactory storeFactory = new StoreFactory( config, idGeneratorFactory,
-                new DefaultWindowPoolFactory(), new DefaultFileSystemAbstraction(), StringLogger.SYSTEM,
+                new DefaultWindowPoolFactory(), new DefaultFileSystemAbstraction(), StringLogger.DEV_NULL,
                 new DefaultTxHook() );
 
         File fileName = new File( storeDir, NeoStore.DEFAULT_NAME + ".nodestore.db" );
@@ -63,7 +63,7 @@ public class TestGrowingFileMemoryMapping
                 NodeStore.TYPE_DESCRIPTOR ) );
 
         NodeStore nodeStore = new NodeStore( fileName, config, idGeneratorFactory, new DefaultWindowPoolFactory(),
-                new DefaultFileSystemAbstraction(), StringLogger.SYSTEM, null );
+                new DefaultFileSystemAbstraction(), StringLogger.DEV_NULL, null );
 
         // when
         for ( int i = 0; i < 2 * NUMBER_OF_RECORDS; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -108,7 +108,7 @@ public class TestNeoStore
         path = targetDirectory.directory( "dir", true );
         Config config = new Config( new HashMap<String, String>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( config, new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(),
-                fs.get(), StringLogger.SYSTEM, null );
+                fs.get(), StringLogger.DEV_NULL, null );
         sf.createNeoStore( file( NeoStore.DEFAULT_NAME ) ).close();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/UpgradeStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/UpgradeStoreIT.java
@@ -307,7 +307,7 @@ public class UpgradeStoreIT
     {
         File fileName = new File( path, "neostore.relationshiptypestore.db" );
         DynamicStringStore stringStore = new DynamicStringStore( new File( fileName.getPath() + ".names"), null, IdType.RELATIONSHIP_TYPE_BLOCK,
-                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), new DefaultFileSystemAbstraction(), StringLogger.SYSTEM );
+                new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(), new DefaultFileSystemAbstraction(), StringLogger.DEV_NULL );
         RelationshipTypeStore store = new RelationshipTypeStoreWithOneOlderVersion( fileName, stringStore );
         for ( int i = 0; i < numberOfTypes; i++ )
         {
@@ -334,7 +334,7 @@ public class UpgradeStoreIT
         public RelationshipTypeStoreWithOneOlderVersion( File fileName, DynamicStringStore stringStore )
         {
             super( fileName, new Config( stringMap() ), new NoLimitIdGeneratorFactory(), new DefaultWindowPoolFactory(),
-                    new DefaultFileSystemAbstraction(), StringLogger.SYSTEM, stringStore );
+                    new DefaultFileSystemAbstraction(), StringLogger.DEV_NULL, stringStore );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogicTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelRecordLogicTest.java
@@ -358,7 +358,7 @@ public class NodeLabelRecordLogicTest
     public void startUp()
     {
         StoreFactory storeFactory = new StoreFactory( new Config(), new DefaultIdGeneratorFactory(),
-                new DefaultWindowPoolFactory(), fs.get(), StringLogger.SYSTEM,
+                new DefaultWindowPoolFactory(), fs.get(), StringLogger.DEV_NULL,
                 new DefaultTxHook() );
         File storeFile = new File( "store" );
         storeFactory.createNodeStore( storeFile );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -35,7 +35,7 @@ import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
 import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.util.StringLogger.SYSTEM;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 import java.io.File;
 import java.io.IOException;
@@ -472,7 +472,7 @@ public class WriteTransactionTest
     {
         transactionState = TransactionState.NO_STATE;
         storeFactory = new StoreFactory( config, idGeneratorFactory, windowPoolFactory,
-                fs.get(), SYSTEM, new DefaultTxHook() );
+                fs.get(), DEV_NULL, new DefaultTxHook() );
         neoStore = storeFactory.createNeoStore( new File( "neostore" ) );
         cacheAccessBackDoor = mock( CacheAccessBackDoor.class );
     }
@@ -484,7 +484,7 @@ public class WriteTransactionTest
         public VerifyingXaLogicalLog( FileSystemAbstraction fs, Visitor<XaCommand> verifier )
         {
             super( new File( "log" ), null, null, null, new DefaultLogBufferFactory(),
-                    fs, new SingleLoggingService( SYSTEM ), LogPruneStrategies.NO_PRUNING, null );
+                    fs, new SingleLoggingService( DEV_NULL ), LogPruneStrategies.NO_PRUNING, null );
             this.verifier = verifier;
         }
         
@@ -521,7 +521,7 @@ public class WriteTransactionTest
                     new DefaultSchemaIndexProviderMap( NO_INDEX_PROVIDER ),
                     new NeoStoreIndexStoreView( neoStore ),
                     new KernelSchemaStateStore(),
-                    new SingleLoggingService( SYSTEM )
+                    new SingleLoggingService( DEV_NULL )
                 );
         }
         

--- a/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/LifeSupportTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/LifeSupportTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.lifecycle;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.neo4j.kernel.impl.util.StringLogger;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedList;
 import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.neo4j.kernel.impl.util.StringLogger;
 
 /**
  * Test LifeSupport lifecycle transitions
@@ -37,7 +37,7 @@ public class LifeSupportTest
     public void testOkLifecycle()
         throws LifecycleException
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -80,7 +80,7 @@ public class LifeSupportTest
     @Test()
     public void testFailingInit()
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -108,7 +108,7 @@ public class LifeSupportTest
     @Test()
     public void testFailingStart()
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -136,7 +136,7 @@ public class LifeSupportTest
     @Test()
     public void testFailingStartAndFailingStop()
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         Exception stopThrowable = new Exception();
         LifecycleMock instance1 = new LifecycleMock( null, null, stopThrowable, null );
@@ -158,7 +158,7 @@ public class LifeSupportTest
             assertEquals( startThrowable, throwable.getCause().getCause().getCause() );
         }
 
-        lifeSupport.dump( StringLogger.SYSTEM );
+        lifeSupport.dump( StringLogger.DEV_NULL );
 
         assertEquals( LifecycleStatus.STOPPED, lifeSupport.getStatus() );
         assertEquals( LifecycleStatus.STOPPED , instance1.getStatus());
@@ -170,7 +170,7 @@ public class LifeSupportTest
     public void testFailingStop()
         throws LifecycleException
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -201,7 +201,7 @@ public class LifeSupportTest
     public void testFailingShutdown()
         throws LifecycleException
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -232,7 +232,7 @@ public class LifeSupportTest
     public void testRestartOk()
         throws LifecycleException
     {
-        LifeSupport lifeSupport = new LifeSupport();
+        LifeSupport lifeSupport = newLifeSupport();
 
         LifecycleMock instance1 = new LifecycleMock( null, null, null, null );
         lifeSupport.add( instance1 );
@@ -276,7 +276,7 @@ public class LifeSupportTest
     public void testAddInstanceWhenInitInitsInstance()
             throws LifecycleException
     {
-        LifeSupport support = new LifeSupport();
+        LifeSupport support = newLifeSupport();
 
         support.init();
 
@@ -294,7 +294,7 @@ public class LifeSupportTest
     public void testAddInstanceWhenStartedStartsInstance()
         throws LifecycleException
     {
-        LifeSupport support = new LifeSupport();
+        LifeSupport support = newLifeSupport();
 
         support.init();
         support.start();
@@ -315,7 +315,7 @@ public class LifeSupportTest
     public void testAddInstanceWhenStoppedInitsInstance()
             throws LifecycleException
     {
-        LifeSupport support = new LifeSupport();
+        LifeSupport support = newLifeSupport();
 
         support.init();
         support.start();
@@ -337,7 +337,7 @@ public class LifeSupportTest
     public void testAddInstanceWhenShutdownDoesNotAffectInstance()
             throws LifecycleException
     {
-        LifeSupport support = new LifeSupport();
+        LifeSupport support = newLifeSupport();
 
         support.init();
         support.start();
@@ -422,5 +422,10 @@ public class LifeSupportTest
         {
             return transitions.get( transitions.size() - 1 );
         }
+    }
+
+    private LifeSupport newLifeSupport()
+    {
+        return new LifeSupport( StringLogger.DEV_NULL );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/preflight/PerformUpgradeIfNecessary.java
+++ b/community/server/src/main/java/org/neo4j/server/preflight/PerformUpgradeIfNecessary.java
@@ -85,7 +85,7 @@ public class PerformUpgradeIfNecessary implements PreflightTask
             Config conf = new Config( dbConfig, GraphDatabaseSettings.class );
             StoreUpgrader storeUpgrader = new StoreUpgrader( conf,
                     new ConfigMapUpgradeConfiguration( conf ),
-                    upgradableDatabase, new StoreMigrator( new VisibleMigrationProgressMonitor( StringLogger.SYSTEM, out ) ),
+                    upgradableDatabase, new StoreMigrator( new VisibleMigrationProgressMonitor( StringLogger.DEV_NULL, out ) ),
                     new DatabaseFiles( fileSystem ), new DefaultIdGeneratorFactory(), fileSystem );
 
             try

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
@@ -19,6 +19,16 @@
  */
 package org.neo4j.server.web;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.junit.Test;
 import org.neo4j.kernel.AbstractGraphDatabase;
 import org.neo4j.kernel.guard.Guard;
@@ -30,15 +40,6 @@ import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerConfigurator;
 import org.neo4j.server.logging.InMemoryAppender;
 import org.neo4j.test.ImpermanentGraphDatabase;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.util.Arrays;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 @Path("/")
 public class TestJetty6WebServer {
@@ -89,7 +90,7 @@ public class TestJetty6WebServer {
     public void shouldBeAbleToSetExecutionLimit() throws Throwable
     {
         InMemoryAppender appender = new InMemoryAppender(AbstractNeoServer.log);
-        final Guard dummyGuard = new Guard(StringLogger.SYSTEM);
+        final Guard dummyGuard = new Guard(StringLogger.DEV_NULL);
         ImpermanentGraphDatabase db = new ImpermanentGraphDatabase()
         {
             @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/GCResistantCache.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/GCResistantCache.java
@@ -68,6 +68,9 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
     
     public GCResistantCache( long maxSizeInBytes, float arrayHeapFraction, long minLogInterval, String name, StringLogger logger )
     {
+        if ( logger == null )
+            throw new IllegalArgumentException( "Null logger" );
+        
         this.minLogInterval = minLogInterval;
         if ( arrayHeapFraction < 1 || arrayHeapFraction > 10 )
         {
@@ -89,15 +92,15 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
         this.cache = new AtomicReferenceArray<E>( (int) maxElementCount );
         this.maxSize = maxSizeInBytes;
         this.name = name == null ? super.toString() : name;
-        this.logger = logger == null ? StringLogger.SYSTEM : logger;
+        this.logger = logger;
         calculateSizes();
     }
 
     private void calculateSizes()
     {
-        this.closeToMaxSize = (long)((double)maxSize * 0.95d);
-        this.purgeStopSize = (long)((double)maxSize * 0.90d);
-        this.purgeHandoffSize = (long)((double)maxSize * 1.05d);
+        this.closeToMaxSize = (long)(maxSize * 0.95d);
+        this.purgeStopSize = (long)(maxSize * 0.90d);
+        this.purgeHandoffSize = (long)(maxSize * 1.05d);
     }
     
     private int getPosition( EntityWithSize obj )
@@ -112,6 +115,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
 
     private long putTimeStamp = 0;
 
+    @Override
     public void put( E obj )
     {
         long time = System.currentTimeMillis();
@@ -168,6 +172,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
         }
     }
 
+    @Override
     public E remove( long id )
     {
         int pos = getPosition( id );
@@ -182,6 +187,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
         return obj;
     }
 
+    @Override
     public E get( long id )
     {
         int pos = getPosition( id );
@@ -314,6 +320,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
                     ", perceived:" + getSize( currentSize.get() ) + " (diff:" + getSize(currentSize.get() - actualSize) + "), registered:" + getSize( registeredSize ), true );
     }
 
+    @Override
     public void printStatistics()
     {
         logStatistics( logger );
@@ -376,6 +383,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
         return size + "b";
     }
 
+    @Override
     public void clear()
     {
         for ( int i = 0; i <= highestIdSet.get() /*cache.length()*/; i++ )
@@ -386,6 +394,7 @@ public class GCResistantCache<E extends EntityWithSize> implements Cache<E>, Dia
         highestIdSet.set( 0 );
     }
 
+    @Override
     public void putAll( Collection<E> objects )
     {
         for ( E obj : objects )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigratorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigratorTest.java
@@ -41,7 +41,7 @@ public class EnterpriseConfigurationMigratorTest
         throws Exception
     {
         Map<String, String> original = MapUtil.stringMap( "enable_online_backup", "true" );
-        Map<String, String> migrated = migrator.apply( original, StringLogger.SYSTEM );
+        Map<String, String> migrated = migrator.apply( original, StringLogger.DEV_NULL );
         Assert.assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
         Assert.assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
         Assert.assertThat( migrated.get( "online_backup_server" ), is( OnlineBackupSettings.online_backup_server.getDefaultValue() ) );
@@ -52,7 +52,7 @@ public class EnterpriseConfigurationMigratorTest
         throws Exception
     {
         Map<String, String> original = MapUtil.stringMap( "enable_online_backup", "port=123" );
-        Map<String, String> migrated = migrator.apply( original, StringLogger.SYSTEM );
+        Map<String, String> migrated = migrator.apply( original, StringLogger.DEV_NULL );
         Assert.assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
         Assert.assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
         Assert.assertThat( migrated.get( "online_backup_server" ), is( "0.0.0.0:123" ) );
@@ -63,7 +63,7 @@ public class EnterpriseConfigurationMigratorTest
         throws Exception
     {
         Map<String, String> original = MapUtil.stringMap( "ha.machine_id", "123" );
-        Map<String, String> migrated = migrator.apply( original, StringLogger.SYSTEM );
+        Map<String, String> migrated = migrator.apply( original, StringLogger.DEV_NULL );
         Assert.assertThat( migrated.containsKey( "ha.machine_id" ), is( false ) );
         Assert.assertThat( migrated.get( "ha.server_id" ), is( "123" ) );
     }

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
@@ -117,7 +117,7 @@ public class StandaloneClusterClientIT
     
     // === Everything else ===
     
-    private File directory = TargetDirectory.forTest( getClass() ).directory( "temp", true );
+    private final File directory = TargetDirectory.forTest( getClass() ).directory( "temp", true );
     private LifeSupport life;
     private ClusterClient[] clients;
     
@@ -138,13 +138,13 @@ public class StandaloneClusterClientIT
                 @Override
                 public StringLogger getMessagesLog( Class loggingClass )
                 {
-                    return StringLogger.SYSTEM;
+                    return StringLogger.DEV_NULL;
                 }
 
                 @Override
                 public ConsoleLogger getConsoleLog( Class loggingClass )
                 {
-                    return new ConsoleLogger( StringLogger.SYSTEM );
+                    return new ConsoleLogger( StringLogger.DEV_NULL );
                 }
             };
             final ClusterClient client = new ClusterClient( adapt( new Config( config ) ), logging, new ServerIdElectionCredentialsProvider() );


### PR DESCRIPTION
as well as, abstractions instead of printStackTrace() and such. This greatly reduces
amount of logging to the console when running kernel tests.
