### PR TITLE
Modify SchemaLock to be only one class.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperationParts.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperationParts.java
@@ -436,11 +436,6 @@ public class StatementOperationParts
                 return schemaWriteOperations.indexCreate( state, labelId, propertyKeyId );
             }
             @Override
-            public IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey ) throws SchemaKernelException
-            {
-                return schemaWriteOperations.uniqueIndexCreate( state, labelId, propertyKey );
-            }
-            @Override
             public void indexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException
             {
                 schemaWriteOperations.indexDrop( state, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/SchemaWriteOperations.java
@@ -32,22 +32,14 @@ public interface SchemaWriteOperations
      */
     IndexDescriptor indexCreate( StatementState state, long labelId, long propertyKeyId ) throws SchemaKernelException;
 
-    /**
-     * Creates an index for use with a uniqueness constraint. The index indexes properties with the given
-     * {@code propertyKeyId} for nodes with the given {@code labelId}, and assumes that the database provides it with
-     * unique property values. If unique property values are not provided by the database, the index will notify
-     * through an exception and enter a "bad state". (This notification facility is used during the verification phase
-     * of uniqueness constraint creation).
-     *
-     * This method is not used from the outside. It is used internally when
-     * {@link #uniquenessConstraintCreate(long, long) creating a uniqueness constraint}, invoked through a separate
-     * transaction (the separate transaction is why it has to be exposed in this API).
-     */
-    IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey ) throws SchemaKernelException;
-
     /** Drops a {@link IndexDescriptor} from the database */
     void indexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException;
 
+    /**
+     * This should not be used, it is exposed to allow an external job to clean up constraint indexes.
+     * That external job should become an internal job, at which point this operation should go away.
+     */
+    @Deprecated
     void uniqueIndexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException;
 
     UniquenessConstraint uniquenessConstraintCreate( StatementState state, long labelId, long propertyKeyId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -83,13 +83,6 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey ) throws SchemaKernelException
-    {
-        state.locks().acquireSchemaWriteLock();
-        return schemaWriteDelegate.uniqueIndexCreate( state, labelId, propertyKey );
-    }
-
-    @Override
     public void indexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException
     {
         state.locks().acquireSchemaWriteLock();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyStatementOperations.java
@@ -137,12 +137,6 @@ public class ReadOnlyStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey ) throws SchemaKernelException
-    {
-        throw notInTransaction();
-    }
-
-    @Override
     public void indexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException
     {
         throw notInTransaction();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -191,15 +191,6 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey )
-            throws SchemaKernelException
-    {
-        IndexDescriptor rule = new IndexDescriptor( labelId, propertyKey );
-        state.txState().constraintIndexRuleDoAdd( rule );
-        return rule;
-    }
-
-    @Override
     public void indexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException
     {
         state.txState().indexDoDrop( descriptor );
@@ -216,7 +207,7 @@ public class StateHandlingStatementOperations implements
             throws SchemaKernelException
     {
         UniquenessConstraint constraint = new UniquenessConstraint( labelId, propertyKeyId );
-        if ( !state.txState().constraintDoUnRemove( constraint ) )
+        if ( ! state.txState().constraintDoUnRemove( constraint ) )
         {
             for ( Iterator<UniquenessConstraint> it = schemaReadDelegate.constraintsGetForLabelAndPropertyKey(
                     state, labelId, propertyKeyId ); it.hasNext(); )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingKernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/UniquenessConstraintStoppingKernelTransaction.java
@@ -69,12 +69,6 @@ public class UniquenessConstraintStoppingKernelTransaction extends DelegatingKer
         }
 
         @Override
-        public IndexDescriptor uniqueIndexCreate( StatementState state, long labelId, long propertyKey ) throws SchemaKernelException
-        {
-            throw unsupportedOperation();
-        }
-
-        @Override
         public void uniqueIndexDrop( StatementState state, IndexDescriptor descriptor ) throws DropIndexFailureException
         {
             throw unsupportedOperation();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
@@ -34,6 +34,10 @@ import org.neo4j.kernel.logging.Logging;
  * Used to assert that Indexes required by Uniqueness Constraints don't remain if the constraint never got created.
  * Solves the case where the database crashes after the index for the constraint has been created but before the
  * constraint itself has been committed.
+ *
+ * TODO: This forces the KernelAPI to expose methods that should not be accessed from outside the kernel,
+ * make this an internal job to run during the Kernel startup cycle, rather than an external job that runs
+ * "on top" of the kernel.
  */
 public class RemoveOrphanConstraintIndexesOnStartup
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -649,6 +649,8 @@ public final class TxStateImpl implements TxState
             // TODO: someone needs to make sure that the index we created gets dropped.
             // I think this can wait until commit/rollback, but we need to be able to know that the index was created...
         }
+
+        constraintIndexDoDrop( new IndexDescriptor( constraint.label(), constraint.property() ));
         constraintsChangesForLabel( constraint.label() ).remove( constraint );
         hasChanges = true;
     }
@@ -657,7 +659,12 @@ public final class TxStateImpl implements TxState
     public boolean constraintDoUnRemove( UniquenessConstraint constraint )
     {
         // hasChanges should already be set correctly when this is called
-        return constraintsChanges().unRemove( constraint );
+        if(constraintsChanges().unRemove( constraint ))
+        {
+            constraintIndexChanges.unRemove( new IndexDescriptor( constraint.label(), constraint.property() ) );
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -385,10 +385,9 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertEquals(
-                String.format("Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERT my_label.my_property_key " +
-                    "IS UNIQUE:%nUnable to add index on [label: MY_LABEL, my_property_key] : " +
-                    "Already indexed :MY_LABEL(my_property_key)."), e.getMessage() );
+            assertEquals("Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERT my_label.my_property_key IS " +
+                    "UNIQUE:\n" +
+                    "Already indexed :MY_LABEL(my_property_key).", e.getMessage() );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
@@ -107,34 +107,6 @@ public class DataIntegrityValidatingStatementOperationsTest
     }
 
     @Test
-    public void shouldDisallowReAddingConstraintIndex() throws Exception
-    {
-        // GIVEN
-        long label = 0, propertyKey = 7;
-        IndexDescriptor rule = new IndexDescriptor( label, propertyKey );
-        SchemaReadOperations innerRead = mock( SchemaReadOperations.class );
-        SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
-        DataIntegrityValidatingStatementOperations ctx =
-                new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.indexesGetForLabel( state, rule.getLabelId() ) ).thenAnswer( withIterator(  ) );
-        when( innerRead.uniqueIndexesGetForLabel( state, rule.getLabelId() ) ).thenAnswer( withIterator( rule ) );
-
-        // WHEN
-        try
-        {
-            ctx.uniqueIndexCreate( state, label, propertyKey );
-            fail( "Should have thrown exception." );
-        }
-        catch ( AddIndexFailureException e )
-        {
-            assertThat(e.getCause(), instanceOf( AlreadyConstrainedException.class) );
-        }
-
-        // THEN
-        verify( innerWrite, never() ).indexCreate( eq( state ), anyLong(), anyLong() );
-    }
-
-    @Test
     public void shouldDisallowDroppingIndexThatDoesNotExist() throws Exception
     {
         // GIVEN

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -56,7 +56,6 @@ public class ConstraintIndexCreatorTest
 
         IndexDescriptor descriptor = new IndexDescriptor( 123, 456 );
         StatementState state = mockedState();
-        when( indexCreationContext.schemaWriteOperations().uniqueIndexCreate( state, 123, 456 ) ).thenReturn( descriptor );
 
         IndexingService indexingService = mock( IndexingService.class );
         StubTransactor transactor = new StubTransactor( state, indexCreationContext );
@@ -72,7 +71,6 @@ public class ConstraintIndexCreatorTest
 
         // then
         assertEquals( 2468l, indexId );
-        verify( indexCreationContext.schemaWriteOperations() ).uniqueIndexCreate( state, 123, 456 );
         verifyNoMoreInteractions( indexCreationContext.schemaWriteOperations() );
         verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, descriptor );
         verifyNoMoreInteractions( constraintCreationContext.schemaReadOperations() );
@@ -89,7 +87,6 @@ public class ConstraintIndexCreatorTest
         StatementState state = mockedState();
 
         IndexDescriptor descriptor = new IndexDescriptor( 123, 456 );
-        when( indexCreationContext.schemaWriteOperations().uniqueIndexCreate( state, 123, 456 ) ).thenReturn( descriptor );
 
         IndexingService indexingService = mock( IndexingService.class );
         StubTransactor transactor = new StubTransactor( state, indexCreationContext, indexDestructionContext );
@@ -115,11 +112,9 @@ public class ConstraintIndexCreatorTest
             assertEquals( "Existing data does not satisfy CONSTRAINT ON ( n:label[123] ) ASSERT n.property[456] IS UNIQUE.",
                           e.getMessage() );
         }
-        verify( indexCreationContext.schemaWriteOperations() ).uniqueIndexCreate( state, 123, 456 );
         verifyNoMoreInteractions( indexCreationContext.schemaWriteOperations() );
         verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, descriptor );
         verifyNoMoreInteractions( constraintCreationContext.schemaReadOperations() );
-        verify( indexDestructionContext.schemaWriteOperations() ).uniqueIndexDrop( state, descriptor );
         verifyNoMoreInteractions( indexDestructionContext.schemaWriteOperations() );
     }
 
@@ -141,7 +136,6 @@ public class ConstraintIndexCreatorTest
 
         // then
         verifyZeroInteractions( indexingService );
-        verify( indexDestructionTransaction.schemaWriteOperations() ).uniqueIndexDrop( state, descriptor );
         verifyNoMoreInteractions( indexDestructionTransaction.schemaWriteOperations() );
     }
 


### PR DESCRIPTION
The approach taken here to solve the constraint index creation is to move the ability to create schema constraint indexes in as an internal operation inside the Kernel. The inner transaction that creates the index is triggered from within the kernel, and has access to this internal way of creating the index. Since we are in complete control of the call, we can then drop the requirement for a schema write lock for the index creation, since we know that the outer transaction will always hold a write lock.

o Resolves issue where multiple transactions could hold a schema write lock
o Improves index lookup performance by one order of magnitude
o Refactors uniqueness constraint code to not deadlock when constraint index is
  created.
o Removes some of the uniqueness index methods that were leaking through
  the kernel API.
o Drop and list uniqueness indexes are still exposed, since the constraint
  index cleanup job uses them. Added appropriate TODOs for pulling that job
  into the kernel, rather than keeping it on the outside.
