### PR TITLE
Introduce UnboundValue for keeping track of missing optional nodes.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -76,3 +76,5 @@ class LabelScanHintException(identifier: String, label: String, message: String)
 class UnableToPickStartPointException(message: String) extends CypherException(message)
 
 class InvalidSemanticsException( message: String ) extends CypherException(message)
+
+class UnboundIdentifierException extends EntityNotFoundException("Unbound entity encountered")

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/ClosingIterator.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/ClosingIterator.scala
@@ -23,7 +23,7 @@ import org.neo4j.graphdb.ConstraintViolationException
 import spi.QueryContext
 import org.neo4j.graphdb.TransactionFailureException
 import org.neo4j.cypher.NodeStillHasRelationshipsException
-import org.neo4j.cypher.internal.helpers.IsCollection
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 /**
  * An iterator that decorates an inner iterator, and calls close() on the QueryContext once
@@ -53,6 +53,7 @@ class ClosingIterator(inner: Iterator[collection.Map[String, Any]], queryContext
     case (x: Stream[_])   => x.map(materialize).toList
     case (x: Map[_, _])   => x.mapValues(materialize)
     case (x: Iterable[_]) => x.map(materialize)
+    case UnboundValue     => null
     case x                => x
   }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/ComparablePredicate.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/ComparablePredicate.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.{ExecutionContext, Comparer}
 import org.neo4j.cypher.internal.symbols._
 import org.neo4j.cypher.internal.helpers.IsCollection
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 abstract sealed class ComparablePredicate(left: Expression, right: Expression) extends Predicate with Comparer {
   def compare(comparisonResult: Int): Boolean
@@ -62,10 +63,13 @@ case class Equals(a: Expression, b: Expression) extends Predicate with Comparer 
     val a1 = a(m)
     val b1 = b(m)
 
-    (a1, b1) match {
+    val result = (a1, b1) match {
       case (IsCollection(l), IsCollection(r)) => l == r
-      case _                              => a1 == b1
+      case (UnboundValue, x)                  => x == null
+      case (x, UnboundValue)                  => x == null
+      case _                                  => a1 == b1
     }
+    result
   }
 
   override def toString() = a.toString() + " == " + b.toString()

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PatternPredicate.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/PatternPredicate.scala
@@ -27,6 +27,7 @@ import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.cypher.internal.executionplan.builders.PatternGraphBuilder
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 case class PatternPredicate(pathPattern: Seq[Pattern], predicate:Predicate = True()) extends Predicate
   with PathExtractor
@@ -45,7 +46,7 @@ case class PatternPredicate(pathPattern: Seq[Pattern], predicate:Predicate = Tru
     val returnNull = interestingPoints.exists(key => ctx.get(key) match {
       case None       => throw new ThisShouldNotHappenError("Andres", "This execution plan should not exist.")
       case Some(null) => true
-      case Some(x)    => false
+      case Some(x)    => UnboundValue.is(x)
     })
 
     if (returnNull) {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/Identifier.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/Identifier.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.symbols._
 import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 object Identifier {
   def isNamed(x: String) = !notNamed(x)
@@ -35,7 +36,7 @@ case class Identifier(entityName: String) extends Expression with Typed {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any =
     ctx.getOrElse(entityName, throw new NotFoundException("Unknown identifier `%s`.".format(entityName)))
 
-  override def toString(): String = entityName
+  override def toString: String = entityName
 
   def rewrite(f: (Expression) => Expression) = f(this)
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/Property.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/expressions/Property.scala
@@ -24,7 +24,7 @@ import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.cypher.internal.helpers.IsMap
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
-import org.neo4j.cypher.internal.commands.values.KeyToken
+import org.neo4j.cypher.internal.commands.values.{UnboundValue, KeyToken}
 
 import org.neo4j.graphdb.NotFoundException
 import org.neo4j.cypher.EntityNotFoundException
@@ -62,6 +62,7 @@ class Property(val mapExpr: Expression,
 
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = mapExpr(ctx) match {
     case null           => null
+    case UnboundValue   => null
     case IsMap(mapFunc) => try {
       mapFunc(state.query).apply(propertyKey.name)
     } catch {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/values/UnboundValue.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/values/UnboundValue.scala
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.commands.values
+
+/**
+ * This singleton value represents unbound entities inside expressions or predicates.
+ *
+ * It currently only may occur due to patterns containing optional relationships which may introduce
+ * unbound identifiers.  It mainly serves to differentiate this situation from plain null values.
+ *
+ * Semantics:
+ *
+ * [X] You can't compare it, two unbound are always unequal
+ * [X] You can't return it. It will always be mapped to null prior to returning any value.
+ * [ ] UnboundValue equals null
+ * [ ] Figure out the type. Candidate: UnboundType() subtype of nothing. Alternative: Just use AnyType()
+ * [ ] You cannot ask for labels from an unbound value.
+ * [ ] Unbound values are invalid arguments to expressions that compute a result value
+ * [ ] You cannot get properties from an unbound value.
+ * [ ] You cannot remove properties from an unbound value.
+ * [ ] You cannot set properties to an unbound value.
+ */
+case object UnboundValue {
+  def is(v: Any): Boolean = v == this
+
+  override def toString = "UNBOUND_VALUE"
+}

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/executionplan/ExecutionPlanBuilder.scala
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.cypher.ExecutionResult
 import org.neo4j.cypher.internal.commands.values.{TokenType, KeyToken}
 import org.neo4j.cypher.internal.commands.expressions.ExpressionResolver
-import org.neo4j.cypher.internal.helpers.IsMap
 
 class ExecutionPlanBuilder(graph: GraphDatabaseService) extends PatternGraphBuilder {
 
@@ -75,7 +74,8 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService) extends PatternGraphBuil
   }
 
   def buildQuery(inputQuery: Query, context: PlanContext): PipeAndIsUpdating = {
-    val initialPSQ = PartiallySolvedQuery(inputQuery).rewrite(ExpressionResolver(context))
+    val plainPSQ = PartiallySolvedQuery(inputQuery)
+    val initialPSQ = plainPSQ.rewrite(ExpressionResolver(context))
 
     var continue = true
     var planInProgress = ExecutionPlanInProgress(initialPSQ, NullPipe, isUpdating = false)

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/MatchPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/MatchPipe.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.pipes
 
 import matching.{PatternGraph, MatchingContext}
 import org.neo4j.cypher.internal.commands.Predicate
-import org.neo4j.cypher.internal.data.SimpleVal
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.symbols.SymbolTable
 
@@ -31,7 +30,9 @@ class MatchPipe(source: Pipe, predicates: Seq[Predicate], patternGraph: PatternG
 
   protected def internalCreateResults(input: Iterator[ExecutionContext],state: QueryState) = {
     input.flatMap {
-      ctx => matchingContext.getMatches(ctx, state)
+      ctx =>
+        val result = matchingContext.getMatches(ctx, state)
+        result
     }
   }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/CollectFunction.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/CollectFunction.scala
@@ -23,15 +23,17 @@ import collection.mutable.ListBuffer
 import org.neo4j.cypher.internal.commands.expressions.Expression
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 
 class CollectFunction(value:Expression) extends AggregationFunction {
   val collection = new ListBuffer[Any]()
 
   def apply(data: ExecutionContext)(implicit state:QueryState) {
-    val v = value(data)
-    if (v != null) {
-      collection += v
+    value(data) match {
+      case null                    =>
+      case x if UnboundValue.is(x) =>
+      case v                       => collection += v
     }
   }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/CountFunction.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/CountFunction.scala
@@ -22,14 +22,16 @@ package org.neo4j.cypher.internal.pipes.aggregation
 import org.neo4j.cypher.internal.commands.expressions.Expression
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 class CountFunction(value: Expression) extends AggregationFunction {
   var count: Long = 0
 
   def apply(data: ExecutionContext)(implicit state: QueryState) {
     value(data) match {
-      case null =>
-      case _ => count += 1
+      case null                    =>
+      case x if UnboundValue.is(x) =>
+      case _                       => count += 1
     }
   }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/DistinctFunction.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/aggregation/DistinctFunction.scala
@@ -22,17 +22,18 @@ package org.neo4j.cypher.internal.pipes.aggregation
 import org.neo4j.cypher.internal.commands.expressions.Expression
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.pipes.QueryState
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 class DistinctFunction(value: Expression, inner: AggregationFunction) extends AggregationFunction {
   val seen = scala.collection.mutable.Set[Any]()
-  var seenNull = false
+  var seenNullOrUnbound = false
 
   def apply(ctx: ExecutionContext)(implicit state: QueryState) {
     val data = value(ctx)
 
-    if (data == null) {
-      if (!seenNull) {
-        seenNull = true
+    if (data == null || UnboundValue.is(data)) {
+      if (!seenNullOrUnbound) {
+        seenNullOrUnbound = true
         inner(ctx)
       }
     } else if (!seen.contains(data)) {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/symbols/CypherType.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/symbols/CypherType.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.symbols
 
 import org.neo4j.cypher.CypherTypeException
-import org.neo4j.cypher.internal.commands.values.KeyToken
 import org.neo4j.cypher.internal.helpers.{IsCollection, IsMap}
 
 trait CypherType {
@@ -66,8 +65,9 @@ TypeSafe is everything that needs to check it's types
 trait TypeSafe {
   def throwIfSymbolsMissing(symbols: SymbolTable)
 
-  def symbolDependenciesMet(symbols: SymbolTable): Boolean =
+  def symbolDependenciesMet(symbols: SymbolTable): Boolean = {
     symbolTableDependencies.forall(name => check(symbols, name))
+  }
 
   def symbolTableDependencies: Set[String]
 

--- a/community/cypher/src/test/scala/UnboundValueAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/UnboundValueAcceptanceTest.scala
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.junit.Assert._
+import org.neo4j.graphdb._
+import org.junit.Test
+
+class UnboundValueAcceptanceTest extends ExecutionEngineHelper {
+
+  @Test
+  def should_return_unbound_node_as_null() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m) RETURN m" )
+
+    // then
+    assert( null.asInstanceOf[Node] === result.columnAs[Node]("m").next())
+  }
+
+  @Test
+  def should_return_unbound_relationship_as_null() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m) RETURN r" )
+
+    // then
+    assert( null.asInstanceOf[Relationship] === result.columnAs[Relationship]("r").next())
+  }
+
+  @Test
+  def should_not_fail_due_to_label_test_on_unbound() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m:Person) RETURN m AS result" )
+
+    // then
+    val iterator = result.columnAs[Node]("result")
+    assert( null.asInstanceOf[Node] === iterator.next() )
+    assertFalse( "expected iterator to be exhausted", iterator.hasNext )
+  }
+
+  @Test
+  def should_compare_unbound_as_non_equal() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m) RETURN m = m AS result" )
+
+    // then
+    val next: Boolean = result.columnAs[Boolean]("result").next()
+    assertFalse( "unbound should not be equal to itself", next )
+  }
+
+  @Test
+  def should_compare_two_different_unbounds_as_non_equal() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m), (n)-[l?]->(k) RETURN m = k AS result" )
+
+    // then
+    val next: Boolean = result.columnAs[Boolean]("result").next()
+    assertFalse( "unbound values should not be equal", next )
+  }
+
+  @Test
+  def should_compare_unbound_and_null_as_equal() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m) RETURN m = null AS result" )
+
+    // then
+    val next: Boolean = result.columnAs[Boolean]("result").next()
+    assertTrue( "unbound should be equal to null", next )
+  }
+
+  @Test
+  def should_handle_labels_on_optional_nodes() {
+    // given
+    val a = createLabeledNode("Person")
+    val b = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("START n=node(*) MATCH (n:Person)-[r?]->(m:Person) RETURN n, m" )
+
+    // then
+    assert( Set(a, b) === result.columnAs[Node]("n").toSet)
+  }
+
+
+  @Test
+  def should_handle_labels_on_optional_nodes_in_with() {
+    // given
+    val a = createLabeledNode("Person")
+
+    // when
+    val result = parseAndExecute("MATCH (n:Person) WITH n MATCH n-[r?]->(m:Person) RETURN n, m" )
+
+    // then
+    assert( Set(a) === result.columnAs[Node]("n").toSet)
+  }
+}

--- a/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestBase.scala
@@ -28,9 +28,7 @@ import org.neo4j.kernel.ThreadToStatementContextBridge
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.cypher.internal.helpers.GraphIcing
 import org.neo4j.cypher.internal.spi.PlanContext
-import org.neo4j.cypher.internal.spi.gdsimpl.TransactionBoundPlanContext
 import org.scalatest.Assertions
-import org.neo4j.kernel.api.StatementOperations
 import org.neo4j.kernel.api.operations.StatementState
 import org.neo4j.kernel.api.StatementOperationParts
 import org.neo4j.cypher.internal.spi.gdsimpl.TransactionBoundPlanContext
@@ -65,6 +63,10 @@ class GraphDatabaseTestBase extends GraphIcing with Assertions {
   def indexRel(r: Relationship, idxName: String, key: String, value: String) {
     graph.inTx(r.getGraphDatabase.index.forRelationships(idxName).add(r, key, value))
   }
+
+  def nodeId(n: Node) = graph.inTx { n.getId }
+
+  def relationshipId(r: Relationship) = graph.inTx { r.getId }
 
   def createNode(): Node = createNode(Map[String, Any]())
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/MatchingContextTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/pipes/matching/MatchingContextTest.scala
@@ -32,6 +32,7 @@ import org.neo4j.cypher.internal.commands.Equals
 import org.neo4j.cypher.internal.pipes.{QueryStateHelper, QueryState}
 import org.neo4j.cypher.internal.ExecutionContext
 import org.neo4j.cypher.internal.commands.values.TokenType.PropertyKey
+import org.neo4j.cypher.internal.commands.values.UnboundValue
 
 class MatchingContextTest extends GraphDatabaseTestBase with Assertions with PatternGraphBuilder {
   var a: Node = null
@@ -270,7 +271,7 @@ class MatchingContextTest extends GraphDatabaseTestBase with Assertions with Pat
     val patterns: Seq[Pattern] = Seq(RelatedTo("a", "b", "r", Seq("t1"), Direction.OUTGOING, true))
     createMatchingContextWithNodes(patterns, Seq("a"))
 
-    assertMatches(getMatches("a" -> a), 1, Map("a" -> a, "b" -> null, "r" -> null))
+    assertMatches(getMatches("a" -> a), 1, Map("a" -> a, "b" -> UnboundValue, "r" -> null))
   }
 
   @Test def doubleOptional() {


### PR DESCRIPTION
o ClosingIterator.materialize converts UnboundValue to null
o Equality behaves correctly when comparing against UnboundValue
