### PR TITLE
Fixes #58

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -176,6 +176,12 @@ public abstract class GraphDatabaseSettings
     public static final StringSetting keep_logical_logs = new StringSetting( setting("keep_logical_logs", STRING, TRUE, illegalValueMessage( "Must be 'true'/'false' or of format '<number><optional unit> <type>' for example '100M size' for " +
                         "limiting logical log space on disk to 100Mb," +
                         " or '200k txs' for limiting the number of transactions to keep to 200 000.", matches(ANY))));
+    
+    @Description( "Specifies at which file size the logical log will auto-rotate. " +
+                  "0 means that no rotation will automatically occur based on file size. " +
+                  "Default is 25M" )
+    public static final Setting<Long> logical_log_rotation_threshold = setting( "logical_log_rotation_threshold",
+            Settings.LONG_WITH_OPTIONAL_UNIT, "25M" );
 
     @Description("Use a quick approach for rebuilding the ID generators. This give quicker recovery time, " +
             "but will limit the ability to reuse the space of deleted entities.")

--- a/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.FileUtils;
 
 /**
@@ -401,6 +402,24 @@ public final class Settings
         }
     };
 
+    /**
+     * For values such as:
+     * <ul>
+     *   <li>100M</li>   ==> 100 * 1024 * 1024
+     *   <li>37261</li>  ==> 37261
+     *   <li>2g</li>     ==> 2 * 1024 * 1024 * 1024
+     *   <li>50m</li>    ==> 50 * 1024 * 1024
+     *   <li>10k</li>    ==> 10 * 1024
+     * </ul>
+     */
+    public static final Function<String, Long> LONG_WITH_OPTIONAL_UNIT = new Function<String, Long>()
+    {
+        @Override
+        public Long apply( String from )
+        {
+            return Config.parseLongWithUnit( from );
+        }
+    };
 
     public static <T extends Enum> Function<String, T> options( final Class<T> enumClass )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -41,6 +41,8 @@ import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.kernel.info.DiagnosticsProvider;
 import org.neo4j.kernel.logging.BufferingLogger;
 
+import static java.lang.Character.isDigit;
+
 /**
  * This class holds the overall configuration of a Neo4j database instance. Use the accessors
  * to convert the internal key-value settings to other types.
@@ -61,8 +63,8 @@ public class Config implements DiagnosticsProvider
     // instantiated.
     private StringLogger log = new BufferingLogger();
     private final ConfigurationValidator validator;
-    private Function<String, String> settingsFunction;
-    private Iterable<Class<?>> settingsClasses;
+    private final Function<String, String> settingsFunction;
+    private final Iterable<Class<?>> settingsClasses;
 
     public Config()
     {
@@ -555,25 +557,51 @@ public class Config implements DiagnosticsProvider
 
     public static long parseLongWithUnit( String numberWithPotentialUnit )
     {
-        numberWithPotentialUnit = numberWithPotentialUnit.toLowerCase();
+        int firstNonDigitIndex = findFirstNonDigit( numberWithPotentialUnit );
+        String number = numberWithPotentialUnit.substring( 0, firstNonDigitIndex );
+        
         long multiplier = 1;
-        if ( numberWithPotentialUnit.endsWith( "k" ) )
+        if ( firstNonDigitIndex < numberWithPotentialUnit.length() )
         {
-            multiplier = 1024;
-            numberWithPotentialUnit = numberWithPotentialUnit.substring( 0, numberWithPotentialUnit.length() - 1 );
+            String unit = numberWithPotentialUnit.substring( firstNonDigitIndex );
+            if ( unit.equalsIgnoreCase( "k" ) )
+            {
+                multiplier = 1024;
+            }
+            else if ( unit.equalsIgnoreCase( "m" ) )
+            {
+                multiplier = 1024 * 1024;
+            }
+            else if ( unit.equalsIgnoreCase( "g" ) )
+            {
+                multiplier = 1024 * 1024 * 1024;
+            }
+            else
+            {
+                throw new IllegalArgumentException(
+                        "Illegal unit '" + unit + "' for number '" + numberWithPotentialUnit + "'" );
+            }
         }
-        else if ( numberWithPotentialUnit.endsWith( "m" ) )
-        {
-            multiplier = 1024 * 1024;
-            numberWithPotentialUnit = numberWithPotentialUnit.substring( 0, numberWithPotentialUnit.length() - 1 );
-        }
-        else if ( numberWithPotentialUnit.endsWith( "g" ) )
-        {
-            multiplier = 1024 * 1024 * 1024;
-            numberWithPotentialUnit = numberWithPotentialUnit.substring( 0, numberWithPotentialUnit.length() - 1 );
-        }
+        
+        return Long.parseLong( number ) * multiplier;
+    }
 
-        return Long.parseLong( numberWithPotentialUnit ) * multiplier;
+    /**
+     * @return index of first non-digit character in {@code numberWithPotentialUnit}. If all digits then
+     * {@code numberWithPotentialUnit.length()} is returned.
+     */
+    private static int findFirstNonDigit( String numberWithPotentialUnit )
+    {
+        int firstNonDigitIndex = numberWithPotentialUnit.length();
+        for ( int i = 0; i < numberWithPotentialUnit.length(); i++ )
+        {
+            if ( !isDigit( numberWithPotentialUnit.charAt( i ) ) )
+            {
+                firstNonDigitIndex = i;
+                break;
+            }
+        }
+        return firstNonDigitIndex;
     }
 
     @Deprecated

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InterceptingXaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InterceptingXaLogicalLog.java
@@ -38,9 +38,10 @@ public class InterceptingXaLogicalLog extends XaLogicalLog
             XaCommandFactory cf, XaTransactionFactory xaTf,
             TransactionInterceptorProviders providers, LogBufferFactory logBufferFactory,
             FileSystemAbstraction fileSystem, Logging logging,
-            LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory )
+            LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory, long rotateAtSize )
     {
-        super( fileName, xaRm, cf, xaTf, logBufferFactory, fileSystem, logging, pruneStrategy, stateFactory );
+        super( fileName, xaRm, cf, xaTf, logBufferFactory, fileSystem, logging, pruneStrategy,
+                stateFactory, rotateAtSize );
         this.providers = providers;
         this.ds = xaRm.getDataSource();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.ClosableIterable;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -209,7 +210,9 @@ public abstract class XaDataSource implements Lifecycle
      * Turns off/on auto rotate of logical logs. Default is <CODE>true</CODE>.
      *
      * @param rotate <CODE>true</CODE> to turn on
+     * @deprecated in favor of {@link GraphDatabaseSettings#logical_log_rotation_threshold}
      */
+    @Deprecated
     public void setAutoRotate( boolean rotate )
     {
         throw new UnsupportedOperationException( getClass().getName() );
@@ -220,7 +223,9 @@ public abstract class XaDataSource implements Lifecycle
      * the log if {@link #setAutoRotate(boolean)} is set to <CODE>true</CODE>.
      *
      * @param size target size in bytes
+     * @deprecated in favor of setting {@link GraphDatabaseSettings#logical_log_rotation_threshold} to {@code 0}.
      */
+    @Deprecated
     public void setLogicalLogTargetSize( long size )
     {
         throw new UnsupportedOperationException( getClass().getName() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaFactory.java
@@ -28,6 +28,8 @@ import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.logging.Logging;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_log_rotation_threshold;
+
 /**
 * TODO
 */
@@ -69,15 +71,17 @@ public class XaFactory
         // TODO The dependencies between XaRM, LogicalLog and XaTF should be resolved to avoid the setter
         XaResourceManager rm = new XaResourceManager( xaDataSource, tf, txIdGenerator, txManager, recoveryVerifier, logicalLog.getName() );
 
+        long rotateAtSize = config.get( logical_log_rotation_threshold );
         XaLogicalLog log;
         if ( providers.shouldInterceptDeserialized() && providers.hasAnyInterceptorConfigured() )
         {
             log = new InterceptingXaLogicalLog( logicalLog, rm, cf, tf, providers, logBufferFactory,
-                    fileSystemAbstraction, logging, pruneStrategy, stateFactory );
+                    fileSystemAbstraction, logging, pruneStrategy, stateFactory, rotateAtSize );
         }
         else
         {
-            log = new XaLogicalLog( logicalLog, rm, cf, tf, logBufferFactory, fileSystemAbstraction, logging, pruneStrategy, stateFactory );
+            log = new XaLogicalLog( logicalLog, rm, cf, tf, logBufferFactory, fileSystemAbstraction,
+                    logging, pruneStrategy, stateFactory, rotateAtSize );
         }
 
         // TODO These setters should be removed somehow

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -93,8 +93,8 @@ public class XaLogicalLog implements LogLoader
     private final XaCommandFactory cf;
     private final XaTransactionFactory xaTf;
     private char currentLog = CLEAN;
-    private boolean autoRotate = true;
-    private long rotateAtSize = 25 * 1024 * 1024; // 25MB
+    private boolean autoRotate;
+    private long rotateAtSize;
 
     private final LogBufferFactory logBufferFactory;
     private boolean doingRecovery;
@@ -114,7 +114,8 @@ public class XaLogicalLog implements LogLoader
 
     public XaLogicalLog( File fileName, XaResourceManager xaRm, XaCommandFactory cf,
                          XaTransactionFactory xaTf, LogBufferFactory logBufferFactory, FileSystemAbstraction fileSystem,
-                         Logging logging, LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory )
+                         Logging logging, LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory,
+                         long rotateAtSize )
     {
         this.fileName = fileName;
         this.xaRm = xaRm;
@@ -124,6 +125,8 @@ public class XaLogicalLog implements LogLoader
         this.fileSystem = fileSystem;
         this.pruneStrategy = pruneStrategy;
         this.stateFactory = stateFactory;
+        this.rotateAtSize = rotateAtSize;
+        this.autoRotate = rotateAtSize > 0;
         this.logFiles = new XaLogicalLogFiles( fileName, fileSystem );
 
         sharedBuffer = ByteBuffer.allocateDirect( 9 + Xid.MAXGTRIDSIZE
@@ -1420,7 +1423,8 @@ public class XaLogicalLog implements LogLoader
         this.logVersion = xaTf.getCurrentVersion();
         if ( xaTf.getCurrentVersion() != (currentVersion + 1) )
         {
-            throw new IOException( "version change failed" );
+            throw new IOException( "Version change failed, expected " + (currentVersion + 1) + ", but was " +
+                    xaTf.getCurrentVersion() );
         }
         pruneStrategy.prune( this );
         fileChannel = newLog;
@@ -1488,21 +1492,25 @@ public class XaLogicalLog implements LogLoader
         currentLog = c;
     }
 
+    @Deprecated
     public void setAutoRotateLogs( boolean autoRotate )
     {
         this.autoRotate = autoRotate;
     }
 
+    @Deprecated
     public boolean isLogsAutoRotated()
     {
         return this.autoRotate;
     }
 
+    @Deprecated
     public void setLogicalLogTargetSize( long size )
     {
         this.rotateAtSize = size;
     }
 
+    @Deprecated
     public long getLogicalLogTargetSize()
     {
         return this.rotateAtSize;

--- a/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
@@ -19,9 +19,12 @@
  */
 package org.neo4j.helpers;
 
-import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.Functions.map;
 import static org.neo4j.helpers.Settings.DURATION;
 import static org.neo4j.helpers.Settings.INTEGER;
@@ -43,7 +46,9 @@ import java.io.File;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
 public class SettingsTest
 {
@@ -261,5 +266,22 @@ public class SettingsTest
         Setting<String> y = setting( "Y", STRING, MANDATORY, x );
 
         y.apply( Functions.<String, String>nullFunction() );
+    }
+    
+    @Test
+    public void testLogicalLogRotationThreshold() throws Exception
+    {
+        // WHEN
+        Setting<Long> setting = GraphDatabaseSettings.logical_log_rotation_threshold;
+        long defaultValue = setting.apply( map( stringMap() ) );
+        long kiloValue = setting.apply( map( stringMap( setting.name(), "10k" ) ) );
+        long megaValue = setting.apply( map( stringMap( setting.name(), "10M" ) ) );
+        long gigaValue = setting.apply( map( stringMap( setting.name(), "10g" ) ) );
+        
+        // THEN
+        assertThat( defaultValue, greaterThan( 0L ) );
+        assertEquals( 10 * 1024, kiloValue );
+        assertEquals( 10 * 1024 * 1024, megaValue );
+        assertEquals( 10L * 1024 * 1024 * 1024, gigaValue );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestUpgradeOneDotFourToFiveIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestUpgradeOneDotFourToFiveIT.java
@@ -52,8 +52,9 @@ public class TestUpgradeOneDotFourToFiveIT
 //        config.put( FileSystemAbstraction.class, CommonFactories.defaultFileSystemAbstraction() );
 //        config.put( LogBufferFactory.class, CommonFactories.defaultLogBufferFactory() );
         
-        XaLogicalLog log = new XaLogicalLog( resourceFile(), null, null, null, defaultLogBufferFactory(), defaultFileSystemAbstraction(), new DevNullLoggingService(),
-                LogPruneStrategies.NO_PRUNING, TransactionStateFactory.noStateFactory( new DevNullLoggingService() ) );
+        XaLogicalLog log = new XaLogicalLog( resourceFile(), null, null, null, defaultLogBufferFactory(),
+                defaultFileSystemAbstraction(), new DevNullLoggingService(), LogPruneStrategies.NO_PRUNING,
+                TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), 25 * 1024 * 1024 );
         log.open();
         fail( "Shouldn't be able to start" );
     }


### PR DESCRIPTION
o Introduces GraphDatabaseSettings#logical_log_rotation_threshold for
  controlling log size for auto-rotation.
o a logical_log_rotation_threshold=0 value means no auto-rotation.
o These two above will replace the setters on XaLogicalLog and
  XaDataSource, namely #setLogicalLogTargetSize() and #setAutoRotate(),
  but they are just deprecated for now.
