### PR TITLE
Ensure predicates are applied during matching

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PathExpression.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PathExpression.scala
@@ -35,7 +35,7 @@ case class PathExpression(pathPattern: Seq[Pattern], predicate:Predicate=True())
   val identifiers: Seq[(String, CypherType)] = pathPattern.flatMap(pattern => pattern.possibleStartPoints.filter(p => isNamed(p._1)))
 
   val symbols2 = SymbolTable(identifiers.toMap)
-  val matchingContext = new MatchingContext(symbols2, predicate.atoms, buildPatternGraph(symbols2, pathPattern))
+  val matchingContext = new MatchingContext(symbols2, predicate.atoms, buildPatternGraph(symbols2, pathPattern, true))
   val interestingPoints: Seq[String] = pathPattern.
     flatMap(_.possibleStartPoints.map(_._1)).
     filter(isNamed).

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PatternPredicate.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PatternPredicate.scala
@@ -34,7 +34,7 @@ case class PatternPredicate(pathPattern: Seq[Pattern], predicate:Predicate = Tru
   val identifiers: Seq[(String, CypherType)] = pathPattern.flatMap(pattern => pattern.possibleStartPoints.filter(p => isNamed(p._1)))
 
   val symbols2 = SymbolTable(identifiers.toMap)
-  val matchingContext = new MatchingContext(symbols2, predicate.atoms, buildPatternGraph(symbols2, pathPattern))
+  val matchingContext = new MatchingContext(symbols2, predicate.atoms, buildPatternGraph(symbols2, pathPattern, false))
   val interestingPoints: Seq[String] = pathPattern.
     flatMap(_.possibleStartPoints.map(_._1)).
     filter(isNamed).

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Query.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/Query.scala
@@ -60,7 +60,8 @@ case class Query(returns: Return,
                  slice: Option[Slice],
                  namedPaths: Seq[NamedPath],
                  tail:Option[Query] = None,
-                 queryString: QueryString = QueryString.empty) extends AbstractQuery {
+                 queryString: QueryString = QueryString.empty,
+                 legacyNullPredicateCheck: Boolean = false) extends AbstractQuery {
 
   override def toString: String =
     """

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/PartiallySolvedQuery.scala
@@ -61,7 +61,8 @@ object PartiallySolvedQuery {
       namedPaths = q.namedPaths.map(Unsolved(_)),
       aggregateToDo = q.aggregation.isDefined,
       extracted = false,
-      tail = q.tail.map(q => PartiallySolvedQuery(q))
+      tail = q.tail.map(q => PartiallySolvedQuery(q)),
+      legacyNullPredicateCheck = q.legacyNullPredicateCheck
     )
   }
 
@@ -77,7 +78,8 @@ object PartiallySolvedQuery {
     namedPaths = Seq(),
     aggregateToDo = false,
     extracted = false,
-    tail = None
+    tail = None,
+    legacyNullPredicateCheck = false
   )
 }
 
@@ -100,7 +102,8 @@ case class PartiallySolvedQuery(returns: Seq[QueryToken[ReturnColumn]],
                                 namedPaths: Seq[QueryToken[NamedPath]],
                                 aggregateToDo: Boolean,
                                 extracted: Boolean,
-                                tail: Option[PartiallySolvedQuery]) extends AstNode[PartiallySolvedQuery] with PatternGraphBuilder  {
+                                tail: Option[PartiallySolvedQuery],
+                                legacyNullPredicateCheck: Boolean) extends AstNode[PartiallySolvedQuery] with PatternGraphBuilder  {
 
   val matchPattern : MatchPattern = MatchPattern(patterns.map(_.token))
 
@@ -153,7 +156,8 @@ case class PartiallySolvedQuery(returns: Seq[QueryToken[ReturnColumn]],
         case Unsolved(namedPath) => Unsolved(namedPath.rewrite(f))
         case x => x
       },
-      start = start.map { (qt: QueryToken[StartItem]) => qt.map( _.rewrite(f) ) } )
+      start = start.map { (qt: QueryToken[StartItem]) => qt.map( _.rewrite(f) ) },
+      legacyNullPredicateCheck = legacyNullPredicateCheck)
   }
 
   def unsolvedExpressions = {
@@ -196,7 +200,7 @@ case class PartiallySolvedQuery(returns: Seq[QueryToken[ReturnColumn]],
 case class  ExecutionPlanInProgress(query: PartiallySolvedQuery, pipe: Pipe, isUpdating: Boolean=false)
 
 trait PatternGraphBuilder {
-  def buildPatternGraph(patterns: Seq[Pattern]): PatternGraph = {
+  def buildPatternGraph(patterns: Seq[Pattern], legacyNullPredicateCheck: Boolean): PatternGraph = {
     val patternNodeMap: scala.collection.mutable.Map[String, PatternNode] = scala.collection.mutable.Map()
     val patternRelMap: scala.collection.mutable.Map[String, PatternRelationship] = scala.collection.mutable.Map()
 
@@ -219,6 +223,6 @@ trait PatternGraphBuilder {
       case _ =>
     })
 
-    new PatternGraph(patternNodeMap.toMap, patternRelMap.toMap, patternNodeMap.keys.toSeq)
+    new PatternGraph(patternNodeMap.toMap, patternRelMap.toMap, patternNodeMap.keys.toSeq, legacyNullPredicateCheck)
   }
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/MatchBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/MatchBuilder.scala
@@ -35,7 +35,7 @@ class MatchBuilder extends LegacyPlanBuilder with PatternGraphBuilder {
     val items = q.patterns.filter(yesOrNo(_, p, q.start))
     val patterns = items.map(_.token)
     val predicates = q.where.filter(!_.solved).map(_.token)
-    val graph = buildPatternGraph(p.symbols, patterns)
+    val graph = buildPatternGraph(p.symbols, patterns, q.legacyNullPredicateCheck)
 
     val mandatoryGraph = graph.mandatoryGraph
 
@@ -78,7 +78,7 @@ class MatchBuilder extends LegacyPlanBuilder with PatternGraphBuilder {
 }
 
 trait PatternGraphBuilder {
-  def buildPatternGraph(symbols: SymbolTable, patterns: Seq[Pattern]): PatternGraph = {
+  def buildPatternGraph(symbols: SymbolTable, patterns: Seq[Pattern], legacyNullPredicateCheck: Boolean): PatternGraph = {
     val patternNodeMap: scala.collection.mutable.Map[String, PatternNode] = scala.collection.mutable.Map()
     val patternRelMap: scala.collection.mutable.Map[String, PatternRelationship] = scala.collection.mutable.Map()
 
@@ -105,6 +105,6 @@ trait PatternGraphBuilder {
       case _ =>
     })
 
-    new PatternGraph(patternNodeMap.toMap, patternRelMap.toMap, symbols.keys)
+    new PatternGraph(patternNodeMap.toMap, patternRelMap.toMap, symbols.keys, legacyNullPredicateCheck)
   }
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/TraversalMatcherBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/builders/TraversalMatcherBuilder.scala
@@ -64,14 +64,14 @@ class TraversalMatcherBuilder extends PlanBuilder with PatternGraphBuilder {
   private def checkPattern(plan: ExecutionPlanInProgress, tokens: Seq[QueryToken[StartItem]]) {
     val newIdentifiers = tokens.map(_.token).map(x => x.identifierName -> NodeType()).toMap
     val newSymbolTable = plan.pipe.symbols.add(newIdentifiers)
-    validatePattern(newSymbolTable, plan.query.patterns.map(_.token))
+    validatePattern(newSymbolTable, plan.query.patterns.map(_.token), plan.query.legacyNullPredicateCheck)
   }
 
 
-  private def validatePattern(symbols: SymbolTable, patterns: Seq[Pattern]) = {
+  private def validatePattern(symbols: SymbolTable, patterns: Seq[Pattern], legacyNullPredicateCheck: Boolean) = {
     //We build the graph here, because the pattern graph builder finds problems with the pattern
     //that we don't find other wise. This should be moved out from the patternGraphBuilder, but not right now
-    buildPatternGraph(symbols, patterns)
+    buildPatternGraph(symbols, patterns, legacyNullPredicateCheck)
   }
 
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/verifiers/OptionalPatternWithoutStartVerifier.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/verifiers/OptionalPatternWithoutStartVerifier.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.PatternException
 
 object OptionalPatternWithoutStartVerifier extends Verifier {
   def verifyFunction = {
-    case Query(_, start, _, patterns, _, _, _, _, _, _, _, _)
+    case Query(_, start, _, patterns, _, _, _, _, _, _, _, _, _)
       if start.isEmpty && patterns.exists(_.optional) =>
 
       val optionalRelationships: String = patterns.

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/CypherParserImpl.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/CypherParserImpl.scala
@@ -117,14 +117,14 @@ Thank you, the Neo4j Team.
   private def expandQuery(start: Seq[StartItem], namedPaths: Seq[NamedPath], updates: Seq[UpdateAction], body: Body): Query = body match {
     case b: BodyWith => {
       checkForAggregates(b.where)
-      Query(b.returns, start, updates, b.matching, Seq(), b.where.getOrElse(True()), b.aggregate, b.order, b.slice, b.namedPath ++ namedPaths, Some(expandQuery(b.start, b.startPaths, b.updates, b.next)))
+      Query(b.returns, start, updates, b.matching, Seq(), b.where.getOrElse(True()), b.aggregate, b.order, b.slice, b.namedPath ++ namedPaths, Some(expandQuery(b.start, b.startPaths, b.updates, b.next)), legacyNullPredicateCheck = true)
     }
     case b: BodyReturn => {
       checkForAggregates(b.where)
-      Query(b.returns, start, updates, b.matching, Seq(), b.where.getOrElse(True()), b.aggregate, b.order, b.slice, b.namedPath ++ namedPaths, None)
+      Query(b.returns, start, updates, b.matching, Seq(), b.where.getOrElse(True()), b.aggregate, b.order, b.slice, b.namedPath ++ namedPaths, None, legacyNullPredicateCheck = true)
     }
     case NoBody() => {
-      Query(Return(Nil), start, updates, Seq(), Seq(), True(), None, Seq(), None, namedPaths, None)
+      Query(Return(Nil), start, updates, Seq(), Seq(), True(), None, Seq(), None, namedPaths, None, legacyNullPredicateCheck = true)
     }
   }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/DoubleOptionalPatternMatcher.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/DoubleOptionalPatternMatcher.scala
@@ -38,8 +38,9 @@ class DoubleOptionalPatternMatcher(bindings: Map[String, MatchingPair],
                                    includeOptionals: Boolean,
                                    source: ExecutionContext,
                                    state: QueryState,
-                                   doubleOptionalPaths: Seq[DoubleOptionalPath])
-  extends PatternMatcher(bindings, predicates, includeOptionals, source, state) {
+                                   doubleOptionalPaths: Seq[DoubleOptionalPath],
+                                   legacyNullPredicateCheck: Boolean)
+  extends PatternMatcher(bindings, predicates, includeOptionals, source, state, legacyNullPredicateCheck) {
 
   override protected def traverseNextSpecificNode[U](remaining: Set[MatchingPair],
                                                      history: History,

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatterMatchingBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatterMatchingBuilder.scala
@@ -83,9 +83,9 @@ class PatterMatchingBuilder(patternGraph: PatternGraph, predicates: Seq[Predicat
 
   private def createPatternMatcher(boundPairs: Map[String, MatchingPair], includeOptionals: Boolean, source: ExecutionContext, state:QueryState): Traversable[ExecutionContext] = {
     val patternMatcher = if (patternGraph.hasDoubleOptionals)
-      new DoubleOptionalPatternMatcher(boundPairs, predicates, includeOptionals, source, state, patternGraph.doubleOptionalPaths)
+      new DoubleOptionalPatternMatcher(boundPairs, predicates, includeOptionals, source, state, patternGraph.doubleOptionalPaths, patternGraph.legacyNullPredicateCheck)
     else
-      new PatternMatcher(boundPairs, predicates, includeOptionals, source, state)
+      new PatternMatcher(boundPairs, predicates, includeOptionals, source, state, patternGraph.legacyNullPredicateCheck)
 
     if (includeOptionals)
       patternMatcher.map(matchedGraph => matchedGraph ++ createNullValuesForOptionalElements(matchedGraph))

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternGraph.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternGraph.scala
@@ -24,7 +24,8 @@ import org.neo4j.cypher.PatternException
 
 class PatternGraph(val patternNodes: Map[String, PatternNode],
                    val patternRels: Map[String, PatternRelationship],
-                   val boundElements: Seq[String]) {
+                   val boundElements: Seq[String],
+                   val legacyNullPredicateCheck: Boolean = false) {
   def nonEmpty: Boolean = !isEmpty
 
 
@@ -68,7 +69,7 @@ class PatternGraph(val patternNodes: Map[String, PatternNode],
         pr.key -> s.relateTo(pr.key, e, pr.relTypes, pr.dir, pr.optional)
     }.toMap
 
-    new PatternGraph(newNodes, newRelationships, boundPoints)
+    new PatternGraph(newNodes, newRelationships, boundPoints, legacyNullPredicateCheck)
   }
 
   def apply(key: String) = patternGraph(key)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternMatcher.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/matching/PatternMatcher.scala
@@ -30,7 +30,8 @@ class PatternMatcher(bindings: Map[String, MatchingPair],
                      predicates: Seq[Predicate],
                      includeOptionals: Boolean,
                      source:ExecutionContext,
-                     state:QueryState)
+                     state:QueryState,
+                     legacyNullPredicateCheck: Boolean)
   extends Traversable[ExecutionContext] {
   val boundNodes = bindings.filter(_._2.patternElement.isInstanceOf[PatternNode])
   val boundRels = bindings.filter(_._2.patternElement.isInstanceOf[PatternRelationship])
@@ -164,7 +165,7 @@ class PatternMatcher(bindings: Map[String, MatchingPair],
 
   private def isMatchSoFar(history: History): Boolean = {
     val m = history.toMap
-    val predicate = predicates.filter(predicate=> !predicate.containsIsNull && predicate.symbolTableDependencies.forall(m contains))
+    val predicate = predicates.filter(predicate=> !(legacyNullPredicateCheck && predicate.containsIsNull) && predicate.symbolTableDependencies.forall(m contains))
     predicate.forall(_.isMatch(m)(state))
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -1058,6 +1058,34 @@ return x""", "A" -> 1, "B" -> 2, "C" -> 3)
     assert(List(d, e) === result.columnAs[Node]("x").toList)
   }
 
+  @Test def shouldHandleCollaborativeFiltering1_9() {
+    val a = createNode("A")
+    val b = createNode("B")
+    val c = createNode("C")
+    val d = createNode("D")
+    val e = createNode("E")
+    val f = createNode("F")
+
+    relate(a, b, "knows", "rAB")
+    relate(a, c, "knows", "rAC")
+    relate(a, f, "knows", "rAF")
+
+    relate(b, c, "knows", "rBC")
+    relate(b, d, "knows", "rBD")
+    relate(b, e, "knows", "rBE")
+
+    relate(c, e, "knows", "rCE")
+
+    val result = parseAndExecute( """cypher 1.9
+start a  = node(1)
+match a-[r1:knows]->friend-[r2:knows]->foaf, a-[foafR?:knows]->foaf
+where foafR IS NULL
+return foaf, count(*)
+order by count(*)""")
+
+    assert(Set(Map("foaf" -> d, "count(*)" -> 1), Map("foaf" -> e, "count(*)" -> 2)) === result.toSet)
+  }
+
   @Test def shouldHandleCollaborativeFiltering() {
     val a = createNode("A")
     val b = createNode("B")
@@ -1079,7 +1107,8 @@ return x""", "A" -> 1, "B" -> 2, "C" -> 3)
     val result = parseAndExecute( """
 start a  = node(1)
 match a-[r1:knows]->friend-[r2:knows]->foaf, a-[foafR?:knows]->foaf
-where foafR is null
+with foafR, foaf
+where foafR IS NULL
 return foaf, count(*)
 order by count(*)""")
 
@@ -2625,7 +2654,7 @@ RETURN x0.name?
   }
 
   @Test
-  def should_not_create_when_match_exists() {
+  def should_create_when_match_exists() {
     //GIVEN
     val a = createNode()
     val b = createNode()
@@ -2635,13 +2664,12 @@ RETURN x0.name?
     val result = parseAndExecute(
       """START a=node(1), b=node(2)
          MATCH a-[old?:FOO]->b
-         WHERE old = null
          CREATE a-[new:FOO]->b
          RETURN new""")
 
     //THEN
-    assert(result.size === 0)
-    assert(result.queryStatistics().relationshipsCreated === 0)
+    assert(result.size === 1)
+    assert(result.queryStatistics().relationshipsCreated === 1)
   }
 
   @Test

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/MatchingContextTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/MatchingContextTest.scala
@@ -511,7 +511,7 @@ class MatchingContextTest extends GraphDatabaseTestBase with Assertions with Pat
 
     val identifiers2 = (nodeIdentifiers2 ++ relIdentifiers2).toMap
     val symbols2 = SymbolTable(identifiers2)
-    matchingContext = new MatchingContext(symbols2, predicates, buildPatternGraph(symbols2, patterns))
+    matchingContext = new MatchingContext(symbols2, predicates, buildPatternGraph(symbols2, patterns, false))
   }
 
   private def createMatchingContextWithRels(patterns: Seq[Pattern], rels: Seq[String], predicates: Seq[Predicate] = Seq[Predicate]()) {


### PR DESCRIPTION
Currently null checks are done separately, which is inconsistent.
Normalizing this behaviour for 2.0

Note that all the `legacyNullPredicateCheck` parameters should be removed when the 1.9 parser is expired.
