### PR TITLE
LSB Compliant Init scripts for Debian Packages

### DIFF
--- a/packaging/installer-linux/build.xml
+++ b/packaging/installer-linux/build.xml
@@ -29,6 +29,7 @@
     <macrodef name="package">
 
         <attribute name="name"/>
+
         <sequential>
             <!-- Unzip the standalone distributions -->
             <local name="source.distribution" />
@@ -38,7 +39,7 @@
                    dest="${project.build.outputDirectory}"
                    compression="gzip"/>
 
-            <!-- Handle the case of the co-ordinator -->
+            <!-- Handle the case of the arbiter -->
             <copy toDir="${project.build.outputDirectory}/neo4j-arbiter-${neo4j.version}" failonerror="false">
                 <fileset dir="${project.build.outputDirectory}/neo4j-enterprise-${neo4j.version}"/>
             </copy>
@@ -48,6 +49,13 @@
                 <fileset dir="${project.build.outputDirectory}/neo4j-@{name}-${neo4j.version}"
                          includes="**"/>
             </move>
+
+            <!-- Make the init scripts available to debuild -->
+            <copy toDir="${project.build.outputDirectory}/@{name}/server">
+                <fileset dir="${project.build.sourceDirectory}/../resources/@{name}/debian/">
+                    <include name="*-service"/>
+                </fileset>
+            </copy>
 
             <udc_source name="@{name}"/>
             <chmod perm="700">
@@ -70,7 +78,7 @@
             <!-- Run installer projects -->
             <exec executable="debuild"
                   dir="${project.build.outputDirectory}/@{name}"
-                  failonerror="true">
+                  failonerror="true" >
                 <arg line="-us"/>
                 <arg line="-uc"/>
                 <arg line="-B"/>

--- a/packaging/installer-linux/src/main/resources/advanced/debian/control
+++ b/packaging/installer-linux/src/main/resources/advanced/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-advanced
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre, lsb-base
 Conflicts: 
 Replaces: neo4j-enterprise, neo4j
 Description: graph database server

--- a/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-advanced.install
+++ b/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-advanced.install
@@ -13,3 +13,4 @@ server/plugins      usr/share/neo4j
 server/system       usr/share/neo4j
 
 server/conf/*       etc/neo4j
+server/neo4j-service    etc/init.d

--- a/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-advanced.postinst
+++ b/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-advanced.postinst
@@ -35,9 +35,7 @@ case "$1" in
         chown -R $NEO_USER:adm /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
         chmod u+rwx /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
 
-        # Tell neo4j to install itself as a service using headless (-h) mode
-        # with user (-u) neo4j as running user.
-        /var/lib/neo4j/bin/neo4j -h -u neo4j install
+        update-rc.d neo4j-service defaults
         
         # Start neo4j
         invoke-rc.d neo4j-service start

--- a/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-service
+++ b/packaging/installer-linux/src/main/resources/advanced/debian/neo4j-service
@@ -1,0 +1,132 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          neo4j
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Neo4j Graph Database server
+# Description:       Neo4j is a Graph Database, which is a compelling
+#                    alternative to an RDBMS. http://www.neo4j.org
+### END INIT INFO
+
+# Author: Julian Simpson <julian.simpson@neotechnology.com>
+#
+# Copyright (c) 2002-2013 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Neo4j Graph Database"
+NAME=neo4j
+DAEMON=/var/lib/$NAME/bin/$NAME
+DAEMON_ARGS="start"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME-service
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Copy the Neo4j PID to the sytem's PID store
+	cp /var/lib/${NAME}/data/neo4j-service.pid $PIDFILE
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter-service
+++ b/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter-service
@@ -1,0 +1,132 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          neo4j-arbiter
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Neo4j Graph Database server
+# Description:       Neo4j is a Graph Database, which is a compelling
+#                    alternative to an RDBMS. http://www.neo4j.org
+### END INIT INFO
+
+# Author: Julian Simpson <julian.simpson@neotechnology.com>
+#
+# Copyright (c) 2002-2013 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Neo4j Arbiter Service"
+NAME=neo4j-arbiter
+DAEMON=/var/lib/$NAME/bin/$NAME
+DAEMON_ARGS="start"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/arbiter-service
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Copy the Neo4j PID to the sytem's PID store
+	cp /var/lib/${NAME}/data/neo4j-arbiter.pid $PIDFILE
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.install
+++ b/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.install
@@ -19,3 +19,4 @@ server/conf/arbiter.cfg               etc/neo4j-arbiter
 server/conf/arbiter-wrapper.conf      etc/neo4j-arbiter
 server/conf/log4j.properties        etc/neo4j-arbiter
 server/conf/neo4j-wrapper.conf      etc/neo4j-arbiter
+server/neo4j-arbiter-service        etc/init.d

--- a/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.postinst
+++ b/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.postinst
@@ -35,9 +35,9 @@ case "$1" in
         chown -R $NEO_USER:adm /var/lib/neo4j-arbiter /var/log/neo4j-arbiter /etc/neo4j-arbiter /usr/share/neo4j-arbiter
         chmod u+rwx /var/lib/neo4j-arbiter /var/log/neo4j-arbiter /etc/neo4j-arbiter /usr/share/neo4j-arbiter
 
-        # Tell neo4j-arbiter to install itself as a service using headless (-h) mode
-        # with user (-u) neo4j as running user.
-        /var/lib/neo4j-arbiter/bin/neo4j-arbiter -h -u neo4j install
+        update-rc.d neo4j-arbiter-service defaults
+
+        invoke-rc.d neo4j-arbiter-service start
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.postrm
+++ b/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.postrm
@@ -26,6 +26,7 @@ case "$1" in
     ;;
     
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        update-rc.d -f neo4j-arbiter-service remove
     ;;
 
     *)

--- a/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.prerm
+++ b/packaging/installer-linux/src/main/resources/arbiter/debian/neo4j-arbiter.prerm
@@ -21,10 +21,8 @@ case "$1" in
     remove|upgrade|deconfigure)
 
         # Stop the neo4j service
-        invoke-rc.d neo4j-arbiter stop
+        invoke-rc.d neo4j-arbiter-service stop
 
-        # Tell neo4j to uninstall itself
-        /var/lib/neo4j-arbiter/bin/neo4j-arbiter -h -u neo4j remove
     ;;
 
     failed-upgrade)

--- a/packaging/installer-linux/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/src/main/resources/community/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre, lsb-base
 Conflicts: 
 Replaces: neo4j-enterprise, neo4j-advanced
 Description: graph database server

--- a/packaging/installer-linux/src/main/resources/community/debian/neo4j-service
+++ b/packaging/installer-linux/src/main/resources/community/debian/neo4j-service
@@ -1,0 +1,132 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          neo4j
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Neo4j Graph Database server
+# Description:       Neo4j is a Graph Database, which is a compelling
+#                    alternative to an RDBMS. http://www.neo4j.org
+### END INIT INFO
+
+# Author: Julian Simpson <julian.simpson@neotechnology.com>
+#
+# Copyright (c) 2002-2013 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Neo4j Graph Database"
+NAME=neo4j
+DAEMON=/var/lib/$NAME/bin/$NAME
+DAEMON_ARGS="start"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME-service
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Copy the Neo4j PID to the sytem's PID store
+	cp /var/lib/${NAME}/data/neo4j-service.pid $PIDFILE
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/packaging/installer-linux/src/main/resources/community/debian/neo4j.install
+++ b/packaging/installer-linux/src/main/resources/community/debian/neo4j.install
@@ -13,3 +13,4 @@ server/plugins      usr/share/neo4j
 server/system       usr/share/neo4j
 
 server/conf/*       etc/neo4j
+server/neo4j-service    etc/init.d

--- a/packaging/installer-linux/src/main/resources/community/debian/neo4j.postinst
+++ b/packaging/installer-linux/src/main/resources/community/debian/neo4j.postinst
@@ -35,9 +35,7 @@ case "$1" in
         chown -R $NEO_USER:adm /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
         chmod u+rwx /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
 
-        # Tell neo4j to install itself as a service using headless (-h) mode
-        # with user (-u) neo4j as running user.
-        /var/lib/neo4j/bin/neo4j -h -u neo4j install
+        update-rc.d neo4j-service defaults
         
         # Start neo4j
         invoke-rc.d neo4j-service start

--- a/packaging/installer-linux/src/main/resources/community/debian/neo4j.postrm
+++ b/packaging/installer-linux/src/main/resources/community/debian/neo4j.postrm
@@ -26,6 +26,7 @@ case "$1" in
     ;;
     
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        update-rc.d neo4j-service remove
     ;;
 
     *)

--- a/packaging/installer-linux/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/src/main/resources/enterprise/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-enterprise
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, default-jre, lsb-base
 Conflicts: 
 Replaces: neo4j, neo4j-advanced
 Description: graph database server

--- a/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-enterprise.install
+++ b/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-enterprise.install
@@ -3,7 +3,7 @@ server/LICENSES.txt var/lib/neo4j
 server/README.txt   var/lib/neo4j
 server/UPGRADE.txt  var/lib/neo4j
 
-server/data/README.txt  var/lib/neo4j/data
+server/data/README.txt var/lib/neo4j/data
 
 server/doc          var/lib/neo4j
 server/bin          var/lib/neo4j
@@ -13,3 +13,4 @@ server/plugins      usr/share/neo4j
 server/system       usr/share/neo4j
 
 server/conf/*       etc/neo4j
+server/neo4j-service    etc/init.d

--- a/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-enterprise.postinst
+++ b/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-enterprise.postinst
@@ -35,9 +35,7 @@ case "$1" in
         chown -R $NEO_USER:adm /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
         chmod u+rwx /var/lib/neo4j /var/log/neo4j /etc/neo4j /usr/share/neo4j
 
-        # Tell neo4j to install itself as a service using headless (-h) mode
-        # with user (-u) neo4j as running user.
-        /var/lib/neo4j/bin/neo4j -h -u neo4j install
+        update-rc.d neo4j-service defaults
         
         # Start neo4j
         invoke-rc.d neo4j-service start

--- a/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-service
+++ b/packaging/installer-linux/src/main/resources/enterprise/debian/neo4j-service
@@ -1,0 +1,132 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          neo4j
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Neo4j Graph Database server
+# Description:       Neo4j is a Graph Database, which is a compelling
+#                    alternative to an RDBMS. http://www.neo4j.org
+### END INIT INFO
+
+# Author: Julian Simpson <julian.simpson@neotechnology.com>
+#
+# Copyright (c) 2002-2013 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Neo4j Graph Database"
+NAME=neo4j
+DAEMON=/var/lib/$NAME/bin/$NAME
+DAEMON_ARGS="start"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME-service
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+	# Copy the Neo4j PID to the sytem's PID store
+	cp /var/lib/${NAME}/data/neo4j-service.pid $PIDFILE
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:


### PR DESCRIPTION
We've been asked by a customer and in #820 to provide some LSB compliant init scripts.

This PR introduces those for the Debian packages.  The new init scripts call down to the existing Neo4j start script, so the only impact should be for the Debian packages.

We'll have to test these for the 1.9.1 release.
