### PR TITLE
Script to upload an enterprise customer's store to S3 

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-support-upload
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-support-upload
@@ -15,29 +15,10 @@ action() {
 
 }
 
-set -e
-
-read -p "I need to know the ticket number that you're uploading the data store with: " ticket_number
-[ -n "${ticket_number}" ] || die "Sorry, I really need that support ticket number"
-
-read -p "THIS WILL UPLOAD ALL YOUR DATA TO A PRIVATE S3 BUCKET. Do you agree with this? (Y/N): " confirmation
-
-shopt -s nocasematch
-case "${confirmation}" in 
-  y)
-    echo "Ok. Starting the upload process in 10 seconds"
-    sleep 1 #0
-  ;;
-  n)
-    echo "OK. This script will exit and NOT upload your data"
-    exit 0 
-  ;;
-  *)
-    "I need to press you for an answer on that one"
-    exit 1
-  ;;
-
-esac
+[ $# -eq 1 ] || die "Usage: $0 <support ticket number>"  
+echo "THIS WILL UPLOAD ALL YOUR DATA TO A PRIVATE S3 BUCKET. Hit <ctrl>-c now if you disagree with this"
+sleep 10 
+echo "Waited 10 seconds, proceeding to upload"
 
 script_dir=$(dirname $0)
 data_dir="${script_dir}/../data"

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -68,6 +68,7 @@
       <fileMode>0755</fileMode>
       <excludes>
         <exclude>bin/neo4j</exclude>
+        <exclude>bin/neo4j-support-upload</exclude>
         <exclude>**/*.bat</exclude>
         <exclude>**/neo4j-backup*</exclude>
         <exclude>**/neo4j-coord*</exclude>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -55,6 +55,7 @@
       <fileMode>0755</fileMode>
       <excludes>
         <exclude>bin/neo4j</exclude>
+        <exclude>bin/neo4j-support-upload</exclude>
         <exclude>**/*.bat</exclude>
         <exclude>**/neo4j-backup*</exclude>
         <exclude>**/neo4j-coord*</exclude>


### PR DESCRIPTION
This PR allows an enterprise customer to upload their store and logs to S3.

Notes:
- It's *nix only.  I don't believe that Windows ships with enough PowerShell goodness to do this OOB.   If this is successful we could write a new, improved version in Java.
- It's relying on S3 policy to be a write-only store for anonymous users.
