### PR TITLE
Allow returning the "old" REST format from the transactional endpoint.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/mocking/GraphMock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mocking/GraphMock.java
@@ -78,6 +78,11 @@ public class GraphMock
         return mockRelationship( id, start, type, end, properties( properties ) );
     }
 
+    public static Link link( Relationship relationship, Node node )
+    {
+        return Link.link( relationship, node );
+    }
+
     public static Path path( Node node, Link... links )
     {
         List<Node> nodes = new ArrayList<>( links.length + 1 );

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/Representation.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/Representation.java
@@ -78,8 +78,7 @@ public abstract class Representation
 		return this.type;
 	}
 	
-    abstract String serialize( RepresentationFormat format, URI baseUri,
-            ExtensionInjector extensions ) ;
+    abstract String serialize( RepresentationFormat format, URI baseUri, ExtensionInjector extensions );
 
     abstract void addTo( ListSerializer serializer );
 

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -238,7 +238,8 @@ public abstract class AbstractNeoServer implements NeoServer
                 new TransitionalPeriodTransactionMessContainer( database.getGraph() ),
                 new ExecutionEngine( database.getGraph(), logging.getMessagesLog( ExecutionEngine.class ) ),
                 transactionRegistry,
-                logging.getMessagesLog( TransactionFacade.class ));
+                baseUri(), logging.getMessagesLog( TransactionFacade.class )
+        );
     }
 
     private long getTransactionTimeoutMillis()

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
@@ -115,4 +115,9 @@ public class JsonHelper
             throw new JsonBuildRuntimeException( e );
         }
     }
+
+    public static String prettyPrint( Object item ) throws IOException
+    {
+        return OBJECT_MAPPER.writer().withDefaultPrettyPrinter().writeValueAsString( item );
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
@@ -181,6 +181,11 @@ public class OutputFormat
         };
     }
 
+    public static void write( Representation representation, RepresentationFormat format, URI baseUri )
+    {
+        representation.serialize( format, baseUri, null );
+    }
+
     private byte[] toBytes( String entity, boolean mustFail )
     {
         byte[] entityAsBytes;

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -50,8 +50,9 @@ import org.neo4j.server.rest.transactional.error.Neo4jError;
  */
 public class ExecutionResultSerializer
 {
-    public ExecutionResultSerializer( OutputStream output, StringLogger log )
+    public ExecutionResultSerializer( OutputStream output, URI baseUri, StringLogger log )
     {
+        this.baseUri = baseUri;
         this.log = log;
         JsonGenerator generator = null;
         try
@@ -197,16 +198,16 @@ public class ExecutionResultSerializer
     {
         if ( specifiers == null || specifiers.length == 0 )
         {
-            return ResultDataContent.row.writer(); // default
+            return ResultDataContent.row.writer( baseUri ); // default
         }
         if ( specifiers.length == 1 )
         {
-            return specifiers[0].writer();
+            return specifiers[0].writer( baseUri );
         }
         ResultDataContentWriter[] writers = new ResultDataContentWriter[specifiers.length];
         for ( int i = 0; i < specifiers.length; i++ )
         {
-            writers[i] = specifiers[i].writer();
+            writers[i] = specifiers[i].writer( baseUri );
         }
         return new AggregatingWriter( writers );
     }
@@ -220,6 +221,7 @@ public class ExecutionResultSerializer
 
     private static final JsonFactory JSON_FACTORY = new JsonFactory( new Neo4jJsonCodec() );
     private final JsonGenerator out;
+    private final URI baseUri;
     private final StringLogger log;
 
     private void ensureDocumentOpen() throws IOException

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.JsonGenerator;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.server.rest.repr.NodeRepresentation;
+import org.neo4j.server.rest.repr.OutputFormat;
+import org.neo4j.server.rest.repr.PathRepresentation;
+import org.neo4j.server.rest.repr.RelationshipRepresentation;
+import org.neo4j.server.rest.repr.Representation;
+import org.neo4j.server.rest.repr.RepresentationFormat;
+import org.neo4j.server.rest.repr.formats.StreamingJsonFormat;
+
+class RestRepresentationWriter implements ResultDataContentWriter
+{
+    private final URI baseUri;
+
+    RestRepresentationWriter( URI baseUri )
+    {
+        this.baseUri = baseUri;
+    }
+
+    @Override
+    public void write( JsonGenerator out, Iterable<String> columns, Map<String, Object> row ) throws IOException
+    {
+        RepresentationFormat format = new StreamingJsonFormat.StreamingRepresentationFormat( out, null );
+        out.writeArrayFieldStart( "rest" );
+        try
+        {
+            for ( String key : columns )
+            {
+                write( out, format, row.get( key ) );
+            }
+        }
+        finally
+        {
+            out.writeEndArray();
+        }
+    }
+
+    private void write( JsonGenerator out, RepresentationFormat format, Object value ) throws IOException
+    {
+        if ( value instanceof Map<?, ?> )
+        {
+            out.writeStartObject();
+            try
+            {
+                out.writeObjectFieldStart( "data" );
+                try
+                {
+                    @SuppressWarnings("unchecked")
+                    Map<String, ?> map = (Map<String, ?>) value;
+                    for ( Map.Entry<String, ?> entry : map.entrySet() )
+                    {
+                        out.writeFieldName( entry.getKey() );
+                        write( out, format, entry.getValue() );
+                    }
+                }
+                finally
+                {
+                    out.writeEndObject();
+                }
+            }
+            finally
+            {
+                out.writeEndObject();
+            }
+        }
+        else if ( value instanceof List<?> )
+        {
+            out.writeStartArray();
+            try
+            {
+                for ( Object item : (List<?>) value )
+                {
+                    write( out, format, item );
+                }
+            }
+            finally
+            {
+                out.writeEndArray();
+            }
+        }
+        else if ( value instanceof Node )
+        {
+            write( format, new NodeRepresentation( (Node) value ) );
+        }
+        else if ( value instanceof Relationship )
+        {
+            write( format, new RelationshipRepresentation( (Relationship) value ) );
+        }
+        else if ( value instanceof Path )
+        {
+            write( format, new PathRepresentation<>( (Path) value ) );
+        }
+        else
+        {
+            out.writeObject( value );
+        }
+    }
+
+    private void write( RepresentationFormat format, Representation representation )
+    {
+        OutputFormat.write( representation, format, baseUri );
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContent.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ResultDataContent.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,7 +28,7 @@ public enum ResultDataContent
     row
     {
         @Override
-        public ResultDataContentWriter writer()
+        public ResultDataContentWriter writer( URI baseUri )
         {
             return new RowWriter();
         }
@@ -35,13 +36,21 @@ public enum ResultDataContent
     graph
     {
         @Override
-        public ResultDataContentWriter writer()
+        public ResultDataContentWriter writer( URI baseUri )
         {
             return new GraphExtractionWriter();
         }
+    },
+    rest
+    {
+        @Override
+        public ResultDataContentWriter writer( URI baseUri )
+        {
+            return new RestRepresentationWriter( baseUri );
+        }
     };
 
-    public abstract ResultDataContentWriter writer();
+    public abstract ResultDataContentWriter writer( URI baseUri );
 
     public static ResultDataContent[] fromNames( List<?> names )
     {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -21,6 +21,7 @@ package org.neo4j.server.rest.transactional;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.kernel.api.KernelAPI;
@@ -54,14 +55,16 @@ public class TransactionFacade
     private final ExecutionEngine engine;
     private final TransactionRegistry registry;
     private final StringLogger log;
+    private final URI baseUri;
 
     public TransactionFacade( KernelAPI kernel, ExecutionEngine engine,
-                              TransactionRegistry registry, StringLogger log )
+                              TransactionRegistry registry, URI baseUri, StringLogger log )
     {
         this.kernel = kernel;
         this.engine = engine;
         this.registry = registry;
         this.log = log;
+        this.baseUri = baseUri;
     }
 
     public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme ) throws TransactionLifecycleException
@@ -81,6 +84,6 @@ public class TransactionFacade
 
     public ExecutionResultSerializer serializer( OutputStream output )
     {
-        return new ExecutionResultSerializer( output, log );
+        return new ExecutionResultSerializer( output, baseUri, log );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -47,7 +47,7 @@ public class ConcurrentTransactionAccessTest
                 new TransactionHandleRegistry( mock( Clock.class), 0, StringLogger.DEV_NULL );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
         when(kernel.newTransaction()).thenReturn( mock(TransitionalTxManagementKernelTransaction.class) );
-        TransactionFacade actions = new TransactionFacade( kernel, null, registry, null );
+        TransactionFacade actions = new TransactionFacade( kernel, null, registry, null, null );
 
         final TransactionHandle transactionHandle = actions.newTransactionHandle( new DisgustingUriScheme() );
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
@@ -39,9 +41,11 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.impl.util.TestLogger;
+import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
 import org.neo4j.server.rest.transactional.error.StatusCode;
 import org.neo4j.test.mocking.GraphMock;
+import org.neo4j.test.mocking.Link;
 
 import static java.util.Arrays.asList;
 
@@ -54,9 +58,10 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.util.TestLogger.LogCall.error;
 import static org.neo4j.test.Property.property;
+import static org.neo4j.test.mocking.GraphMock.link;
 import static org.neo4j.test.mocking.GraphMock.node;
 import static org.neo4j.test.mocking.GraphMock.path;
-import static org.neo4j.test.mocking.Link.link;
+import static org.neo4j.test.mocking.GraphMock.relationship;
 import static org.neo4j.test.mocking.Properties.properties;
 
 public class ExecutionResultSerializerTest
@@ -66,7 +71,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, org.neo4j.kernel.impl.util
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, org.neo4j.kernel.impl.util
                 .StringLogger.DEV_NULL );
 
         // when
@@ -83,7 +88,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "column1", "value1",
@@ -105,7 +110,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "column1", "value1",
@@ -126,7 +131,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "column1", "value1",
@@ -151,7 +156,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "column1", "value1",
@@ -175,7 +180,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         // when
         serializer.transactionCommitUri( URI.create( "commit/uri/1" ) );
@@ -194,7 +199,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         // when
         serializer.errors( asList( new Neo4jError( StatusCode.INVALID_REQUEST_FORMAT, new Exception( "cause1" ) ) ) );
@@ -212,7 +217,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         // when
         serializer.finish();
@@ -227,7 +232,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "column1", "value1",
@@ -251,7 +256,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult1 = mockExecutionResult( map(
                 "column1", "value1",
@@ -278,7 +283,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "node", node( 1, properties(
@@ -304,7 +309,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         ExecutionResult executionResult = mockExecutionResult( map(
                 "path", mockPath( map( "key1", "value1" ), map( "key2", "value2" ), map( "key3", "value3" ) ) ) );
@@ -325,7 +330,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         Map<String, Object> data = map(
                 "column1", "value1",
@@ -363,7 +368,7 @@ public class ExecutionResultSerializerTest
     {
         // given
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         Map<String, Object> data = map(
                 "column1", "value1",
@@ -408,11 +413,11 @@ public class ExecutionResultSerializerTest
                 node( 2, properties( property( "name", "node2" ) ), "This", "That" ),
                 node( 3, properties( property( "name", "node3" ) ), "Other" )};
         Relationship[] rel = {
-                GraphMock.relationship( 0, node[0], "KNOWS", node[1], property( "name", "rel0" ) ),
-                GraphMock.relationship( 1, node[2], "LOVES", node[3], property( "name", "rel1" ) )};
+                relationship( 0, node[0], "KNOWS", node[1], property( "name", "rel0" ) ),
+                relationship( 1, node[2], "LOVES", node[3], property( "name", "rel1" ) )};
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, StringLogger.DEV_NULL );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, StringLogger.DEV_NULL );
 
         // when
         serializer.statementResult( mockExecutionResult(
@@ -451,13 +456,60 @@ public class ExecutionResultSerializerTest
     }
 
     @Test
+    public void shouldProduceResultStreamWithLegacyRestFormat() throws Exception
+    {
+        // given
+        Node[] node = {
+                node( 0, properties( property( "name", "node0" ) ) ),
+                node( 1, properties( property( "name", "node1" ) ) ),
+                node( 2, properties( property( "name", "node2" ) ) )};
+        Relationship[] rel = {
+                relationship( 0, node[0], "KNOWS", node[1], property( "name", "rel0" ) ),
+                relationship( 1, node[2], "LOVES", node[1], property( "name", "rel1" ) )};
+        Path path = GraphMock.path( node[0], link( rel[0], node[1] ), link( rel[1], node[2] ) );
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer(
+                output, URI.create( "http://base.uri/" ), StringLogger.DEV_NULL );
+
+        // when
+        serializer.statementResult( mockExecutionResult(
+                map( "node", node[0], "rel", rel[0], "path", path, "map", map( "n1", node[1], "r1", rel[1] ) )
+        ), ResultDataContent.rest );
+        serializer.finish();
+
+        // then
+        String result = output.toString( "UTF-8" );
+        JsonNode json = JsonHelper.jsonNode( result );
+        Map<String, Integer> columns = new HashMap<>();
+        int col = 0;
+        JsonNode results = json.get( "results" ).get( 0 );
+        for ( JsonNode column : results.get( "columns" ) )
+        {
+            columns.put( column.getTextValue(), col++ );
+        }
+        JsonNode row = results.get( "data" ).get( 0 ).get( "rest" );
+        JsonNode jsonNode = row.get( columns.get( "node" ) );
+        JsonNode jsonRel = row.get( columns.get( "rel" ) );
+        JsonNode jsonPath = row.get( columns.get( "path" ) );
+        JsonNode jsonMap = row.get( columns.get( "map" ) );
+        assertEquals( "http://base.uri/node/0", jsonNode.get( "self" ).getTextValue() );
+        assertEquals( "http://base.uri/relationship/0", jsonRel.get( "self" ).getTextValue() );
+        assertEquals( 2, jsonPath.get( "length" ).getNumberValue() );
+        assertEquals( "http://base.uri/node/0", jsonPath.get( "start" ).getTextValue() );
+        assertEquals( "http://base.uri/node/2", jsonPath.get( "end" ).getTextValue() );
+        assertEquals( "http://base.uri/node/1", jsonMap.get( "data" ).get( "n1" ).get( "self" ).getTextValue() );
+        assertEquals( "http://base.uri/relationship/1", jsonMap.get( "data" ).get( "r1" ).get( "self" ).getTextValue() );
+    }
+
+    @Test
     public void shouldLogIOErrors() throws Exception
     {
         // given
         IOException failure = new IOException();
         OutputStream output = mock( OutputStream.class, new ThrowsException( failure ) );
         TestLogger log = new TestLogger();
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, log );
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, log );
 
         // when
         serializer.finish();
@@ -513,9 +565,9 @@ public class ExecutionResultSerializerTest
     {
         Node startNode = node( 1, properties( startNodeProperties ) );
         Node endNode = node( 2, properties( endNodeProperties ) );
-        Relationship relationship = GraphMock.relationship( 1, properties( relationshipProperties ),
-                                                            startNode, "RELATED", endNode );
-        return path( startNode, link( relationship, endNode ) );
+        Relationship relationship = relationship( 1, properties( relationshipProperties ),
+                                                  startNode, "RELATED", endNode );
+        return path( startNode, Link.link( relationship, endNode ) );
     }
 
     private String replaceStackTrace( String json, String matchableStackTrace )


### PR DESCRIPTION
For compatibility, in particular for existing clients, enable returning Nodes,
Relationships, and Paths in the "traditional" format of the Neo4j HTTP API.
This format also adds one level of indirection for returned maps in order to
be able to distinguish them from Nodes/Relationships/Paths...

This is implemented the same way as returning an extraction of the graph
in the result set. This format is specified as ["rest"] in the resultDataContent.

This is an outline of a potential (transitional?) solution to the questions posed in this thread:
https://groups.google.com/forum/#!topic/neo4j/ZPjBW6wARI8
