### PR TITLE
Cheaper StatementState ref counting

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -155,6 +155,7 @@ import static java.lang.String.format;
 import static org.neo4j.helpers.Settings.setting;
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.map;
+
 import static org.slf4j.impl.StaticLoggerBinder.getSingleton;
 
 /**
@@ -346,6 +347,7 @@ public abstract class InternalAbstractGraphDatabase
         }
         
         kernelAPI.bootstrapAfterRecovery();
+        statementContextProvider.bootstrapAfterRecovery();
         if ( txManager instanceof TxManager )
         {
             NeoStoreXaDataSource neoStoreDataSource = xaDataSourceManager.getNeoStoreDataSource();
@@ -1362,7 +1364,7 @@ public abstract class InternalAbstractGraphDatabase
             {
                 return type.cast( DependencyResolverImpl.this );
             }
-            return null;                                      
+            return null;
         }
         
         @Override
@@ -1371,7 +1373,9 @@ public abstract class InternalAbstractGraphDatabase
             // Try known single dependencies
             T result = resolveKnownSingleDependency( type );
             if ( result != null )
+            {
                 return selector.select( type, Iterables.option( result ) );
+            }
             
             // Try with kernel extensions
             return kernelExtensions.resolveDependency( type, selector );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -19,17 +19,11 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.StatementOperationParts;
-import org.neo4j.kernel.api.operations.ReadOnlyStatementState;
-import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.impl.api.constraints.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
@@ -131,7 +125,6 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private SchemaCache schemaCache;
     private final UpdateableSchemaState schemaState;
     private final boolean highlyAvailableInstance;
-    private final StatementStateOwners statementContextOwners = new StatementStateOwners();
     private SchemaIndexProviderMap providerMap = null;
 
     // These non-final components are all circular dependencies in various configurations.
@@ -141,8 +134,8 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private NodeManager nodeManager;
     private PersistenceCache persistenceCache;
     private boolean isShutdown = false;
-    private StatementOperationParts statementLogic;
-    private StatementOperationParts readOnlyStatementLogic;
+    private StatementOperationParts statementOperations;
+    private StatementOperationParts readOnlyStatementOperations;
 
     public Kernel( AbstractTransactionManager transactionManager,
                    PropertyKeyTokenHolder propertyKeyTokenHolder, LabelTokenHolder labelTokenHolder,
@@ -199,10 +192,10 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     public void bootstrapAfterRecovery()
     {
             StatementOperationParts parts = newTransaction().newStatementOperations();
-            this.statementLogic = parts;
+            this.statementOperations = parts;
             
             ReadOnlyStatementOperations readOnlyParts = new ReadOnlyStatementOperations( parts.schemaStateOperations() );
-            this.readOnlyStatementLogic = parts.override(
+            this.readOnlyStatementOperations = parts.override(
                     parts.keyReadOperations(),
                     readOnlyParts,
                     parts.entityReadOperations(),
@@ -216,7 +209,6 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     @Override
     public void stop() throws Throwable
     {
-        statementContextOwners.close();
         isShutdown = true;
     }
 
@@ -271,7 +263,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
         // TODO statementLogic is null the first call (since we're building the cake), but that's OK.
         // This is an artifact of KernelTransaction having too many responsibilities (i.e. being a transaction,
         // as well as being able to construct the layered StatementOperations cake).
-        result = new ReferenceCountingKernelTransaction( result, statementLogic != null ? statementLogic.lifecycleOperations() : null );
+        result = new ReferenceCountingKernelTransaction( result, statementOperations != null ? statementOperations.lifecycleOperations() : null );
         
         // done
         return result;
@@ -288,47 +280,18 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     @Override
     public StatementOperationParts statementOperations()
     {
-        return statementLogic;
+        return statementOperations;
     }
     
     @Override
     public StatementOperationParts readOnlyStatementOperations()
     {
-        return readOnlyStatementLogic;
+        return readOnlyStatementOperations;
     }
     
     private TxState newTxState()
     {
         return new TxStateImpl( new OldTxStateBridgeImpl( nodeManager, transactionManager.getTransactionState() ),
                 persistenceManager, NO_ID_GENERATION );
-    }
-
-    private class StatementStateOwners extends ThreadLocal<StatementStateOwner>
-    {
-        private final Collection<StatementStateOwner> all =
-                Collections.synchronizedList( new ArrayList<StatementStateOwner>() );
-
-        @Override
-        protected StatementStateOwner initialValue()
-        {
-            StatementStateOwner owner = new StatementStateOwner( statementLogic.lifecycleOperations() )
-            {
-                @Override
-                protected StatementState createStatementState()
-                {
-                    return new ReadOnlyStatementState( new IndexReaderFactory.Caching( indexService ) );
-                }
-            };
-            all.add( owner );
-            return owner;
-        }
-
-        void close()
-        {
-            for ( StatementStateOwner owner : all )
-            {
-                owner.closeAllStatements();
-            }
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReferenceCountingStatementOperations.java
@@ -30,5 +30,8 @@ public class ReferenceCountingStatementOperations implements LifecycleOperations
         state.markAsClosed();
         
         // Delegation of close method happens via StatementStateOwner
+        // ReferenceCountingStatementOperations.close() -->
+        //         ReferencedStatementState.markAsClosed() -->
+        //                 if no refs left then: delegate StatementOperations.close()
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingKernelTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ReferenceCountingKernelTransactionTest.java
@@ -20,7 +20,9 @@
 package org.neo4j.kernel.impl.api;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.operations.LifecycleOperations;
@@ -111,29 +113,8 @@ public class ReferenceCountingKernelTransactionTest
         verify( otherActualState ).markAsClosed();
     }
 
-//    @Ignore( "Not valid I(MP)'d say" )
-//    @Test
-//    public void shouldNotBeAbleToInteractWithAClosedStatementContext() throws Exception
-//    {
-//        // GIVEN
-//        StatementState first = refCountingContext.newStatementState();
-//        refCountingContext.newStatementState();
-//        statementLogic.close( first );
-//
-//        // WHEN
-//        try
-//        {
-//            statementLogic.keyReadOperations().labelGetName( first, 0 );
-//
-//            fail( "expected exception" );
-//        }
-//        // THEN
-//        catch ( IllegalStateException e )
-//        {
-//            assertEquals( "This StatementContext has been closed. No more interaction allowed", e.getMessage() );
-//        }
-//    }
-
+    @Ignore( "Not valid I(MP)'d say, we don't check that anymore. Such checks are costly and " +
+          "should only be used for debugging" )
     @Test
     public void shouldNotBeAbleToCloseTheSameStatementContextTwice() throws Exception
     {
@@ -167,22 +148,12 @@ public class ReferenceCountingKernelTransactionTest
     public void shouldCloseAllStatementContextsOnCommit() throws Exception
     {
         // given
-        StatementState context = refCountingContext.newStatementState();
+        refCountingContext.newStatementState();
 
         // when
         refCountingContext.commit();
 
         // then
-        try
-        {
-            refCountingOperations.close( context );
-
-            fail( "expected exception" );
-        }
-        catch ( IllegalStateException e )
-        {
-            assertEqualsStatementClosed( e );
-        }
         verify( actualState, times( 1 ) ).markAsClosed();
     }
 
@@ -190,22 +161,12 @@ public class ReferenceCountingKernelTransactionTest
     public void shouldCloseAllStatementContextsOnRollback() throws Exception
     {
         // given
-        StatementState context = refCountingContext.newStatementState();
+        refCountingContext.newStatementState();
 
         // when
         refCountingContext.rollback();
 
         // then
-        try
-        {
-            refCountingOperations.close( context );
-
-            fail( "expected exception" );
-        }
-        catch ( IllegalStateException e )
-        {
-            assertEqualsStatementClosed( e );
-        }
         verify( actualState, times( 1 ) ).markAsClosed();
     }
 
@@ -213,24 +174,13 @@ public class ReferenceCountingKernelTransactionTest
     public void shouldBeAbleToOpenNewStatementContextsAfterCommit() throws Exception
     {
         // given
-        StatementState before = refCountingContext.newStatementState();
+        refCountingContext.newStatementState();
 
         // when
         refCountingContext.commit();
 
         // then
         StatementState after = refCountingContext.newStatementState();
-
-        try
-        {
-            refCountingOperations.close( before );
-
-            fail( "expected exception" );
-        }
-        catch ( IllegalStateException e )
-        {
-            assertEqualsStatementClosed( e );
-        }
         verify( actualState, times( 1 ) ).markAsClosed();
         verifyZeroInteractions( otherActualState );
         refCountingOperations.close( after );


### PR DESCRIPTION
o Cheaper ref counting
ReferenceCountingStatementOperations adds sharing of StatementState instances
among potentially multiple consumers, where they will be individually
closed, but the statement state not actually closed until ref count
reaches 0.

Previously a new "referenced" StatementState was returned for each of
these shared instances. And the single reason for that was to prevent and
fast-fail closing any given statement state instance multiple times. There
were no other such checks, just for closing. Keeping in mind that
KernelAPI is an internal API, having such checks should merely exist for
debugging purposes, _when_ debugging; not at runtime in production. As
seen by performance benchmarks all these StatementState instances are
costly.

This commit returns the same "referenced" StatementState (just inc/dec its
ref counter) for all the same shared instances to gain performance.

o StatementStateOwners moved to ThreadToStatementContextBridge since this
functionality is specific to the core API, and ThreadToStatementContextBridge
is specific to the core API.
