### PR TITLE
Start Neo4j with nohup

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -182,7 +182,7 @@ startit() {
     CONSOLE_LOG="$NEO4J_LOG/console.log"
 
     if [ $UID == 0 ] ; then
-      su $NEO4J_USER -c "$JAVACMD -cp '$CLASSPATH' $JAVA_OPTS -Dlog4j.configuration=file:conf/log4j.properties \
+      su $NEO4J_USER -c "nohup $JAVACMD -cp '$CLASSPATH' $JAVA_OPTS -Dlog4j.configuration=file:conf/log4j.properties \
         -Dorg.neo4j.server.properties=\"${NEO4J_CONFIG}/neo4j-server.properties\" \
         -Djava.util.logging.config.file=\"${NEO4J_CONFIG}/logging.properties\" \
         -Dneo4j.home=\"${NEO4J_HOME}\" -Dneo4j.instance=\"${NEO4J_INSTANCE}\" \
@@ -191,7 +191,7 @@ startit() {
     else
       checkwriteaccess
       echo "WARNING: not changing user"
-      $JAVACMD -cp "${CLASSPATH}" $JAVA_OPTS -Dlog4j.configuration=file:conf/log4j.properties \
+      nohup $JAVACMD -cp "${CLASSPATH}" $JAVA_OPTS -Dlog4j.configuration=file:conf/log4j.properties \
         -Dorg.neo4j.server.properties="${NEO4J_CONFIG}/neo4j-server.properties" \
         -Djava.util.logging.config.file="${NEO4J_CONFIG}/logging.properties" \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \


### PR DESCRIPTION
This prevents Neo4j from exiting when the parent process ends, e.g.
when started via SSH.  It should address issue #867.

Want to test this PR?  Previous revisions of Neo4j are vulnerable to **pkill -HUP java**. This should not be.
