### PR TITLE
Make sure UNION queries have columns

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
@@ -123,6 +123,8 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService) extends PatternGraphBuil
         case x   => Seq(x)
       }
 
+    case union: Union => getQueryResultColumns(union.queries.head, currentSymbols)
+
     case _ => List.empty
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.scalatest.Assertions
+import org.junit.Test
+
+
+class UnionAcceptanceTest extends ExecutionEngineHelper with Assertions {
+  @Test
+  def should_be_able_to_create_text_output_from_union_queries() {
+
+    // When
+    val result = parseAndExecute("merge (a) return a union merge (a) return a")
+
+    // Then
+    assert(result.columns.nonEmpty, "Union queries must have columns")
+  }
+}


### PR DESCRIPTION
Fixes problem where text output from a UNION query always seemed to be empty.
