### PR TITLE
Fixes #795 - Inconsistent behaviour when using ORDER BY and LIMIT while updating the graph

### DIFF
--- a/community/cypher/CHANGES.txt
+++ b/community/cypher/CHANGES.txt
@@ -1,3 +1,8 @@
+1.9
+---
+o Fixes #795 - Inconsistent behaviour when using ORDER BY and LIMIT while
+  updating the graph
+
 1.9.RC2 (2013-04-30)
 --------------------
 o Fixes problem when sending down custom queries to index providers

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
@@ -98,11 +98,12 @@ case class PartiallySolvedQuery(returns: Seq[QueryToken[ReturnColumn]],
     slice.forall(_.solved) &&
     namedPaths.forall(_.solved)
 
+  def sortedDone = sort.filter(_.unsolved).isEmpty
+
   def readyToAggregate = !(start.exists(_.unsolved) ||
     patterns.exists(_.unsolved) ||
     where.exists(_.unsolved) ||
-    namedPaths.exists(_.unsolved) ||
-    updates.exists(_.unsolved))
+    namedPaths.exists(_.unsolved))
 
   def rewrite(f: Expression => Expression): PartiallySolvedQuery = {
     this.copy(

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PlanBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PlanBuilder.scala
@@ -40,12 +40,12 @@ object PlanBuilder extends Enumeration {
   val TraversalMatcher = -11
   val Filter = -10
   val NamedPath = -9
+  val TopX = -2
   val Mutation = -1
   val NodeById = -1
   val RelationshipById = -1
   val IndexQuery = 0
   val Extraction = 0
-  val TopX = -1
   val Slice = 0
   val ColumnFilter = 0
   val GlobalStart = 1

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/SliceBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/SliceBuilder.scala
@@ -32,8 +32,16 @@ class SliceBuilder extends PlanBuilder {
 
   def canWorkWith(plan: ExecutionPlanInProgress) = {
     val q = plan.query
-    q.extracted && !q.sort.exists(_.unsolved) && q.slice.exists(_.unsolved)
+    val sortDone = q.sortedDone
+    val slice = q.slice.exists(_.unsolved)
+    val startPointsDone = !q.start.exists(_.unsolved)
+    val patternsDone = !q.patterns.exists(_.unsolved)
+
+    val noAggregationLeftToDo = !(q.aggregateQuery == Unsolved(true))
+
+    slice && noAggregationLeftToDo && sortDone && startPointsDone && patternsDone
   }
+
 
   def priority: Int = PlanBuilder.Slice
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/UpdateActionBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/UpdateActionBuilder.scala
@@ -64,7 +64,8 @@ class UpdateActionBuilder(db: GraphDatabaseService) extends PlanBuilder with Upd
     val uas = extractValidUpdateActions(plan, plan.pipe).toSeq
     val sitems = extractValidStartItems(plan, plan.pipe).toSeq
 
-    uas.nonEmpty || sitems.nonEmpty
+    val sliceFirst = !plan.query.slice.exists(_.unsolved)
+    (uas.nonEmpty || sitems.nonEmpty) && sliceFirst
   }
 
   def priority = PlanBuilder.Mutation

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -475,12 +475,7 @@ class ExecutionEngineTest extends ExecutionEngineHelper {
   @Test def shouldLimitToTwoHits() {
     createNodes("A", "B", "C", "D", "E")
 
-    val query = Query.
-      start(NodeById("start", nodeIds: _*)).
-      limit(2).
-      returns(ReturnItem(Identifier("start"), "start"))
-
-    val result = execute(query)
+    val result = parseAndExecute("start n=node({nodes}) return n limit 2", "nodes"->nodeIds.toSeq)
 
     assertEquals("Result was not trimmed down", 2, result.size)
   }
@@ -1088,7 +1083,7 @@ return foaf""")
     val b = createNode("B")
     val c = createNode("C")
 
-    val result = parseAndExecute( """
+    val result = parseAndExecute("""
 start a  = node(1,2,3,1)
 return distinct a
 order by a.name""")
@@ -2508,5 +2503,48 @@ RETURN x0.name?
 
     val result = parseAndExecute("start p1=node:stuff('key:*'), p2=node:stuff('key:*') match (p1)--(e), (p2)--(e) where p1.value = 0 and p2.value = 0 AND p1 <> p2 return p1,p2,e")
     assert(result.toList === List())
+  }
+
+  @Test
+  def should_respect_limit_when_updating() {
+    //GIVEN
+    createNode("a")
+    createNode("b")
+    val c = createNode("c")
+
+    //WHEN
+    parseAndExecute("start n=node(*) match n set n.touched = true return n order by n.name? limit 2")
+
+    //THEN c should not have the property set
+    assert(c.getProperty("touched", false) === false, "Should not have had the property set")
+  }
+
+  @Test
+  def should_respect_skip_when_updating() {
+    //GIVEN
+    val a = createNode("a")
+    createNode("b")
+    createNode("c")
+
+    //WHEN
+    parseAndExecute("start n=node(*) match n set n.touched = true return n order by n.name? skip 1")
+
+    //THEN a should not have the property set
+    assert(a.getProperty("touched", false) === false, "Should not have had the property set")
+  }
+
+  @Test
+  def should_respect_skip_and_limit_when_updating() {
+    //GIVEN
+    val a = createNode("a")
+    createNode("b")
+    val c = createNode("c")
+
+    //WHEN
+    parseAndExecute("start n=node(*) match n set n.touched = true return n order by n.name? skip 1 limit 1")
+
+    //THEN a && c should not have the property set
+    assert(a.getProperty("touched", false) === false, "Should not have had the property set")
+    assert(c.getProperty("touched", false) === false, "Should not have had the property set")
   }
 }


### PR DESCRIPTION
- Changes priority of ORDER BY...LIMIT (PlanBuilder.TopX) so it is executed
  before updating the graph
- Changes so TopPipeBuilder waits for aggregation, but not for return
  expressions execution
- UpdateActionBuilder waits on slice to be done before accepting work
- SliceBuilder does not wait for updates to be done
