### PR TITLE
Use | for extract, reduce & foreach in 2.0

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/prettifier/Prettifier.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/prettifier/Prettifier.scala
@@ -120,6 +120,7 @@ case object Prettifier extends (String => String) {
     else {
       (token, tail.head) match {
         // FOREACH : <NEXT>
+        case (_: SyntaxToken,         _) if token.text.endsWith("|") => token.toString + space
         case (_: SyntaxToken,         _) if token.text.endsWith(":") => token.toString + space
 
         // <NON-BREAKING-KW> <NEXT>

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Expressions.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Expressions.scala
@@ -102,12 +102,12 @@ trait Expressions extends Base with ParserPattern with Predicates with StringLit
     property <~ "?" ^^ (p => new Nullable(p) with DefaultTrue) |
     property <~ "!" ^^ (p => new Nullable(p) with DefaultFalse)
 
-  def extract: Parser[Expression] = EXTRACT ~> parens(identity ~ IN ~ expression ~ ":" ~ expression) ^^ {
-    case (id ~ in ~ iter ~ ":" ~ expression) => ExtractFunction(iter, id, expression)
+  def extract: Parser[Expression] = EXTRACT ~> parens(identity ~ IN ~ expression ~ (":" | "|") ~ expression) ^^ {
+    case (id ~ _ ~ iter ~ _ ~ expression) => ExtractFunction(iter, id, expression)
   }
 
-  def reduce: Parser[Expression] = REDUCE ~> parens(identity ~ "=" ~ expression ~ "," ~ identity ~ IN ~ expression ~ ":" ~ expression) ^^ {
-    case (acc ~ "=" ~ init ~ "," ~ id ~ in ~ iter ~ ":" ~ expression) => ReduceFunction(iter, id, expression, acc, init)
+  def reduce: Parser[Expression] = REDUCE ~> parens(identity ~ "=" ~ expression ~ "," ~ identity ~ IN ~ expression ~ (":" | "|") ~ expression) ^^ {
+    case (acc ~ _ ~ init ~ _ ~ id ~ _ ~ iter ~ _ ~ expression) => ReduceFunction(iter, id, expression, acc, init)
   }
 
   def coalesceFunc: Parser[Expression] = COALESCE ~> parens(commaList(expression)) ^^ {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Updates.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/Updates.scala
@@ -28,8 +28,8 @@ trait Updates extends Base with Expressions with StartAndCreateClause {
   def updates: Parser[Seq[UpdateAction]]=
     rep(foreach | set | remove | delete) ^^ { x => x.flatten }
 
-  private def foreach: Parser[Seq[UpdateAction]] = FOREACH ~> parens( identity ~ IN ~ expression ~ ":" ~ opt(createStart) ~ opt(updates) ) ^^ {
-    case id ~ in ~ collection ~ ":" ~ creates ~ innerUpdates =>
+  private def foreach: Parser[Seq[UpdateAction]] = FOREACH ~> parens( identity ~ IN ~ expression ~ (":" | "|") ~ opt(createStart) ~ opt(updates) ) ^^ {
+    case id ~ _ ~ collection ~ _ ~ creates ~ innerUpdates =>
       val createCmds: Seq[UpdateAction] = creates.toSeq.map(_._1.map(_.asInstanceOf[UpdatingStartItem].updateAction)).flatten
       val updateCmds = innerUpdates.toSeq.flatten.toSeq
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/symbols/type_system.txt
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/symbols/type_system.txt
@@ -25,7 +25,7 @@ not a Scalar expression.
 Lastly, an expression has dependencies on what identifiers exists in the symbol table,
 and their types. An example is always in place:
 
-+`LENGTH(FILTER(n in nodes(p) : n.prop = 'foo'))`+
++`LENGTH(FILTER(n in nodes(p) WHERE n.prop = 'foo'))`+
 
 In this expression, LENGTH has an expectation on FILTER, and FILTER has one on NODES,
 and so one. But the dependency on identifiers on the symbol table is just one - it has

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
@@ -359,7 +359,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineHelper with Assertions w
     val result = parseAndExecute("""
 START root = node(1)
 CREATE book
-FOREACH(name in ['a','b','c'] :
+FOREACH(name in ['a','b','c'] |
   CREATE UNIQUE root-[:tag]->(tag {name:name})<-[:tagged]-book
 )
 return book
@@ -392,7 +392,7 @@ return book
 
     val result = parseAndExecute("""
 START root = node(1)
-FOREACH(name in ['a','b','c'] :
+FOREACH(name in ['a','b','c'] |
   CREATE UNIQUE root-[:tag]->(tag {name:name})
 )
 """)
@@ -455,8 +455,8 @@ RETURN x""")
     val result = parseAndExecute("""
 START a = node(*)
 WITH collect(a) as nodes
-FOREACH( x in nodes :
-      FOREACH( y in nodes :
+FOREACH( x in nodes |
+      FOREACH( y in nodes |
           CREATE UNIQUE x-[:FOO]->y
       )
 )""")

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -38,9 +38,9 @@ class ExecutionEngineTest extends ExecutionEngineHelper {
   @Test def assignToPathInsideForeachShouldWork() {
     val result = parseAndExecute(
 """start n=node(0)
-foreach(x in [1,2,3] :
+foreach(x in [1,2,3] |
   create p = ({foo:x})-[:X]->()
-  foreach( i in p :
+  foreach( i in p |
     set i.touched = true))""")
     println(result.dumpToString())
   }
@@ -1691,9 +1691,9 @@ RETURN x0.name?
     val b = createNode("foo" -> 3)
     val r = relate(a, b, "rel", Map("foo" -> 2))
 
-    val result = parseAndExecute("start a=node(1) match p=a-->() return filter(x in p : x.foo = 2)").toList
+    val result = parseAndExecute("start a=node(1) match p=a-->() return filter(x in p WHERE x.foo = 2)").toList
 
-    val resultingCollection = result.head("filter(x in p : x.foo = 2)").asInstanceOf[Seq[_]].toList
+    val resultingCollection = result.head("filter(x in p WHERE x.foo = 2)").asInstanceOf[Seq[_]].toList
 
     assert(List(r) == resultingCollection)
   }
@@ -1896,7 +1896,7 @@ RETURN x0.name?
 
   @Test def length_on_filter() {
     // https://github.com/neo4j/community/issues/526
-    val q = "start n=node(*) match n-[r?]->m return length(filter(x in collect(r) : x <> null)) as cn"
+    val q = "start n=node(*) match n-[r?]->m return length(filter(x in collect(r) WHERE x <> null)) as cn"
 
     assert(executeScalar[Long](q) === 0)
   }
@@ -2045,7 +2045,7 @@ RETURN x0.name?
     relate(a,b)
     relate(a,c)
 
-    val result = parseAndExecute("CYPHER 1.9 START a=node(1) foreach(n in extract(p in a-->() : last(p)) : set n.touched = true) return a-->()").dumpToString()
+    val result = parseAndExecute("CYPHER 1.9 START a=node(1) foreach(n in extract(p in a-->() | last(p)) | set n.touched = true) return a-->()").dumpToString()
   }
 
   @Test
@@ -2305,7 +2305,7 @@ RETURN x0.name?
 
   @Test
   def can_use_identifiers_created_inside_the_foreach() {
-    val result = parseAndExecute("start n=node(0) foreach (x in [1,2,3] : create (a { name: 'foo'})  set a.id = x)")
+    val result = parseAndExecute("start n=node(0) foreach (x in [1,2,3] | create (a { name: 'foo'})  set a.id = x)")
 
     assert(result.toList === List())
   }
@@ -2346,7 +2346,7 @@ RETURN x0.name?
   def extract_string_from_node_collection() {
     val a = createNode("name"->"a")
 
-    val result = parseAndExecute("""START n=node(1) with collect(n) as nodes return head(extract(x in nodes: x.name)) + "test" as test """)
+    val result = parseAndExecute("""START n=node(1) with collect(n) as nodes return head(extract(x in nodes | x.name)) + "test" as test """)
 
     assert(result.toList === List(Map("test" -> "atest")))
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
@@ -52,7 +52,7 @@ class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker 
   }
 
   @Test def Add_labels_to_nodes_in_a_foreach() {
-    assertThat("CREATE a,b,c WITH [a,b,c] as nodes FOREACH(n in nodes : SET n :FOO:BAR)", List("FOO", "BAR"))
+    assertThat("CREATE a,b,c WITH [a,b,c] as nodes FOREACH(n in nodes | SET n :FOO:BAR)", List("FOO", "BAR"))
   }
 
   @Test def Using_labels_in_RETURN_clauses() {

--- a/community/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -185,7 +185,7 @@ class MutatingIntegrationTest extends ExecutionEngineHelper with Assertions with
   def set_a_property_to_an_empty_collection() {
     createNode("Andres")
 
-    val result = parseAndExecute("start n=node(1) with filter(x in collect(n.name) : x = 12) as names create ({x : names})")
+    val result = parseAndExecute("start n=node(1) with filter(x in collect(n.name) WHERE x = 12) as names create ({x : names})")
     assertStats(result,
       propertiesSet = 1,
       nodesCreated = 1
@@ -234,7 +234,7 @@ class MutatingIntegrationTest extends ExecutionEngineHelper with Assertions with
 start a = node(1), c = node(3)
 match p=a-->b-->c
 with p
-foreach(n in nodes(p) :
+foreach(n in nodes(p) |
   set n.marked = true
 )
             """
@@ -326,7 +326,7 @@ foreach(n in nodes(p) :
   def create_node_and_rel_in_foreach() {
     parseAndExecute("""
 create center
-foreach(x in range(1,10) :
+foreach(x in range(1,10) |
   create (leaf1 {number : x}) , center-[:X]->leaf1
 )
 return distinct center""")
@@ -334,7 +334,7 @@ return distinct center""")
 
   @Test
   def extract_on_arrays() {
-    val result = parseAndExecute( """start n=node(0) set n.x=[1,2,3] return extract (i in n.x : i/2.0) as x""")
+    val result = parseAndExecute( """start n=node(0) set n.x=[1,2,3] return extract (i in n.x | i/2.0) as x""")
     assert(result.toList === List(Map("x" -> List(0.5, 1.0, 1.5))))
   }
 
@@ -450,7 +450,7 @@ return distinct center""")
   @Test
   def delete_and_delete_again() {
     createNode()
-    val result = parseAndExecute("start a=node(1) delete a foreach( x in [1] : delete a)")
+    val result = parseAndExecute("start a=node(1) delete a foreach( x in [1] | delete a)")
 
     assertStats(result, nodesDeleted = 1)
   }
@@ -510,14 +510,14 @@ return distinct center""")
 
   @Test
   def can_create_anonymous_nodes_inside_foreach() {
-    val result = parseAndExecute("start me=node(0) foreach (i in range(1,10) : create me-[:FRIEND]->())")
+    val result = parseAndExecute("start me=node(0) foreach (i in range(1,10) | create me-[:FRIEND]->())")
 
     assert(result.toList === List())
   }
 
   @Test
   def should_be_able_to_use_external_identifiers_inside_foreach() {
-    val result = parseAndExecute("start a=node(0), b=node(0) foreach(x in [b] : create x-[:FOO]->a) ")
+    val result = parseAndExecute("start a=node(0), b=node(0) foreach(x in [b] | create x-[:FOO]->a) ")
 
     assert(result.toList === List())
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ForeachTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ForeachTest.scala
@@ -50,7 +50,7 @@ class ForeachTest extends DocumentingTestBase {
     testQuery(
       title = "Mark all nodes along a path",
       text = "This query will set the property `marked` to true on all nodes along a path.",
-      queryText = "match p = begin -[*]-> end where begin.name='A' and end.name='D' foreach(n in nodes(p) : set n.marked = true)",
+      queryText = "match p = begin -[*]-> end where begin.name='A' and end.name='D' foreach(n in nodes(p) | set n.marked = true)",
       returns = "Nothing is returned from this query.",
       assertions = (p) => {})
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -133,7 +133,7 @@ class FunctionsTest extends DocumentingTestBase {
   @Test def extract() {
     testThis(
       title = "EXTRACT",
-      syntax = "EXTRACT( identifier in collection : expression )",
+      syntax = "EXTRACT( identifier in collection | expression )",
       arguments = List(
         "collection" -> "An expression that returns a collection",
         "identifier" -> "The closure will have an identifier introduced in it's context. Here you decide which identifier to use.",
@@ -142,15 +142,15 @@ class FunctionsTest extends DocumentingTestBase {
       text = """To return a single property, or the value of a function from a collection of nodes or relationships,
  you can use `EXTRACT`. It will go through a collection, run an expression on every element, and return the results
  in an collection with these values. It works like the `map` method in functional languages such as Lisp and Scala.""",
-      queryText = """match p=a-->b-->c where a.name='Alice' and b.name='Bob' and c.name='Daniel' return extract(n in nodes(p) : n.age)""",
+      queryText = """match p=a-->b-->c where a.name='Alice' and b.name='Bob' and c.name='Daniel' return extract(n in nodes(p) | n.age)""",
       returns = """The age property of all nodes in the path are returned.""",
-      assertions = (p) => assertEquals(List(Map("extract(n in nodes(p) : n.age)" -> List(38, 25, 54))), p.toList))
+      assertions = (p) => assertEquals(List(Map("extract(n in nodes(p) | n.age)" -> List(38, 25, 54))), p.toList))
   }
 
   @Test def reduce() {
     testThis(
       title = "REDUCE",
-      syntax = "REDUCE( accumulator = initial,  identifier in collection : expression )",
+      syntax = "REDUCE( accumulator = initial,  identifier in collection | expression )",
       arguments = List(
         "accumulator" -> "An identifier that will hold the result and the partial results as the collection is iterated",
         "initial"    -> "An expression that runs once to give a starting value to the accumulator",
@@ -161,9 +161,9 @@ class FunctionsTest extends DocumentingTestBase {
       text = """To run an expression against individual elements of a collection, and store the result of the expression in
  an accumulator, you can use `REDUCE`. It will go through a collection, run an expression on every element, storing the partial result
  in the accumulator. It works like the `fold` or `reduce` method in functional languages such as Lisp and Scala.""",
-      queryText = """match p=a-->b-->c where a.name='Alice' and b.name='Bob' and c.name='Daniel' return reduce(totalAge = 0, n in nodes(p) : totalAge + n.age)""",
+      queryText = """match p=a-->b-->c where a.name='Alice' and b.name='Bob' and c.name='Daniel' return reduce(totalAge = 0, n in nodes(p) | totalAge + n.age)""",
       returns = """The age property of all nodes in the path are summed and returned as a single value.""",
-      assertions = (p) => assertEquals(List(Map("reduce(totalAge = 0, n in nodes(p) : totalAge + n.age)" -> 117)), p.toList))
+      assertions = (p) => assertEquals(List(Map("reduce(totalAge = 0, n in nodes(p) | totalAge + n.age)" -> 117)), p.toList))
   }
 
   @Test def head() {
@@ -211,13 +211,13 @@ class FunctionsTest extends DocumentingTestBase {
   @Test def filter() {
     testThis(
       title = "FILTER",
-      syntax = "FILTER(identifier in collection : predicate)",
+      syntax = "FILTER(identifier in collection WHERE predicate)",
       arguments = common_arguments,
       text = "`FILTER` returns all the elements in a collection that comply to a predicate.",
-      queryText = """match a where a.name='Eskil' return a.array, filter(x in a.array : length(x) = 3)""",
+      queryText = """match a where a.name='Eskil' return a.array, filter(x in a.array WHERE length(x) = 3)""",
       returns = "This returns the property named `array` and a list of values in it, which have the length `3`.",
       assertions = (p) => {
-        val array = p.columnAs[Iterable[_]]("filter(x in a.array : length(x) = 3)").toList.head
+        val array = p.columnAs[Iterable[_]]("filter(x in a.array WHERE length(x) = 3)").toList.head
         assert(List("one","two") === array.toList)
       })
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/InsertStatusUpdateTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/InsertStatusUpdateTest.scala
@@ -45,7 +45,7 @@ WHERE me.name='Bob'
 CREATE me-[:STATUS]->(latest_update{text:'Status',date:123})
 DELETE r
 WITH latest_update, collect(secondlatestupdate) as seconds
-FOREACH(x in seconds : CREATE latest_update-[:NEXT]->x)
+FOREACH(x in seconds | CREATE latest_update-[:NEXT]->x)
 RETURN latest_update.text as new_status""",
       returns =
 """

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsCompleteGraphTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsCompleteGraphTest.scala
@@ -40,7 +40,7 @@ class PrettyGraphsCompleteGraphTest extends DocumentingTestBase {
         self relationships. Using said match, relationships between all these nodes are created. Lastly, 
         the center node and all relationships connected to it are removed.""",
       queryText = """create center
-foreach( x in range(1,6) : 
+foreach( x in range(1,6) |
    create (leaf {count : x}), center-[:X]->leaf
 )
 WITH center

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsFriendshipGraphTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsFriendshipGraphTest.scala
@@ -36,7 +36,7 @@ class PrettyGraphsFriendshipGraphTest extends DocumentingTestBase {
       text =
 """This query first creates a center node, and then once per element in the range, creates a cycle graph and connects it to the center""",
       queryText = """CREATE center
-foreach( x in range(1,3) : 
+foreach( x in range(1,3) |
    CREATE leaf1, leaf2, center-[:X]->leaf1, center-[:X]->leaf2, leaf1-[:X]->leaf2
 )
 RETURN ID(center) as id""",

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsStarTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsStarTest.scala
@@ -36,7 +36,7 @@ class PrettyGraphsStarTest extends DocumentingTestBase {
       text =
 """The graph is created by first creating a center node, and then once per element in the range, creates a leaf node and connects it to the center.""",
       queryText = """create center
-foreach( x in range(1,6) : 
+foreach( x in range(1,6) |
    create leaf, center-[:X]->leaf
 )
 return id(center) as id;""",

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsWheel.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsWheel.scala
@@ -42,7 +42,7 @@ class PrettyGraphsWheelTest extends DocumentingTestBase {
 - Find the minimum and maximum leaf and connect these.
 - Return the id of the center node.""",
       queryText = """CREATE center
-foreach( x in range(1,6) : 
+foreach( x in range(1,6) |
    CREATE (leaf {count:x}), center-[:X]->leaf
 )
 WITH center

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/prettifier/PrettifierTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/prettifier/PrettifierTest.scala
@@ -41,13 +41,13 @@ class PrettifierTest extends Assertions {
 
   @Test
   def shouldNotBreakCreateInForeach() {
-    assertIsPrettified("MATCH p=n%nFOREACH (x IN p : CREATE x--())", "match p=n foreach(x in p : create x--())")
+    assertIsPrettified("MATCH p=n%nFOREACH (x IN p | CREATE x--())", "match p=n foreach(x in p | create x--())")
   }
 
   @Test
   def shouldNotBreakCreateInComplexForeach() {
-    assertIsPrettified("MATCH p=n%nFOREACH (x IN p : CREATE x--()%nSET x.foo = 'bar')%nRETURN DISTINCT p;",
-      "match p=n foreach(x in p : create x--() set x.foo = 'bar') return distinct p;")
+    assertIsPrettified("MATCH p=n%nFOREACH (x IN p | CREATE x--()%nSET x.foo = 'bar')%nRETURN DISTINCT p;",
+      "match p=n foreach(x in p | create x--() set x.foo = 'bar') return distinct p;")
   }
 
   @Test


### PR DESCRIPTION
And WHERE for filter. Also make these the default in documentation.

Note this was already in 1.9, but was not added to 2.0 during the master merge
