### PR TITLE
HTTP logging has proper status codes instead of 200

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
@@ -354,11 +354,6 @@ public class Jetty6WebServer implements WebServer
             }
         } );
 
-        if( requestLoggingConfiguration != null )
-        {
-            loadRequestLogging();
-        }
-
         mountpoints.addAll( staticContent.keySet() );
         mountpoints.addAll( jaxRSPackages.keySet() );
 
@@ -385,6 +380,12 @@ public class Jetty6WebServer implements WebServer
                 throw new RuntimeException( format( "content-key '%s' is not mapped", contentKey ) );
             }
         }
+
+        if( requestLoggingConfiguration != null )
+        {
+            loadRequestLogging();
+        }
+
     }
     
     private void loadRequestLogging() {


### PR DESCRIPTION
This is mostly for testing against the whole build, make sure there are no test failures as before.
