### PR TITLE
'.. SET n += {param}'

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/MapPropertySetAction.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/MapPropertySetAction.scala
@@ -29,7 +29,7 @@ import collection.Map
 import collection.JavaConverters._
 import org.neo4j.cypher.internal.ExecutionContext
 
-case class MapPropertySetAction(element: Expression, mapExpression: Expression)
+case class MapPropertySetAction(element: Expression, mapExpression: Expression, mergeProperties:Boolean = false)
   extends UpdateAction with GraphElementPropertyFunctions with MapSupport {
 
   def exec(context: ExecutionContext, state: QueryState) = {
@@ -57,6 +57,9 @@ case class MapPropertySetAction(element: Expression, mapExpression: Expression)
             }
         }
       })
+
+      if (mergeProperties)
+        return
 
       /*Remove all other properties from the property container*/
       pc match {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Updates.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v1_9/Updates.scala
@@ -48,10 +48,15 @@ trait Updates extends Base with Expressions with StartClause {
 
   def set: Parser[(Seq[UpdateAction], Seq[NamedPath])] =
     setSingleProperty ^^ ((_, Nil)) |
-    setToMap ^^ (x => (Seq(x), Nil))
+    setToMap ^^ (x => (Seq(x), Nil)) |
+    updateToMap ^^ (x => (Seq(x), Nil))
 
   def setToMap : Parser[UpdateAction] = ignoreCase("set") ~> expression ~ "=" ~ expression ^^ {
-    case element ~ "=" ~ map => MapPropertySetAction(element, map)
+    case element ~ "=" ~ map => MapPropertySetAction(element, map, mergeProperties = false)
+  }
+
+  def updateToMap : Parser[UpdateAction] = ignoreCase("set") ~> expression ~ "+=" ~ expression ^^ {
+    case element ~ "+=" ~ map => MapPropertySetAction(element, map, mergeProperties = true)
   }
 
   def setSingleProperty: Parser[Seq[UpdateAction]] = ignoreCase("set") ~> commaList(propertySet)

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CypherParserTest.scala
@@ -2159,7 +2159,7 @@ foreach(x in [1,2,3] :
       ))
   }
 
-  @Test def set_to_map() {
+  @Test def set_node_to_map() {
     val q2 = Query.
       start().
       updates(MapPropertySetAction(Identifier("n"), ParameterExpression("prop"))).
@@ -2172,6 +2172,44 @@ foreach(x in [1,2,3] :
         returns(AllIdentifiers()))
   }
 
+  @Test def set_rel_to_map() {
+    val q2 = Query.
+      start().
+      updates(MapPropertySetAction(Identifier("r"), ParameterExpression("prop"))).
+      returns()
+
+    testFrom_1_9("start r=relationship(0) set r = {prop}",
+      Query.
+        start(RelationshipById("r", 0)).
+        tail(q2).
+        returns(AllIdentifiers()))
+  }
+
+  @Test def merge_node_to_map() {
+    val q2 = Query.
+      start().
+      updates(MapPropertySetAction(Identifier("n"), ParameterExpression("prop"), mergeProperties = true)).
+      returns()
+
+    testFrom_1_9("start n=node(0) set n += {prop}",
+      Query.
+        start(NodeById("n", 0)).
+        tail(q2).
+        returns(AllIdentifiers()))
+  }
+
+  @Test def merge_rel_to_map() {
+    val q2 = Query.
+      start().
+      updates(MapPropertySetAction(Identifier("r"), ParameterExpression("prop"), mergeProperties = true)).
+      returns()
+
+    testFrom_1_9("start r=relationship(0) set r += {prop}",
+      Query.
+        start(RelationshipById("r", 0)).
+        tail(q2).
+        returns(AllIdentifiers()))
+  }
 
   @Ignore("slow test") @Test def multi_thread_parsing() {
     val q = """start root=node(0) return x"""


### PR DESCRIPTION
extend cypher-SET syntax to allow merge of node/relationship-properties.
this will allow to modify only properties from the given parameter/map, in contrast replacing all properties using the 'SET n = {param}' operation

this operation is useful for general crud-operations which tend not to overwrite a complete node in most cases
