### PR TITLE
Document keep alive and include new timeout in response headers

### DIFF
--- a/community/server/src/docs/dev/rest-api/transactional.asciidoc
+++ b/community/server/src/docs/dev/rest-api/transactional.asciidoc
@@ -35,6 +35,8 @@ include::begin-a-transaction.asciidoc[]
 
 include::execute-statements-in-an-open-transaction.asciidoc[]
 
+include::reset-transaction-timeout-of-an-open-transaction.asciidoc[]
+
 include::commit-an-open-transaction.asciidoc[]
 
 include::rollback-an-open-transaction.asciidoc[]

--- a/community/server/src/docs/dev/server-configuration.asciidoc
+++ b/community/server/src/docs/dev/server-configuration.asciidoc
@@ -73,6 +73,14 @@ org.neo4j.server.webserver.maxthreads=200
 
 NOTE: The default value is 10 times the number of CPUs reported available by the JVM.
 
+The server guards against orphaned transactions by using a timeout. If there are no requests for a given transaction
+within the timeout period, the server will roll it back. You can configure the timeout period by setting
+the following property to the number of seconds before timeout. The default timeout is 60 seconds.
+[source]
+----
+org.neo4j.server.transaction.timeout=60
+----
+
 Low-level performance tuning parameters can be explicitly set by referring
 to the following property:
 

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/util/RFC1123.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/util/RFC1123.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.repr.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public final class RFC1123
+{
+    private static final ThreadLocal<RFC1123> INSTANCES = new ThreadLocal<RFC1123>();
+
+    public static final TimeZone GMT = TimeZone.getTimeZone( "GMT" );
+
+    private static final Date Y2K_START_DATE;
+
+    static {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone( GMT );
+        calendar.set( 2000, Calendar.JANUARY, 1, 0, 0, 0 );
+        calendar.set( Calendar.MILLISECOND, 0 );
+        Y2K_START_DATE = calendar.getTime();
+    }
+
+    private final SimpleDateFormat format;
+
+    private RFC1123()
+    {
+        format = new SimpleDateFormat( "EEE, dd MMM yyyy HH:mm:ss Z", Locale.US );
+        format.setTimeZone( GMT );
+    }
+
+    public Date parse(String input) throws ParseException
+    {
+        format.set2DigitYearStart( Y2K_START_DATE );
+        return format.parse( input );
+    }
+
+    public String format(Date date)
+    {
+        if ( null == date )
+            throw new IllegalArgumentException( "Date is null" );
+
+        return format.format( date );
+    }
+
+    static final RFC1123 instance()
+    {
+        RFC1123 instance = INSTANCES.get();
+        if ( null == instance )
+        {
+            instance = new RFC1123();
+            INSTANCES.set( instance );
+        }
+        return instance;
+    }
+
+    public static Date parseTimestamp(String input) throws ParseException
+    {
+        return instance().parse( input );
+    }
+
+    public static String formatDate(Date date)
+    {
+        return instance().format( date );
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -23,13 +23,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
+
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.server.rest.repr.util.RFC1123;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
 
 /**
@@ -39,6 +42,7 @@ import org.neo4j.server.rest.transactional.error.Neo4jError;
  * <li>{@link #transactionCommitUri(URI) transactionId}{@code ?}</li>
  * <li>{@link #statementResult(ExecutionResult) statementResult}{@code *}</li>
  * <li>{@link #errors(Iterable) errors}{@code ?}</li>
+ * <li>{@link}#transactionStatus(Date expiryDate){@code ?}</li>
  * <li>{@link #finish() finish}</li>
  * </ul>
  * <p/>
@@ -144,6 +148,22 @@ public class ExecutionResultSerializer
                 out.writeEndArray();
                 currentState = State.ERRORS_WRITTEN;
             }
+        }
+        catch ( IOException e )
+        {
+            loggedIOException( e );
+        }
+    }
+
+    public void transactionStatus( long expiryDate )
+    {
+        try
+        {
+            ensureDocumentOpen();
+            ensureResultsFieldClosed();
+            out.writeObjectFieldStart( "transaction" );
+            out.writeStringField( "expires", RFC1123.formatDate( new Date ( expiryDate ) ) );
+            out.writeEndObject();
         }
         catch ( IOException e )
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -21,6 +21,7 @@ package org.neo4j.server.rest.transactional;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Date;
 
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.kernel.api.KernelAPI;
@@ -71,7 +72,7 @@ public class TransactionFacade
 
     public TransactionHandle findTransactionHandle( long txId ) throws TransactionLifecycleException
     {
-        return registry.acquire( txId );
+       return registry.acquire( txId );
     }
 
     public StatementDeserializer deserializer( InputStream input )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -173,7 +173,8 @@ public class TransactionHandle
         if ( errors.isEmpty() )
         {
             context.suspendSinceTransactionsAreStillThreadBound();
-            registry.release( id, this );
+            long lastActiveTimestamp = registry.release( id, this );
+            output.transactionStatus( lastActiveTimestamp );
         }
         else
         {
@@ -285,5 +286,4 @@ public class TransactionHandle
             errors.add( new Neo4jError( StatusCode.INTERNAL_DATABASE_ERROR, e ) );
         }
     }
-
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionRegistry.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionRegistry.java
@@ -30,7 +30,7 @@ public interface TransactionRegistry
 {
     public long begin();
 
-    public void release( long id, TransactionHandle transactionHandle );
+    public long release( long id, TransactionHandle transactionHandle );
 
     public TransactionHandle acquire( long id ) throws TransactionLifecycleException;
 

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.server.rest.web;
 
-import static java.lang.String.format;
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
-import static org.neo4j.helpers.collection.MapUtil.toMap;
-import static org.neo4j.server.rest.domain.JsonHelper.readJson;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -34,7 +28,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -68,6 +61,13 @@ import org.neo4j.server.rest.repr.OutputFormat;
 import org.neo4j.server.rest.repr.PropertiesRepresentation;
 import org.neo4j.server.rest.repr.Representation;
 import org.neo4j.server.rest.web.DatabaseActions.RelationshipDirection;
+
+import static java.lang.String.format;
+
+import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+import static org.neo4j.helpers.collection.MapUtil.toMap;
+import static org.neo4j.server.rest.domain.JsonHelper.readJson;
 
 @Path( "/" )
 public class RestfulGraphDatabase

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/util/RFC1123Test.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/util/RFC1123Test.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.repr.util;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RFC1123Test
+{
+    private final Calendar calendar = Calendar.getInstance( RFC1123.GMT, Locale.US );
+
+    @Test
+    public void shouldParseRFC1123() throws Exception
+    {
+        // given
+        String input = "Mon, 15 Aug 2005 15:52:01 +0000";
+
+        // when
+        Date result = RFC1123.parseTimestamp( input );
+
+        // then
+        calendar.setTime( result );
+        assertEquals( Calendar.MONDAY, calendar.get( Calendar.DAY_OF_WEEK ) );
+        assertEquals( 15, calendar.get( Calendar.DAY_OF_MONTH ) );
+        assertEquals( Calendar.AUGUST, calendar.get( Calendar.MONTH ) );
+        assertEquals( 2005, calendar.get( Calendar.YEAR ) );
+        assertEquals( 15, calendar.get( Calendar.HOUR_OF_DAY ) );
+        assertEquals( 52, calendar.get( Calendar.MINUTE ) );
+        assertEquals( 1, calendar.get( Calendar.SECOND ) );
+    }
+
+    @Test
+    public void shouldFormatRFC1123() throws Exception
+    {
+        // given
+        String input = "Mon, 15 Aug 2005 15:52:01 +0000";
+
+        // when
+        String output = RFC1123.formatDate( RFC1123.parseTimestamp( input ) );
+
+        // then
+        assertEquals( input, output );
+    }
+
+    @Test
+    public void shouldReturnSameInstanceInSameThread() throws Exception
+    {
+        // given
+        RFC1123 instance = RFC1123.instance();
+
+        // when
+        RFC1123 instance2 = RFC1123.instance();
+
+        // then
+        assertTrue(
+                "Expected to get same instance from second call to RFC1123.instance() in same thread",
+                instance == instance2 );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -19,21 +19,23 @@
  */
 package org.neo4j.server.rest.transactional;
 
-import static javax.xml.bind.DatatypeConverter.parseLong;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.net.URI;
 
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.paging.Clock;
 import org.neo4j.server.rest.transactional.error.InvalidConcurrentTransactionAccess;
 import org.neo4j.server.rest.web.TransactionUriScheme;
 import org.neo4j.test.DoubleLatch;
+
+import static javax.xml.bind.DatatypeConverter.parseLong;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConcurrentTransactionAccessTest
 {
@@ -42,7 +44,7 @@ public class ConcurrentTransactionAccessTest
     {
         // given
         TransactionRegistry registry =
-                new TransactionHandleRegistry( mock( Clock.class), StringLogger.DEV_NULL );
+                new TransactionHandleRegistry( mock( Clock.class), 0, StringLogger.DEV_NULL );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
         when(kernel.newTransactionContext()).thenReturn( mock(TransitionalTxManagementTransactionContext.class) );
         TransactionFacade actions = new TransactionFacade( kernel, null, registry, null );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleRegistryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleRegistryTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
 import static org.neo4j.kernel.impl.util.TestLogger.LogCall.info;
 
 public class TransactionHandleRegistryTest
@@ -41,7 +42,7 @@ public class TransactionHandleRegistryTest
     {
         // given
         TestLogger log = new TestLogger();
-        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), log );
+        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), 0, log );
 
         // when
         long id1 = registry.begin();
@@ -57,7 +58,7 @@ public class TransactionHandleRegistryTest
     {
         // Given
         TestLogger log = new TestLogger();
-        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), log );
+        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), 0, log );
         TransactionHandle handle = mock( TransactionHandle.class );
 
         long id = registry.begin();
@@ -76,7 +77,7 @@ public class TransactionHandleRegistryTest
     {
         // Given
         TestLogger log = new TestLogger();
-        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), log );
+        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), 0, log );
         TransactionHandle handle = mock( TransactionHandle.class );
 
         long id = registry.begin();
@@ -103,7 +104,7 @@ public class TransactionHandleRegistryTest
     {
         // Given
         TestLogger log = new TestLogger();
-        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), log );
+        TransactionHandleRegistry registry = new TransactionHandleRegistry( new FakeClock(), 0, log );
 
         long madeUpTransactionId = 1337;
 
@@ -128,7 +129,7 @@ public class TransactionHandleRegistryTest
         // Given
         FakeClock clock = new FakeClock();
         TestLogger log = new TestLogger();
-        TransactionHandleRegistry registry = new TransactionHandleRegistry( clock, log );
+        TransactionHandleRegistry registry = new TransactionHandleRegistry( clock, 0, log );
         TransactionHandle oldTx = mock( TransactionHandle.class );
         TransactionHandle newTx = mock( TransactionHandle.class );
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -41,6 +41,7 @@ import org.neo4j.server.rest.web.TransactionUriScheme;
 import static java.util.Arrays.asList;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -80,6 +81,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( any( ExecutionResult.class ) );
+        outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -111,6 +113,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( any( ExecutionResult.class ) );
+        outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -149,6 +152,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( any( ExecutionResult.class ) );
+        outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -238,6 +242,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( any( ExecutionResult.class ) );
+        outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );

--- a/community/server/src/test/java/org/neo4j/test/server/HTTP.java
+++ b/community/server/src/test/java/org/neo4j/test/server/HTTP.java
@@ -19,22 +19,23 @@
  */
 package org.neo4j.test.server;
 
-import static java.util.Collections.unmodifiableMap;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.ws.rs.core.MediaType;
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
+
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
+
+import static java.util.Collections.unmodifiableMap;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
 
 /**
  * A tool for performing REST HTTP requests
@@ -237,6 +238,11 @@ public class HTTP
             }
             throw new RuntimeException( "The request did not contain a location header, " +
                     "unable to provide location. Status code was: " + status() );
+        }
+
+        public String firstHeader( String key )
+        {
+            return response.getHeaders().getFirst( key );
         }
 
         public <T> T content()


### PR DESCRIPTION
o Update docs
o Ensure rollbackSuspended is called with a minimum timeout of 500 ms
o Report new timeout after updating it
o Use RFC1123 format similar to established HTTP Expires header
