### PR TITLE
fix compliance for non-default logback implemenatations

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -399,6 +399,16 @@ public class ComponentVersion extends Version
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.ow2.jotm</groupId>
       <artifactId>jotm-core</artifactId>
       <version>2.2.3</version>

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -771,7 +771,7 @@ public abstract class InternalAbstractGraphDatabase
             getClass().getClassLoader().loadClass( "ch.qos.logback.classic.LoggerContext" );
             logging = new LogbackService( config, (LoggerContext) getSingleton().getLoggerFactory() );
         }
-        catch ( ClassNotFoundException e )
+        catch ( Exception e )
         {
             logging = new ClassicLoggingService( config );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LoggerFactoryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LoggerFactoryIT.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.impl.StaticLoggerBinder;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * checking the creation of {@link org.neo4j.kernel.InternalAbstractGraphDatabase}'s logging facility
+ * since this depends on static methods, we need to mock this using PowerMock.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StaticLoggerBinder.class)
+public class LoggerFactoryIT
+{
+
+    private TemporaryFolder graphDbFolder = new TemporaryFolder();
+
+    @Before
+    public void setupTempFolder() throws IOException
+    {
+        graphDbFolder.create();
+    }
+
+    @After
+    public void cleanupTempFolder()
+    {
+        graphDbFolder.delete();
+    }
+
+
+    @Test
+    public void shouldFallbackToClassicLoggingServiceIfCustomStaticLoggerBinder() throws Exception
+    {
+        StaticLoggerBinder mockedInstance = PowerMockito.spy( StaticLoggerBinder.getSingleton() );
+        PowerMockito.when( mockedInstance.getLoggerFactory() ).thenReturn( new DummyLoggerFactory() );
+
+        PowerMockito.mockStatic( StaticLoggerBinder.class );
+        PowerMockito.when( StaticLoggerBinder.getSingleton() ).thenReturn( mockedInstance );
+
+        GraphDatabaseService graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase( graphDbFolder
+                .getRoot().getAbsolutePath() );
+        assertGraphDatabaseLoggingMatches( "org.neo4j.kernel.logging.ClassicLoggingService", graphDatabaseService );
+
+    }
+
+    @Test
+    public void shouldUseLogbackServiceWithStandardStaticLoggerBinder() throws Exception
+    {
+        GraphDatabaseService graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase( graphDbFolder
+                .getRoot().getAbsolutePath() );
+        assertGraphDatabaseLoggingMatches( "org.neo4j.kernel.logging.LogbackService", graphDatabaseService );
+    }
+
+    /**
+     * helper class to be return upon {@link org.slf4j.impl.StaticLoggerBinder#getLoggerFactory()} in a mocked
+     * environment
+     */
+    static class DummyLoggerFactory implements ILoggerFactory
+    {
+
+        @Override
+        public Logger getLogger( String name )
+        {
+            return null;
+        }
+    }
+
+    private void assertGraphDatabaseLoggingMatches( String expectedLoggingClassname, Object graphDatabaseService )
+    {
+        assertThat( graphDatabaseService, notNullValue() );
+        Object logging = getFieldValueByReflection( graphDatabaseService, "logging" );
+
+        assertThat( logging, notNullValue() );
+        assertThat( "gds.logging is not a " + expectedLoggingClassname + " instance", logging.getClass().getName(),
+                is( expectedLoggingClassname ) );
+    }
+
+    private Object getFieldValueByReflection( Object instance, String fieldName )
+    {
+        Field field = findFieldRecursively( instance.getClass(), fieldName );
+        if ( field == null )
+        {
+            throw new IllegalArgumentException( "found no field '" + fieldName + "' in class " + instance.getClass()
+                    + " or its superclasses." );
+        }
+        else
+        {
+            try
+            {
+                field.setAccessible( true );
+                return field.get( instance );
+            }
+            catch ( IllegalAccessException e )
+            {
+                throw new RuntimeException( e );
+            }
+        }
+    }
+
+    private Field findFieldRecursively( Class<? extends Object> clazz, String fieldName )
+    {
+        try
+        {
+            return clazz.getDeclaredField( fieldName );
+        }
+        catch ( NoSuchFieldException e )
+        {
+            return findFieldRecursively( clazz.getSuperclass(), fieldName );
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <licensing.prepend.text>notice-agpl-prefix.txt</licensing.prepend.text>
     <licensing.phase>compile</licensing.phase>
     <lucene.version>3.6.2</lucene.version>
+    <powermock.version>1.4.12</powermock.version>
   </properties>
 
   <modules>
@@ -312,6 +313,18 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>1.9.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
There are use cases when Neo4j is used embedded and the environment provides a custom implementation of SLF4j's StaticLoggerBinder (e.g. https://github.com/grails/grails-core/blob/061f020de1b8563c2ac7aaed421f079d10208237/grails-plugin-log4j/src/main/groovy/org/slf4j/impl/StaticLoggerBinder.java)

These custom implementation might not return a LoggerContext when getSingleton().getLoggerFactory() is called, since it's only guaranteed to retrieve a ILoggerFactory. Neo4j needs to deal with this situation gracefully.

Therefore InternalAbstractGraphDatabase should catch any exceptions upon logging initialization and fall back to ClassicLoggingService if necessary.

Testing this is a PITA, since static methods need to be mocked. PowerMock to the rescue!
