### PR TITLE
Prevents timeouts during long write operations on the master side

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -335,6 +335,7 @@ public abstract class Server<T, R> extends Protocol implements ChannelPipelineFa
              */
             Pair<RequestContext, AtomicLong> slave = connectedSlaveChannels.get( ctx.getChannel() );
             slave.other().set( System.currentTimeMillis() );
+            super.writeComplete( ctx, e );
         }
 
         @Override
@@ -433,7 +434,7 @@ public abstract class Server<T, R> extends Protocol implements ChannelPipelineFa
                 {
                     finishOffChannel( null, slave );
                 }
-                catch ( IllegalStateException e )
+                catch ( TransactionNotPresentOnMasterException e )
                 {
                     // It's ok, there is nothing to finish anyway, since this is thrown when the transaction was not
                     // found

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionNotPresentOnMasterException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionNotPresentOnMasterException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+/**
+ * Used to indicate that the master tried to resume a transaction that was not present
+ */
+public class TransactionNotPresentOnMasterException extends IllegalStateException
+{
+    public TransactionNotPresentOnMasterException()
+    {
+        super();
+    }
+
+    public TransactionNotPresentOnMasterException( String s )
+    {
+        super( s );
+    }
+
+    public TransactionNotPresentOnMasterException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    public TransactionNotPresentOnMasterException( Throwable cause )
+    {
+        super( cause );
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -40,6 +40,7 @@ import org.neo4j.com.ResourceReleaser;
 import org.neo4j.com.Response;
 import org.neo4j.com.ServerUtil;
 import org.neo4j.com.StoreWriter;
+import org.neo4j.com.TransactionNotPresentOnMasterException;
 import org.neo4j.com.TransactionStream;
 import org.neo4j.com.TxExtractor;
 import org.neo4j.graphdb.Node;
@@ -275,9 +276,9 @@ public class MasterImpl extends LifecycleAdapter implements Master
                     }
                     else
                     {
-                        throw new IllegalStateException( "Transaction " + txId + " has either timed out on the" +
-                                " master or was not started on this master. There may have been a master switch" +
-                                " between the time this transaction started and up to now. This transaction" +
+                        throw new TransactionNotPresentOnMasterException( "Transaction " + txId + " has either timed " +
+                                "out on the master or was not started on this master. There may have been a master " +
+                                "switch between the time this transaction started and up to now. This transaction" +
                                 " cannot continue since the state from the previous master isn't transferred." );
                     }
                 }


### PR DESCRIPTION
Adds a writeComplete() handler on the Server.ServerHandler to update
 the corresponding transaction's timestamp
Properly handles exceptions for finishing channels that do not really
 have corresponding transactions
