### PR TITLE
Fixes an ArrayIndexOutOfBounds issue iterating over relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipIterator.java
@@ -61,6 +61,7 @@ class RelationshipIterator extends PrefetchingIterator<Relationship> implements 
         this.currentTypeIndex = 0;
     }
 
+    @Override
     public Iterator<Relationship> iterator()
     {
         return this;
@@ -74,22 +75,25 @@ class RelationshipIterator extends PrefetchingIterator<Relationship> implements 
         {
             if ( currentTypeIterator.hasNext() )
             {
+                // There are more relationships loaded of this relationship type, let's return it
                 long nextId = currentTypeIterator.next();
                 try
                 {
                     return nodeManager.newRelationshipProxyById( nextId );
                 }
                 catch ( NotFoundException e )
-                { // ok deleted 
+                { // OK, deleted. Skip it and move on
                 }
             }
             
             LoadStatus status;
             while ( !currentTypeIterator.hasNext() )
             {
-                if ( ++currentTypeIndex < rels.length )
+                // There aren't any more relationships loaded of this relationship type
+                if ( currentTypeIndex+1 < rels.length )
                 {
-                    currentTypeIterator = rels[currentTypeIndex];
+                    // There are other relationship types to try to get relationships from, go to the next type
+                    currentTypeIterator = rels[++currentTypeIndex];
                 }
                 else if ( (status = fromNode.getMoreRelationships( nodeManager )).loaded()
                         // This is here to guard for that someone else might have loaded
@@ -99,6 +103,9 @@ class RelationshipIterator extends PrefetchingIterator<Relationship> implements 
                         // isn't fully loaded when starting iterating.
                         || lastTimeILookedThereWasMoreToLoad )
                 {
+                    // There aren't any more relationship types to try to get relationships from,
+                    // but it's likely there are more relationships to load for this node,
+                    // so try to go and load more relationships
                     lastTimeILookedThereWasMoreToLoad = status.hasMoreToLoad();
                     Map<Integer,RelIdIterator> newRels = new HashMap<Integer,RelIdIterator>();
                     for ( RelIdIterator itr : rels )
@@ -144,11 +151,14 @@ class RelationshipIterator extends PrefetchingIterator<Relationship> implements 
                 }
                 else
                 {
+                    // There aren't any more relationship types to try to get relationships from
+                    // and there are no more relationships to load for this node
                     break;
                 }
             }
         } while ( currentTypeIterator.hasNext() );
-        // no next element found
+
+        // Denotes the end of the iterator
         return null;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CombinedRelIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CombinedRelIdIterator.java
@@ -51,12 +51,6 @@ public class CombinedRelIdIterator implements RelIdIterator
     }
 
     @Override
-    public RelIdArray getIds()
-    {
-        return srcIterator.getIds();
-    }
-
-    @Override
     public RelIdIterator updateSource( RelIdArray newSource, DirectionWrapper direction )
     {
         srcIterator = srcIterator.updateSource( newSource, direction );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArray.java
@@ -101,7 +101,7 @@ public class RelIdArray implements SizeOfObject
     @Override
     public int sizeOfObjectInBytesIncludingOverhead()
     {
-        return withObjectOverhead( 8 /*type (padded)*/ + sizeOfBlockWithReference( outBlock ) + sizeOfBlockWithReference( inBlock ) ); 
+        return withObjectOverhead( 8 /*type (padded)*/ + sizeOfBlockWithReference( outBlock ) + sizeOfBlockWithReference( inBlock ) );
     }
     
     static int sizeOfBlockWithReference( IdBlock block )
@@ -689,12 +689,6 @@ public class RelIdArray implements SizeOfObject
         public int getType()
         {
             return ids.getType();
-        }
-        
-        @Override
-        public RelIdArray getIds()
-        {
-            return ids;
         }
         
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdIterator.java
@@ -25,8 +25,6 @@ public interface RelIdIterator
 {
     int getType();
 
-    RelIdArray getIds();
-
     RelIdIterator updateSource( RelIdArray newSource, DirectionWrapper direction );
 
     boolean hasNext();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.graphdb.Direction.OUTGOING;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+
+/**
+ * Ensures the absence of an issue where iterating through a {@link RelationshipIterator} would result in
+ * {@link ArrayIndexOutOfBoundsException} due to incrementing an array index too eagerly so that a consecutive
+ * call to {@link RelationshipIterator#next()} would try to get the internal type iterator with a too high index.
+ * 
+ * This test is probabilistic in trying to produce the issue. There's a chance this test will be unsuccessful in
+ * reproducing the issue (test being successful where it should have failed), but it will never randomly fail
+ * where it should have been successful. After the point where the issue has been fixed this test will use
+ * the full 0.5 seconds to try to reproduce it.
+ * 
+ * @see RelationshipIteratorIssuesTest for unit test
+ */
+public class ConcurrentCreateAndGetRelationshipsIT
+{
+    @Test
+    public void tryToReproduceTheIssue() throws Exception
+    {
+        // GIVEN
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        CountDownLatch startSignal = new CountDownLatch( 1 );
+        AtomicBoolean stopSignal = new AtomicBoolean();
+        AtomicReference<Exception> failure = new AtomicReference<Exception>();
+        Node parentNode = createNode( db );
+        Collection<Worker> workers = createWorkers( db, startSignal, stopSignal, failure, parentNode );
+        
+        // WHEN
+        startSignal.countDown();
+        sleep( 500 );
+        stopSignal.set( true );
+        awaitWorkersToEnd( workers );
+        
+        // THEN
+        if ( failure.get() != null )
+        {
+            throw new Exception( "A worker failed", failure.get() );
+        }
+    }
+
+    private void awaitWorkersToEnd( Collection<Worker> workers ) throws InterruptedException
+    {
+        for ( Worker worker : workers )
+        {
+            worker.join();
+        }
+    }
+
+    private Collection<Worker> createWorkers( GraphDatabaseService db, CountDownLatch startSignal,
+            AtomicBoolean stopSignal, AtomicReference<Exception> failure, Node parentNode )
+    {
+        Collection<Worker> workers = new ArrayList<Worker>();
+        for ( int i = 0; i < 2; i++ )
+        {
+            workers.add( newWorker( db, startSignal, stopSignal, failure, parentNode ) );
+        }
+        return workers;
+    }
+
+    private Worker newWorker( GraphDatabaseService db, CountDownLatch startSignal, AtomicBoolean stopSignal,
+            AtomicReference<Exception> failure, Node parentNode )
+    {
+        Worker worker = new Worker( db, startSignal, stopSignal, failure, parentNode );
+        worker.start();
+        return worker;
+    }
+
+    private Node createNode( GraphDatabaseService db )
+    {
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node node = db.createNode();
+            tx.success();
+            return node;
+        }
+        finally
+        {
+            tx.finish();
+        }
+    }
+
+    public final @Rule ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    private static final RelationshipType RELTYPE = MyRelTypes.TEST;
+
+    private static class Worker extends Thread
+    {
+        private final GraphDatabaseService db;
+        private final CountDownLatch startSignal;
+        private final AtomicReference<Exception> failure;
+        private final Node parentNode;
+        private final AtomicBoolean stopSignal;
+
+        public Worker( GraphDatabaseService db, CountDownLatch startSignal, AtomicBoolean stopSignal,
+                AtomicReference<Exception> failure, Node parentNode )
+        {
+            this.db = db;
+            this.startSignal = startSignal;
+            this.stopSignal = stopSignal;
+            this.failure = failure;
+            this.parentNode = parentNode;
+        }
+
+        @Override
+        public void run()
+        {
+            awaitStartSignal();
+            while ( failure.get() == null && !stopSignal.get() )
+            {
+                Transaction tx = db.beginTx();
+                try
+                {
+                    // ArrayIndexOutOfBoundsException happens here
+                    count( parentNode.getRelationships( RELTYPE, OUTGOING ) );
+                    
+                    parentNode.createRelationshipTo( db.createNode(), RELTYPE );
+                    tx.success();
+                }
+                catch ( Exception e )
+                {
+                    failure.compareAndSet( null, e );
+                }
+                finally
+                {
+                    tx.finish();
+                }
+            }
+        }
+
+        private void awaitStartSignal()
+        {
+            try
+            {
+                startSignal.await( 10, SECONDS );
+            }
+            catch ( InterruptedException e )
+            {
+                throw new RuntimeException( e );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIteratorIssuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIteratorIssuesTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.impl.core.NodeImpl.LoadStatus;
+import org.neo4j.kernel.impl.util.RelIdArray;
+import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+import org.neo4j.kernel.impl.util.RelIdIterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.OUTGOING;
+
+/**
+ * @see ConcurrentCreateAndGetRelationshipsIT for integration/probabilistic test
+ */
+public class RelationshipIteratorIssuesTest
+{
+    @Test
+    public void arrayIndexOutOfBoundsInRelTypeArrayWhenCreatingRelationshipsConcurrently() throws Exception
+    {
+        // GIVEN
+        // -- a node manager capable of serving light-weight RelationshipProxy capable of answering getId()
+        NodeManager nodeManager = mock( NodeManager.class );
+        when( nodeManager.newRelationshipProxyById( anyLong() ) ).thenAnswer( relationshipProxyWithId() );
+        
+        // -- a node that says it cannot load any more relationships
+        NodeImpl node = mock( NodeImpl.class );
+        when( node.getMoreRelationships( nodeManager ) ).thenReturn( LoadStatus.NOTHING );
+        
+        // -- a type iterator that at this point contains one relationship (0)
+        ControlledRelIdIterator typeIterator = new ControlledRelIdIterator( 0L );
+        RelationshipIterator iterator = new RelationshipIterator( new RelIdIterator[] { typeIterator },
+                node, OUTGOING, nodeManager, false, false );
+        // -- go forth one step in the iterator
+        iterator.next();
+        
+        // WHEN
+        // -- one relationship has been returned, and we're in the middle of the next call to next()
+        //    typeIterator will get one more relationship in it. To mimic this we control the outcome of
+        //    RelIdIterator#hasNext() so that we get to the correct branch in the RelationshipIterator code
+        typeIterator.queueHasNextAnswers( false, false, true );
+        long otherRelationship = 1, thirdRelationship = 2;
+        typeIterator.add( otherRelationship, thirdRelationship );
+        
+        // -- go one more step, getting us into the state where the type index in RelationshipIterator
+        //    was incremented by mistake. Although this particular call to next() succeeds
+        iterator.next();
+        
+        // -- call next() again, where the first thing happening is to get the RelIdIterator with the
+        //    now invalid type index, causing ArrayIndexOutOfBoundsException
+        Relationship returnedThirdRelationship = iterator.next();
+        
+        // THEN
+        assertEquals( thirdRelationship, returnedThirdRelationship.getId() );
+    }
+
+    private Answer<RelationshipProxy> relationshipProxyWithId()
+    {
+        return new Answer<RelationshipProxy>()
+        {
+            @Override
+            public RelationshipProxy answer( InvocationOnMock invocation ) throws Throwable
+            {
+                RelationshipProxy relationship = mock( RelationshipProxy.class );
+                when( relationship.getId() ).thenReturn( (Long) invocation.getArguments()[0] );
+                return relationship;
+            }
+        };
+    }
+    
+    private static class ControlledRelIdIterator implements RelIdIterator
+    {
+        private final List<Long> ids;
+        private int index;
+        private final Queue<Boolean> controlledHasNextResults = new LinkedList<Boolean>();
+
+        ControlledRelIdIterator( Long... ids )
+        {
+            this.ids = new ArrayList<Long>( Arrays.asList( ids ) );
+        }
+        
+        void add( long... ids )
+        {
+            for ( long id : ids )
+            {
+                this.ids.add( id );
+            }
+        }
+        
+        void queueHasNextAnswers( boolean... answers )
+        {
+            for ( boolean answer : answers )
+            {
+                controlledHasNextResults.add( answer );
+            }
+        }
+        
+        @Override
+        public int getType()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            Boolean controlledAnswer = controlledHasNextResults.poll();
+            if ( controlledAnswer != null )
+            {
+                return controlledAnswer.booleanValue();
+            }
+            
+            return index < ids.size();
+        }
+
+        @Override
+        public long next()
+        {
+            if ( !hasNext() )
+            {
+                throw new NoSuchElementException();
+            }
+            return ids.get( index++ );
+        }
+
+        @Override
+        public RelIdIterator updateSource( RelIdArray newSource, DirectionWrapper direction )
+        {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public void doAnotherRound()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Issue manifests in calling #next() on the iterator gotten from
Node#getRelationships(...) would suddenly throw ArrayIndexOutOfBoundsException.

Cause of the issue was this: Internally a RelationshipIterator would have
all internal per-type relationship iterators in an array. Exhausting one
would try to move to the next, if any. The check that tested if there were
more per-type iterators to visit incremented the array index and if that
check would yield false an additional check to load more relationships
would be made, and if that also yielded false the current per-type iterator
would be tested again. In this case another transaction would have created
another relationship so that relationship would be returned.
  The consecutive call to #next() would start off getting the current
per-type iterator and this is where the array index would point to an
index that was one too high than allowed.

Fix is to not increment the index in the check, but instead increment if
the check yields true.
