### PR TITLE
Changes constraint syntax

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/Constraint.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/Constraint.scala
@@ -23,12 +23,12 @@ import org.neo4j.cypher.internal.commands.{AbstractQuery, CreateUniqueConstraint
 
 trait Constraint extends Base with Labels {
   def createUniqueConstraint: Parser[CreateUniqueConstraint] =
-    CREATE ~> CONSTRAINT ~> ON ~> parens(identity ~ labelName) ~ opt(ASSERT) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
+    CREATE ~> CONSTRAINT ~> ON ~> parens(identity ~ labelName) ~ opt(ASSERTING) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
       case id ~ label ~ _ ~ idForProperty ~ "." ~ propertyKey => CreateUniqueConstraint(id, label.name, idForProperty, propertyKey)
     }
 
   def dropUniqueConstraint: Parser[DropUniqueConstraint] =
-    DROP ~> CONSTRAINT ~> ON ~> parens(identity ~ labelName) ~ opt(ASSERT) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
+    DROP ~> CONSTRAINT ~> ON ~> parens(identity ~ labelName) ~ opt(ASSERTING) ~ identity ~ "." ~ escapableString <~ IS <~ UNIQUE ^^ {
       case id ~ label ~ _ ~ idForProperty ~ "." ~ propertyKey => DropUniqueConstraint(id, label.name, idForProperty, propertyKey)
     }
 

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/Strings.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/Strings.scala
@@ -26,7 +26,7 @@ trait Strings extends JavaTokenParsers {
   def KEYWORDS =
     START | CREATE | SET | DELETE | FOREACH | MATCH | WHERE | WITH |
     RETURN | SKIP | LIMIT | ORDER | BY | ASC | DESC | ON | WHEN | CASE | THEN |
-    ELSE | DROP | USING | MERGE | CONSTRAINT | ASSERT | SCAN | REMOVE | UNION
+    ELSE | DROP | USING | MERGE | CONSTRAINT | ASSERTING | SCAN | REMOVE | UNION
 
   // KEYWORDS
   def START = ignoreCase("start")
@@ -54,7 +54,7 @@ trait Strings extends JavaTokenParsers {
   def USING = ignoreCase("using")
   def SCAN = ignoreCase("scan")
   def MERGE = ignoreCase("merge")
-  def ASSERT = ignoreCase("assert")
+  def ASSERTING = ignoreCase("asserting")
   def UNIQUE = ignoreCase("unique")
   def REMOVE = ignoreCase("remove")
   def UNION = ignoreCase("union")

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Command.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Command.scala
@@ -50,5 +50,5 @@ trait Command extends Parser
   }
 
   private def ConstraintSyntax = keyword("CONSTRAINT", "ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
-    optional(keyword("ASSERT")) ~~ Identifier ~~ "." ~~ Identifier ~~ keyword("IS", "UNIQUE")
+    optional(keyword("ASSERTING")) ~~ Identifier ~~ "." ~~ Identifier ~~ keyword("IS", "UNIQUE")
 }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -302,22 +302,22 @@ class ErrorMessagesTest extends ExecutionEngineHelper with Assertions with Strin
     createLabeledNode(Map("name" -> "A"), "Person")
     createLabeledNode(Map("name" -> "A"), "Person")
 
-    expectError("CREATE CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE",
-      v2_0 -> String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS UNIQUE:%n" +
+    expectError("CREATE CONSTRAINT ON (person:Person) ASSERTING person.name IS UNIQUE",
+      v2_0 -> String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERTING person.name IS UNIQUE:%n" +
         "Multiple nodes with label `Person` have property `name` = 'A':%n  node(1)%n  node(2)")
     )
   }
 
   @Test def trying_to_add_a_constraint_that_already_exists() {
-    parseAndExecute("CREATE CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE")
+    parseAndExecute("CREATE CONSTRAINT ON (person:Person) ASSERTING person.name IS UNIQUE")
 
-    expectError("CREATE CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE",
-      v2_0 -> "Already constrained CONSTRAINT ON ( person:Person ) ASSERT person.name IS UNIQUE."
+    expectError("CREATE CONSTRAINT ON (person:Person) ASSERTING person.name IS UNIQUE",
+      v2_0 -> "Already constrained CONSTRAINT ON ( person:Person ) ASSERTING person.name IS UNIQUE."
     )
   }
 
   @Test def drop_a_non_existent_constraint() {
-    expectError("DROP CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE",
+    expectError("DROP CONSTRAINT ON (person:Person) ASSERTING person.name IS UNIQUE",
       v2_0 -> "No such constraint"
     )
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintValidationAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintValidationAcceptanceTest.scala
@@ -31,7 +31,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_enforce_uniqueness_constraint_on_create_node_with_label_and_property() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
     parseAndExecute("create ( node:Label1 { key1:'value1' } )")
 
     // WHEN
@@ -50,7 +50,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_enforce_uniqueness_constraint_on_set_property() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
     parseAndExecute("create ( node1:Label1 { seq: 1, key1:'value1' } ), ( node2:Label1 { seq: 2 } )")
 
     // WHEN
@@ -69,7 +69,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_enforce_uniqueness_constraint_on_add_label() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
     parseAndExecute("create ( node1:Label1 { seq: 1, key1:'value1' } ), ( node2 { seq: 2, key1:'value1' } )")
 
     // WHEN
@@ -88,7 +88,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_enforce_uniqueness_constraint_on_conflicting_data_in_same_statement() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
 
     // WHEN
     try {
@@ -106,7 +106,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_allow_remove_and_add_conflicting_data_in_one_statement() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
     parseAndExecute("create ( node:Label1 { seq:1, key1:'value1' } )")
 
     var seq = 2
@@ -129,7 +129,7 @@ class UniqueConstraintValidationAcceptanceTest
   @Test
   def should_allow_creation_of_non_conflicting_data() {
     // GIVEN
-    parseAndExecute("create constraint on (node:Label1) assert node.key1 is unique")
+    parseAndExecute("create constraint on (node:Label1) asserting node.key1 is unique")
     parseAndExecute("create ( node:Label1 { key1:'value1' } )")
 
     // WHEN

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintVerificationAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintVerificationAcceptanceTest.scala
@@ -35,7 +35,7 @@ class UniqueConstraintVerificationAcceptanceTest
     //GIVEN
 
     //WHEN
-    parseAndExecute("create constraint on (node:Label) assert node.propertyKey is unique")
+    parseAndExecute("create constraint on (node:Label) asserting node.propertyKey is unique")
 
     //THEN
     graph.inTx {
@@ -56,7 +56,7 @@ class UniqueConstraintVerificationAcceptanceTest
     parseAndExecute("create (a:Person{name:\"Alistair\"}), (b:Person{name:\"Stefan\"})")
 
     // WHEN
-    parseAndExecute("create constraint on (n:Person) assert n.name is unique")
+    parseAndExecute("create constraint on (n:Person) asserting n.name is unique")
 
     // THEN
     graph.inTx {
@@ -79,7 +79,7 @@ class UniqueConstraintVerificationAcceptanceTest
     parseAndExecute("create (a:Person{name:\"Alistair\"}), (b:Person{name:\"Stefan\"})")
 
     // WHEN
-    parseAndExecute("create constraint on (n:Person) assert n.name is unique")
+    parseAndExecute("create constraint on (n:Person) asserting n.name is unique")
 
     // THEN
     graph.inTx {
@@ -97,10 +97,10 @@ class UniqueConstraintVerificationAcceptanceTest
   @Test
   def should_drop_constraint() {
     //GIVEN
-    parseAndExecute("create constraint on (node:Label) assert node.propertyKey is unique")
+    parseAndExecute("create constraint on (node:Label) asserting node.propertyKey is unique")
 
     //WHEN
-    parseAndExecute("drop constraint on (node:Label) assert node.propertyKey is unique")
+    parseAndExecute("drop constraint on (node:Label) asserting node.propertyKey is unique")
 
     //THEN
     graph.inTx {
@@ -123,7 +123,7 @@ class UniqueConstraintVerificationAcceptanceTest
     // WHEN
     try
     {
-      parseAndExecute("create constraint on (n:Person) assert n.id is unique")
+      parseAndExecute("create constraint on (n:Person) asserting n.id is unique")
 
       fail("expected exception")
     }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -33,19 +33,19 @@ class ConstraintsTest extends DocumentingTestBase {
       title = "Create uniqueness constraint",
       text = "To create a constraint that makes sure that your database will never contain more than one node with a specific " +
         "label and one property value, use the +IS+ +UNIQUE+ syntax.",
-      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE",
+      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERTING book.isbn IS UNIQUE",
       returns = "",
       assertions = (p) => assertConstraintExist("Book", "isbn")
     )
   }
 
   @Test def drop_unique_constraint() {
-    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE")
+    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERTING book.isbn IS UNIQUE")
 
     testQuery(
       title = "Drop uniqueness constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
-      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE",
+      queryText = "DROP CONSTRAINT ON (book:Book) ASSERTING book.isbn IS UNIQUE",
       returns = "",
       assertions = (p) => assertConstraintDoesNotExist("Book", "isbn")
     )

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/CypherParserTest.scala
@@ -2974,7 +2974,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def constraint_creation() {
-    test(vFrom2_0, "CREATE CONSTRAINT ON (id:Label) ASSERT id.property IS UNIQUE",
+    test(vFrom2_0, "CREATE CONSTRAINT ON (id:Label) ASSERTING id.property IS UNIQUE",
       CreateUniqueConstraint("id", "Label", "id", "property")
     )
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/rules/ConstraintTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/rules/ConstraintTest.scala
@@ -31,23 +31,23 @@ class ConstraintTest extends ParserTest[ast.Command, legacyCommands.AbstractQuer
 
   @Test
   def create_uniqueness_constraint() {
-    parsing("CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE") or
+    parsing("CREATE CONSTRAINT ON (foo:Foo) ASSERTING foo.name IS UNIQUE") or
       parsing("CREATE CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE") or
-      parsing("create constraint on (foo:Foo) assert foo.name is unique") shouldGive
+      parsing("create constraint on (foo:Foo) asserting foo.name is unique") shouldGive
       legacyCommands.CreateUniqueConstraint("foo", "Foo", "foo", "name")
 
-    parsing("CREATE CONSTRAINT ON (foo:Foo) ASSERT bar.name IS UNIQUE") shouldGive
+    parsing("CREATE CONSTRAINT ON (foo:Foo) ASSERTING bar.name IS UNIQUE") shouldGive
       legacyCommands.CreateUniqueConstraint("foo", "Foo", "bar", "name")
   }
 
   @Test
   def drop_uniqueness_constraint() {
-    parsing("DROP CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE") or
+    parsing("DROP CONSTRAINT ON (foo:Foo) ASSERTING foo.name IS UNIQUE") or
       parsing("DROP CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE") or
-      parsing("drop constraint on (foo:Foo) assert foo.name is unique") shouldGive
+      parsing("drop constraint on (foo:Foo) asserting foo.name is unique") shouldGive
       legacyCommands.DropUniqueConstraint("foo", "Foo", "foo", "name")
 
-    parsing("DROP CONSTRAINT ON (foo:Foo) ASSERT bar.name IS UNIQUE") shouldGive
+    parsing("DROP CONSTRAINT ON (foo:Foo) ASSERTING bar.name IS UNIQUE") shouldGive
       legacyCommands.DropUniqueConstraint("foo", "Foo", "bar", "name")
   }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
@@ -75,14 +75,14 @@ public class UniquenessConstraint
     @Override
     public String toString()
     {
-        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERT n.property[%s] IS UNIQUE", labelId, propertyKeyId );
+        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERTING n.property[%s] IS UNIQUE", labelId, propertyKeyId );
     }
 
     public String userDescription( TokenNameLookup tokenNameLookup )
     {
         String labelName = tokenNameLookup.labelGetName( labelId );
         String boundIdentifier = labelName.toLowerCase();
-        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS UNIQUE", boundIdentifier, labelName,
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERTING %s.%s IS UNIQUE", boundIdentifier, labelName,
                 boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -34,14 +33,12 @@ import org.neo4j.graphdb.schema.UniquenessConstraintDefinition;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static java.lang.String.format;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.Neo4jMatchers.contains;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.createIndex;
@@ -387,7 +384,7 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertEquals( format( "Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERT my_label" +
+            assertEquals( format( "Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERTING my_label" +
                     ".my_property_key IS " +
                     "UNIQUE:%n" +
                     "Already indexed :MY_LABEL(my_property_key)." ), e.getMessage() );
@@ -418,7 +415,7 @@ public class SchemaAcceptanceTest
         catch ( ConstraintViolationException e )
         {
             assertEquals(
-                format( "Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERT my_label.my_property_key " +
+                format( "Unable to create CONSTRAINT ON ( my_label:MY_LABEL ) ASSERTING my_label.my_property_key " +
                         "IS UNIQUE:%nMultiple nodes with label `MY_LABEL` have property `my_property_key` = " +
                         "'value1':%n" +
                         "  node(1)%n" +
@@ -440,7 +437,7 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertEquals( "Already constrained CONSTRAINT ON ( my_label:MY_LABEL ) ASSERT my_label.my_property_key IS" +
+            assertEquals( "Already constrained CONSTRAINT ON ( my_label:MY_LABEL ) ASSERTING my_label.my_property_key IS" +
                     " UNIQUE.", e.getMessage() );
         }
     }
@@ -460,7 +457,7 @@ public class SchemaAcceptanceTest
         catch ( ConstraintViolationException e )
         {
             assertEquals( "Unable to add index :MY_LABEL(my_property_key) : Already constrained CONSTRAINT" +
-                    " ON ( my_label:MY_LABEL ) ASSERT my_label.my_property_key IS UNIQUE.", e.getMessage() );
+                    " ON ( my_label:MY_LABEL ) ASSERTING my_label.my_property_key IS UNIQUE.", e.getMessage() );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.impl.api.index.IndexProxy;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
@@ -109,7 +108,7 @@ public class ConstraintIndexCreatorTest
         // then
         catch ( ConstraintVerificationFailedKernelException e )
         {
-            assertEquals( "Existing data does not satisfy CONSTRAINT ON ( n:label[123] ) ASSERT n.property[456] IS UNIQUE.",
+            assertEquals( "Existing data does not satisfy CONSTRAINT ON ( n:label[123] ) ASSERTING n.property[456] IS UNIQUE.",
                           e.getMessage() );
         }
         verifyNoMoreInteractions( indexCreationContext.schemaWriteOperations() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.index;
 import java.util.Set;
 
 import org.junit.Test;
-
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.impl.api.Transactor;
@@ -34,7 +33,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
 
@@ -166,7 +164,7 @@ public class IndexIT extends KernelIntegrationTest
         {
             assertEquals( "Unable to add index :label[5](property[8]) : " +
                     "Already constrained CONSTRAINT ON ( n:label[5] ) " +
-                    "ASSERT n.property[8] IS UNIQUE.", e.getMessage() );
+                    "ASSERTING n.property[8] IS UNIQUE.", e.getMessage() );
         }
     }
 


### PR DESCRIPTION
The syntax was CREATE/DELETE CONSTRAINT ON (<id>:<label>) ASSERT <id>.<property> IS UNIQUE.
That syntax works well for create, but not as well for delete. This commit changes ASSERT to ASSERTING,
which better supports both CREATE and DELETE.
