### PR TITLE
Test rule for muting System.out/err and j.u.logging in tests

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Buffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Buffer.java
@@ -33,8 +33,6 @@ import java.nio.ByteBuffer;
  */
 public class Buffer
 {
-//    private static Logger logger = Logger.getLogger( Buffer.class.getName() );
-
     private final ByteBuffer buf;
     private final PersistenceWindow persistenceWindow;
 
@@ -250,6 +248,7 @@ public class Buffer
         buf.limit( 0 );
     }
     
+    @Override
     public String toString()
     {
         return "Buffer[[" + buf.position() + "," + buf.capacity() + "]," + 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jConstrains.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jConstrains.java
@@ -23,9 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.junit.Test;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
@@ -38,7 +35,7 @@ import org.neo4j.tooling.GlobalGraphOperations;
 
 public class TestNeo4jConstrains extends AbstractNeo4jTestCase
 {
-    private String key = "testproperty";
+    private final String key = "testproperty";
 
     @Test
     public void testDeleteReferenceNodeOrLastNodeIsOk()
@@ -350,85 +347,75 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
     @Test
     public void testIllegalPropertyType()
     {
-        Logger log = Logger.getLogger( NodeManager.class.getName() );
-        Level level = log.getLevel();
-        log.setLevel( Level.OFF );
+        Node node1 = getGraphDb().createNode();
         try
         {
-            Node node1 = getGraphDb().createNode();
-            try
-            {
-                node1.setProperty( key, new Object() );
-                fail( "Shouldn't validate" );
-            }
-            catch ( Exception e )
-            { // good
-            }
-            try
-            {
-                Transaction tx = getTransaction();
-                tx.success();
-                tx.finish();
-                fail( "Shouldn't validate" );
-            }
-            catch ( Exception e )
-            {
-            } // good
-            setTransaction( getGraphDb().beginTx() );
-            try
-            {
-                getGraphDb().getNodeById( node1.getId() );
-                fail( "Node should not exist, previous tx didn't rollback" );
-            }
-            catch ( NotFoundException e )
-            {
-                // good
-            }
-            node1 = getGraphDb().createNode();
-            Node node2 = getGraphDb().createNode();
-            Relationship rel = node1.createRelationshipTo( node2,
-                    MyRelTypes.TEST );
-            try
-            {
-                rel.setProperty( key, new Object() );
-                fail( "Shouldn't validate" );
-            }
-            catch ( Exception e )
-            { // good
-            }
-            try
-            {
-                Transaction tx = getTransaction();
-                tx.success();
-                tx.finish();
-                fail( "Shouldn't validate" );
-            }
-            catch ( Exception e )
-            {
-            } // good
-            setTransaction( getGraphDb().beginTx() );
-            try
-            {
-                getGraphDb().getNodeById( node1.getId() );
-                fail( "Node should not exist, previous tx didn't rollback" );
-            }
-            catch ( NotFoundException e )
-            {
-                // good
-            }
-            try
-            {
-                getGraphDb().getNodeById( node2.getId() );
-                fail( "Node should not exist, previous tx didn't rollback" );
-            }
-            catch ( NotFoundException e )
-            {
-                // good
-            }
+            node1.setProperty( key, new Object() );
+            fail( "Shouldn't validate" );
         }
-        finally
+        catch ( Exception e )
+        { // good
+        }
+        try
         {
-            log.setLevel( level );
+            Transaction tx = getTransaction();
+            tx.success();
+            tx.finish();
+            fail( "Shouldn't validate" );
+        }
+        catch ( Exception e )
+        {
+        } // good
+        setTransaction( getGraphDb().beginTx() );
+        try
+        {
+            getGraphDb().getNodeById( node1.getId() );
+            fail( "Node should not exist, previous tx didn't rollback" );
+        }
+        catch ( NotFoundException e )
+        {
+            // good
+        }
+        node1 = getGraphDb().createNode();
+        Node node2 = getGraphDb().createNode();
+        Relationship rel = node1.createRelationshipTo( node2,
+                MyRelTypes.TEST );
+        try
+        {
+            rel.setProperty( key, new Object() );
+            fail( "Shouldn't validate" );
+        }
+        catch ( Exception e )
+        { // good
+        }
+        try
+        {
+            Transaction tx = getTransaction();
+            tx.success();
+            tx.finish();
+            fail( "Shouldn't validate" );
+        }
+        catch ( Exception e )
+        {
+        } // good
+        setTransaction( getGraphDb().beginTx() );
+        try
+        {
+            getGraphDb().getNodeById( node1.getId() );
+            fail( "Node should not exist, previous tx didn't rollback" );
+        }
+        catch ( NotFoundException e )
+        {
+            // good
+        }
+        try
+        {
+            getGraphDb().getNodeById( node2.getId() );
+            fail( "Node should not exist, previous tx didn't rollback" );
+        }
+        catch ( NotFoundException e )
+        {
+            // good
         }
     }
     

--- a/community/kernel/src/test/java/org/neo4j/test/Mute.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Mute.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Mutes outputs such as System.out, System.err and java.util.logging for example when running a test.
+ * It's also a {@link TestRule} which makes it fit in nicely in JUnit.
+ * 
+ * The muting occurs visitor-style and if there's an exception in the code executed when being muted
+ * all the logging that was temporarily muted will be resent to the peers as if they weren't muted to begin with.
+ */
+public final class Mute implements TestRule
+{
+    public static Mute mute( Mutable... mutables )
+    {
+        return new Mute( mutables );
+    }
+    
+    public static Mute muteAll()
+    {
+        return mute( System.out, System.err, java_util_logging );
+    }
+
+    public enum System implements Mutable
+    {
+        out
+        {
+            @Override
+            PrintStream replace( PrintStream replacement )
+            {
+                PrintStream old = java.lang.System.out;
+                java.lang.System.setOut( replacement );
+                return old;
+            }
+        },
+        err
+        {
+            @Override
+            PrintStream replace( PrintStream replacement )
+            {
+                PrintStream old = java.lang.System.err;
+                java.lang.System.setErr( replacement );
+                return old;
+            }
+        };
+
+        @Override
+        public Voice mute()
+        {
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            final PrintStream old = replace( new PrintStream( buffer ) );
+            return new Voice()
+            {
+                @Override
+                void restore( boolean failure ) throws IOException
+                {
+                    replace( old ).flush();
+                    if ( failure )
+                    {
+                        old.write( buffer.toByteArray() );
+                    }
+                }
+            };
+        }
+
+        abstract PrintStream replace( PrintStream replacement );
+    }
+
+    public static final Mutable java_util_logging = java_util_logging( null, null );
+
+    public static Mutable java_util_logging( OutputStream redirectTo, Level level )
+    {
+        final Handler replacement = redirectTo == null ? null : new StreamHandler( redirectTo, new SimpleFormatter() );
+        if ( replacement != null && level != null )
+        {
+            replacement.setLevel( level );
+        }
+        return new Mutable()
+        {
+            @Override
+            public Voice mute()
+            {
+                final Logger logger = LogManager.getLogManager().getLogger( "" );
+                final Level level = logger.getLevel();
+                final Handler[] handlers = logger.getHandlers();
+                for ( Handler handler : handlers )
+                {
+                    logger.removeHandler( handler );
+                }
+                if ( replacement != null )
+                {
+                    logger.addHandler( replacement );
+                    logger.setLevel( Level.ALL );
+                }
+                return new Voice()
+                {
+                    @Override
+                    void restore( boolean failure ) throws IOException
+                    {
+                        for ( Handler handler : handlers )
+                        {
+                            logger.addHandler( handler );
+                        }
+                        logger.setLevel( level );
+                        if ( replacement != null )
+                        {
+                            logger.removeHandler( replacement );
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    public <T> T call( Callable<T> callable ) throws Exception
+    {
+        Voice[] voices = captureVoices();
+        boolean failure = true;
+        try
+        {
+            T result = callable.call();
+            failure = false;
+            return result;
+        }
+        finally
+        {
+            releaseVoices( voices, failure );
+        }
+    }
+
+    private final Mutable[] mutables;
+
+    private Mute( Mutable[] mutables )
+    {
+        this.mutables = mutables;
+    }
+
+    @Override
+    public Statement apply( final Statement base, Description description )
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                Voice[] voices = captureVoices();
+                boolean failure = true;
+                try
+                {
+                    base.evaluate();
+                    failure = false;
+                }
+                finally
+                {
+                    releaseVoices( voices, failure );
+                }
+            }
+        };
+    }
+
+    public interface Mutable
+    {
+        Voice mute();
+    }
+
+    private static abstract class Voice
+    {
+        abstract void restore( boolean failure ) throws IOException;
+    }
+
+    Voice[] captureVoices()
+    {
+        Voice[] voices = new Voice[mutables.length];
+        boolean ok = false;
+        try
+        {
+            for ( int i = 0; i < voices.length; i++ )
+            {
+                voices[i] = mutables[i].mute();
+            }
+            ok = true;
+        }
+        finally
+        {
+            if ( !ok )
+            {
+                releaseVoices( voices, false );
+            }
+        }
+        return voices;
+    }
+
+    void releaseVoices( Voice[] voices, boolean failure )
+    {
+        List<Throwable> failures = null;
+        try
+        {
+            failures = new ArrayList<Throwable>( voices.length );
+        }
+        catch ( Throwable oom )
+        {
+            // nothing we can do...
+        }
+        for ( Voice voice : voices )
+        {
+            if ( voice != null )
+            {
+                try
+                {
+                    voice.restore( failure );
+                }
+                catch ( Throwable exception )
+                {
+                    if ( failures != null )
+                    {
+                        failures.add( exception );
+                    }
+                }
+            }
+        }
+        if ( failures != null && !failures.isEmpty() )
+        {
+            for ( Throwable exception : failures )
+            {
+                exception.printStackTrace();
+            }
+        }
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/InterruptThreadTimer.java
+++ b/community/server/src/main/java/org/neo4j/server/InterruptThreadTimer.java
@@ -22,13 +22,11 @@ package org.neo4j.server;
 import java.util.Timer;
 import java.util.TimerTask;
 
-
 /**
  * Interrupts a thread after a given timeout, can be cancelled if needed.
  */
 public abstract class InterruptThreadTimer 
 {
-
     public enum State
     {
         COUNTING,
@@ -37,7 +35,7 @@ public abstract class InterruptThreadTimer
 
     public static class InterruptThreadTask extends TimerTask
 	{
-		private Thread threadToInterrupt;
+		private final Thread threadToInterrupt;
 		private boolean wasExecuted = false;
 
 		public InterruptThreadTask(Thread threadToInterrupt)
@@ -46,10 +44,8 @@ public abstract class InterruptThreadTimer
 		}
 		
 		@Override
-		public void run() {
-            // TODO: Remove. Added because I don't have windows, and need a stack trace from here to fix broken test
-            // Should be removed in 2 hrs or so. /jake
-            new Throwable().printStackTrace(  );
+		public void run()
+		{
 			wasExecuted = true;
 			threadToInterrupt.interrupt();
 		}
@@ -72,9 +68,9 @@ public abstract class InterruptThreadTimer
 	
 	private static class ActualInterruptThreadTimer extends InterruptThreadTimer
 	{
-		private Timer timer = new Timer();
+		private final Timer timer = new Timer();
 		private final InterruptThreadTask task;
-		private long timeout;
+		private final long timeout;
         private State state = State.IDLE;
 		
 		public ActualInterruptThreadTimer(long timeoutMillis, Thread threadToInterrupt)
@@ -100,20 +96,20 @@ public abstract class InterruptThreadTimer
         @Override
         public State getState()
         {
-            switch(state)
+            switch ( state )
             {
-                case IDLE:
-                    return State.IDLE;
-                case COUNTING:
-                default:
-                    // We don't know if the timeout has triggered at this point,
-                    // so we need to check that
-                    if(wasTriggered())
-                    {
-                        state = State.IDLE;
-                    }
+            case IDLE:
+                return State.IDLE;
+            case COUNTING:
+            default:
+                // We don't know if the timeout has triggered at this point,
+                // so we need to check that
+                if ( wasTriggered() )
+                {
+                    state = State.IDLE;
+                }
 
-                    return state;
+                return state;
             }
         }
 		
@@ -169,9 +165,12 @@ public abstract class InterruptThreadTimer
 	}
 	
 	public abstract void startCountdown();
-	public abstract void stopCountdown();
-	public abstract boolean wasTriggered();
-    public abstract State getState();
-	public abstract long getTimeoutMillis();
 	
+	public abstract void stopCountdown();
+	
+	public abstract boolean wasTriggered();
+	
+    public abstract State getState();
+    
+	public abstract long getTimeoutMillis();
 }

--- a/community/server/src/test/java/org/neo4j/server/ServerConfigDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerConfigDocIT.java
@@ -21,11 +21,11 @@ package org.neo4j.server;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.neo4j.server.helpers.ServerBuilder.server;
 
 import java.io.IOException;
-import java.lang.String;
 
 import javax.ws.rs.core.MediaType;
 
@@ -39,7 +39,6 @@ import org.neo4j.test.server.ExclusiveServerTestBase;
 
 public class ServerConfigDocIT extends ExclusiveServerTestBase
 {
-
     private CommunityNeoServer server;
 
     @After

--- a/community/server/src/test/java/org/neo4j/server/configuration/PropertyFileConfiguratorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/PropertyFileConfiguratorTest.java
@@ -26,14 +26,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.server.logging.InMemoryAppender;
+import org.neo4j.test.Mute;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.test.Mute.muteAll;
 
 public class PropertyFileConfiguratorTest
 {
+    @Rule
+    public Mute mute = muteAll();
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(  );
 

--- a/community/server/src/test/java/org/neo4j/server/database/TestCommunityDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestCommunityDatabase.java
@@ -28,8 +28,8 @@ import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.server.ServerTestUtils;
@@ -38,6 +38,7 @@ import org.neo4j.server.logging.InMemoryAppender;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.ShellLobby;
 import org.neo4j.shell.ShellSettings;
+import org.neo4j.test.Mute;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -46,9 +47,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.ServerTestUtils.createTempDir;
+import static org.neo4j.test.Mute.muteAll;
 
 public class TestCommunityDatabase
 {
+    @Rule
+    public Mute mute = muteAll();
     private File databaseDirectory;
     private Database theDatabase;
     private boolean deletionFailureOk;

--- a/community/server/src/test/java/org/neo4j/server/modules/DiscoveryModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/DiscoveryModuleTest.java
@@ -19,6 +19,16 @@
  */
 package org.neo4j.server.modules;
 
+import java.net.URI;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.web.WebServer;
+import org.neo4j.test.Mute;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Matchers.anyString;
@@ -26,16 +36,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
-import java.util.List;
-
-import org.junit.Test;
-import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.server.CommunityNeoServer;
-import org.neo4j.server.web.WebServer;
-
 public class DiscoveryModuleTest
 {
+    @Rule
+    public Mute mute = Mute.mute( Mute.System.err );
+    
     @SuppressWarnings( "unchecked" )
     @Test
     public void shouldRegisterAtRootByDefault() throws Exception

--- a/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
+++ b/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.server.preflight;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.server.logging.InMemoryAppender;
+import org.neo4j.test.Mute;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-import org.neo4j.server.logging.InMemoryAppender;
-import org.neo4j.server.preflight.PreFlightTasks;
-import org.neo4j.server.preflight.PreflightTask;
+import static org.neo4j.test.Mute.muteAll;
 
 public class TestPreflightTasks
 {
-
     @Test
     public void shouldPassWithNoRules()
     {
@@ -139,4 +139,7 @@ public class TestPreflightTasks
 
         return rules;
     }
+    
+    @Rule
+    public Mute mute = muteAll();
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.server.rest;
 
-import static java.lang.String.format;
-import static java.net.URLEncoder.encode;
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
-
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,6 +39,12 @@ import org.neo4j.test.GraphHolder;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.SharedServerTestBase;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
+
+import static java.lang.String.format;
+import static java.net.URLEncoder.encode;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
 
 public class AbstractRestFunctionalTestBase extends SharedServerTestBase implements GraphHolder
 {
@@ -68,7 +69,6 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         cleanDatabase();
         gen().setGraph( graphdb() );
     }
-
 
     protected String doCypherRestCall( String endpoint, String scriptTemplate, Status status, Pair<String, String>... params ) {
         data.get();
@@ -130,6 +130,7 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
     {
         return server().getDatabase().getGraph();
     }
+    
     protected String getDataUri()
     {
         return "http://localhost:7474/db/data/";

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.server.rest.paging;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import javax.ws.rs.core.MediaType;
 
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.test.Mute.muteAll;
 
 public class PagedTraverserDocIT extends ExclusiveServerTestBase
 {
@@ -79,7 +80,7 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
     }
     
     @BeforeClass
-    public static void setupServer() throws IOException
+    public static void setupServer() throws Exception
     {
         clock = new FakeClock();
         server = ServerBuilder.server()
@@ -87,7 +88,15 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
                 .withClock( clock )
                 .build();
 
-        server.start();
+        muteAll().call( new Callable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                server.start();
+                return null;
+            }
+        } );
         functionalTestHelper = new FunctionalTestHelper( server );
     }
 
@@ -98,9 +107,17 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
     }
 
     @AfterClass
-    public static void stopServer()
+    public static void stopServer() throws Exception
     {
-        server.stop();
+        muteAll().call( new Callable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                server.stop();
+                return null;
+            }
+        } );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rrd/RrdFactoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/RrdFactoryTest.java
@@ -36,6 +36,7 @@ import org.neo4j.server.database.Database;
 import org.neo4j.server.database.RrdDbWrapper;
 import org.neo4j.server.database.WrappingDatabase;
 import org.neo4j.test.ImpermanentGraphDatabase;
+import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
 import org.rrd4j.ConsolFun;
 import org.rrd4j.DsType;
@@ -47,6 +48,7 @@ import static java.lang.Double.NaN;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.neo4j.test.Mute.muteAll;
 
 public class RrdFactoryTest
 {
@@ -57,6 +59,8 @@ public class RrdFactoryTest
 
     @Rule
     public TargetDirectory.TestDirectory testDirectory = target.cleanTestDirectory();
+    @Rule
+    public Mute mute = muteAll();
 
     @Before
     public void setUp() throws IOException

--- a/community/server/src/test/java/org/neo4j/server/web/JettyThreadLimitTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/JettyThreadLimitTest.java
@@ -19,17 +19,22 @@
  */
 package org.neo4j.server.web;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.mortbay.thread.QueuedThreadPool;
+import org.neo4j.test.Mute;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.test.Mute.muteAll;
 
 public class JettyThreadLimitTest
 {
+    @Rule
+    public Mute mute = muteAll();
 
     @Test
     public void shouldHaveSensibleDefaultJettyThreadPoolSize() throws Exception

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
@@ -20,13 +20,14 @@
 package org.neo4j.server.web;
 
 import java.util.Arrays;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.kernel.AbstractGraphDatabase;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -37,10 +38,12 @@ import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerConfigurator;
 import org.neo4j.server.logging.InMemoryAppender;
 import org.neo4j.test.ImpermanentGraphDatabase;
+import org.neo4j.test.Mute;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.test.Mute.muteAll;
 
 @Path("/")
 public class TestJetty6WebServer
@@ -110,4 +113,7 @@ public class TestJetty6WebServer
         assertThat( appender.toString(), containsString( "Server started on" ) );
         testBootstrapper.stop();
     }
+    
+    @Rule
+    public Mute mute = muteAll();
 }

--- a/community/server/src/test/java/org/neo4j/test/server/ExclusiveServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/ExclusiveServerTestBase.java
@@ -19,18 +19,33 @@
  */
 package org.neo4j.test.server;
 
+import java.util.concurrent.Callable;
+
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.neo4j.test.Mute;
+
+import static org.neo4j.test.Mute.muteAll;
 
 public class ExclusiveServerTestBase
 {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+    @Rule
+    public Mute mute = muteAll();
 
     @BeforeClass
-    public static final void ensureServerNotRunning()
+    public static final void ensureServerNotRunning() throws Exception
     {
-        ServerHolder.ensureNotRunning();
+        muteAll().call( new Callable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                ServerHolder.ensureNotRunning();
+                return null;
+            }
+        } );
     }
 }


### PR DESCRIPTION
(until failure happens, where stuff that the test printed actually gets printed)

Very useful in e.g. server tests which are very chatty to console. Many
tests are now muted with this rule.

There are still 10 lines or so being printed, but it might break my back
to hunt for them. Given the time spent it's a pretty good coverage of mutage.
