### PR TITLE
Better error message for failed constraint index.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.exceptions.KernelException;
+
+public class IndexBrokenKernelException extends KernelException
+{
+    public IndexBrokenKernelException( String indexFailureCause )
+    {
+        super( "The index is in a failed state: '%s'.", indexFailureCause );
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
@@ -38,9 +37,8 @@ import org.neo4j.kernel.impl.api.constraints.UnableToValidateConstraintKernelExc
 import org.neo4j.test.TargetDirectory;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.test.TargetDirectory.cleanTestDirForTest;
 
@@ -70,7 +68,7 @@ public class ConstraintIndexFailureIT
             catch ( ConstraintViolationException e )
             {
                 assertThat( e.getCause(), instanceOf( UnableToValidateConstraintKernelException.class ) );
-                //TODO: assertThat( e.getCause().getCause().getMessage(), containsString( "Injected Failure" ) );
+                assertThat( e.getCause().getCause().getMessage(), equalTo( "The index is in a failed state: 'Injected failure'.") );
             }
             finally
             {


### PR DESCRIPTION
If a constraint index fails, the error message provided to users that interact with the broken constraint now

contains the original cause of the index failing.
