### PR TITLE
Fixes #911

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
@@ -101,6 +101,53 @@ public abstract class FutureAdapter<V> implements Future<V>
         };
     }
     
+    public static Future<Integer> processFuture( final Process process )
+    {
+        return new FutureAdapter<Integer>()
+        {
+            @Override
+            public boolean isDone()
+            {
+                return tryGetExitValue( process ) != null;
+            }
+
+            private Integer tryGetExitValue( final Process process )
+            {
+                try
+                {
+                    return process.exitValue();
+                }
+                catch ( IllegalThreadStateException e )
+                {   // Thrown if this process hasn't exited yet.
+                    return null;
+                }
+            }
+
+            @Override
+            public Integer get() throws InterruptedException
+            {
+                return process.waitFor();
+            }
+
+            @Override
+            public Integer get( long timeout, TimeUnit unit ) throws InterruptedException, ExecutionException,
+                    TimeoutException
+            {
+                long end = System.currentTimeMillis() + unit.toMillis( timeout );
+                while ( System.currentTimeMillis() < end )
+                {
+                    Integer result = tryGetExitValue( process );
+                    if ( result != null )
+                    {
+                        return result;
+                    }
+                    Thread.sleep( 10 );
+                }
+                throw new TimeoutException( "Process '" + process + "' didn't exit within " + timeout + " " + unit );
+            }
+        };
+    }
+    
     public static <T> Future<T> future( final Callable<T> task )
     {
         ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Command.java
@@ -1257,7 +1257,8 @@ public abstract class Command extends XaCommand
                 ByteBuffer deserialized = AbstractDynamicStore.concatData( records, new byte[100] );
                 rule = SchemaRule.Kind.deserialize( first( records ).getId(), deserialized );
             }
-            return new SchemaRuleCommand( neoStore.getSchemaStore(), indexes, records, rule );
+            return new SchemaRuleCommand( neoStore != null ? neoStore.getSchemaStore() : null,
+                    indexes, records, rule );
         }
     }
     

--- a/community/kernel/src/test/java/org/neo4j/test/AllItemsMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AllItemsMatcher.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.neo4j.helpers.collection.IteratorUtil;
+
+import static java.util.Arrays.asList;
+
+public class AllItemsMatcher<T> extends BaseMatcher<Iterable<T>>
+{
+    private final Iterable<T> expected;
+    
+    public AllItemsMatcher( T... expected )
+    {
+        this.expected = asList( expected );
+    }
+
+    public AllItemsMatcher( Iterable<T> expected )
+    {
+        this.expected = expected;
+    }
+    
+    @Override
+    public void describeTo( Description description )
+    {
+        description.appendText( "All items (no more, no less) must be equal to" );
+        description.appendValueList( "[", ",", "]", expected );
+    }
+
+    @Override
+    public boolean matches( Object item )
+    {
+        Iterable<T> items = (Iterable<T>) item;
+        return IteratorUtil.iteratorsEqual( expected.iterator(), items.iterator() );
+    }
+    
+    public static <T> Matcher<Iterable<T>> matchesAll( T... expected )
+    {
+        return new AllItemsMatcher<>( expected );
+    }
+    
+    public static <T> Matcher<Iterable<T>> matchesAll( Iterable<T> expected )
+    {
+        return new AllItemsMatcher<>( expected );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.test;
 
+import java.io.PrintStream;
+
 import org.neo4j.test.StreamConsumer.StreamExceptionHandler;
 
 import static org.neo4j.test.StreamConsumer.PRINT_FAILURES;
@@ -54,9 +56,15 @@ public class ProcessStreamHandler
     public ProcessStreamHandler( Process process, boolean quiet, String prefix,
             StreamExceptionHandler failureHandler )
     {
+        this( process, quiet, "", PRINT_FAILURES, System.out, System.err );
+    }
+    
+    public ProcessStreamHandler( Process process, boolean quiet, String prefix,
+            StreamExceptionHandler failureHandler, PrintStream out, PrintStream err )
+    {
         this.process = process;
-        out = new Thread( new StreamConsumer( process.getInputStream(), System.out, quiet, prefix, failureHandler ) );
-        err = new Thread( new StreamConsumer( process.getErrorStream(), System.err, quiet, prefix, failureHandler ) );
+        this.out = new Thread( new StreamConsumer( process.getInputStream(), out, quiet, prefix, failureHandler ) );
+        this.err = new Thread( new StreamConsumer( process.getErrorStream(), err, quiet, prefix, failureHandler ) );
     }
 
     /**

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessUtil.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.helpers.FutureAdapter;
+
+import static java.util.Arrays.asList;
+
+public class ProcessUtil
+{
+    public static void executeSubProcess( Class<?> mainClass, long timeout, TimeUnit unit,
+            String... arguments ) throws Exception
+    {
+        Future<Integer> future = startSubProcess( mainClass, arguments );
+        int result = future.get( timeout, unit );
+        if ( result != 0 )
+        {
+            throw new RuntimeException( "Process for " + mainClass +
+                    " with arguments " + Arrays.toString( arguments ) +
+                    " failed, returned exit value " + result );
+        }
+    }
+    
+    public static Future<Integer> startSubProcess( Class<?> mainClass, String... arguments ) throws IOException
+    {
+        List<String> args = new ArrayList<>();
+        args.addAll( asList( "java", "-cp", System.getProperty( "java.class.path" ), mainClass.getName() ) );
+        args.addAll( asList( arguments ) );
+        Process process = Runtime.getRuntime().exec( args.toArray( new String[args.size()] ) );
+        final ProcessStreamHandler processOutput = new ProcessStreamHandler( process, false );
+        processOutput.launch();
+        final Future<Integer> realFuture = FutureAdapter.processFuture( process );
+        return new Future<Integer>()
+        {
+            @Override
+            public boolean cancel( boolean mayInterruptIfRunning )
+            {
+                try
+                {
+                    return realFuture.cancel( mayInterruptIfRunning );
+                }
+                finally
+                {
+                    processOutput.done();
+                }
+            }
+
+            @Override
+            public boolean isCancelled()
+            {
+                return realFuture.isCancelled();
+            }
+
+            @Override
+            public boolean isDone()
+            {
+                return realFuture.isDone();
+            }
+
+            @Override
+            public Integer get() throws InterruptedException, ExecutionException
+            {
+                try
+                {
+                    return realFuture.get();
+                }
+                finally
+                {
+                    processOutput.done();
+                }
+            }
+
+            @Override
+            public Integer get( long timeout, TimeUnit unit ) throws InterruptedException, ExecutionException,
+                    TimeoutException
+            {
+                try
+                {
+                    return realFuture.get( timeout, unit );
+                }
+                finally
+                {
+                    processOutput.done();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Problem manifested like this:
After an unclean shutdown and recovery some index queries seemed to
return nodes duplicated in the same result.

Problem distilled to be:
When applying a transaction property updates (to be fed to indexes) are
derived by looking at the before/after views of the changed records.
Except for one case: where a label gets added to a node, in which case
updates for all its existing properties needs to also be generated. This
special case weren't previously isolated to labels added/removed to/from
existing nodes, but were always considered, even for (in that tx) created nodes.
This resulted in a normal commit working since properties aren't loaded
if the node already exists. But recovery would see those properties and
hence generate duplicate updates.

Solution:
Only generate label-changes-updates for (not previously existing) modified nodes.
