### PR TITLE
Preventing buffer overflow

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
@@ -101,7 +101,7 @@ abstract class AbstractPersistenceWindow extends LockableWindow
     
     private void writeContents()
     {
-        ByteBuffer byteBuffer = buffer.getBuffer();
+        ByteBuffer byteBuffer = buffer.getBuffer().duplicate();
         byteBuffer.clear();
 
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBackedXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBackedXaDataSource.java
@@ -101,7 +101,9 @@ public abstract class LogBackedXaDataSource extends XaDataSource
     @Override
     public long rotateLogicalLog() throws IOException
     {
-        return logicalLog.rotate();
+        // Go through XaResourceManager so that all paths which rotates the
+        // logical log will go through its lock
+        return getXaContainer().getResourceManager().rotateLogicalLog();
     }
 
     @Override


### PR DESCRIPTION
Log rotation can cause buffer overflow (and probably underflow too) if there is concurrent access to the byte buffer underneath a persistence window being flushed.
This prevents interference from reads by duplicating the state flags on the byte buffer such that flushing can happens even while the window is being read.
Also, it prevents there are no writes in flight by ensuring all code paths leading to a log rotation go through XaResourceManager and thus it's locking behaviour
