### PR TITLE
Fixes problem with relationship iterator not seeing new loaded relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArray.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.kernel.impl.util;
 
-import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverhead;
-import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
-import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
-
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.impl.cache.SizeOfObject;
-import org.neo4j.kernel.impl.cache.SizeOfs;
+
+import static java.lang.System.arraycopy;
+
+import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverhead;
+import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
+import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
 public class RelIdArray implements SizeOfObject
 {
@@ -56,10 +58,12 @@ public class RelIdArray implements SizeOfObject
                 return false;
             }
             
+            @Override
             public void doAnotherRound()
             {
             }
             
+            @Override
             public RelIdIterator updateSource( RelIdArray newSource, DirectionWrapper direction )
             {
                 return direction.iterator( newSource );
@@ -86,17 +90,18 @@ public class RelIdArray implements SizeOfObject
     public static final RelIdArray EMPTY = new EmptyRelIdArray( -1 );
     
     private final int type;
-    private IdBlock lastOutBlock;
-    private IdBlock lastInBlock;
+    private IdBlock outBlock;
+    private IdBlock inBlock;
     
     public RelIdArray( int type )
     {
         this.type = type;
     }
     
+    @Override
     public int sizeOfObjectInBytesIncludingOverhead()
     {
-        return withObjectOverhead( 8 /*type (padded)*/ + sizeOfBlockWithReference( lastOutBlock ) + sizeOfBlockWithReference( lastInBlock ) ); 
+        return withObjectOverhead( 8 /*type (padded)*/ + sizeOfBlockWithReference( outBlock ) + sizeOfBlockWithReference( inBlock ) ); 
     }
     
     static int sizeOfBlockWithReference( IdBlock block )
@@ -112,15 +117,15 @@ public class RelIdArray implements SizeOfObject
     protected RelIdArray( RelIdArray from )
     {
         this( from.type );
-        this.lastOutBlock = from.lastOutBlock;
-        this.lastInBlock = from.lastInBlock;
+        this.outBlock = from.outBlock;
+        this.inBlock = from.inBlock;
     }
     
     protected RelIdArray( int type, IdBlock out, IdBlock in )
     {
         this( type );
-        this.lastOutBlock = out;
-        this.lastInBlock = in;
+        this.outBlock = out;
+        this.inBlock = in;
     }
     
     /*
@@ -128,48 +133,47 @@ public class RelIdArray implements SizeOfObject
      */
     public void add( long id, DirectionWrapper direction )
     {
-        IdBlock lastBlock = direction.getLastBlock( this );
-        long highBits = id&0xFFFFFFFF00000000L;
-        if ( lastBlock == null || lastBlock.getHighBits() != highBits )
+        IdBlock block = direction.getBlock( this );
+        if ( block == null || !block.accepts( id ) )
         {
-            IdBlock newLastBlock = null;
-            if ( highBits == 0 && lastBlock == null )
+            IdBlock newBlock = null;
+            if ( block == null && LowIdBlock.idIsLow( id ) )
             {
-                newLastBlock = new LowIdBlock();
+                newBlock = new LowIdBlock();
             }
             else
             {
-                // TODO: instead of always creating a new id block when high bits change
-                // traverse back and try find a fit
-                newLastBlock = new HighIdBlock( highBits );
-                if ( lastBlock != null )
-                {
-                    lastBlock = lastBlock.upgradeIfNeeded();
-                    newLastBlock.setPrev( lastBlock );
-                }
+                newBlock = block != null ? block.upgradeToHighIdBlock() : new HighIdBlock();
             }
-            direction.setLastBlock( this, newLastBlock );
-            lastBlock = newLastBlock;
+            direction.setBlock( this, newBlock );
+            block = newBlock;
         }
-        lastBlock.add( (int) id );
+        block.add( id );
+    }
+    
+    protected boolean accepts( RelIdArray source )
+    {
+        return source.getLastLoopBlock() == null;
     }
     
     public RelIdArray addAll( RelIdArray source )
     {
-        if ( source == null )
-        {
-            return this;
-        }
+//        if ( source == null )
+//        {
+//            return this;
+//        }
         
-        if ( source.getLastLoopBlock() != null )
+        if ( !accepts( source ) )
         {
             return upgradeIfNeeded( source ).addAll( source );
         }
-        
-        append( source, DirectionWrapper.OUTGOING );
-        append( source, DirectionWrapper.INCOMING );
-        append( source, DirectionWrapper.BOTH );
-        return this;
+        else
+        {
+            appendFrom( source, DirectionWrapper.OUTGOING );
+            appendFrom( source, DirectionWrapper.INCOMING );
+            appendFrom( source, DirectionWrapper.BOTH );
+            return this;
+        }
     }
     
     protected IdBlock getLastLoopBlock()
@@ -179,10 +183,9 @@ public class RelIdArray implements SizeOfObject
     
     public RelIdArray shrink()
     {
-        IdBlock shrunkOut = lastOutBlock != null ? lastOutBlock.shrink() : null;
-        IdBlock shrunkIn = lastInBlock != null ? lastInBlock.shrink() : null;
-        return shrunkOut == lastOutBlock && shrunkIn == lastInBlock ? this : 
-                new RelIdArray( type, shrunkOut, shrunkIn );
+        IdBlock shrunkOut = outBlock != null ? outBlock.shrink() : null;
+        IdBlock shrunkIn = inBlock != null ? inBlock.shrink() : null;
+        return shrunkOut == outBlock && shrunkIn == inBlock ? this : new RelIdArray( type, shrunkOut, shrunkIn );
     }
     
     protected void setLastLoopBlock( IdBlock block )
@@ -200,69 +203,34 @@ public class RelIdArray implements SizeOfObject
         return this;
     }
     
-    protected void append( RelIdArray source, DirectionWrapper direction )
+    protected void appendFrom( RelIdArray source, DirectionWrapper direction )
     {
-        IdBlock toBlock = direction.getLastBlock( this );
-        IdBlock fromBlock = direction.getLastBlock( source );
-        if ( fromBlock != null )
+        IdBlock toBlock = direction.getBlock( this );
+        IdBlock fromBlock = direction.getBlock( source );
+        if ( fromBlock == null )
         {
-            if ( toBlock == null )
-            {
-                direction.setLastBlock( this, fromBlock.copy() );
-            }
-            else if ( toBlock.getHighBits() == fromBlock.getHighBits() )
-            {
-                toBlock.addAll( fromBlock );
-                if ( fromBlock.getPrev() != null )
-                {
-                    boolean isTheOnlyOne = toBlock.getPrev() == null;
-                    IdBlock last = last( toBlock );
-                    last.setPrev( fromBlock.getPrev().copy() );
-                    if ( isTheOnlyOne )
-                    {
-                        direction.setLastBlock( this, last );
-                    }
-                }
-            }
-            else
-            {
-                boolean isTheOnlyOne = toBlock.getPrev() == null;
-                IdBlock last = last( toBlock );
-                last.setPrev( fromBlock.copy() );
-                if ( isTheOnlyOne )
-                {
-                    direction.setLastBlock( this, last );
-                }
-            }
+            return;
         }
-    }
-    
-    /**
-     * Also upgrade along the way if necessary
-     */
-    private static IdBlock last( IdBlock block )
-    {
-        IdBlock previousInLoop = null;
-        while ( true )
-        {
-            block = block.upgradeIfNeeded();
-            if ( previousInLoop != null )
-            {
-                previousInLoop.setPrev( block );
-            }
-            IdBlock prev = block.getPrev();
-            if ( prev == null )
-            {
-                return block;
-            }
-            previousInLoop = block;
-            block = prev;
+        
+        if ( toBlock == null )
+        {   // We've got no ids for that direction, just pop it right in (a copy of it)
+            direction.setBlock( this, fromBlock.copyAndShrink() );
+        }
+        else if ( toBlock.accepts( fromBlock ) )
+        {   // We've got some existing ids and the new ids are compatible, so add them
+            toBlock.addAll( fromBlock );
+        }
+        else
+        {   // We've got some existing ids, but ids aren't compatible. Upgrade and add them to the upgraded block
+            toBlock = toBlock.upgradeToHighIdBlock();
+            toBlock.addAll( fromBlock );
+            direction.setBlock( this, toBlock );
         }
     }
     
     public boolean isEmpty()
     {
-        return lastOutBlock == null && lastInBlock == null && getLastLoopBlock() == null ;
+        return outBlock == null && inBlock == null && getLastLoopBlock() == null ;
     }
     
     public RelIdIterator iterator( DirectionWrapper direction )
@@ -270,7 +238,7 @@ public class RelIdArray implements SizeOfObject
         return direction.iterator( this );
     }
     
-    public RelIdArray newSimilarInstance()
+    protected RelIdArray newSimilarInstance()
     {
         return new RelIdArray( type );
     }
@@ -288,15 +256,15 @@ public class RelIdArray implements SizeOfObject
             }
 
             @Override
-            IdBlock getLastBlock( RelIdArray ids )
+            IdBlock getBlock( RelIdArray ids )
             {
-                return ids.lastOutBlock;
+                return ids.outBlock;
             }
 
             @Override
-            void setLastBlock( RelIdArray ids, IdBlock block )
+            void setBlock( RelIdArray ids, IdBlock block )
             {
-                ids.lastOutBlock = block;
+                ids.outBlock = block;
             }
         },
         INCOMING( Direction.INCOMING )
@@ -308,15 +276,15 @@ public class RelIdArray implements SizeOfObject
             }
 
             @Override
-            IdBlock getLastBlock( RelIdArray ids )
+            IdBlock getBlock( RelIdArray ids )
             {
-                return ids.lastInBlock;
+                return ids.inBlock;
             }
 
             @Override
-            void setLastBlock( RelIdArray ids, IdBlock block )
+            void setBlock( RelIdArray ids, IdBlock block )
             {
-                ids.lastInBlock = block;
+                ids.inBlock = block;
             }
         },
         BOTH( Direction.BOTH )
@@ -328,13 +296,13 @@ public class RelIdArray implements SizeOfObject
             }
 
             @Override
-            IdBlock getLastBlock( RelIdArray ids )
+            IdBlock getBlock( RelIdArray ids )
             {
                 return ids.getLastLoopBlock();
             }
 
             @Override
-            void setLastBlock( RelIdArray ids, IdBlock block )
+            void setBlock( RelIdArray ids, IdBlock block )
             {
                 ids.setLastLoopBlock( block );
             }
@@ -352,12 +320,12 @@ public class RelIdArray implements SizeOfObject
         /*
          * Only used during add
          */
-        abstract IdBlock getLastBlock( RelIdArray ids );
+        abstract IdBlock getBlock( RelIdArray ids );
         
         /*
          * Only used during add
          */
-        abstract void setLastBlock( RelIdArray ids, IdBlock block );
+        abstract void setBlock( RelIdArray ids, IdBlock block );
         
         public Direction direction()
         {
@@ -378,212 +346,281 @@ public class RelIdArray implements SizeOfObject
     
     public static abstract class IdBlock implements SizeOfObject
     {
-        // First element is the actual length w/o the slack
-        private int[] ids = new int[3];
-        
-        /**
-         * @return a copy of itself. The copy is also shrunk so that there's no
-         * slack in the id array.
-         */
-        IdBlock copy()
-        {
-            IdBlock copy = copyInstance();
-            int length = length();
-            copy.ids = new int[length+1];
-            System.arraycopy( ids, 0, copy.ids, 0, length+1 );
-            return copy;
-        }
-        
-        public int sizeOfObjectInBytesIncludingOverhead()
-        {
-            return withObjectOverhead( withReference( withArrayOverhead( 4*ids.length ) ) );
-        }
-        
         /**
          * @return a shrunk version of itself. It returns itself if there is
-         * no need to shrink it or a {@link #copy()} if there is slack in the array.
+         * no need to shrink it or a {@link #copyAndShrink()} if there is slack in the array.
          */
         IdBlock shrink()
         {
-            return length() == ids.length-1 ? this : copy();
+            return length() == capacity() ? this : copyAndShrink();
         }
         
-        /**
-         * Upgrades to a {@link HighIdBlock} if this is a {@link LowIdBlock}.
-         */
-        abstract IdBlock upgradeIfNeeded();
-        
-        int length()
-        {
-            return ids[0];
-        }
-
-        IdBlock getPrev()
-        {
-            return null;
-        }
-        
-        abstract void setPrev( IdBlock prev );
-        
-        protected abstract IdBlock copyInstance();
-
-        // Assume id has same high bits
-        void add( int id )
+        void add( long id )
         {
             int length = ensureSpace( 1 );
-            ids[length+1] = id;
-            ids[0] = length+1;
-        }
-        
-        int ensureSpace( int delta )
-        {
-            int length = length();
-            int newLength = length+delta;
-            if ( newLength >= ids.length-1 )
-            {
-                int calculatedLength = ids.length*2;
-                if ( newLength > calculatedLength )
-                {
-                    calculatedLength = newLength*2;
-                }
-                int[] newIds = new int[calculatedLength];
-                System.arraycopy( ids, 0, newIds, 0, length+1 );
-                ids = newIds;
-            }
-            return length;
+            set( id, length );
+            setLength( length+1 );
         }
         
         void addAll( IdBlock block )
         {
             int otherBlockLength = block.length();
             int length = ensureSpace( otherBlockLength+1 );
-            System.arraycopy( block.ids, 1, ids, length+1, otherBlockLength );
-            ids[0] = otherBlockLength+length;
+            append( block, length+1, otherBlockLength );
+            setLength( otherBlockLength+length );
         }
         
-        long get( int index )
+        /**
+         * Returns the number of ids in the array, not the array size.
+         */
+        int ensureSpace( int delta )
         {
-            assert index >= 0 && index < length();
-            return transform( ids[index+1] );
+            int length = length();
+            int newLength = length+delta;
+            int capacity = capacity();
+            if ( newLength >= capacity )
+            {   // We're out of space, try doubling the size
+                int calculatedLength = capacity*2;
+                if ( newLength > calculatedLength )
+                {   // Doubling the size wasn't enough, go with double what was required
+                    calculatedLength = newLength*2;
+                }
+                extendArrayTo( length, calculatedLength );
+            }
+            return length;
         }
         
-        abstract long transform( int id );
+        protected abstract boolean accepts( long id );
         
-        void set( long id, int index )
-        {
-            // Assume same high bits
-            ids[index+1] = (int) id;
-        }
+        protected abstract boolean accepts( IdBlock block );
         
-        abstract long getHighBits();
+        protected abstract IdBlock copyAndShrink();
+        
+        abstract IdBlock upgradeToHighIdBlock();
+        
+        protected abstract void extendArrayTo( int numberOfItemsToCopy, int newLength );
+        
+        protected abstract void setLength( int length );
+        
+        protected abstract int length();
+        
+        protected abstract int capacity();
+        
+        protected abstract void append( IdBlock source, int targetStartIndex, int itemsToCopy );
+
+        protected abstract long get( int index );
+
+        protected abstract void set( long id, int index );
     }
     
     private static class LowIdBlock extends IdBlock
     {
+        // First element is the actual length w/o the slack
+        private int[] ids = new int[3];
+        
         @Override
-        void setPrev( IdBlock prev )
+        public int sizeOfObjectInBytesIncludingOverhead()
         {
-            throw new UnsupportedOperationException();
+            return withObjectOverhead( withReference( withArrayOverhead( 4*ids.length ) ) );
+        }
+        
+        public static boolean idIsLow( long id )
+        {
+            return (id & 0xFF00000000L) == 0;
         }
         
         @Override
-        IdBlock upgradeIfNeeded()
+        protected boolean accepts( long id )
         {
-            IdBlock highBlock = new HighIdBlock( 0 );
-            highBlock.ids = ((IdBlock)this).ids;
-            return highBlock;
+            return idIsLow( id );
+        }
+        
+        @Override
+        protected boolean accepts( IdBlock block )
+        {
+            return block instanceof LowIdBlock;
         }
 
         @Override
-        long transform( int id )
+        protected void append( IdBlock source, int targetStartIndex, int itemsToCopy )
         {
-            return (long)(id&0xFFFFFFFFL);
+            if ( source instanceof LowIdBlock )
+            {
+                arraycopy( ((LowIdBlock)source).ids, 1, ids, targetStartIndex, itemsToCopy );
+            }
+            else
+            {
+                throw new IllegalArgumentException( source.toString() );
+            }
         }
         
         @Override
-        protected IdBlock copyInstance()
+        IdBlock upgradeToHighIdBlock()
         {
-            return new LowIdBlock();
+            return new HighIdBlock( this );
         }
         
         @Override
-        long getHighBits()
+        protected IdBlock copyAndShrink()
         {
-            return 0;
+            LowIdBlock copy = new LowIdBlock();
+            copy.ids = Arrays.copyOf( ids, length()+1 );
+            return copy;
+        }
+        
+        @Override
+        protected void extendArrayTo( int numberOfItemsToCopy, int newLength )
+        {
+            int[] newIds = new int[newLength];
+            arraycopy( ids, 0, newIds, 0, numberOfItemsToCopy+1 );
+            ids = newIds;
+        }
+        
+        @Override
+        protected int length()
+        {
+            return ids[0];
+        }
+        
+        @Override
+        protected int capacity()
+        {
+            return ids.length-1;
+        }
+        
+        @Override
+        protected void setLength( int length )
+        {
+            ids[0] = length;
+        }
+        
+        @Override
+        protected long get( int index )
+        {
+            assert index >= 0 && index < length();
+            return ids[index+1]&0xFFFFFFFFL;
+        }
+        
+        @Override
+        protected void set( long id, int index )
+        {
+            ids[index+1] = (int) id; // guarded from outside that this is indeed an int
         }
     }
     
     private static class HighIdBlock extends IdBlock
     {
-        private final long highBits;
-        private IdBlock prev;
-
-        HighIdBlock( long highBits )
+        // First element is the actual length w/o the slack
+        private int[] ids;
+        private byte[] highBits;
+        
+        public HighIdBlock()
         {
-            this.highBits = highBits;
+            ids = new int[3];
+            highBits = new byte[3];
         }
         
-        public int sizeOfObjectInBytesIncludingOverhead()
+        private HighIdBlock( LowIdBlock lowIdBlock )
         {
-            int size = super.sizeOfObjectInBytesIncludingOverhead() + 8 + SizeOfs.REFERENCE_SIZE;
-            if ( prev != null )
-            {
-                size += prev.sizeOfObjectInBytesIncludingOverhead();
-            }
-            return size;
+            ids = Arrays.copyOf( lowIdBlock.ids, lowIdBlock.ids.length );
+            highBits = new byte[ids.length];
         }
         
         @Override
-        IdBlock upgradeIfNeeded()
+        public int sizeOfObjectInBytesIncludingOverhead()
+        {
+            return withObjectOverhead(
+                    withReference( withArrayOverhead( 4*ids.length ) ) +
+                    withReference( withArrayOverhead( ids.length ) ) );
+        }
+        
+        @Override
+        protected boolean accepts( long id )
+        {
+            return true;
+        }
+        
+        @Override
+        protected boolean accepts( IdBlock block )
+        {
+            return true;
+        }
+        
+        @Override
+        protected void append( IdBlock source, int targetStartIndex, int itemsToCopy )
+        {
+            if ( source instanceof LowIdBlock )
+            {
+                arraycopy( ((LowIdBlock)source).ids, 1, ids, targetStartIndex, itemsToCopy );
+            }
+            else
+            {
+                arraycopy( ((HighIdBlock)source).ids, 1, ids, targetStartIndex, itemsToCopy );
+                arraycopy( ((HighIdBlock)source).highBits, 1, highBits, targetStartIndex, itemsToCopy );
+            }
+        }
+        
+        @Override
+        IdBlock upgradeToHighIdBlock()
         {
             return this;
         }
         
         @Override
-        IdBlock copy()
+        protected IdBlock copyAndShrink()
         {
-            IdBlock copy = super.copy();
-            if ( prev != null )
-            {
-                copy.setPrev( prev.copy() );
-            }
+            HighIdBlock copy = new HighIdBlock();
+            int itemsToCopy = length()+1;
+            copy.ids = Arrays.copyOf( ids, itemsToCopy );
+            copy.highBits = Arrays.copyOf( highBits, itemsToCopy );
             return copy;
         }
-
+        
         @Override
-        IdBlock getPrev()
+        protected void extendArrayTo( int numberOfItemsToCopy, int newLength )
         {
-            return prev;
+            int[] newIds = new int[newLength];
+            byte[] newHighBits = new byte[newLength];
+            arraycopy( ids, 0, newIds, 0, numberOfItemsToCopy+1 );
+            arraycopy( highBits, 0, newHighBits, 0, numberOfItemsToCopy+1 );
+            ids = newIds;
+            highBits = newHighBits;
         }
 
         @Override
-        void setPrev( IdBlock prev )
+        protected int length()
         {
-            this.prev = prev;
-        }
-
-        @Override
-        long transform( int id )
-        {
-            return (((long)(id&0xFFFFFFFFL))|(highBits));
+            return ids[0];
         }
         
         @Override
-        protected IdBlock copyInstance()
+        protected int capacity()
         {
-            return new HighIdBlock( highBits );
+            return ids.length-1;
         }
         
         @Override
-        long getHighBits()
+        protected void setLength( int length )
         {
-            return highBits;
+            ids[0] = length;
+        }
+
+        @Override
+        protected long get( int index )
+        {
+            return ((long)highBits[index+1] << 32) | ids[index+1]&0xFFFFFFFFL;
+        }
+
+        @Override
+        protected void set( long id, int index )
+        {
+            ids[index+1] = (int)id;
+            highBits[index+1] = (byte) ((id&0xFF00000000L) >>> 32);
         }
     }
     
     private static class IteratorState
     {
-        private int blockIndex;
         private IdBlock block;
         private int relativePosition;
         
@@ -591,18 +628,6 @@ public class RelIdArray implements SizeOfObject
         {
             this.block = block;
             this.relativePosition = relativePosition;
-        }
-        
-        boolean nextBlock()
-        {
-            if ( block.getPrev() != null )
-            {
-                block = block.getPrev();
-                relativePosition = 0;
-                blockIndex++;
-                return true;
-            }
-            return false;
         }
         
         boolean hasNext()
@@ -615,16 +640,13 @@ public class RelIdArray implements SizeOfObject
          */
         long next()
         {
-            return block.get( relativePosition++ );
+            long id = block.get( relativePosition++ );
+            return id;
         }
 
-        public void update( IdBlock lastBlock )
+        public void update( IdBlock block )
         {
-            for ( int i = 0; i < blockIndex; i++ )
-            {
-                lastBlock = lastBlock.getPrev();
-            }
-            this.block = lastBlock;
+            this.block = block;
         }
     }
     
@@ -653,7 +675,7 @@ public class RelIdArray implements SizeOfObject
             while ( block == null && directionPosition+1 < directions.length )
             {
                 currentDirection = directions[++directionPosition];
-                block = currentDirection.getLastBlock( ids );
+                block = currentDirection.getBlock( ids );
             }
             
             if ( block != null )
@@ -688,7 +710,7 @@ public class RelIdArray implements SizeOfObject
                 {
                     if ( states[i] != null )
                     {
-                        states[i].update( directions[i].getLastBlock( ids ) );
+                        states[i].update( directions[i].getBlock( ids ) );
                     }
                 }
             }
@@ -729,30 +751,6 @@ public class RelIdArray implements SizeOfObject
 
         protected boolean nextBlock()
         {
-            // Try next block in the chain
-            if ( currentState != null && currentState.nextBlock() )
-            {
-                return true;
-            }
-            
-            // It's ok to return null here... which will result in hasNext
-            // returning false. IntArrayIterator will try to get more relationships
-            // and call hasNext again.
-            return findNextBlock();
-        }
-        
-        /* (non-Javadoc)
-         * @see org.neo4j.kernel.impl.util.RelIdIterator#doAnotherRound()
-         */
-        @Override
-        public void doAnotherRound()
-        {
-            directionPosition = -1;
-            findNextBlock();
-        }
-
-        protected boolean findNextBlock()
-        {
             while ( directionPosition+1 < directions.length )
             {
                 currentDirection = directions[++directionPosition];
@@ -762,7 +760,7 @@ public class RelIdArray implements SizeOfObject
                     currentState = nextState;
                     return true;
                 }
-                IdBlock block = currentDirection.getLastBlock( ids );
+                IdBlock block = currentDirection.getBlock( ids );
                 if ( block != null )
                 {
                     currentState = new IteratorState( block, 0 );
@@ -773,9 +771,13 @@ public class RelIdArray implements SizeOfObject
             return false;
         }
         
-        /* (non-Javadoc)
-         * @see org.neo4j.kernel.impl.util.RelIdIterator#next()
-         */
+        @Override
+        public void doAnotherRound()
+        {
+            directionPosition = -1;
+            nextBlock();
+        }
+
         @Override
         public long next()
         {
@@ -823,7 +825,8 @@ public class RelIdArray implements SizeOfObject
             if ( add != null )
             {
                 newArray = newArray.upgradeIfNeeded( add );
-                for ( RelIdIteratorImpl fromIterator = (RelIdIteratorImpl) add.iterator( DirectionWrapper.BOTH ); fromIterator.hasNext();)
+                for ( RelIdIteratorImpl fromIterator = (RelIdIteratorImpl) add.iterator( DirectionWrapper.BOTH );
+                        fromIterator.hasNext();)
                 {
                     long value = fromIterator.next();
                     if ( !remove.contains( value ) )
@@ -838,7 +841,8 @@ public class RelIdArray implements SizeOfObject
 
     private static void evictExcluded( RelIdArray ids, Collection<Long> excluded )
     {
-        for ( RelIdIteratorImpl iterator = (RelIdIteratorImpl) DirectionWrapper.BOTH.iterator( ids ); iterator.hasNext(); )
+        for ( RelIdIteratorImpl iterator = (RelIdIteratorImpl) DirectionWrapper.BOTH.iterator( ids );
+                iterator.hasNext(); )
         {
             long value = iterator.next();
             if ( excluded.contains( value ) )
@@ -849,7 +853,7 @@ public class RelIdArray implements SizeOfObject
                 for ( int j = block.length() - 1; j >= state.relativePosition; j--)
                 {
                     long backValue = block.get( j );
-                    block.ids[0] = block.ids[0]-1;
+                    block.setLength( block.length()-1 );
                     if ( !excluded.contains( backValue) )
                     {
                         block.set( backValue, state.relativePosition-1 );
@@ -859,7 +863,7 @@ public class RelIdArray implements SizeOfObject
                 }
                 if ( !swapSuccessful ) // all elements from pos in remove
                 {
-                    block.ids[0] = block.ids[0]-1;
+                    block.setLength( block.length()-1 );
                 }
             }
         }
@@ -874,7 +878,7 @@ public class RelIdArray implements SizeOfObject
      */
     public boolean couldBeNeedingUpdate()
     {
-        return (lastOutBlock != null && lastOutBlock.getPrev() != null) ||
-                (lastInBlock != null && lastInBlock.getPrev() != null);
+        return (outBlock != null && outBlock instanceof HighIdBlock) ||
+                (inBlock != null && inBlock instanceof HighIdBlock);
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArrayWithLoops.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArrayWithLoops.java
@@ -71,21 +71,15 @@ public class RelIdArrayWithLoops extends RelIdArray
     }
     
     @Override
-    public RelIdArray addAll( RelIdArray source )
-    {
-        if ( source == null )
-        {
-            return this;
-        }
-        append( source, DirectionWrapper.OUTGOING );
-        append( source, DirectionWrapper.INCOMING );
-        append( source, DirectionWrapper.BOTH );
-        return this;
-    }
-
     public RelIdArray newSimilarInstance()
     {
         return new RelIdArrayWithLoops( getType() );
+    }
+    
+    @Override
+    protected boolean accepts( RelIdArray source )
+    {
+        return true;
     }
     
     @Override
@@ -97,8 +91,8 @@ public class RelIdArrayWithLoops extends RelIdArray
     @Override
     public RelIdArray shrink()
     {
-        IdBlock lastOutBlock = DirectionWrapper.OUTGOING.getLastBlock( this );
-        IdBlock lastInBlock = DirectionWrapper.INCOMING.getLastBlock( this );
+        IdBlock lastOutBlock = DirectionWrapper.OUTGOING.getBlock( this );
+        IdBlock lastInBlock = DirectionWrapper.INCOMING.getBlock( this );
         IdBlock shrunkOut = lastOutBlock != null ? lastOutBlock.shrink() : null;
         IdBlock shrunkIn = lastInBlock != null ? lastInBlock.shrink() : null;
         IdBlock shrunkLoop = lastLoopBlock != null ? lastLoopBlock.shrink() : null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/HighIdRelationshipLoadingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/HighIdRelationshipLoadingIT.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.Pair;
+import org.neo4j.test.IdJumpingGraphDatabase;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.relationship_grab_size;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class HighIdRelationshipLoadingIT
+{
+    private final int
+        ISLAND_SIZE = 188, //RANDOM.nextInt( 100 )+100,
+        GRAB_SIZE = 100; //RANDOM.nextInt( ISLAND_SIZE*2 );
+
+    @Test
+    public void loadStuffWithHighIdsWhileIterating() throws Exception
+    {
+        // GIVEN -- a node with relationships of mixed ids, some below 2^32-1 and some above.
+        int rels = GRAB_SIZE*2;
+        Pair<Node, Set<Relationship>> data = createNodeWithRelationships( rels );
+        Node node = data.first();
+
+        // WHEN -- loading those relationships.
+        clearCache();
+        Set<Relationship> loadedRelationships = new HashSet<Relationship>();
+        for ( Relationship relationship : node.getRelationships() )
+        {
+            assertTrue( loadedRelationships.add( relationship ) );
+        }
+
+        // THEN -- they should all be found in the iterator loading them.
+        assertEquals( data.other(), loadedRelationships );
+    }
+
+    private void clearCache()
+    {
+        db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+    }
+
+    private Pair<Node,Set<Relationship>> createNodeWithRelationships( int rels )
+    {
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node node = db.createNode();
+            Set<Relationship> relationships = new HashSet<Relationship>();
+            for ( int i = 0; i < rels; i++ )
+            {
+                relationships.add( node.createRelationshipTo( db.createNode(), withName( "A" ) ) );
+            }
+            tx.success();
+            return Pair.of( node, relationships );
+        }
+        finally
+        {
+            tx.finish();
+        }
+    }
+
+    private final String storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath();
+    private IdJumpingGraphDatabase db;
+
+    @Before
+    public void before() throws Exception
+    {
+        db = new IdJumpingGraphDatabase( storeDir,
+                stringMap( relationship_grab_size.name(), "" + GRAB_SIZE ), ISLAND_SIZE );
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        db.shutdown();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
@@ -26,8 +26,10 @@ import java.nio.ByteBuffer;
 import org.junit.Test;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
-import org.neo4j.kernel.impl.core.JumpingFileSystemAbstraction.JumpingFileChannel;
 import org.neo4j.kernel.impl.nioneo.store.IdGenerator;
+import org.neo4j.test.IdJumpingFileSystemAbstraction;
+import org.neo4j.test.IdJumpingIdGeneratorFactory;
+import org.neo4j.test.IdJumpingFileSystemAbstraction.IdJumpingFileChannel;
 
 import static org.junit.Assert.assertEquals;
 
@@ -37,7 +39,7 @@ public class TestJumpingIdGenerator
     public void testIt() throws Exception
     {
         int sizePerJump = 1000;
-        IdGeneratorFactory factory = new JumpingIdGeneratorFactory( sizePerJump );
+        IdGeneratorFactory factory = new IdJumpingIdGeneratorFactory( sizePerJump );
         IdGenerator generator = factory.get( IdType.NODE );
         for ( int i = 0; i < sizePerJump/2; i++ )
         {
@@ -69,11 +71,11 @@ public class TestJumpingIdGenerator
     public void testOffsettedFileChannel() throws Exception
     {
         File fileName = new File("target/var/neostore.nodestore.db");
-        JumpingFileSystemAbstraction offsettedFileSystem = new JumpingFileSystemAbstraction( 10 );
+        IdJumpingFileSystemAbstraction offsettedFileSystem = new IdJumpingFileSystemAbstraction( 10 );
         offsettedFileSystem.deleteFile( fileName );
         offsettedFileSystem.mkdirs( fileName.getParentFile() );
-        IdGenerator idGenerator = new JumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
-        JumpingFileChannel channel = (JumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
+        IdGenerator idGenerator = new IdJumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
+        IdJumpingFileChannel channel = (IdJumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
         
         for ( int i = 0; i < 16; i++ )
         {
@@ -81,8 +83,8 @@ public class TestJumpingIdGenerator
         }
         
         channel.close();
-        channel = (JumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
-        idGenerator = new JumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
+        channel = (IdJumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
+        idGenerator = new IdJumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
         
         for ( int i = 0; i < 16; i++ )
         {
@@ -93,7 +95,7 @@ public class TestJumpingIdGenerator
         offsettedFileSystem.shutdown();
     }
 
-    private byte readSomethingLikeNodeRecord( JumpingFileChannel channel, long id ) throws IOException
+    private byte readSomethingLikeNodeRecord( IdJumpingFileChannel channel, long id ) throws IOException
     {
         ByteBuffer buffer = ByteBuffer.allocate( 9 );
         channel.position( id*9 );
@@ -103,7 +105,7 @@ public class TestJumpingIdGenerator
         return buffer.get();
     }
 
-    private void writeSomethingLikeNodeRecord( JumpingFileChannel channel, long id, int justAByte ) throws IOException
+    private void writeSomethingLikeNodeRecord( IdJumpingFileChannel channel, long id, int justAByte ) throws IOException
     {
         channel.position( id*9 );
         ByteBuffer buffer = ByteBuffer.allocate( 9 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelIdArray.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelIdArray.java
@@ -19,24 +19,26 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.BOTH;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.INCOMING;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.OUTGOING;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.neo4j.kernel.impl.util.RelIdArray;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.RelIdIterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.BOTH;
+import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.INCOMING;
+import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.OUTGOING;
 
 // TODO Add some tests for loops, i.e. add with direction BOTH.
 public class TestRelIdArray
@@ -141,6 +143,33 @@ public class TestRelIdArray
         
         assertEquals( new HashSet<Long>( Arrays.asList(
                 0L, 1L, justOverIntMax, justOverIntMax+1 ) ), new HashSet<Long>( asList( all ) ) );
+    }
+    
+    @Test
+    public void iterateThroughMultipleHighBitsSignaturesWhereIdsAreAdded() throws Exception
+    {
+        // GIVEN
+        RelIdArray ids = new RelIdArray( 0 );
+        ids.add( 0, OUTGOING );
+        ids.add( 0x1FFFFFFFFL, OUTGOING );
+        RelIdIterator iterator = ids.iterator( OUTGOING );
+
+        // WHEN -- depleting the current iterator
+        assertEquals( asSet( 0L, 0x1FFFFFFFFL ), deplete( iterator ) );
+
+        // and adding one more id of the first "high bits" kind
+        ids.add( 1, OUTGOING );
+
+        // THEN
+        assertEquals( "Should see the added id after depleting two IdBlocks", asSet( 1L ), deplete( iterator ) );
+    }
+
+    private Set<Long> deplete( RelIdIterator iterator )
+    {
+        HashSet<Long> set = new HashSet<Long>();
+        while ( iterator.hasNext() )
+            set.add( iterator.next() );
+        return set;
     }
     
     private List<Long> asList( RelIdArray ids )

--- a/community/kernel/src/test/java/org/neo4j/test/IdJumpingFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/IdJumpingFileSystemAbstraction.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.core;
+package org.neo4j.test;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,12 +44,12 @@ import org.neo4j.test.impl.ChannelInputStream;
 import org.neo4j.test.impl.ChannelOutputStream;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 
-public class JumpingFileSystemAbstraction extends LifecycleAdapter implements FileSystemAbstraction
+public class IdJumpingFileSystemAbstraction extends LifecycleAdapter implements FileSystemAbstraction
 {
     private final int sizePerJump;
     private final EphemeralFileSystemAbstraction actualFileSystem = new EphemeralFileSystemAbstraction();
 
-    public JumpingFileSystemAbstraction( int sizePerJump )
+    public IdJumpingFileSystemAbstraction( int sizePerJump )
     {
         this.sizePerJump = sizePerJump;
     }
@@ -66,7 +66,7 @@ public class JumpingFileSystemAbstraction extends LifecycleAdapter implements Fi
                 fileName.getName().equals( "neostore.propertystore.db.strings" ) ||
                 fileName.getName().equals( "neostore.propertystore.db.arrays" ) )
         {        
-            return new JumpingFileChannel( channel, recordSizeFor( fileName ) );
+            return new IdJumpingFileChannel( channel, recordSizeFor( fileName ) );
         }
         return channel;
     }
@@ -201,12 +201,12 @@ public class JumpingFileSystemAbstraction extends LifecycleAdapter implements Fi
         throw new IllegalArgumentException( fileName.getPath() );
     }
     
-    public class JumpingFileChannel extends FileChannel
+    public class IdJumpingFileChannel extends FileChannel
     {
         private final FileChannel actual;
         private final int recordSize;
         
-        public JumpingFileChannel( FileChannel actual, int recordSize )
+        public IdJumpingFileChannel( FileChannel actual, int recordSize )
         {
             this.actual = actual;
             this.recordSize = recordSize;

--- a/community/kernel/src/test/java/org/neo4j/test/IdJumpingGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/IdJumpingGraphDatabase.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.index.IndexProvider;
+import org.neo4j.helpers.Service;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.InternalAbstractGraphDatabase;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.cache.CacheProvider;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptorProvider;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class IdJumpingGraphDatabase extends InternalAbstractGraphDatabase
+{
+    private final int sizePerJump;
+
+    public IdJumpingGraphDatabase( String path, Map<String, String> params, int sizePerJump )
+    {
+        super( path, disableMemoryMapping( params ),
+                Iterables.<Class<?>, Class<?>>iterable( (Class<?>) GraphDatabaseSettings.class ),
+                Service.load( IndexProvider.class ), Iterables.<KernelExtensionFactory<?>,
+                KernelExtensionFactory>cast( Service.load( KernelExtensionFactory.class ) ),
+                Service.load( CacheProvider.class ), Service.load( TransactionInterceptorProvider.class ) );
+        this.sizePerJump = sizePerJump;
+        run();
+    }
+
+    private static Map<String, String> disableMemoryMapping( Map<String, String> params )
+    {
+        return stringMap( new HashMap<String,String>( params ),
+                Config.USE_MEMORY_MAPPED_BUFFERS, "false",
+                "neostore.nodestore.db.mapped_memory", "0M",
+                "neostore.relationshipstore.db.mapped_memory", "0M",
+                "neostore.propertystore.db.mapped_memory", "0M",
+                "neostore.propertystore.db.strings.mapped_memory", "0M",
+                "neostore.propertystore.db.arrays.mapped_memory", "0M" );
+    }
+
+    @Override
+    protected IdGeneratorFactory createIdGeneratorFactory()
+    {
+        return new IdJumpingIdGeneratorFactory( sizePerJump );
+    }
+
+    @Override
+    protected FileSystemAbstraction createFileSystemAbstraction()
+    {
+        return life.add( new IdJumpingFileSystemAbstraction( sizePerJump ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/IdJumpingIdGeneratorFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/IdJumpingIdGeneratorFactory.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.core;
+package org.neo4j.test;
 
 import java.io.File;
 import java.util.EnumMap;
@@ -32,14 +32,14 @@ import org.neo4j.kernel.impl.nioneo.store.IdGeneratorImpl;
 import org.neo4j.kernel.impl.nioneo.store.IdRange;
 import org.neo4j.test.impl.EphemeralIdGenerator;
 
-public class JumpingIdGeneratorFactory implements IdGeneratorFactory
+public class IdJumpingIdGeneratorFactory implements IdGeneratorFactory
 {
     private final Map<IdType, IdGenerator> generators = new EnumMap<IdType, IdGenerator>( IdType.class );
     private final IdGenerator forTheRest = new EphemeralIdGenerator( null );
 
     private final int sizePerJump;
 
-    public JumpingIdGeneratorFactory( int sizePerJump )
+    public IdJumpingIdGeneratorFactory( int sizePerJump )
     {
         this.sizePerJump = sizePerJump;
     }
@@ -57,7 +57,7 @@ public class JumpingIdGeneratorFactory implements IdGeneratorFactory
             IdGenerator generator = generators.get( idType );
             if ( generator == null )
             {
-                generator = new JumpingIdGenerator();
+                generator = new IdJumpingIdGenerator();
                 generators.put( idType, generator );
             }
             return generator;
@@ -69,7 +69,7 @@ public class JumpingIdGeneratorFactory implements IdGeneratorFactory
     {
     }
 
-    private class JumpingIdGenerator implements IdGenerator
+    private class IdJumpingIdGenerator implements IdGenerator
     {
         private final AtomicLong nextId = new AtomicLong();
         private int leftToNextJump = sizePerJump/2;


### PR DESCRIPTION
Problem manifests like this:
Calling node.getRelationships() and iterating through them might give
only a subset of all relationships the first time, compared to subsequent
calls.

Problem distilled to be:
A problem with the chained IdBlocks in RelIdArray objects. To save memory
the IdBlock kept relationship ids as int[], grouped them by the "high bits"
alongside a long containing the high bits separately. Ids <= 0xFFFFFFFF
even has got an IdBlock implementation without a high bits field.
When a new id where added its high bits signature was compared to the last
IdBlock created in the chain of IdBlocks - if matching it was added,
otherwise a new IdBlock was created with that high bits signature, its
"prev" link pointing to the IdBlock that previously was the last one and
the id added to it.
RelIdArray is capable of having three of these chains (out, in, loop).

  (RelIdArray)-[:out]->(A)

  ==> becomes

  (RelIdArray)-[:out]->(B)-[:prev]->(A)

An iterator (RelIdIterator) started from the last created IdBlock (in this
case B) going backwards, iterating through each IdBlock in its wake. After
fully depleting the iterator new relationships might get loaded lazily
(happens the first time a node visits each relationships if not cached).
Loaded ids would always be added to (B) or even a new IdBlock (C) if there was
a high bits signature mismatch, and so the iterator would be left stranded
on (A), never being able to see added ids.

Solution in this commit:
Simplify by removing the concept of chain of IdBlocks and have one
space-efficient IdBlock implementation capable of storing ids <= 0xFFFFFFFF
and another less space-efficient implementation capable of storing any id
and use the upgrade ability (upgrading from the "low" IdBlock to the
"high" IdBlock when needed). This will make sure there's only zero or one
IdBlock for any given direction (out, in, loop) and simpler code. At the
expense of slightly higher memory consumption.

Future solition:
Only have one IdBlock implementation that is capable of efficiently
storing any id, e.g. using a byte[] where each id added only consume least
necessary amount of bytes.
