### PR TITLE
Fixes #973

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -20,7 +20,8 @@
 package org.neo4j.kernel;
 
 import static java.lang.String.format;
-import static org.slf4j.impl.StaticLoggerBinder.getSingleton;
+
+import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,6 @@ import java.util.concurrent.Executors;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
-import ch.qos.logback.classic.LoggerContext;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -119,8 +119,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.kernel.lifecycle.LifecycleListener;
 import org.neo4j.kernel.lifecycle.LifecycleStatus;
-import org.neo4j.kernel.logging.ClassicLoggingService;
-import org.neo4j.kernel.logging.LogbackService;
+import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.tooling.GlobalGraphOperations;
 
@@ -765,17 +764,7 @@ public abstract class InternalAbstractGraphDatabase
 
     protected Logging createLogging()
     {
-        Logging logging;
-        try
-        {
-            getClass().getClassLoader().loadClass( "ch.qos.logback.classic.LoggerContext" );
-            logging = new LogbackService( config, (LoggerContext) getSingleton().getLoggerFactory() );
-        }
-        catch ( Exception e )
-        {
-            logging = new ClassicLoggingService( config );
-        }
-        return life.add( logging );
+        return life.add( new LogbackWeakDependency().tryLoadLogbackService( config, DEFAULT_TO_CLASSIC ) );
     }
 
     protected void createNeoDataSource()
@@ -1338,7 +1327,9 @@ public abstract class InternalAbstractGraphDatabase
             // Try known single dependencies
             T result = resolveKnownSingleDependency( type );
             if ( result != null )
+            {
                 return selector.select( type, Iterables.option( result ) );
+            }
             
             // Try with kernel extensions
             return kernelExtensions.resolveDependency( type, selector );

--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackWeakDependency.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackWeakDependency.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.logging;
+
+import org.neo4j.helpers.Function;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
+/**
+ * This class is here since kernel has a weak dependency on logback, i.e. it will be used if available,
+ * otherwise a fallback will transparently be used in its place. So even if some other classes this class
+ * may refer to are available at compile time, it cannot be written in a way that assumes them being there.
+ * For example it cannot import those classes, but should resolve them by reflection instead.
+ */
+public class LogbackWeakDependency
+{
+    public static final Function<Config, Logging> DEFAULT_TO_CLASSIC = new Function<Config, Logging>()
+    {
+        @Override
+        public Logging apply( Config config )
+        {
+            return new ClassicLoggingService( config );
+        }
+    };
+    public static final Function<Config, Object> NEW_LOGGER_CONTEXT = new Function<Config, Object>()
+    {
+        @Override
+        public Object apply( Config from )
+        {
+            try
+            {
+                return Class.forName( LOGGER_CONTEXT_CLASS_NAME ).getConstructor().newInstance();
+            }
+            catch ( Exception e )
+            {
+                throw launderedException( e );
+            }
+        }
+    };
+    public static final Function<Config, Object> STATIC_LOGGER_CONTEXT = new Function<Config, Object>()
+    {
+        @Override
+        public Object apply( Config config )
+        {
+            try
+            {
+                Class<?> loggerBinderClass = Class.forName( LOGGER_BINDER_CLASS_NAME );
+                Object loggerBinder = loggerBinderClass.getDeclaredMethod( "getSingleton" ).invoke( null );
+                return loggerBinder.getClass().getDeclaredMethod( "getLoggerFactory" ).invoke( loggerBinder );
+            }
+            catch ( Exception e )
+            {
+                throw launderedException( e );
+            }
+        }
+    };
+    private static final String LOGGER_CONTEXT_CLASS_NAME = "ch.qos.logback.classic.LoggerContext";
+    private static final String LOGGER_BINDER_CLASS_NAME = "org.slf4j.impl.StaticLoggerBinder";
+
+    public Logging tryLoadLogbackService( Config config, Function<Config, Object> loggerContextGetter,
+            Function<Config, Logging> otherwiseDefaultTo )
+    {
+        try
+        {
+            if ( logbackIsOnClasspath() )
+            {
+                return newLogbackService( config, loggerContextGetter.apply( config ) );
+            }
+        }
+        catch ( Exception e )
+        {   // OK, we'll return fallback below
+        }
+        return otherwiseDefaultTo.apply( config );
+    }
+    
+    public Logging tryLoadLogbackService( Config config, Function<Config, Logging> otherwiseDefaultTo )
+    {
+        return tryLoadLogbackService( config, STATIC_LOGGER_CONTEXT, otherwiseDefaultTo );
+    }
+
+    /**
+     * To work around the problem where we have an object that is actually a LoggerContext, but we
+     * cannot refer to it as such since that class may not exist at runtime.
+     */
+    private Logging newLogbackService( Config config, Object loggerContext ) throws Exception
+    {
+        Class<?> loggerContextClass = Class.forName( LOGGER_CONTEXT_CLASS_NAME );
+        return LogbackService.class
+                .getConstructor( Config.class, loggerContextClass )
+                .newInstance( config, loggerContext );
+    }
+
+    private boolean logbackIsOnClasspath()
+    {
+        try
+        {
+            getClass().getClassLoader().loadClass( LOGGER_CONTEXT_CLASS_NAME );
+            return true;
+        }
+        catch ( ClassNotFoundException e )
+        {
+            return false;
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestAutoIndexing.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestAutoIndexing.java
@@ -22,9 +22,7 @@ package org.neo4j.index.impl.lucene;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
@@ -35,7 +35,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.ha;
 
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.NEW_LOGGER_CONTEXT;
 
 import java.io.File;
 import java.lang.reflect.Proxy;
@@ -32,6 +34,7 @@ import java.util.Map;
 import javax.transaction.Transaction;
 
 import ch.qos.logback.classic.LoggerContext;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
@@ -94,8 +97,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-import org.neo4j.kernel.logging.ClassicLoggingService;
-import org.neo4j.kernel.logging.LogbackService;
+import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 
 public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
@@ -206,16 +208,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected Logging createLogging()
     {
-        try
-        {
-            getClass().getClassLoader().loadClass( "ch.qos.logback.classic.LoggerContext" );
-            loggerContext = new LoggerContext();
-            return life.add( new LogbackService( config, loggerContext ) );
-        }
-        catch ( ClassNotFoundException e )
-        {
-            return life.add( new ClassicLoggingService( config ) );
-        }
+        return life.add( new LogbackWeakDependency().tryLoadLogbackService( config, NEW_LOGGER_CONTEXT, DEFAULT_TO_CLASSIC ) );
     }
 
     @Override

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
@@ -24,15 +24,16 @@ import static org.neo4j.helpers.Exceptions.exceptionsOfType;
 import static org.neo4j.helpers.Exceptions.peel;
 import static org.neo4j.helpers.collection.MapUtil.loadStrictly;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
 import static org.neo4j.server.configuration.Configurator.DB_TUNING_PROPERTY_FILE_KEY;
 import static org.neo4j.server.configuration.Configurator.NEO_SERVER_CONFIG_FILE_KEY;
-import static org.slf4j.impl.StaticLoggerBinder.getSingleton;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.netty.channel.ChannelException;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
@@ -42,11 +43,8 @@ import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleException;
-import org.neo4j.kernel.logging.ClassicLoggingService;
-import org.neo4j.kernel.logging.LogbackService;
+import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
-
-import ch.qos.logback.classic.LoggerContext;
 
 /**
  * Wrapper around a {@link ClusterClient} to fit the environment of the Neo4j server,
@@ -169,19 +167,7 @@ public class StandaloneClusterClient
                 new File( new File( new File ( home, "data" ), "log" ), "arbiter" ).getPath() );
         Config config = new Config( stringMap( InternalAbstractGraphDatabase.Configuration.store_dir.name(), logDir ) );
 
-        // Copied from InternalAbstractGraphDatabase#createStringLogger
-        Logging logging;
-        try
-        {
-            StandaloneClusterClient.class.getClassLoader().loadClass( "ch.qos.logback.classic.LoggerContext" );
-            LogbackService logback = new LogbackService( config, (LoggerContext) getSingleton().getLoggerFactory() );
-            logging = logback;
-        }
-        catch ( ClassNotFoundException e )
-        {
-            logging = new ClassicLoggingService( config );
-        }
-        return logging;
+        return new LogbackWeakDependency().tryLoadLogbackService( config, DEFAULT_TO_CLASSIC );
     }
     
     private static File extractDbTuningProperties( String propertiesFile )


### PR DESCRIPTION
Since logback is a weak dependency, i.e. it may or may not be present at
runtime there cannot be an import referring to it. Instead a
LogbackWeakDependency class is introduced which contains reflection code
to try to load it, with a fallback if not present.
