### PR TITLE
Changes how the kernel version/revision gets generated

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -173,6 +173,8 @@ the relevant Commercial Agreement.
               <target>
                 <mkdir dir="target/generated-sources/version/org/neo4j/kernel/impl/" />
                 <property name="git.describe" value="${git.commit.id.describe}" />
+                <property name="git.branch" value="${git.commit.id.branch}" />
+                <property name="git.commit" value="${git.commit.id}" />
                 <echo file="target/generated-sources/version/org/neo4j/${short-name}/impl/ComponentVersion.java">package org.neo4j.${short-name}.impl;
 
 import org.neo4j.kernel.Version;
@@ -189,7 +191,27 @@ public class ComponentVersion extends Version
     @Override
     public String getRevision()
     {
-        return "${git.describe}";
+        // Goals with the revision returned from this method:
+        // 1. Which version of Neo4j is this?
+        // 2. If not a release version (i.e. SNAPSHOT), which git branch and commit hash was it built from?
+        // 3. Is there local modifications or not in this build? 
+        //
+        // This is a generated class, so why is there logic in here instead of generating this class
+        // with the correct revision directly? Because it's generated from a place that doesn't allow this
+        // kind of logic to build the revision at the place of generating it.
+        
+        String fromGitDescribe = "${git.describe}";
+        String version = "${project.version}";
+        StringBuilder result = new StringBuilder( version );
+        if ( version.endsWith( "-SNAPSHOT" ) )
+        {
+            result.append( "-${git.branch}-${git.commit}" );
+        }
+        if ( fromGitDescribe.endsWith( "-dirty" ) )
+        {
+            result.append( "-dirty" );
+        }
+        return result.toString();
     }
 }
 </echo>

--- a/community/kernel/src/main/java/org/neo4j/kernel/Version.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Version.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel;
 import java.util.NoSuchElementException;
 
 import org.neo4j.helpers.Service;
+import org.neo4j.kernel.impl.ComponentVersion;
 
 public class Version extends Service
 {
@@ -118,5 +119,17 @@ public class Version extends Service
     public static String getKernelRevision()
     {
         return KERNEL_VERSION.getRevision();
+    }
+    
+    /**
+     * A very nice to have main-method for quickly checking the version of a neo4j kernel,
+     * for example given a kernel jar file.
+     */
+    public static void main( String[] args )
+    {
+        ComponentVersion componentVersion = new ComponentVersion();
+        System.out.println( "Release version: " + componentVersion.getReleaseVersion() );
+        System.out.println( "Version: " + componentVersion.getVersion() );
+        System.out.println( "Revision: " + componentVersion.getRevision() );
     }
 }


### PR DESCRIPTION
The problem:
Kernel version is gotten from 'git describe' which looks at the most
recent tag reachable from HEAD. If HEAD _is_ that commit then it'll be a
clean e.g. '1.9.RC2' version, otherwise it'll add
'-<nr-of-commits-ahead>-<short-commit-hash>'. They way the branches are
set up currently yields that tags made in master will be merged into 2.0.
Therefore the latest tag (i.e. release) of either 1.9 or 2.0 will be
chosen by 'git describe' when describing 2.0.

The solution proposed here:
Don't use 'git describe' since it doesn't suite our branch strategy.
Or rather, still get the 'dirty' part from it (i.e. whether there are
local changes or not when doing the build).
Instead use the version found in the pom, along with current branch and
commit hash (if the version is a SNAPSHOT version). Examples:

  2.0.0-M02
  2.0-SNAPSHOT-2.0-58f0e945df96d9a71184e4a0bbcdaf4e42271770-dirty
  2.0-SNAPSHOT-mylocalbranch-58f0e945df96d9a71184e4a0bbcdaf4e42271770

Caveat for not showing branch+commit-hash if not a SNAPSHOT is of
course that the version can be faked, but that goes for the previous
solution as well of course where one could alter tags before building.
