### PR TITLE
Correctly decode property value supplied as a query parameter.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
@@ -180,7 +180,7 @@ public class PropertySettingStrategy
        return Array.newInstance( cls, 0);
     }
 
-    private Object convertToNativeArray( Collection<?> collection )
+    public static Object convertToNativeArray( Collection<?> collection )
     {
         Object[] array = null;
         Iterator<?> objects = collection.iterator();

--- a/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
@@ -37,11 +37,14 @@ import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.LABEL;
 import org.neo4j.test.GraphDescription.NODE;
 
+import static java.util.Arrays.asList;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
@@ -49,6 +52,8 @@ import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
 import static org.neo4j.server.rest.domain.JsonHelper.readJson;
 import static org.neo4j.test.GraphDescription.PROP;
+import static org.neo4j.test.GraphDescription.PropType.ARRAY;
+import static org.neo4j.test.GraphDescription.PropType.STRING;
 
 public class LabelsDocIT extends AbstractRestFunctionalTestBase
 {
@@ -221,17 +226,19 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
             .entity();
         
         List<?> parsed = (List<?>) readJson( body );
-        assertEquals( asSet( "a", "b" ), asSet( map( getNameProperty, parsed ) ) );
+        assertEquals( asSet( "a", "b" ), asSet( map( getProperty( "name", String.class ), parsed ) ) );
     }
 
     /**
      * Get nodes by label and property.
      *
      * You can retrieve all nodes with a given label and property by passing one property as a query parameter.
-     * Currently, it is not possible to specify multiple properties to search by.
+     * Notice that the property value is JSON-encoded and then URL-encoded.
      *
      * If there is an index available on the label/property combination you send, that index will be used. If no
      * index is available, all nodes with the given label will be filtered through to find matching nodes.
+     *
+     * Currently, it is not possible to search using multiple properties.
      */
     @Test
     @Documented
@@ -251,7 +258,39 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
                 .entity();
 
         List<?> parsed = (List<?>) readJson( result );
-        assertEquals( asSet( "bob ross" ), asSet( map( getNameProperty, parsed ) ) );
+        assertEquals( asSet( "bob ross" ), asSet( map( getProperty( "name", String.class ), parsed ) ) );
+    }
+
+    /**
+     * Get nodes by label and array property.
+     */
+    @Test
+    @GraphDescription.Graph( nodes = {
+            @NODE(name = "I", labels = {@LABEL("Person")}),
+            @NODE(name = "you", labels = {@LABEL("Person")}, properties =
+                    {@PROP(key = "names", value = "bob,ross", type = ARRAY, componentType = STRING)}),
+            @NODE(name = "him", labels = {@LABEL("Person")}, properties =
+                    {@PROP(key = "names", value = "cat,stevens", type = ARRAY, componentType = STRING)})})
+    public void get_nodes_with_label_and_array_property() throws PropertyValueException, UnsupportedEncodingException
+    {
+        data.get();
+
+        String labelName = "Person";
+
+        String uri = getNodesWithLabelAndPropertyUri( labelName, "names", new String[] { "bob", "ross" } );
+        System.out.println( "uri = " + uri );
+
+        String result = gen.get()
+                .expectedStatus( 200 )
+                .get( uri )
+                .entity();
+
+        List<?> parsed = (List<?>) readJson( result );
+        assertEquals( 1, parsed.size() );
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals( asSet( asList( asList( "bob", "ross" ) ) ),
+                asSet( map( getProperty( "names", List.class ), parsed ) ) );
     }
 
     /**
@@ -278,14 +317,17 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
         assertTrue( parsed.contains( "second" ) );
     }
 
-    private Function<Object,String> getNameProperty = new Function<Object, String>()
+    private <T> Function<Object, T> getProperty( final String propertyKey, final Class<T> propertyType )
     {
-        @Override
-        public String apply( Object from )
+        return new Function<Object, T>()
         {
-            Map<?, ?> node = (Map<?, ?>) from;
-            Map<?, ?> data = (Map<?, ?>) node.get( "data" );
-            return (String) data.get( "name" );
-        }
-    };
+            @Override
+            public T apply( Object from )
+            {
+                Map<?, ?> node = (Map<?, ?>) from;
+                Map<?, ?> data = (Map<?, ?>) node.get( "data" );
+                return propertyType.cast( data.get( propertyKey ) );
+            }
+        };
+    }
 }


### PR DESCRIPTION
Now uses the same InputFormat mechanism used elsewhere in the REST API.
There is still special handling for JSON lists, that must be converted to native arrays.
It was not practical/safe to reuse all the logic from PropertySettingStrategy;
the ultimate solution will only come when we introduce an explicit type system.
