### PR TITLE
Added CREATE/DROP CONSTRAINT syntax in Cypher

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -72,3 +72,5 @@ class IndexHintException(identifier: String, label: String, property: String, me
 }
 
 class UnableToPickStartPointException(message: String) extends CypherException(message)
+
+class InvalidSemanticsException( message: String ) extends CypherException(message)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/CypherParser.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/CypherParser.scala
@@ -53,10 +53,12 @@ class CypherParser(version: String) {
       case _ => (version, queryText)
     }
 
-    v match {
+    val result = v match {
       case v1_9.name          => v1_9.parser.parse(q)
       case v2_0.name          => v2_0.parser.parse(q)
       case _                  => throw new SyntaxException("Versions supported are 1.9 and 2.0")
     }
+    result.verifySemantics()
+    result
   }
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Query.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Query.scala
@@ -45,7 +45,8 @@ object Query {
 trait AbstractQuery {
   def queryString: QueryString
   def setQueryText(t:String):AbstractQuery
-  def getQueryText : String = queryString.text
+  def getQueryText: String = queryString.text
+  def verifySemantics() {}
 }
 
 case class Query(returns: Return,

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Constraint.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Constraint.scala
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.parser.v2_0
+
+import org.neo4j.cypher.internal.commands.CreateConstraint
+import org.neo4j.cypher.internal.commands.CreateConstraint
+import org.neo4j.cypher.SyntaxException
+import org.neo4j.cypher.internal.commands.DropConstraint
+
+trait Constraint extends Base with Labels {
+    def createConstraint:Parser[CreateConstraint] =
+      CREATE ~> CONSTRAINT ~> ON ~> parens( identity ~ labelName ) ~ opt( ASSERT ) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
+        case id ~ label ~ _ ~ idForProperty ~ "." ~ propertyKey => CreateConstraint( id, label.name, idForProperty, propertyKey )
+      }
+      
+   def dropConstraint:Parser[DropConstraint] =
+      DROP ~> CONSTRAINT ~> ON ~> parens( identity ~ labelName ) ~ opt( ASSERT ) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
+        case id ~ label ~ _ ~ idForProperty ~ "." ~ propertyKey => DropConstraint( id, label.name, idForProperty, propertyKey )
+      }
+      
+    def constraintOps = createConstraint | dropConstraint
+}

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/CypherParserImpl.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/CypherParserImpl.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.ReattachAliasedExpressions
 
 class CypherParserImpl extends Base
 with Index
+with Constraint
 with Unions
 with QueryParser
 with Expressions
@@ -50,9 +51,7 @@ Thank you, the Neo4j Team.
     }
   }
 
-  def cypherQuery: Parser[AbstractQuery] = (createIndex | dropIndex | union | query) <~ opt(";")
+  def cypherQuery: Parser[AbstractQuery] = (indexOps | constraintOps | union | query) <~ opt(";")
 
   def createProperty(entity: String, propName: String): Expression = Property(Identifier(entity), propName)
 }
-
-

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Index.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Index.scala
@@ -24,15 +24,17 @@ import org.neo4j.cypher.internal.commands.{DropIndex, CreateIndex}
 
 
 trait Index extends Base with Labels {
-  def createIndex = CREATE ~> indexOps ^^ {
+  def createIndex = CREATE ~> indexTail ^^ {
     case (label, properties) => CreateIndex(label, properties)
   }
 
-  def dropIndex = DROP ~> indexOps ^^ {
+  def dropIndex = DROP ~> indexTail ^^ {
     case (label, properties) => DropIndex(label, properties)
   }
+  
+  def indexOps = createIndex | dropIndex
 
-  private def indexOps: Parser[(String, List[String])] = INDEX ~> ON ~> labelName ~ parens(identity) ^^ {
+  private def indexTail: Parser[(String, List[String])] = INDEX ~> ON ~> labelName ~ parens(identity) ^^ {
     case LabelName(labelName) ~ property => (labelName, List(property))
   }
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Labels.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Labels.scala
@@ -30,6 +30,4 @@ trait Labels extends Base {
   def optLabelShortForm: Parser[Seq[LabelValue]] = opt(labelShortForm) ^^ {
     case optSpec => optSpec.getOrElse(Seq.empty)
   }
-
-  def expression: Parser[Expression]
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Strings.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Strings.scala
@@ -26,11 +26,12 @@ trait Strings extends JavaTokenParsers {
   def KEYWORDS =
     START | CREATE | SET | DELETE | FOREACH | MATCH | WHERE | WITH |
     RETURN | SKIP | LIMIT | ORDER | BY | ASC | DESC | ON | WHEN | CASE | THEN |
-    ELSE | DROP | USING | MERGE
+    ELSE | DROP | USING | MERGE | CONSTRAINT | ASSERT
 
   // KEYWORDS
   def START = ignoreCase("start")
   def CREATE = ignoreCase("create")
+  def CONSTRAINT = ignoreCase("constraint")
   def SET = ignoreCase("set")
   def DELETE = ignoreCase("delete")
   def FOREACH = ignoreCase("foreach")
@@ -52,6 +53,7 @@ trait Strings extends JavaTokenParsers {
   def DROP = ignoreCase("drop")
   def USING = ignoreCase("using")
   def MERGE = ignoreCase("merge")
+  def ASSERT = ignoreCase("assert")
 
   // SHOULD THESE ALSO BE KEYWORDS?
   def UNIQUE = ignoreCase("unique")

--- a/community/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorTest.scala
@@ -67,7 +67,17 @@ class SemanticErrorTest extends ExecutionEngineHelper {
     expectedError("start n=node(0) match p=shortestPath(n-->b) return p",
       "Unknown identifier `b`")
   }
+  
+  @Test def shouldBeSemanticallyIncorrectToReferToUnknownIdentifierInCreateConstraint() {
+    expectedError("create constraint on (foo:Foo) bar.name is unique",
+        "Unknown identifier `bar`, was expecting `foo`")
+  }
 
+  @Test def shouldBeSemanticallyIncorrectToReferToUnknownIdentifierInDropConstraint() {
+    expectedError("drop constraint on (foo:Foo) bar.name is unique",
+        "Unknown identifier `bar`, was expecting `foo`")
+  }
+  
   def expectedError(query: String, message: String) {
     try {
       val result = parseAndExecute(query)

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ConstraintTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ConstraintTest.scala
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.parser
+
+import v2_0._
+import org.junit.Test
+import org.neo4j.cypher.internal.mutation.{NamedExpectation, UniqueLink}
+import org.neo4j.graphdb.Direction
+import org.neo4j.cypher.internal.helpers.LabelSupport
+import org.neo4j.cypher.internal.commands.expressions.{Collection, Identifier}
+import org.neo4j.cypher.internal.commands.CreateConstraint
+import org.neo4j.cypher.internal.commands.DropConstraint
+
+class ConstraintTest extends Constraint with ParserTest {
+
+  @Test
+  def create_uniqueness_constraint() {
+    implicit val parserToTest = createConstraint
+    
+    parsing( "CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE" ) or
+    parsing( "CREATE CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE" ) or
+    parsing( "create constraint on (foo:Foo) assert foo.name is unique" ) shouldGive
+      CreateConstraint( "foo", "Foo", "foo", "name" )
+    
+    parsing( "CREATE CONSTRAINT ON (foo:Foo) ASSERT bar.name IS UNIQUE" ) shouldGive
+      CreateConstraint( "foo", "Foo", "bar", "name" )
+  }
+
+  @Test
+  def drop_uniqueness_constraint() {
+    implicit val parserToTest = dropConstraint
+    
+    parsing( "DROP CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE" ) or
+    parsing( "DROP CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE" ) or
+    parsing( "drop constraint on (foo:Foo) assert foo.name is unique" ) shouldGive
+      DropConstraint( "foo", "Foo", "foo", "name" )
+    
+    parsing( "DROP CONSTRAINT ON (foo:Foo) ASSERT bar.name IS UNIQUE" ) shouldGive
+      DropConstraint( "foo", "Foo", "bar", "name" )
+  }
+}

--- a/community/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
+++ b/community/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
@@ -177,9 +177,9 @@ public class AsciidocHelper
 
     public static String createCypherSnippet( final String query )
     {
-        String[] keywordsToBreakOn = new String[]{"start", "create unique", "set", "delete", "foreach",
+        String[] keywordsToBreakOn = new String[]{"start", "create", "unique", "set", "delete", "foreach",
                 "match", "where", "with", "return", "skip", "limit", "order by", "asc", "ascending",
-                "desc", "descending", "create", "remove", "drop", "using", "merge"};
+                "desc", "descending", "create", "remove", "drop", "using", "merge", "assert", "constraint"};
 
         String[] unbreakableKeywords = new String[]{"label", "values", "on", "index"};
         return createLanguageSnippet( query, "cypher", keywordsToBreakOn, unbreakableKeywords );


### PR DESCRIPTION
o Create contraint syntax, for example:
  CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE
o Drop constraint syntax, for example:
  DROP CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE
o Doesn't actually do anything, just able to parse it.
