### PR TITLE
Reverts change in API for Configurator by properly @Depracating removed method

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.server.configuration;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -33,9 +36,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.info.DiagnosticsExtractor;
 import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.server.webadmin.console.ShellSessionCreator;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 
 public interface Configurator
 {
@@ -110,6 +110,9 @@ public interface Configurator
 
     Map<String, String> getDatabaseTuningProperties();
 
+    @Deprecated
+    Set<ThirdPartyJaxRsPackage> getThirdpartyJaxRsClasses();
+
     Set<ThirdPartyJaxRsPackage> getThirdpartyJaxRsPackages();
 
     DiagnosticsExtractor<Configurator> DIAGNOSTICS = new DiagnosticsExtractor<Configurator>()
@@ -147,6 +150,12 @@ public interface Configurator
     
     public static abstract class Adapter implements Configurator
     {
+        @Override
+        public Set<ThirdPartyJaxRsPackage> getThirdpartyJaxRsClasses()
+        {
+            return getThirdpartyJaxRsPackages();
+        }
+
         @Override
         public Set<ThirdPartyJaxRsPackage> getThirdpartyJaxRsPackages()
         {

--- a/community/server/src/main/java/org/neo4j/server/configuration/PropertyFileConfigurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/PropertyFileConfigurator.java
@@ -39,7 +39,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.server.configuration.validation.Validator;
 import org.neo4j.server.logging.Logger;
 
-public class PropertyFileConfigurator implements Configurator
+public class PropertyFileConfigurator extends Configurator.Adapter
 {
 
     private static final String NEO4J_PROPERTIES_FILENAME = "neo4j.properties";

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurator.java
@@ -47,7 +47,7 @@ import org.neo4j.server.WrappingNeoServerBootstrapper;
  * See the neo4j manual for information about what configuration directives the
  * server takes, or take a look at the static strings in {@link Configurator}.
  */
-public class ServerConfigurator implements Configurator
+public class ServerConfigurator extends Configurator.Adapter
 {
 
     private MapBasedConfiguration config = new MapBasedConfiguration();


### PR DESCRIPTION
...method

Configurator.getThirdpartyJaxRsClasses was removed while being a public method,
 leading to breakage of users of that method, which included the
 authentication-extension. That method is now reintroduced, with
 a @Depracated warning.
