### PR TITLE
Adhere to naming conventions in StatementContext.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundPlanContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundPlanContext.scala
@@ -25,17 +25,16 @@ import org.neo4j.kernel.api.{KernelException, StatementContext}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.api.index.InternalIndexState
 import org.neo4j.kernel.impl.api.index.IndexDescriptor
-import org.neo4j.graphdb.schema.{UniquenessConstraintDefinition, ConstraintDefinition}
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 
 class TransactionBoundPlanContext(ctx: StatementContext, gdb:GraphDatabaseService) extends PlanContext {
 
   def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] = try {
-    val labelId = ctx.getLabelId(labelName)
-    val propertyKeyId = ctx.getPropertyKeyId(propertyKey)
+    val labelId = ctx.labelGetForName(labelName)
+    val propertyKeyId = ctx.propertyKeyGetForName(propertyKey)
 
-    val rule = ctx.getIndex(labelId, propertyKeyId)
-    ctx.getIndexState(rule) match {
+    val rule = ctx.indexesGetForLabelAndPropertyKey(labelId, propertyKeyId)
+    ctx.indexGetState(rule) match {
       case InternalIndexState.ONLINE => Some(rule)
       case _                         => None
     }
@@ -44,10 +43,10 @@ class TransactionBoundPlanContext(ctx: StatementContext, gdb:GraphDatabaseServic
   }
 
   def getUniquenessConstraint(labelName: String, propertyKey: String): Option[UniquenessConstraint] = try {
-    val labelId = ctx.getLabelId(labelName)
-    val propertyKeyId = ctx.getPropertyKeyId(propertyKey)
+    val labelId = ctx.labelGetForName(labelName)
+    val propertyKeyId = ctx.propertyKeyGetForName(propertyKey)
 
-    val matchingConstraints = ctx.getConstraints(labelId, propertyKeyId)
+    val matchingConstraints = ctx.constraintsGetForLabelAndPropertyKey(labelId, propertyKeyId)
     if ( matchingConstraints.hasNext ) Some(matchingConstraints.next()) else None
   } catch {
     case _: KernelException => None
@@ -69,5 +68,5 @@ class TransactionBoundPlanContext(ctx: StatementContext, gdb:GraphDatabaseServic
     case _: KernelException => None
   }
 
-  def getLabelId(labelName: String): Option[Long] = tryGet(ctx.getLabelId(labelName))
+  def getLabelId(labelName: String): Option[Long] = tryGet(ctx.labelGetForName(labelName))
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContext.scala
@@ -34,7 +34,7 @@ import org.neo4j.helpers.collection.IteratorUtil
 class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx: StatementContext) extends QueryContext {
 
   def setLabelsOnNode(node: Long, labelIds: Iterable[Long]): Int = labelIds.foldLeft(0) {
-    case (count, labelId) => if (ctx.addLabelToNode(labelId, node)) count + 1 else count
+    case (count, labelId) => if (ctx.nodeAddLabel(node, labelId)) count + 1 else count
   }
 
   def close(success: Boolean) {
@@ -54,20 +54,20 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
     start.createRelationshipTo(end, withName(relType))
 
   def getLabelName(id: Long) =
-    ctx.getLabelName(id)
+    ctx.labelGetName(id)
 
   def getLabelsForNode(node: Long) =
-    ctx.getLabelsForNode(node).asScala.map(_.asInstanceOf[Long])
+    ctx.nodeGetLabels(node).asScala.map(_.asInstanceOf[Long])
 
   override def isLabelSetOnNode(label: Long, node: Long) =
-    ctx.isLabelSetOnNode(label, node)
+    ctx.nodeHasLabel(node, label)
 
   def getOrCreateLabelId(labelName: String) =
-    ctx.getOrCreateLabelId(labelName)
+    ctx.labelGetOrCreateForName(labelName)
 
 
   def getLabelId(labelName: String): Option[Long] = try {
-    Some(ctx.getLabelId(labelName))
+    Some(ctx.labelGetForName(labelName))
   } catch {
     case _: LabelNotFoundKernelException => None
   }
@@ -81,17 +81,17 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
   def getTransaction = tx
 
   def exactIndexSearch(index: IndexDescriptor, value: Any) =
-    ctx.exactIndexLookup(index, value).asScala.map((id: java.lang.Long) => nodeOps.getById(id))
+    ctx.nodesGetFromIndexLookup(index, value).asScala.map((id: java.lang.Long) => nodeOps.getById(id))
 
   val nodeOps = new NodeOperations
 
   val relationshipOps = new RelationshipOperations
 
   def removeLabelsFromNode(node: Long, labelIds: Iterable[Long]): Int = labelIds.foldLeft(0) {
-    case (count, labelId) => if (ctx.removeLabelFromNode(labelId, node)) count + 1 else count
+    case (count, labelId) => if (ctx.nodeRemoveLabel(node, labelId)) count + 1 else count
   }
 
-  def getNodesByLabel(id: Long): Iterator[Node] = ctx.getNodesWithLabel(id).asScala.map(nodeOps.getById(_))
+  def getNodesByLabel(id: Long): Iterator[Node] = ctx.nodesGetForLabel(id).asScala.map(nodeOps.getById(_))
 
   class NodeOperations extends BaseOperations[Node] {
     def delete(obj: Node) {
@@ -132,33 +132,33 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
   }
 
   def getOrCreatePropertyKeyId(propertyKey: String) =
-    ctx.getOrCreatePropertyKeyId(propertyKey)
+    ctx.propertyKeyGetOrCreateForName(propertyKey)
 
   def getPropertyKeyId(propertyKey: String) =
-    ctx.getPropertyKeyId(propertyKey)
+    ctx.propertyKeyGetForName(propertyKey)
 
   def addIndexRule(labelIds: Long, propertyKeyId: Long) {
     try {
-      ctx.addIndex(labelIds, propertyKeyId)
+      ctx.indexCreate(labelIds, propertyKeyId)
     } catch {
       case e: DataIntegrityKernelException =>
         val labelName = getLabelName(labelIds)
-        val propName = ctx.getPropertyKeyName(propertyKeyId)
+        val propName = ctx.propertyKeyGetName(propertyKeyId)
         throw new IndexAlreadyDefinedException(labelName, propName, e)
     }
   }
 
   def dropIndexRule(labelId: Long, propertyKeyId: Long) {
     try {
-      ctx.dropIndex(ctx.getIndex(labelId, propertyKeyId))
+      ctx.indexDrop(ctx.indexesGetForLabelAndPropertyKey(labelId, propertyKeyId))
     } catch {
       case e: DataIntegrityKernelException =>
         val labelName = getLabelName(labelId)
-        val propName = ctx.getPropertyKeyName(propertyKeyId)
+        val propName = ctx.propertyKeyGetName(propertyKeyId)
         throw new CouldNotDropIndexException(labelName, propName, e)
       case e: SchemaRuleNotFoundException        =>
         val labelName = getLabelName(labelId)
-        val propName = ctx.getPropertyKeyName(propertyKeyId)
+        val propName = ctx.propertyKeyGetName(propertyKeyId)
         throw new CouldNotDropIndexException(labelName, propName, e)
     }
   }
@@ -195,17 +195,17 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
     val javaCreator = new org.neo4j.helpers.Function[K, V]() {
       def apply(key: K) = creator
     }
-    ctx.getOrCreateFromSchemaState(key, javaCreator)
+    ctx.schemaStateGetOrCreate(key, javaCreator)
   }
 
   def schemaStateContains(key: String) = ctx.schemaStateContains(key)
 
   def createUniqueConstraint(labelId: Long, propertyKeyId: Long) {
-    ctx.addUniquenessConstraint(labelId, propertyKeyId)
+    ctx.uniquenessConstraintCreate(labelId, propertyKeyId)
   }
 
   def dropUniqueConstraint(labelId: Long, propertyKeyId: Long) {
-    val constraint = IteratorUtil.single(ctx.getConstraints(labelId, propertyKeyId))
-    ctx.dropConstraint(constraint)
+    val constraint = IteratorUtil.single(ctx.constraintsGetForLabelAndPropertyKey(labelId, propertyKeyId))
+    ctx.constraintDrop(constraint)
   }
 }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintAcceptanceTest.scala
@@ -40,10 +40,10 @@ class UniqueConstraintAcceptanceTest
     //THEN
     val statementCtx = graph.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId("propertyKey")
-    val label = statementCtx.getLabelId("Label")
+    val prop = statementCtx.propertyKeyGetForName("propertyKey")
+    val label = statementCtx.labelGetForName("Label")
 
-    val constraints = statementCtx.getConstraints(label, prop).asScala
+    val constraints = statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
 
     assert(constraints.size === 1)
   }
@@ -59,10 +59,10 @@ class UniqueConstraintAcceptanceTest
     // THEN
     val statementCtx = graph.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId("name")
-    val label = statementCtx.getLabelId("Person")
+    val prop = statementCtx.propertyKeyGetForName("name")
+    val label = statementCtx.labelGetForName("Person")
 
-    val constraints = statementCtx.getConstraints(label, prop).asScala
+    val constraints = statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
 
     assertTrue("Constraint should exist", constraints.size == 1)
   }
@@ -80,10 +80,10 @@ class UniqueConstraintAcceptanceTest
     // THEN
     val statementCtx = graph.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId("name")
-    val label = statementCtx.getLabelId("Person")
+    val prop = statementCtx.propertyKeyGetForName("name")
+    val label = statementCtx.labelGetForName("Person")
 
-    val constraints = statementCtx.getConstraints(label, prop).asScala
+    val constraints = statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
 
     assertTrue("Constraint should exist", constraints.size == 1)
   }
@@ -99,10 +99,10 @@ class UniqueConstraintAcceptanceTest
     //THEN
     val statementCtx = graph.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId("propertyKey")
-    val label = statementCtx.getLabelId("Label")
+    val prop = statementCtx.propertyKeyGetForName("propertyKey")
+    val label = statementCtx.labelGetForName("Label")
 
-    val constraints = statementCtx.getConstraints(label, prop).asScala
+    val constraints = statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
 
     assertTrue("No constraints should exist", constraints.isEmpty)
   }
@@ -126,10 +126,10 @@ class UniqueConstraintAcceptanceTest
 
     val statementCtx = graph.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId("id")
-    val label = statementCtx.getLabelId("Person")
+    val prop = statementCtx.propertyKeyGetForName("id")
+    val label = statementCtx.labelGetForName("Person")
 
-    val constraints = statementCtx.getConstraints(label, prop).asScala
+    val constraints = statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
 
     assertTrue("No constraints should exist", constraints.isEmpty)
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -62,9 +62,9 @@ class ConstraintsTest extends DocumentingTestBase {
   private def getConstraintIterator(labelName: String, propName: String): Iterator[UniquenessConstraint] = {
     val statementCtx = db.statementContextForReading
 
-    val prop = statementCtx.getPropertyKeyId(propName)
-    val label = statementCtx.getLabelId(labelName)
+    val prop = statementCtx.propertyKeyGetForName(propName)
+    val label = statementCtx.labelGetForName(labelName)
 
-    statementCtx.getConstraints(label, prop).asScala
+    statementCtx.constraintsGetForLabelAndPropertyKey(label, prop).asScala
   }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -747,13 +747,6 @@ public abstract class InternalAbstractGraphDatabase
         return new RelationshipProxy.RelationshipLookups()
         {
             @Override
-            public Node lookupNode( long nodeId )
-            {
-                // TODO: add CAS check here for requests not in tx to guard against shutdown
-                return nodeManager.getNodeById( nodeId );
-            }
-
-            @Override
             public RelationshipImpl lookupRelationship( long relationshipId )
             {
                 // TODO: add CAS check here for requests not in tx to guard against shutdown
@@ -1487,8 +1480,8 @@ public abstract class InternalAbstractGraphDatabase
         long labelId;
         try
         {
-            propertyId = ctx.getPropertyKeyId( key );
-            labelId = ctx.getLabelId( myLabel.name() );
+            propertyId = ctx.propertyKeyGetForName( key );
+            labelId = ctx.labelGetForName( myLabel.name() );
         }
         catch ( KernelException e )
         {
@@ -1498,11 +1491,11 @@ public abstract class InternalAbstractGraphDatabase
 
         try
         {
-            IndexDescriptor indexRule = ctx.getIndex( labelId, propertyId );
-            if(ctx.getIndexState( indexRule ) == InternalIndexState.ONLINE)
+            IndexDescriptor indexRule = ctx.indexesGetForLabelAndPropertyKey( labelId, propertyId );
+            if(ctx.indexGetState( indexRule ) == InternalIndexState.ONLINE)
             {
                 // Ha! We found an index - let's use it to find matching nodes
-                return map2nodes( ctx.exactIndexLookup( indexRule, value ), ctx );
+                return map2nodes( ctx.nodesGetFromIndexLookup( indexRule, value ), ctx );
             }
         }
         catch ( SchemaRuleNotFoundException e )
@@ -1519,7 +1512,7 @@ public abstract class InternalAbstractGraphDatabase
 
     private ResourceIterator<Node> getNodesByLabelAndPropertyWithoutIndex( final long propertyId, final Object value, final StatementContext ctx, long labelId )
     {
-        Iterator<Long> nodesWithLabel = ctx.getNodesWithLabel( labelId );
+        Iterator<Long> nodesWithLabel = ctx.nodesGetForLabel( labelId );
 
         Iterator<Long> matches = filter( new Predicate<Long>()
         {
@@ -1528,7 +1521,7 @@ public abstract class InternalAbstractGraphDatabase
             {
                 try
                 {
-                    return ctx.getNodePropertyValue( item, propertyId ).equals( value );
+                    return ctx.nodeGetPropertyValue( item, propertyId ).equals( value );
                 }
                 catch ( KernelException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/StatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/StatementContext.java
@@ -35,10 +35,19 @@ import org.neo4j.kernel.api.operations.WriteOperations;
  *
  * Note that this interface only combines a set of interfaces that define operations that the
  * database can perform.
- * 
+ *
  * One main difference between a {@link TransactionContext} and a {@link StatementContext}
  * is life cycle of some locks, where read locks can live within one statement,
  * whereas write locks will live for the entire transaction.
+ *
+ * === Method Names ===
+ *
+ * The most prominent entity the method deals with is the first word of the method name.
+ * If dealt with in general, the word is pluralized.
+ * We prefer physical entities to meta-entities (e.g. node is preferred to index and label).
+ * {@link #nodesGetFromIndexLookup(org.neo4j.kernel.impl.api.index.IndexDescriptor, Object)} is a good example for both
+ * of the last two rules, nodes are the physical entities we are interested in, therefore that word is first, the
+ * index is just a means of getting to the nodes.
  */
 public interface StatementContext
         extends ReadOperations, WriteOperations,
@@ -49,7 +58,7 @@ public interface StatementContext
      * Closes this statement. Statements must be closed when done and before
      * their parent transaction finishes.
      * As an example statement-bound locks can be released when closing
-     * a statement. 
+     * a statement.
      */
     void close();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityReadOperations.java
@@ -35,32 +35,31 @@ public interface EntityReadOperations
      * @param labelId the label id of the label that returned nodes are guaranteed to have
      * @return ids of all nodes that have the given label
      */
-    Iterator<Long> getNodesWithLabel( long labelId );
+    Iterator<Long> nodesGetForLabel( long labelId );
 
     /**
      * Returns an iterable with the matched nodes.
      *
-     * @throws org.neo4j.kernel.api.index.IndexNotFoundKernelException
-     *          if no such index found.
+     * @throws IndexNotFoundKernelException if no such index found.
      */
-    Iterator<Long> exactIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException;
+    Iterator<Long> nodesGetFromIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException;
 
     /**
      * Checks if a node is labeled with a certain label or not. Returns
      * {@code true} if the node is labeled with the label, otherwise {@code false.}
-     * Label ids are retrieved from {@link KeyWriteOperations#getOrCreateLabelId(String)} or
-     * {@link KeyReadOperations#getLabelId(String)}.
+     * Label ids are retrieved from {@link KeyWriteOperations#labelGetOrCreateForName(String)} or
+     * {@link KeyReadOperations#labelGetForName(String)}.
      */
-    boolean isLabelSetOnNode( long labelId, long nodeId ) throws EntityNotFoundException;
+    boolean nodeHasLabel( long nodeId, long labelId ) throws EntityNotFoundException;
 
     /**
      * Returns all labels set on node with id {@code nodeId}.
      * If the node has no labels an empty {@link Iterable} will be returned.
      */
-    Iterator<Long> getLabelsForNode( long nodeId ) throws EntityNotFoundException;
+    Iterator<Long> nodeGetLabels( long nodeId ) throws EntityNotFoundException;
 
     /** Returns the value of the property given it's property key id for the node with the given node id */
-    Object getNodePropertyValue( long nodeId, long propertyId )
+    Object nodeGetPropertyValue( long nodeId, long propertyId )
             throws PropertyKeyIdNotFoundException, PropertyNotFoundException, EntityNotFoundException;
 
     /** Returns true if node has the property given it's property key id for the node with the given node id */
@@ -68,8 +67,8 @@ public interface EntityReadOperations
             throws PropertyKeyIdNotFoundException, EntityNotFoundException;
 
     /** Return all property keys associated with a node. */
-    Iterator<Long> listNodePropertyKeys( long nodeId );
+    Iterator<Long> nodeGetPropertyKeys( long nodeId );
 
     /** Return all property keys associated with a relationship. */
-    Iterator<Long> listRelationshipPropertyKeys( long relationshipId );
+    Iterator<Long> relationshipGetPropertyKeys( long relationshipId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityWriteOperations.java
@@ -26,23 +26,23 @@ public interface EntityWriteOperations
 {
     // Currently, of course, most relevant operations here are still in the old core API implementation.
 
-    void deleteNode( long nodeId );
+    void nodeDelete( long nodeId );
 
     /**
      * Labels a node with the label corresponding to the given label id.
      * If the node already had that label nothing will happen. Label ids
-     * are retrieved from {@link KeyWriteOperations#getOrCreateLabelId(String)} or {@link
-     * KeyReadOperations#getLabelId(String)}.
+     * are retrieved from {@link KeyWriteOperations#labelGetOrCreateForName(String)} or {@link
+     * KeyReadOperations#labelGetForName(String)}.
      */
-    boolean addLabelToNode( long labelId, long nodeId ) throws EntityNotFoundException;
+    boolean nodeAddLabel( long nodeId, long labelId ) throws EntityNotFoundException;
 
     /**
      * Removes a label with the corresponding id from a node.
      * If the node doesn't have that label nothing will happen. Label ids
-     * are retrieved from {@link KeyWriteOperations#getOrCreateLabelId(String)} or {@link
-     * KeyReadOperations#getLabelId(String)}.
+     * are retrieved from {@link KeyWriteOperations#labelGetOrCreateForName(String)} or {@link
+     * KeyReadOperations#labelGetForName(String)}.
      */
-    boolean removeLabelFromNode( long labelId, long nodeId ) throws EntityNotFoundException;
+    boolean nodeRemoveLabel( long nodeId, long labelId ) throws EntityNotFoundException;
 
     /** Set a node's property given the node's id, the property key id, and the value */
     void nodeSetPropertyValue( long nodeId, long propertyId, Object value )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyOperations.java
@@ -21,5 +21,4 @@ package org.neo4j.kernel.api.operations;
 
 public interface KeyOperations extends KeyReadOperations, KeyWriteOperations
 {
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyReadOperations.java
@@ -32,20 +32,20 @@ public interface KeyReadOperations
      * Returns a label id for a label name. If the label doesn't exist a
      * {@link org.neo4j.kernel.api.LabelNotFoundKernelException} will be thrown.
      */
-    long getLabelId( String label ) throws LabelNotFoundKernelException;
+    long labelGetForName( String labelName ) throws LabelNotFoundKernelException;
 
     /** Returns the label name for the given label id. */
-    String getLabelName( long labelId ) throws LabelNotFoundKernelException;
+    String labelGetName( long labelId ) throws LabelNotFoundKernelException;
 
     /**
      * Returns a property key id for the given property key. If the property key doesn't exist a
      * {@link org.neo4j.kernel.api.PropertyKeyNotFoundException} will be thrown.
      */
-    long getPropertyKeyId( String propertyKey ) throws PropertyKeyNotFoundException;
+    long propertyKeyGetForName( String propertyKeyName ) throws PropertyKeyNotFoundException;
 
     /** Returns the name of a property given it's property key id */
-    String getPropertyKeyName( long propertyId ) throws PropertyKeyIdNotFoundException;
+    String propertyKeyGetName( long propertyKeyId ) throws PropertyKeyIdNotFoundException;
 
     /** Returns the labels currently stored in the database **/
-    Iterator<Token> listLabels();
+    Iterator<Token> labelsGetAllTokens(); // TODO: Token is a store level concern, should not make it this far up the stack
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyWriteOperations.java
@@ -27,11 +27,11 @@ public interface KeyWriteOperations
      * Returns a label id for a label name. If the label doesn't exist prior to
      * this call it gets created.
      */
-    long getOrCreateLabelId( String label ) throws DataIntegrityKernelException;
+    long labelGetOrCreateForName( String labelName ) throws DataIntegrityKernelException;
 
     /**
      * Returns a property key id for a property key. If the key doesn't exist prior to
      * this call it gets created.
      */
-    long getOrCreatePropertyKeyId( String propertyKey ) throws DataIntegrityKernelException;
+    long propertyKeyGetOrCreateForName( String propertyKeyName ) throws DataIntegrityKernelException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaReadOperations.java
@@ -32,59 +32,59 @@ public interface SchemaReadOperations
     /**
      * Returns the index rule for the given labelId and propertyKey.
      */
-    IndexDescriptor getIndex( long labelId, long propertyKey ) throws SchemaRuleNotFoundException;
+    IndexDescriptor indexesGetForLabelAndPropertyKey( long labelId, long propertyKey ) throws SchemaRuleNotFoundException;
 
     /**
      * Get all indexes for a label.
      */
-    Iterator<IndexDescriptor> getIndexes( long labelId );
+    Iterator<IndexDescriptor> indexesGetForLabel( long labelId );
 
     /**
      * Returns all indexes.
      */
-    Iterator<IndexDescriptor> getIndexes();
+    Iterator<IndexDescriptor> indexesGetAll();
 
     /**
      * Get all constraint indexes for a label.
      */
-    Iterator<IndexDescriptor> getConstraintIndexes( long labelId );
+    Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId );
 
     /**
      * Returns all constraint indexes.
      */
-    Iterator<IndexDescriptor> getConstraintIndexes();
+    Iterator<IndexDescriptor> uniqueIndexesGetAll();
 
     /**
      * Retrieve the state of an index.
      */
-    InternalIndexState getIndexState( IndexDescriptor indexRule ) throws IndexNotFoundKernelException;
+    InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Get all constraints applicable to label and propertyKey. There are only {@link UniquenessConstraint}
      * for the time being.
      */
-    Iterator<UniquenessConstraint> getConstraints( long labelId, long propertyKeyId );
+    Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, long propertyKeyId );
 
     /**
      * Get all constraints applicable to label. There are only {@link UniquenessConstraint}
      * for the time being.
      */
-    Iterator<UniquenessConstraint> getConstraints( long labelId );
+    Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId );
 
     /**
      * Get all constraints. There are only {@link UniquenessConstraint}
      * for the time being.
      */
-    Iterator<UniquenessConstraint> getConstraints();
+    Iterator<UniquenessConstraint> constraintsGetAll();
 
     /**
-     * Get the owning constraint for a constraint index.
+     * Get the owning constraint for a constraint index. Returns null if the index does not have an owning constraint.
      */
-    Long getOwningConstraint( IndexDescriptor index ) throws SchemaRuleNotFoundException;
+    Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
 
     /**
      * Get the index id (the id or the schema rule record) for a committed index
      * - throws exception for indexes that aren't committed.
      */
-    long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
+    long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaStateOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaStateOperations.java
@@ -34,7 +34,7 @@ public interface SchemaStateOperations
      * NOTE: This currently is solely used by Cypher and might or might not be turned into
      * a more generic facility in teh future
      */
-    <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator );
+    <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator );
 
     /**
      * Check if some key is in the schema state.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaWriteOperations.java
@@ -27,23 +27,32 @@ import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 public interface SchemaWriteOperations
 {
     /**
-     * Adds a {@link IndexDescriptor} to the database which applies globally on both
-     * existing as well as new data.
+     * Creates an index, indexing properties with the given {@code propertyKeyId} for nodes with the given
+     * {@code labelId}.
      */
-    IndexDescriptor addIndex( long labelId, long propertyKey ) throws DataIntegrityKernelException;
-
-    IndexDescriptor addConstraintIndex( long labelId, long propertyKey ) throws
-                                                                         DataIntegrityKernelException;
+    IndexDescriptor indexCreate( long labelId, long propertyKeyId ) throws DataIntegrityKernelException;
 
     /**
-     * Drops a {@link IndexDescriptor} from the database
+     * Creates an index for use with a uniqueness constraint. The index indexes properties with the given
+     * {@code propertyKeyId} for nodes with the given {@code labelId}, and assumes that the database provides it with
+     * unique property values. If unique property values are not provided by the database, the index will notify
+     * through an exception and enter a "bad state". (This notification facility is used during the verification phase
+     * of uniqueness constraint creation).
+     *
+     * This method is not used from the outside. It is used internally when
+     * {@link #uniquenessConstraintCreate(long, long) creating a uniqueness constraint}, invoked through a separate
+     * transaction (the separate transaction is why it has to be exposed in this API).
      */
-    void dropIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException;
+    IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
+            throws DataIntegrityKernelException;
 
-    void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException;
+    /** Drops a {@link IndexDescriptor} from the database */
+    void indexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException;
 
-    UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+    void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException;
+
+    UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
             throws DataIntegrityKernelException, ConstraintCreationKernelException;
 
-    void dropConstraint( UniquenessConstraint constraint );
+    void constraintDrop( UniquenessConstraint constraint );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingStatementContext.java
@@ -79,48 +79,48 @@ public class CachingStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public boolean isLabelSetOnNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeHasLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         Set<Long> labels = persistenceCache.getLabels( nodeId );
         if ( labels != null )
         {
             return labels.contains( labelId );
         }
-        return delegate.isLabelSetOnNode( labelId, nodeId );
+        return delegate.nodeHasLabel( nodeId, labelId );
     }
 
     @Override
-    public Iterator<Long> getLabelsForNode( long nodeId ) throws EntityNotFoundException
+    public Iterator<Long> nodeGetLabels( long nodeId ) throws EntityNotFoundException
     {
         Set<Long> labels = persistenceCache.getLabels( nodeId );
         if ( labels != null )
         {
             return labels.iterator();
         }
-        return delegate.getLabelsForNode( nodeId );
+        return delegate.nodeGetLabels( nodeId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( long labelId )
     {
         return toIndexDescriptors( schemaCache.getSchemaRulesForLabel( labelId ), SchemaRule.Kind.INDEX_RULE );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
         return toIndexDescriptors( schemaCache.getSchemaRules(), SchemaRule.Kind.INDEX_RULE );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId )
     {
         return toIndexDescriptors( schemaCache.getSchemaRulesForLabel( labelId ),
                                    SchemaRule.Kind.CONSTRAINT_INDEX_RULE );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
         return toIndexDescriptors( schemaCache.getSchemaRules(), SchemaRule.Kind.CONSTRAINT_INDEX_RULE );
     }
@@ -140,25 +140,25 @@ public class CachingStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Long getOwningConstraint( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         IndexRule rule = indexRule( index );
         if ( rule != null )
         {
             return rule.getOwningConstraint();
         }
-        return delegate.getOwningConstraint( index );
+        return delegate.indexGetOwningUniquenessConstraintId( index );
     }
 
     @Override
-    public long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         IndexRule rule = indexRule( index );
         if ( rule != null )
         {
             return rule.getId();
         }
-        return delegate.getCommittedIndexId( index );
+        return delegate.indexGetCommittedId( index );
     }
 
     private IndexRule indexRule( IndexDescriptor index )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CompositeStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CompositeStatementContext.java
@@ -157,11 +157,11 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
         beforeOperation();
 
-        V result = schemaStateOperations.getOrCreateFromSchemaState( key, creator );
+        V result = schemaStateOperations.schemaStateGetOrCreate( key, creator );
 
         afterOperation();
         return result;
@@ -172,12 +172,12 @@ public class CompositeStatementContext implements StatementContext
     //
 
     @Override
-    public Iterator<Long> getNodesWithLabel( long labelId )
+    public Iterator<Long> nodesGetForLabel( long labelId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Long> result = entityOperations.getNodesWithLabel( labelId );
+        Iterator<Long> result = entityOperations.nodesGetForLabel( labelId );
 
         afterReadOperation();
         afterOperation();
@@ -185,12 +185,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> exactIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
+    public Iterator<Long> nodesGetFromIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Long> result = entityOperations.exactIndexLookup( index, value );
+        Iterator<Long> result = entityOperations.nodesGetFromIndexLookup( index, value );
 
         afterReadOperation();
         afterOperation();
@@ -198,12 +198,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public long getLabelId( String label ) throws LabelNotFoundKernelException
+    public long labelGetForName( String label ) throws LabelNotFoundKernelException
     {
         beforeOperation();
         beforeReadOperation();
 
-        long result = keyOperations.getLabelId( label );
+        long result = keyOperations.labelGetForName( label );
 
         afterReadOperation();
         afterOperation();
@@ -211,12 +211,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public String getLabelName( long labelId ) throws LabelNotFoundKernelException
+    public String labelGetName( long labelId ) throws LabelNotFoundKernelException
     {
         beforeOperation();
         beforeReadOperation();
 
-        String result = keyOperations.getLabelName( labelId );
+        String result = keyOperations.labelGetName( labelId );
 
         afterReadOperation();
         afterOperation();
@@ -224,12 +224,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public boolean isLabelSetOnNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeHasLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        boolean result = entityOperations.isLabelSetOnNode( labelId, nodeId );
+        boolean result = entityOperations.nodeHasLabel( nodeId, labelId );
 
         afterReadOperation();
         afterOperation();
@@ -237,12 +237,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> getLabelsForNode( long nodeId ) throws EntityNotFoundException
+    public Iterator<Long> nodeGetLabels( long nodeId ) throws EntityNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Long> result = entityOperations.getLabelsForNode( nodeId );
+        Iterator<Long> result = entityOperations.nodeGetLabels( nodeId );
 
         afterReadOperation();
         afterOperation();
@@ -250,12 +250,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public long getPropertyKeyId( String propertyKey ) throws PropertyKeyNotFoundException
+    public long propertyKeyGetForName( String propertyKey ) throws PropertyKeyNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        long result = keyOperations.getPropertyKeyId( propertyKey );
+        long result = keyOperations.propertyKeyGetForName( propertyKey );
 
         afterReadOperation();
         afterOperation();
@@ -263,12 +263,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public String getPropertyKeyName( long propertyId ) throws PropertyKeyIdNotFoundException
+    public String propertyKeyGetName( long propertyId ) throws PropertyKeyIdNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        String result = keyOperations.getPropertyKeyName( propertyId );
+        String result = keyOperations.propertyKeyGetName( propertyId );
 
         afterReadOperation();
         afterOperation();
@@ -276,13 +276,13 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Object getNodePropertyValue( long nodeId, long propertyId ) throws PropertyKeyIdNotFoundException,
+    public Object nodeGetPropertyValue( long nodeId, long propertyId ) throws PropertyKeyIdNotFoundException,
             PropertyNotFoundException, EntityNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        Object result = entityOperations.getNodePropertyValue( nodeId, propertyId );
+        Object result = entityOperations.nodeGetPropertyValue( nodeId, propertyId );
 
         afterReadOperation();
         afterOperation();
@@ -305,12 +305,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> listNodePropertyKeys( long nodeId )
+    public Iterator<Long> nodeGetPropertyKeys( long nodeId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Long> result = entityOperations.listNodePropertyKeys( nodeId );
+        Iterator<Long> result = entityOperations.nodeGetPropertyKeys( nodeId );
 
         afterReadOperation();
         afterOperation();
@@ -318,12 +318,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> listRelationshipPropertyKeys( long relationshipId )
+    public Iterator<Long> relationshipGetPropertyKeys( long relationshipId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Long> result = entityOperations.listRelationshipPropertyKeys( relationshipId );
+        Iterator<Long> result = entityOperations.relationshipGetPropertyKeys( relationshipId );
 
         afterReadOperation();
         afterOperation();
@@ -331,12 +331,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public IndexDescriptor getIndex( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
+    public IndexDescriptor indexesGetForLabelAndPropertyKey( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        IndexDescriptor result = schemaOperations.getIndex( labelId, propertyKey );
+        IndexDescriptor result = schemaOperations.indexesGetForLabelAndPropertyKey( labelId, propertyKey );
 
         afterReadOperation();
         afterOperation();
@@ -344,12 +344,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( long labelId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<IndexDescriptor> result = schemaOperations.getIndexes( labelId );
+        Iterator<IndexDescriptor> result = schemaOperations.indexesGetForLabel( labelId );
 
         afterReadOperation();
         afterOperation();
@@ -357,12 +357,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<IndexDescriptor> result = schemaOperations.getIndexes();
+        Iterator<IndexDescriptor> result = schemaOperations.indexesGetAll();
 
         afterReadOperation();
         afterOperation();
@@ -370,12 +370,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<IndexDescriptor> result = schemaOperations.getConstraintIndexes( labelId );
+        Iterator<IndexDescriptor> result = schemaOperations.uniqueIndexesGetForLabel( labelId );
 
         afterReadOperation();
         afterOperation();
@@ -383,12 +383,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<IndexDescriptor> result = schemaOperations.getConstraintIndexes();
+        Iterator<IndexDescriptor> result = schemaOperations.uniqueIndexesGetAll();
 
         afterReadOperation();
         afterOperation();
@@ -396,12 +396,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public InternalIndexState getIndexState( IndexDescriptor indexRule ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         beforeOperation();
         beforeReadOperation();
 
-        InternalIndexState result = schemaOperations.getIndexState( indexRule );
+        InternalIndexState result = schemaOperations.indexGetState( descriptor );
 
         afterReadOperation();
         afterOperation();
@@ -409,12 +409,13 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId, long propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, long propertyKeyId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<UniquenessConstraint> result = schemaOperations.getConstraints( labelId, propertyKeyId );
+        Iterator<UniquenessConstraint> result = schemaOperations.constraintsGetForLabelAndPropertyKey( labelId,
+                                                                                                       propertyKeyId );
 
         afterReadOperation();
         afterOperation();
@@ -422,12 +423,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId )
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<UniquenessConstraint> result = schemaOperations.getConstraints( labelId );
+        Iterator<UniquenessConstraint> result = schemaOperations.constraintsGetForLabel( labelId );
 
         afterReadOperation();
         afterOperation();
@@ -435,12 +436,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Long getOwningConstraint( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        Long result = schemaOperations.getOwningConstraint( index );
+        Long result = schemaOperations.indexGetOwningUniquenessConstraintId( index );
 
         afterReadOperation();
         afterOperation();
@@ -448,12 +449,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         beforeOperation();
         beforeReadOperation();
 
-        long result = schemaOperations.getCommittedIndexId( index );
+        long result = schemaOperations.indexGetCommittedId( index );
 
         afterReadOperation();
         afterOperation();
@@ -461,12 +462,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints()
+    public Iterator<UniquenessConstraint> constraintsGetAll()
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<UniquenessConstraint> result = schemaOperations.getConstraints();
+        Iterator<UniquenessConstraint> result = schemaOperations.constraintsGetAll();
 
         afterReadOperation();
         afterOperation();
@@ -474,12 +475,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Token> listLabels()
+    public Iterator<Token> labelsGetAllTokens()
     {
         beforeOperation();
         beforeReadOperation();
 
-        Iterator<Token> result = keyOperations.listLabels();
+        Iterator<Token> result = keyOperations.labelsGetAllTokens();
 
         afterReadOperation();
         afterOperation();
@@ -491,12 +492,12 @@ public class CompositeStatementContext implements StatementContext
     //
 
     @Override
-    public long getOrCreateLabelId( String label ) throws DataIntegrityKernelException
+    public long labelGetOrCreateForName( String label ) throws DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        long result = keyOperations.getOrCreateLabelId( label );
+        long result = keyOperations.labelGetOrCreateForName( label );
 
         afterWriteOperation();
         afterOperation();
@@ -504,12 +505,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public boolean addLabelToNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeAddLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        boolean result = entityOperations.addLabelToNode( labelId, nodeId );
+        boolean result = entityOperations.nodeAddLabel( nodeId, labelId );
 
         afterWriteOperation();
         afterOperation();
@@ -517,12 +518,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public boolean removeLabelFromNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeRemoveLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        boolean result = entityOperations.removeLabelFromNode( labelId, nodeId );
+        boolean result = entityOperations.nodeRemoveLabel( nodeId, labelId );
 
         afterWriteOperation();
         afterOperation();
@@ -530,12 +531,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public long getOrCreatePropertyKeyId( String propertyKey ) throws DataIntegrityKernelException
+    public long propertyKeyGetOrCreateForName( String propertyKey ) throws DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        long result = keyOperations.getOrCreatePropertyKeyId( propertyKey );
+        long result = keyOperations.propertyKeyGetOrCreateForName( propertyKey );
 
         afterWriteOperation();
         afterOperation();
@@ -543,13 +544,13 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public IndexDescriptor addIndex( long labelId, long propertyKey ) throws
+    public IndexDescriptor indexCreate( long labelId, long propertyKey ) throws
                                                                       DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        IndexDescriptor result = schemaOperations.addIndex( labelId, propertyKey );
+        IndexDescriptor result = schemaOperations.indexCreate( labelId, propertyKey );
 
         afterWriteOperation();
         afterOperation();
@@ -557,13 +558,13 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+    public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        IndexDescriptor result = schemaOperations.addConstraintIndex( labelId, propertyKey );
+        IndexDescriptor result = schemaOperations.uniqueIndexCreate( labelId, propertyKey );
 
         afterWriteOperation();
         afterOperation();
@@ -571,13 +572,13 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+    public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
             throws DataIntegrityKernelException, ConstraintCreationKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        UniquenessConstraint result = schemaOperations.addUniquenessConstraint( labelId, propertyKeyId );
+        UniquenessConstraint result = schemaOperations.uniquenessConstraintCreate( labelId, propertyKeyId );
 
         afterWriteOperation();
         afterOperation();
@@ -585,36 +586,36 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public void dropConstraint( UniquenessConstraint constraint )
+    public void constraintDrop( UniquenessConstraint constraint )
     {
         beforeOperation();
         beforeWriteOperation();
 
-        schemaOperations.dropConstraint( constraint );
+        schemaOperations.constraintDrop( constraint );
 
         afterWriteOperation();
         afterOperation();
     }
 
     @Override
-    public void dropIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void indexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        schemaOperations.dropIndex( descriptor );
+        schemaOperations.indexDrop( descriptor );
 
         afterWriteOperation();
         afterOperation();
     }
 
     @Override
-    public void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         beforeOperation();
         beforeWriteOperation();
 
-        schemaOperations.dropConstraintIndex( descriptor );
+        schemaOperations.uniqueIndexDrop( descriptor );
 
         afterWriteOperation();
         afterOperation();
@@ -649,12 +650,12 @@ public class CompositeStatementContext implements StatementContext
     }
 
     @Override
-    public void deleteNode( long nodeId )
+    public void nodeDelete( long nodeId )
     {
         beforeOperation();
         beforeWriteOperation();
 
-        entityOperations.deleteNode( nodeId );
+        entityOperations.nodeDelete( nodeId );
 
         afterWriteOperation();
         afterOperation();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementContext.java
@@ -37,7 +37,7 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
     }
 
     @Override
-    public long getOrCreatePropertyKeyId( String propertyKey ) throws DataIntegrityKernelException
+    public long propertyKeyGetOrCreateForName( String propertyKey ) throws DataIntegrityKernelException
     {
         // KISS - but refactor into a general purpose constraint checker later on
         if ( propertyKey == null )
@@ -45,11 +45,11 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
             throw new DataIntegrityKernelException.IllegalTokenNameException( null );
         }
 
-        return delegate.getOrCreatePropertyKeyId( propertyKey );
+        return delegate.propertyKeyGetOrCreateForName( propertyKey );
     }
 
     @Override
-    public long getOrCreateLabelId( String label ) throws DataIntegrityKernelException
+    public long labelGetOrCreateForName( String label ) throws DataIntegrityKernelException
     {
         // KISS - but refactor into a general purpose constraint checker later on
         if ( label == null || label.length() == 0 )
@@ -57,35 +57,35 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
             throw new DataIntegrityKernelException.IllegalTokenNameException( label );
         }
 
-        return delegate.getOrCreateLabelId( label );
+        return delegate.labelGetOrCreateForName( label );
     }
 
     @Override
-    public IndexDescriptor addIndex( long labelId, long propertyKey )
+    public IndexDescriptor indexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
         checkIndexExistence( labelId, propertyKey );
-        return delegate.addIndex( labelId, propertyKey );
+        return delegate.indexCreate( labelId, propertyKey );
     }
 
     @Override
-    public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+    public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
         checkIndexExistence( labelId, propertyKey );
-        return delegate.addConstraintIndex( labelId, propertyKey );
+        return delegate.uniqueIndexCreate( labelId, propertyKey );
     }
 
     private void checkIndexExistence( long labelId, long propertyKey ) throws DataIntegrityKernelException
     {
-        for ( IndexDescriptor descriptor : loop( getIndexes( labelId ) ) )
+        for ( IndexDescriptor descriptor : loop( indexesGetForLabel( labelId ) ) )
         {
             if ( descriptor.getPropertyKeyId() == propertyKey )
             {
                 throw new DataIntegrityKernelException.AlreadyIndexedException( labelId, propertyKey );
             }
         }
-        for ( IndexDescriptor descriptor : loop( getConstraintIndexes( labelId ) ) )
+        for ( IndexDescriptor descriptor : loop( uniqueIndexesGetForLabel( labelId ) ) )
         {
             if ( descriptor.getPropertyKeyId() == propertyKey )
             {
@@ -95,13 +95,13 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
     }
 
     @Override
-    public void dropIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void indexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
-        for ( IndexDescriptor existing : loop( getIndexes( descriptor.getLabelId() ) ) )
+        for ( IndexDescriptor existing : loop( indexesGetForLabel( descriptor.getLabelId() ) ) )
         {
             if ( existing.getPropertyKeyId() == descriptor.getPropertyKeyId() )
             {
-                delegate.dropIndex( descriptor );
+                delegate.indexDrop( descriptor );
                 return;
             }
         }
@@ -110,13 +110,13 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
     }
 
     @Override
-    public void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
-        for ( IndexDescriptor existing : loop( getConstraintIndexes( descriptor.getLabelId() ) ) )
+        for ( IndexDescriptor existing : loop( uniqueIndexesGetForLabel( descriptor.getLabelId() ) ) )
         {
             if ( existing.getPropertyKeyId() == descriptor.getPropertyKeyId() )
             {
-                delegate.dropConstraintIndex( descriptor );
+                delegate.uniqueIndexDrop( descriptor );
                 return;
             }
         }
@@ -125,14 +125,14 @@ public class DataIntegrityValidatingStatementContext extends CompositeStatementC
     }
 
     @Override
-    public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKey )
+    public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException, ConstraintCreationKernelException
     {
-        if ( getConstraints( labelId, propertyKey ).hasNext() )
+        if ( constraintsGetForLabelAndPropertyKey( labelId, propertyKey ).hasNext() )
         {
             throw new DataIntegrityKernelException.AlreadyConstrainedException( labelId, propertyKey );
         }
 
-        return delegate.addUniquenessConstraint( labelId, propertyKey );
+        return delegate.uniquenessConstraintCreate( labelId, propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DelegatingSchemaOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DelegatingSchemaOperations.java
@@ -40,114 +40,114 @@ public class DelegatingSchemaOperations implements SchemaOperations
     }
 
     @Override
-    public IndexDescriptor getIndex( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
+    public IndexDescriptor indexesGetForLabelAndPropertyKey( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
     {
-        return delegate.getIndex( labelId, propertyKey );
+        return delegate.indexesGetForLabelAndPropertyKey( labelId, propertyKey );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( long labelId )
     {
-        return delegate.getIndexes( labelId );
+        return delegate.indexesGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
-        return delegate.getIndexes();
+        return delegate.indexesGetAll();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId )
     {
-        return delegate.getConstraintIndexes( labelId );
+        return delegate.uniqueIndexesGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
-        return delegate.getConstraintIndexes();
+        return delegate.uniqueIndexesGetAll();
     }
 
     @Override
-    public InternalIndexState getIndexState( IndexDescriptor indexRule ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return delegate.getIndexState( indexRule );
+        return delegate.indexGetState( descriptor );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId, long propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, long propertyKeyId )
     {
-        return delegate.getConstraints( labelId, propertyKeyId );
+        return delegate.constraintsGetForLabelAndPropertyKey( labelId, propertyKeyId );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId )
     {
-        return delegate.getConstraints( labelId );
+        return delegate.constraintsGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints()
+    public Iterator<UniquenessConstraint> constraintsGetAll()
     {
-        return delegate.getConstraints();
+        return delegate.constraintsGetAll();
     }
 
     @Override
-    public Long getOwningConstraint( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
-        return delegate.getOwningConstraint( index );
+        return delegate.indexGetOwningUniquenessConstraintId( index );
     }
 
     @Override
-    public long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
-        return delegate.getCommittedIndexId( index );
+        return delegate.indexGetCommittedId( index );
     }
 
     @Override
-    public IndexDescriptor addIndex( long labelId, long propertyKey ) throws
+    public IndexDescriptor indexCreate( long labelId, long propertyKey ) throws
                                                                       DataIntegrityKernelException
     {
-        return delegate.addIndex( labelId, propertyKey );
+        return delegate.indexCreate( labelId, propertyKey );
     }
 
     @Override
-    public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+    public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
-        return delegate.addConstraintIndex( labelId, propertyKey );
+        return delegate.uniqueIndexCreate( labelId, propertyKey );
     }
 
     @Override
-    public void dropIndex( IndexDescriptor indexRule ) throws DataIntegrityKernelException
+    public void indexDrop( IndexDescriptor indexRule ) throws DataIntegrityKernelException
     {
-        delegate.dropIndex( indexRule );
+        delegate.indexDrop( indexRule );
     }
 
     @Override
-    public void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
-        delegate.dropConstraintIndex( descriptor );
+        delegate.uniqueIndexDrop( descriptor );
     }
 
     @Override
-    public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+    public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
             throws DataIntegrityKernelException, ConstraintCreationKernelException
     {
-        return delegate.addUniquenessConstraint( labelId, propertyKeyId );
+        return delegate.uniquenessConstraintCreate( labelId, propertyKeyId );
     }
 
     @Override
-    public void dropConstraint( UniquenessConstraint constraint )
+    public void constraintDrop( UniquenessConstraint constraint )
     {
-        delegate.dropConstraint( constraint );
+        delegate.constraintDrop( constraint );
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
-        return delegate.getOrCreateFromSchemaState( key, creator );
+        return delegate.schemaStateGetOrCreate( key, creator );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementContext.java
@@ -41,54 +41,54 @@ public class LockingStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public boolean addLabelToNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeAddLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         lockHolder.acquireNodeWriteLock( nodeId );
-        return delegate.addLabelToNode( labelId, nodeId );
+        return delegate.nodeAddLabel( nodeId, labelId );
     }
 
     @Override
-    public boolean removeLabelFromNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeRemoveLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         lockHolder.acquireNodeWriteLock( nodeId );
-        return delegate.removeLabelFromNode( labelId, nodeId );
+        return delegate.nodeRemoveLabel( nodeId, labelId );
     }
 
     @Override
-    public IndexDescriptor addIndex( long labelId, long propertyKey ) throws
+    public IndexDescriptor indexCreate( long labelId, long propertyKey ) throws
                                                                       DataIntegrityKernelException
     {
         lockHolder.acquireSchemaWriteLock();
-        return delegate.addIndex( labelId, propertyKey );
+        return delegate.indexCreate( labelId, propertyKey );
     }
 
     @Override
-    public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+    public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
         lockHolder.acquireSchemaWriteLock();
-        return delegate.addConstraintIndex( labelId, propertyKey );
+        return delegate.uniqueIndexCreate( labelId, propertyKey );
     }
 
     @Override
-    public void dropIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void indexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         lockHolder.acquireSchemaWriteLock();
-        delegate.dropIndex( descriptor );
+        delegate.indexDrop( descriptor );
     }
 
     @Override
-    public void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         lockHolder.acquireSchemaWriteLock();
-        delegate.dropConstraintIndex( descriptor );
+        delegate.uniqueIndexDrop( descriptor );
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getOrCreateFromSchemaState( key, creator );
+        return delegate.schemaStateGetOrCreate( key, creator );
     }
 
     @Override
@@ -99,73 +99,73 @@ public class LockingStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( long labelId )
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getIndexes( labelId );
+        return delegate.indexesGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getIndexes();
+        return delegate.indexesGetAll();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId )
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getConstraintIndexes( labelId );
+        return delegate.uniqueIndexesGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getConstraintIndexes();
+        return delegate.uniqueIndexesGetAll();
     }
 
     @Override
-    public void deleteNode( long nodeId )
+    public void nodeDelete( long nodeId )
     {
         lockHolder.acquireNodeWriteLock( nodeId );
-        delegate.deleteNode( nodeId );
+        delegate.nodeDelete( nodeId );
     }
 
     @Override
-    public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+    public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
             throws DataIntegrityKernelException, ConstraintCreationKernelException
     {
         lockHolder.acquireSchemaWriteLock();
-        return delegate.addUniquenessConstraint( labelId, propertyKeyId );
+        return delegate.uniquenessConstraintCreate( labelId, propertyKeyId );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId, long propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, long propertyKeyId )
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getConstraints( labelId, propertyKeyId );
+        return delegate.constraintsGetForLabelAndPropertyKey( labelId, propertyKeyId );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId )
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getConstraints( labelId );
+        return delegate.constraintsGetForLabel( labelId );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints()
+    public Iterator<UniquenessConstraint> constraintsGetAll()
     {
         lockHolder.acquireSchemaReadLock();
-        return delegate.getConstraints();
+        return delegate.constraintsGetAll();
     }
 
     @Override
-    public void dropConstraint( UniquenessConstraint constraint )
+    public void constraintDrop( UniquenessConstraint constraint )
     {
         lockHolder.acquireSchemaWriteLock();
-        delegate.dropConstraint( constraint );
+        delegate.constraintDrop( constraint );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaStateConcern.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaStateConcern.java
@@ -32,7 +32,7 @@ public class SchemaStateConcern implements SchemaStateOperations
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
         return schemaState.getOrCreate( key, creator );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementContext.java
@@ -90,7 +90,7 @@ public class StoreStatementContext extends CompositeStatementContext
         {
             try
             {
-                return getPropertyKeyId( s );
+                return propertyKeyGetForName( s );
             }
             catch ( PropertyKeyNotFoundException e )
             {
@@ -142,7 +142,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public long getOrCreateLabelId( String label ) throws DataIntegrityKernelException
+    public long labelGetOrCreateForName( String label ) throws DataIntegrityKernelException
     {
         try
         {
@@ -167,7 +167,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public long getLabelId( String label ) throws LabelNotFoundKernelException
+    public long labelGetForName( String label ) throws LabelNotFoundKernelException
     {
         try
         {
@@ -180,11 +180,11 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public boolean isLabelSetOnNode( long labelId, long nodeId )
+    public boolean nodeHasLabel( long nodeId, long labelId )
     {
         try
         {
-            return contains( getLabelsForNode( nodeId ), labelId );
+            return contains( nodeGetLabels( nodeId ), labelId );
         }
         catch ( InvalidRecordException e )
         {
@@ -193,7 +193,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Long> getLabelsForNode( long nodeId )
+    public Iterator<Long> nodeGetLabels( long nodeId )
     {
         try
         {
@@ -207,7 +207,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public String getLabelName( long labelId ) throws LabelNotFoundKernelException
+    public String labelGetName( long labelId ) throws LabelNotFoundKernelException
     {
         try
         {
@@ -220,7 +220,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Long> getNodesWithLabel( final long labelId )
+    public Iterator<Long> nodesGetForLabel( final long labelId )
     {
         final NodeStore nodeStore = neoStore.getNodeStore();
         final long highestId = nodeStore.getHighestPossibleIdInUse();
@@ -251,13 +251,13 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Token> listLabels()
+    public Iterator<Token> labelsGetAllTokens()
     {
         return labelTokenHolder.getAllTokens().iterator();
     }
 
     @Override
-    public IndexDescriptor getIndex( final long labelId, final long propertyKey ) throws SchemaRuleNotFoundException
+    public IndexDescriptor indexesGetForLabelAndPropertyKey( final long labelId, final long propertyKey ) throws SchemaRuleNotFoundException
     {
         return descriptor( schemaStorage.indexRule( labelId, propertyKey ) );
     }
@@ -268,25 +268,25 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( final long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( final long labelId )
     {
         return getIndexDescriptorsFor( indexRules( labelId ) );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
         return getIndexDescriptorsFor( INDEX_RULES );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( final long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( final long labelId )
     {
         return getIndexDescriptorsFor( constraintIndexRules( labelId ) );
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
         return getIndexDescriptorsFor( CONSTRAINT_INDEX_RULES );
     }
@@ -346,19 +346,19 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Long getOwningConstraint( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         return schemaStorage.indexRule( index.getLabelId(), index.getPropertyKeyId() ).getOwningConstraint();
     }
 
     @Override
-    public long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         return schemaStorage.indexRule( index.getLabelId(), index.getPropertyKeyId() ).getId();
     }
 
     @Override
-    public InternalIndexState getIndexState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         return indexService.getProxyForRule( indexId( descriptor ) ).getState();
     }
@@ -376,7 +376,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId, final long propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, final long propertyKeyId )
     {
         return schemaStorage.schemaRules( UNIQUENESS_CONSTRAINT_TO_RULE, UniquenessConstraintRule.class,
                                           labelId, new Predicate<UniquenessConstraintRule>()
@@ -391,27 +391,27 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId )
     {
         return schemaStorage.schemaRules( UNIQUENESS_CONSTRAINT_TO_RULE, UniquenessConstraintRule.class,
                                           labelId, Predicates.<UniquenessConstraintRule>TRUE() );
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints()
+    public Iterator<UniquenessConstraint> constraintsGetAll()
     {
         return schemaStorage.schemaRules( UNIQUENESS_CONSTRAINT_TO_RULE, SchemaRule.Kind.UNIQUENESS_CONSTRAINT,
                                           Predicates.<UniquenessConstraintRule>TRUE() );
     }
 
     @Override
-    public long getOrCreatePropertyKeyId( String propertyKey )
+    public long propertyKeyGetOrCreateForName( String propertyKey )
     {
         return propertyKeyTokenHolder.getOrCreateId( propertyKey );
     }
 
     @Override
-    public long getPropertyKeyId( String propertyKey ) throws PropertyKeyNotFoundException
+    public long propertyKeyGetForName( String propertyKey ) throws PropertyKeyNotFoundException
     {
         try
         {
@@ -424,7 +424,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public String getPropertyKeyName( long propertyKeyId ) throws PropertyKeyIdNotFoundException
+    public String propertyKeyGetName( long propertyKeyId ) throws PropertyKeyIdNotFoundException
     {
         try
         {
@@ -437,7 +437,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Long> listNodePropertyKeys( long nodeId )
+    public Iterator<Long> nodeGetPropertyKeys( long nodeId )
     {
         // TODO: This is temporary, it should be split up to handle tx state up in the correct layers, this is just
         // a first step to move it into the kernel.
@@ -446,7 +446,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Long> listRelationshipPropertyKeys( long relId )
+    public Iterator<Long> relationshipGetPropertyKeys( long relId )
     {
         // TODO: This is temporary, it should be split up to handle tx state up in the correct layers, this is just
         // a first step to move it into the kernel.
@@ -455,7 +455,7 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Object getNodePropertyValue( long nodeId, long propertyKeyId )
+    public Object nodeGetPropertyValue( long nodeId, long propertyKeyId )
             throws PropertyKeyIdNotFoundException, PropertyNotFoundException, EntityNotFoundException
     {
         try
@@ -479,7 +479,7 @@ public class StoreStatementContext extends CompositeStatementContext
     {
         try
         {
-            String propertyKey = getPropertyKeyName( propertyKeyId );
+            String propertyKey = propertyKeyGetName( propertyKeyId );
             return nodeManager.getNodeForProxy( nodeId, null ).hasProperty( nodeManager, propertyKey );
         }
         catch ( IllegalStateException e )
@@ -495,7 +495,7 @@ public class StoreStatementContext extends CompositeStatementContext
         try
         {
             // TODO: Move locking to LockingStatementContext et cetera, don't create a new node proxy for every call!
-            String propertyKey = getPropertyKeyName( propertyKeyId );
+            String propertyKey = propertyKeyGetName( propertyKeyId );
             NodeImpl nodeImpl = nodeManager.getNodeForProxy( nodeId, LockType.WRITE );
             NodeProxy nodeProxy = nodeManager.newNodeProxyById( nodeId );
             nodeImpl.setProperty( nodeManager, nodeProxy, propertyKey, value );
@@ -513,7 +513,7 @@ public class StoreStatementContext extends CompositeStatementContext
         try
         {
             // TODO: Move locking to LockingStatementContext et cetera, don't create a new node proxy for every call!
-            String propertyKey = getPropertyKeyName( propertyKeyId );
+            String propertyKey = propertyKeyGetName( propertyKeyId );
             NodeImpl nodeImpl = nodeManager.getNodeForProxy( nodeId, LockType.WRITE );
             NodeProxy nodeProxy = nodeManager.newNodeProxyById( nodeId );
             return nodeImpl.removeProperty( nodeManager, nodeProxy, propertyKey );
@@ -525,13 +525,13 @@ public class StoreStatementContext extends CompositeStatementContext
     }
 
     @Override
-    public Iterator<Long> exactIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
+    public Iterator<Long> nodesGetFromIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
     {
         return indexReaderFactory.newReader( indexId( index ) ).lookup( value );
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
         throw new UnsupportedOperationException( "Schema state is not handled by the stores" );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingTransactionContext.java
@@ -50,27 +50,27 @@ public class UniquenessConstraintStoppingTransactionContext extends DelegatingTr
         }
 
         @Override
-        public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+        public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
                 throws DataIntegrityKernelException
         {
             throw unsupportedOperation();
         }
 
         @Override
-        public void dropConstraint( UniquenessConstraint constraint )
+        public void constraintDrop( UniquenessConstraint constraint )
         {
             throw unsupportedOperation();
         }
 
         @Override
-        public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+        public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
                 throws DataIntegrityKernelException
         {
             throw unsupportedOperation();
         }
 
         @Override
-        public void dropConstraintIndex( IndexDescriptor descriptor ) throws
+        public void uniqueIndexDrop( IndexDescriptor descriptor ) throws
                                                                       DataIntegrityKernelException
         {
             throw unsupportedOperation();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UnsupportiveStatementContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UnsupportiveStatementContext.java
@@ -52,91 +52,91 @@ public enum UnsupportiveStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> getNodesWithLabel( long labelId )
+    public Iterator<Long> nodesGetForLabel( long labelId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<Long> exactIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
+    public Iterator<Long> nodesGetFromIndexLookup( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public void deleteNode( long nodeId )
+    public void nodeDelete( long nodeId )
     {
         throw unsupported();
     }
 
     @Override
-    public long getOrCreateLabelId( String label ) throws DataIntegrityKernelException
+    public long labelGetOrCreateForName( String label ) throws DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public long getLabelId( String label ) throws LabelNotFoundKernelException
+    public long labelGetForName( String label ) throws LabelNotFoundKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public String getLabelName( long labelId ) throws LabelNotFoundKernelException
+    public String labelGetName( long labelId ) throws LabelNotFoundKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public boolean addLabelToNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeAddLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public boolean isLabelSetOnNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeHasLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<Long> getLabelsForNode( long nodeId ) throws EntityNotFoundException
+    public Iterator<Long> nodeGetLabels( long nodeId ) throws EntityNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public boolean removeLabelFromNode( long labelId, long nodeId ) throws EntityNotFoundException
+    public boolean nodeRemoveLabel( long nodeId, long labelId ) throws EntityNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<Token> listLabels()
+    public Iterator<Token> labelsGetAllTokens()
     {
         throw unsupported();
     }
 
     @Override
-    public long getOrCreatePropertyKeyId( String propertyKey ) throws DataIntegrityKernelException
+    public long propertyKeyGetOrCreateForName( String propertyKey ) throws DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public long getPropertyKeyId( String propertyKey ) throws PropertyKeyNotFoundException
+    public long propertyKeyGetForName( String propertyKey ) throws PropertyKeyNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public String getPropertyKeyName( long propertyId ) throws PropertyKeyIdNotFoundException
+    public String propertyKeyGetName( long propertyId ) throws PropertyKeyIdNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public Object getNodePropertyValue( long nodeId, long propertyId ) throws PropertyKeyIdNotFoundException,
+    public Object nodeGetPropertyValue( long nodeId, long propertyId ) throws PropertyKeyIdNotFoundException,
                                                                               PropertyNotFoundException,
                                                                               EntityNotFoundException
     {
@@ -165,81 +165,81 @@ public enum UnsupportiveStatementContext implements StatementContext
     }
 
     @Override
-    public Iterator<Long> listNodePropertyKeys( long nodeId )
+    public Iterator<Long> nodeGetPropertyKeys( long nodeId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<Long> listRelationshipPropertyKeys( long relationshipId )
+    public Iterator<Long> relationshipGetPropertyKeys( long relationshipId )
     {
         throw unsupported();
     }
 
     @Override
-    public IndexDescriptor addIndex( long labelId, long propertyKey ) throws
+    public IndexDescriptor indexCreate( long labelId, long propertyKey ) throws
                                                                       DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public IndexDescriptor addConstraintIndex( long labelId, long propertyKey )
+    public IndexDescriptor uniqueIndexCreate( long labelId, long propertyKey )
             throws DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public IndexDescriptor getIndex( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
+    public IndexDescriptor indexesGetForLabelAndPropertyKey( long labelId, long propertyKey ) throws SchemaRuleNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes( long labelId )
+    public Iterator<IndexDescriptor> indexesGetForLabel( long labelId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getIndexes()
+    public Iterator<IndexDescriptor> indexesGetAll()
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes( long labelId )
+    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( long labelId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<IndexDescriptor> getConstraintIndexes()
+    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
     {
         throw unsupported();
     }
 
     @Override
-    public InternalIndexState getIndexState( IndexDescriptor indexRule ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public void dropIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void indexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public void dropConstraintIndex( IndexDescriptor descriptor ) throws DataIntegrityKernelException
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DataIntegrityKernelException
     {
         throw unsupported();
     }
 
     @Override
-    public <K, V> V getOrCreateFromSchemaState( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
     {
         throw unsupported();
     }
@@ -251,43 +251,43 @@ public enum UnsupportiveStatementContext implements StatementContext
     }
 
     @Override
-    public UniquenessConstraint addUniquenessConstraint( long labelId, long propertyKeyId )
+    public UniquenessConstraint uniquenessConstraintCreate( long labelId, long propertyKeyId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId, long propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( long labelId, long propertyKeyId )
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints( long labelId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabel( long labelId )
     {
         throw unsupported();
     }
 
     @Override
-    public Long getOwningConstraint( IndexDescriptor index )
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index )
     {
         throw unsupported();
     }
 
     @Override
-    public long getCommittedIndexId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public long indexGetCommittedId( IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         throw unsupported();
     }
 
     @Override
-    public Iterator<UniquenessConstraint> getConstraints()
+    public Iterator<UniquenessConstraint> constraintsGetAll()
     {
         throw unsupported();
     }
 
     @Override
-    public void dropConstraint( UniquenessConstraint constraint )
+    public void constraintDrop( UniquenessConstraint constraint )
     {
         throw unsupported();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreator.java
@@ -54,7 +54,7 @@ public class ConstraintIndexCreator
         long indexId;
         try
         {
-            indexId = schema.getCommittedIndexId( descriptor );
+            indexId = schema.indexGetCommittedId( descriptor );
         }
         catch ( SchemaRuleNotFoundException e )
         {
@@ -154,7 +154,7 @@ public class ConstraintIndexCreator
             public IndexDescriptor perform( StatementContext statement ) throws
                                                                          DataIntegrityKernelException
             {
-                return statement.addConstraintIndex( labelId, propertyKeyId );
+                return statement.uniqueIndexCreate( labelId, propertyKeyId );
             }
         };
     }
@@ -167,7 +167,7 @@ public class ConstraintIndexCreator
             @Override
             public Void perform( StatementContext statement ) throws DataIntegrityKernelException
             {
-                statement.dropConstraintIndex( descriptor );
+                statement.uniqueIndexDrop( descriptor );
                 return null;
             }
         };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
@@ -57,12 +57,12 @@ public class RemoveOrphanConstraintIndexesOnStartup
                 StatementContext context = tx.newStatementContext();
                 try
                 {
-                    for ( Iterator<IndexDescriptor> indexes = context.getConstraintIndexes(); indexes.hasNext(); )
+                    for ( Iterator<IndexDescriptor> indexes = context.uniqueIndexesGetAll(); indexes.hasNext(); )
                     {
                         IndexDescriptor index = indexes.next();
-                        if ( context.getOwningConstraint( index ) == null )
+                        if ( context.indexGetOwningUniquenessConstraintId( index ) == null )
                         {
-                            context.dropConstraintIndex( index );
+                            context.uniqueIndexDrop( index );
                         }
                     }
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -97,7 +97,7 @@ public class NodeProxy implements Node
         StatementContext ctxForWriting = statementCtxProvider.getCtxForWriting();
         try
         {
-            ctxForWriting.deleteNode( getId() );
+            ctxForWriting.nodeDelete( getId() );
         }
         finally
         {
@@ -179,7 +179,7 @@ public class NodeProxy implements Node
         StatementContext ctxForWriting = statementCtxProvider.getCtxForWriting();
         try
         {
-            long propertyId = ctxForWriting.getOrCreatePropertyKeyId( key );
+            long propertyId = ctxForWriting.propertyKeyGetOrCreateForName( key );
             ctxForWriting.nodeSetPropertyValue( nodeId, propertyId, value );
         }
         catch ( PropertyKeyIdNotFoundException e )
@@ -207,7 +207,7 @@ public class NodeProxy implements Node
         StatementContext ctxForWriting = statementCtxProvider.getCtxForWriting();
         try
         {
-            long propertyId = ctxForWriting.getOrCreatePropertyKeyId( key );
+            long propertyId = ctxForWriting.propertyKeyGetOrCreateForName( key );
             return ctxForWriting.nodeRemoveProperty( nodeId, propertyId );
         }
         catch ( PropertyKeyIdNotFoundException e )
@@ -253,7 +253,7 @@ public class NodeProxy implements Node
                 {
                     try
                     {
-                        return context.getPropertyKeyName( aLong );
+                        return context.propertyKeyGetName( aLong );
                     }
                     catch ( PropertyKeyIdNotFoundException e )
                     {
@@ -261,7 +261,7 @@ public class NodeProxy implements Node
                                 "Property key retrieved through kernel API should exist." );
                     }
                 }
-            }, context.listNodePropertyKeys( getId())));
+            }, context.nodeGetPropertyKeys( getId() )));
         }
         finally
         {
@@ -279,8 +279,8 @@ public class NodeProxy implements Node
         StatementContext ctxForReading = statementCtxProvider.getCtxForReading();
         try
         {
-            long propertyId = ctxForReading.getPropertyKeyId( key );
-            return ctxForReading.getNodePropertyValue( nodeId, propertyId );
+            long propertyId = ctxForReading.propertyKeyGetForName( key );
+            return ctxForReading.nodeGetPropertyValue( nodeId, propertyId );
         }
         catch ( EntityNotFoundException e )
         {
@@ -313,7 +313,7 @@ public class NodeProxy implements Node
         StatementContext ctxForReading = statementCtxProvider.getCtxForReading();
         try
         {
-            long propertyId = ctxForReading.getPropertyKeyId( key );
+            long propertyId = ctxForReading.propertyKeyGetForName( key );
             return ctxForReading.nodeHasProperty( nodeId, propertyId );
         }
         catch ( EntityNotFoundException e )
@@ -417,7 +417,7 @@ public class NodeProxy implements Node
         StatementContext ctx = statementCtxProvider.getCtxForWriting();
         try
         {
-            ctx.addLabelToNode( ctx.getOrCreateLabelId( label.name() ), getId() );
+            ctx.nodeAddLabel( getId(), ctx.labelGetOrCreateForName( label.name() ) );
         }
         catch ( DataIntegrityKernelException e )
         {
@@ -439,7 +439,7 @@ public class NodeProxy implements Node
         StatementContext ctx = statementCtxProvider.getCtxForWriting();
         try
         {
-            ctx.removeLabelFromNode( ctx.getLabelId( label.name() ), getId() );
+            ctx.nodeRemoveLabel( getId(), ctx.labelGetForName( label.name() ) );
         }
         catch ( LabelNotFoundKernelException e )
         {
@@ -461,7 +461,7 @@ public class NodeProxy implements Node
         StatementContext ctx = statementCtxProvider.getCtxForReading();
         try
         {
-            return ctx.isLabelSetOnNode( ctx.getLabelId( label.name() ), getId() );
+            return ctx.nodeHasLabel( getId(), ctx.labelGetForName( label.name() ) );
         }
         catch ( LabelNotFoundKernelException e )
         {
@@ -491,7 +491,7 @@ public class NodeProxy implements Node
 
                 try
                 {
-                    labels = ctx.getLabelsForNode( getId() );
+                    labels = ctx.nodeGetLabels( getId() );
                 }
                 catch ( EntityNotFoundException e )
                 {
@@ -506,7 +506,7 @@ public class NodeProxy implements Node
                     {
                         try
                         {
-                            return label( ctx.getLabelName( labelId ) );
+                            return label( ctx.labelGetName( labelId ) );
                         }
                         catch ( LabelNotFoundKernelException e )
                         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -34,11 +31,13 @@ import org.neo4j.kernel.api.PropertyKeyIdNotFoundException;
 import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.impl.transaction.LockType;
 
+import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
 public class RelationshipProxy implements Relationship
 {
     public interface RelationshipLookups
     {
-        Node lookupNode(long nodeId);
         Node newNodeProxy( long nodeId );
         RelationshipImpl lookupRelationship(long relationshipId);
         GraphDatabaseService getGraphDatabaseService();
@@ -128,7 +127,7 @@ public class RelationshipProxy implements Relationship
                 {
                     try
                     {
-                        return context.getPropertyKeyName( aLong );
+                        return context.propertyKeyGetName( aLong );
                     }
                     catch ( PropertyKeyIdNotFoundException e )
                     {
@@ -136,7 +135,7 @@ public class RelationshipProxy implements Relationship
                                 "Property key retrieved through kernel API should exist." );
                     }
                 }
-            }, context.listRelationshipPropertyKeys( getId() )));
+            }, context.relationshipGetPropertyKeys( getId() )));
         }
         finally
         {
@@ -213,11 +212,7 @@ public class RelationshipProxy implements Relationship
     @Override
     public boolean equals( Object o )
     {
-        if ( !(o instanceof Relationship) )
-        {
-            return false;
-        }
-        return this.getId() == ((Relationship) o).getId();
+        return o instanceof Relationship && this.getId() == ((Relationship) o).getId();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/tooling/GlobalGraphOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/tooling/GlobalGraphOperations.java
@@ -145,7 +145,7 @@ public class GlobalGraphOperations
                     {
                         return label( labelToken.name() );
                     }
-                }, ctx.listLabels() ), ctx );
+                }, ctx.labelsGetAllTokens() ), ctx );
             }
         };
     }
@@ -176,8 +176,8 @@ public class GlobalGraphOperations
         StatementContext context = statementCtxProvider.getCtxForReading();
         try
         {
-            long labelId = context.getLabelId( label );
-            final Iterator<Long> nodeIds = context.getNodesWithLabel( labelId );
+            long labelId = context.labelGetForName( label );
+            final Iterator<Long> nodeIds = context.nodesGetForLabel( labelId );
             return cleanupService.resourceIterator( map( new Function<Long, Node>()
             {
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CachingStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CachingStatementContextTest.java
@@ -19,18 +19,20 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.api.EntityNotFoundException;
 import org.neo4j.kernel.api.StatementContext;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 
 public class CachingStatementContextTest
 {
@@ -46,7 +48,7 @@ public class CachingStatementContextTest
         StatementContext context = new CachingStatementContext( actual, cache, null );
         
         // WHEN
-        Iterator<Long> receivedLabels = context.getLabelsForNode( nodeId );
+        Iterator<Long> receivedLabels = context.nodeGetLabels( nodeId );
         
         // THEN
         assertEquals( labels, addToCollection(receivedLabels, new HashSet<Long>() ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementContextTest.java
@@ -47,12 +47,12 @@ public class DataIntegrityValidatingStatementContextTest
         IndexDescriptor rule = new IndexDescriptor( label, propertyKey );
         StatementContext inner = Mockito.mock(StatementContext.class);
         DataIntegrityValidatingStatementContext ctx = new DataIntegrityValidatingStatementContext( inner );
-        when( inner.getIndexes( rule.getLabelId() ) ).thenAnswer( withIterator( rule ) );
+        when( inner.indexesGetForLabel( rule.getLabelId() ) ).thenAnswer( withIterator( rule ) );
 
         // WHEN
         try
         {
-            ctx.addIndex( label, propertyKey );
+            ctx.indexCreate( label, propertyKey );
             fail( "Should have thrown exception." );
         }
         catch ( DataIntegrityKernelException e )
@@ -60,7 +60,7 @@ public class DataIntegrityValidatingStatementContextTest
         }
 
         // THEN
-        verify( inner, never() ).addIndex( anyLong(), anyLong() );
+        verify( inner, never() ).indexCreate( anyLong(), anyLong() );
     }
 
     private static <T> Answer<Iterator<T>> withIterator( final T... content )
@@ -82,7 +82,7 @@ public class DataIntegrityValidatingStatementContextTest
         DataIntegrityValidatingStatementContext ctx = new DataIntegrityValidatingStatementContext( null );
 
         // When
-        ctx.getOrCreateLabelId( "" );
+        ctx.labelGetOrCreateForName( "" );
     }
 
     @Test(expected = DataIntegrityKernelException.class)
@@ -92,7 +92,7 @@ public class DataIntegrityValidatingStatementContextTest
         DataIntegrityValidatingStatementContext ctx = new DataIntegrityValidatingStatementContext( null );
 
         // When
-        ctx.getOrCreateLabelId( null );
+        ctx.labelGetOrCreateForName( null );
     }
 
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/InteractionStoppingStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/InteractionStoppingStatementContextTest.java
@@ -36,7 +36,7 @@ public class InteractionStoppingStatementContextTest
         statement.close();
 
         // WHEN
-        statement.getLabelId( "my label" );
+        statement.labelGetForName( "my label" );
     }
     
     @Test
@@ -49,10 +49,10 @@ public class InteractionStoppingStatementContextTest
         StatementContext statement = new SimpleInteractionStoppingStatementContext( actual );
 
         // WHEN
-        statement.addLabelToNode( labelId, nodeId );
+        statement.nodeAddLabel( nodeId, labelId );
 
         // THEN
-        verify( actual ).addLabelToNode( labelId, nodeId );
+        verify( actual ).nodeAddLabel( nodeId, labelId );
     }
 
     private static class SimpleInteractionStoppingStatementContext extends InteractionStoppingStatementContext

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -136,7 +136,7 @@ public class KernelSchemaStateFlushingTest
         Transaction tx = db.beginTx();
         TransactionContext txc = txManager.getTransactionContext();
         StatementContext ctx = txc.newStatementContext();
-        UniquenessConstraint descriptor = ctx.addUniquenessConstraint( 1, 1 );
+        UniquenessConstraint descriptor = ctx.uniquenessConstraintCreate( 1, 1 );
         ctx.close();
         tx.success();
         tx.finish();
@@ -148,7 +148,7 @@ public class KernelSchemaStateFlushingTest
         Transaction tx = db.beginTx();
         TransactionContext txc = txManager.getTransactionContext();
         StatementContext ctx = txc.newStatementContext();
-        ctx.dropConstraint( descriptor );
+        ctx.constraintDrop( descriptor );
         ctx.close();
         tx.success();
         tx.finish();
@@ -159,7 +159,7 @@ public class KernelSchemaStateFlushingTest
         Transaction tx = db.beginTx();
         TransactionContext txc = txManager.getTransactionContext();
         StatementContext ctx = txc.newStatementContext();
-        IndexDescriptor descriptor = ctx.addIndex( 1, 1 );
+        IndexDescriptor descriptor = ctx.indexCreate( 1, 1 );
         ctx.close();
         tx.success();
         tx.finish();
@@ -171,7 +171,7 @@ public class KernelSchemaStateFlushingTest
         Transaction tx = db.beginTx();
         TransactionContext txc = txManager.getTransactionContext();
         StatementContext ctx = txc.newStatementContext();
-        ctx.dropIndex( descriptor );
+        ctx.indexDrop( descriptor );
         ctx.close();
         tx.success();
         tx.finish();
@@ -210,14 +210,14 @@ public class KernelSchemaStateFlushingTest
         StatementContext ctx = tx.newStatementContext();
         try 
         {
-            String result = ctx.getOrCreateFromSchemaState( key, new Function<String, String>() {
+            return ctx.schemaStateGetOrCreate( key, new Function<String, String>()
+            {
                 @Override
                 public String apply( String from )
                 {
                     return value;
                 }
-            }); 
-            return result;
+            } );
         }
         finally 
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
@@ -73,7 +73,7 @@ public class KernelTest
         StatementContext ctx = tx.newStatementContext();
         try
         {
-            ctx.addUniquenessConstraint( 1, 1 );
+            ctx.uniquenessConstraintCreate( 1, 1 );
             fail("expected exception here");
         }
         catch ( UnsupportedSchemaModificationException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementContextTest.java
@@ -58,7 +58,7 @@ public class LockingStatementContextTest
         LockingStatementContext statementContext = new LockingStatementContext( inner, lockHolder );
 
         // WHEN
-        statementContext.deleteNode( nodeId );
+        statementContext.nodeDelete( nodeId );
 
         //THEN
 //        verify( inner ).deleteNode( null, nodeId );
@@ -72,18 +72,18 @@ public class LockingStatementContextTest
         StatementContext delegate = mock( StatementContext.class );
         LockHolder lockHolder = mock( LockHolder.class );
         IndexDescriptor rule = mock( IndexDescriptor.class );
-        when( delegate.addIndex( 123, 456 ) ).thenReturn( rule );
+        when( delegate.indexCreate( 123, 456 ) ).thenReturn( rule );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        IndexDescriptor result = context.addIndex( 123, 456 );
+        IndexDescriptor result = context.indexCreate( 123, 456 );
 
         // then
         assertSame( rule, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaWriteLock();
-        order.verify( delegate ).addIndex( 123, 456 );
+        order.verify( delegate ).indexCreate( 123, 456 );
         verifyNoMoreInteractions( lockHolder, delegate );
     }
 
@@ -98,12 +98,12 @@ public class LockingStatementContextTest
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        context.dropIndex( rule );
+        context.indexDrop( rule );
 
         // then
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaWriteLock();
-        order.verify( delegate ).dropIndex( rule );
+        order.verify( delegate ).indexDrop( rule );
         verifyNoMoreInteractions( lockHolder, delegate );
     }
 
@@ -115,18 +115,18 @@ public class LockingStatementContextTest
         LockHolder lockHolder = mock( LockHolder.class );
         @SuppressWarnings("unchecked")
         Iterator<IndexDescriptor> rules = mock( Iterator.class );
-        when( delegate.getIndexes() ).thenReturn( rules );
+        when( delegate.indexesGetAll() ).thenReturn( rules );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        Iterator<IndexDescriptor> result = context.getIndexes();
+        Iterator<IndexDescriptor> result = context.indexesGetAll();
 
         // then
         assertSame( rules, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaReadLock();
-        order.verify( delegate ).getIndexes();
+        order.verify( delegate ).indexesGetAll();
         verifyNoMoreInteractions( lockHolder, delegate );
     }
 
@@ -137,18 +137,18 @@ public class LockingStatementContextTest
         StatementContext delegate = mock( StatementContext.class );
         LockHolder lockHolder = mock( LockHolder.class );
         UniquenessConstraint constraint = mock( UniquenessConstraint.class );
-        when( delegate.addUniquenessConstraint( 123, 456 ) ).thenReturn( constraint );
+        when( delegate.uniquenessConstraintCreate( 123, 456 ) ).thenReturn( constraint );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        UniquenessConstraint result = context.addUniquenessConstraint( 123, 456 );
+        UniquenessConstraint result = context.uniquenessConstraintCreate( 123, 456 );
 
         // then
         assertEquals( constraint, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaWriteLock();
-        order.verify( delegate ).addUniquenessConstraint( 123, 456 );
+        order.verify( delegate ).uniquenessConstraintCreate( 123, 456 );
         verifyNoMoreInteractions( lockHolder, delegate );
     }
 
@@ -163,12 +163,12 @@ public class LockingStatementContextTest
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        context.dropConstraint( constraint );
+        context.constraintDrop( constraint );
 
         // then
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaWriteLock();
-        order.verify( delegate ).dropConstraint( constraint );
+        order.verify( delegate ).constraintDrop( constraint );
         verifyNoMoreInteractions( lockHolder, delegate );
     }
 
@@ -180,18 +180,18 @@ public class LockingStatementContextTest
         LockHolder lockHolder = mock( LockHolder.class );
         @SuppressWarnings("unchecked")
         Iterator<UniquenessConstraint> constraints = mock( Iterator.class );
-        when( delegate.getConstraints( 123, 456 ) ).thenReturn( constraints );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 123, 456 ) ).thenReturn( constraints );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        Iterator<UniquenessConstraint> result = context.getConstraints( 123, 456 );
+        Iterator<UniquenessConstraint> result = context.constraintsGetForLabelAndPropertyKey( 123, 456 );
 
         // then
         assertEquals( constraints, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaReadLock();
-        order.verify( delegate ).getConstraints( 123, 456 );
+        order.verify( delegate ).constraintsGetForLabelAndPropertyKey( 123, 456 );
         verifyNoMoreInteractions( lockHolder, delegate );
         
         // cleanup
@@ -206,18 +206,18 @@ public class LockingStatementContextTest
         LockHolder lockHolder = mock( LockHolder.class );
         @SuppressWarnings("unchecked")
         Iterator<UniquenessConstraint> constraints = mock( Iterator.class );
-        when( delegate.getConstraints( 123 ) ).thenReturn( constraints );
+        when( delegate.constraintsGetForLabel( 123 ) ).thenReturn( constraints );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        Iterator<UniquenessConstraint> result = context.getConstraints( 123 );
+        Iterator<UniquenessConstraint> result = context.constraintsGetForLabel( 123 );
 
         // then
         assertEquals( constraints, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaReadLock();
-        order.verify( delegate ).getConstraints( 123 );
+        order.verify( delegate ).constraintsGetForLabel( 123 );
         verifyNoMoreInteractions( lockHolder, delegate );
         
         // cleanup
@@ -232,18 +232,18 @@ public class LockingStatementContextTest
         LockHolder lockHolder = mock( LockHolder.class );
         @SuppressWarnings("unchecked")
         Iterator<UniquenessConstraint> constraints = mock( Iterator.class );
-        when( delegate.getConstraints( ) ).thenReturn( constraints );
+        when( delegate.constraintsGetAll() ).thenReturn( constraints );
 
         LockingStatementContext context = new LockingStatementContext( delegate, lockHolder );
 
         // when
-        Iterator<UniquenessConstraint> result = context.getConstraints( );
+        Iterator<UniquenessConstraint> result = context.constraintsGetAll();
 
         // then
         assertEquals( constraints, result );
         InOrder order = inOrder( lockHolder, delegate );
         order.verify( lockHolder ).acquireSchemaReadLock();
-        order.verify( delegate ).getConstraints( );
+        order.verify( delegate ).constraintsGetAll();
         verifyNoMoreInteractions( lockHolder, delegate );
         
         // cleanup

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContextTest.java
@@ -117,7 +117,7 @@ public class ReferenceCountingTransactionContextTest
         // WHEN
         try
         {
-            first.getLabelName( 0 );
+            first.labelGetName( 0 );
 
             fail( "expected exception" );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementContextTest.java
@@ -67,7 +67,7 @@ public class StoreStatementContextTest
     {
         // When
         try {
-            statement.addLabelToNode( 12, 12);
+            statement.nodeAddLabel( 12, 12 );
             fail("Should have thrown unsupported operation.");
         } catch(UnsupportedOperationException e)
         {
@@ -90,8 +90,8 @@ public class StoreStatementContextTest
         tx.finish();
 
         // WHEN
-        long propertyKeyId = statement.getPropertyKeyId( propertyKey );
-        int result = (Integer) statement.getNodePropertyValue( nodeId, propertyKeyId );
+        long propertyKeyId = statement.propertyKeyGetForName( propertyKey );
+        int result = (Integer) statement.nodeGetPropertyValue( nodeId, propertyKeyId );
 
         // THEN
         assertThat( propertyValue, equalTo( result ) );
@@ -112,10 +112,10 @@ public class StoreStatementContextTest
         tx.finish();
 
         // WHEN
-        long propertyKeyId = statement.getPropertyKeyId( propertyKey );
+        long propertyKeyId = statement.propertyKeyGetForName( propertyKey );
         try
         {
-            statement.getNodePropertyValue( nodeId, propertyKeyId );
+            statement.nodeGetPropertyValue( nodeId, propertyKeyId );
 
             fail( "Should have thrown exception" );
         }
@@ -133,13 +133,13 @@ public class StoreStatementContextTest
         Transaction tx = db.beginTx();
         long nodeId = db.createNode(label, label2).getId();
         String labelName1 = label.name(), labelName2 = label2.name();
-        long labelId1 = statement.getLabelId( labelName1 );
-        long labelId2 = statement.getOrCreateLabelId( labelName2 );
+        long labelId1 = statement.labelGetForName( labelName1 );
+        long labelId2 = statement.labelGetOrCreateForName( labelName2 );
         tx.success();
         tx.finish();
 
         // THEN
-        Iterator<Long> readLabels = statement.getLabelsForNode( nodeId );
+        Iterator<Long> readLabels = statement.nodeGetLabels( nodeId );
         assertEquals( new HashSet<Long>( asList( labelId1, labelId2 ) ),
                 addToCollection( readLabels, new HashSet<Long>() ) );
     }
@@ -149,10 +149,10 @@ public class StoreStatementContextTest
     {
         // GIVEN
         String labelName = label.name();
-        long labelId = statement.getOrCreateLabelId( labelName );
+        long labelId = statement.labelGetOrCreateForName( labelName );
 
         // WHEN
-        String readLabelName = statement.getLabelName( labelId );
+        String readLabelName = statement.labelGetName( labelId );
 
         // THEN
         assertEquals( labelName, readLabelName );
@@ -185,8 +185,8 @@ public class StoreStatementContextTest
         Node node2 = createLabeledNode( db, map( "type", "Node", "count", 10 ), label, label2 );
 
         // WHEN
-        Iterator<Long> nodesForLabel1 = statement.getNodesWithLabel( statement.getLabelId( label.name() ) );
-        Iterator<Long> nodesForLabel2 = statement.getNodesWithLabel( statement.getLabelId( label2.name() ) );
+        Iterator<Long> nodesForLabel1 = statement.nodesGetForLabel( statement.labelGetForName( label.name() ) );
+        Iterator<Long> nodesForLabel2 = statement.nodesGetForLabel( statement.labelGetForName( label2.name() ) );
 
         // THEN
         assertEquals( asSet( node1.getId(), node2.getId() ), asSet( nodesForLabel1 ) );
@@ -197,7 +197,7 @@ public class StoreStatementContextTest
     public void should_create_property_key_if_not_exists() throws Exception
     {
         // WHEN
-        long id = statement.getOrCreatePropertyKeyId( propertyKey );
+        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
 
         // THEN
         assertTrue( "Should have created a non-negative id", id >= 0 );
@@ -207,10 +207,10 @@ public class StoreStatementContextTest
     public void should_get_previously_created_property_key() throws Exception
     {
         // GIVEN
-        long id = statement.getOrCreatePropertyKeyId( propertyKey );
+        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
 
         // WHEN
-        long secondId = statement.getPropertyKeyId( propertyKey );
+        long secondId = statement.propertyKeyGetForName( propertyKey );
 
         // THEN
         assertEquals( id, secondId );
@@ -220,10 +220,10 @@ public class StoreStatementContextTest
     public void should_be_able_to_get_or_create_previously_created_property_key() throws Exception
     {
         // GIVEN
-        long id = statement.getOrCreatePropertyKeyId( propertyKey );
+        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
 
         // WHEN
-        long secondId = statement.getOrCreatePropertyKeyId( propertyKey );
+        long secondId = statement.propertyKeyGetOrCreateForName( propertyKey );
 
         // THEN
         assertEquals( id, secondId );
@@ -235,7 +235,7 @@ public class StoreStatementContextTest
         // WHEN
         try
         {
-            statement.getPropertyKeyId( "non-existent-property-key" );
+            statement.propertyKeyGetForName( "non-existent-property-key" );
             fail( "Should have failed with property key not found exception" );
         }
         catch ( PropertyKeyNotFoundException e )
@@ -253,7 +253,7 @@ public class StoreStatementContextTest
         Node mrTaylor = createLabeledNode( db, map( propertyKey, name ), label );
 
         // WHEN
-        Set<Long> foundNodes = asUniqueSet( statement.exactIndexLookup( index, name ) );
+        Set<Long> foundNodes = asUniqueSet( statement.nodesGetFromIndexLookup( index, name ) );
 
         // THEN
         assertEquals( asSet( mrTaylor.getId() ), foundNodes );
@@ -319,7 +319,7 @@ public class StoreStatementContextTest
         }
         
         db.schema().awaitIndexOnline( index, 10, SECONDS );
-        return statement.getIndex( statement.getLabelId( label.name() ),
-                                   statement.getPropertyKeyId( propertyKey ) );
+        return statement.indexesGetForLabelAndPropertyKey( statement.labelGetForName( label.name() ),
+                                                           statement.propertyKeyGetForName( propertyKey ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -78,8 +78,8 @@ public class IndexCRUDIT
         Node node = createNode( map( indexProperty, value1, otherProperty, otherValue ), myLabel );
 
         // Then, for now, this should trigger two NodePropertyUpdates
-        long propertyKey1 = ctxProvider.getCtxForReading().getPropertyKeyId( indexProperty );
-        long[] labels = new long[] {ctxProvider.getCtxForReading().getLabelId( myLabel.name() )};
+        long propertyKey1 = ctxProvider.getCtxForReading().propertyKeyGetForName( indexProperty );
+        long[] labels = new long[] {ctxProvider.getCtxForReading().labelGetForName( myLabel.name() )};
         assertThat( writer.updates, equalTo( asSet(
                 NodePropertyUpdate.add( node.getId(), propertyKey1, value1, labels ) ) ) );
 
@@ -112,8 +112,8 @@ public class IndexCRUDIT
         tx.finish();
 
         // THEN
-        long propertyKey1 = ctxProvider.getCtxForReading().getPropertyKeyId( indexProperty );
-        long[] labels = new long[] {ctxProvider.getCtxForReading().getLabelId( myLabel.name() )};
+        long propertyKey1 = ctxProvider.getCtxForReading().propertyKeyGetForName( indexProperty );
+        long[] labels = new long[] {ctxProvider.getCtxForReading().labelGetForName( myLabel.name() )};
         assertThat( writer.updates, equalTo( asSet(
                 NodePropertyUpdate.add( node.getId(), propertyKey1, value, labels ) ) ) );
     }
@@ -193,8 +193,9 @@ public class IndexCRUDIT
         {
             try
             {
-                updates.add( NodePropertyUpdate.add( nodeId, ctxProvider.getCtxForReading().getPropertyKeyId( propertyKey ),
-                        propertyValue, new long[] {ctxProvider.getCtxForReading().getLabelId( myLabel.name() )} ) );
+                updates.add( NodePropertyUpdate.add( nodeId, ctxProvider.getCtxForReading().propertyKeyGetForName(
+                        propertyKey ),
+                        propertyValue, new long[] {ctxProvider.getCtxForReading().labelGetForName( myLabel.name() )} ) );
             }
             catch ( PropertyKeyNotFoundException e )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -47,7 +47,7 @@ public class IndexIT extends KernelIntegrationTest
         newTransaction();
 
         // WHEN
-        IndexDescriptor rule = statement.addIndex( labelId, propertyKey );
+        IndexDescriptor rule = statement.indexCreate( labelId, propertyKey );
         commit();
 
         // AND WHEN the index is created
@@ -63,14 +63,14 @@ public class IndexIT extends KernelIntegrationTest
         newTransaction();
 
         // WHEN
-        IndexDescriptor expectedRule = statement.addIndex( labelId, propertyKey );
+        IndexDescriptor expectedRule = statement.indexCreate( labelId, propertyKey );
         commit();
 
         // THEN
         StatementContext roStatement = readOnlyContext();
         assertEquals( asSet( expectedRule ),
-                      asSet( roStatement.getIndexes( labelId ) ) );
-        assertEquals( expectedRule, roStatement.getIndex( labelId, propertyKey ) );
+                      asSet( roStatement.indexesGetForLabel( labelId ) ) );
+        assertEquals( expectedRule, roStatement.indexesGetForLabelAndPropertyKey( labelId, propertyKey ) );
     }
 
     @Test
@@ -78,14 +78,14 @@ public class IndexIT extends KernelIntegrationTest
     {
         // GIVEN
         newTransaction();
-        IndexDescriptor existingRule = statement.addIndex( labelId, propertyKey );
+        IndexDescriptor existingRule = statement.indexCreate( labelId, propertyKey );
         commit();
 
         // WHEN
         newTransaction();
         long propertyKey2 = 10;
-        IndexDescriptor addedRule = statement.addIndex( labelId, propertyKey2 );
-        Set<IndexDescriptor> indexRulesInTx = asSet( statement.getIndexes( labelId ) );
+        IndexDescriptor addedRule = statement.indexCreate( labelId, propertyKey2 );
+        Set<IndexDescriptor> indexRulesInTx = asSet( statement.indexesGetForLabel( labelId ) );
         commit();
 
         // THEN
@@ -99,12 +99,12 @@ public class IndexIT extends KernelIntegrationTest
         newTransaction();
 
         // WHEN
-        statement.addIndex( labelId, propertyKey );
+        statement.indexCreate( labelId, propertyKey );
         // don't mark as success
         rollback();
 
         // THEN
-        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOnlyContext().getIndexes( labelId ) ) );
+        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOnlyContext().indexesGetForLabel( labelId ) ) );
     }
 
     @Test
@@ -112,14 +112,14 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        statement.addConstraintIndex( labelId, propertyKey );
+        statement.uniqueIndexCreate( labelId, propertyKey );
         commit();
 
         // when
         restartDb();
 
         // then
-        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOnlyContext().getIndexes( labelId ) ) );
+        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOnlyContext().indexesGetForLabel( labelId ) ) );
     }
 
     @Test
@@ -127,17 +127,17 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        IndexDescriptor index = statement.addIndex( labelId, propertyKey );
+        IndexDescriptor index = statement.indexCreate( labelId, propertyKey );
         commit();
         newTransaction();
-        statement.dropIndex( index );
+        statement.indexDrop( index );
         commit();
 
         // when
         try
         {
             newTransaction();
-            statement.dropIndex( index );
+            statement.indexDrop( index );
             commit();
         }
         // then
@@ -153,14 +153,14 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        statement.addConstraintIndex( labelId, propertyKey );
+        statement.uniqueIndexCreate( labelId, propertyKey );
         commit();
 
         // when
         try
         {
             newTransaction();
-            statement.addIndex( labelId, propertyKey );
+            statement.indexCreate( labelId, propertyKey );
             commit();
 
             fail( "expected exception" );
@@ -179,14 +179,14 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        IndexDescriptor index = statement.addConstraintIndex( labelId, propertyKey );
+        IndexDescriptor index = statement.uniqueIndexCreate( labelId, propertyKey );
         commit();
 
         // when
         try
         {
             newTransaction();
-            statement.dropIndex( index );
+            statement.indexDrop( index );
             commit();
 
             fail( "expected exception" );
@@ -204,8 +204,8 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        statement.addConstraintIndex( statement.getOrCreateLabelId( "Label1" ),
-                                      statement.getOrCreatePropertyKeyId( "property1" ) );
+        statement.uniqueIndexCreate( statement.labelGetOrCreateForName( "Label1" ),
+                                     statement.propertyKeyGetOrCreateForName( "property1" ) );
         commit();
 
         // when
@@ -238,13 +238,13 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        statement.addConstraintIndex( labelId, propertyKey );
+        statement.uniqueIndexCreate( labelId, propertyKey );
         commit();
 
         // then/when
         newTransaction();
-        assertFalse( statement.getIndexes().hasNext() );
-        assertFalse( statement.getIndexes( labelId ).hasNext() );
+        assertFalse( statement.indexesGetAll().hasNext() );
+        assertFalse( statement.indexesGetForLabel( labelId ).hasNext() );
     }
 
     @Test
@@ -252,13 +252,13 @@ public class IndexIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        statement.addIndex( labelId, propertyKey );
+        statement.indexCreate( labelId, propertyKey );
         commit();
 
         // then/when
         newTransaction();
-        assertFalse( statement.getConstraintIndexes().hasNext() );
-        assertFalse( statement.getConstraintIndexes( labelId ).hasNext() );
+        assertFalse( statement.uniqueIndexesGetAll().hasNext() );
+        assertFalse( statement.uniqueIndexesGetForLabel( labelId ).hasNext() );
     }
 
     private void awaitIndexOnline( IndexDescriptor indexRule ) throws IndexNotFoundKernelException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -148,7 +148,7 @@ public class IndexPopulationJobTest
         long node3 = createNode( map( name, value3 ), FIRST );
         @SuppressWarnings("UnnecessaryLocalVariable")
         long changeNode = node1;
-        long propertyKeyId = context.getPropertyKeyId( name );
+        long propertyKeyId = context.propertyKeyGetForName( name );
         NodeChangingWriter populator = new NodeChangingWriter( changeNode, propertyKeyId, value1, changedValue,
                 firstLabelId );
         IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy() );
@@ -174,7 +174,7 @@ public class IndexPopulationJobTest
         long node1 = createNode( map( name, value1 ), FIRST );
         long node2 = createNode( map( name, value2 ), FIRST );
         long node3 = createNode( map( name, value3 ), FIRST );
-        long propertyKeyId = context.getPropertyKeyId( name );
+        long propertyKeyId = context.propertyKeyGetForName( name );
         NodeDeletingWriter populator = new NodeDeletingWriter( node2, propertyKeyId, value2, firstLabelId );
         IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy() );
         populator.setJob( job );
@@ -435,8 +435,8 @@ public class IndexPopulationJobTest
         
         Transaction tx = db.beginTx();
         StatementContext ctxForWriting = ctxProvider.getCtxForWriting();
-        firstLabelId = ctxForWriting.getOrCreateLabelId( FIRST.name() );
-        ctxForWriting.getOrCreateLabelId( SECOND.name() );
+        firstLabelId = ctxForWriting.labelGetOrCreateForName( FIRST.name() );
+        ctxForWriting.labelGetOrCreateForName( SECOND.name() );
         ctxForWriting.close();
         tx.success();
         tx.finish();
@@ -462,8 +462,8 @@ public class IndexPopulationJobTest
             FlippableIndexProxy flipper, IndexStoreView storeView, StringLogger logger )
             throws LabelNotFoundKernelException, PropertyKeyNotFoundException
     {
-        IndexDescriptor descriptor = new IndexDescriptor( context.getLabelId( label.name() ),
-                                                          context.getPropertyKeyId( propertyKey ) );
+        IndexDescriptor descriptor = new IndexDescriptor( context.labelGetForName( label.name() ),
+                                                          context.propertyKeyGetForName( propertyKey ) );
         flipper.setFlipTarget( mock( IndexProxyFactory.class ) );
         return
             new IndexPopulationJob( descriptor, PROVIDER_DESCRIPTOR, populator, flipper, storeView,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -288,8 +288,8 @@ public class IndexRecoveryIT
             {
                 Node node = db.createNode( label );
                 node.setProperty( key, number );
-                updates.add( NodePropertyUpdate.add( node.getId(), context.getPropertyKeyId( key ), number,
-                        new long[] {context.getLabelId( label.name() )} ) );
+                updates.add( NodePropertyUpdate.add( node.getId(), context.propertyKeyGetForName( key ), number,
+                        new long[] {context.labelGetForName( label.name() )} ) );
             }
             context.close();
             tx.success();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -30,6 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Ignore;
+
 import org.neo4j.helpers.FutureAdapter;
 import org.neo4j.kernel.api.StatementContext;
 import org.neo4j.kernel.api.index.IndexNotFoundKernelException;
@@ -37,6 +34,10 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Ignore( "This is not a test" )
 public class SchemaIndexTestHelper
@@ -119,7 +120,7 @@ public class SchemaIndexTestHelper
         long start = System.currentTimeMillis();
         while(true)
         {
-           if(ctx.getIndexState(indexRule) == InternalIndexState.ONLINE)
+           if(ctx.indexGetState( indexRule ) == InternalIndexState.ONLINE)
            {
                break;
            }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -99,8 +99,8 @@ public class KernelIT extends KernelIntegrationTest
         //    same transaction.
         Node node = db.createNode();
 
-        long labelId = statement.getOrCreateLabelId( "labello" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "labello" );
+        statement.nodeAddLabel( node.getId(), labelId );
 
         // 4: Close the StatementContext
         statement.close();
@@ -129,8 +129,8 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         Node node = db.createNode();
-        long labelId = statement.getOrCreateLabelId( "labello" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "labello" );
+        statement.nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.commit();
         outerTx.finish();
@@ -145,8 +145,8 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         Node node = db.createNode();
-        long labelId = statement.getOrCreateLabelId( "labello" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "labello" );
+        statement.nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.finish();
 
@@ -154,7 +154,7 @@ public class KernelIT extends KernelIntegrationTest
         statement = statementContextProvider.getCtxForReading();
         try
         {
-            statement.isLabelSetOnNode( labelId, node.getId() );
+            statement.nodeHasLabel( node.getId(), labelId );
             fail( "should have thrown exception" );
         }
         catch ( EntityNotFoundException e )
@@ -171,8 +171,8 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         Node node = db.createNode();
-        long labelId = statement.getOrCreateLabelId( "labello" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "labello" );
+        statement.nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.failure();
         tx.success();
@@ -182,7 +182,7 @@ public class KernelIT extends KernelIntegrationTest
         statement = statementContextProvider.getCtxForReading();
         try
         {
-            statement.isLabelSetOnNode( labelId, node.getId() );
+            statement.nodeHasLabel( node.getId(), labelId );
             fail( "should have thrown exception" );
         }
         catch ( EntityNotFoundException e )
@@ -199,18 +199,18 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         Node node = db.createNode();
-        long labelId1 = statement.getOrCreateLabelId( "labello1" );
-        long labelId2 = statement.getOrCreateLabelId( "labello2" );
-        statement.addLabelToNode( labelId1, node.getId() );
-        statement.addLabelToNode( labelId2, node.getId() );
-        statement.removeLabelFromNode( labelId2, node.getId() );
+        long labelId1 = statement.labelGetOrCreateForName( "labello1" );
+        long labelId2 = statement.labelGetOrCreateForName( "labello2" );
+        statement.nodeAddLabel( node.getId(), labelId1 );
+        statement.nodeAddLabel( node.getId(), labelId2 );
+        statement.nodeRemoveLabel( node.getId(), labelId2 );
         statement.close();
         tx.success();
         tx.finish();
 
         // THEN
         statement = statementContextProvider.getCtxForReading();
-        assertEquals( asSet( labelId1 ), asSet( statement.getLabelsForNode( node.getId() ) ) );
+        assertEquals( asSet( labelId1 ), asSet( statement.nodeGetLabels( node.getId() ) ) );
     }
 
     @Test
@@ -221,15 +221,15 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         Node node = db.createNode();
-        long labelId1 = statement.getOrCreateLabelId( "labello1" );
-        long labelId2 = statement.getOrCreateLabelId( "labello2" );
-        statement.addLabelToNode( labelId1, node.getId() );
-        statement.addLabelToNode( labelId2, node.getId() );
-        statement.removeLabelFromNode( labelId2, node.getId() );
+        long labelId1 = statement.labelGetOrCreateForName( "labello1" );
+        long labelId2 = statement.labelGetOrCreateForName( "labello2" );
+        statement.nodeAddLabel( node.getId(), labelId1 );
+        statement.nodeAddLabel( node.getId(), labelId2 );
+        statement.nodeRemoveLabel( node.getId(), labelId2 );
 
         // THEN
-        assertFalse( statement.isLabelSetOnNode( labelId2, node.getId() ) );
-        assertEquals( asSet( labelId1 ), asSet( statement.getLabelsForNode( node.getId() ) ) );
+        assertFalse( statement.nodeHasLabel( node.getId(), labelId2 ) );
+        assertEquals( asSet( labelId1 ), asSet( statement.nodeGetLabels( node.getId() ) ) );
 
         statement.close();
         tx.success();
@@ -243,10 +243,10 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         StatementContext statement = statementContextProvider.getCtxForWriting();
         Node node = db.createNode();
-        long labelId1 = statement.getOrCreateLabelId( "labello1" );
-        long labelId2 = statement.getOrCreateLabelId( "labello2" );
-        statement.addLabelToNode( labelId1, node.getId() );
-        statement.addLabelToNode( labelId2, node.getId() );
+        long labelId1 = statement.labelGetOrCreateForName( "labello1" );
+        long labelId2 = statement.labelGetOrCreateForName( "labello2" );
+        statement.nodeAddLabel( node.getId(), labelId1 );
+        statement.nodeAddLabel( node.getId(), labelId2 );
         statement.close();
         tx.success();
         tx.finish();
@@ -254,12 +254,12 @@ public class KernelIT extends KernelIntegrationTest
         statement = statementContextProvider.getCtxForWriting();
 
         // WHEN
-        statement.removeLabelFromNode( labelId2, node.getId() );
+        statement.nodeRemoveLabel( node.getId(), labelId2 );
 
         // THEN
-        Iterator<Long> labelsIterator = statement.getLabelsForNode( node.getId() );
+        Iterator<Long> labelsIterator = statement.nodeGetLabels( node.getId() );
         Set<Long> labels = asSet( labelsIterator );
-        assertFalse( statement.isLabelSetOnNode( labelId2, node.getId() ) );
+        assertFalse( statement.nodeHasLabel( node.getId(), labelId2 ) );
         assertEquals( asSet( labelId1 ), labels );
         statement.close();
         tx.success();
@@ -273,8 +273,8 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         StatementContext statement = statementContextProvider.getCtxForWriting();
         Node node = db.createNode();
-        long labelId1 = statement.getOrCreateLabelId( "labello1" );
-        statement.addLabelToNode( labelId1, node.getId() );
+        long labelId1 = statement.labelGetOrCreateForName( "labello1" );
+        statement.nodeAddLabel( node.getId(), labelId1 );
         statement.close();
         tx.success();
         tx.finish();
@@ -282,7 +282,7 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        statement.removeLabelFromNode( labelId1, node.getId() );
+        statement.nodeRemoveLabel( node.getId(), labelId1 );
         statement.close();
         tx.success();
         tx.finish();
@@ -290,7 +290,7 @@ public class KernelIT extends KernelIntegrationTest
         // THEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        Iterator<Long> labels = statement.getLabelsForNode( node.getId() );
+        Iterator<Long> labels = statement.nodeGetLabels( node.getId() );
         statement.close();
         tx.success();
         tx.finish();
@@ -305,8 +305,8 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         Node node = db.createNode();
         StatementContext statement = statementContextProvider.getCtxForWriting();
-        long labelId = statement.getOrCreateLabelId( "mylabel" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "mylabel" );
+        statement.nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.success();
         tx.finish();
@@ -314,7 +314,7 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        boolean added = statement.addLabelToNode( labelId, node.getId() );
+        boolean added = statement.nodeAddLabel( node.getId(), labelId );
 
         // THEN
         assertFalse( "Shouldn't have been added now", added );
@@ -328,7 +328,7 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         Node node = db.createNode();
         StatementContext statement = statementContextProvider.getCtxForWriting();
-        long labelId = statement.getOrCreateLabelId( "mylabel" );
+        long labelId = statement.labelGetOrCreateForName( "mylabel" );
         statement.close();
         tx.success();
         tx.finish();
@@ -336,7 +336,7 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        boolean added = statement.addLabelToNode( labelId, node.getId() );
+        boolean added = statement.nodeAddLabel( node.getId(), labelId );
 
         // THEN
         assertTrue( "Should have been added now", added );
@@ -350,8 +350,8 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         Node node = db.createNode();
         StatementContext statement = statementContextProvider.getCtxForWriting();
-        long labelId = statement.getOrCreateLabelId( "mylabel" );
-        statement.addLabelToNode( labelId, node.getId() );
+        long labelId = statement.labelGetOrCreateForName( "mylabel" );
+        statement.nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.success();
         tx.finish();
@@ -359,7 +359,7 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        boolean removed = statement.removeLabelFromNode( labelId, node.getId() );
+        boolean removed = statement.nodeRemoveLabel( node.getId(), labelId );
 
         // THEN
         assertTrue( "Should have been removed now", removed );
@@ -373,7 +373,7 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx = db.beginTx();
         Node node = db.createNode();
         StatementContext statement = statementContextProvider.getCtxForWriting();
-        long labelId = statement.getOrCreateLabelId( "mylabel" );
+        long labelId = statement.labelGetOrCreateForName( "mylabel" );
         statement.close();
         tx.success();
         tx.finish();
@@ -381,7 +381,7 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        boolean removed = statement.removeLabelFromNode( labelId, node.getId() );
+        boolean removed = statement.nodeRemoveLabel( node.getId(), labelId );
 
         // THEN
         assertFalse( "Shouldn't have been removed now", removed );
@@ -402,13 +402,13 @@ public class KernelIT extends KernelIntegrationTest
         StatementContext statement = statementContextProvider.getCtxForWriting();
 
         // WHEN
-        statement.deleteNode( node.getId() );
+        statement.nodeDelete( node.getId() );
 
         // Then
-        long labelId = statement.getLabelId( label.name() );
-        Set<Long> labels = asSet( statement.getLabelsForNode( node.getId() ) );
-        boolean labelIsSet = statement.isLabelSetOnNode( labelId, node.getId() );
-        Set<Long> nodes = asSet( statement.getNodesWithLabel( labelId ) );
+        long labelId = statement.labelGetForName( label.name() );
+        Set<Long> labels = asSet( statement.nodeGetLabels( node.getId() ) );
+        boolean labelIsSet = statement.nodeHasLabel( node.getId(), labelId );
+        Set<Long> nodes = asSet( statement.nodesGetForLabel( labelId ) );
 
         statement.close();
 
@@ -439,8 +439,8 @@ public class KernelIT extends KernelIntegrationTest
         // WHEN
         tx = db.beginTx();
         StatementContext statement = statementContextProvider.getCtxForWriting();
-        long labelId = statement.getLabelId( label.name() );
-        Iterator<Long> nodes = statement.getNodesWithLabel( labelId );
+        long labelId = statement.labelGetForName( label.name() );
+        Iterator<Long> nodes = statement.nodesGetForLabel( labelId );
         Set<Long> nodeSet = asSet( nodes );
         tx.success();
         tx.finish();
@@ -485,7 +485,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         newTransaction();
-        statement.dropIndex( idx );
+        statement.indexDrop( idx );
         commit();
 
         // THEN
@@ -494,8 +494,8 @@ public class KernelIT extends KernelIntegrationTest
 
     private IndexDescriptor createIndex( ) throws DataIntegrityKernelException
     {
-        return statement.addIndex( statement.getOrCreateLabelId( "hello" ),
-                                   statement.getOrCreatePropertyKeyId( "hepp" ) );
+        return statement.indexCreate( statement.labelGetOrCreateForName( "hello" ),
+                                      statement.propertyKeyGetOrCreateForName( "hepp" ) );
     }
 
     private String getOrCreateSchemaState( String key, final String maybeSetThisState )
@@ -503,13 +503,14 @@ public class KernelIT extends KernelIntegrationTest
         Transaction tx;StatementContext statement;
         tx = db.beginTx();
         statement = statementContextProvider.getCtxForWriting();
-        String state = statement.getOrCreateFromSchemaState( key, new Function<String, String>(){
+        String state = statement.schemaStateGetOrCreate( key, new Function<String, String>()
+        {
             @Override
             public String apply( String s )
             {
                 return maybeSetThisState;
             }
-        });
+        } );
         tx.success();
         tx.finish();
         return state;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -22,11 +22,11 @@ package org.neo4j.kernel.impl.api.integrationtest;
 import java.util.Iterator;
 
 import org.junit.Test;
+
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.core.Token;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
 
 public class LabelIT extends KernelIntegrationTest
@@ -36,11 +36,11 @@ public class LabelIT extends KernelIntegrationTest
     {
         // given
         newTransaction();
-        long label1Id = statement.getOrCreateLabelId( "label1" );
-        long label2Id = statement.getOrCreateLabelId( "label2" );
+        long label1Id = statement.labelGetOrCreateForName( "label1" );
+        long label2Id = statement.labelGetOrCreateForName( "label2" );
 
         // when
-        Iterator<Token> labelIdsBeforeCommit = statement.listLabels();
+        Iterator<Token> labelIdsBeforeCommit = statement.labelsGetAllTokens();
 
         // then
         assertEquals( asList( new Token( "label1", (int) label1Id ), new Token( "label2", (int) label2Id ) ),
@@ -49,7 +49,7 @@ public class LabelIT extends KernelIntegrationTest
         // when
         commit();
         newTransaction();
-        Iterator<Token> labelIdsAfterCommit = statement.listLabels();
+        Iterator<Token> labelIdsAfterCommit = statement.labelsGetAllTokens();
 
         // then
         assertEquals( asList( new Token( "label1", (int) label1Id ), new Token( "label2", (int) label2Id ) ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -19,16 +19,20 @@
  */
 package org.neo4j.kernel.impl.api.integrationtest;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-
 import java.util.Collections;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 public class PropertyIT extends KernelIntegrationTest
 {
@@ -40,19 +44,19 @@ public class PropertyIT extends KernelIntegrationTest
         Node node = db.createNode();
 
         // WHEN
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         statement.nodeSetPropertyValue( nodeId, propertyId, "bozo" );
 
         // THEN
-        assertEquals( "bozo", statement.getNodePropertyValue( nodeId, propertyId ) );
+        assertEquals( "bozo", statement.nodeGetPropertyValue( nodeId, propertyId ) );
 
         // WHEN
         commit();
         newTransaction();
 
         // THEN
-        assertEquals( "bozo", statement.getNodePropertyValue( nodeId, propertyId ) );
+        assertEquals( "bozo", statement.nodeGetPropertyValue( nodeId, propertyId ) );
     }
 
     @Test
@@ -61,7 +65,7 @@ public class PropertyIT extends KernelIntegrationTest
         // GIVEN
         newTransaction();
         Node node = db.createNode();
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         statement.nodeSetPropertyValue( nodeId, propertyId, "bozo" );
 
@@ -85,7 +89,7 @@ public class PropertyIT extends KernelIntegrationTest
         // GIVEN
         newTransaction();
         Node node = db.createNode();
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         statement.nodeSetPropertyValue( nodeId, propertyId, "bozo" );
         commit();
@@ -112,7 +116,7 @@ public class PropertyIT extends KernelIntegrationTest
         // GIVEN
         newTransaction();
         Node node = db.createNode();
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         commit();
         newTransaction();
@@ -132,7 +136,7 @@ public class PropertyIT extends KernelIntegrationTest
         Node node = db.createNode();
 
         // WHEN
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         statement.nodeSetPropertyValue( nodeId, propertyId, "bozo" );
 
@@ -155,7 +159,7 @@ public class PropertyIT extends KernelIntegrationTest
         Node node = db.createNode();
 
         // WHEN
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
 
         // THEN
@@ -175,7 +179,7 @@ public class PropertyIT extends KernelIntegrationTest
         // GIVEN
         newTransaction();
         Node node = db.createNode();
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         commit();
 
@@ -195,7 +199,7 @@ public class PropertyIT extends KernelIntegrationTest
         // GIVEN
         newTransaction();
         Node node = db.createNode();
-        long propertyId = statement.getOrCreatePropertyKeyId( "clown" );
+        long propertyId = statement.propertyKeyGetOrCreateForName( "clown" );
         long nodeId = node.getId();
         statement.nodeSetPropertyValue( nodeId, propertyId, "bozo" );
         commit();
@@ -207,7 +211,7 @@ public class PropertyIT extends KernelIntegrationTest
 
         // THEN
         newTransaction();
-        assertEquals( 42, statement.getNodePropertyValue( nodeId, propertyId ) );
+        assertEquals( 42, statement.nodeGetPropertyValue( nodeId, propertyId ) );
     }
 
     @Test
@@ -219,16 +223,16 @@ public class PropertyIT extends KernelIntegrationTest
         node.setProperty( "prop", "value" );
 
         // THEN
-        assertThat( asSet( statement.listNodePropertyKeys( node.getId() ) ),
-                equalTo( asSet( statement.getPropertyKeyId( "prop" ) ) ) );
+        assertThat( asSet( statement.nodeGetPropertyKeys( node.getId() ) ),
+                equalTo( asSet( statement.propertyKeyGetForName( "prop" ) ) ) );
 
         // WHEN
         commit();
 
         // THEN
         newTransaction();
-        assertThat( asSet( statement.listNodePropertyKeys( node.getId() ) ),
-                equalTo( asSet( statement.getPropertyKeyId( "prop" ) ) ) );
+        assertThat( asSet( statement.nodeGetPropertyKeys( node.getId() ) ),
+                equalTo( asSet( statement.propertyKeyGetForName( "prop" ) ) ) );
         commit();
 
         // WHEN
@@ -236,7 +240,7 @@ public class PropertyIT extends KernelIntegrationTest
         node.removeProperty( "prop" );
 
         // THEN
-        assertThat( asSet( statement.listNodePropertyKeys( node.getId() ) ),
+        assertThat( asSet( statement.nodeGetPropertyKeys( node.getId() ) ),
                 equalTo( Collections.<Long>emptySet() ) );
 
         // WHEN
@@ -244,7 +248,7 @@ public class PropertyIT extends KernelIntegrationTest
 
         // THEN
         newTransaction();
-        assertThat( asSet( statement.listNodePropertyKeys( node.getId() ) ),
+        assertThat( asSet( statement.nodeGetPropertyKeys( node.getId() ) ),
                 equalTo( Collections.<Long>emptySet() ) );
         commit();
     }
@@ -258,16 +262,16 @@ public class PropertyIT extends KernelIntegrationTest
         rel.setProperty( "prop", "value" );
 
         // THEN
-        assertThat( asSet( statement.listRelationshipPropertyKeys( rel.getId() ) ),
-                equalTo( asSet( statement.getPropertyKeyId( "prop" ) ) ) );
+        assertThat( asSet( statement.relationshipGetPropertyKeys( rel.getId() ) ),
+                equalTo( asSet( statement.propertyKeyGetForName( "prop" ) ) ) );
 
         // WHEN
         commit();
 
         // THEN
         newTransaction();
-        assertThat( asSet( statement.listRelationshipPropertyKeys( rel.getId() ) ),
-                equalTo( asSet( statement.getPropertyKeyId( "prop" ) ) ) );
+        assertThat( asSet( statement.relationshipGetPropertyKeys( rel.getId() ) ),
+                equalTo( asSet( statement.propertyKeyGetForName( "prop" ) ) ) );
         commit();
 
         // WHEN
@@ -275,7 +279,7 @@ public class PropertyIT extends KernelIntegrationTest
         rel.removeProperty( "prop" );
 
         // THEN
-        assertThat( asSet( statement.listRelationshipPropertyKeys( rel.getId() ) ),
+        assertThat( asSet( statement.relationshipGetPropertyKeys( rel.getId() ) ),
                 equalTo( Collections.<Long>emptySet() ) );
 
         // WHEN
@@ -283,7 +287,7 @@ public class PropertyIT extends KernelIntegrationTest
 
         // THEN
         newTransaction();
-        assertThat( asSet( statement.listRelationshipPropertyKeys( rel.getId() ) ),
+        assertThat( asSet( statement.relationshipGetPropertyKeys( rel.getId() ) ),
                 equalTo( Collections.<Long>emptySet() ) );
         commit();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintEvaluationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintEvaluationIT.java
@@ -19,20 +19,13 @@
  */
 package org.neo4j.kernel.impl.api.integrationtest;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.neo4j.graphdb.DynamicLabel.label;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
@@ -41,6 +34,14 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.impl.api.ConstraintCreationKernelException;
 import org.neo4j.kernel.impl.api.constraints.ConstraintVerificationFailedKernelException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 public class UniquenessConstraintEvaluationIT extends KernelIntegrationTest
 {
@@ -56,8 +57,8 @@ public class UniquenessConstraintEvaluationIT extends KernelIntegrationTest
         node = db.createNode( label( "Foo" ) );
         long node2 = node.getId();
         node.setProperty( "name", "foo" );
-        long foo = statement.getLabelId( "Foo" );
-        long name = statement.getPropertyKeyId( "name" );
+        long foo = statement.labelGetForName( "Foo" );
+        long name = statement.propertyKeyGetForName( "name" );
         commit();
 
         newTransaction();
@@ -65,7 +66,7 @@ public class UniquenessConstraintEvaluationIT extends KernelIntegrationTest
         // when
         try
         {
-            statement.addUniquenessConstraint( foo, name );
+            statement.uniquenessConstraintCreate( foo, name );
 
             fail( "expected exception" );
         }
@@ -90,12 +91,12 @@ public class UniquenessConstraintEvaluationIT extends KernelIntegrationTest
         Node node = db.createNode( label( "Foo" ) );
         long node1 = node.getId();
         node.setProperty( "name", "foo" );
-        long foo = statement.getLabelId( "Foo" );
-        long name = statement.getPropertyKeyId( "name" );
+        long foo = statement.labelGetForName( "Foo" );
+        long name = statement.propertyKeyGetForName( "name" );
         commit();
 
         newTransaction();
-        statement.addUniquenessConstraint( foo, name );
+        statement.uniquenessConstraintCreate( foo, name );
         ExecutorService executor = Executors.newSingleThreadExecutor();
         long node2 = executor.submit( new Callable<Long>()
         {
@@ -148,11 +149,11 @@ public class UniquenessConstraintEvaluationIT extends KernelIntegrationTest
         // given
         newTransaction();
         db.createNode( label( "Foo" ) ).setProperty( "name", "foo" );
-        long foo = statement.getLabelId( "Foo" );
-        long name = statement.getPropertyKeyId( "name" );
+        long foo = statement.labelGetForName( "Foo" );
+        long name = statement.propertyKeyGetForName( "name" );
         commit();
         newTransaction();
-        statement.addUniquenessConstraint( foo, name );
+        statement.uniquenessConstraintCreate( foo, name );
         commit();
 
         newTransaction();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -55,13 +55,13 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 1l, 2l, 3l ) ) );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 1l, 2l, 3l ) ) );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn( new DiffSets<Long>() );
 
-        txContext.deleteNode( 2l );
+        txContext.nodeDelete( 2l );
 
         // When
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 1l, 3l ) ) );
@@ -76,14 +76,14 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
 
-        when( store.isLabelSetOnNode( labelId, 1l ) ).thenReturn( false );
+        when( store.nodeHasLabel( 1l, labelId ) ).thenReturn( false );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn(
                 new DiffSets<Long>( asSet( 1l ), Collections.<Long>emptySet() ) );
 
         // When
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 2l, 3l ) ) );
@@ -98,15 +98,15 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
 
-        when( store.isLabelSetOnNode( labelId, 1l ) ).thenReturn( false );
+        when( store.nodeHasLabel( 1l, labelId ) ).thenReturn( false );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn(
                 new DiffSets<Long>( asSet( 1l ), Collections.<Long>emptySet() ) );
 
         // When
-        txContext.addLabelToNode( labelId, 1l );
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        txContext.nodeAddLabel( 1l, labelId );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 1l, 2l, 3l ) ) );
@@ -122,15 +122,15 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
 
-        when( store.isLabelSetOnNode( labelId, 1l ) ).thenReturn( false );
-        when( store.getNodePropertyValue( 1l, propertyKeyId ) ).thenReturn( value );
+        when( store.nodeHasLabel( 1l, labelId ) ).thenReturn( false );
+        when( store.nodeGetPropertyValue( 1l, propertyKeyId ) ).thenReturn( value );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn( new DiffSets<Long>() );
 
         // When
-        txContext.addLabelToNode( labelId, 1l );
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        txContext.nodeAddLabel( 1l, labelId );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 1l, 2l, 3l ) ) );
@@ -146,15 +146,15 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 1l, 2l, 3l ) ) );
-        when( store.isLabelSetOnNode( labelId, 1l ) ).thenReturn( true );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 1l, 2l, 3l ) ) );
+        when( store.nodeHasLabel( 1l, labelId ) ).thenReturn( true );
 
-        when( store.getNodePropertyValue( 1l, propertyKeyId ) ).thenReturn( value );
+        when( store.nodeGetPropertyValue( 1l, propertyKeyId ) ).thenReturn( value );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn( new DiffSets<Long>() );
 
         // When
-        txContext.removeLabelFromNode( labelId, 1l );
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        txContext.nodeRemoveLabel( 1l, labelId );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 2l, 3l ) ) );
@@ -170,15 +170,15 @@ public class IndexQueryTransactionStateTest
         String value = "My Value";
 
         IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
-        when( store.exactIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
+        when( store.nodesGetFromIndexLookup( indexDescriptor, value ) ).then( asAnswer( asList( 2l, 3l ) ) );
 
-        when( store.isLabelSetOnNode( labelId, 1l ) ).thenReturn( true );
+        when( store.nodeHasLabel( 1l, labelId ) ).thenReturn( true );
         when( oldTxState.getNodesWithChangedProperty( propertyKeyId, value ) ).thenReturn(
                 new DiffSets<Long>( Collections.<Long>emptySet(), asSet( 1l ) ) );
 
         // When
-        txContext.addLabelToNode( labelId, 1l );
-        Iterator<Long> result = txContext.exactIndexLookup( indexDescriptor, value );
+        txContext.nodeAddLabel( 1l, labelId );
+        Iterator<Long> result = txContext.nodesGetFromIndexLookup( indexDescriptor, value );
 
         // Then
         assertThat( asSet( result ), equalTo( asSet( 2l, 3l ) ) );
@@ -195,10 +195,10 @@ public class IndexQueryTransactionStateTest
     {
         long labelId1 = 10, labelId2 = 12;
         store = mock( StatementContext.class );
-        when( store.getIndexes( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.addIndex( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
+        when( store.indexesGetForLabel( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetForLabel( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetAll() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexCreate( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
         {
             @Override
             public IndexDescriptor answer( InvocationOnMock invocation ) throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -58,7 +58,7 @@ public class LabelTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        txContext.addLabelToNode( labelId1, nodeId );
+        txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -71,7 +71,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        txContext.addLabelToNode( labelId2, nodeId );
+        txContext.nodeAddLabel( nodeId, labelId2 );
 
         // THEN
         assertLabels( labelId1, labelId2 );
@@ -84,7 +84,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        txContext.addLabelToNode( labelId1, nodeId );
+        txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -97,7 +97,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1, labelId2 );
 
         // WHEN
-        txContext.removeLabelFromNode( labelId1, nodeId );
+        txContext.nodeRemoveLabel( nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId2 );
@@ -110,8 +110,8 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        txContext.addLabelToNode( labelId2, nodeId );
-        txContext.removeLabelFromNode( labelId2, nodeId );
+        txContext.nodeAddLabel( nodeId, labelId2 );
+        txContext.nodeRemoveLabel( nodeId, labelId2 );
 
         // THEN
         assertLabels( labelId1 );
@@ -124,8 +124,8 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        txContext.removeLabelFromNode( labelId1, nodeId );
-        txContext.addLabelToNode( labelId1, nodeId );
+        txContext.nodeRemoveLabel( nodeId, labelId1 );
+        txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -141,10 +141,10 @@ public class LabelTransactionStateTest
                 labels( 2, 1L, 3L ) );
 
         // WHEN
-        txContext.addLabelToNode( 2, 2 );
+        txContext.nodeAddLabel( 2, 2 );
 
         // THEN
-        assertEquals( asSet( 0L, 1L, 2L ), asSet( txContext.getNodesWithLabel( 2 ) ) );
+        assertEquals( asSet( 0L, 1L, 2L ), asSet( txContext.nodesGetForLabel( 2 ) ) );
     }
 
     @Test
@@ -157,10 +157,10 @@ public class LabelTransactionStateTest
                 labels( 2, 1L, 3L ) );
 
         // WHEN
-        txContext.removeLabelFromNode( 2, 1 );
+        txContext.nodeRemoveLabel( 1, 2 );
 
         // THEN
-        assertEquals( asSet( 0L ), asSet( txContext.getNodesWithLabel( 2 ) ) );
+        assertEquals( asSet( 0L ), asSet( txContext.nodesGetForLabel( 2 ) ) );
     }
 
     @Test
@@ -168,11 +168,11 @@ public class LabelTransactionStateTest
     {
         // GIVEN
         commitNoLabels();
-        when( store.addLabelToNode( labelId1, nodeId ) ).thenReturn( true );
+        when( store.nodeAddLabel( nodeId, labelId1 ) ).thenReturn( true );
 
 
         // WHEN
-        boolean added = txContext.addLabelToNode( labelId1, nodeId );
+        boolean added = txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertTrue( "Should have been added now", added );
@@ -185,7 +185,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        boolean added = txContext.addLabelToNode( labelId1, nodeId );
+        boolean added = txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertFalse( "Shouldn't have been added now", added );
@@ -198,7 +198,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        boolean removed = txContext.removeLabelFromNode( labelId1, nodeId );
+        boolean removed = txContext.nodeRemoveLabel( nodeId, labelId1 );
 
         // THEN
         assertTrue( "Should have been removed now", removed );
@@ -211,7 +211,7 @@ public class LabelTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        txContext.addLabelToNode( labelId1, nodeId );
+        txContext.nodeAddLabel( nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -221,40 +221,40 @@ public class LabelTransactionStateTest
     public void should_return_true_when_adding_new_label() throws Exception
     {
         // GIVEN
-        when( store.isLabelSetOnNode( 12, 1337 ) ).thenReturn( false );
+        when( store.nodeHasLabel( 1337, 12 ) ).thenReturn( false );
 
         // WHEN and THEN
-        assertTrue( "Label should have been added", txContext.addLabelToNode( 12, 1337 ) );
+        assertTrue( "Label should have been added", txContext.nodeAddLabel( 1337, 12 ) );
     }
 
     @Test
     public void should_return_false_when_adding_existing_label() throws Exception
     {
         // GIVEN
-        when( store.isLabelSetOnNode( 12, 1337 ) ).thenReturn( true );
+        when( store.nodeHasLabel( 1337, 12 ) ).thenReturn( true );
 
         // WHEN and THEN
-        assertFalse( "Label should have been added", txContext.addLabelToNode( 12, 1337 ) );
+        assertFalse( "Label should have been added", txContext.nodeAddLabel( 1337, 12 ) );
     }
 
     @Test
     public void should_return_true_when_removing_existing_label() throws Exception
     {
         // GIVEN
-        when( store.isLabelSetOnNode( 12, 1337 ) ).thenReturn( true );
+        when( store.nodeHasLabel( 1337, 12 ) ).thenReturn( true );
 
         // WHEN and THEN
-        assertTrue( "Label should have been removed", txContext.removeLabelFromNode( 12, 1337 ) );
+        assertTrue( "Label should have been removed", txContext.nodeRemoveLabel( 1337, 12 ) );
     }
 
     @Test
     public void should_return_true_when_removing_non_existant_label() throws Exception
     {
         // GIVEN
-        when( store.isLabelSetOnNode( 12, 1337 ) ).thenReturn( false );
+        when( store.nodeHasLabel( 1337, 12 ) ).thenReturn( false );
 
         // WHEN and THEN
-        assertFalse( "Label should have been removed", txContext.removeLabelFromNode( 12, 1337 ) );
+        assertFalse( "Label should have been removed", txContext.nodeRemoveLabel( 1337, 12 ) );
     }
 
     // exists
@@ -270,10 +270,10 @@ public class LabelTransactionStateTest
     public void before() throws Exception
     {
         store = mock( StatementContext.class );
-        when( store.getIndexes( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.addIndex( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
+        when( store.indexesGetForLabel( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetForLabel( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetAll() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexCreate( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
         {
             @Override
             public IndexDescriptor answer( InvocationOnMock invocation ) throws Throwable
@@ -327,13 +327,13 @@ public class LabelTransactionStateTest
         Map<Long, Collection<Long>> allLabels = new HashMap<Long, Collection<Long>>();
         for ( Labels nodeLabels : labels )
         {
-            when( store.getLabelsForNode( nodeLabels.nodeId ) ).then( asAnswer( Arrays.<Long>asList( nodeLabels
+            when( store.nodeGetLabels( nodeLabels.nodeId ) ).then( asAnswer( Arrays.<Long>asList( nodeLabels
                     .labelIds ) ) );
             for ( long label : nodeLabels.labelIds )
             {
-                when( store.isLabelSetOnNode( label, nodeLabels.nodeId ) ).thenReturn( true );
-                when( store.removeLabelFromNode( label, nodeLabels.nodeId ) ).thenReturn( true );
-                when( store.addLabelToNode( label, nodeLabels.nodeId ) ).thenReturn( false );
+                when( store.nodeHasLabel( nodeLabels.nodeId, label ) ).thenReturn( true );
+                when( store.nodeRemoveLabel( nodeLabels.nodeId, label ) ).thenReturn( true );
+                when( store.nodeAddLabel( nodeLabels.nodeId, label ) ).thenReturn( false );
 
                 Collection<Long> nodes = allLabels.get( label );
                 if ( nodes == null )
@@ -347,7 +347,7 @@ public class LabelTransactionStateTest
 
         for ( Map.Entry<Long, Collection<Long>> entry : allLabels.entrySet() )
         {
-            when( store.getNodesWithLabel( entry.getKey() ) ).then( asAnswer( entry.getValue() ) );
+            when( store.nodesGetForLabel( entry.getKey() ) ).then( asAnswer( entry.getValue() ) );
         }
     }
 
@@ -363,10 +363,10 @@ public class LabelTransactionStateTest
 
     private void assertLabels( Long... labels ) throws EntityNotFoundException
     {
-        assertEquals( asSet( labels ), asSet( txContext.getLabelsForNode( nodeId ) ) );
+        assertEquals( asSet( labels ), asSet( txContext.nodeGetLabels( nodeId ) ) );
         for ( long label : labels )
         {
-            assertTrue( "Expected labels not found on node", txContext.isLabelSetOnNode( label, nodeId ) );
+            assertTrue( "Expected labels not found on node", txContext.nodeHasLabel( nodeId, label ) );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -64,14 +64,14 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule = txContext.addIndex( labelId1, key1 );
+        IndexDescriptor rule = txContext.indexCreate( labelId1, key1 );
 
         // THEN
-        assertEquals( asSet( rule ), IteratorUtil.asSet( txContext.getIndexes( labelId1 ) ) );
-        verify( store ).getIndexes( labelId1 );
+        assertEquals( asSet( rule ), IteratorUtil.asSet( txContext.indexesGetForLabel( labelId1 ) ) );
+        verify( store ).indexesGetForLabel( labelId1 );
 
-        assertEquals( asSet( rule ), IteratorUtil.asSet( txContext.getIndexes() ) );
-        verify( store ).getIndexes();
+        assertEquals( asSet( rule ), IteratorUtil.asSet( txContext.indexesGetAll() ) );
+        verify( store ).indexesGetAll();
 
         verifyNoMoreInteractions( store );
     }
@@ -83,18 +83,18 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule1 = txContext.addIndex( labelId1, key1 );
-        IndexDescriptor rule2 = txContext.addIndex( labelId2, key2 );
+        IndexDescriptor rule1 = txContext.indexCreate( labelId1, key1 );
+        IndexDescriptor rule2 = txContext.indexCreate( labelId2, key2 );
 
         // THEN
-        assertEquals( asSet( rule1 ), IteratorUtil.asSet( txContext.getIndexes( labelId1 ) ) );
-        verify( store ).getIndexes( labelId1 );
+        assertEquals( asSet( rule1 ), IteratorUtil.asSet( txContext.indexesGetForLabel( labelId1 ) ) );
+        verify( store ).indexesGetForLabel( labelId1 );
 
-        assertEquals( asSet( rule2 ), IteratorUtil.asSet( txContext.getIndexes( labelId2 ) ) );
-        verify( store ).getIndexes( labelId2 );
+        assertEquals( asSet( rule2 ), IteratorUtil.asSet( txContext.indexesGetForLabel( labelId2 ) ) );
+        verify( store ).indexesGetForLabel( labelId2 );
 
-        assertEquals( asSet( rule1, rule2 ), IteratorUtil.asSet( txContext.getIndexes() ) );
-        verify( store ).getIndexes();
+        assertEquals( asSet( rule1, rule2 ), IteratorUtil.asSet( txContext.indexesGetAll() ) );
+        verify( store ).indexesGetAll();
 
         verifyNoMoreInteractions( store );
     }
@@ -106,11 +106,11 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule1 = txContext.addIndex( labelId1, key1 );
-        IndexDescriptor rule2 = txContext.addIndex( labelId1, key2 );
+        IndexDescriptor rule1 = txContext.indexCreate( labelId1, key1 );
+        IndexDescriptor rule2 = txContext.indexCreate( labelId1, key2 );
 
         // THEN
-        assertEquals( asSet( rule1, rule2 ), IteratorUtil.asSet( txContext.getIndexes( labelId1 ) ) );
+        assertEquals( asSet( rule1, rule2 ), IteratorUtil.asSet( txContext.indexesGetForLabel( labelId1 ) ) );
     }
 
     @Test
@@ -118,10 +118,10 @@ public class SchemaTransactionStateTest
     {
         // GIVEN
         commitLabels( labelId1 );
-        IndexDescriptor rule = txContext.addIndex( labelId1, key1 );
+        IndexDescriptor rule = txContext.indexCreate( labelId1, key1 );
 
         // THEN
-        assertEquals( InternalIndexState.POPULATING, txContext.getIndexState( rule ) );
+        assertEquals( InternalIndexState.POPULATING, txContext.indexGetState( rule ) );
     }
 
     @Test
@@ -129,11 +129,11 @@ public class SchemaTransactionStateTest
     {
         // GIVEN
         // -- non-existent rule added in the transaction
-        txContext.addIndex( labelId1, key1 );
+        txContext.indexCreate( labelId1, key1 );
 
         // WHEN
-        IndexDescriptor rule = txContext.getIndex( labelId1, key1 );
-        Iterator<IndexDescriptor> labelRules = txContext.getIndexes( labelId1 );
+        IndexDescriptor rule = txContext.indexesGetForLabelAndPropertyKey( labelId1, key1 );
+        Iterator<IndexDescriptor> labelRules = txContext.indexesGetForLabel( labelId1 );
 
         // THEN
         IndexDescriptor expectedRule = new IndexDescriptor( labelId1, key1 );
@@ -147,13 +147,13 @@ public class SchemaTransactionStateTest
         // GIVEN
         // -- a rule that exists in the store
         IndexDescriptor rule = new IndexDescriptor( labelId1, key1 );
-        when( store.getIndexes( labelId1 ) ).thenReturn( option( rule ).iterator() );
+        when( store.indexesGetForLabel( labelId1 ) ).thenReturn( option( rule ).iterator() );
         // -- that same rule dropped in the transaction
-        txContext.dropIndex( rule );
+        txContext.indexDrop( rule );
 
         // WHEN
         assertException( getIndexRule(), SchemaRuleNotFoundException.class );
-        Iterator<IndexDescriptor> rulesByLabel = txContext.getIndexes( labelId1 );
+        Iterator<IndexDescriptor> rulesByLabel = txContext.indexesGetForLabel( labelId1 );
 
         // THEN
         assertEquals( emptySetOf( IndexDescriptor.class ), asSet( rulesByLabel ) );
@@ -166,7 +166,7 @@ public class SchemaTransactionStateTest
             @Override
             public void call() throws SchemaRuleNotFoundException
             {
-                txContext.getIndex( labelId1, key1 );
+                txContext.indexesGetForLabelAndPropertyKey( labelId1, key1 );
             }
         };
     }
@@ -207,10 +207,10 @@ public class SchemaTransactionStateTest
     public void before() throws Exception
     {
         store = mock( StatementContext.class );
-        when( store.getIndexes( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.getIndexes() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.addIndex( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
+        when( store.indexesGetForLabel( labelId1 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetForLabel( labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexesGetAll() ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
+        when( store.indexCreate( anyLong(), anyLong() ) ).thenAnswer( new Answer<IndexDescriptor>()
         {
             @Override
             public IndexDescriptor answer( InvocationOnMock invocation ) throws Throwable
@@ -263,13 +263,13 @@ public class SchemaTransactionStateTest
         Map<Long, Collection<Long>> allLabels = new HashMap<Long, Collection<Long>>();
         for ( Labels nodeLabels : labels )
         {
-            when( store.getLabelsForNode( nodeLabels.nodeId ) ).then( asAnswer( Arrays.<Long>asList( nodeLabels
+            when( store.nodeGetLabels( nodeLabels.nodeId ) ).then( asAnswer( Arrays.<Long>asList( nodeLabels
                     .labelIds ) ) );
             for ( long label : nodeLabels.labelIds )
             {
-                when( store.isLabelSetOnNode( label, nodeLabels.nodeId ) ).thenReturn( true );
-                when( store.removeLabelFromNode( label, nodeLabels.nodeId ) ).thenReturn( true );
-                when( store.addLabelToNode( label, nodeLabels.nodeId ) ).thenReturn( false );
+                when( store.nodeHasLabel( nodeLabels.nodeId, label ) ).thenReturn( true );
+                when( store.nodeRemoveLabel( nodeLabels.nodeId, label ) ).thenReturn( true );
+                when( store.nodeAddLabel( nodeLabels.nodeId, label ) ).thenReturn( false );
 
                 Collection<Long> nodes = allLabels.get( label );
                 if ( nodes == null )
@@ -283,7 +283,7 @@ public class SchemaTransactionStateTest
 
         for ( Map.Entry<Long, Collection<Long>> entry : allLabels.entrySet() )
         {
-            when( store.getNodesWithLabel( entry.getKey() ) ).then( asAnswer( entry.getValue() ) );
+            when( store.nodesGetForLabel( entry.getKey() ) ).then( asAnswer( entry.getValue() ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementContextTest.java
@@ -67,7 +67,7 @@ public class StateHandlingStatementContextTest
             }
 
             @Override
-            public boolean isLabelSetOnNode( long labelId, long nodeId )
+            public boolean nodeHasLabel( long nodeId, long labelId )
             {
                 return false;
             }
@@ -77,10 +77,10 @@ public class StateHandlingStatementContextTest
                 mock( SchemaStateOperations.class ), mock( TxState.class ), mock( ConstraintIndexCreator.class ) );
 
         // When
-        ctx.addIndex( 0l, 0l );
-        ctx.addLabelToNode( 0l, 0l );
-        ctx.dropIndex( new IndexDescriptor( 0l, 0l ) );
-        ctx.removeLabelFromNode( 0l, 0l );
+        ctx.indexCreate( 0l, 0l );
+        ctx.nodeAddLabel( 0l, 0l );
+        ctx.indexDrop( new IndexDescriptor( 0l, 0l ) );
+        ctx.nodeRemoveLabel( 0l, 0l );
 
         // These are kind of in between.. property key ids are created in
         // micro-transactions, so these methods
@@ -98,13 +98,13 @@ public class StateHandlingStatementContextTest
         // given
         UniquenessConstraint constraint = new UniquenessConstraint( 10, 66 );
         StatementContext delegate = mock( StatementContext.class );
-        when( delegate.getConstraints( 10, 66 ) ).thenAnswer( asAnswer( asList( constraint ) ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 10, 66 ) ).thenAnswer( asAnswer( asList( constraint ) ) );
         TxState state = mock( TxState.class );
         StateHandlingStatementContext context = new StateHandlingStatementContext( delegate,
                 mock( SchemaStateOperations.class ), state, mock( ConstraintIndexCreator.class ) );
 
         // when
-        context.addUniquenessConstraint( 10, 66 );
+        context.uniquenessConstraintCreate( 10, 66 );
 
         // then
         verify( state ).unRemoveConstraint( any( UniquenessConstraint.class ) );
@@ -118,15 +118,15 @@ public class StateHandlingStatementContextTest
         UniquenessConstraint constraint = new UniquenessConstraint( 10, 66 );
 
         StatementContext delegate = mock( StatementContext.class );
-        when( delegate.getConstraints( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
         TxState state = new TxState( mock( OldTxStateBridge.class ), mock( PersistenceManager.class ),
                 mock( IdGeneration.class ) );
         StateHandlingStatementContext context = new StateHandlingStatementContext( delegate,
                 mock( SchemaStateOperations.class ), state, mock( ConstraintIndexCreator.class ) );
-        context.addUniquenessConstraint( 10, 66 );
+        context.uniquenessConstraintCreate( 10, 66 );
 
         // when
-        Set<UniquenessConstraint> result = asSet( asIterable( context.getConstraints( 10, 66 ) ) );
+        Set<UniquenessConstraint> result = asSet( asIterable( context.constraintsGetForLabelAndPropertyKey( 10, 66 ) ) );
 
         // then
         assertEquals( asSet( constraint ), result );
@@ -140,19 +140,19 @@ public class StateHandlingStatementContextTest
         UniquenessConstraint constraint2 = new UniquenessConstraint( 11, 99 );
 
         StatementContext delegate = mock( StatementContext.class );
-        when( delegate.getConstraints( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
-        when( delegate.getConstraints( 11, 99 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
-        when( delegate.getConstraints( 10 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
-        when( delegate.getConstraints( 11 ) ).thenAnswer( asAnswer( asIterable( constraint1 ) ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 11, 99 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetForLabel( 10 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetForLabel( 11 ) ).thenAnswer( asAnswer( asIterable( constraint1 ) ) );
         TxState state = new TxState( mock( OldTxStateBridge.class ), mock( PersistenceManager.class ),
                 mock( IdGeneration.class ) );
         StateHandlingStatementContext context = new StateHandlingStatementContext( delegate,
                 mock( SchemaStateOperations.class ), state, mock( ConstraintIndexCreator.class ) );
-        context.addUniquenessConstraint( 10, 66 );
-        context.addUniquenessConstraint( 11, 99 );
+        context.uniquenessConstraintCreate( 10, 66 );
+        context.uniquenessConstraintCreate( 11, 99 );
 
         // when
-        Set<UniquenessConstraint> result = asSet( asIterable( context.getConstraints( 11 ) ) );
+        Set<UniquenessConstraint> result = asSet( asIterable( context.constraintsGetForLabel( 11 ) ) );
 
         // then
         assertEquals( asSet( constraint1, constraint2 ), result );
@@ -167,17 +167,17 @@ public class StateHandlingStatementContextTest
         UniquenessConstraint constraint2 = new UniquenessConstraint( 11, 99 );
 
         StatementContext delegate = mock( StatementContext.class );
-        when( delegate.getConstraints( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
-        when( delegate.getConstraints( 11, 99 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
-        when( delegate.getConstraints() ).thenAnswer( asAnswer( asIterable( constraint2 ) ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 10, 66 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetForLabelAndPropertyKey( 11, 99 ) ).thenAnswer( asAnswer( Collections.emptyList() ) );
+        when( delegate.constraintsGetAll() ).thenAnswer( asAnswer( asIterable( constraint2 ) ) );
         TxState state = new TxState( mock( OldTxStateBridge.class ), mock( PersistenceManager.class ),
                 mock( IdGeneration.class ) );
         StateHandlingStatementContext context = new StateHandlingStatementContext( delegate,
                 mock( SchemaStateOperations.class ), state, mock( ConstraintIndexCreator.class ) );
-        context.addUniquenessConstraint( 10, 66 );
+        context.uniquenessConstraintCreate( 10, 66 );
 
         // when
-        Set<UniquenessConstraint> result = asSet( asIterable( context.getConstraints() ) );
+        Set<UniquenessConstraint> result = asSet( asIterable( context.constraintsGetAll() ) );
 
         // then
         assertEquals( asSet( constraint1, constraint2 ), result );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreIndexStoreViewTest.java
@@ -45,7 +45,6 @@ import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
 
@@ -163,8 +162,8 @@ public class NeoStoreIndexStoreViewTest
             ThreadToStatementContextBridge bridge = new ThreadToStatementContextBridge( null, txManager );
 
             StatementContext ctx = bridge.getCtxForWriting();
-            labelId = ctx.getOrCreateLabelId( "Person" );
-            propertyKeyId = ctx.getOrCreatePropertyKeyId( "name" );
+            labelId = ctx.labelGetOrCreateForName( "Person" );
+            propertyKeyId = ctx.propertyKeyGetOrCreateForName( "name" );
             ctx.close();
             tx.success();
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
@@ -74,7 +74,7 @@ public class LabelIT
         {
             ThreadToStatementContextBridge bridge = db.getDependencyResolver().resolveDependency(
                     ThreadToStatementContextBridge.class );
-            return bridge.getCtxForReading().getLabelId( label.name() );
+            return bridge.getCtxForReading().labelGetForName( label.name() );
         }
         finally
         {


### PR DESCRIPTION
The naming convention introduced is to have the most prominent entity that the method deals with named first in the method name.
The rationale behind this is to group the methods by name, and to facilitate IDE "tab completion".

The rules applied to the names are:
- The most prominent entity the method deals with is the first word of the method name.
- If dealt with in general, the word is pluralized.
- We prefer physical entities to meta-entities (e.g. node is preferred to index and label).
- `#nodesGetFromIndexLookup(IndexDescriptor, Object)` is a good example for both of the last two rules, nodes are the physical entities we are interested in, therefore that word is first, the index is just a means of getting to the nodes.
