### PR TITLE
Speed increase on startup in presence of many RelTypes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeHolder.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.core;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,13 +56,22 @@ public class RelationshipTypeHolder extends LifecycleAdapter
 
     void addRawRelationshipTypes( NameData[] types )
     {
-        for ( int i = 0; i < types.length; i++ )
+        Map<String, Integer> newTypes = new HashMap<String, Integer>();
+        Map<Integer, RelationshipTypeImpl> newTranslation = new HashMap<Integer, RelationshipTypeImpl>();
+        for ( NameData type : types )
         {
-            addRawRelationshipType( types[i] );
+            addType( type, newTypes, newTranslation );
         }
+        relTypes.putAll( newTypes );
+        relTranslation.putAll( newTranslation );
     }
 
     void addRawRelationshipType( NameData type )
+    {
+        addType( type, relTypes, relTranslation );
+    }
+
+    private void addType( NameData type, Map<String, Integer> relTypes, Map<Integer, RelationshipTypeImpl> relTranslation)
     {
         RelationshipTypeImpl relType = new RelationshipTypeImpl( type.getName(), type.getId() );
         relTypes.put( type.getName(), type.getId() );


### PR DESCRIPTION
On bulk RelType import that happens on startup, instead of using the
 COW map and insert one by one, store all derived data in local Maps
 and addAll() those to the COW in one operation. Equally thread safe
 and much faster.

There are stores that take more than 2 minutes to load because of 50k+ reltypes. That many COW map put operations take a long time because of copy and GC strain. This solves such issues. 
