### PR TITLE
Escaped identifiers in the RETURN clause are kept as the user entered them

### DIFF
--- a/community/cypher/CHANGES.txt
+++ b/community/cypher/CHANGES.txt
@@ -2,6 +2,8 @@
 ---------
 o Fixes #844 - Label predicate do not work on optional nodes that are null
 o Introduced a new experimental PEG parser (Parboiled)
+o BREAKING CHANGE: Escaped identifiers in the RETURN clause are kept as the
+                   user entered them.
 
 2.0.0-M03
 ---------

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/ReturnItem.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/ReturnItem.scala
@@ -42,7 +42,10 @@ case class ReturnItem(expression: Expression, name: String, renamed: Boolean = f
   extends ReturnColumn {
   def expressions(symbols: SymbolTable) = Map(name -> expression)
 
-  override def toString = s"${expression.toString} AS ${name}"
+  override def toString = if(renamed)
+    s"${expression.toString} AS ${name}"
+  else
+    name
 
   def rename(newName: String) = ReturnItem(expression, newName, renamed = true)
 }

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ReturnClause.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ReturnClause.scala
@@ -31,7 +31,7 @@ trait ReturnClause extends Base with Expressions {
   } | "*" ^^^ AllIdentifiers()
 
   def returnItem: Parser[ReturnItem] = trap(exprOrPred) ^^ {
-    case (expression, name) => ReturnItem(expression, name.replace("`", ""))
+    case (expression, name) => ReturnItem(expression, name)
   }
 
   def returns =

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -119,14 +119,6 @@ class CypherParserTest extends JUnitSuite with Assertions {
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
-  @Test def escapedNamesShouldNotContainEscapeChars() {
-    test(
-      """start `a a` = rel:`index a`(`key s` = "value") return `a a`""",
-      Query.
-        start(RelationshipByIndex("a a", "index a", Literal("key s"), Literal("value"))).
-        returns(ReturnItem(Identifier("a a"), "a a")))
-  }
-
   @Test def keywordsShouldBeCaseInsensitive() {
     test(
       "START s = NODE(1) RETURN s",
@@ -2798,6 +2790,22 @@ class CypherParserTest extends JUnitSuite with Assertions {
         ReturnItem(percentileDisc, "percentile_disc(n.property, 0.5)"),
         ReturnItem(stdev, "stdev(n.property)"),
         ReturnItem(stdevP, "stdevp(n.property)")))
+  }
+
+  @Test def escaped_identifier() {
+    test(vFrom2_0, "match `Unusual identifier` return `Unusual identifier`.propertyName",
+      Query.
+        matches(SingleNode("Unusual identifier")).
+        returns(
+        ReturnItem(Property(Identifier("Unusual identifier"), PropertyKey("propertyName")), "`Unusual identifier`.propertyName")))
+  }
+
+  @Test def aliased_column_does_not_keep_escape_symbols() {
+    test(vFrom2_0, "match a return a as `Escaped alias`",
+      Query.
+        matches(SingleNode("a")).
+        returns(
+        ReturnItem(Identifier("a"), "Escaped alias", renamed = true)))
   }
 
   private def run(f: () => Unit) =

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
@@ -72,7 +72,7 @@ class ReturnTest extends DocumentingTestBase {
       queryText = """match `This isn't a common identifier` where `This isn't a common identifier`.name='A'
 return `This isn't a common identifier`.happy""",
       returns = """The node indexed with name "A" is returned""",
-      assertions = (p) => assertEquals(List(Map("This isn't a common identifier.happy" -> "Yes!")), p.toList))
+      assertions = (p) => assertEquals(List(Map("`This isn't a common identifier`.happy" -> "Yes!")), p.toList))
   }
 
   @Test def nullable_properties() {


### PR DESCRIPTION
This means: Given a RETURN clause that looks like this: RETURN `escaped id`.
The old behaviour was to name the column "escaped id". The new behaviour is to use "`escaped id`".
