### PR TITLE
CleanupService doesn't register resources if inside transaction

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintCreator.java
@@ -21,7 +21,6 @@ package org.neo4j.graphdb.schema;
 
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Label;
-import org.neo4j.kernel.api.ConstraintViolationKernelException;
 
 /**
  * A builder for entering details about a constraint to create. After all details have been entered

--- a/community/kernel/src/main/java/org/neo4j/helpers/Thunk.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Thunk.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+/**
+ * http://en.wikipedia.org/wiki/Thunk_%28functional_programming%29
+ * 
+ * A parameter-less function for lazy evaluation to prevent the evaluation of an
+ * expression until forced at a later time.
+ * 
+ * @param <T>
+ */
+public interface Thunk<T>
+{
+    T evaluate();
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/Thunks.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Thunks.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+public class Thunks
+{
+    private Thunks()
+    {
+    }
+
+    public static final Thunk<Boolean> TRUE = new Thunk<Boolean>()
+    {
+        @Override
+        public Boolean evaluate()
+        {
+            return Boolean.TRUE;
+        }
+    };
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/BaseConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/BaseConstraintCreator.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.schema.ConstraintCreator;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
-import org.neo4j.kernel.api.ConstraintViolationKernelException;
 
 public class BaseConstraintCreator implements ConstraintCreator
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/PropertyConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/PropertyConstraintCreator.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.schema.ConstraintCreator;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
-import org.neo4j.kernel.api.ConstraintViolationKernelException;
 
 public class PropertyConstraintCreator extends BaseConstraintCreator
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/SchemaImpl.java
@@ -19,6 +19,17 @@
  */
 package org.neo4j.kernel;
 
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.schema.Schema.IndexState.FAILED;
+import static org.neo4j.graphdb.schema.Schema.IndexState.ONLINE;
+import static org.neo4j.graphdb.schema.Schema.IndexState.POPULATING;
+import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -43,17 +54,6 @@ import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
-
-import static java.lang.String.format;
-import static java.util.Collections.emptyList;
-import static org.neo4j.graphdb.DynamicLabel.label;
-import static org.neo4j.graphdb.schema.Schema.IndexState.FAILED;
-import static org.neo4j.graphdb.schema.Schema.IndexState.ONLINE;
-import static org.neo4j.graphdb.schema.Schema.IndexState.POPULATING;
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
 
 public class SchemaImpl implements Schema
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cleanup/CleanupService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cleanup/CleanupService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.Thunk;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -33,10 +34,18 @@ import org.neo4j.kernel.logging.Logging;
 
 public abstract class CleanupService extends LifecycleAdapter
 {
-    public static CleanupService create( JobScheduler scheduler, Logging logging )
+    /**
+     * @param scheduler {@link JobScheduler} to add the cleanup job on.
+     * @param logging {@link Logging} where cleanup happens.
+     * @param cleanupNecessity {@link Thunk} for deciding what gets registered at this CleanupService and
+     * what doesn't. More specifically 
+     * @return a new {@link CleanupService}.
+     */
+    public static CleanupService create( JobScheduler scheduler, Logging logging, Thunk<Boolean> cleanupNecessity )
     {
         // TODO: implement this by using sun.misc.Cleaner, since those is more efficient than PhantomReferences
-        return new ReferenceQueueBasedCleanupService( scheduler, logging, new CleanupReferenceQueue( 1000 ) );
+        return new ReferenceQueueBasedCleanupService( scheduler, logging, new CleanupReferenceQueue( 1000 ),
+                cleanupNecessity );
     }
 
     private final StringLogger logger;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -518,7 +518,7 @@ public class NodeProxy implements Node
                                     ", but the returned label " + labelId + " doesn't exist anymore" );
                         }
                     }
-                }, labels), ctx );
+                }, labels ), ctx );
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.Iterables.map;
@@ -35,7 +34,6 @@ import static org.neo4j.helpers.collection.IteratorUtil.single;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.schema.ConstraintCreator;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintsCreationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintsCreationIT.java
@@ -23,19 +23,17 @@ import java.util.Iterator;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.helpers.Function;
 import org.neo4j.kernel.api.ConstraintViolationKernelException;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 
-import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
 
 public class ConstraintsCreationIT extends KernelIntegrationTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ResourceIteratorInTxIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ResourceIteratorInTxIT.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+@Ignore( "Not a test, merely a debugging helper or something" )
+public class ResourceIteratorInTxIT
+{
+    @Test
+    public void shouldNotStrainCleanupServiceWhenLeavingStuffBehindWhenInsideTransaction() throws Exception
+    {
+        // GIVEN
+        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        Label label = DynamicLabel.label( "PERSON" );
+        {
+            Transaction tx = db.beginTx();
+            try
+            {
+                db.schema().indexCreator( label ).on( "name" ).create();
+                for ( int i = 0; i < 10; i++ )
+                {
+                    Node node = db.createNode( label );
+                    node.setProperty( "name", "Mattias" );
+                }
+                tx.success();
+            }
+            finally
+            {
+                tx.finish();
+            }
+        }
+
+        // WHEN
+        while ( true )
+        {
+            Transaction tx = db.tx().unforced().begin();
+            try
+            {
+                ResourceIterator<Node> iterator =
+                        db.findNodesByLabelAndProperty( label, "name", "Mattias" ).iterator();
+                iterator.next(); // Don't exhaust it
+                tx.success();
+            }
+            finally
+            {
+                tx.finish();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Methods that returned ResourceIterator still does so, but the actual
returned iterator may not be registered for cleanup if the call was made when
inside a transaction. This is because the transaction will close statement
contexts (i.e. the resource) so it would be unnecessary strain on CleanupService.
