### PR TITLE
Omits norms and document frquency statistics from lucene documents

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
@@ -19,18 +19,71 @@
  */
 package org.neo4j.test;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.junit.rules.TemporaryFolder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 
 /**
  * JUnit @Rule for configuring, creating and managing an EmbeddedGraphDatabase instance.
  */
 public class EmbeddedDatabaseRule extends DatabaseRule
 {
-    private final TemporaryFolder temp = new TemporaryFolder();
+    private final TempDirectory temp;
+    
+    public EmbeddedDatabaseRule()
+    {
+        this.temp = new TempDirectory()
+        {
+            private final TemporaryFolder folder = new TemporaryFolder();
+            
+            @Override
+            public File root()
+            {
+                return folder.getRoot();
+            }
+            
+            @Override
+            public void delete()
+            {
+                folder.delete();
+            }
+            
+            @Override
+            public void create() throws IOException
+            {
+                folder.create();
+            }
+        };
+    }
+    
+    public EmbeddedDatabaseRule( final Class<?> testClass )
+    {
+        this.temp = new TempDirectory()
+        {
+            private final TargetDirectory targetDirectory = TargetDirectory.forTest( testClass );
+            
+            @Override
+            public File root()
+            {
+                return targetDirectory.graphDbDir( false );
+            }
+            
+            @Override
+            public void delete() throws IOException
+            {
+                targetDirectory.cleanup();
+            }
+            
+            @Override
+            public void create()
+            {
+                targetDirectory.graphDbDir( true );
+            }
+        };
+    }
     
     @Override
     protected GraphDatabaseFactory newFactory()
@@ -41,7 +94,7 @@ public class EmbeddedDatabaseRule extends DatabaseRule
     @Override
     protected GraphDatabaseBuilder newBuilder(GraphDatabaseFactory factory )
     {
-        return factory.newEmbeddedDatabaseBuilder( temp.getRoot().getAbsolutePath() );
+        return factory.newEmbeddedDatabaseBuilder( temp.root().getAbsolutePath() );
     }
 
     @Override
@@ -53,6 +106,22 @@ public class EmbeddedDatabaseRule extends DatabaseRule
     @Override
     protected void deleteResources()
     {
-        temp.delete();
+        try
+        {
+            temp.delete();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+    
+    private interface TempDirectory
+    {
+        File root();
+        
+        void create() throws IOException;
+        
+        void delete() throws IOException;
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructure.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.impl.index;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericField;
+import org.apache.lucene.index.FieldInfo.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -30,7 +31,6 @@ import org.neo4j.index.impl.lucene.LuceneUtil;
 import static org.apache.lucene.document.Field.Index.NOT_ANALYZED;
 import static org.apache.lucene.document.Field.Store.NO;
 import static org.apache.lucene.document.Field.Store.YES;
-import static org.neo4j.index.impl.lucene.IndexType.newBaseDocument;
 import static org.neo4j.kernel.api.index.ArrayEncoder.encode;
 
 class LuceneDocumentStructure
@@ -43,8 +43,8 @@ class LuceneDocumentStructure
 
     Document newDocument( long nodeId, Object value )
     {
-        Document document = newBaseDocument( nodeId );
-        document.add( new Field( NODE_ID_KEY, "" + nodeId, YES, NOT_ANALYZED ) );
+        Document document = new Document();
+        document.add( field( NODE_ID_KEY, "" + nodeId, YES ) );
 
         if ( value instanceof Number )
         {
@@ -70,7 +70,15 @@ class LuceneDocumentStructure
 
     private Field field( String fieldIdentifier, String value )
     {
-        return new Field( fieldIdentifier, value, NO, NOT_ANALYZED );
+        return field( fieldIdentifier, value, NO );
+    }
+    
+    private Field field( String fieldIdentifier, String value, Field.Store store )
+    {
+        Field result = new Field( fieldIdentifier, value, store, NOT_ANALYZED );
+        result.setOmitNorms( true );
+        result.setIndexOptions( IndexOptions.DOCS_ONLY );
+        return result;
     }
 
     public Query newQuery( Object value )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
@@ -32,7 +32,6 @@ import org.apache.lucene.store.RAMDirectory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
@@ -43,7 +42,6 @@ import static java.lang.Long.parseLong;
 import static java.util.Arrays.asList;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -257,7 +255,7 @@ public class LuceneSchemaIndexPopulatorTest
             for ( int i = 0; i < hits.totalHits; i++ )
             {
                 Document document = searcher.doc( hits.scoreDocs[i].doc );
-                foundNodeIds.add( parseLong( document.get( "_id_" ) ) );
+                foundNodeIds.add( parseLong( document.get( "id" ) ) );
             }
             assertEquals( asSet( hit.nodeIds ), foundNodeIds );
         }


### PR DESCRIPTION
They are not used a.t.m. and removing them reduces disk space to 50% from basic measurements.
Also the previous code added to node id fields ("id" and "_id_"), which was also removed here.
