### PR TITLE
Small step towards LSB spec for linux services

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
@@ -145,6 +145,7 @@ reportstatus() {
 
   if [ -z $NEO4J_PID ] ; then
     echo "$FRIENDLY_NAME is not running"
+	exit 3
   else
     echo "$FRIENDLY_NAME is running at pid $NEO4J_PID"
   fi


### PR DESCRIPTION
Move towards LSB init spec. Allows opscode chef to manage the neo4j
service.
