### PR TITLE
Adds schema state invalidation when creating or dropping constraints

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
@@ -137,6 +137,7 @@ public class StateHandlingTransactionContext extends DelegatingTransactionContex
             {
                 try
                 {
+                    clearState.set( true );
                     UniquenessConstraintRule rule = schemaStorage
                             .uniquenessConstraint( element.label(), element.property() );
                     persistenceManager.dropSchemaRule( rule.getId() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.Function;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.api.ConstraintViolationKernelException;
+import org.neo4j.kernel.api.StatementContext;
+import org.neo4j.kernel.api.TransactionContext;
+import org.neo4j.kernel.api.TransactionFailureException;
+import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.impl.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+public class KernelSchemaStateFlushingTest
+{
+    public @Rule ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+
+    private GraphDatabaseAPI db;
+    private AbstractTransactionManager txManager;
+
+    @Test
+    public void shouldKeepSchemaStateIfSchemaIsNotModified() throws TransactionFailureException
+    {
+        // given
+        String before = commitToSchemaState( "test", "before" );
+
+        // then
+        assertEquals( "before", before );
+
+        // given
+        String after = commitToSchemaState( "test", "after" );
+
+        // then
+        assertEquals( "before", after );
+    }
+
+    @Test
+    public void shouldInvalidateSchemaStateOnCreateIndex() throws Exception
+    {
+        // given
+        commitToSchemaState( "test", "before" );
+        
+        IndexDescriptor descriptor = createIndex();
+
+        awatIndexOnline( descriptor );
+        
+        // when
+        String after = commitToSchemaState( "test", "after" );
+
+        // then
+        assertEquals( "after", after );
+    }
+
+    @Test
+    public void shouldInvalidateSchemaStateOnDropIndex() throws Exception
+    {
+        IndexDescriptor descriptor = createIndex();
+
+        awatIndexOnline( descriptor );
+
+        commitToSchemaState( "test", "before" );
+
+        dropIndex( descriptor );
+
+        // when
+        String after = commitToSchemaState( "test", "after" );
+
+        // then
+        assertEquals( "after", after );
+    }
+
+    @Test
+    public void shouldInvalidateSchemaStateOnCreateConstraint() throws Exception
+    {
+        // given
+        commitToSchemaState( "test", "before" );
+
+        createConstraint();
+
+        // when
+        String after = commitToSchemaState( "test", "after" );
+
+        // then
+        assertEquals( "after", after );
+    }
+
+    @Test
+    public void shouldInvalidateSchemaStateOnDropConstraint() throws Exception
+    {
+        // given
+        UniquenessConstraint descriptor = createConstraint();
+
+        commitToSchemaState( "test", "before" );
+
+        dropConstraint( descriptor );
+
+        // when
+        String after = commitToSchemaState( "test", "after" );
+
+        // then
+        assertEquals( "after", after );
+    }
+
+    private UniquenessConstraint createConstraint() throws ConstraintViolationKernelException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        StatementContext ctx = txc.newStatementContext();
+        UniquenessConstraint descriptor = ctx.addUniquenessConstraint( 1, 1 );
+        ctx.close();
+        tx.success();
+        tx.finish();
+        return descriptor;
+    }
+
+    private void dropConstraint( UniquenessConstraint descriptor ) throws ConstraintViolationKernelException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        StatementContext ctx = txc.newStatementContext();
+        ctx.dropConstraint( descriptor );
+        ctx.close();
+        tx.success();
+        tx.finish();
+    }
+
+    private IndexDescriptor createIndex() throws ConstraintViolationKernelException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        StatementContext ctx = txc.newStatementContext();
+        IndexDescriptor descriptor = ctx.addIndex( 1, 1 );
+        ctx.close();
+        tx.success();
+        tx.finish();
+        return descriptor;
+    }
+
+    private void dropIndex( IndexDescriptor descriptor ) throws ConstraintViolationKernelException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        StatementContext ctx = txc.newStatementContext();
+        ctx.dropIndex( descriptor );
+        ctx.close();
+        tx.success();
+        tx.finish();
+    }
+
+    private void awatIndexOnline( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        StatementContext ctx = txc.newStatementContext();
+        SchemaIndexTestHelper.awaitIndexOnline( ctx, descriptor );
+        ctx.close();
+        tx.success();
+        tx.finish();
+    }
+
+    private String commitToSchemaState( String key, String value ) throws TransactionFailureException
+    {
+        Transaction tx = db.beginTx();
+        TransactionContext txc = txManager.getTransactionContext();
+        String result;
+        try 
+        {
+            result = getOrCreateFromState( txc, key, value );
+            return result;            
+        }
+        finally
+        {
+            tx.success();
+            tx.finish();
+        }
+    }
+    
+    private String getOrCreateFromState( TransactionContext tx, String key, final String value )
+    {
+        StatementContext ctx = tx.newStatementContext();
+        try 
+        {
+            String result = ctx.getOrCreateFromSchemaState( key, new Function<String, String>() {
+                @Override
+                public String apply( String from )
+                {
+                    return value;
+                }
+            }); 
+            return result;
+        }
+        finally 
+        {
+            ctx.close();
+        }
+    }
+    
+    @Before
+    public void setup() 
+    {
+        db = dbRule.getGraphDatabaseAPI();         
+        txManager = db.getDependencyResolver().resolveDependency( AbstractTransactionManager.class );
+    }
+    
+    @After
+    public void afer()
+    {
+        db.shutdown();
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -19,22 +19,20 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import java.util.Set;
-
-import org.junit.Test;
-
-import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.kernel.api.ConstraintViolationKernelException;
-import org.neo4j.kernel.api.StatementContext;
-import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
-import org.neo4j.kernel.api.index.InternalIndexState;
-import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.kernel.api.ConstraintViolationKernelException;
+import org.neo4j.kernel.api.StatementContext;
+import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 
 public class IndexIT extends KernelIntegrationTest
 {
@@ -265,19 +263,6 @@ public class IndexIT extends KernelIntegrationTest
 
     private void awaitIndexOnline( IndexDescriptor indexRule ) throws IndexNotFoundKernelException
     {
-        StatementContext ctx = readOnlyContext();
-        long start = System.currentTimeMillis();
-        while ( true )
-        {
-            if ( ctx.getIndexState( indexRule ) == InternalIndexState.ONLINE )
-            {
-                break;
-            }
-
-            if ( start + 1000 * 10 < System.currentTimeMillis() )
-            {
-                throw new RuntimeException( "Index didn't come online within a reasonable time." );
-            }
-        }
+        SchemaIndexTestHelper.awaitIndexOnline( readOnlyContext(), indexRule );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -27,13 +31,12 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.Ignore;
 import org.neo4j.helpers.FutureAdapter;
+import org.neo4j.kernel.api.StatementContext;
+import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @Ignore( "This is not a test" )
 public class SchemaIndexTestHelper
@@ -108,4 +111,24 @@ public class SchemaIndexTestHelper
             throw new RuntimeException( e );
         }
     }
+    
+    public static void awaitIndexOnline( StatementContext ctx, IndexDescriptor indexRule ) 
+            throws IndexNotFoundKernelException
+    {
+
+        long start = System.currentTimeMillis();
+        while(true)
+        {
+           if(ctx.getIndexState(indexRule) == InternalIndexState.ONLINE)
+           {
+               break;
+           }
+
+           if(start + 1000 * 10 < System.currentTimeMillis())
+           {
+               throw new RuntimeException( "Index didn't come online within a reasonable time." );
+           }
+        }
+    }
+    
 }


### PR DESCRIPTION
o Adds kernel-level test for all schema state invalidating operations
o Adds SchmemaIndexTestHelper.awaitIndexOnline
o Adds state invalidation on dropConstraint in StateHandlingTxContext
