### PR TITLE
Centralize dependency and mvn plugin versions. 

### DIFF
--- a/community/embedded-examples/pom.xml
+++ b/community/embedded-examples/pom.xml
@@ -75,7 +75,6 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.2.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/community/graphviz/pom.xml
+++ b/community/graphviz/pom.xml
@@ -58,13 +58,11 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock</artifactId>
-      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
-      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -238,8 +238,8 @@ public class ComponentVersion extends Version
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-launcher</artifactId>
             <version>1.8.4</version>
-        </dependency>
-      </dependencies>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -267,15 +267,17 @@ public class ComponentVersion extends Version
                   <additionnalDependency>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
+                    <version>${logback-classic.version}</version>
                   </additionnalDependency>
                   <additionnalDependency>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-core</artifactId>
+                    <version>${logback-classic.version}</version>
                   </additionnalDependency>
                   <additionnalDependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                    <version>1.6.4</version>
+                    <version>${slf4j-api.version}</version>
                   </additionnalDependency>
                 </additionnalDependencies>
                 <detectJavaApiLink>true</detectJavaApiLink>
@@ -320,15 +322,17 @@ public class ComponentVersion extends Version
             <additionnalDependency>
               <groupId>ch.qos.logback</groupId>
               <artifactId>logback-classic</artifactId>
+              <version>${logback-classic.version}</version>
             </additionnalDependency>
             <additionnalDependency>
               <groupId>ch.qos.logback</groupId>
               <artifactId>logback-core</artifactId>
+              <version>${logback-classic.version}</version>
             </additionnalDependency>
             <additionnalDependency>
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
-              <version>1.6.4</version>
+              <version>${slf4j-api.version}</version>
             </additionnalDependency>
           </additionnalDependencies>
           <groups>
@@ -350,7 +354,6 @@ public class ComponentVersion extends Version
       <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>1.0</version>
         <executions>
           <execution>
             <id>default</id>
@@ -423,7 +426,6 @@ public class ComponentVersion extends Version
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -444,13 +446,11 @@ public class ComponentVersion extends Version
     <dependency>
       <groupId>org.ow2.jotm</groupId>
       <artifactId>jotm-core</artifactId>
-      <version>2.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>geronimo-spec</groupId>
       <artifactId>geronimo-spec-j2ee</artifactId>
-      <version>1.4-rc4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -460,7 +460,6 @@ public class ComponentVersion extends Version
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <includes>
             <include>org/neo4j/graphdb/**</include>
@@ -474,17 +473,17 @@ public class ComponentVersion extends Version
             <additionnalDependency>
               <groupId>ch.qos.logback</groupId>
               <artifactId>logback-classic</artifactId>
-              <version>1.0.0</version>
+              <version>${logback-classic.version}</version>
             </additionnalDependency>
             <additionnalDependency>
               <groupId>ch.qos.logback</groupId>
               <artifactId>logback-core</artifactId>
-              <version>1.0.0</version>
+              <version>${logback-classic.version}</version>
             </additionnalDependency>
             <additionnalDependency>
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
-              <version>1.6.4</version>
+              <version>${slf4j-api.version}</version>
             </additionnalDependency>
           </additionnalDependencies>
           <detectJavaApiLink>true</detectJavaApiLink>

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
@@ -230,7 +230,7 @@ public class LuceneSchemaIndexPopulatorTest
         DirectoryFactory directoryFactory = new DirectoryFactory.Single(
                 new DirectoryFactory.UncloseableDirectory( directory ) );
         provider = new LuceneSchemaIndexProvider( directoryFactory,
-                new Config( stringMap( store_dir.name(), "whatever" ) ) );
+                new Config( stringMap( store_dir.name(), "target/whatever" ) ) );
         index = provider.getPopulator( indexId, new IndexConfiguration( false ) );
         index.create();
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
@@ -43,7 +43,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         DirectoryFactory.InMemoryDirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-        File indexDirectory = new File( "whatever" );
+        File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
                 documentStructure, standard(),
@@ -66,7 +66,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         DirectoryFactory.InMemoryDirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-        File indexDirectory = new File( "whatever" );
+        File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
                 documentStructure, standard(),
@@ -91,7 +91,7 @@ public class UniqueLuceneIndexPopulatorTest
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
                 new LuceneDocumentStructure(), standard(),
-                new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "whatever" ),
+                new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );
         populator.create();
@@ -117,7 +117,7 @@ public class UniqueLuceneIndexPopulatorTest
     public void shouldRejectEntryWithAlreadyIndexedValueFromPreviousBatch() throws Exception
     {
         DirectoryFactory.InMemoryDirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-        File indexDirectory = new File( "whatever" );
+        File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentLogic = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 2,
                 documentLogic, standard(),
@@ -149,7 +149,7 @@ public class UniqueLuceneIndexPopulatorTest
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
                 new LuceneDocumentStructure(), standard(),
-                new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "whatever" ),
+                new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );
         populator.create();

--- a/community/server-api/pom.xml
+++ b/community/server-api/pom.xml
@@ -64,30 +64,17 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j.3rdparty.javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
-      <version>1.1.2.r612</version>
     </dependency>
 
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
-      <version>1.6</version>
-      <type>jar</type>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-digester</artifactId>
-          <groupId>commons-digester</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Added directly to avoid version clash in commons-configuration. -->
     <dependency>
       <groupId>commons-digester</groupId>
       <artifactId>commons-digester</artifactId>
-      <version>1.8.1</version>
-      <type>jar</type>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/community/server-plugin-test/pom.xml
+++ b/community/server-plugin-test/pom.xml
@@ -65,7 +65,6 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -83,5 +82,12 @@ the relevant Commercial Agreement.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <distributionManagement>
+    <site>
+      <id>neo4j-site</id>
+      <url>scpexe://static.neo4j.org/var/www/components.neo4j.org/${project.artifactId}/${project.version}</url>
+    </site>
+  </distributionManagement>
 
 </project>

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -94,6 +94,24 @@
             </comments>
         </license>
     </licenses>
+    
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+            <version>4.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <scope>test</scope>
+            <version>4.1.3</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -141,7 +159,6 @@
         <dependency>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
-            <version>6.1.25</version>
         </dependency>
 
         <dependency>
@@ -152,24 +169,12 @@
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
-            <version>1.6</version>
-            <type>jar</type>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-digester</artifactId>
-                    <groupId>commons-digester</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Added directly to avoid version clash in commons-configuration. -->
         <dependency>
             <groupId>commons-digester</groupId>
             <artifactId>commons-digester</artifactId>
-            <version>1.8.1</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -180,26 +185,22 @@
         <dependency>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-jaxrs</artifactId>
-          <version>1.9.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.rrd4j</groupId>
             <artifactId>rrd4j</artifactId>
-            <version>2.0.7</version>
         </dependency>
 
         <dependency>
           <groupId>org.mozilla</groupId>
           <artifactId>rhino</artifactId>
-          <version>1.7R3</version>
         </dependency>
 
         <!-- File uploads -->
         <dependency>
             <groupId>com.sun.jersey.contribs</groupId>
             <artifactId>jersey-multipart</artifactId>
-            <version>1.9</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -207,14 +208,12 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.9</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -222,14 +221,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>test</scope>
-            <version>4.1.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <scope>test</scope>
-            <version>4.1.3</version>
         </dependency>
 
         <dependency>
@@ -297,7 +294,6 @@
         <dependency>
             <groupId>bouncycastle</groupId>
             <artifactId>bcprov-jdk16</artifactId>
-            <version>140</version>
         </dependency>
     </dependencies>
 
@@ -504,7 +500,6 @@
             <plugin>
                 <groupId>com.voltvoodoo</groupId>
                 <artifactId>brew</artifactId>
-                <version>0.2.10</version>
                 <executions>
                     <execution>
                         <id>compile-webadmin</id>
@@ -547,7 +542,6 @@
           <plugin>
             <groupId>com.github.searls</groupId>
             <artifactId>jasmine-maven-plugin</artifactId>
-            <version>1.2.0.0</version>
             <extensions>true</extensions>
             <executions>
               <execution>

--- a/enterprise/enterprise-performance-tests/pom.xml
+++ b/enterprise/enterprise-performance-tests/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-lgpl</artifactId>
-      <version>1.9.7</version>
     </dependency>
   </dependencies>
   <build>

--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -143,17 +143,6 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.3.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jline</groupId>
-          <artifactId>jline</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/enterprise/server-enterprise/pom.xml
+++ b/enterprise/server-enterprise/pom.xml
@@ -112,7 +112,6 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.9</version>
       <scope>test</scope>
     </dependency>
 
@@ -145,7 +144,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.6.1</version>
     </dependency>
 
     <dependency>

--- a/manual/cypherdoc/pom.xml
+++ b/manual/cypherdoc/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -48,7 +47,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -80,4 +78,12 @@
             </plugin>
         </plugins>
     </build>
+
+  <distributionManagement>
+    <site>
+      <id>neo4j-site</id>
+      <url>scpexe://static.neo4j.org/var/www/components.neo4j.org/${project.artifactId}/${project.version}</url>
+    </site>
+  </distributionManagement>
+
 </project>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -156,7 +156,6 @@ terms of the relevant Commercial Agreement.
        <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>licensing-maven-plugin</artifactId>
-        <version>1.7.5</version>
         <configuration>
           <failIfDisliked>true</failIfDisliked>
           <failIfMissing>true</failIfMissing>

--- a/packaging/standalone/standalone-advanced/pom.xml
+++ b/packaging/standalone/standalone-advanced/pom.xml
@@ -180,7 +180,6 @@ terms of the relevant Commercial Agreement.
       <!-- Ugly addition just to make the download package contain the same jars. -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.6.1</version>
       <!-- Remove conflicting version (why do we have this conflict?) -->
       <exclusions>
         <exclusion>

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -183,7 +183,6 @@ terms of the relevant Commercial Agreement.
       <!-- Ugly addition just to make the download package contain the same jars. -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.6.1</version>
       <!-- Remove conflicting version (why do we have this conflict?) -->
       <exclusions>
         <exclusion>

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -182,7 +182,7 @@ terms of the relevant Commercial Agreement.
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <!-- This actually conflicts with the jcl-over-slf4j version which is 1.6.1. -->
-      <version>1.6.2</version>
+      <!--  version>1.6.2</version -->
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <licensing.phase>compile</licensing.phase>
     <lucene.version>3.6.2</lucene.version>
     <powermock.version>1.4.12</powermock.version>
+    <slf4j-api.version>1.6.2</slf4j-api.version>
+    <logback-classic.version>0.9.30</logback-classic.version>
   </properties>
 
   <modules>
@@ -37,9 +39,39 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.neo4j.build.plugins</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.0</version> <!-- 2.1 ? -->
+        </plugin>
+        <plugin>
+          <groupId>com.voltvoodoo</groupId>
+          <artifactId>brew</artifactId>
+          <version>0.2.10</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.searls</groupId>
+          <artifactId>jasmine-maven-plugin</artifactId>
+          <version>1.2.0.0</version>
+        </plugin>
+        <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.1.4</version>
+          <version>2.1.5</version>
           <executions>
             <execution>
               <id>generate-git-hash</id>
@@ -276,6 +308,21 @@
           <artifactId>lucene-core</artifactId>
           <version>${lucene.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>3.3.2</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <!-- special -->
       <dependency>
         <groupId>${jta.groupId}</groupId>
@@ -326,6 +373,36 @@
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock</artifactId>
+        <version>2.5.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock-junit4</artifactId>
+        <version>2.5.1</version> <!-- 2.6.0 ? -->
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.jotm</groupId>
+        <artifactId>jotm-core</artifactId>
+        <version>2.2.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>geronimo-spec</groupId>
+        <artifactId>geronimo-spec-j2ee</artifactId>
+        <version>1.4-rc4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hsqldb</groupId>
+        <artifactId>hsqldb</artifactId>
+        <version>2.3.0</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- other -->
       <dependency>
@@ -337,6 +414,32 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>1.4</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-configuration</groupId>
+        <artifactId>commons-configuration</artifactId>
+        <version>1.6</version>
+        <type>jar</type>
+        <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-digester</artifactId>
+            <groupId>commons-digester</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- Added (directly) to avoid version clash in commons-configuration. -->
+      <dependency>
+        <groupId>commons-digester</groupId>
+        <artifactId>commons-digester</artifactId>
+        <version>1.8.1</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.1</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -351,22 +454,33 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>0.9.30</version>
+        <version>${logback-classic.version}</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>0.9.30</version>
+        <version>${logback-classic.version}</version>
       </dependency>
       <dependency>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-access</artifactId>
-          <version>0.9.30</version>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-access</artifactId>
+        <version>${logback-classic.version}</version>
       </dependency>
       <dependency>
-          <groupId>janino</groupId>
-          <artifactId>janino</artifactId>
-          <version>2.5.10</version>
+        <groupId>janino</groupId>
+        <artifactId>janino</artifactId>
+        <version>2.5.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <!-- This actually conflicts with the jcl-over-slf4j version which is 1.6.1. -->
+        <version>${slf4j-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>1.6.1</version>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
@@ -391,6 +505,46 @@
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
         <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.jersey.contribs</groupId>
+        <artifactId>jersey-multipart</artifactId>
+        <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-core-lgpl</artifactId>
+        <version>1.9.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-jaxrs</artifactId>
+        <version>1.9.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty</artifactId>
+        <version>6.1.25</version>
+      </dependency>
+      <dependency>
+        <groupId>org.rrd4j</groupId>
+        <artifactId>rrd4j</artifactId>
+        <version>2.0.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mozilla</groupId>
+        <artifactId>rhino</artifactId>
+        <version>1.7R3</version>
+      </dependency>
+      <dependency>
+        <groupId>bouncycastle</groupId>
+        <artifactId>bcprov-jdk16</artifactId>
+        <version>140</version>
+      </dependency>
+      <dependency>
+        <groupId>org.neo4j.3rdparty.javax.ws.rs</groupId>
+        <artifactId>jsr311-api</artifactId>
+        <version>1.1.2.r612</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Centralizes most dependency and plugin versions to the top level pom.

Also avoid creating dir outside of target in index tests.
