### PR TITLE
Remove spurious messages to users who have the GuardingRequestFilter enabled

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.kernel;
 
-import static java.lang.Integer.MAX_VALUE;
-import static java.lang.System.currentTimeMillis;
-import static java.lang.Thread.sleep;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -39,6 +28,12 @@ import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.guard.GuardOperationsCountException;
 import org.neo4j.kernel.guard.GuardTimeoutException;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.sleep;
+import static junit.framework.Assert.*;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class TestGuard
 {
@@ -125,7 +120,7 @@ public class TestGuard
         db.shutdown();
     }
 
-    @Test @Ignore
+    @Test
     public void testTimeoutGuardFail() throws InterruptedException
     {
         GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().

--- a/community/server/src/main/java/org/neo4j/server/guard/GuardingRequestFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/guard/GuardingRequestFilter.java
@@ -19,30 +19,19 @@
  */
 package org.neo4j.server.guard;
 
-import static javax.servlet.http.HttpServletResponse.SC_REQUEST_TIMEOUT;
-
-import java.io.IOException;
-import java.util.Timer;
-import java.util.TimerTask;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.guard.GuardException;
 
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Timer;
+
+import static javax.servlet.http.HttpServletResponse.SC_REQUEST_TIMEOUT;
+
 public class GuardingRequestFilter implements Filter
 {
-
-    private static final Log LOG = LogFactory.getLog( GuardingRequestFilter.class );
 
     private final Guard guard;
     private final int timeout;
@@ -73,18 +62,6 @@ public class GuardingRequestFilter implements Filter
             } else
             {
                 guard.startTimeout( timeLimit );
-                final TimerTask timerTask = new TimerTask()
-                {
-
-                    @Override
-                    public void run()
-                    {
-                        LOG.warn( "request canceled" );
-                        LOG.error( "TODO: restarting the server is not proper implemented, request was not canceled" );
-                        // TODO current.interrupt(); + restart server
-                    }
-                };
-                timer.schedule( timerTask, timeLimit + 5000 );
 
                 try
                 {
@@ -94,7 +71,6 @@ public class GuardingRequestFilter implements Filter
                     response.setStatus( SC_REQUEST_TIMEOUT );
                 } finally
                 {
-                    timerTask.cancel();
                     guard.stop();
                 }
             }


### PR DESCRIPTION
The present GuardingRequestFilter sets a Timer that logs 2 messages, and then does nothing.  This PR removes the unused code, in order to improve the user experience for Cloud (the only place I know of that uses the GuardingRequestFilter).
