### PR TITLE
Remove support for bare nodes with props in patterns

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/experimental/rules/Patterns.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/experimental/rules/Patterns.scala
@@ -103,7 +103,7 @@ trait Patterns extends Parser
 
   private def NodePattern : Rule1[ast.NodePattern] = rule("a node pattern") (
       group("(" ~~ MaybeIdentifier ~~ MaybeNodeLabels ~~ MaybeProperties ~~ ")") ~~> t(toNodePattern _)
-    | group(Identifier ~~ MaybeNodeLabels ~~ MaybeProperties) ~~> t(ast.NamedNodePattern(_, _, _, _))
+    | group(Identifier ~~ MaybeNodeLabels) ~~> t(ast.NamedNodePattern(_, _, None, _))
   )
 
   private def MaybeIdentifier : Rule1[Option[ast.Identifier]] = rule("an identifier") {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ParserPattern.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/ParserPattern.scala
@@ -90,6 +90,12 @@ trait ParserPattern extends Base with Labels {
       nodeInParenthesis | // (singleNodeDefinition)
       failure("expected an expression that is a node")
 
+  private def labels: Parser[(Seq[KeyToken], Map[String, Expression], Boolean)] = optLabelShortForm ^^ {
+    case labels =>
+      val bare = labels.isEmpty
+      (labels, Map.empty, bare)
+  }
+
   private def labelsAndValues: Parser[(Seq[KeyToken], Map[String, Expression], Boolean)] = optLabelShortForm ~ opt(curlyMap) ^^ {
     case labels ~ optMap =>
       val mapVal = optMap.getOrElse(Map.empty)
@@ -97,9 +103,9 @@ trait ParserPattern extends Base with Labels {
       (labels, mapVal, bare)
   }
 
-  private def singleNodeDefinition = identity ~ labelsAndValues ^^ {
-    case name ~ labelsAndValues =>
-      val (labelsVal, mapVal, bare) = labelsAndValues
+  private def singleNodeDefinition = identity ~ labels ^^ {
+    case name ~ labels =>
+      val (labelsVal, mapVal, bare) = labels
       ParsedEntity(name, Identifier(name), mapVal, labelsVal, bare)
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -2824,8 +2824,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
         ReturnItem(Identifier("a"), "Escaped alias", renamed = true)))
   }
 
-  @Test def create_with_labels_and_props_without_parens() {
-    test(vFrom2_0, "CREATE node :FOO:BAR {name: 'Stefan'}",
+  @Test def create_with_labels_and_props_with_parens() {
+    test(vFrom2_0, "CREATE (node :FOO:BAR {name: 'Stefan'})",
       Query.
         start(CreateNodeStartItem(CreateNode("node", Map("name"->Literal("Stefan")),
                                              LabelSupport.labelCollection("FOO", "BAR"), bare = false))).

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -100,7 +100,7 @@ class ErrorMessagesTest extends ExecutionEngineHelper with Assertions with Strin
   @Test def badMatch5() {
     expectSyntaxError("start p=node(2) match p[:likes]->dude return dude.name",
       v2_0    -> ("expected valid query body", 23),
-      vExperimental -> ("Invalid input '[': expected an identifier character, whitespace, '=', node labels, property map, a relationship pattern, ',', USING, WHERE, CREATE, DELETE, SET, REMOVE, RETURN, WITH, UNION, ';' or end of input (line 1, column 24)", 23)
+      vExperimental -> ("Invalid input '[': expected an identifier character, whitespace, '=', node labels, a relationship pattern, ',', USING, WHERE, CREATE, DELETE, SET, REMOVE, RETURN, WITH, UNION, ';' or end of input (line 1, column 24)", 23)
     )
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
@@ -39,7 +39,8 @@ class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker 
   }
 
   @Test def Creating_nodes_with_literal_labels() {
-    assertThat("CREATE node :FOO:BAR {name: 'Stefan'}", List("FOO", "BAR"))
+    assertDoesNotWork("CREATE node :FOO:BAR {name: 'Stefan'}")
+    assertThat("CREATE node :FOO:BAR", List("FOO", "BAR"))
     assertThat("CREATE (node:FOO:BAR {name: 'Mattias'})", List("FOO", "BAR"))
     assertThat("CREATE (n:Person)-[:OWNS]->(x:Dog) RETURN n AS node", List("Person"))
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ParserPatternTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/ParserPatternTest.scala
@@ -49,8 +49,10 @@ class ParserPatternTest extends ParserPattern with ParserTest with Expressions {
     parsing("(n)") shouldGive
       ParsedEntity("n", Identifier("n"), Map.empty, Seq.empty, true)
 
-    parsing("n {name:'Andres'}") shouldGive
+    parsing("(n {name:'Andres'})") shouldGive
       ParsedEntity("n", Identifier("n"), Map("name" -> Literal("Andres")), Seq.empty, false)
+
+    assertFails("n {name:'Andres'}")
   }
 
   @Test def paths() {


### PR DESCRIPTION
When using properties in patterns, parenthesis must be used.
ie. CREATE (n {foo:'bar'})
