### PR TITLE
Use constants instead of exceptions for non-existant labels.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundTokenContext.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundTokenContext.scala
@@ -31,11 +31,25 @@ abstract class TransactionBoundTokenContext(ctx: KeyReadOperations, state: State
   def getOptPropertyKeyId(propertyKeyName: String): Option[Long] =
     TokenContext.tryGet[PropertyKeyNotFoundException](getPropertyKeyId(propertyKeyName))
 
-  def getPropertyKeyId(propertyKeyName: String) = ctx.propertyKeyGetForName(state, propertyKeyName)
+  def getPropertyKeyId(propertyKeyName: String) = {
+    val propertyId: Long = ctx.propertyKeyGetForName(state, propertyKeyName)
+    if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+    {
+      throw new PropertyKeyNotFoundException("No such property.", null)
+    }
+    propertyId
+  }
 
   def getPropertyKeyName(propertyKeyId: Long): String = ctx.propertyKeyGetName(state, propertyKeyId)
 
-  def getLabelId(labelName: String): Long = ctx.labelGetForName(state, labelName)
+  def getLabelId(labelName: String): Long = {
+    val labelId: Long = ctx.labelGetForName(state, labelName)
+    if(labelId == KeyReadOperations.NO_SUCH_LABEL)
+    {
+      throw new LabelNotFoundKernelException("No such label", null)
+    }
+    labelId
+  }
 
   def getOptLabelId(labelName: String): Option[Long] =
     TokenContext.tryGet[LabelNotFoundKernelException](getLabelId(labelName))

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -61,7 +61,6 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
@@ -154,6 +153,8 @@ import org.neo4j.tooling.GlobalGraphOperations;
 import static java.lang.String.format;
 import static org.neo4j.helpers.Settings.setting;
 import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.kernel.api.operations.KeyReadOperations.NO_SUCH_LABEL;
+import static org.neo4j.kernel.api.operations.KeyReadOperations.NO_SUCH_PROPERTY;
 import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
 
 /**
@@ -1475,14 +1476,10 @@ public abstract class InternalAbstractGraphDatabase
         StatementOperationParts ctx = statementContextProvider.getCtxForReading();
         StatementState state = statementContextProvider.statementForReading();
 
-        long propertyId;
-        long labelId;
-        try
-        {
-            propertyId = ctx.keyReadOperations().propertyKeyGetForName( state, key );
-            labelId = ctx.keyReadOperations().labelGetForName( state, myLabel.name() );
-        }
-        catch ( KernelException e )
+        long propertyId = ctx.keyReadOperations().propertyKeyGetForName( state, key );
+        long labelId = ctx.keyReadOperations().labelGetForName( state, myLabel.name() );
+
+        if(propertyId == NO_SUCH_PROPERTY || labelId == NO_SUCH_LABEL)
         {
             state.close();
             return IteratorUtil.emptyIterator();

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperationParts.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/StatementOperationParts.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
@@ -194,7 +193,7 @@ public class StatementOperationParts
         return new StatementOperations()
         {
             @Override
-            public long labelGetForName( StatementState state, String labelName ) throws LabelNotFoundKernelException
+            public long labelGetForName( StatementState state, String labelName )
             {
                 return keyReadOperations.labelGetForName( state, labelName );
             }
@@ -204,7 +203,7 @@ public class StatementOperationParts
                 return keyReadOperations.labelGetName( state, labelId );
             }
             @Override
-            public long propertyKeyGetForName( StatementState state, String propertyKeyName ) throws PropertyKeyNotFoundException
+            public long propertyKeyGetForName( StatementState state, String propertyKeyName )
             {
                 return keyReadOperations.propertyKeyGetForName( state, propertyKeyName );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/operations/KeyReadOperations.java
@@ -23,25 +23,24 @@ import java.util.Iterator;
 
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.impl.core.Token;
 
 public interface KeyReadOperations
 {
-    /**
-     * Returns a label id for a label name. If the label doesn't exist a
-     * {@link org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException} will be thrown.
-     */
-    long labelGetForName( StatementState state, String labelName ) throws LabelNotFoundKernelException;
+    long NO_SUCH_LABEL = -1;
+    long NO_SUCH_PROPERTY = -1;
+
+    /** Returns a label id for a label name. If the label doesn't exist, {@link #NO_SUCH_LABEL} will be returned. */
+    long labelGetForName( StatementState state, String labelName );
 
     /** Returns the label name for the given label id. */
     String labelGetName( StatementState state, long labelId ) throws LabelNotFoundKernelException;
 
     /**
-     * Returns a property key id for the given property key. If the property key doesn't exist a
-     * {@link org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException} will be thrown.
+     * Returns a property key id for the given property key. If the property key doesn't exist,
+     * {@link #NO_SUCH_PROPERTY} will be returned.
      */
-    long propertyKeyGetForName( StatementState state, String propertyKeyName ) throws PropertyKeyNotFoundException;
+    long propertyKeyGetForName( StatementState state, String propertyKeyName );
 
     /** Returns the name of a property given its property key id */
     String propertyKeyGetName( StatementState state, long propertyKeyId ) throws PropertyKeyIdNotFoundException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
@@ -34,7 +34,6 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
@@ -54,6 +53,7 @@ import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.core.TokenHolder;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
@@ -187,16 +187,15 @@ public class StoreStatementOperations implements
     }
 
     @Override
-    public long labelGetForName( StatementState state, String label ) throws LabelNotFoundKernelException
+    public long labelGetForName( StatementState state, String label )
     {
-        try
+        int id = labelTokenHolder.getIdByName( label );
+
+        if(id == LabelTokenHolder.NO_ID)
         {
-            return labelTokenHolder.getIdByName( label );
+            return NO_SUCH_LABEL;
         }
-        catch ( TokenNotFoundException e )
-        {
-            throw new LabelNotFoundKernelException( label, e );
-        }
+        return id;
     }
 
     @Override
@@ -447,16 +446,14 @@ public class StoreStatementOperations implements
     }
 
     @Override
-    public long propertyKeyGetForName( StatementState state, String propertyKey ) throws PropertyKeyNotFoundException
+    public long propertyKeyGetForName( StatementState state, String propertyKey )
     {
-        try
+        int id = propertyKeyTokenHolder.getIdByName( propertyKey );
+        if(id == TokenHolder.NO_ID)
         {
-            return propertyKeyTokenHolder.getIdByName( propertyKey );
+            return NO_SUCH_PROPERTY;
         }
-        catch ( TokenNotFoundException e )
-        {
-            throw new PropertyKeyNotFoundException( propertyKey, e );
-        }
+        return id;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesImpl.java
@@ -35,9 +35,9 @@ import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
+import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
@@ -118,13 +118,13 @@ public class GraphPropertiesImpl extends Primitive implements GraphProperties
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return false;
+            }
             return ctxForReading.entityReadOperations().graphHasProperty( state, propertyId );
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return false;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return false;
         }
@@ -147,9 +147,13 @@ public class GraphPropertiesImpl extends Primitive implements GraphProperties
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return false;
+            }
             return ctxForReading.entityReadOperations().graphGetProperty( state, propertyId ).value();
         }
-        catch ( PropertyKeyIdNotFoundException | PropertyKeyNotFoundException | PropertyNotFoundException e )
+        catch ( PropertyKeyIdNotFoundException | PropertyNotFoundException e )
         {
             throw new NotFoundException( e );
         }
@@ -162,8 +166,6 @@ public class GraphPropertiesImpl extends Primitive implements GraphProperties
     @Override
     public Object getProperty( String key, Object defaultValue )
     {
-        // TODO: Push this check to getPropertyKeyId
-        // ^^^^^ actually, if the key is null, we could fail before getting the statement context...
         if ( null == key )
             throw new IllegalArgumentException( "(null) property key is not allowed" );
 
@@ -172,13 +174,13 @@ public class GraphPropertiesImpl extends Primitive implements GraphProperties
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return false;
+            }
             return ctxForReading.entityReadOperations().graphGetProperty( state, propertyId ).value(defaultValue);
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return defaultValue;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return defaultValue;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -44,9 +44,9 @@ import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
+import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
@@ -272,6 +272,10 @@ public class NodeProxy implements Node
         try
         {
             long propertyKeyId = context.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyKeyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return defaultValue;
+            }
             return context.entityReadOperations().nodeGetProperty( state, nodeId, propertyKeyId ).value(defaultValue);
         }
         catch ( EntityNotFoundException e )
@@ -279,10 +283,6 @@ public class NodeProxy implements Node
             throw new NotFoundException( e );
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return defaultValue;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return defaultValue;
         }
@@ -368,21 +368,13 @@ public class NodeProxy implements Node
         try
         {
             long propertyKeyId = context.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyKeyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return false;
+            }
             return context.entityReadOperations().nodeGetProperty( state, nodeId, propertyKeyId ).value();
         }
-        catch ( EntityNotFoundException e )
-        {
-            throw new NotFoundException( e );
-        }
-        catch ( PropertyKeyIdNotFoundException e )
-        {
-            throw new NotFoundException( e );
-        }
-        catch ( PropertyKeyNotFoundException e )
-        {
-            throw new NotFoundException( e );
-        }
-        catch ( PropertyNotFoundException e )
+        catch ( EntityNotFoundException | PropertyKeyIdNotFoundException | PropertyNotFoundException e )
         {
             throw new NotFoundException( e );
         }
@@ -403,6 +395,10 @@ public class NodeProxy implements Node
         try
         {
             long propertyKeyId = context.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyKeyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return false;
+            }
             return context.entityReadOperations().nodeHasProperty( state, nodeId, propertyKeyId );
         }
         catch ( EntityNotFoundException e )
@@ -410,10 +406,6 @@ public class NodeProxy implements Node
             throw new NotFoundException( e );
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return false;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return false;
         }
@@ -536,11 +528,10 @@ public class NodeProxy implements Node
         try
         {
             long labelId = context.keyReadOperations().labelGetForName( state, label.name() );
-            context.entityWriteOperations().nodeRemoveLabel( state, getId(), labelId );
-        }
-        catch ( LabelNotFoundKernelException e )
-        {
-            return;
+            if(labelId != KeyReadOperations.NO_SUCH_LABEL)
+            {
+                context.entityWriteOperations().nodeRemoveLabel( state, getId(), labelId );
+            }
         }
         catch ( EntityNotFoundException e )
         {
@@ -559,11 +550,10 @@ public class NodeProxy implements Node
         StatementState state = statementCtxProvider.statementForReading();
         try
         {
-            return context.entityReadOperations().nodeHasLabel( state, getId(), context.keyReadOperations().labelGetForName( state, label.name() ) );
-        }
-        catch ( LabelNotFoundKernelException e )
-        {
-            return false;
+            long labelId = context.keyReadOperations().labelGetForName( state, label.name() );
+
+            return labelId != KeyReadOperations.NO_SUCH_LABEL &&
+                   context.entityReadOperations().nodeHasLabel( state, getId(), labelId );
         }
         catch ( EntityNotFoundException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -33,9 +33,9 @@ import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.StatementOperationParts;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
+import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
@@ -221,21 +221,13 @@ public class RelationshipProxy implements Relationship
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                throw new NotFoundException( String.format("No such property, '%s'.", key) );
+            }
             return ctxForReading.entityReadOperations().relationshipGetProperty( state, relId, propertyId ).value();
         }
-        catch ( EntityNotFoundException e )
-        {
-            throw new IllegalStateException( e );
-        }
-        catch ( PropertyKeyIdNotFoundException e )
-        {
-            throw new NotFoundException( e );
-        }
-        catch ( PropertyKeyNotFoundException e )
-        {
-            throw new NotFoundException( e );
-        }
-        catch ( PropertyNotFoundException e )
+        catch ( EntityNotFoundException | PropertyKeyIdNotFoundException | PropertyNotFoundException e )
         {
             throw new NotFoundException( e );
         }
@@ -258,6 +250,10 @@ public class RelationshipProxy implements Relationship
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
+            if(propertyId == KeyReadOperations.NO_SUCH_PROPERTY)
+            {
+                return defaultValue;
+            }
             return ctxForReading.entityReadOperations().relationshipGetProperty( state, relId, propertyId ).value(defaultValue);
         }
         catch ( EntityNotFoundException e )
@@ -265,10 +261,6 @@ public class RelationshipProxy implements Relationship
             throw new IllegalStateException( e );
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return defaultValue;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return defaultValue;
         }
@@ -289,17 +281,14 @@ public class RelationshipProxy implements Relationship
         try
         {
             long propertyId = ctxForReading.keyReadOperations().propertyKeyGetForName( state, key );
-            return ctxForReading.entityReadOperations().relationshipHasProperty( state, relId, propertyId );
+            return propertyId != KeyReadOperations.NO_SUCH_PROPERTY &&
+                   ctxForReading.entityReadOperations().relationshipHasProperty( state, relId, propertyId );
         }
         catch ( EntityNotFoundException e )
         {
             throw new IllegalStateException( e );
         }
         catch ( PropertyKeyIdNotFoundException e )
-        {
-            return false;
-        }
-        catch ( PropertyKeyNotFoundException e )
         {
             return false;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 public abstract class TokenHolder<TOKEN extends Token> extends LifecycleAdapter
 {
+    public static final int NO_ID = -1;
     private final Map<String,Integer> nameToId = new CopyOnWriteHashMap<String, Integer>();
     private final Map<Integer, TOKEN> idToToken = new CopyOnWriteHashMap<Integer, TOKEN>();
 
@@ -136,17 +137,19 @@ public abstract class TokenHolder<TOKEN extends Token> extends LifecycleAdapter
         return idToToken.containsKey( id );
     }
 
-    public final int idOf( TOKEN token ) throws TokenNotFoundException
+    /** Returns the id, or {@link #NO_ID} if no token with this name exists. */
+    public final int idOf( TOKEN token )
     {
         return getIdByName( token.name() );
     }
 
-    public int getIdByName( String name ) throws TokenNotFoundException
+    /** Returns the id, or {@link #NO_ID} if no token with this name exists. */
+    public int getIdByName( String name )
     {
         Integer id = nameToId.get( name );
         if ( id == null )
         {
-            throw new TokenNotFoundException( name );
+            return NO_ID;
         }
         return id;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -37,7 +36,7 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.StatementOperations;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
+import org.neo4j.kernel.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.operations.StatementState;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
@@ -53,12 +52,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.getPropertyKeys;
@@ -250,15 +244,10 @@ public class StoreStatementOperationsTest
     public void should_fail_if_get_non_existent_property_key() throws Exception
     {
         // WHEN
-        try
-        {
-            statement.propertyKeyGetForName( state, "non-existent-property-key" );
-            fail( "Should have failed with property key not found exception" );
-        }
-        catch ( PropertyKeyNotFoundException e )
-        {
-            // Good
-        }
+        long propertyKey = statement.propertyKeyGetForName( state, "non-existent-property-key" );
+
+        // THEN
+        assertEquals( KeyReadOperations.NO_SUCH_PROPERTY, propertyKey );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -35,8 +35,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.StatementOperations;
-import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyNotFoundException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -48,11 +46,10 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.createIndex;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
@@ -205,21 +202,10 @@ public class IndexCRUDIT
         @Override
         public void add( long nodeId, Object propertyValue )
         {
-            try
-            {
-                StatementOperations context = ctxProvider.getCtxForReading().asStatementOperations();
-                StatementState state = ctxProvider.statementForReading();
-                updates.add( NodePropertyUpdate.add( nodeId, context.propertyKeyGetForName( state, propertyKey ),
-                        propertyValue, new long[] {context.labelGetForName( state, myLabel.name() )} ) );
-            }
-            catch ( PropertyKeyNotFoundException e )
-            {
-                throw new RuntimeException( e );
-            }
-            catch ( LabelNotFoundKernelException e )
-            {
-                throw new RuntimeException( e );
-            }
+            StatementOperations context = ctxProvider.getCtxForReading().asStatementOperations();
+            StatementState state = ctxProvider.statementForReading();
+            updates.add( NodePropertyUpdate.add( nodeId, context.propertyKeyGetForName( state, propertyKey ),
+                    propertyValue, new long[] {context.labelGetForName( state, myLabel.name() )} ) );
         }
 
         @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -49,7 +50,6 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Predicate;
-import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdType;
@@ -67,7 +67,6 @@ import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.SchemaLock;
-import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.IdGenerator;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
@@ -498,15 +497,8 @@ public class MasterImpl extends LifecycleAdapter implements Master
     @Override
     public Response<Integer> createRelationshipType( RequestContext context, String name )
     {
-        try
-        {
-            graphDb.getRelationshipTypeTokenHolder().getOrCreateId( name );
-            return packResponse( context, graphDb.getRelationshipTypeTokenHolder().getIdByName( name ) );
-        }
-        catch ( TokenNotFoundException e )
-        {
-            throw new ThisShouldNotHappenError( "Mattias", "Relationship type create failed for some reason" );
-        }
+        graphDb.getRelationshipTypeTokenHolder().getOrCreateId( name );
+        return packResponse( context, graphDb.getRelationshipTypeTokenHolder().getIdByName( name ) );
     }
 
     @Override


### PR DESCRIPTION
Replaced the use of exceptions to signal a non-existant label or property key with constants (-1). This seems to have a significant positive effect in performance profiling.
