### PR TITLE
Makes a graph database give a helpful message when it's been shutdown

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/DatabaseShutdownException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/DatabaseShutdownException.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+public class DatabaseShutdownException extends RuntimeException
+{
+    public DatabaseShutdownException( )
+    {
+        super( "This database is shutdown." );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -25,7 +25,6 @@ import static org.neo4j.helpers.collection.Iterables.map;
 import static org.slf4j.impl.StaticLoggerBinder.getSingleton;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -39,6 +38,7 @@ import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -154,8 +154,6 @@ import org.neo4j.kernel.logging.ClassicLoggingService;
 import org.neo4j.kernel.logging.LogbackService;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.tooling.GlobalGraphOperations;
-
-import ch.qos.logback.classic.LoggerContext;
 
 /**
  * Base implementation of GraphDatabaseService. Responsible for creating services, handling dependencies between them,
@@ -477,8 +475,7 @@ public abstract class InternalAbstractGraphDatabase
         // XXX: Circular dependency, temporary during transition to KernelAPI - TxManager should not depend on KernelAPI
         txManager.setKernel(kernelAPI);
 
-        statementContextProvider = life.add( new ThreadToStatementContextBridge( kernelAPI, txManager
-        ) );
+        statementContextProvider = life.add( new ThreadToStatementContextBridge( kernelAPI, txManager ) );
 
         nodeManager = guard != null ?
                 createGuardedNodeManager( readOnly, cacheProvider, nodeCache, relCache ) :
@@ -883,19 +880,11 @@ public abstract class InternalAbstractGraphDatabase
     protected void createNeoDataSource()
     {
         // Create DataSource
-        try
-        {
-            // TODO IO stuff should be done in lifecycle. Refactor!
-            neoDataSource = new NeoStoreXaDataSource( config,
-                    storeFactory, lockManager, logging.getMessagesLog( NeoStoreXaDataSource.class ),
-                    xaFactory, stateFactory, transactionInterceptorProviders, jobScheduler, logging,
-                    updateableSchemaState, nodeManager, dependencyResolver );
-            xaDataSourceManager.registerDataSource( neoDataSource );
-        }
-        catch ( IOException e )
-        {
-            throw new IllegalStateException( "Could not create Neo XA datasource", e );
-        }
+        neoDataSource = new NeoStoreXaDataSource( config,
+                storeFactory, lockManager, logging.getMessagesLog( NeoStoreXaDataSource.class ),
+                xaFactory, stateFactory, transactionInterceptorProviders, jobScheduler, logging,
+                updateableSchemaState, nodeManager, dependencyResolver );
+        xaDataSourceManager.registerDataSource( neoDataSource );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.StatementContext;
@@ -120,6 +121,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private NeoStore neoStore;
     private NodeManager nodeManager;
     private PersistenceCache persistenceCache;
+    private boolean isShutdown = false;
 
     public Kernel( AbstractTransactionManager transactionManager,
                    PropertyKeyTokenHolder propertyKeyTokenHolder, LabelTokenHolder labelTokenHolder,
@@ -187,11 +189,15 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     public void stop() throws Throwable
     {
         statementContextOwners.close();
+        isShutdown = true;
     }
 
     @Override
     public TransactionContext newTransactionContext()
     {
+        checkIfShutdown();
+
+
         // I/O
         // TODO The store layer should depend on a clean abstraction of the data, not on all the XXXManagers from the
         // old code base
@@ -221,14 +227,25 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
         return result;
     }
 
+    private void checkIfShutdown()
+    {
+        if ( isShutdown )
+        {
+            throw new DatabaseShutdownException();
+        }
+    }
+
     @Override
     public StatementContext newReadOnlyStatementContext()
     {
+        checkIfShutdown();
         return statementContextOwners.get().getStatementContext();
     }
 
     private StatementContext createReadOnlyStatementContext()
     {
+        checkIfShutdown();
+
         // I/O
         SchemaStorage schemaStorage = new SchemaStorage( neoStore.getSchemaStore() );
         StatementContext result = new StoreStatementContext( propertyKeyTokenHolder, labelTokenHolder, nodeManager,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
+import static org.neo4j.helpers.collection.Iterables.filter;
+import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.kernel.api.index.SchemaIndexProvider.HIGHEST_PRIORITIZED_OR_NONE;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -87,10 +91,6 @@ import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
-
-import static org.neo4j.helpers.collection.Iterables.filter;
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.kernel.api.index.SchemaIndexProvider.HIGHEST_PRIORITIZED_OR_NONE;
 
 /**
  * A <CODE>NeoStoreXaDataSource</CODE> is a factory for
@@ -237,7 +237,6 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource
                                  JobScheduler scheduler, Logging logging,
                                  UpdateableSchemaState updateableSchemaState, NodeManager nodeManager,
                                  DependencyResolver dependencyResolver )
-            throws IOException
     {
         super( BRANCH_ID, Config.DEFAULT_DATA_SOURCE_NAME );
         this.config = config;
@@ -254,7 +253,6 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource
         this.storeFactory = sf;
         this.xaFactory = xaFactory;
         this.updateableSchemaState = updateableSchemaState;
-
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.util.List;
+
+import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.ClosableIterable;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.PersistenceCache;
+import org.neo4j.kernel.impl.api.SchemaCache;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.StoreId;
+import org.neo4j.kernel.impl.nioneo.store.WindowPoolStats;
+import org.neo4j.kernel.impl.transaction.xaframework.LogBuffer;
+import org.neo4j.kernel.impl.transaction.xaframework.LogExtractor;
+import org.neo4j.kernel.impl.transaction.xaframework.XaContainer;
+import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
+import org.neo4j.kernel.info.DiagnosticsManager;
+
+public class ShutdownXaDataSource extends NeoStoreXaDataSource
+{
+    public ShutdownXaDataSource()
+    {
+        super( new Config(), null, null, null, null, null, null, null, null, null, null, null );
+    }
+
+    @Override
+    public long getCreationTime()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getCurrentLogVersion()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getHighestPossibleIdInUse( Class<?> clazz )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public IndexingService getIndexService()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getLastCommittedTxId()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public NeoStore getNeoStore()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getNumberOfIdsInUse( Class<?> clazz )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public PersistenceCache getPersistenceCache()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public DefaultSchemaIndexProviderMap getProviderMap()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getRandomIdentifier()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    ReadTransaction getReadOnlyTransaction()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public SchemaCache getSchemaCache()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public String getStoreDir()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public StoreId getStoreId()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public List<WindowPoolStats> getWindowPoolStats()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public NeoStoreXaConnection getXaConnection()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public XaContainer getXaContainer()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long incrementAndGetLogVersion()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void init()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public boolean isReadOnly()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public ClosableIterable<File> listStoreFiles( boolean includeLogicalLogs )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void logIdUsage()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void logStoreVersions()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long nextId( Class<?> clazz )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void registerDiagnosticsWith( DiagnosticsManager manager )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void setCurrentLogVersion( long version )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void setLastCommittedTxId( long txId )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public boolean setRecovered( boolean recovered )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void shutdown()
+    {
+    }
+
+    @Override
+    public void start() throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void stop()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public boolean deleteLogicalLog( long version )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public File getFileName( long version )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public LogExtractor getLogExtractor( long startTxId, long endTxIdHint ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public ReadableByteChannel getLogicalLog( long version ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long getLogicalLogLength( long version )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public Pair<Integer, Long> getMasterForCommittedTx( long txId ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public ReadableByteChannel getPreparedTransaction( int identifier ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void getPreparedTransaction( int identifier, LogBuffer targetBuffer ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public boolean hasLogicalLog( long version )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long rotateLogicalLog() throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void setAutoRotate( boolean rotate )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    protected void setLogicalLogAtCreationTime( XaLogicalLog logicalLog )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void setLogicalLogTargetSize( long size )
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public void applyCommittedTransaction( long txId, ReadableByteChannel transaction ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public long applyPreparedTransaction( ReadableByteChannel transaction ) throws IOException
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public byte[] getBranchId()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    @Override
+    public String getName()
+    {
+        throw databaseIsShutdownError();
+    }
+
+    private DatabaseShutdownException databaseIsShutdownError()
+    {
+        return new DatabaseShutdownException( );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/XaDataSourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/XaDataSourceManager.java
@@ -40,6 +40,7 @@ import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.nioneo.xa.ShutdownXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.XaResource;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -74,6 +75,7 @@ public class XaDataSourceManager
     private LifeSupport life = new LifeSupport();
 
     private final StringLogger msgLog;
+    private boolean isShutdown = false;
 
     public XaDataSourceManager( StringLogger msgLog )
     {
@@ -158,6 +160,7 @@ public class XaDataSourceManager
         dataSources.clear();
         branchIdMapping.clear();
         sourceIdMapping.clear();
+        isShutdown = true;
     }
 
     /**
@@ -169,6 +172,11 @@ public class XaDataSourceManager
      */
     public XaDataSource getXaDataSource( String name )
     {
+        if ( isShutdown )
+        {
+            return new ShutdownXaDataSource();
+        }
+
         return dataSources.get( name );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -444,21 +444,19 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         NeoStoreXaDataSource nioneoDataSource = (NeoStoreXaDataSource) xaDataSourceManager.getXaDataSource( Config.DEFAULT_DATA_SOURCE_NAME );
         if ( nioneoDataSource == null )
         {
-            try
-            {
-                nioneoDataSource = new NeoStoreXaDataSource( config,
-                        resolver.resolveDependency( StoreFactory.class ),
-                        resolver.resolveDependency( LockManager.class ),
-                        resolver.resolveDependency( StringLogger.class ),
-                        resolver.resolveDependency( XaFactory.class ),
-                        resolver.resolveDependency( TransactionStateFactory.class ),
-                        resolver.resolveDependency( TransactionInterceptorProviders.class ),
-                        resolver.resolveDependency( JobScheduler.class ),
-                        logging,
-                        updateableSchemaState,
-                        resolver.resolveDependency( NodeManager.class ),
-                        resolver );
-                xaDataSourceManager.registerDataSource( nioneoDataSource );
+            nioneoDataSource = new NeoStoreXaDataSource( config,
+                    resolver.resolveDependency( StoreFactory.class ),
+                    resolver.resolveDependency( LockManager.class ),
+                    resolver.resolveDependency( StringLogger.class ),
+                    resolver.resolveDependency( XaFactory.class ),
+                    resolver.resolveDependency( TransactionStateFactory.class ),
+                    resolver.resolveDependency( TransactionInterceptorProviders.class ),
+                    resolver.resolveDependency( JobScheduler.class ),
+                    logging,
+                    updateableSchemaState,
+                    resolver.resolveDependency( NodeManager.class ),
+                    resolver );
+            xaDataSourceManager.registerDataSource( nioneoDataSource );
                 /*
                  * CAUTION: The next line may cause severe eye irritation, mental instability and potential
                  * emotional breakdown. On the plus side, it is correct.
@@ -467,13 +465,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                  * register the datasource with the DsMgr we need to make sure that NodeManager re-reads the reltype
                  * and propindex information. Normally, we would have shutdown everything before getting here.
                  */
-                resolver.resolveDependency( NodeManager.class ).start();
-            }
-            catch ( IOException e )
-            {
-                msgLog.logMessage( "Failed while trying to create datasource", e );
-                throw e;
-            }
+            resolver.resolveDependency( NodeManager.class ).start();
         }
         return nioneoDataSource;
     }


### PR DESCRIPTION
- Removed throws IOException from NeoStoreXaDataSource constructor, because it's not true
- Made ThreadToStatementContextBridge implement Lifecycle so it's told when to shutdown
- Kernel keeps track of shutdown state and throws appropriate exception when used after
