### PR TITLE
Upgrade maven plugin versions

### DIFF
--- a/advanced/pom.xml
+++ b/advanced/pom.xml
@@ -19,6 +19,8 @@
   <properties>
     <short-name>advanced-build</short-name>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/advanced/server-advanced/pom.xml
+++ b/advanced/server-advanced/pom.xml
@@ -414,15 +414,6 @@
 
   </profiles>
 
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <repositories>
     <repository>
       <id>selenium-repository</id>

--- a/community/embedded-examples/pom.xml
+++ b/community/embedded-examples/pom.xml
@@ -197,22 +197,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <id>javadoc-aggregated-report</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>neo4j-site</id>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -465,62 +465,6 @@ public class ComponentVersion extends Version
     </dependency>
   </dependencies>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <includes>
-            <include>org/neo4j/graphdb/**</include>
-          </includes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <additionnalDependencies>
-            <additionnalDependency>
-              <groupId>ch.qos.logback</groupId>
-              <artifactId>logback-classic</artifactId>
-              <version>${logback-classic.version}</version>
-            </additionnalDependency>
-            <additionnalDependency>
-              <groupId>ch.qos.logback</groupId>
-              <artifactId>logback-core</artifactId>
-              <version>${logback-classic.version}</version>
-            </additionnalDependency>
-            <additionnalDependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-              <version>${slf4j-api.version}</version>
-            </additionnalDependency>
-          </additionnalDependencies>
-          <detectJavaApiLink>true</detectJavaApiLink>
-          <detectLinks>true</detectLinks>
-          <quiet>true</quiet>
-          <excludePackageNames>*.impl.*</excludePackageNames>
-          <groups>
-            <group>
-              <title>Graph database</title>
-<packages>org.neo4j.kernel:org.neo4j.graphdb:org.neo4j.kernel.*:org.neo4j.graphdb.*</packages>
-            </group>
-            <group>
-              <title>Helpers</title>
-              <packages>org.neo4j.helpers:org.neo4j.helpers.*</packages>
-            </group>
-            <group>
-              <title>Tooling</title>
-              <packages>org.neo4j.tooling:org.neo4j.tooling.*</packages>
-            </group>
-          </groups>
-        </configuration>
-      </plugin>
-
-    </plugins>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>neo4j-site</id>

--- a/community/licensecheck-config/pom.xml
+++ b/community/licensecheck-config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>parent-central</artifactId>
     <groupId>org.neo4j.build</groupId>
-    <version>39</version>
+    <version>40</version>
     <relativePath />
   </parent>
   <groupId>org.neo4j.build</groupId>
@@ -16,6 +16,8 @@
 
   <properties>
     <short-name>licenses</short-name>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -130,18 +130,6 @@ the relevant Commercial Agreement.
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- Override parent to include impl package in javadocs. -->
-          <excludePackageNames>*.dummy</excludePackageNames>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>neo4j-site</id>

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -20,6 +20,8 @@
     <short-name>community-build</short-name>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/community/server-plugin-test/pom.xml
+++ b/community/server-plugin-test/pom.xml
@@ -17,6 +17,8 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
   </properties>
 

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -861,30 +861,6 @@
         </profile>
     </profiles>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <groups>
-                        <group>
-                            <title>Server</title>
-                            <packages>org.neo4j.server:org.neo4j.server.*</packages>
-                        </group>
-                        <group>
-                            <title>Server REST Interface</title>
-                            <packages>org.neo4j.server.rest:org.neo4j.server.rest.*</packages>
-                        </group>
-                        <group>
-                            <title>Server Admin Interface</title>
-                            <packages>org.neo4j.server.webadmin:org.neo4j.server.webadmin.*</packages>
-                        </group>
-                    </groups>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
-
     <repositories>
         <repository>
             <id>java.net</id>

--- a/enterprise/enterprise-performance-tests/pom.xml
+++ b/enterprise/enterprise-performance-tests/pom.xml
@@ -15,6 +15,8 @@
 
   <properties>
     <bundle.namespace>org.neo4j.perftest.enterprise</bundle.namespace>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <short-name>enterprise-build</short-name>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/enterprise/server-enterprise/pom.xml
+++ b/enterprise/server-enterprise/pom.xml
@@ -481,15 +481,6 @@
 
   </profiles>
 
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <repositories>
     <repository>
       <id>selenium-repository</id>

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -25,6 +25,8 @@
     <neo4j.version>${project.version}</neo4j.version>
     <doctools.version>13</doctools.version>
     <attach-docs-phase>none</attach-docs-phase>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
   
   <modules>

--- a/packaging/installer-linux/pom.xml
+++ b/packaging/installer-linux/pom.xml
@@ -33,6 +33,8 @@
     
     <neo4j.debian.maintainer>Anders Nawroth &lt;anders@neotechnology.com&gt;</neo4j.debian.maintainer>
     <licensing.phase>none</licensing.phase>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <dependencies>

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -19,6 +19,8 @@
 
   <properties>
     <config.destination>${project.build.outputDirectory}/org/neo4j/server/config/community</config.destination>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <dependencies>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <short-name>packaging-build</short-name>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
 
   <scm>

--- a/packaging/qa/pom.xml
+++ b/packaging/qa/pom.xml
@@ -13,6 +13,11 @@
   <groupId>org.neo4j.qa</groupId>
   <artifactId>neo4j-server-qa</artifactId>
   <packaging>jar</packaging>
+  
+  <properties>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -33,8 +33,10 @@
   <properties>
     <short-name>neo4j-standalone</short-name>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
 
-    <!-- Document substituion properties are in document.properties file -->
+    <!-- Document substitution properties are in document.properties file -->
 
     <!-- other filter properties -->
     <wrapper.conf>conf/neo4j-wrapper.conf</wrapper.conf>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.neo4j.build</groupId>
     <artifactId>parent-central</artifactId>
-    <version>39</version>
+    <version>40</version>
     <relativePath />
   </parent>
 
@@ -36,6 +36,17 @@
   </modules>
   
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <skip>true</skip>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -560,24 +571,5 @@
       <url>scpexe://static.neo4j.org/var/www/components.neo4j.org/${project.artifactId}/${project.version}</url>
     </site>
   </distributionManagement>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>2.7.1</version>
-        <configuration>
-          <linkXref>true</linkXref>
-          <sourceEncoding>utf-8</sourceEncoding>
-          <minimumTokens>100</minimumTokens>
-          <targetJdk>1.6</targetJdk>
-          <rulesets>
-            <ruleset>${project.basedir}/code-analysis/pmd.xml</ruleset>
-          </rulesets>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 
 </project>


### PR DESCRIPTION
POM maintenance:
- New parent where plugin version has been upgraded to bring in many bugfixes.
- Excluded projects from generation of mvn sites, so the site-deploy goal can be used across all projects (without deploying sites we don't want to deploy).
- Removed the PMD plugin configuration, can't be used like that anyhow.
- Removed mvn2 compliant reporting config.
