### PR TITLE
Reintroduce correct logging of response status of HTTP requests

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
@@ -22,7 +22,6 @@ package org.neo4j.server.modules;
 import static org.neo4j.server.JAXRSHelper.listFrom;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -83,13 +82,7 @@ public class ManagementApiModule implements ServerModule
 
     private URI managementApiUri( ) throws UnknownHostException
     {
-        try
-        {
-            return new URI( config.getString( Configurator.MANAGEMENT_PATH_PROPERTY_KEY, Configurator.DEFAULT_MANAGEMENT_API_PATH ) );
-        }
-        catch ( URISyntaxException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return URI.create( config.getString( Configurator.MANAGEMENT_PATH_PROPERTY_KEY,
+                Configurator.DEFAULT_MANAGEMENT_API_PATH ) );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
@@ -354,11 +354,6 @@ public class Jetty6WebServer implements WebServer
             }
         } );
 
-        if( requestLoggingConfiguration != null )
-        {
-            loadRequestLogging();
-        }
-
         mountpoints.addAll( staticContent.keySet() );
         mountpoints.addAll( jaxRSPackages.keySet() );
 
@@ -385,6 +380,12 @@ public class Jetty6WebServer implements WebServer
                 throw new RuntimeException( format( "content-key '%s' is not mapped", contentKey ) );
             }
         }
+
+        if( requestLoggingConfiguration != null )
+        {
+            loadRequestLogging();
+        }
+
     }
     
     private void loadRequestLogging() {


### PR DESCRIPTION
Update breaking test so that it passes with this change.
Random change of new URI() to URI.create()
