### PR TITLE
Startup sequence changes for proper management of errors on NodeManager.start()

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyIndexManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyIndexManager.java
@@ -58,11 +58,6 @@ public class PropertyIndexManager
         idToIndexMap = new ConcurrentHashMap<Integer, PropertyIndex>();
     }
 
-    @Override
-    public void shutdown()
-    {
-    }
-
     public PropertyIndex[] index( String key, TransactionState state )
     {
         PropertyIndex[] existing = null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeHolder.java
@@ -60,7 +60,7 @@ public class RelationshipTypeHolder extends LifecycleAdapter
             addRawRelationshipType( types[i] );
         }
     }
-    
+
     void addRawRelationshipType( NameData type )
     {
         RelationshipTypeImpl relType = new RelationshipTypeImpl( type.getName(), type.getId() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
@@ -98,7 +98,7 @@ abstract class AbstractPersistenceWindow extends LockableWindow
                 + position + "] @[" + position * recordSize + "]", e );
         }
     }
-    
+
     private void writeContents()
     {
         ByteBuffer byteBuffer = buffer.getBuffer().duplicate();

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -366,10 +366,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
              * down on switchover
              */
             compatibilityLifecycle.add( memberStateMachine );
-//            compatibilityLifecycle.add( highAvailabilityModeSwitcher );
             compatibilityLifecycle.add( (Lifecycle) clusterEvents );
             life.add( memberStateMachine );
-//            life.add( highAvailabilityModeSwitcher );
             life.add( clusterEvents );
         }
         /*
@@ -424,16 +422,23 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 clusterMemberAvailability, memberStateMachine, this, (HaIdGeneratorFactory) idGeneratorFactory, config,
                 logging );
         /*
-        * We always need the mode switcher and we need it to restart on switchover. So:
-        * 1) if in compatibility mode, it must be added in all 3 - to start on start and restart on switchover
-        * 2) if not in compatibility mode it must be added in paxosLife, which is started anyway.
-        */
+         * We always need the mode switcher and we need it to restart on switchover. So:
+         * 1) if in compatibility mode, it must be added in all 3 - to start on start and restart on switchover
+         * 2) if not in compatibility mode it must be added in paxosLife, which is started anyway.
+         */
         paxosLife.add( highAvailabilityModeSwitcher );
         if ( compatibilityMode )
         {
             compatibilityLifecycle.add( 1, highAvailabilityModeSwitcher );
             life.add( highAvailabilityModeSwitcher );
         }
+
+        /*
+         * We don't really switch to master here. We just need to initialize the idGenerator so the initial store
+         * can be started (if required). In any case, the rest of the database is in pending state, so nothing will
+         * happen until events start arriving and that will set us to the proper state anyway.
+         */
+        ((HaIdGeneratorFactory) idGeneratorFactory).switchToMaster();
 
         return idGeneratorFactory;
     }
@@ -467,12 +472,6 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     protected Caches createCaches()
     {
         return new HaCaches( logging.getMessagesLog( Caches.class ) );
-    }
-
-    @Override
-    protected void createNeoDataSource()
-    {
-        // no op, we must wait to join the cluster to do stuff
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
@@ -245,7 +245,9 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
                 logger.debug( "Instantiated master delegate " + delegate + " of type " + idType + " with highid " + highId );
             }
             else
+            {
                 logger.debug( "Keeps " + delegate );
+            }
 
             state = IdGeneratorState.MASTER;
         }

--- a/enterprise/ha/src/test/java/slavetest/TestStoreCopy.java
+++ b/enterprise/ha/src/test/java/slavetest/TestStoreCopy.java
@@ -19,10 +19,11 @@
  */
 package slavetest;
 
-import static org.apache.commons.io.FileUtils.moveToDirectory;
+import static org.apache.commons.io.FileUtils.copyFileToDirectory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.kernel.ha.SlaveStoreWriter.COPY_FROM_MASTER_TEMP;
+import static org.neo4j.kernel.impl.util.FileUtils.deleteFiles;
 import static org.neo4j.kernel.impl.util.StringLogger.DEFAULT_NAME;
 import static org.neo4j.test.ha.ClusterManager.clusterWithAdditionalClients;
 
@@ -59,10 +60,12 @@ public class TestStoreCopy extends AbstractClusterTest
 
         long secondNodeId = createIndexedNode( cluster.getMaster(), KEY2, VALUE2 );
 
-        moveToDirectory( new File( slaveDir, "neostore" ), slaveTempCopyDir, false );
-        moveToDirectory( new File( slaveDir, "neostore.propertystore.db" ), slaveTempCopyDir, false );
+        copyFileToDirectory( new File( slaveDir, "neostore" ), slaveTempCopyDir, false );
+        copyFileToDirectory( new File( slaveDir, "neostore.propertystore.db" ), slaveTempCopyDir, false );
         assertEquals( "Found these files:" + filesAsString( slaveTempCopyDir ), 3,
                 slaveTempCopyDir.listFiles( DISREGARD_ACTIVE_LOG_FILES ).length );
+
+        deleteFiles( slaveDir, "neostore.*");
 
         slave = slaveDown.repair();
 


### PR DESCRIPTION
The driver for this is a reported issue where failure to initialise the relationship type store because of a sticky id file caused the same types (same as in the String representing them) to be created, creating a store that returned inconsistent results when filtering on relationship type.
