### PR TITLE
Resolves issue where removing multiple labels from a node with a large number of labels would result in corruption.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -66,6 +66,8 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         public static final Setting<Boolean> rebuild_idgenerators_fast = GraphDatabaseSettings.rebuild_idgenerators_fast;
     }
 
+    public static final byte[] NO_DATA = new byte[0];
+
     private final Config conf;
     private int blockSize;
     protected final DynamicRecordAllocator recordAllocator;
@@ -285,6 +287,10 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     {
         if ( !record.isLight() )
             return;
+        if ( record.getLength() == 0 ) // don't go though the trouble of acquiring the window if we would read nothing
+        {
+            record.setData( NO_DATA );
+        }
 
         long blockId = record.getId();
         PersistenceWindow window = acquireWindow( blockId, OperationType.READ );
@@ -582,7 +588,8 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     @Override
     public String toString()
     {
-        return super.toString() + "[blockSize:" + (getRecordSize()-getRecordHeaderSize()) + "]";
+        return super.toString() + "[fileName:" + storageFileName.getName() +
+               ", blockSize:" + (getRecordSize() - getRecordHeaderSize()) + "]";
     }
 
     public Pair<byte[]/*header in the first record*/,byte[]/*all other bytes*/> readFullByteArray(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
@@ -115,6 +115,7 @@ public class DynamicNodeLabels implements NodeLabels
                     if ( !newRecords.contains( record ) )
                     {
                         record.setInUse( false );
+                        record.setLength( 0 ); // so that it will not be made heavy again...
                     }
                 }
             }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.graphdb;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -443,6 +444,59 @@ public class LabelsAcceptanceTest
 
         // THEN
         assertEquals( 0, count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+    }
+
+    @Test
+    public void shouldCreateNodeWithLotsOfLabelsAndThenRemoveMostOfThem() throws Exception
+    {
+        // given
+        final int TOTAL_NUMBER_OF_LABELS = 200, NUMBER_OF_PRESERVED_LABELS = 20;
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        Node node;
+        {
+            Transaction tx = db.beginTx();
+            try
+            {
+                node = db.createNode();
+                for ( int i = 0; i < TOTAL_NUMBER_OF_LABELS; i++ )
+                {
+                    node.addLabel( DynamicLabel.label( "label:" + i ) );
+                }
+
+                tx.success();
+            }
+            finally
+            {
+                tx.finish();
+            }
+        }
+
+        // when
+        {
+            Transaction tx = db.beginTx();
+            try
+            {
+                for ( int i = NUMBER_OF_PRESERVED_LABELS; i < TOTAL_NUMBER_OF_LABELS; i++ )
+                {
+                    node.removeLabel( DynamicLabel.label( "label:" + i ) );
+                }
+
+                tx.success();
+            }
+            finally
+            {
+                tx.finish();
+            }
+        }
+        dbRule.clearCache();
+
+        // then
+        List<String> labels = new ArrayList<>();
+        for ( Label label : node.getLabels() )
+        {
+            labels.add( label.name() );
+        }
+        assertEquals( "labels on node: " + labels, NUMBER_OF_PRESERVED_LABELS, labels.size() );
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This problem manifested in scenarios when a node has so many labels that multiple
dynamic records are used for holding them.

The problem was that when a label was removed that caused one of the dynamic records
to not be in use anymore, this record would be marked as !inUse, which makes it light.
If in the same transaction another label is removed from that same node, the labels are
first read from the records, including the one marked as !inUse. Since this record is light,
reading data from it will cause it to be made heavy, reading back the data from the store
into it, thus reading back data that should have been removed, leading to an inconsistent
state.

The solution implemented is to also mark the record as empty, meaning that when the
record is made heavy as part of reading the labels from it, no data will be read (a byte[0]).
A simple optimization has been implemented for the case when a record is empty, to not
actually read any data from the store, only mark it as heavy by assigning a pre-allocated
byte[0].
