### PR TITLE
Fix reference to osx-docbook-register in manual/README

### DIFF
--- a/manual/README.asciidoc
+++ b/manual/README.asciidoc
@@ -38,7 +38,7 @@ Install libraries
 
 Register the docbook xml DTD
 
-  sudo ./osx-register-docbook
+  sudo ./osx-docbook-register
 
 === With apt-get on Ubuntu ===
 


### PR DESCRIPTION
Fixed a typo in the readme of the manual,
where osx-register-docbook was referenced,
whereas the filename is actually osx-docbook-register.

I know it's a simple fix, but I hope it helps.

I also noticed that the readme in the community folder still references the old `neo4j/community.git` repository in the 'Build Steps Community' section.
Is building only the community version deprecated since the repository moved to here?
If so, I could state so in the readme.
If not, could anyone point me to some documentation on how to build just the community version?
