### PR TITLE
Restructured interaction between TxManager and KernelAPI

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionContext.java
@@ -66,6 +66,7 @@ public interface TransactionContext
 
     /**
      * Roll back this transaction, undoing any changes that have been made.
+     * @throws TransactionFailureException 
      */
-    void rollback();
+    void rollback() throws TransactionFailureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DelegatingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DelegatingTransactionContext.java
@@ -51,7 +51,7 @@ public class DelegatingTransactionContext implements TransactionContext
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
         delegate.rollback();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import static java.util.Collections.synchronizedList;
+import static org.neo4j.helpers.collection.IteratorUtil.loop;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -43,9 +46,6 @@ import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-
-import static java.util.Collections.synchronizedList;
-import static org.neo4j.helpers.collection.IteratorUtil.loop;
 
 /**
  * This is the beginnings of an implementation of the Kernel API, which is meant to be an internal API for
@@ -88,6 +88,16 @@ import static org.neo4j.helpers.collection.IteratorUtil.loop;
  * change, and the implementation of that API is responsible for keeping caches in sync.
  *
  * Please expand and update this as you learn things or find errors in the text above.
+ * 
+ * The current interaction with the TransactionManager looks like this:
+ * 
+ * <ol>
+ * <li>
+ * tx.finish() --> TransactionImpl.commit() --> TransactionContext.commit() --> TxManager.commit()
+ * </li>
+ * <li>
+ * TxManager.commit() --> TransactionImpl.doCommit() --> dataSource.commit()
+ * </li>
  */
 public class Kernel extends LifecycleAdapter implements KernelAPI
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingTransactionContext.java
@@ -60,30 +60,18 @@ public class LockingTransactionContext extends DelegatingTransactionContext
     @Override
     public void commit() throws TransactionFailureException
     {
-        // TODO: this checking should be removed at some point in the future.
-        // Currently the TxManager will release all locks if the transaction fails to commit.
-        // That should not be the case when the transaction code has been refactored (moved away from JTA).
-        boolean unlock = true;
         try
         {
             super.commit();
         }
-        catch ( TransactionFailureException e )
-        {
-            unlock = false;
-            throw e;
-        }
         finally
         {
-            if ( unlock )
-            {
-                lockHolder.releaseLocks();
-            }
+            lockHolder.releaseLocks();
         }
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContext.java
@@ -53,7 +53,7 @@ public class ReferenceCountingTransactionContext extends DelegatingTransactionCo
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
         statementContextOwner.closeAllStatements();
         delegate.rollback();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SingleStatementTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SingleStatementTransactionContext.java
@@ -62,7 +62,7 @@ public class SingleStatementTransactionContext extends DelegatingTransactionCont
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
         closeShop();
         super.rollback();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreTransactionContext.java
@@ -98,7 +98,23 @@ public class StoreTransactionContext implements TransactionContext
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
+        try
+        {
+            transactionManager.rollback();
+        }
+        catch ( IllegalStateException e )
+        {
+            throw new TransactionFailureException( e );
+        }
+        catch ( SecurityException e )
+        {
+            throw new TransactionFailureException( e );
+        }
+        catch ( SystemException e )
+        {
+            throw new TransactionFailureException( e );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/AbstractTransactionManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/AbstractTransactionManager.java
@@ -25,6 +25,7 @@ import javax.transaction.TransactionManager;
 
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.StatementContext;
+import org.neo4j.kernel.api.TransactionContext;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -83,15 +84,29 @@ public abstract class AbstractTransactionManager implements TransactionManager, 
      *         can do this using the kernel api that is provided at startup through the (ick) setKernel method.
      */
     @Deprecated
-    public StatementContext getStatementContext() {
+    public StatementContext getStatementContext()
+    {
         throw new UnsupportedOperationException( "The current transaction manager implementation does not support the " +
                 "new StatementContext interface. This is an intermediary problem during transition to a new internal API." );
     }
-
+    
     /**
      * Temporarily here during transition to Kernel API
      * @param kernel
      */
     @Deprecated
     public abstract void setKernel( KernelAPI kernel );
+    
+    /**
+     * Temporarily here during transition to Kernel API.
+     *
+     * @return an open transaction context for the current transaction. If none exists, it should create one. It
+     *         can do this using the kernel api that is provided at startup through the (ick) setKernel method.
+     */
+    @Deprecated
+    public TransactionContext getTransactionContext()
+    {
+        throw new UnsupportedOperationException( "The current transaction manager implementation does not support the " +
+                "new TransactionContext interface. This is an intermediary problem during transition to a new internal API." );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -45,6 +45,7 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.StatementContext;
+import org.neo4j.kernel.api.TransactionContext;
 import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
@@ -968,6 +969,21 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     public void setKernel(KernelAPI kernel)
     {
         this.kernel = kernel;
+    }
+    
+    @Override
+    public TransactionContext getTransactionContext()
+    {
+        Transaction tx;
+        try
+        {
+            tx = getTransaction();
+        }
+        catch ( SystemException e )
+        {
+            throw new RuntimeException( e );
+        }
+        return tx != null ? ((TransactionImpl)tx).getTransactionContext() : null;
     }
     
     private class TxManagerDataSourceRegistrationListener implements DataSourceRegistrationListener

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -29,6 +29,7 @@ import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.api.TransactionFailureException;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.transactional.error.InternalBeginTransactionError;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
@@ -138,7 +139,7 @@ public class TransactionHandle
         }
     }
 
-    public void forceRollback()
+    public void forceRollback() throws TransactionFailureException
     {
         context.resumeSinceTransactionsAreStillThreadBound();
         context.rollback();
@@ -193,7 +194,7 @@ public class TransactionHandle
                 {
                     context.commit();
                 }
-                catch ( RuntimeException e )
+                catch ( Exception e )
                 {
                     log.error( "Failed to commit transaction.", e );
                     errors.add( new Neo4jError( StatusCode.INTERNAL_COMMIT_TRANSACTION_ERROR, e ) );
@@ -205,7 +206,7 @@ public class TransactionHandle
                 {
                     context.rollback();
                 }
-                catch ( RuntimeException e )
+                catch ( Exception e )
                 {
                     log.error( "Failed to rollback transaction.", e );
                     errors.add( new Neo4jError( StatusCode.INTERNAL_ROLLBACK_TRANSACTION_ERROR, e ) );
@@ -224,7 +225,7 @@ public class TransactionHandle
         {
             context.rollback();
         }
-        catch ( RuntimeException e )
+        catch ( Exception e )
         {
             log.error( "Failed to rollback transaction.", e );
             errors.add( new Neo4jError( StatusCode.INTERNAL_ROLLBACK_TRANSACTION_ERROR, e ) );

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -27,22 +27,23 @@ import org.neo4j.kernel.impl.transaction.TxManager;
 
 public class TransitionalPeriodTransactionMessContainer implements KernelAPI
 {
-
-    private final KernelAPI kernel;
     private final GraphDatabaseAPI db;
     private final TxManager txManager;
 
     public TransitionalPeriodTransactionMessContainer( GraphDatabaseAPI db )
     {
         this.db = db;
-        this.kernel = db.getDependencyResolver().resolveDependency( KernelAPI.class );
         this.txManager = db.getDependencyResolver().resolveDependency( TxManager.class );
     }
 
+    @Override
     public TransactionContext newTransactionContext()
     {
         db.beginTx();
-        return new TransitionalTxManagementTransactionContext( kernel.newTransactionContext(), txManager );
+        
+        // Get and use the TransactionContext created in db.beginTx(). The role of creating
+        // TransactionContexts will be reversed soonish.
+        return new TransitionalTxManagementTransactionContext( txManager.getTransactionContext(), txManager );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementTransactionContext.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementTransactionContext.java
@@ -24,6 +24,7 @@ import javax.transaction.Transaction;
 
 import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.api.TransactionContext;
+import org.neo4j.kernel.api.TransactionFailureException;
 import org.neo4j.kernel.impl.transaction.TxManager;
 
 class TransitionalTxManagementTransactionContext implements TransactionContext
@@ -52,29 +53,15 @@ class TransitionalTxManagementTransactionContext implements TransactionContext
     }
 
     @Override
-    public void commit()
+    public void commit() throws TransactionFailureException
     {
-        try
-        {
-            txManager.commit();
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e );
-        }
+        ctx.commit();
     }
 
     @Override
-    public void rollback()
+    public void rollback() throws TransactionFailureException
     {
-        try
-        {
-            txManager.rollback();
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e );
-        }
+        ctx.rollback();
     }
 
     public void suspendSinceTransactionsAreStillThreadBound()

--- a/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
@@ -26,11 +26,12 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+import static org.neo4j.server.rest.domain.JsonHelper.jsonToMap;
 import static org.neo4j.test.server.HTTP.POST;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 import static org.neo4j.test.server.HTTP.RawPayload.rawPayload;
-import static org.neo4j.test.server.HTTP.Response;
 
 import java.util.Iterator;
 import java.util.List;
@@ -44,6 +45,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.server.rest.transactional.error.StatusCode;
 import org.neo4j.test.server.HTTP;
+import org.neo4j.test.server.HTTP.Response;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
@@ -249,6 +251,31 @@ public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
         assertErrorCodes( response, StatusCode.INVALID_REQUEST_FORMAT );
 
         assertThat( countNodes(), equalTo( nodesInDatabaseBeforeTransaction ) );
+    }
+    
+    @SuppressWarnings( { "rawtypes" } )
+    @Test
+    public void begin_create_two_nodes_delete_one() throws Exception
+    {
+        /*
+         * This issue was reported from the community. It resulted in a refactoring of the interaction
+         * between TxManager and TransactionContexts.
+         */
+        
+        // GIVEN
+        long nodesInDatabaseBeforeTransaction = countNodes();
+        Response response = http.POST( "/db/data/transaction/commit",
+                rawPayload( "{ \"statements\" : [{\"statement\" : \"CREATE (n0:DecibelEntity :AlbumGroup{DecibelID : '34a2201b-f4a9-420f-87ae-00a9c691cc5c', Title : 'Dance With Me', ArtistString : 'Ra Ra Riot', MainArtistAlias : 'Ra Ra Riot', OriginalReleaseDate : '2013-01-08', IsCanon : 'False'}) return id(n0)\"}, {\"statement\" : \"CREATE (n1:DecibelEntity :AlbumRelease{DecibelID : '9ed529fa-7c19-11e2-be78-bcaec5bea3c3', Title : 'Dance With Me', ArtistString : 'Ra Ra Riot', MainArtistAlias : 'Ra Ra Riot', LabelName : 'Barsuk Records', FormatNames : 'File', TrackCount : '3', MediaCount : '1', Duration : '460.000000', ReleaseDate : '2013-01-08', ReleaseYear : '2013', ReleaseRegion : 'USA', Cline : 'Barsuk Records', Pline : 'Barsuk Records', CYear : '2013', PYear : '2013', ParentalAdvisory : 'False', IsLimitedEdition : 'False'}) return id(n1)\"}]}" ) );
+        assertEquals( 200, response.status() );
+        Map<String,Object> everything = jsonToMap( response.rawContent() );
+        Map result = (Map) ((List) everything.get( "results" )).get( 0 );
+        long id = ((Number) ((List) ((List) result.get( "data" )).get( 0 )).get( 0 )).longValue();
+        
+        // WHEN
+        http.POST( "/db/data/cypher", rawPayload( "{\"query\":\"start n = node(" + id + ") delete n\"}" ) );
+
+        // THEN
+        assertThat( countNodes(), equalTo( nodesInDatabaseBeforeTransaction+1 ) );
     }
 
     private void assertNoErrors( Response response )


### PR DESCRIPTION
o Unified the way commit/rollback works by means of interaction between
  TxManager and TransactionContext.
o Rest transaction context (TransitionalPeriodTransactionMessContainer)
  uses the TransactionContext instead of TxManager for communicating
  commit/rollback.
o Removed lock releasing checks stemming from confusion about the
  interaction between these two
