### PR TITLE
Hang-prone tests got proper process dumping added

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Predicates.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Predicates.java
@@ -221,4 +221,16 @@ public class Predicates
             return Predicates.or( flatten );
         }
     }
+
+    public static Predicate<String> stringContains( final String string )
+    {
+        return new Predicate<String>()
+        {
+            @Override
+            public boolean accept( String item )
+            {
+                return item.contains( string );
+            }
+        };
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -42,6 +41,11 @@ import org.neo4j.test.subprocess.EnabledBreakpoints;
 import org.neo4j.test.subprocess.ForeignBreakpoints;
 import org.neo4j.test.subprocess.SubProcessTestRunner;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import static org.neo4j.helpers.Predicates.or;
+import static org.neo4j.helpers.Predicates.stringContains;
+
 @ForeignBreakpoints( {
                       @ForeignBreakpoints.BreakpointDef( type = "org.neo4j.kernel.impl.core.ArrayBasedPrimitive",
                               method = "setProperties" ),
@@ -55,9 +59,11 @@ public class TestPropertyDataRace
 
     public static final TargetDirectory targetDir = TargetDirectory.forTest( TestPropertyDataRace.class );
 
+    @SuppressWarnings( "unchecked" )
     @Rule
-    public DumpProcessInformationRule dumpingRule = new DumpProcessInformationRule( "", targetDir.directory( "dumps" ),
-            60, TimeUnit.SECONDS );
+    public DumpProcessInformationRule dumpingRule = new DumpProcessInformationRule(
+            or( stringContains( "SubProcess" ), stringContains( "TestRunner" ) ),
+            targetDir.directory( "dumps" ), 1, MINUTES );
 
     @Test
     @EnabledBreakpoints( { "enable breakpoints", "done" } )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentModificationOfRelationshipChains.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentModificationOfRelationshipChains.java
@@ -165,7 +165,7 @@ public class TestConcurrentModificationOfRelationshipChains
         tx.success();
         tx.finish();
 
-        db.getNodeManager().clearCache();
+        db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
         return Triplet.of( node1.getRelationships(), node1.getId(), firstFromSecondBatch );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.qa.tooling;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.junit.Test;
+import org.neo4j.helpers.Pair;
+import org.neo4j.test.TargetDirectory;
+
+import static java.lang.Runtime.getRuntime;
+import static java.lang.System.getProperty;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.Predicates.stringContains;
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+public class DumpProcessInformationTest
+{
+    @Test
+    public void shouldDumpProcessInformation() throws Exception
+    {
+        // GIVEN
+        // a process spawned from this test which pauses at a specific point of execution
+        Process process = getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
+                DumpableProcess.class.getName(), SIGNAL } );
+        awaitSignal( process );
+
+        // WHEN
+        // dumping process information for that spawned process (knowing it's in the expected position)
+        Pair<Long, String> pid = single( DumpProcessInformation.getJPids(
+                stringContains( DumpableProcess.class.getSimpleName() ) ) );
+        File threaddumpFile = DumpProcessInformation.doThreadDump( pid, directory );
+        process.destroy();
+
+        // THEN
+        // the produced thread dump should contain that expected method at least
+        assertTrue( fileContains( threaddumpFile, "traceableMethod", DumpableProcess.class.getName() ) );
+    }
+
+    private boolean fileContains( File file, String... expectedStrings )
+    {
+        Set<String> expectedStringSet = asSet( expectedStrings );
+        for ( String line : asIterable( file, "UTF-8" ) )
+        {
+            Iterator<String> expectedStringIterator = expectedStringSet.iterator();
+            while ( expectedStringIterator.hasNext() )
+            {
+                if ( line.contains( expectedStringIterator.next() ) )
+                {
+                    expectedStringIterator.remove();
+                }
+            }
+        }
+        return expectedStringSet.isEmpty();
+    }
+
+    private static final String SIGNAL = "here";
+
+    private final File directory = TargetDirectory.forTest( getClass() ).directory( "dump" );
+
+    private void awaitSignal( Process process ) throws IOException
+    {
+        BufferedReader reader = new BufferedReader( new InputStreamReader( process.getInputStream() ) );
+        try
+        {
+            String line = reader.readLine();
+            if ( !SIGNAL.equals( line ) )
+            {
+                fail( "Got weird signal " + line );
+            }
+            // We got signal, great
+        }
+        finally
+        {
+            reader.close();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpableProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpableProcess.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.qa.tooling;
+
+import java.rmi.RemoteException;
+import java.rmi.server.UnicastRemoteObject;
+
+import org.junit.Ignore;
+
+@Ignore( "Not a test, just a helper for DumpProcessInformationTest" )
+public class DumpableProcess extends UnicastRemoteObject
+{
+    public DumpableProcess() throws RemoteException
+    {
+        super();
+    }
+
+    public static void main( String[] args ) throws Exception
+    {
+        new DumpableProcess().traceableMethod( args[0] );
+    }
+
+    public synchronized void traceableMethod( String signal ) throws Exception
+    {
+        // The parent process will listen to this signal to know that it's here.
+        System.out.println( signal );
+
+        wait();
+    }
+}


### PR DESCRIPTION
They were using DumpProcessInformationRule, but incorrectly. So this
commit fixes that as well as making DumpProcessInformation/Rule a bit more
flexible in process selection.

Also added a test for DumpProcessInformation.
