### PR TITLE
fix start script for SmartOS

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -138,10 +138,15 @@ buildclasspath() {
 }
 
 detectrunning() {
-  ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
-  ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-  newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
-  newpid=${newpid:1}
+  if [ $DIST_OS = "solaris" ] ; then
+      ## SmartOS has a different lsof command line arguments
+      newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
+  else
+      ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
+      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=${newpid:1}
+  fi
 }
 
 startit() {


### PR DESCRIPTION
Here is the change I made to resolve Issue #576 on SmartOS (and maybe Solaris in general). It has a different lsof. It should still work for other OS's.
