### PR TITLE
A couple of performance improvements

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContext.scala
@@ -35,14 +35,16 @@ import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.exceptions.schema.{SchemaKernelException, DropIndexFailureException}
 import org.neo4j.kernel.api.operations.StatementState
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException
+import org.neo4j.kernel.impl.api.PrimitiveLongIterator
+import scala.collection.Iterator
 
-class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx: StatementOperations, theState: StatementState)
-  extends TransactionBoundTokenContext(ctx, theState) with QueryContext {
+class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx: StatementOperationParts, theState: StatementState)
+  extends TransactionBoundTokenContext(ctx.keyReadOperations, theState) with QueryContext {
 
   private var open = true
 
   def setLabelsOnNode(node: Long, labelIds: Iterable[Long]): Int = labelIds.foldLeft(0) {
-    case (count, labelId) => if (ctx.nodeAddLabel(theState, node, labelId)) count + 1 else count
+    case (count, labelId) => if (ctx.entityWriteOperations.nodeAddLabel(theState, node, labelId)) count + 1 else count
   }
 
   def close(success: Boolean) {
@@ -92,13 +94,13 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
     start.createRelationshipTo(end, withName(relType))
 
   def getLabelsForNode(node: Long) =
-    ctx.nodeGetLabels(theState, node).asScala.map(_.asInstanceOf[Long])
+    ctx.entityReadOperations.nodeGetLabels(theState, node).asScala.map(_.asInstanceOf[Long])
 
   override def isLabelSetOnNode(label: Long, node: Long) =
-    ctx.nodeHasLabel(theState, node, label)
+    ctx.entityReadOperations.nodeHasLabel(theState, node, label)
 
   def getOrCreateLabelId(labelName: String) =
-    ctx.labelGetOrCreateForName(theState, labelName)
+    ctx.keyWriteOperations.labelGetOrCreateForName(theState, labelName)
 
 
   def getRelationshipsFor(node: Node, dir: Direction, types: Seq[String]) = types match {
@@ -109,37 +111,37 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
   def getTransaction = tx
 
   def exactIndexSearch(index: IndexDescriptor, value: Any) =
-    ctx.nodesGetFromIndexLookup(theState, index, value).asScala.map((id: java.lang.Long) => nodeOps.getById(id))
+    ctx.entityReadOperations.nodesGetFromIndexLookup(theState, index, value).asScala.map((id: java.lang.Long) => nodeOps.getById(id))
 
   val nodeOps = new NodeOperations
 
   val relationshipOps = new RelationshipOperations
 
   def removeLabelsFromNode(node: Long, labelIds: Iterable[Long]): Int = labelIds.foldLeft(0) {
-    case (count, labelId) => if (ctx.nodeRemoveLabel(theState, node, labelId)) count + 1 else count
+    case (count, labelId) => if (ctx.entityWriteOperations.nodeRemoveLabel(theState, node, labelId)) count + 1 else count
   }
 
-  def getNodesByLabel(id: Long): Iterator[Node] = ctx.nodesGetForLabel(theState, id).asScala.map(nodeOps.getById(_))
+  def getNodesByLabel(id: Long): Iterator[Node] = ctx.entityReadOperations.nodesGetForLabel(theState, id).asScala.map(nodeOps.getById(_))
 
   class NodeOperations extends BaseOperations[Node] {
     def delete(obj: Node) {
-      ctx.nodeDelete(theState, obj.getId)
+      ctx.entityWriteOperations.nodeDelete(theState, obj.getId)
     }
 
-    def propertyKeyIds(obj: Node): Iterator[Long] = ctx.nodeGetPropertyKeys(theState, obj.getId).asScala.map(_.longValue())
+    def propertyKeyIds(obj: Node): Iterator[Long] = primitiveLongIteratorToScalaIterator(ctx.entityReadOperations.nodeGetPropertyKeys(theState, obj.getId)).map(_.longValue())
 
     def getProperty(obj: Node, propertyKeyId: Long): Any = {
-      ctx.nodeGetProperty(theState, obj.getId, propertyKeyId).value(null)
+      ctx.entityReadOperations.nodeGetProperty(theState, obj.getId, propertyKeyId).value(null)
     }
 
-    def hasProperty(obj: Node, propertyKey: Long) = ctx.nodeHasProperty(theState, obj.getId, propertyKey)
+    def hasProperty(obj: Node, propertyKey: Long) = ctx.entityReadOperations.nodeHasProperty(theState, obj.getId, propertyKey)
 
     def removeProperty(obj: Node, propertyKeyId: Long) {
-      ctx.nodeRemoveProperty(theState, obj.getId, propertyKeyId)
+      ctx.entityWriteOperations.nodeRemoveProperty(theState, obj.getId, propertyKeyId)
     }
 
     def setProperty(obj: Node, propertyKeyId: Long, value: Any) {
-      ctx.nodeSetProperty(theState, obj.getId, properties.Property.property(propertyKeyId, value) )
+      ctx.entityWriteOperations.nodeSetProperty(theState, obj.getId, properties.Property.property(propertyKeyId, value) )
     }
 
 
@@ -161,23 +163,23 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
 
   class RelationshipOperations extends BaseOperations[Relationship] {
     def delete(obj: Relationship) {
-      ctx.relationshipDelete(theState, obj.getId)
+      ctx.entityWriteOperations.relationshipDelete(theState, obj.getId)
     }
 
     def propertyKeyIds(obj: Relationship): Iterator[Long] =
-      ctx.relationshipGetPropertyKeys(theState, obj.getId).asScala.map(_.longValue())
+      primitiveLongIteratorToScalaIterator( ctx.entityReadOperations.relationshipGetPropertyKeys(theState, obj.getId)).map(_.longValue())
 
     def getProperty(obj: Relationship, propertyKeyId: Long): Any =
-      ctx.relationshipGetProperty(theState, obj.getId, propertyKeyId).value(null)
+      ctx.entityReadOperations.relationshipGetProperty(theState, obj.getId, propertyKeyId).value(null)
 
-    def hasProperty(obj: Relationship, propertyKey: Long) = ctx.relationshipHasProperty(theState, obj.getId, propertyKey)
+    def hasProperty(obj: Relationship, propertyKey: Long) = ctx.entityReadOperations.relationshipHasProperty(theState, obj.getId, propertyKey)
 
     def removeProperty(obj: Relationship, propertyKeyId: Long) {
-      ctx.relationshipRemoveProperty(theState, obj.getId, propertyKeyId)
+      ctx.entityWriteOperations.relationshipRemoveProperty(theState, obj.getId, propertyKeyId)
     }
 
     def setProperty(obj: Relationship, propertyKeyId: Long, value: Any) {
-      ctx.relationshipSetProperty(theState, obj.getId, properties.Property.property(propertyKeyId, value) )
+      ctx.entityWriteOperations.relationshipSetProperty(theState, obj.getId, properties.Property.property(propertyKeyId, value) )
     }
 
     def getById(id: Long) = graph.getRelationshipById(id)
@@ -193,25 +195,25 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
   }
 
   def getOrCreatePropertyKeyId(propertyKey: String) =
-    ctx.propertyKeyGetOrCreateForName(theState, propertyKey)
+    ctx.keyWriteOperations.propertyKeyGetOrCreateForName(theState, propertyKey)
 
   def addIndexRule(labelIds: Long, propertyKeyId: Long) {
     try {
-      ctx.indexCreate(theState, labelIds, propertyKeyId)
+      ctx.schemaWriteOperations.indexCreate(theState, labelIds, propertyKeyId)
     } catch {
       case e: SchemaKernelException =>
         val labelName = getLabelName(labelIds)
-        val propName = ctx.propertyKeyGetName(theState, propertyKeyId)
+        val propName = ctx.keyReadOperations.propertyKeyGetName(theState, propertyKeyId)
         throw new IndexAlreadyDefinedException(labelName, propName, e)
     }
   }
 
   def dropIndexRule(labelId: Long, propertyKeyId: Long) {
     try {
-      ctx.indexDrop(theState, new IndexDescriptor(labelId, propertyKeyId))
+      ctx.schemaWriteOperations.indexDrop(theState, new IndexDescriptor(labelId, propertyKeyId))
     } catch {
       case e: DropIndexFailureException =>
-        throw new CouldNotDropIndexException(e.getUserMessage(new KeyNameLookup(theState, ctx)), e)
+        throw new CouldNotDropIndexException(e.getUserMessage(new KeyNameLookup(theState, ctx.keyReadOperations)), e)
     }
   }
 
@@ -229,33 +231,42 @@ class TransactionBoundQueryContext(graph: GraphDatabaseAPI, tx: Transaction, ctx
 
   abstract class BaseOperations[T <: PropertyContainer] extends Operations[T] {
     def propertyKeys(obj: T) = obj.getPropertyKeys.asScala
+    
+    def primitiveLongIteratorToScalaIterator( primitiveIterator: PrimitiveLongIterator ): Iterator[Long] = {
+      new Iterator[Long]
+      {
+        def hasNext(): Boolean = primitiveIterator.hasNext
+        
+        def next(): Long = primitiveIterator.next
+      }
+    }
   }
 
   def getOrCreateFromSchemaState[K, V](key: K, creator: => V) = {
     val javaCreator = new org.neo4j.helpers.Function[K, V]() {
       def apply(key: K) = creator
     }
-    ctx.schemaStateGetOrCreate(theState, key, javaCreator)
+    ctx.schemaStateOperations.schemaStateGetOrCreate(theState, key, javaCreator)
   }
 
-  def schemaStateContains(key: String) = ctx.schemaStateContains(theState, key)
+  def schemaStateContains(key: String) = ctx.schemaStateOperations.schemaStateContains(theState, key)
 
   def createUniqueConstraint(labelId: Long, propertyKeyId: Long) {
     try {
-      ctx.uniquenessConstraintCreate(theState, labelId, propertyKeyId)
+      ctx.schemaWriteOperations.uniquenessConstraintCreate(theState, labelId, propertyKeyId)
     } catch {
         case e: KernelException =>
-          throw new CouldNotCreateConstraintException(e.getUserMessage(new KeyNameLookup(theState, ctx)), e)
+          throw new CouldNotCreateConstraintException(e.getUserMessage(new KeyNameLookup(theState, ctx.keyReadOperations)), e)
     }
   }
 
   def dropUniqueConstraint(labelId: Long, propertyKeyId: Long) {
-    val constraint = IteratorUtil.singleOrNull(ctx.constraintsGetForLabelAndPropertyKey(theState, labelId, propertyKeyId))
+    val constraint = IteratorUtil.singleOrNull(ctx.schemaReadOperations.constraintsGetForLabelAndPropertyKey(theState, labelId, propertyKeyId))
 
     if (constraint == null) {
       throw new MissingConstraintException()
     }
 
-    ctx.constraintDrop(theState, constraint)
+    ctx.schemaWriteOperations.constraintDrop(theState, constraint)
   }
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundTokenContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundTokenContext.scala
@@ -23,8 +23,10 @@ import org.neo4j.cypher.internal.spi.TokenContext
 import org.neo4j.kernel.api.exceptions.{PropertyKeyNotFoundException, LabelNotFoundKernelException}
 import org.neo4j.kernel.api.StatementOperations
 import org.neo4j.kernel.api.operations.StatementState
+import org.neo4j.kernel.api.StatementOperationParts
+import org.neo4j.kernel.api.operations.KeyReadOperations
 
-abstract class TransactionBoundTokenContext(ctx: StatementOperations, state: StatementState) extends TokenContext
+abstract class TransactionBoundTokenContext(ctx: KeyReadOperations, state: StatementState) extends TokenContext
 {
   def getOptPropertyKeyId(propertyKeyName: String): Option[Long] =
     TokenContext.tryGet[PropertyKeyNotFoundException](getPropertyKeyId(propertyKeyName))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
@@ -32,6 +32,8 @@ import org.neo4j.cypher.internal.spi.gdsimpl.TransactionBoundPlanContext
 import org.scalatest.Assertions
 import org.neo4j.kernel.api.StatementOperations
 import org.neo4j.kernel.api.operations.StatementState
+import org.neo4j.kernel.api.StatementOperationParts
+import org.neo4j.cypher.internal.spi.gdsimpl.TransactionBoundPlanContext
 
 class GraphDatabaseTestBase extends GraphIcing with Assertions {
 
@@ -97,7 +99,7 @@ class GraphDatabaseTestBase extends GraphIcing with Assertions {
 
   def createNode(values: (String, Any)*): Node = createNode(values.toMap)
 
-  def execStatement[T](f: (StatementOperations => T)): T = {
+  def execStatement[T](f: (StatementOperationParts => T)): T = {
     val tx = graph.beginTx
     val ctx = graph
       .getDependencyResolver
@@ -176,16 +178,17 @@ class GraphDatabaseTestBase extends GraphIcing with Assertions {
     (a, b, c, d)
   }
 
-  def statementContext:StatementOperations =
+  def statementContext:StatementOperationParts =
     graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).getCtxForWriting
 
   def cakeState:StatementState =
     graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).statementForWriting
     
-  def readOnlyStatementContext:StatementOperations =
+  def readOnlyStatementContext:StatementOperationParts =
     graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).getCtxForReading
 
-  def planContext:PlanContext= new TransactionBoundPlanContext(statementContext, cakeState, graph)
+  def planContext:PlanContext= new TransactionBoundPlanContext(
+      statementContext.keyReadOperations, statementContext.schemaReadOperations, cakeState, graph)
 
   def readOnlyCakeState:StatementState =
     graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).statementForReading

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -63,9 +63,9 @@ class ConstraintsTest extends DocumentingTestBase {
     val statementCtx = db.statementContextForReading
     val state = db.stateForReading
 
-    val prop = statementCtx.propertyKeyGetForName(state, propName)
-    val label = statementCtx.labelGetForName(state, labelName)
+    val prop = statementCtx.keyReadOperations.propertyKeyGetForName(state, propName)
+    val label = statementCtx.keyReadOperations.labelGetForName(state, labelName)
 
-    statementCtx.constraintsGetForLabelAndPropertyKey(state, label, prop).asScala
+    statementCtx.schemaReadOperations.constraintsGetForLabelAndPropertyKey(state, label, prop).asScala
   }
 }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/TraversalMatcherBuilderTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/executionplan/builders/TraversalMatcherBuilderTest.scala
@@ -40,7 +40,7 @@ class TraversalMatcherBuilderTest extends GraphDatabaseTestBase with Assertions 
   @Before def init() {
     builder = new TraversalMatcherBuilder
     tx = graph.beginTx()
-    ctx = new TransactionBoundPlanContext(statementContext, cakeState, graph)
+    ctx = new TransactionBoundPlanContext(statementContext.keyReadOperations, statementContext.schemaReadOperations, cakeState, graph)
   }
 
   @After def cleanup() {

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/GraphIcing.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/GraphIcing.scala
@@ -26,6 +26,7 @@ import collection.JavaConverters._
 import java.util.concurrent.TimeUnit
 import org.neo4j.kernel.api.StatementOperations
 import org.neo4j.kernel.api.operations.StatementState
+import org.neo4j.kernel.api.StatementOperationParts
 
 trait GraphIcing {
 
@@ -60,7 +61,7 @@ trait GraphIcing {
       }
     }
 
-    def statementContextForReading: StatementOperations = graph.
+    def statementContextForReading: StatementOperationParts = graph.
       getDependencyResolver.
       resolveDependency(classOf[ThreadToStatementContextBridge]).
       getCtxForReading
@@ -74,7 +75,7 @@ trait GraphIcing {
       resolveDependency(classOf[ThreadToStatementContextBridge]).
       statementForWriting
 
-    def inTx[T](f: StatementOperations => T): T = {
+    def inTx[T](f: StatementOperationParts => T): T = {
       val tx = graph.beginTx()
       try {
         val context = graph.

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundQueryContextTest.scala
@@ -28,19 +28,20 @@ import org.scalatest.junit.JUnitSuite
 import org.scalatest.mock.MockitoSugar
 import org.neo4j.kernel.api.StatementOperations
 import org.neo4j.kernel.api.operations.StatementState
+import org.neo4j.kernel.api.StatementOperationParts
 
 class TransactionBoundQueryContextTest extends JUnitSuite with Assertions with MockitoSugar {
 
   var graph: ImpermanentGraphDatabase = null
   var outerTx: Transaction = null
-  var statementContext: StatementOperations = null
+  var statementContext: StatementOperationParts = null
   var state: StatementState = null
 
   @Before
   def init() {
     graph = new ImpermanentGraphDatabase
     outerTx = mock[Transaction]
-    statementContext = mock[StatementOperations]
+    statementContext = mock[StatementOperationParts]
     state = mock[StatementState]
   }
 

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.helpers.collection;
 
-import static java.util.Arrays.asList;
-import static java.util.EnumSet.allOf;
-import static org.neo4j.helpers.collection.Iterables.map;
-
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +36,12 @@ import java.util.Set;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.CloneableInPublic;
 import org.neo4j.helpers.Function;
+import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
+
+import static java.util.Arrays.asList;
+import static java.util.EnumSet.allOf;
+
+import static org.neo4j.helpers.collection.Iterables.map;
 
 /**
  * Contains common functionality regarding {@link Iterator}s and
@@ -531,6 +533,16 @@ public abstract class IteratorUtil
     public static <T> Set<T> asSet( Iterator<T> iterator )
     {
         return addToCollection( iterator, new HashSet<T>() );
+    }
+    
+    public static Set<Long> asSet( PrimitiveLongIterator iterator )
+    {
+        Set<Long> set = new HashSet<>();
+        while ( iterator.hasNext() )
+        {
+            set.add( iterator.next() );
+        }
+        return set;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/ThreadToStatementContextBridge.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.api.operations.ReadOnlyStatementState;
 import org.neo4j.kernel.api.operations.StatementState;
@@ -69,12 +70,12 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter
         } ) );
     }
     
-    public StatementOperations getCtxForReading()
+    public StatementOperationParts getCtxForReading()
     {
         return kernelAPI.readOnlyStatementOperations();
     }
 
-    public StatementOperations getCtxForWriting()
+    public StatementOperationParts getCtxForWriting()
     {
         return kernelAPI.statementOperations();
     }
@@ -128,13 +129,13 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter
         }
         
         @Override
-        public StatementOperations getCtxForWriting()
+        public StatementOperationParts getCtxForWriting()
         {
             return kernelAPI.readOnlyStatementOperations();
         }
 
         @Override
-        public StatementOperations getCtxForReading()
+        public StatementOperationParts getCtxForReading()
         {
             return kernelAPI.readOnlyStatementOperations();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelAPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelAPI.java
@@ -57,7 +57,7 @@ public interface KernelAPI
      * @return a new {@link StatementOperations} used for read operations not associated
      * with any transaction.
      */
-    StatementOperations statementOperations();
+    StatementOperationParts statementOperations();
 
-    StatementOperations readOnlyStatementOperations();
+    StatementOperationParts readOnlyStatementOperations();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperations.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.kernel.api.operations.EntityOperations;
 import org.neo4j.kernel.api.operations.KeyOperations;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.ReadOperations;
 import org.neo4j.kernel.api.operations.SchemaOperations;
 import org.neo4j.kernel.api.operations.WriteOperations;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/EntityReadOperations.java
@@ -25,6 +25,7 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 
 public interface EntityReadOperations
@@ -79,19 +80,19 @@ public interface EntityReadOperations
     
     // TODO: decide if this should be replaced by nodeGetAllProperties()
     /** Return all property keys associated with a node. */
-    Iterator<Long> nodeGetPropertyKeys( StatementState state, long nodeId ) throws EntityNotFoundException;
+    PrimitiveLongIterator nodeGetPropertyKeys( StatementState state, long nodeId ) throws EntityNotFoundException;
 
     Iterator<Property> nodeGetAllProperties( StatementState state, long nodeId ) throws EntityNotFoundException;
 
     // TODO: decide if this should be replaced by relationshipGetAllProperties()
     /** Return all property keys associated with a relationship. */
-    Iterator<Long> relationshipGetPropertyKeys( StatementState state, long relationshipId ) throws EntityNotFoundException;
+    PrimitiveLongIterator relationshipGetPropertyKeys( StatementState state, long relationshipId ) throws EntityNotFoundException;
 
     Iterator<Property> relationshipGetAllProperties( StatementState state, long relationshipId ) throws EntityNotFoundException;
 
     // TODO: decide if this should be replaced by relationshipGetAllProperties()
     /** Return all property keys associated with a relationship. */
-    Iterator<Long> graphGetPropertyKeys( StatementState state );
+    PrimitiveLongIterator graphGetPropertyKeys( StatementState state );
 
     Iterator<Property> graphGetAllProperties( StatementState state );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyNameLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyNameLookup.java
@@ -27,10 +27,10 @@ public class KeyNameLookup
     private final KeyReadOperations keyReadOperations;
     private final StatementState state;
 
-    public KeyNameLookup( StatementState state, KeyReadOperations keyReadOperations )
+    public KeyNameLookup( StatementState state, KeyReadOperations context )
     {
         this.state = state;
-        this.keyReadOperations = keyReadOperations;
+        this.keyReadOperations = context;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/LifecycleOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/LifecycleOperations.java
@@ -17,9 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api;
+package org.neo4j.kernel.api.operations;
 
-import org.neo4j.kernel.api.operations.StatementState;
 
 public interface LifecycleOperations
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/ReadOnlyStatementState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/ReadOnlyStatementState.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.neo4j.graphdb.NotInTransactionException;
-import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
@@ -65,13 +64,12 @@ public class ReadOnlyStatementState implements StatementState
     }
     
     @Override
-    public RefCounting refCounting()
+    public void markAsClosed()
     {
-        return WritableStatementState.NO_REF_COUNTING;
     }
-
+    
     @Override
-    public Closeable closeable( final StatementOperations logic )
+    public Closeable closeable( final LifecycleOperations logic )
     {
         return new Closeable()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/StatementState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/StatementState.java
@@ -22,12 +22,14 @@ package org.neo4j.kernel.api.operations;
 import java.io.Closeable;
 
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
 import org.neo4j.kernel.impl.api.LockHolder;
+import org.neo4j.kernel.impl.api.ReferenceCountingStatementOperations;
 import org.neo4j.kernel.impl.api.state.TxState;
 
 /**
+ * Contains all state necessary for satisfying operations performed on a statement.
+ * 
  * There's a possibility that this object, since it's built by {@link KernelTransaction#newStatementState()},
  * can be generic and be decorated with whatever state objects the layers in the {@link KernelTransaction}
  * needs. But for now I'd say it's enough with a specific cake knowing the layout of the cake.
@@ -43,7 +45,11 @@ public interface StatementState
     
     IndexReaderFactory indexReaderFactory();
     
-    RefCounting refCounting();
+    /**
+     * A hook provided for satisfying reference counting.
+     * @see ReferenceCountingStatementOperations
+     */
+    void markAsClosed();
     
-    Closeable closeable( StatementOperations logic );
+    Closeable closeable( LifecycleOperations logic );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintValidatingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintValidatingTransactionContext.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.StatementOperationParts;
 
 /**
  * Adds constraint checking to the kernel implementation, for instance ensuring label names are valid.
@@ -46,7 +46,6 @@ public class ConstraintValidatingTransactionContext extends DelegatingTransactio
                 parts.schemaReadOperations(),
                 parts.schemaWriteOperations() );
 
-        parts.replace( null, dataIntegrityContext, null, null, null, dataIntegrityContext, null, null );
-        return parts;
+        return parts.override( null, dataIntegrityContext, null, null, null, dataIntegrityContext, null, null );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -21,16 +21,13 @@ package org.neo4j.kernel.impl.api;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import javax.transaction.NotSupportedException;
-import javax.transaction.SystemException;
+import java.util.Collections;
 
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.StatementOperationParts;
-import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.api.operations.ReadOnlyStatementState;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.impl.api.constraints.ConstraintIndexCreator;
@@ -52,8 +49,6 @@ import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-
-import static java.util.Collections.synchronizedList;
 
 import static org.neo4j.helpers.collection.IteratorUtil.loop;
 import static org.neo4j.kernel.impl.transaction.XaDataSourceManager.neoStoreListener;
@@ -146,8 +141,8 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private NodeManager nodeManager;
     private PersistenceCache persistenceCache;
     private boolean isShutdown = false;
-    private StatementOperations statementLogic;
-    private StatementOperations readOnlyStatementLogic;
+    private StatementOperationParts statementLogic;
+    private StatementOperationParts readOnlyStatementLogic;
 
     public Kernel( AbstractTransactionManager transactionManager,
                    PropertyKeyTokenHolder propertyKeyTokenHolder, LabelTokenHolder labelTokenHolder,
@@ -203,14 +198,8 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     @Override
     public void bootstrapAfterRecovery()
     {
-        try
-        {
-            // Requiring to start a transaction here is an artefact of having KernelTransaction used
-            // for both creating the StatementOperations cake and being a transaction.
-            transactionManager.begin();
-            
             StatementOperationParts parts = newTransaction().newStatementOperations();
-            this.statementLogic = parts.asStatementOperations();
+            this.statementLogic = parts;
             
             ReadOnlyStatementOperations readOnlyParts = new ReadOnlyStatementOperations( parts.schemaStateOperations() );
             this.readOnlyStatementLogic = parts.override(
@@ -221,25 +210,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
                     parts.schemaReadOperations(),
                     readOnlyParts,
                     readOnlyParts,
-                    parts.lifecycleOperations() ).asStatementOperations();
-        }
-        catch ( SystemException | NotSupportedException e )
-        {
-            throw new IllegalStateException(
-                    "Unable to start transaction for creating a statement operations cake", e );
-        }
-        finally
-        {
-            try
-            {
-                transactionManager.rollback();
-            }
-            catch ( IllegalStateException | SecurityException | SystemException e )
-            {
-                throw new IllegalStateException(
-                        "Unable to close transaction after creating a statement operations cake", e );
-            }
-        }
+                    parts.lifecycleOperations() );
     }
 
     @Override
@@ -300,7 +271,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
         // TODO statementLogic is null the first call (since we're building the cake), but that's OK.
         // This is an artifact of KernelTransaction having too many responsibilities (i.e. being a transaction,
         // as well as being able to construct the layered StatementOperations cake).
-        result = new ReferenceCountingTransactionContext( result, statementLogic );
+        result = new ReferenceCountingTransactionContext( result, statementLogic != null ? statementLogic.lifecycleOperations() : null );
         
         // done
         return result;
@@ -315,13 +286,13 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     }
 
     @Override
-    public StatementOperations statementOperations()
+    public StatementOperationParts statementOperations()
     {
         return statementLogic;
     }
     
     @Override
-    public StatementOperations readOnlyStatementOperations()
+    public StatementOperationParts readOnlyStatementOperations()
     {
         return readOnlyStatementLogic;
     }
@@ -335,12 +306,12 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private class StatementStateOwners extends ThreadLocal<StatementStateOwner>
     {
         private final Collection<StatementStateOwner> all =
-                synchronizedList( new ArrayList<StatementStateOwner>() );
+                Collections.synchronizedList( new ArrayList<StatementStateOwner>() );
 
         @Override
         protected StatementStateOwner initialValue()
         {
-            StatementStateOwner owner = new StatementStateOwner( statementLogic )
+            StatementStateOwner owner = new StatementStateOwner( statementLogic.lifecycleOperations() )
             {
                 @Override
                 protected StatementState createStatementState()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockHolderImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockHolderImpl.java
@@ -50,10 +50,6 @@ public class LockHolderImpl implements LockHolder
 
     public LockHolderImpl( LockManager lockManager, Transaction tx, NodeManager nodeManager )
     {
-        if ( tx == null )
-        {
-            throw new RuntimeException( "Cannot initialize lock holder without a transaction, got null." );
-        }
         this.lockManager = lockManager;
         this.tx = tx;
 
@@ -185,11 +181,6 @@ public class LockHolderImpl implements LockHolder
             throw unsupportedOperation();
         }
         
-        public GraphDatabaseService getGraphDatabaseService()
-        {
-            throw unsupportedOperation();
-        }
-
         @Override
         public GraphDatabaseService getGraphDatabase()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingTransactionContext.java
@@ -63,9 +63,8 @@ public class LockingTransactionContext extends DelegatingTransactionContext
                 parts.schemaWriteOperations(),
                 parts.schemaStateOperations() );
         
-        parts.replace(
+        return parts.override(
                 null, null, null, lockingContext, lockingContext, lockingContext, lockingContext, null );
-        return parts;
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
@@ -136,10 +136,18 @@ public class PersistenceCache
         nodeCache.remove( nodeId );
     }
 
-    public Iterator<Property> nodeGetProperties( StatementState state, long nodeId, CacheLoader<Iterator<Property>> cacheLoader )
+    public Iterator<Property> nodeGetProperties( StatementState state, long nodeId,
+            CacheLoader<Iterator<Property>> cacheLoader )
             throws EntityNotFoundException
     {
         return getNode( nodeId ).getProperties( state, cacheLoader, NODE_CACHE_SIZE_LISTENER );
+    }
+    
+    public PrimitiveLongIterator nodeGetPropertyKeys( StatementState state, long nodeId,
+            CacheLoader<Iterator<Property>> cacheLoader )
+            throws EntityNotFoundException
+    {
+        return getNode( nodeId ).getPropertyKeys( state, cacheLoader, NODE_CACHE_SIZE_LISTENER );
     }
     
     public Property nodeGetProperty( StatementState state, long nodeId, long propertyKeyId,
@@ -152,9 +160,17 @@ public class PersistenceCache
     public Iterator<Property> relationshipGetProperties( StatementState state, long relationshipId,
             CacheLoader<Iterator<Property>> cacheLoader ) throws EntityNotFoundException
     {
-        return getRelationship( relationshipId ).getProperties( state, cacheLoader, RELATIONSHIP_CACHE_SIZE_LISTENER );
+        return getRelationship( relationshipId ).getProperties( state, cacheLoader,
+                RELATIONSHIP_CACHE_SIZE_LISTENER );
     }
 
+    public PrimitiveLongIterator relationshipGetPropertyKeys( StatementState state, long relationshipId,
+            CacheLoader<Iterator<Property>> cacheLoader ) throws EntityNotFoundException
+    {
+        return getRelationship( relationshipId ).getPropertyKeys( state, cacheLoader,
+                RELATIONSHIP_CACHE_SIZE_LISTENER );
+    }
+    
     public Property relationshipGetProperty( StatementState state, long relationshipId, long propertyKeyId,
             CacheLoader<Iterator<Property>> cacheLoader ) throws EntityNotFoundException
     {
@@ -165,6 +181,12 @@ public class PersistenceCache
     public Iterator<Property> graphGetProperties( StatementState state, CacheLoader<Iterator<Property>> cacheLoader )
     {
         return graphProperties.evaluate().getProperties( state, cacheLoader, NO_UPDATES );
+    }
+    
+    public PrimitiveLongIterator graphGetPropertyKeys( StatementState state,
+            CacheLoader<Iterator<Property>> cacheLoader )
+    {
+        return graphProperties.evaluate().getPropertyKeys( state, cacheLoader, NO_UPDATES );
     }
 
     public Property graphGetProperty( StatementState state, CacheLoader<Iterator<Property>> cacheLoader,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PrimitiveLongIterator.java
@@ -17,28 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.operations;
+package org.neo4j.kernel.impl.api;
 
-public interface RefCounting
+public interface PrimitiveLongIterator
 {
-    boolean isOpen();
+    boolean hasNext();
     
-    void close();
-    
-    public static class Default implements RefCounting
-    {
-        private boolean open = true;
-
-        @Override
-        public boolean isOpen()
-        {
-            return open;
-        }
-
-        @Override
-        public void close()
-        {
-            open = false;
-        }
-    }
+    long next();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingStatementOperations.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.neo4j.kernel.api.LifecycleOperations;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 
 public class ReferenceCountingStatementOperations implements LifecycleOperations
@@ -27,6 +27,8 @@ public class ReferenceCountingStatementOperations implements LifecycleOperations
     @Override
     public void close( StatementState state )
     {
-        state.refCounting().close();
+        state.markAsClosed();
+        
+        // Delegation of close method happens via StatementStateOwner
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContext.java
@@ -20,9 +20,9 @@
 package org.neo4j.kernel.impl.api;
 
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.LifecycleOperations;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 
 public class ReferenceCountingTransactionContext extends DelegatingTransactionContext
@@ -48,8 +48,7 @@ public class ReferenceCountingTransactionContext extends DelegatingTransactionCo
     {
         StatementOperationParts parts = delegate.newStatementOperations();
         ReferenceCountingStatementOperations ops = new ReferenceCountingStatementOperations();
-        parts.replace( null, null, null, null, null, null, null, ops );
-        return parts;
+        return parts.override( null, null, null, null, null, null, null, ops );
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingTransactionContext.java
@@ -33,8 +33,8 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.operations.AuxiliaryStoreOperations;
-import org.neo4j.kernel.api.operations.WritableStatementState;
 import org.neo4j.kernel.api.operations.StatementState;
+import org.neo4j.kernel.api.operations.WritableStatementState;
 import org.neo4j.kernel.impl.api.constraints.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
@@ -93,7 +93,7 @@ public class StateHandlingTransactionContext extends DelegatingTransactionContex
                 parts.entityReadOperations(),
                 parts.schemaReadOperations(),
                 persistenceCache, schemaCache );
-        parts.replace( null, null, cachingContext, null, cachingContext, null, null, null );
+        parts = parts.override( null, null, cachingContext, null, cachingContext, null, null, null );
 
         // + Transaction-local state awareness
         AuxiliaryStoreOperations auxStoreOperations = parts.resolve( AuxiliaryStoreOperations.class );
@@ -105,7 +105,7 @@ public class StateHandlingTransactionContext extends DelegatingTransactionContex
                 parts.schemaReadOperations(),
                 auxStoreOperations,
                 constraintIndexCreator );
-        parts.replace(
+        parts = parts.override(
                 null, null, stateHandlingContext, stateHandlingContext, stateHandlingContext, stateHandlingContext,
                 new SchemaStateConcern( schemaState ), null );
                 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
@@ -31,7 +31,6 @@ import org.neo4j.helpers.Predicates;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.api.EntityType;
-import org.neo4j.kernel.api.LifecycleOperations;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
@@ -48,6 +47,7 @@ import org.neo4j.kernel.api.operations.EntityReadOperations;
 import org.neo4j.kernel.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.KeyWriteOperations;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
@@ -721,19 +721,19 @@ public class StoreStatementOperations implements
     }
 
     @Override
-    public Iterator<Long> nodeGetPropertyKeys( StatementState state, long nodeId ) throws EntityNotFoundException
+    public PrimitiveLongIterator nodeGetPropertyKeys( StatementState state, long nodeId ) throws EntityNotFoundException
     {
         throw shouldNotHaveReachedAllTheWayHere();
     }
 
     @Override
-    public Iterator<Long> relationshipGetPropertyKeys( StatementState state, long relationshipId ) throws EntityNotFoundException
+    public PrimitiveLongIterator relationshipGetPropertyKeys( StatementState state, long relationshipId ) throws EntityNotFoundException
     {
         throw shouldNotHaveReachedAllTheWayHere();
     }
 
     @Override
-    public Iterator<Long> graphGetPropertyKeys( StatementState state )
+    public PrimitiveLongIterator graphGetPropertyKeys( StatementState state )
     {
         throw shouldNotHaveReachedAllTheWayHere();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingTransactionContext.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
-import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.operations.SchemaWriteOperations;
+import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 
 public class UniquenessConstraintStoppingTransactionContext extends DelegatingTransactionContext
@@ -43,8 +43,7 @@ public class UniquenessConstraintStoppingTransactionContext extends DelegatingTr
         UniquenessConstraintStoppingStatementOperations stoppingContext =
                 new UniquenessConstraintStoppingStatementOperations( parts.schemaWriteOperations() );
         
-        parts.replace( null, null, null, null, null, stoppingContext, null, null );
-        return parts;
+        return parts.override( null, null, null, null, null, stoppingContext, null, null );
     }
 
     private static class UniquenessConstraintStoppingStatementOperations implements SchemaWriteOperations

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.StatementOperations;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
@@ -60,17 +60,17 @@ public class RemoveOrphanConstraintIndexesOnStartup
             try
             {
                 tx = txManager.getKernelTransaction();
-                StatementOperations context = ctxProvider.getCtxForWriting();
+                StatementOperationParts context = ctxProvider.getCtxForWriting();
                 StatementState state = tx.newStatementState();
                 try
                 {
-                    for ( Iterator<IndexDescriptor> indexes = context.uniqueIndexesGetAll( state );
+                    for ( Iterator<IndexDescriptor> indexes = context.schemaReadOperations().uniqueIndexesGetAll( state );
                             indexes.hasNext(); )
                     {
                         IndexDescriptor index = indexes.next();
-                        if ( context.indexGetOwningUniquenessConstraintId( state, index ) == null )
+                        if ( context.schemaReadOperations().indexGetOwningUniquenessConstraintId( state, index ) == null )
                         {
-                            context.uniqueIndexDrop( state, index );
+                            context.schemaWriteOperations().uniqueIndexDrop( state, index );
                         }
                     }
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ArrayBasedPrimitive.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ArrayBasedPrimitive.java
@@ -23,8 +23,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.cache.EntityWithSizeObject;
 import org.neo4j.kernel.impl.cache.SizeOfs;
 import org.neo4j.kernel.impl.nioneo.store.PropertyData;
@@ -140,6 +142,32 @@ abstract class ArrayBasedPrimitive extends Primitive implements EntityWithSizeOb
     protected Iterator<Property> getCachedProperties()
     {
         return iterator( properties );
+    }
+    
+    @Override
+    protected PrimitiveLongIterator getCachedPropertyKeys()
+    {
+        return new PrimitiveLongIterator()
+        {
+            private final Property[] localProperties = properties;
+            private int i;
+            
+            @Override
+            public long next()
+            {
+                if ( !hasNext() )
+                {
+                    throw new NoSuchElementException();
+                }
+                return localProperties[i++].propertyKeyId();
+            }
+            
+            @Override
+            public boolean hasNext()
+            {
+                return i < localProperties.length;
+            }
+        };
     }
     
     @SuppressWarnings( "unchecked" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/Primitive.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/Primitive.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.CacheLoader;
 import org.neo4j.kernel.impl.api.CacheUpdateListener;
+import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.cache.SizeOfObject;
 import org.neo4j.kernel.impl.core.WritableTransactionState.CowEntityElement;
 import org.neo4j.kernel.impl.core.WritableTransactionState.PrimitiveElement;
@@ -57,11 +58,18 @@ public abstract class Primitive implements SizeOfObject
         return ensurePropertiesLoaded( state, loader, updateListener );
     }
 
-    public Property getProperty( StatementState state, CacheLoader<Iterator<Property>> loader, CacheUpdateListener updateListener,
-            int key )
+    public Property getProperty( StatementState state, CacheLoader<Iterator<Property>> loader,
+            CacheUpdateListener updateListener, int key )
     {
         ensurePropertiesLoaded( state, loader, updateListener );
         return getCachedProperty( key );
+    }
+    
+    public PrimitiveLongIterator getPropertyKeys( StatementState state, CacheLoader<Iterator<Property>> cacheLoader,
+            CacheUpdateListener updateListener )
+    {
+        ensurePropertiesLoaded( state, cacheLoader, updateListener );
+        return getCachedPropertyKeys();
     }
     
     private Iterator<Property> ensurePropertiesLoaded( StatementState state, CacheLoader<Iterator<Property>> loader,
@@ -97,6 +105,8 @@ public abstract class Primitive implements SizeOfObject
     protected abstract Iterator<Property> getCachedProperties();
     
     protected abstract Property getCachedProperty( int key );
+    
+    protected abstract PrimitiveLongIterator getCachedPropertyKeys();
 
     protected abstract boolean hasLoadedProperties();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
@@ -27,9 +27,8 @@ import org.junit.Test;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.KernelAPI;
-import org.neo4j.kernel.api.StatementOperations;
-import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -115,7 +114,7 @@ public class KernelTest
             try
             {
                 latch.start();
-                StatementOperations statement = kernel.readOnlyStatementOperations();
+                StatementOperationParts statement = kernel.readOnlyStatementOperations();
 //                statement.close();
             }
             catch ( Throwable e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingTransactionContextTest.java
@@ -22,9 +22,8 @@ package org.neo4j.kernel.impl.api;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.LifecycleOperations;
 import org.neo4j.kernel.api.StatementOperationParts;
-import org.neo4j.kernel.api.operations.RefCounting;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 
 import static org.junit.Assert.assertEquals;
@@ -49,9 +48,7 @@ public class ReferenceCountingTransactionContextTest
     {
         inner = mock( KernelTransaction.class );
         actualState = mock( StatementState.class );
-        when( actualState.refCounting() ).thenReturn( mock( RefCounting.class ) );
         otherActualState = mock( StatementState.class );
-        when( otherActualState.refCounting() ).thenReturn( mock( RefCounting.class ) );
         when( inner.newStatementState() )
                 .thenReturn( actualState )
                 .thenReturn( otherActualState );
@@ -83,7 +80,7 @@ public class ReferenceCountingTransactionContextTest
         refCountingOperations.close( first );
 
         // THEN
-        verify( actualState.refCounting(), never() ).close();
+        verify( actualState, never() ).markAsClosed();
     }
 
     @Test
@@ -98,7 +95,7 @@ public class ReferenceCountingTransactionContextTest
         refCountingOperations.close( other );
 
         // THEN
-        verify( actualState.refCounting(), times( 1 ) ).close();
+        verify( actualState, times( 1 ) ).markAsClosed();
     }
 
     @Test
@@ -110,8 +107,8 @@ public class ReferenceCountingTransactionContextTest
 
         // THEN
         verify( inner, times( 2 ) ).newStatementState();
-        verify( actualState.refCounting() ).close();
-        verify( otherActualState.refCounting() ).close();
+        verify( actualState ).markAsClosed();
+        verify( otherActualState ).markAsClosed();
     }
 
 //    @Ignore( "Not valid I(MP)'d say" )
@@ -157,7 +154,7 @@ public class ReferenceCountingTransactionContextTest
         {
             assertEqualsStatementClosed( e );
         }
-        verify( actualState.refCounting(), never() ).close();
+        verify( actualState, never() ).markAsClosed();
     }
 
     private void assertEqualsStatementClosed( IllegalStateException e )
@@ -186,7 +183,7 @@ public class ReferenceCountingTransactionContextTest
         {
             assertEqualsStatementClosed( e );
         }
-        verify( actualState.refCounting(), times( 1 ) ).close();
+        verify( actualState, times( 1 ) ).markAsClosed();
     }
 
     @Test
@@ -209,7 +206,7 @@ public class ReferenceCountingTransactionContextTest
         {
             assertEqualsStatementClosed( e );
         }
-        verify( actualState.refCounting(), times( 1 ) ).close();
+        verify( actualState, times( 1 ) ).markAsClosed();
     }
 
     @Test
@@ -234,9 +231,9 @@ public class ReferenceCountingTransactionContextTest
         {
             assertEqualsStatementClosed( e );
         }
-        verify( actualState.refCounting(), times( 1 ) ).close();
+        verify( actualState, times( 1 ) ).markAsClosed();
         verifyZeroInteractions( otherActualState );
         refCountingOperations.close( after );
-        verify( otherActualState.refCounting(), times( 1 ) ).close();
+        verify( otherActualState, times( 1 ) ).markAsClosed();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -23,12 +23,12 @@ import java.util.Collections;
 
 import org.mockito.Matchers;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.LifecycleOperations;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.operations.EntityReadOperations;
 import org.neo4j.kernel.api.operations.EntityWriteOperations;
+import org.neo4j.kernel.api.operations.LifecycleOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.KeyWriteOperations;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -84,7 +84,7 @@ public class IndexCRUDIT
         Transaction tx = db.beginTx();
         try
         {
-            StatementOperations context = ctxProvider.getCtxForWriting();
+            StatementOperations context = ctxProvider.getCtxForWriting().asStatementOperations();
             StatementState state = ctxProvider.statementForWriting();
             long propertyKey1 = context.propertyKeyGetForName( state, indexProperty );
             long[] labels = new long[]{context.labelGetForName( state, myLabel.name() )};
@@ -127,7 +127,7 @@ public class IndexCRUDIT
         tx = db.beginTx();
         try
         {
-            StatementOperations context = ctxProvider.getCtxForWriting();
+            StatementOperations context = ctxProvider.getCtxForWriting().asStatementOperations();
             StatementState state = ctxProvider.statementForWriting();
             long propertyKey1 = context.propertyKeyGetForName( state, indexProperty );
             long[] labels = new long[]{context.labelGetForName( state, myLabel.name() )};
@@ -207,7 +207,7 @@ public class IndexCRUDIT
         {
             try
             {
-                StatementOperations context = ctxProvider.getCtxForReading();
+                StatementOperations context = ctxProvider.getCtxForReading().asStatementOperations();
                 StatementState state = ctxProvider.statementForReading();
                 updates.add( NodePropertyUpdate.add( nodeId, context.propertyKeyGetForName( state, propertyKey ),
                         propertyValue, new long[] {context.labelGetForName( state, myLabel.name() )} ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -457,7 +457,7 @@ public class IndexPopulationJobTest
         stateHolder = new KernelSchemaStateStore();
 
         Transaction tx = db.beginTx();
-        StatementOperations ctxForWriting = ctxProvider.getCtxForWriting();
+        StatementOperations ctxForWriting = ctxProvider.getCtxForWriting().asStatementOperations();
         StatementState state = ctxProvider.statementForReading();
         firstLabelId = ctxForWriting.labelGetOrCreateForName( state, FIRST.name() );
         ctxForWriting.labelGetOrCreateForName( state, SECOND.name() );
@@ -491,7 +491,7 @@ public class IndexPopulationJobTest
         Transaction tx = db.beginTx();
         try
         {
-            StatementOperations ctx = ctxProvider.getCtxForWriting();
+            StatementOperations ctx = ctxProvider.getCtxForWriting().asStatementOperations();
             StatementState state = ctxProvider.statementForReading();
             descriptor = new IndexDescriptor( ctx.labelGetForName( state, label.name() ),
                     ctx.propertyKeyGetForName( state, propertyKey ) );
@@ -533,7 +533,7 @@ public class IndexPopulationJobTest
         Transaction tx = db.beginTx();
         try
         {
-            StatementOperations context = ctxProvider.getCtxForWriting();
+            StatementOperations context = ctxProvider.getCtxForWriting().asStatementOperations();
             result = context.propertyKeyGetForName( ctxProvider.statementForWriting(), name );
             tx.success();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -38,7 +38,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
-import org.neo4j.kernel.api.StatementOperations;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.index.IndexAccessor;
@@ -267,14 +267,14 @@ public class IndexRecoveryIT
         {
             ThreadToStatementContextBridge ctxProvider = db.getDependencyResolver().resolveDependency(
                     ThreadToStatementContextBridge.class );
-            StatementOperations context = ctxProvider.getCtxForWriting();
+            StatementOperationParts context = ctxProvider.getCtxForWriting();
             StatementState state = ctxProvider.statementForReading();
             for ( int number : new int[] {4, 10} )
             {
                 Node node = db.createNode( label );
                 node.setProperty( key, number );
-                updates.add( NodePropertyUpdate.add( node.getId(), context.propertyKeyGetForName( state, key ), number,
-                        new long[] {context.labelGetForName( state, label.name() )} ) );
+                updates.add( NodePropertyUpdate.add( node.getId(), context.keyReadOperations().propertyKeyGetForName( state, key ), number,
+                        new long[] {context.keyReadOperations().labelGetForName( state, label.name() )} ) );
             }
             context.close( state );
             tx.success();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -30,8 +30,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Function;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.api.StatementOperationParts;
+import org.neo4j.kernel.api.StatementOperations;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.operations.StatementState;
@@ -95,7 +95,7 @@ public class KernelIT extends KernelIntegrationTest
         Transaction beansAPITx = db.beginTx();
 
         // 2: Get a hold of a KernelAPI statement context for the *current* transaction this way:
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // 3: Now you can interact through both the statement context and the kernel API to manipulate the
@@ -145,7 +145,7 @@ public class KernelIT extends KernelIntegrationTest
     {
         // GIVEN
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -157,7 +157,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         try
         {
@@ -175,7 +175,7 @@ public class KernelIT extends KernelIntegrationTest
     public void shouldNotBeAbleToCommitIfFailedTransactionContext() throws Exception
     {
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -189,7 +189,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         try
         {
@@ -207,7 +207,7 @@ public class KernelIT extends KernelIntegrationTest
     public void transactionStateShouldRemovePreviouslyAddedLabel() throws Exception
     {
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -223,7 +223,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
 
         assertEquals( asSet( labelId1 ), asSet( context.nodeGetLabels( statement, node.getId() ) ) );
@@ -235,7 +235,7 @@ public class KernelIT extends KernelIntegrationTest
     public void transactionStateShouldReflectRemovingAddedLabelImmediately() throws Exception
     {
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -260,7 +260,7 @@ public class KernelIT extends KernelIntegrationTest
     {
         // GIVEN
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         Node node = db.createNode();
         long labelId1 = context.labelGetOrCreateForName( statement, "labello1" );
@@ -271,7 +271,7 @@ public class KernelIT extends KernelIntegrationTest
         tx.success();
         tx.finish();
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -292,7 +292,7 @@ public class KernelIT extends KernelIntegrationTest
     {
         // GIVEN
         Transaction tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         Node node = db.createNode();
         long labelId1 = context.labelGetOrCreateForName( statement, "labello1" );
@@ -303,7 +303,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         context.nodeRemoveLabel( statement, node.getId(), labelId1 );
         context.close( statement );
@@ -312,7 +312,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         Iterator<Long> labels = context.nodeGetLabels( statement, node.getId() );
         context.close( statement );
@@ -328,7 +328,7 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         long labelId = context.labelGetOrCreateForName( statement, "mylabel" );
         context.nodeAddLabel( statement, node.getId(), labelId );
@@ -338,7 +338,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         boolean added = context.nodeAddLabel( statement, node.getId(), labelId );
 
@@ -353,7 +353,7 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         long labelId = context.labelGetOrCreateForName( statement, "mylabel" );
         context.close( statement );
@@ -362,7 +362,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         boolean added = context.nodeAddLabel( statement, node.getId(), labelId );
 
@@ -377,7 +377,7 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         long labelId = context.labelGetOrCreateForName( statement, "mylabel" );
         context.nodeAddLabel( statement, node.getId(), labelId );
@@ -387,7 +387,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         boolean removed = context.nodeRemoveLabel( statement, node.getId(), labelId );
 
@@ -402,7 +402,7 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         long labelId = context.labelGetOrCreateForName( statement, "mylabel" );
         context.close( statement );
@@ -411,7 +411,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        context = statementContextProvider.getCtxForWriting();
+        context = statementContextProvider.getCtxForWriting().asStatementOperations();
         statement = statementContextProvider.statementForWriting();
         boolean removed = context.nodeRemoveLabel( statement, node.getId(), labelId );
 
@@ -431,7 +431,7 @@ public class KernelIT extends KernelIntegrationTest
         tx.finish();
 
         tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
 
         // WHEN
@@ -471,7 +471,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        StatementOperations context = statementContextProvider.getCtxForWriting();
+        StatementOperations context = statementContextProvider.getCtxForWriting().asStatementOperations();
         StatementState statement = statementContextProvider.statementForWriting();
         long labelId = context.labelGetForName( statement, label.name() );
         Iterator<Long> nodes = context.nodesGetForLabel( statement, labelId );
@@ -536,7 +536,7 @@ public class KernelIT extends KernelIntegrationTest
     {
         Transaction tx;StatementOperations statement;
         tx = db.beginTx();
-        statement = statementContextProvider.getCtxForWriting();
+        statement = statementContextProvider.getCtxForWriting().asStatementOperations();
         String state = statement.schemaStateGetOrCreate( getState(), key, new Function<String, String>()
         {
             @Override
@@ -554,7 +554,7 @@ public class KernelIT extends KernelIntegrationTest
     {
         Transaction tx;StatementOperations statement;
         tx = db.beginTx();
-        statement = statementContextProvider.getCtxForWriting();
+        statement = statementContextProvider.getCtxForWriting().asStatementOperations();
         boolean state = statement.schemaStateContains( getState(), key );
         tx.success();
         tx.finish();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -50,7 +50,7 @@ public abstract class KernelIntegrationTest
     protected StatementState newTransaction()
     {
         beansTx = db.beginTx();
-        statement = statementContextProvider.getCtxForWriting();
+        statement = statementContextProvider.getCtxForWriting().asStatementOperations();
         return (state = statementContextProvider.statementForWriting());
     }
     
@@ -61,7 +61,7 @@ public abstract class KernelIntegrationTest
 
     protected StatementOperations readOnlyContext()
     {
-        StatementOperations context = statementContextProvider.getCtxForReading();
+        StatementOperations context = statementContextProvider.getCtxForReading().asStatementOperations();
         state = statementContextProvider.statementForReading();
         return context;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -253,7 +253,7 @@ public class PropertyIT extends KernelIntegrationTest
                 equalTo( Collections.<Long>emptySet() ) );
         commit();
     }
-
+    
     @Test
     public void shouldListRelationshipPropertyKeys() throws Exception
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreIndexStoreViewTest.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
-import org.neo4j.kernel.api.StatementOperations;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.operations.StatementState;
@@ -159,10 +159,10 @@ public class NeoStoreIndexStoreViewTest
             ThreadToStatementContextBridge bridge =
                     graphDb.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
 
-            StatementOperations ctx = bridge.getCtxForWriting();
+            StatementOperationParts ctx = bridge.getCtxForWriting();
             StatementState state = bridge.statementForWriting();
-            labelId = ctx.labelGetOrCreateForName( state, "Person" );
-            propertyKeyId = ctx.propertyKeyGetOrCreateForName( state, "name" );
+            labelId = ctx.keyWriteOperations().labelGetOrCreateForName( state, "Person" );
+            propertyKeyId = ctx.keyWriteOperations().propertyKeyGetOrCreateForName( state, "name" );
             ctx.close( state );
             tx.success();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestTransactionImpl.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestTransactionImpl.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import javax.transaction.RollbackException;
 import javax.transaction.Synchronization;
 
@@ -33,6 +28,11 @@ import org.neo4j.kernel.impl.util.MultipleCauseException;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.SystemOutLogging;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
 public class TestTransactionImpl
 {
     @Test
@@ -40,7 +40,9 @@ public class TestTransactionImpl
             throws IllegalStateException, RollbackException
     {
         TxManager mockedTxManager = mock( TxManager.class );
-        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced, TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), new SystemOutLogging().getMessagesLog( TxManager.class ) );
+        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced,
+                TransactionStateFactory.noStateFactory( new DevNullLoggingService() ),
+                new SystemOutLogging().getMessagesLog( TxManager.class ) );
 
         // Evil synchronizations
         final RuntimeException firstException = new RuntimeException( "Ex1" );
@@ -94,7 +96,9 @@ public class TestTransactionImpl
             RollbackException
     {
         TxManager mockedTxManager = mock( TxManager.class );
-        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced, TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), new SystemOutLogging().getMessagesLog( TxManager.class ) );
+        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced,
+                TransactionStateFactory.noStateFactory( new DevNullLoggingService() ),
+                new SystemOutLogging().getMessagesLog( TxManager.class ) );
 
         // Evil synchronizations
         final RuntimeException firstException = new RuntimeException( "Ex1" );

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -22,7 +22,7 @@ package org.neo4j.server.rest.transactional;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.StatementOperations;
+import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.impl.transaction.TxManager;
 
 public class TransitionalPeriodTransactionMessContainer implements KernelAPI
@@ -47,13 +47,13 @@ public class TransitionalPeriodTransactionMessContainer implements KernelAPI
     }
 
     @Override
-    public StatementOperations readOnlyStatementOperations()
+    public StatementOperationParts readOnlyStatementOperations()
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public StatementOperations statementOperations()
+    public StatementOperationParts statementOperations()
     {
         throw new UnsupportedOperationException();
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
@@ -74,7 +74,7 @@ public class LabelIT
         {
             ThreadToStatementContextBridge bridge = db.getDependencyResolver().resolveDependency(
                     ThreadToStatementContextBridge.class );
-            return bridge.getCtxForReading().labelGetForName( bridge.statementForReading(), label.name() );
+            return bridge.getCtxForReading().keyReadOperations().labelGetForName( bridge.statementForReading(), label.name() );
         }
         finally
         {


### PR DESCRIPTION
o Created and uses PrimitiveLongIterator for getPropertyKeys(). Should be
  used for more as well.
o Use individual statement operation parts to remove the tiny
  StatementOperations delegation at the top.
o TxState#hasChanges() is cheaper
o StateHandlingStatementOperations#getPropertyKeys and getProperty
  just delegates if there's no tx changes.
