### PR TITLE
Transaction compatible in try-with-resource

### DIFF
--- a/community/embedded-examples/src/main/java/org/neo4j/examples/CalculateShortestPath.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/CalculateShortestPath.java
@@ -19,6 +19,7 @@
 package org.neo4j.examples;
 
 import java.io.File;
+
 import org.neo4j.graphalgo.GraphAlgoFactory;
 import org.neo4j.graphalgo.PathFinder;
 import org.neo4j.graphdb.Direction;
@@ -47,8 +48,7 @@ public class CalculateShortestPath
         graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( DB_PATH );
         indexService = graphDb.index().forNodes( "nodes" );
         registerShutdownHook();
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             /*
              *  (Neo) --> (Trinity)
@@ -64,10 +64,6 @@ public class CalculateShortestPath
             createChain( "Morpheus", "Cypher", "Agent Smith" );
             createChain( "Morpheus", "Agent Smith" );
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
 
         // So let's find the shortest path between Neo and Agent Smith

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4j.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4j.java
@@ -21,6 +21,7 @@ package org.neo4j.examples;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -67,8 +68,7 @@ public class EmbeddedNeo4j
         // END SNIPPET: startDb
 
         // START SNIPPET: transaction
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Updating operations go here
             // END SNIPPET: transaction
@@ -95,10 +95,6 @@ public class EmbeddedNeo4j
             // START SNIPPET: transaction
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
         // END SNIPPET: transaction
     }
 
@@ -116,8 +112,7 @@ public class EmbeddedNeo4j
 
     void removeData()
     {
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // START SNIPPET: removingData
             // let's remove the data
@@ -127,10 +122,6 @@ public class EmbeddedNeo4j
             // END SNIPPET: removingData
 
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithIndexing.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithIndexing.java
@@ -39,8 +39,7 @@ public class EmbeddedNeo4jWithIndexing
         // END SNIPPET: startDb
 
         // START SNIPPET: addUsers
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             nodeIndex = graphDb.index().forNodes( "nodes" );
             // Create some users and index their names with the IndexService
@@ -68,10 +67,6 @@ public class EmbeddedNeo4jWithIndexing
                 user.delete();
             }
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
         shutdown();
     }

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithNewIndexing.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithNewIndexing.java
@@ -46,8 +46,7 @@ public class EmbeddedNeo4jWithNewIndexing
         {
             // START SNIPPET: createIndex
             IndexDefinition indexDefinition;
-            Transaction tx = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Schema schema = graphDb.schema();
                 indexDefinition = schema.indexFor( DynamicLabel.label( "User" ) )
@@ -55,29 +54,19 @@ public class EmbeddedNeo4jWithNewIndexing
                         .create();
                 tx.success();
             }
-            finally
-            {
-                tx.finish();
-            }
             // END SNIPPET: createIndex
             // START SNIPPET: wait
-            Transaction transaction = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Schema schema = graphDb.schema();
                 schema.awaitIndexOnline( indexDefinition, 10, TimeUnit.SECONDS );
-            }
-            finally
-            {
-                transaction.finish();
             }
             // END SNIPPET: wait
         }
 
         {
             // START SNIPPET: addUsers
-            Transaction tx = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Label label = DynamicLabel.label( "User" );
 
@@ -90,10 +79,6 @@ public class EmbeddedNeo4jWithNewIndexing
                 System.out.println( "Users created" );
                 tx.success();
             }
-            finally
-            {
-                tx.finish();
-            }
             // END SNIPPET: addUsers
         }
 
@@ -102,8 +87,7 @@ public class EmbeddedNeo4jWithNewIndexing
             Label label = DynamicLabel.label( "User" );
             int idToFind = 45;
             String nameToFind = "user" + idToFind + "@neo4j.org";
-            Transaction transaction = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 ResourceIterator<Node> users = graphDb.findNodesByLabelAndProperty( label, "username", nameToFind )
                         .iterator();
@@ -118,10 +102,6 @@ public class EmbeddedNeo4jWithNewIndexing
                     System.out.println( "The username of user " + idToFind + " is " + node.getProperty( "username" ) );
                 }
             }
-            finally
-            {
-                transaction.finish();
-            }
             // END SNIPPET: findUsers
         }
 
@@ -130,30 +110,23 @@ public class EmbeddedNeo4jWithNewIndexing
             Label label = DynamicLabel.label( "User" );
             int idToFind = 45;
             String nameToFind = "user" + idToFind + "@neo4j.org";
-            Transaction transaction = graphDb.beginTx();
-            try
-            {
-                ResourceIterator<Node> users = graphDb
+            try ( Transaction tx = graphDb.beginTx();
+                  ResourceIterator<Node> users = graphDb
                         .findNodesByLabelAndProperty( label, "username", nameToFind )
-                        .iterator();
+                        .iterator() )
+            {
                 Node firstUserNode;
                 if ( users.hasNext() )
                 {
                     firstUserNode = users.next();
                 }
-                users.close();
-            }
-            finally
-            {
-                transaction.finish();
             }
             // END SNIPPET: resourceIterator
         }
 
         {
             // START SNIPPET: updateUsers
-            Transaction tx = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Label label = DynamicLabel.label( "User" );
                 int idToFind = 45;
@@ -165,17 +138,12 @@ public class EmbeddedNeo4jWithNewIndexing
                 }
                 tx.success();
             }
-            finally
-            {
-                tx.finish();
-            }
             // END SNIPPET: updateUsers
         }
 
         {
             // START SNIPPET: deleteUsers
-            Transaction tx = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Label label = DynamicLabel.label( "User" );
                 int idToFind = 46;
@@ -187,17 +155,12 @@ public class EmbeddedNeo4jWithNewIndexing
                 }
                 tx.success();
             }
-            finally
-            {
-                tx.finish();
-            }
             // END SNIPPET: deleteUsers
         }
 
         {
             // START SNIPPET: dropIndex
-            Transaction tx = graphDb.beginTx();
-            try
+            try ( Transaction tx = graphDb.beginTx() )
             {
                 Label label = DynamicLabel.label( "User" );
                 for ( IndexDefinition indexDefinition : graphDb.schema()
@@ -208,10 +171,6 @@ public class EmbeddedNeo4jWithNewIndexing
                 }
 
                 tx.success();
-            }
-            finally
-            {
-                tx.finish();
             }
             // END SNIPPET: dropIndex
         }

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/Matrix.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/Matrix.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.examples;
 
-import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -35,6 +33,8 @@ import org.neo4j.graphdb.TraversalPosition;
 import org.neo4j.graphdb.Traverser;
 import org.neo4j.graphdb.Traverser.Order;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
+import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 
 public class Matrix
 {
@@ -73,8 +73,7 @@ public class Matrix
 
     public void createNodespace()
     {
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create base Matrix node
             Node matrix = graphDb.createNode();
@@ -119,10 +118,6 @@ public class Matrix
 
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
     }
 
     /**
@@ -139,8 +134,7 @@ public class Matrix
 
     public String printNeoFriends()
     {
-        Transaction transaction = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             Node neoNode = getNeoNode();
             // START SNIPPET: friends-usage
@@ -158,10 +152,6 @@ public class Matrix
             // END SNIPPET: friends-usage
             return output.toString();
         }
-        finally
-        {
-            transaction.finish();
-        }
     }
 
     // START SNIPPET: get-friends
@@ -176,8 +166,7 @@ public class Matrix
 
     public String printMatrixHackers()
     {
-        Transaction transaction = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // START SNIPPET: find--hackers-usage
             StringBuilder output = new StringBuilder("Hackers:\n");
@@ -193,10 +182,6 @@ public class Matrix
             output.append( String.format( "Number of hackers found: %d\n", numberOfHackers ) );
             // END SNIPPET: find--hackers-usage
             return output.toString();
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/Neo4jShell.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/Neo4jShell.java
@@ -102,8 +102,7 @@ public class Neo4jShell
 
     private static void createExampleGraph()
     {
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create users sub reference node.
             System.out.println( "Creating example graph ..." );
@@ -138,16 +137,11 @@ public class Neo4jShell
             }
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
     }
 
     private static void deleteExampleNodeSpace()
     {
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Delete the persons and remove them from the index
             System.out.println( "Deleting example graph ..." );
@@ -168,10 +162,6 @@ public class Neo4jShell
                     Direction.INCOMING ).delete();
             usersReferenceNode.delete();
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/NewMatrix.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/NewMatrix.java
@@ -19,6 +19,7 @@
 package org.neo4j.examples;
 
 import java.io.File;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -69,8 +70,7 @@ public class NewMatrix
 
     public void createNodespace()
     {
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create matrix node
             Node matrix = graphDb.createNode();
@@ -115,10 +115,6 @@ public class NewMatrix
 
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
     }
 
     /**
@@ -135,8 +131,7 @@ public class NewMatrix
 
     public String printNeoFriends()
     {
-        Transaction transaction = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             Node neoNode = getNeoNode();
             // START SNIPPET: friends-usage
@@ -154,10 +149,6 @@ public class NewMatrix
             // END SNIPPET: friends-usage
             return output;
         }
-        finally
-        {
-            transaction.finish();
-        }
     }
 
     // START SNIPPET: get-friends
@@ -174,8 +165,7 @@ public class NewMatrix
 
     public String printMatrixHackers()
     {
-        Transaction transaction = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // START SNIPPET: find--hackers-usage
             String output = "Hackers:\n";
@@ -191,10 +181,6 @@ public class NewMatrix
             output += "Number of hackers found: " + numberOfHackers + "\n";
             // END SNIPPET: find--hackers-usage
             return output;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/orderedpath/OrderedPath.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/orderedpath/OrderedPath.java
@@ -57,32 +57,36 @@ public class OrderedPath
 
     public Node createTheGraph()
     {
-        Transaction tx = db.beginTx();
-        // START SNIPPET: createGraph
-        Node A = db.createNode();
-        Node B = db.createNode();
-        Node C = db.createNode();
-        Node D = db.createNode();
-
-        A.createRelationshipTo( C, REL2 );
-        C.createRelationshipTo( D, REL3 );
-        A.createRelationshipTo( B, REL1 );
-        B.createRelationshipTo( C, REL2 );
-        // END SNIPPET: createGraph
-        A.setProperty( "name", "A" );
-        B.setProperty( "name", "B" );
-        C.setProperty( "name", "C" );
-        D.setProperty( "name", "D" );
-        tx.success();
-        tx.finish();
-        return A;
+        try ( Transaction tx = db.beginTx() )
+        {
+            // START SNIPPET: createGraph
+            Node A = db.createNode();
+            Node B = db.createNode();
+            Node C = db.createNode();
+            Node D = db.createNode();
+    
+            A.createRelationshipTo( C, REL2 );
+            C.createRelationshipTo( D, REL3 );
+            A.createRelationshipTo( B, REL1 );
+            B.createRelationshipTo( C, REL2 );
+            // END SNIPPET: createGraph
+            A.setProperty( "name", "A" );
+            B.setProperty( "name", "B" );
+            C.setProperty( "name", "C" );
+            D.setProperty( "name", "D" );
+            tx.success();
+            return A;
+        }
     }
 
     public void shutdownGraph()
     {
         try
         {
-            if ( db != null ) db.shutdown();
+            if ( db != null )
+            {
+                db.shutdown();
+            }
         }
         finally
         {
@@ -122,8 +126,7 @@ public class OrderedPath
 
     String printPaths( TraversalDescription td, Node A )
     {
-        Transaction transaction = db.beginTx();
-        try
+        try ( Transaction transaction = db.beginTx() )
         {
             String output = "";
             // START SNIPPET: printPath
@@ -136,10 +139,6 @@ public class OrderedPath
             // END SNIPPET: printPath
             output += "\n";
             return output;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
@@ -20,16 +20,19 @@ package org.neo4j.examples;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * An example of unit testing with Neo4j.
@@ -80,22 +83,12 @@ public class Neo4jBasicDocTest
     public void shouldCreateNode()
     {
         // START SNIPPET: unitTest
-        Transaction tx = graphDb.beginTx();
-
         Node n = null;
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             n = graphDb.createNode();
             n.setProperty( "name", "Nancy" );
             tx.success();
-        }
-        catch ( Exception e )
-        {
-            tx.failure();
-        }
-        finally
-        {
-            tx.finish();
         }
 
         // The node should have an id greater than 0, which is the id of the
@@ -104,11 +97,12 @@ public class Neo4jBasicDocTest
 
         // Retrieve a node by using the id of the created node. The id's and
         // property should match.
-        Transaction transaction = graphDb.beginTx();
-        Node foundNode = graphDb.getNodeById( n.getId() );
-        assertThat( foundNode.getId(), is( n.getId() ) );
-        assertThat( (String) foundNode.getProperty( "name" ), is( "Nancy" ) );
-        transaction.finish();
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            Node foundNode = graphDb.getNodeById( n.getId() );
+            assertThat( foundNode.getId(), is( n.getId() ) );
+            assertThat( (String) foundNode.getProperty( "name" ), is( "Nancy" ) );
+        }
         // END SNIPPET: unitTest
     }
 }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/RolesDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/RolesDocTest.java
@@ -19,21 +19,24 @@
 
 package org.neo4j.examples;
 
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.createOutputSnippet;
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.createQueryResultSnippet;
-
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.kernel.Traversal;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.GraphDescription.Graph;
+
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createOutputSnippet;
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createQueryResultSnippet;
 
 public class RolesDocTest extends AbstractJavaDocTestbase
 {
@@ -47,26 +50,26 @@ public class RolesDocTest extends AbstractJavaDocTestbase
     }
 
     /**
-     * This is an example showing a hierarchy of 
-     * roles. 
+     * This is an example showing a hierarchy of
+     * roles.
      * What's interesting is that a tree is not sufficient for storing this kind of structure,
      * as elaborated below.
      * 
      * image::roles.png[scaledwidth="100%"]
      * 
-     * This is an implementation of an example found in the article 
-     * http://www.codeproject.com/Articles/22824/A-Model-to-Represent-Directed-Acyclic-Graphs-DAG-o[A Model to Represent Directed Acyclic Graphs (DAG) on SQL Databases] 
+     * This is an implementation of an example found in the article
+     * http://www.codeproject.com/Articles/22824/A-Model-to-Represent-Directed-Acyclic-Graphs-DAG-o[A Model to Represent Directed Acyclic Graphs (DAG) on SQL Databases]
      * by http://www.codeproject.com/script/Articles/MemberArticles.aspx?amid=274518[Kemal Erdogan].
      * The article discusses how to store http://en.wikipedia.org/wiki/Directed_acyclic_graph[
-     * directed acyclic graphs] (DAGs) 
-     * in SQL based DBs. DAGs are almost trees, but with a twist: it may be possible to reach 
-     * the same node through different paths. Trees are restricted from this possibility, which 
-     * makes them much easier to handle. In our case it is ``Ali'' and ``Engin'', 
+     * directed acyclic graphs] (DAGs)
+     * in SQL based DBs. DAGs are almost trees, but with a twist: it may be possible to reach
+     * the same node through different paths. Trees are restricted from this possibility, which
+     * makes them much easier to handle. In our case it is ``Ali'' and ``Engin'',
      * as they are both admins and users and thus reachable through these group nodes.
      * Reality often looks this way and can't be captured by tree structures.
      * 
-     * In the article an SQL Stored Procedure solution is provided. The main idea, 
-     * that also have some support from scientists, is to pre-calculate all possible (transitive) paths. 
+     * In the article an SQL Stored Procedure solution is provided. The main idea,
+     * that also have some support from scientists, is to pre-calculate all possible (transitive) paths.
      * Pros and cons of this approach:
      * 
      * * decent performance on read
@@ -74,10 +77,10 @@ public class RolesDocTest extends AbstractJavaDocTestbase
      * * wastes _lots_ of space
      * * relies on stored procedures
      * 
-     * In Neo4j storing the roles is trivial. In this case we use +PART_OF+ (green edges) relationships 
-     * to model the group hierarchy and +MEMBER_OF+ (blue edges) to model membership in groups. 
-     * We also connect the top level groups to the reference node by +ROOT+ relationships. 
-     * This gives us a useful partitioning of the graph. Neo4j has no predefined relationship 
+     * In Neo4j storing the roles is trivial. In this case we use +PART_OF+ (green edges) relationships
+     * to model the group hierarchy and +MEMBER_OF+ (blue edges) to model membership in groups.
+     * We also connect the top level groups to the reference node by +ROOT+ relationships.
+     * This gives us a useful partitioning of the graph. Neo4j has no predefined relationship
      * types, you are free to create any relationship types and give them the semantics you want.
      * 
      * Lets now have a look at how to retrieve information from the graph. The Java code is using
@@ -109,7 +112,7 @@ public class RolesDocTest extends AbstractJavaDocTestbase
      * 
      * @@get-user-memberships
      * 
-     * resuling in: 
+     * resuling in:
      * 
      * @@o-get-user-memberships
      *
@@ -121,7 +124,7 @@ public class RolesDocTest extends AbstractJavaDocTestbase
      * 
      * == Get all groups ==
      * 
-     * In Java: 
+     * In Java:
      * 
      * @@get-groups
      * 
@@ -185,90 +188,92 @@ public class RolesDocTest extends AbstractJavaDocTestbase
         Traverser traverser = traversalDescription.traverse( admins );
         // END SNIPPET: get-admins
 
-        graphdb().beginTx();
-        gen.get().addSnippet( "o-get-admins", createOutputSnippet( traverserToString( traverser ) ) );
-        String query = "start admins=node("
-                       + admins.getId()
-                       + ") match admins<-[:PART_OF*0..]-group<-[:MEMBER_OF]-user return user.name, group.name";
-        gen.get().addSnippet( "query-get-admins", createCypherSnippet( query ) );
-        String result = engine.execute( query )
-                .dumpToString();
-        assertTrue( result.contains("Engin") );
-        gen.get().addSnippet( "o-query-get-admins", createQueryResultSnippet( result ) );
-        
-        //Jale's memberships
-        // START SNIPPET: get-user-memberships
-        Node jale = getNodeByName( "Jale" );
-        traversalDescription = Traversal.description()
-                .depthFirst()
-                .evaluator( Evaluators.excludeStartPosition() )
-                .relationships( RoleRels.MEMBER_OF, Direction.OUTGOING )
-                .relationships( RoleRels.PART_OF, Direction.OUTGOING );
-        traverser = traversalDescription.traverse( jale );
-        // END SNIPPET: get-user-memberships
-
-        gen.get().addSnippet( "o-get-user-memberships", createOutputSnippet( traverserToString( traverser ) ) );
-        query = "start jale=node("
-                + jale.getId()
-                + ") match jale-[:MEMBER_OF]->()-[:PART_OF*0..]->group return group.name";
-        gen.get().addSnippet( "query-get-user-memberships", createCypherSnippet( query ) );
-        result = engine.execute( query )
-                .dumpToString();
-        assertTrue( result.contains("Users") );
-        gen.get()
-                .addSnippet( "o-query-get-user-memberships",
-                        createQueryResultSnippet( result ) );
-        
-        // get all groups
-        // START SNIPPET: get-groups
-        Node referenceNode = getNodeByName( "Reference_Node") ;
-        traversalDescription = Traversal.description()
-                .breadthFirst()
-                .evaluator( Evaluators.excludeStartPosition() )
-                .relationships( RoleRels.ROOT, Direction.INCOMING )
-                .relationships( RoleRels.PART_OF, Direction.INCOMING );
-        traverser = traversalDescription.traverse( referenceNode );
-        // END SNIPPET: get-groups
-
-        gen.get().addSnippet( "o-get-groups", createOutputSnippet( traverserToString( traverser ) ) );
-        query = "start refNode=node("
-                + referenceNode.getId()
-                + ") match refNode<-[:ROOT]->()<-[:PART_OF*0..]-group return group.name";
-        gen.get().addSnippet( "query-get-groups", createCypherSnippet( query ) );
-        result = engine.execute( query )
-                .dumpToString();
-        assertTrue( result.contains("Users") );
-        gen.get()
-                .addSnippet( "o-query-get-groups",
-                        createQueryResultSnippet( result ) );
-        
-        //get all members
-        // START SNIPPET: get-members
-        traversalDescription = Traversal.description()
-                .breadthFirst()
-                .evaluator(
-                        Evaluators.includeWhereLastRelationshipTypeIs( RoleRels.MEMBER_OF ) );
-        traverser = traversalDescription.traverse( referenceNode );
-        // END SNIPPET: get-members
-
-        gen.get().addSnippet( "o-get-members", createOutputSnippet( traverserToString( traverser ) ) );
-        query = "start refNode=node("+ referenceNode.getId() +") " +
-        		"match refNode<-[:ROOT]->root, p=root<-[PART_OF*0..]-()<-[:MEMBER_OF]-user " +
-        		"return user.name, min(length(p)) " +
-        		"order by min(length(p)), user.name";
-        gen.get().addSnippet( "query-get-members", createCypherSnippet( query ) );
-        result = engine.execute( query )
-                .dumpToString();
-        assertTrue( result.contains("Engin") );
-        gen.get()
-                .addSnippet( "o-query-get-members",
-                        createQueryResultSnippet( result ) );
-
-        /* more advanced example
-        query = "start refNode=node("+ referenceNode.getId() +") " +
-                "match p=refNode<-[:ROOT]->parent<-[:PART_OF*0..]-group, group<-[:MEMBER_OF]-user return group.name, user.name, LENGTH(p) " +
-                "order by LENGTH(p)";
-                */
+        try ( Transaction tx = graphdb().beginTx() )
+        {
+            gen.get().addSnippet( "o-get-admins", createOutputSnippet( traverserToString( traverser ) ) );
+            String query = "start admins=node("
+                           + admins.getId()
+                           + ") match admins<-[:PART_OF*0..]-group<-[:MEMBER_OF]-user return user.name, group.name";
+            gen.get().addSnippet( "query-get-admins", createCypherSnippet( query ) );
+            String result = engine.execute( query )
+                    .dumpToString();
+            assertTrue( result.contains("Engin") );
+            gen.get().addSnippet( "o-query-get-admins", createQueryResultSnippet( result ) );
+            
+            //Jale's memberships
+            // START SNIPPET: get-user-memberships
+            Node jale = getNodeByName( "Jale" );
+            traversalDescription = Traversal.description()
+                    .depthFirst()
+                    .evaluator( Evaluators.excludeStartPosition() )
+                    .relationships( RoleRels.MEMBER_OF, Direction.OUTGOING )
+                    .relationships( RoleRels.PART_OF, Direction.OUTGOING );
+            traverser = traversalDescription.traverse( jale );
+            // END SNIPPET: get-user-memberships
+    
+            gen.get().addSnippet( "o-get-user-memberships", createOutputSnippet( traverserToString( traverser ) ) );
+            query = "start jale=node("
+                    + jale.getId()
+                    + ") match jale-[:MEMBER_OF]->()-[:PART_OF*0..]->group return group.name";
+            gen.get().addSnippet( "query-get-user-memberships", createCypherSnippet( query ) );
+            result = engine.execute( query )
+                    .dumpToString();
+            assertTrue( result.contains("Users") );
+            gen.get()
+                    .addSnippet( "o-query-get-user-memberships",
+                            createQueryResultSnippet( result ) );
+            
+            // get all groups
+            // START SNIPPET: get-groups
+            Node referenceNode = getNodeByName( "Reference_Node") ;
+            traversalDescription = Traversal.description()
+                    .breadthFirst()
+                    .evaluator( Evaluators.excludeStartPosition() )
+                    .relationships( RoleRels.ROOT, Direction.INCOMING )
+                    .relationships( RoleRels.PART_OF, Direction.INCOMING );
+            traverser = traversalDescription.traverse( referenceNode );
+            // END SNIPPET: get-groups
+    
+            gen.get().addSnippet( "o-get-groups", createOutputSnippet( traverserToString( traverser ) ) );
+            query = "start refNode=node("
+                    + referenceNode.getId()
+                    + ") match refNode<-[:ROOT]->()<-[:PART_OF*0..]-group return group.name";
+            gen.get().addSnippet( "query-get-groups", createCypherSnippet( query ) );
+            result = engine.execute( query )
+                    .dumpToString();
+            assertTrue( result.contains("Users") );
+            gen.get()
+                    .addSnippet( "o-query-get-groups",
+                            createQueryResultSnippet( result ) );
+            
+            //get all members
+            // START SNIPPET: get-members
+            traversalDescription = Traversal.description()
+                    .breadthFirst()
+                    .evaluator(
+                            Evaluators.includeWhereLastRelationshipTypeIs( RoleRels.MEMBER_OF ) );
+            traverser = traversalDescription.traverse( referenceNode );
+            // END SNIPPET: get-members
+    
+            gen.get().addSnippet( "o-get-members", createOutputSnippet( traverserToString( traverser ) ) );
+            query = "start refNode=node("+ referenceNode.getId() +") " +
+            		"match refNode<-[:ROOT]->root, p=root<-[PART_OF*0..]-()<-[:MEMBER_OF]-user " +
+            		"return user.name, min(length(p)) " +
+            		"order by min(length(p)), user.name";
+            gen.get().addSnippet( "query-get-members", createCypherSnippet( query ) );
+            result = engine.execute( query )
+                    .dumpToString();
+            assertTrue( result.contains("Engin") );
+            gen.get()
+                    .addSnippet( "o-query-get-members",
+                            createQueryResultSnippet( result ) );
+    
+            /* more advanced example
+            query = "start refNode=node("+ referenceNode.getId() +") " +
+                    "match p=refNode<-[:ROOT]->parent<-[:PART_OF*0..]-group, group<-[:MEMBER_OF]-user return group.name, user.name, LENGTH(p) " +
+                    "order by LENGTH(p)";
+                    */
+        }
     }
 
     private String traverserToString( Traverser traverser )

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/TraversalDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/TraversalDocTest.java
@@ -21,12 +21,14 @@
 package org.neo4j.examples;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.GraphDescription.Graph;
 
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.*;
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createGraphVizWithNodeId;
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createOutputSnippet;
 
 public class TraversalDocTest extends AbstractJavaDocTestbase
 {
@@ -50,8 +52,8 @@ public class TraversalDocTest extends AbstractJavaDocTestbase
      * 
      * @@knowslikesoutput
      * 
-     * Since http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/TraversalDescription.html[+TraversalDescription+]s 
-     * are immutable it is also useful to create template descriptions which holds common 
+     * Since http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/TraversalDescription.html[+TraversalDescription+]s
+     * are immutable it is also useful to create template descriptions which holds common
      * settings shared by different traversals. For example, let's start with this traverser:
      * 
      * @@basetraverser
@@ -77,13 +79,13 @@ public class TraversalDocTest extends AbstractJavaDocTestbase
      * 
      * @@output4
      * 
-     * For various useful evaluators, see the 
+     * For various useful evaluators, see the
      * http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/Evaluators.html[Evaluators] Java API
      * or simply implement the
      * http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/Evaluator.html[Evaluator] interface yourself.
      * 
-     * If you're not interested in the http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/Path.html[+Path+]s, 
-     * but the http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/Node.html[+Node+]s 
+     * If you're not interested in the http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/Path.html[+Path+]s,
+     * but the http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/Node.html[+Node+]s
      * you can transform the traverser into an iterable of http://components.neo4j.org/neo4j/{neo4j-version}/apidocs/org/neo4j/graphdb/traversal/Traverser.html#nodes()[nodes]
      * like this:
      * 
@@ -119,44 +121,30 @@ public class TraversalDocTest extends AbstractJavaDocTestbase
                         createGraphVizWithNodeId( "Traversal Example Graph", graphdb(),
                         gen.get().getTitle() ) );
 
-        Transaction transaction = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             String output = example.knowsLikesTraverser( joe );
-            gen.get()
-                    .addSnippet( "knowslikesoutput", createOutputSnippet( output ) );
+            gen.get().addSnippet( "knowslikesoutput", createOutputSnippet( output ) );
 
             output = example.traverseBaseTraverser( joe );
-            gen.get()
-                    .addSnippet( "baseoutput", createOutputSnippet( output ) );
+            gen.get().addSnippet( "baseoutput", createOutputSnippet( output ) );
 
             output = example.depth3( joe );
-            gen.get()
-                    .addSnippet( "output3", createOutputSnippet( output ) );
+            gen.get().addSnippet( "output3", createOutputSnippet( output ) );
 
             output = example.depth4( joe );
-            gen.get()
-                    .addSnippet( "output4", createOutputSnippet( output ) );
+            gen.get().addSnippet( "output4", createOutputSnippet( output ) );
 
             output = example.nodes( joe );
-            gen.get()
-                    .addSnippet( "nodeoutput", createOutputSnippet( output ) );
+            gen.get().addSnippet( "nodeoutput", createOutputSnippet( output ) );
 
             output = example.relationships( joe );
-            gen.get()
-                    .addSnippet( "relationshipoutput", createOutputSnippet( output ) );
+            gen.get().addSnippet( "relationshipoutput", createOutputSnippet( output ) );
 
-            gen.get()
-                    .addSourceSnippets( example.getClass(), "knowslikestraverser",
-                            "sourceRels", "basetraverser", "depth3", "depth4",
-                            "nodes", "relationships" );
-            gen.get()
-                    .addGithubSourceLink( "github", example.getClass(),
-                            "community/embedded-examples" );
-        }
-        finally
-        {
-            transaction.finish();
+            gen.get().addSourceSnippets( example.getClass(), "knowslikestraverser",
+                    "sourceRels", "basetraverser", "depth3", "depth4",
+                    "nodes", "relationships" );
+            gen.get().addGithubSourceLink( "github", example.getClass(), "community/embedded-examples" );
         }
     }
 }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/UniquenessOfPathsDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/UniquenessOfPathsDocTest.java
@@ -19,6 +19,7 @@
 package org.neo4j.examples;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Transaction;
@@ -31,11 +32,13 @@ import org.neo4j.kernel.Uniqueness;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.test.GraphDescription.Graph;
 
-import static org.junit.Assert.*;
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.*;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createGraphVizWithNodeId;
+import static org.neo4j.visualization.asciidoc.AsciidocHelper.createOutputSnippet;
 
 public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
-{    
+{
     /**
      * Uniqueness of Paths in traversals.
      * 
@@ -45,9 +48,9 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
      * 
      * @@graph
      * 
-     * In order to return all descendants 
+     * In order to return all descendants
      * of +Pet0+ which have the relation +owns+ to +Principal1+ (+Pet1+ and +Pet3+),
-     * the Uniqueness of the traversal needs to be set to 
+     * the Uniqueness of the traversal needs to be set to
      * +NODE_PATH+ rather than the default +NODE_GLOBAL+ so that nodes
      * can be traversed more that once, and paths that have
      * different nodes but can have some nodes in common (like the
@@ -59,7 +62,7 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
      * 
      * @@output
      * 
-     * In the default `path.toString()` implementation, `(1)--[knows,2]-->(4)` denotes 
+     * In the default `path.toString()` implementation, `(1)--[knows,2]-->(4)` denotes
      * a node with ID=1 having a relationship with ID 2 or type `knows` to a node with ID-4.
      * 
      * Let's create a new +TraversalDescription+ from the old one,
@@ -88,8 +91,7 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
         Node start = data.get().get( "Pet0" );
         gen.get().addSnippet( "graph", createGraphVizWithNodeId("Descendants Example Graph", graphdb(), gen.get().getTitle()) );
         gen.get();
-        gen.get()
-                .addTestSourceSnippets( this.getClass(), "traverser", "traverseNodeGlobal" );
+        gen.get().addTestSourceSnippets( this.getClass(), "traverser", "traverseNodeGlobal" );
         // START SNIPPET: traverser
         final Node target = data.get().get( "Principal1" );
         TraversalDescription td = Traversal.description()
@@ -99,11 +101,8 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
             @Override
             public Evaluation evaluate( Path path )
             {
-                if ( path.endNode().equals( target ) )
-                {
-                    return Evaluation.INCLUDE_AND_PRUNE;
-                }
-                return Evaluation.EXCLUDE_AND_CONTINUE;
+                boolean endNodeIsTarget = path.endNode().equals( target );
+                return Evaluation.of( endNodeIsTarget, !endNodeIsTarget );
             }
         } );
         
@@ -112,18 +111,13 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
         String output = "";
         int count = 0;
         //we should get two paths back, through Pet1 and Pet3
-        Transaction transaction = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             for ( Path path : results )
             {
                 count++;
                 output += path.toString() + "\n";
             }
-        }
-        finally
-        {
-            transaction.finish();
         }
         gen.get().addSnippet( "output", createOutputSnippet( output ) );
         assertEquals( 2, count );
@@ -135,8 +129,7 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
         String output2 = "";
         count = 0;
         // we should get two paths back, through Pet1 and Pet3
-        transaction = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             for ( Path path : results )
             {
@@ -144,12 +137,7 @@ public class UniquenessOfPathsDocTest extends AbstractJavaDocTestbase
                 output2 += path.toString() + "\n";
             }
         }
-        finally
-        {
-            transaction.finish();
-        }
-        gen.get()
-                .addSnippet( "outNodeGlobal", createOutputSnippet( output2 ) );
+        gen.get().addSnippet( "outNodeGlobal", createOutputSnippet( output2 ) );
         assertEquals( 1, count );
     }
 }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
@@ -37,6 +37,7 @@ import org.neo4j.visualization.asciidoc.AsciidocHelper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createOutputSnippet;
 
@@ -70,14 +71,9 @@ public class OrderedPathDocTest
     {
         Node A = orderedPath.createTheGraph();
         TraversalDescription traversalDescription = orderedPath.findPaths();
-        Transaction transaction = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             assertEquals( 1, count( traversalDescription.traverse( A ) ) );
-        }
-        finally
-        {
-            transaction.finish();
         }
         String output = orderedPath.printPaths( traversalDescription, A );
         assertTrue( output.contains( "(A)--[REL1]-->(B)--[REL2]-->(C)--[REL3]-->(D)" ) );

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/osgi/Neo4jActivator.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/osgi/Neo4jActivator.java
@@ -33,6 +33,7 @@ import org.neo4j.index.lucene.LuceneKernelExtensionFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.cache.SoftCacheProvider;
+
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -40,7 +41,6 @@ import org.osgi.framework.ServiceRegistration;
 // START SNIPPET: setup
 public class Neo4jActivator implements BundleActivator
 {
-
     private static GraphDatabaseService db;
     private ServiceRegistration serviceRegistration;
     private ServiceRegistration indexServiceRegistration;
@@ -70,8 +70,7 @@ public class Neo4jActivator implements BundleActivator
         indexServiceRegistration = context.registerService(
                 Index.class.getName(), db.index().forNodes( "nodes" ),
                 new Hashtable<String, String>() );
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             Node firstNode = db.createNode();
             Node secondNode = db.createNode();
@@ -84,16 +83,6 @@ public class Neo4jActivator implements BundleActivator
             db.index().forNodes( "nodes" ).add( firstNode, "message", "Hello" );
             tx.success();
         }
-        catch ( Exception e )
-        {
-            e.printStackTrace();
-            throw new RuntimeException( e );
-        }
-        finally
-        {
-            tx.finish();
-        }
-
     }
 
     @Override
@@ -102,8 +91,6 @@ public class Neo4jActivator implements BundleActivator
         serviceRegistration.unregister();
         indexServiceRegistration.unregister();
         db.shutdown();
-
     }
-
 }
 // END SNIPPET: setup

--- a/community/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
+++ b/community/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
@@ -126,8 +126,7 @@ public class AsciidocHelper
                                          GraphDatabaseService graph, String identifier,
                                          GraphStyle graphStyle, String graphvizOptions )
     {
-        Transaction transaction = graph.beginTx();
-        try
+        try ( Transaction tx = graph.beginTx() )
         {
             GraphvizWriter writer = new GraphvizWriter( graphStyle );
             ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -154,23 +153,14 @@ public class AsciidocHelper
                 throw new RuntimeException( e );
             }
         }
-        finally
-        {
-            transaction.finish();
-        }
     }
 
     private static void removeReferenceNode( GraphDatabaseService graph )
     {
-        Transaction tx = graph.beginTx();
-        try
+        try ( Transaction tx = graph.beginTx() )
         {
             graph.getReferenceNode().delete();
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 

--- a/community/graphviz/src/main/java/org/neo4j/visualization/graphviz/Script.java
+++ b/community/graphviz/src/main/java/org/neo4j/visualization/graphviz/Script.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -138,14 +139,9 @@ public class Script extends ConfigurationParser
         GraphvizWriter writer = new GraphvizWriter( styles() );
         try
         {
-            Transaction tx = graphdb.beginTx();
-            try
+            try ( Transaction tx = graphdb.beginTx() )
             {
                 writer.emit( outfile, createGraphWalker( graphdb ) );
-            }
-            finally
-            {
-                tx.finish();
             }
         }
         catch ( IOException e )

--- a/community/kernel/src/docs/dev/batchinsert.asciidoc
+++ b/community/kernel/src/docs/dev/batchinsert.asciidoc
@@ -66,7 +66,7 @@ NOTE: This will not perform as good as using the +BatchInserter+ API directly.
 
 Also be aware of the following:
 
-* Starting a transaction or invoking +Transaction.finish()+ or +Transaction.success()+ will do nothing.
+* Starting a transaction or invoking +Transaction.finish()/close()+ or +Transaction.success()+ will do nothing.
 * Invoking the +Transaction.failure()+ method will generate a +NotInTransaction+ exception.
 * +Node.delete()+ and +Node.traverse()+ are not supported.
 * +Relationship.delete()+ is not supported.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/QuickReadPerformanceTest.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/QuickReadPerformanceTest.java
@@ -34,7 +34,7 @@ public class QuickReadPerformanceTest
     public static void main(String ... args) throws Exception
     {
         File storeDir = new File("/tmp/mydb");
-        if(storeDir.exists())
+        if ( storeDir.exists() )
         {
             FileUtils.deleteRecursively(storeDir);
         }
@@ -58,7 +58,8 @@ public class QuickReadPerformanceTest
             System.out.println("Did " + totalReads + " in " + totalTime + "ms.");
             System.out.println(totalReads / totalTime + "reads/ms");
 
-        } finally
+        }
+        finally
         {
             timer.cancel();
             db.shutdown();
@@ -72,8 +73,7 @@ public class QuickReadPerformanceTest
             @Override
             public void run()
             {
-                Transaction tx = db.beginTx();
-                try
+                try ( Transaction tx = db.beginTx() )
                 {
                     Node node1 = db.createNode();
                     Node node2 = db.createNode();
@@ -86,9 +86,6 @@ public class QuickReadPerformanceTest
                     rel.setProperty( "since", 12 );
 
                     tx.success();
-                } finally
-                {
-                    tx.finish();
                 }
             }
         }, 10, 200 );
@@ -111,8 +108,7 @@ public class QuickReadPerformanceTest
             long time = System.currentTimeMillis();
             for ( int i = 0; i < 10; i++ )
             {
-                Transaction tx = graphDb.beginTx();
-                try
+                try ( Transaction tx = graphDb.beginTx() )
                 {
                     for ( Node node : graphDb.getAllNodes() )
                     {
@@ -144,9 +140,6 @@ public class QuickReadPerformanceTest
                             }
                         }
                     }
-                } finally
-                {
-                    tx.finish();
                 }
             }
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Transaction.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Transaction.java
@@ -22,15 +22,52 @@ package org.neo4j.graphdb;
 /**
  * A programmatically handled transaction.
  * <p>
- * <em>All database operations that access the graph, indexes, or the schema must be performed in a transaction.</em> 
+ * <em>All database operations that access the graph, indexes, or the schema must be performed in a transaction.</em>
  * <p>
- * If you attempt to access the graph outside of a transaction, those operations will throw 
+ * If you attempt to access the graph outside of a transaction, those operations will throw
  * {@link NotInTransactionException}.
  * <p>
- * Transactions are bound to the thread in which they were created. Transactions can either be handled 
+ * Transactions are bound to the thread in which they were created. Transactions can either be handled
  * programmatically, through this interface, or by a container through the Java Transaction API (JTA). The
- * Transaction interface makes handling programmatic transactions easier than using JTA programmatically. 
- * Here's the idiomatic use of programmatic transactions in Neo4j:
+ * Transaction interface makes handling programmatic transactions easier than using JTA programmatically.
+ * Here's the idiomatic use of programmatic transactions in Neo4j starting from java 7:
+ * 
+ * <pre>
+ * <code>
+ * try ( Transaction tx = graphDb.beginTx() )
+ * {
+ *     // operations on the graph
+ *     // ...
+ * 
+ *     tx.success();
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * Let's walk through this example line by line. First we retrieve a Transaction
+ * object by invoking the {@link GraphDatabaseService#beginTx()} factory method.
+ * This creates a new transaction which has internal state to keep
+ * track of whether the current transaction is successful. Then we wrap all
+ * operations that modify the graph in a try-finally block with the transaction
+ * as resource. At the end of the block, we invoke the {@link #success() tx.success()}
+ * method to indicate that the transaction is successful. As we exit the block,
+ * the transaction will automatically be closed where {@link #finish() tx.close()}
+ * will be called and commit the transaction if the internal state indicates success
+ * or else mark it for rollback.
+ * <p>
+ * If an exception is raised in the try-block, {@link #success()} will never be
+ * invoked and the internal state of the transaction object will cause
+ * {@link #close()} to roll back the transaction. This is very important:
+ * unless {@link #success()} is invoked, the transaction will fail upon
+ * {@link #close()}. A transaction can be explicitly marked for rollback by
+ * invoking the {@link #failure()} method.
+ * <p>
+ * Read operations inside of a transaction will also read uncommitted data from
+ * the same transaction.
+ * <p>
+ * 
+ * Here's the idiomatic use of programmatic transactions in Neo4j on java 6 or earlier:
  * 
  * <pre>
  * <code>
@@ -39,55 +76,35 @@ package org.neo4j.graphdb;
  * {
  *     // operations on the graph
  *     // ...
- *     
+ * 
  *     tx.success();
  * }
  * finally
  * {
- *     tx.finish();
+ *     tx.close();
  * }
  * </code>
  * </pre>
  * <p>
- * Let's walk through this example line by line. First we retrieve a Transaction
- * object by invoking the {@link GraphDatabaseService#beginTx()} factory method.
- * This creates a new transaction which has internal state to keep
- * track of whether the current transaction is successful. Then we wrap all
- * operations that modify the graph in a try-finally block. At the end
- * of the block, we invoke the {@link #success() tx.success()} method to indicate
- * that the transaction is successful. As we exit the block, the finally clause
- * will kick in and {@link #finish() tx.finish()} will commit the transaction if
- * the internal state indicates success or else mark it for rollback.
- * <p>
- * If an exception is raised in the try-block, {@link #success()} will never be
- * invoked and the internal state of the transaction object will cause
- * {@link #finish()} to roll back the transaction. This is very important:
- * unless {@link #success()} is invoked, the transaction will fail upon
- * {@link #finish()}. A transaction can be explicitly marked for rollback by
- * invoking the {@link #failure()} method.
- * <p>
- * Read operations inside of a transaction will also read uncommitted data from
- * the same transaction.
- * <p>
- * All {@link ResourceIterable ResourceIterables} that where returned from operations executed inside a transaction 
+ * All {@link ResourceIterable ResourceIterables} that where returned from operations executed inside a transaction
  * will be automatically closed when the transaction is committed or rolled back.
  * Note however, that the {@link ResourceIterator} should be {@link ResourceIterator#close() closed} as soon as
  * possible if you don't intend to exhaust the iterator.
  */
-public interface Transaction
+public interface Transaction extends AutoCloseable
 {
     /**
      * Marks this transaction as failed, which means that it will
-     * unconditionally be rolled back when {@link #finish()} is called. Once
+     * unconditionally be rolled back when {@link #close()} is called. Once
      * this method has been invoked, it doesn't matter if
-     * {@link #success()} is invoked afterwards -- the transaction will still be 
+     * {@link #success()} is invoked afterwards -- the transaction will still be
      * rolled back.
      */
     void failure();
 
     /**
      * Marks this transaction as successful, which means that it will be
-     * committed upon invocation of {@link #finish()} unless {@link #failure()}
+     * committed upon invocation of {@link #close()} unless {@link #failure()}
      * has or will be invoked before then.
      */
     void success();
@@ -96,10 +113,36 @@ public interface Transaction
      * Commits or marks this transaction for rollback, depending on whether
      * {@link #success()} or {@link #failure()} has been previously invoked.
      * 
-     * All {@link ResourceIterable ResourceIterables} that where returned from operations executed inside this 
+     * All {@link ResourceIterable ResourceIterables} that where returned from operations executed inside this
      * transaction will be automatically closed by this method.
+     * 
+     * Preferably this method will not be used, instead a {@link Transaction} should participate in a
+     * try-with-resource statement so that {@link #close()} is automatically called instead.
+     * 
+     * Invoking {@link #close()} (which is unnecessary when in try-with-resource statement) or {@link #finish()}
+     * has the exact same effect.
+     * 
+     * @deprecated due to implementing {@link AutoCloseable}, where {@link #close()} is called automatically
+     * when used in try-with-resource statements.
      */
+    @Deprecated
     void finish();
+    
+    /**
+     * Commits or marks this transaction for rollback, depending on whether
+     * {@link #success()} or {@link #failure()} has been previously invoked.
+     * 
+     * All {@link ResourceIterable ResourceIterables} that where returned from operations executed inside this
+     * transaction will be automatically closed by this method.
+     * 
+     * This method comes from {@link AutoCloseable} so that a {@link Transaction} can participate
+     * in try-with-resource statements. It will not throw any declared exception, just like {@link #finish()}.
+     * 
+     * Invoking {@link #close()} (which is unnecessary when in try-with-resource statement) or {@link #finish()}
+     * has the exact same effect.
+     */
+    @Override
+    void close();
     
     /**
      * Acquires a write lock for {@code entity} for this transaction.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/UniqueFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/UniqueFactory.java
@@ -230,8 +230,7 @@ public abstract class UniqueFactory<T extends PropertyContainer>
         boolean wasCreated = false;
         if ( result == null )
         {
-            Transaction tx = graphDatabase().beginTx();
-            try
+            try ( Transaction tx = graphDatabase().beginTx() )
             {
                 Map<String, Object> properties = Collections.singletonMap( key, value );
                 T created = create( properties );
@@ -247,10 +246,6 @@ public abstract class UniqueFactory<T extends PropertyContainer>
                     delete( created );
                 }
                 tx.success();
-            }
-            finally
-            {
-                tx.finish();
             }
         }
         return new UniqueEntity<T>( result, wasCreated );

--- a/community/kernel/src/main/java/org/neo4j/kernel/IndexManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/IndexManagerImpl.java
@@ -269,17 +269,12 @@ class IndexManagerImpl implements IndexManager, IndexProviders
             String dataSourceName = getIndexProvider( provider ).getDataSourceName();
             XaDataSource dataSource = xaDataSourceManager.getXaDataSource( dataSourceName );
             IndexXaConnection connection = (IndexXaConnection) dataSource.getXaConnection();
-            Transaction tx = graphDatabaseAPI.tx().begin();
-            try
+            try ( Transaction tx = graphDatabaseAPI.tx().begin() )
             {
                 javax.transaction.Transaction javaxTx = txManager.getTransaction();
                 connection.enlistResource( javaxTx );
                 connection.createIndex( cls, indexName, config );
                 tx.success();
-            }
-            finally
-            {
-                tx.finish();
             }
             return null;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/PlaceboTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/PlaceboTransaction.java
@@ -39,7 +39,7 @@ public class PlaceboTransaction extends TopLevelTransaction
     }
 
     @Override
-    public void finish()
+    public void close()
     {
         if ( !transactionOutcome.successCalled() && !transactionOutcome.failureCalled() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/TopLevelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/TopLevelTransaction.java
@@ -114,7 +114,13 @@ public class TopLevelTransaction implements Transaction
     }
 
     @Override
-    public void finish()
+    public final void finish()
+    {
+        close();
+    }
+    
+    @Override
+    public void close()
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.RollbackException;
@@ -121,7 +122,7 @@ import static org.neo4j.kernel.impl.transaction.XaDataSourceManager.neoStoreList
  *
  * <ol>
  * <li>
- * tx.finish() --> TransactionImpl.commit() --> *KernelTransaction.commit()* --> TxManager.commit()
+ * tx.close() --> TransactionImpl.commit() --> *KernelTransaction.commit()* --> TxManager.commit()
  * </li>
  * <li>
  * TxManager.commit() --> TransactionImpl.doCommit() --> dataSource.commit()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchGraphDatabaseImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchGraphDatabaseImpl.java
@@ -230,6 +230,11 @@ class BatchGraphDatabaseImpl implements GraphDatabaseService
         public void finish()
         {
         }
+        
+        @Override
+        public void close()
+        {
+        }
 
         @Override
         public void success()

--- a/community/lucene-index/src/test/java/examples/AutoIndexerExampleTests.java
+++ b/community/lucene-index/src/test/java/examples/AutoIndexerExampleTests.java
@@ -19,10 +19,6 @@
  */
 package examples;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -31,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -46,6 +43,10 @@ import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AutoIndexerExampleTests implements GraphHolder
 {
@@ -82,10 +83,9 @@ public class AutoIndexerExampleTests implements GraphHolder
             setConfig( GraphDatabaseSettings.relationship_auto_indexing, "true" ).
             newGraphDatabase();
 
-        Transaction tx = graphDb.beginTx();
         Node node1 = null, node2 = null;
         Relationship rel = null;
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create the primitives
             node1 = graphDb.createNode();
@@ -103,43 +103,36 @@ public class AutoIndexerExampleTests implements GraphHolder
             // Make things persistent
             tx.success();
         }
-        catch ( Exception e )
-        {
-            tx.failure();
-        }
-        finally
-        {
-            tx.finish();
-        }
         // END SNIPPET: ConfigAutoIndexer
 
         // START SNIPPET: APIReadAutoIndex
-        Transaction transaction = graphDb.beginTx();
-        // Get the Node auto index
-        ReadableIndex<Node> autoNodeIndex = graphDb.index()
-                .getNodeAutoIndexer()
-                .getAutoIndex();
-        // node1 and node2 both had auto indexed properties, get them
-        assertEquals( node1,
-                autoNodeIndex.get( "nodeProp1", "nodeProp1Value" ).getSingle() );
-        assertEquals( node2,
-                autoNodeIndex.get( "nodeProp2", "nodeProp2Value" ).getSingle() );
-        // node2 also had a property that should be ignored.
-        assertFalse( autoNodeIndex.get( "nonIndexed",
-                "nodeProp2NonIndexedValue" ).hasNext() );
-
-        // Get the relationship auto index
-        ReadableIndex<Relationship> autoRelIndex = graphDb.index()
-                .getRelationshipAutoIndexer()
-                .getAutoIndex();
-        // One property was set for auto indexing
-        assertEquals( rel,
-                autoRelIndex.get( "relProp1", "relProp1Value" ).getSingle() );
-        // The rest should be ignored
-        assertFalse( autoRelIndex.get( "relPropNonIndexed",
-                "relPropValueNonIndexed" ).hasNext() );
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            // Get the Node auto index
+            ReadableIndex<Node> autoNodeIndex = graphDb.index()
+                    .getNodeAutoIndexer()
+                    .getAutoIndex();
+            // node1 and node2 both had auto indexed properties, get them
+            assertEquals( node1,
+                    autoNodeIndex.get( "nodeProp1", "nodeProp1Value" ).getSingle() );
+            assertEquals( node2,
+                    autoNodeIndex.get( "nodeProp2", "nodeProp2Value" ).getSingle() );
+            // node2 also had a property that should be ignored.
+            assertFalse( autoNodeIndex.get( "nonIndexed",
+                    "nodeProp2NonIndexedValue" ).hasNext() );
+    
+            // Get the relationship auto index
+            ReadableIndex<Relationship> autoRelIndex = graphDb.index()
+                    .getRelationshipAutoIndexer()
+                    .getAutoIndex();
+            // One property was set for auto indexing
+            assertEquals( rel,
+                    autoRelIndex.get( "relProp1", "relProp1Value" ).getSingle() );
+            // The rest should be ignored
+            assertFalse( autoRelIndex.get( "relPropNonIndexed",
+                    "relPropValueNonIndexed" ).hasNext() );
+        }
         // END SNIPPET: APIReadAutoIndex
-        transaction.finish();
         graphDb.shutdown();
     }
 
@@ -170,10 +163,9 @@ public class AutoIndexerExampleTests implements GraphHolder
 
         // END SNIPPET: APIAutoIndexer
 
-        Transaction tx = graphDb.beginTx();
         Node node1 = null, node2 = null;
         Relationship rel = null;
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create the primitives
             node1 = graphDb.createNode();
@@ -191,34 +183,27 @@ public class AutoIndexerExampleTests implements GraphHolder
             // Make things persistent
             tx.success();
         }
-        catch ( Exception e )
-        {
-            tx.failure();
-        }
-        finally
-        {
-            tx.finish();
-        }
 
-        Transaction transaction = graphDb.beginTx();
-        // Get the Node auto index
-        ReadableIndex<Node> autoNodeIndex = nodeAutoIndexer.getAutoIndex();
-        // node1 and node2 both had auto indexed properties, get them
-        assertEquals( node1,
-                autoNodeIndex.get( "nodeProp1", "nodeProp1Value" ).getSingle() );
-        assertEquals( node2,
-                autoNodeIndex.get( "nodeProp2", "nodeProp2Value" ).getSingle() );
-        // node2 also had a property that should be ignored.
-        assertFalse( autoNodeIndex.get( "nonIndexed",
-                "nodeProp2NonIndexedValue" ).hasNext() );
-
-        // Get the relationship auto index
-        ReadableIndex<Relationship> autoRelIndex = relAutoIndexer.getAutoIndex();
-        // All properties ignored
-        assertEquals( rel,
-                autoRelIndex.get( "relProp1", "relProp1Value1" ).getSingle() );
-        assertFalse( autoRelIndex.get( "relPropNonIndexed", "relProp1Value2" ).hasNext() );
-        transaction.finish();
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            // Get the Node auto index
+            ReadableIndex<Node> autoNodeIndex = nodeAutoIndexer.getAutoIndex();
+            // node1 and node2 both had auto indexed properties, get them
+            assertEquals( node1,
+                    autoNodeIndex.get( "nodeProp1", "nodeProp1Value" ).getSingle() );
+            assertEquals( node2,
+                    autoNodeIndex.get( "nodeProp2", "nodeProp2Value" ).getSingle() );
+            // node2 also had a property that should be ignored.
+            assertFalse( autoNodeIndex.get( "nonIndexed",
+                    "nodeProp2NonIndexedValue" ).hasNext() );
+    
+            // Get the relationship auto index
+            ReadableIndex<Relationship> autoRelIndex = relAutoIndexer.getAutoIndex();
+            // All properties ignored
+            assertEquals( rel,
+                    autoRelIndex.get( "relProp1", "relProp1Value1" ).getSingle() );
+            assertFalse( autoRelIndex.get( "relPropNonIndexed", "relProp1Value2" ).hasNext() );
+        }
         graphDb.shutdown();
     }
 
@@ -236,9 +221,8 @@ public class AutoIndexerExampleTests implements GraphHolder
             setConfig( GraphDatabaseSettings.node_auto_indexing, "true" ).
             newGraphDatabase();
 
-        Transaction tx = graphDb.beginTx();
         Node node1 = null, node2 = null, node3 = null, node4 = null;
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             // Create the primitives
             node1 = graphDb.createNode();
@@ -255,14 +239,6 @@ public class AutoIndexerExampleTests implements GraphHolder
             // Make things persistent
             tx.success();
         }
-        catch ( Exception e )
-        {
-            tx.failure();
-        }
-        finally
-        {
-            tx.finish();
-        }
 
         /*
          *  Here both nodes are indexed. To demonstrate removal, we stop
@@ -271,8 +247,7 @@ public class AutoIndexerExampleTests implements GraphHolder
         AutoIndexer<Node> nodeAutoIndexer = graphDb.index().getNodeAutoIndexer();
         nodeAutoIndexer.stopAutoIndexingProperty( "nodeProp1" );
 
-        tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             /*
              * nodeProp1 is no longer auto indexed. It will be
@@ -290,35 +265,28 @@ public class AutoIndexerExampleTests implements GraphHolder
             // Make things persistent
             tx.success();
         }
-        catch ( Exception e )
-        {
-            tx.failure();
-        }
-        finally
-        {
-            tx.finish();
-        }
 
-        Transaction transaction = graphDb.beginTx();
-        // Verify
-        ReadableIndex<Node> nodeAutoIndex = nodeAutoIndexer.getAutoIndex();
-        // node1 is completely gone
-        assertFalse( nodeAutoIndex.get( "nodeProp1", "nodeProp1Value" ).hasNext() );
-        assertFalse( nodeAutoIndex.get( "nodeProp1", "nodeProp1Value2" ).hasNext() );
-        // node2 is updated
-        assertFalse( nodeAutoIndex.get( "nodeProp2", "nodeProp2Value" ).hasNext() );
-        assertEquals( node2,
-                nodeAutoIndex.get( "nodeProp2", "nodeProp2Value2" ).getSingle() );
-        /*
-         * node3 is still there, despite its nodeProp1 property not being monitored
-         * any more because it was not touched, in contrast with node1.
-         */
-        assertEquals( node3,
-                nodeAutoIndex.get( "nodeProp1", "nodeProp3Value" ).getSingle() );
-        // Finally, node4 is removed because the property was removed.
-        assertFalse( nodeAutoIndex.get( "nodeProp2", "nodeProp4Value" ).hasNext() );
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            // Verify
+            ReadableIndex<Node> nodeAutoIndex = nodeAutoIndexer.getAutoIndex();
+            // node1 is completely gone
+            assertFalse( nodeAutoIndex.get( "nodeProp1", "nodeProp1Value" ).hasNext() );
+            assertFalse( nodeAutoIndex.get( "nodeProp1", "nodeProp1Value2" ).hasNext() );
+            // node2 is updated
+            assertFalse( nodeAutoIndex.get( "nodeProp2", "nodeProp2Value" ).hasNext() );
+            assertEquals( node2,
+                    nodeAutoIndex.get( "nodeProp2", "nodeProp2Value2" ).getSingle() );
+            /*
+             * node3 is still there, despite its nodeProp1 property not being monitored
+             * any more because it was not touched, in contrast with node1.
+             */
+            assertEquals( node3,
+                    nodeAutoIndex.get( "nodeProp1", "nodeProp3Value" ).getSingle() );
+            // Finally, node4 is removed because the property was removed.
+            assertFalse( nodeAutoIndex.get( "nodeProp2", "nodeProp4Value" ).hasNext() );
+        }
         // END SNIPPET: Mutations
-        transaction.finish();
         graphDb.shutdown();
     }
 
@@ -342,7 +310,10 @@ public class AutoIndexerExampleTests implements GraphHolder
     @AfterClass
     public static void stopDatabase()
     {
-        if ( graphdb != null ) graphdb.shutdown();
+        if ( graphdb != null )
+        {
+            graphdb.shutdown();
+        }
         graphdb = null;
     }
 
@@ -351,5 +322,4 @@ public class AutoIndexerExampleTests implements GraphHolder
     {
         return graphdb;
     }
-
 }

--- a/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
+++ b/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
@@ -43,8 +43,7 @@ public class RelatedNodesQuestionTest
     public void question5346011()
     {
         GraphDatabaseService service = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        Transaction transaction = service.beginTx();
-        try
+        try ( Transaction tx = service.beginTx() )
         {
             RelationshipIndex index = service.index().forRelationships( "exact" );
             // ...creation of the nodes and relationship
@@ -56,11 +55,7 @@ public class RelatedNodesQuestionTest
             // query
             IndexHits<Relationship> hits = index.get( "uuid", a_uuid, node1, node2 );
             assertEquals( 1, hits.size() );
-            transaction.success();
-        }
-        finally
-        {
-            transaction.finish();
+            tx.success();
         }
         service.shutdown();
     }

--- a/community/server/src/main/java/org/neo4j/server/plugins/PluginMethod.java
+++ b/community/server/src/main/java/org/neo4j/server/plugins/PluginMethod.java
@@ -49,17 +49,12 @@ class PluginMethod extends PluginPoint
             throws BadPluginInvocationException, PluginInvocationFailureException, BadInputException
     {
         Object[] arguments = new Object[extractors.length];
-        Transaction tx = graphDb.beginTx();
-        try
+        try ( Transaction tx = graphDb.beginTx() )
         {
             for ( int i = 0; i < arguments.length; i++ )
             {
                 arguments[i] = extractors[i].extract( graphDb, source, params );
             }
-        }
-        finally
-        {
-            tx.finish();
         }
         try
         {
@@ -69,17 +64,17 @@ class PluginMethod extends PluginPoint
             {
                 return Representation.emptyRepresentation();
             }
-            else
-            {
-                return result.convert( returned );
-            }
+            return result.convert( returned );
         }
         catch ( InvocationTargetException exc )
         {
             Throwable targetExc = exc.getTargetException();
             for ( Class<?> excType : method.getExceptionTypes() )
             {
-                if ( excType.isInstance( targetExc ) ) throw new BadPluginInvocationException( targetExc );
+                if ( excType.isInstance( targetExc ) )
+                {
+                    throw new BadPluginInvocationException( targetExc );
+                }
             }
             throw new PluginInvocationFailureException( targetExc );
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
@@ -57,16 +57,12 @@ public class PropertySettingStrategy
                 new HashMap<String, Object>() :
                 properties;
 
-        Transaction tx = db.beginTx();
-        try {
-
+        try ( Transaction tx = db.beginTx() )
+        {
             setProperties( entity, properties );
             ensureHasOnlyTheseProperties( entity, propsToSet.keySet() );
 
             tx.success();
-        } finally
-        {
-            tx.finish();
         }
     }
 
@@ -85,28 +81,22 @@ public class PropertySettingStrategy
     {
         if ( properties != null )
         {
-            Transaction tx = db.beginTx();
-            try {
+            try ( Transaction tx = db.beginTx() )
+            {
                 for ( Map.Entry<String, Object> property : properties.entrySet() )
                 {
-                    setProperty(
-                            entity,
-                            property.getKey(),
-                            property.getValue() );
+                    setProperty( entity, property.getKey(), property.getValue() );
                 }
                 tx.success();
-            } finally
-            {
-                tx.finish();
             }
         }
     }
 
     public void setProperty(PropertyContainer entity, String key, Object value) throws PropertyValueException
     {
-        if(value instanceof Collection)
+        if ( value instanceof Collection )
         {
-            if(((Collection<?>)value).size() == 0)
+            if ( ((Collection<?>) value).size() == 0 )
             {
                 // Special case: Trying to set an empty array property. We cannot determine the type
                 // of the collection now, so we fall back to checking if there already is a collection
@@ -116,16 +106,16 @@ public class PropertySettingStrategy
                 if(currentValue != null &&
                    currentValue.getClass().isArray())
                 {
-                    if(Array.getLength( currentValue ) == 0)
+                    if ( Array.getLength( currentValue ) == 0 )
                     {
                         // Ok, leave it this way
                         return;
-                    } else
-                    {
-                        value = emptyArrayOfType(currentValue.getClass().getComponentType());
                     }
+                    
+                    value = emptyArrayOfType(currentValue.getClass().getComponentType());
 
-                } else
+                }
+                else
                 {
                     throw new PropertyValueException(
                             "Unable to set property '" + key + "' to an empty array, " +
@@ -133,15 +123,15 @@ public class PropertySettingStrategy
                             "and no pre-existing collection to infer type from, it is not possible " +
                             "to determine what type of array to store." );
                 }
-            } else
+            }
+            else
             {
                 // Non-empty collection
                 value = convertToNativeArray( (Collection<?>) value );
             }
         }
 
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             entity.setProperty( key, value );
             tx.success();
@@ -149,10 +139,6 @@ public class PropertySettingStrategy
         catch ( IllegalArgumentException e )
         {
             throw new PropertyValueException( key, value );
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/StartupTimeoutDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/StartupTimeoutDocIT.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -46,6 +47,7 @@ import org.neo4j.tooling.GlobalGraphOperations;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.Platforms.platformIsWindows;
 
 public class StartupTimeoutDocIT
@@ -72,7 +74,9 @@ public class StartupTimeoutDocIT
     public void shouldTimeoutIfStartupTakesLongerThanTimeout() throws IOException
     {
         if(platformIsWindows())
+        {
             return;
+        }
 
         Configurator configurator = buildProperties();
         configurator.configuration().setProperty( Configurator.STARTUP_TIMEOUT, 1 );
@@ -90,7 +94,7 @@ public class StartupTimeoutDocIT
     }
 
 	@Test
-	public void shouldNotFailIfStartupTakesLessTimeThanTimeout() throws IOException 
+	public void shouldNotFailIfStartupTakesLessTimeThanTimeout() throws IOException
 	{
 		Configurator configurator = buildProperties();
 		configurator.configuration().setProperty(Configurator.STARTUP_TIMEOUT, 100);
@@ -120,7 +124,7 @@ public class StartupTimeoutDocIT
 	}
     
 	@Test
-	public void shouldNotTimeOutIfTimeoutDisabled() throws IOException 
+	public void shouldNotTimeOutIfTimeoutDisabled() throws IOException
 	{
         Configurator configurator = buildProperties();
         configurator.configuration().setProperty( Configurator.STARTUP_TIMEOUT, 0 );
@@ -194,19 +198,22 @@ public class StartupTimeoutDocIT
     ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
 
     @Test
-    public void shoulWOrk() throws Exception
+    public void shoulWork() throws Exception
     {
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
-        Transaction tx = db.beginTx();
-        db.createNode();
-        tx.success();
-        tx.finish();
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
 
         clearAll();
         
-        tx = db.beginTx();
-        db.createNode();
-        tx.success();tx.finish();
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
 
         clearAll();
     }

--- a/community/server/src/test/java/org/neo4j/server/WrappingNeoServerBootstrapperDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/WrappingNeoServerBootstrapperDocIT.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.ClientResponse.Status;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.Settings;
 import org.neo4j.jmx.Primitives;
@@ -46,7 +46,11 @@ import org.neo4j.test.TestData;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientResponse.Status;
+
 import static java.lang.String.format;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -165,8 +169,7 @@ public class WrappingNeoServerBootstrapperDocIT extends ExclusiveServerTestBase
     @Test
     public void shouldResponseAndBeAbleToModifyDb()
     {
-        WrappingNeoServerBootstrapper srv = new WrappingNeoServerBootstrapper(
-                myDb );
+        WrappingNeoServerBootstrapper srv = new WrappingNeoServerBootstrapper( myDb );
         srv.start();
 
         long originalNodeNumber = myDb.getDependencyResolver().resolveDependency( JmxKernelExtension.class )
@@ -188,7 +191,9 @@ public class WrappingNeoServerBootstrapperDocIT extends ExclusiveServerTestBase
         srv.stop();
 
         // Should be able to still talk to the db
-        myDb.beginTx();
-        assertTrue( myDb.getReferenceNode() != null );
+        try ( Transaction tx = myDb.beginTx() )
+        {
+            assertTrue( myDb.getReferenceNode() != null );
+        }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexDocIT.java
@@ -19,23 +19,23 @@
  */
 package org.neo4j.server.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
-import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.server.rest.web.RestfulGraphDatabase;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphDescription.NODE;
 import org.neo4j.test.GraphDescription.PROP;
 import org.neo4j.test.GraphDescription.REL;
 import org.neo4j.test.TestData.Title;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
 {
@@ -47,7 +47,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @Graph( nodes = { @NODE( name = "I", setNameProperty = true ) }, autoIndexNodes = true )
-    public void shouldRetrieveFromAutoIndexByQuery() throws PropertyValueException
+    public void shouldRetrieveFromAutoIndexByQuery()
     {
         data.get();
         assertSize( 1, gen.get()
@@ -69,7 +69,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @Graph( nodes = { @NODE( name = "I", setNameProperty = true ) }, autoIndexNodes = true )
-    public void find_node_by_exact_match_from_an_automatic_index() throws PropertyValueException
+    public void find_node_by_exact_match_from_an_automatic_index()
     {
         data.get();
         assertSize( 1, gen.get()
@@ -103,7 +103,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Title( "Node AutoIndex is not removable" )
     @Graph( nodes = { @NODE( name = "I", setNameProperty = true ) }, autoIndexNodes = true )
-    public void AutoIndex_is_not_removable() throws  JsonParseException
+    public void AutoIndex_is_not_removable()
     {
         gen.get()
                 .noGraph()
@@ -156,8 +156,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
                 .getRelationshipAutoIndexer()
                 .getAutoIndex()
                 .getName();
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             gen.get()
                     .noGraph()
@@ -170,10 +169,6 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
                     .post( postRelationshipIndexUri( indexName ) )
                     .entity();
         }
-        finally
-        {
-            transaction.finish();
-        }
     }
 
     /**
@@ -183,7 +178,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Graph( nodes = { @NODE( name = "I", setNameProperty = true ) }, autoIndexNodes = true )
     @Title( "Automatically indexed nodes cannot be removed from the index manually" )
-    public void autoindexed_items_cannot_be_removed_manually() throws  JsonParseException
+    public void autoindexed_items_cannot_be_removed_manually()
     {
         long id = data.get()
                 .get( "I" )
@@ -216,11 +211,9 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Graph( nodes = { @NODE( name = "I" ), @NODE( name = "you" ) }, relationships = { @REL( start = "I", end = "you", type = "know", properties = { @PROP( key = "since", value = "today" ) } ) }, autoIndexRelationships = true )
     @Title( "Automatically indexed relationships cannot be removed from the index manually" )
-    public void autoindexed_relationships_cannot_be_removed_manually() throws 
-            JsonParseException
+    public void autoindexed_relationships_cannot_be_removed_manually()
     {
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             long id = data.get()
                     .get( "I" )
@@ -248,10 +241,6 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
                     .delete( getDataUri() + "index/relationship/" + indexName + "/" + id )
                     .entity();
         }
-        finally
-        {
-            transaction.finish();
-        }
     }
 
     /**
@@ -261,7 +250,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Title( "Find relationship by query from an automatic index" )
     @Test
     @Graph( nodes = { @NODE( name = "I" ), @NODE( name = "you" ) }, relationships = { @REL( start = "I", end = "you", type = "know", properties = { @PROP( key = "since", value = "today" ) } ) }, autoIndexRelationships = true )
-    public void Find_relationship_by_query_from_an_automatic_index() throws PropertyValueException
+    public void Find_relationship_by_query_from_an_automatic_index()
     {
         data.get();
         assertSize( 1, gen.get()
@@ -278,7 +267,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
     @Title( "Find relationship by exact match from an automatic index" )
     @Test
     @Graph( nodes = { @NODE( name = "I" ), @NODE( name = "you" ) }, relationships = { @REL( start = "I", end = "you", type = "know", properties = { @PROP( key = "since", value = "today" ) } ) }, autoIndexRelationships = true )
-    public void Find_relationship_by_exact_match_from_an_automatic_index() throws PropertyValueException
+    public void Find_relationship_by_exact_match_from_an_automatic_index()
     {
         data.get();
         assertSize( 1, gen.get()
@@ -403,6 +392,7 @@ public class AutoIndexDocIT extends AbstractRestFunctionalTestBase
         assertTrue(properties.contains("myProperty1"));
     }
 
+    @SuppressWarnings( "unchecked" )
     private List<String> getAutoIndexedPropertiesForType(String uriPartForType)
             throws JsonParseException
     {

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
@@ -19,28 +19,28 @@
  */
 package org.neo4j.server.rest;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
-import static org.neo4j.graphdb.Neo4jMatchers.inTx;
-
 import java.util.List;
 import java.util.Map;
 
 import org.json.JSONException;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.GraphDescription.Graph;
 
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.UniformInterfaceException;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
+import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 
 public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
 {
@@ -76,7 +76,8 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     @SuppressWarnings( "unchecked" )
     @Test
     @Graph("Joe knows John")
-    public void shouldPerformMultipleOperations() throws Exception {
+    public void shouldPerformMultipleOperations() throws Exception
+    {
         long idJoe = data.get().get( "Joe" ).getId();
         String jsonString = new PrettyJSON()
             .array()
@@ -163,7 +164,8 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldBeAbleToReferToCreatedResource() throws Exception {
+    public void shouldBeAbleToReferToCreatedResource() throws Exception
+    {
         String jsonString = new PrettyJSON()
             .array()
                 .object()
@@ -229,12 +231,11 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     private String batchUri()
     {
         return getDataUri()+"batch";
-        
     }
 
     @Test
-    public void shouldGetLocationHeadersWhenCreatingThings() throws Exception {
-
+    public void shouldGetLocationHeadersWhenCreatingThings() throws Exception
+    {
         int originalNodeCount = countNodes();
 
         final String jsonString = new PrettyJSON()
@@ -263,14 +264,14 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldForwardUnderlyingErrors() throws Exception {
-
+    public void shouldForwardUnderlyingErrors() throws Exception
+    {
         JaxRsResponse response = RestRequest.req().post(batchUri(), new PrettyJSON()
             .array()
                 .object()
                     .key("method") .value("POST")
                     .key("to")     .value("/node")
-                    .key("body")   
+                    .key("body")
                         .object()
                             .key("age")
                                 .array()
@@ -288,8 +289,9 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
     
     @Test
-    public void shouldRollbackAllWhenGivenIncorrectRequest() throws JsonParseException, ClientHandlerException,
-            UniformInterfaceException, JSONException {
+    public void shouldRollbackAllWhenGivenIncorrectRequest() throws ClientHandlerException,
+            UniformInterfaceException, JSONException
+    {
 
         String jsonString = new PrettyJSON()
             .array()
@@ -319,12 +321,12 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         assertEquals(500, response.getStatus());
         assertEquals(originalNodeCount, countNodes());
-
     }
     
     @Test
     @SuppressWarnings("unchecked")
-    public void shouldHandleUnicodeGetCorrectly() throws Exception {
+    public void shouldHandleUnicodeGetCorrectly() throws Exception
+    {
         String asianText = "\u4f8b\u5b50";
         String germanText = "öäüÖÄÜß";
         
@@ -358,8 +360,8 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void shouldHandleFailingCypherStatementCorrectly() throws Exception {
+    public void shouldHandleFailingCypherStatementCorrectly() throws Exception
+    {
         String jsonString = new PrettyJSON()
             .array()
                 .object()
@@ -394,7 +396,8 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     @Test
     @Graph("Peter likes Jazz")
     public void shouldHandleEscapedStrings() throws ClientHandlerException,
-            UniformInterfaceException, JSONException, PropertyValueException {
+            UniformInterfaceException, JSONException, PropertyValueException
+    {
     	String string = "Jazz";
         Node gnode = getNode( string );
         assertThat( gnode, inTx(graphdb(), hasProperty( "name" ).withValue(string)) );
@@ -438,8 +441,9 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldRollbackAllWhenInsertingIllegalData() throws JsonParseException, ClientHandlerException,
-            UniformInterfaceException, JSONException {
+    public void shouldRollbackAllWhenInsertingIllegalData() throws ClientHandlerException,
+            UniformInterfaceException, JSONException
+    {
 
         String jsonString = new PrettyJSON()
             .array()
@@ -476,8 +480,9 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldRollbackAllOnSingle404() throws JsonParseException, ClientHandlerException,
-            UniformInterfaceException, JSONException {
+    public void shouldRollbackAllOnSingle404() throws ClientHandlerException,
+            UniformInterfaceException, JSONException
+    {
 
         String jsonString = new PrettyJSON()
             .array()
@@ -502,11 +507,11 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         assertEquals(500, response.getStatus());
         assertEquals(originalNodeCount, countNodes());
-
     }
     
     @Test
-    public void shouldBeAbleToReferToUniquelyCreatedEntities() throws Exception {
+    public void shouldBeAbleToReferToUniquelyCreatedEntities() throws Exception
+    {
         String jsonString = new PrettyJSON()
             .array()
                 .object()
@@ -549,7 +554,8 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     // It has to be possible to create relationships among created and not-created nodes
     // in batch operation.  Tests the fix for issue #690.
     @Test
-    public void shouldBeAbleToReferToNotCreatedUniqueEntities() throws Exception {
+    public void shouldBeAbleToReferToNotCreatedUniqueEntities() throws Exception
+    {
         String jsonString = new PrettyJSON()
             .array()
                 .object()
@@ -665,19 +671,14 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     
     private int countNodes()
     {
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             int count = 0;
-            for(Node node : graphdb().getAllNodes())
+            for ( Node node : graphdb().getAllNodes() )
             {
                 count++;
             }
             return count;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/CreateRelationshipDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CreateRelationshipDocTest.java
@@ -60,14 +60,9 @@ public class CreateRelationshipDocTest extends
         gen.get().expectedStatus(
                 Status.CREATED.getStatusCode() ).payload( jsonString ).post(
                 getNodeUri( i ) + "/relationships" );
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             assertTrue( i.hasRelationship( DynamicRelationshipType.withName( "LOVES" ) ) );
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 
@@ -90,14 +85,9 @@ public class CreateRelationshipDocTest extends
         String entity = gen.get().expectedStatus(
                 Status.CREATED.getStatusCode() ).payload( jsonString ).post(
                 getNodeUri( i ) + "/relationships" ).entity();
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             assertTrue( i.hasRelationship( DynamicRelationshipType.withName( "LOVES" ) ) );
-        }
-        finally
-        {
-            transaction.finish();
         }
         assertProperRelationshipRepresentation( JsonHelper.jsonToMap( entity ) );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response.Status;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -34,6 +35,7 @@ import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.Graph;
+import org.neo4j.test.GraphDescription.LABEL;
 import org.neo4j.test.GraphDescription.NODE;
 import org.neo4j.test.GraphDescription.PROP;
 import org.neo4j.test.GraphDescription.REL;
@@ -45,9 +47,11 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.server.rest.domain.JsonHelper.jsonToMap;
-import static org.neo4j.test.GraphDescription.LABEL;
 
 public class CypherDocIT extends AbstractRestFunctionalTestBase {
 
@@ -347,10 +351,11 @@ public class CypherDocIT extends AbstractRestFunctionalTestBase {
         Node i = this.getNode(nodeName);
         GraphDatabaseService db = i.getGraphDatabase();
 
-        Transaction tx = db.beginTx();
-        i.setProperty(propertyName, propertyValue);
-        tx.success();
-        tx.finish();
+        try ( Transaction tx = db.beginTx() )
+        {
+            i.setProperty(propertyName, propertyValue);
+            tx.success();
+        }
     }
 
     /**

--- a/community/server/src/test/java/org/neo4j/server/rest/GetOnRootDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetOnRootDocIT.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.Version;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.RESTDocsGenerator.ResponseEntity;
 import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.repr.formats.StreamingJsonFormat;
+import org.neo4j.server.rest.repr.StreamingFormat;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.TestData.Title;
 
@@ -101,12 +101,13 @@ public class GetOnRootDocIT extends AbstractRestFunctionalTestBase
     private long setReferenceNodeIdToI()
     {
         InternalAbstractGraphDatabase db = (InternalAbstractGraphDatabase) graphdb();
-        Transaction tx = db.beginTx();
-        long referenceNodeId = data.get().get( "I" ).getId();
-        db.getNodeManager().setReferenceNodeId( referenceNodeId );
-        tx.success();
-        tx.finish();
-        return referenceNodeId;
+        try ( Transaction tx = db.beginTx() )
+        {
+            long referenceNodeId = data.get().get( "I" ).getId();
+            db.getNodeManager().setReferenceNodeId( referenceNodeId );
+            tx.success();
+            return referenceNodeId;
+        }
     }
 
     /**
@@ -129,7 +130,7 @@ public class GetOnRootDocIT extends AbstractRestFunctionalTestBase
         data.get();
         setReferenceNodeIdToI();
         ResponseEntity responseEntity = gen().docHeadingLevel( 2 )
-                .withHeader( StreamingJsonFormat.STREAM_HEADER, "true" )
+                .withHeader( StreamingFormat.STREAM_HEADER, "true" )
                 .expectedType( APPLICATION_JSON_TYPE )
                 .expectedStatus( 200 )
                 .get( getDataUri() );
@@ -138,7 +139,7 @@ public class GetOnRootDocIT extends AbstractRestFunctionalTestBase
         // ; stream=true at the end
         String foundMediaType = response.getType()
                 .toString();
-        String expectedMediaType = StreamingJsonFormat.MEDIA_TYPE.toString();
+        String expectedMediaType = StreamingFormat.MEDIA_TYPE.toString();
         assertEquals( expectedMediaType, foundMediaType );
 
         String body = responseEntity.entity();

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexNodeDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexNodeDocIT.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.server.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
-import static org.neo4j.graphdb.Neo4jMatchers.inTx;
-import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
-
-import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,6 +35,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -59,13 +50,23 @@ import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.domain.URIHelper;
 import org.neo4j.server.rest.web.PropertyValueException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
+import static org.neo4j.graphdb.Neo4jMatchers.inTx;
+import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
+
 public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
 {
     private static FunctionalTestHelper functionalTestHelper;
     private static GraphDbHelper helper;
 
     @BeforeClass
-    public static void setupServer() throws IOException
+    public static void setupServer()
     {
         functionalTestHelper = new FunctionalTestHelper( server() );
         helper = functionalTestHelper.getGraphDbHelper();
@@ -81,16 +82,12 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
     long createNode()
     {
         GraphDatabaseAPI graphdb = server().getDatabase().getGraph();
-        Transaction tx = graphdb.beginTx();
-        Node node;
-        try {
-            node = graphdb.createNode();
-
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            Node node = graphdb.createNode();
             tx.success();
-        } finally {
-            tx.finish();
+            return node.getId();
         }
-        return node.getId();
     }
 
     /**
@@ -120,11 +117,11 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldCreateANamedNodeIndex() throws JsonParseException
+    public void shouldCreateANamedNodeIndex()
     {
         String indexName = "favorites";
         int expectedIndexes = helper.getNodeIndexes().length + 1;
-        Map<String, String> indexSpecification = new HashMap<String, String>();
+        Map<String, String> indexSpecification = new HashMap<>();
         indexSpecification.put( "name", indexName );
 
         gen().noGraph()
@@ -138,11 +135,11 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldCreateANamedNodeIndexWithSpaces() throws JsonParseException
+    public void shouldCreateANamedNodeIndexWithSpaces()
     {
         String indexName = "favorites with spaces";
         int expectedIndexes = helper.getNodeIndexes().length + 1;
-        Map<String, String> indexSpecification = new HashMap<String, String>();
+        Map<String, String> indexSpecification = new HashMap<>();
         indexSpecification.put( "name", indexName );
 
         gen()
@@ -215,7 +212,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
 
     private Object generateNodeIndexCreationPayload( String key, String value, String nodeUri )
     {
-        Map<String, String> results = new HashMap<String, String>();
+        Map<String, String> results = new HashMap<>();
         results.put( "key", key );
         results.put( "value", value );
         results.put( "uri", nodeUri );
@@ -415,8 +412,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      * "http://uri.for.node.to.index"
      */
     @Test
-    public void shouldRespondWith201CreatedWhenIndexingJsonNodeUri() throws 
-            JsonParseException
+    public void shouldRespondWith201CreatedWhenIndexingJsonNodeUri()
     {
         final long nodeId = helper.createNode();
         final String key = "key";
@@ -512,7 +508,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         assertEquals( 201, responseToPost.getStatus() );
         String indexLocation2 = responseToPost.getHeaders()
                 .getFirst( HttpHeaders.LOCATION );
-        Map<String, String> uriToName = new HashMap<String, String>();
+        Map<String, String> uriToName = new HashMap<>();
         uriToName.put( indexLocation1, name1 );
         uriToName.put( indexLocation2, name2 );
         responseToPost.close();
@@ -551,7 +547,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldReturn204WhenRemovingNodeIndexes() throws  JsonParseException
+    public void shouldReturn204WhenRemovingNodeIndexes()
     {
         String indexName = "kvnode";
         helper.createNodeIndex( indexName );
@@ -570,7 +566,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldBeAbleToRemoveIndexingById() throws  JsonParseException
+    public void shouldBeAbleToRemoveIndexingById()
     {
         String key1 = "kvkey1";
         String key2 = "kvkey2";
@@ -602,7 +598,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldBeAbleToRemoveIndexingByIdAndKey() throws  JsonParseException
+    public void shouldBeAbleToRemoveIndexingByIdAndKey()
     {
         String key1 = "kvkey1";
         String key2 = "kvkey2";
@@ -634,7 +630,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldBeAbleToRemoveIndexingByIdAndKeyAndValue() throws JsonParseException
+    public void shouldBeAbleToRemoveIndexingByIdAndKeyAndValue()
     {
         String key1 = "kvkey1";
         String key2 = "kvkey2";
@@ -757,15 +753,10 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         Map<String, Object> data = assertCast( Map.class, result.get( "data" ) );
         assertEquals( value, data.get( key ) );
         assertEquals(Arrays.asList( 1, 2, 3), data.get( "array" ) );
-        Transaction transaction = graphdb().beginTx();
         Node node;
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             node = graphdb().index().forNodes(index).get(key, value).getSingle();
-        }
-        finally
-        {
-            transaction.finish();
         }
         assertThat(node, inTx( graphdb(), hasProperty( key ).withValue( value ) ));
         assertThat(node, inTx( graphdb(), hasProperty( "array" ).withValue( new int[]{1, 2, 3} ) ));
@@ -775,7 +766,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      * Get or create unique node (existing).
      * 
      * Here,
-     * a node is not created but the existing unique node returned, since another node 
+     * a node is not created but the existing unique node returned, since another node
      * is indexed with the same data already. The node data returned is then that of the
      * already existing node.
      */
@@ -786,8 +777,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         final String index = "people", key = "name", value = "Peter";
 
         GraphDatabaseService graphdb = graphdb();
-        Transaction tx = graphdb.beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             Node peter = graphdb.createNode();
             peter.setProperty( key, value );
@@ -795,10 +785,6 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
             graphdb.index().forNodes( index ).add( peter, key, value );
 
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
 
         helper.createNodeIndex( index );
@@ -851,7 +837,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      * 
      * Here, in case
      * of an already existing node, an error should be returned. In this
-     * example, an existing node indexed with the same data 
+     * example, an existing node indexed with the same data
      * is found and an error is returned.
      */
     @Documented
@@ -863,8 +849,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         GraphDatabaseService graphdb = graphdb();
         helper.createNodeIndex( index );
         
-        Transaction tx = graphdb.beginTx();
-        try
+        try ( Transaction tx = graphdb.beginTx() )
         {
             Node peter = graphdb.createNode();
             peter.setProperty( key, value );
@@ -873,12 +858,8 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
 
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
        
-        final RestRequest request = RestRequest.req();
+        RestRequest.req();
         
         ResponseEntity response = gen.get().noGraph()
                                     .expectedStatus( 409 /* conflict */)
@@ -899,7 +880,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
     
     /**
      * Backward Compatibility Test (using old syntax ?unique)
-     * Put node if absent - Create. 
+     * Put node if absent - Create.
      * 
      * Add a node to an index unless a node already exists for the given index data. In
      * this case, a new node is created since nothing existing is found in the index.

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipDocIT.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.server.rest;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
-
-import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +33,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -55,6 +49,14 @@ import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.domain.URIHelper;
 import org.neo4j.server.rest.web.PropertyValueException;
 
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
+
 public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
 {
     private static FunctionalTestHelper functionalTestHelper;
@@ -62,12 +64,12 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     private static RestRequest request;
 
     private enum MyRelationshipTypes implements RelationshipType
-	 {
-	     KNOWS
-	 }
-    
+    {
+        KNOWS
+    }
+
     @BeforeClass
-    public static void setupServer() throws IOException
+    public static void setupServer()
     {
         functionalTestHelper = new FunctionalTestHelper( server() );
         helper = functionalTestHelper.getGraphDbHelper();
@@ -105,16 +107,13 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         String indexName = "favorites";
         int expectedIndexes = helper.getRelationshipIndexes().length + 1;
-        Map<String, String> indexSpecification = new HashMap<String, String>();
+        Map<String, String> indexSpecification = new HashMap<>();
         indexSpecification.put( "name", indexName );
         JaxRsResponse response = httpPostIndexRelationshipRoot( JsonHelper.createJsonFrom( indexSpecification ) );
         assertEquals( 201, response.getStatus() );
-        assertNotNull( response.getHeaders()
-                .get( "Location" )
-                .get( 0 ) );
+        assertNotNull( response.getHeaders().get( "Location" ).get( 0 ) );
         assertEquals( expectedIndexes, helper.getRelationshipIndexes().length );
         assertNotNull( helper.createRelationshipIndex( indexName ) );
-
         // Add a relationship to the index
         String key = "key";
         String value = "value";
@@ -125,41 +124,35 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         String indexUri = response.getHeaders().get( "Location" ).get( 0 );
         assertNotNull( indexUri );
         assertEquals( Arrays.asList( (Long) relationshipId ), helper.getIndexedRelationships( indexName, key, value ) );
-
         // Get the relationship from the indexed URI (Location in header)
         response = httpGet( indexUri );
         assertEquals( 200, response.getStatus() );
-
         String discovredEntity = response.getEntity();
-
         Map<String, Object> map = JsonHelper.jsonToMap( discovredEntity );
         assertNotNull( map.get( "self" ) );
     }
 
     private JaxRsResponse httpPostIndexRelationshipRoot( String jsonIndexSpecification )
     {
-        return RestRequest.req()
-                .post( functionalTestHelper.relationshipIndexUri(), jsonIndexSpecification );
+        return RestRequest.req().post( functionalTestHelper.relationshipIndexUri(), jsonIndexSpecification );
     }
 
     private JaxRsResponse httpGetIndexRelationshipNameKeyValue( String indexName, String key, String value )
     {
-        return RestRequest.req()
-                .get( functionalTestHelper.indexRelationshipUri( indexName, key, value ) );
+        return RestRequest.req().get( functionalTestHelper.indexRelationshipUri( indexName, key, value ) );
     }
 
     private JaxRsResponse httpPostIndexRelationshipNameKeyValue( String indexName, long relationshipId, String key,
             String value )
     {
-        return RestRequest.req()
-                .post( functionalTestHelper.indexRelationshipUri( indexName ),
-                        createJsonStringFor( relationshipId, key, value ) );
+        return RestRequest.req().post( functionalTestHelper.indexRelationshipUri( indexName ),
+                createJsonStringFor( relationshipId, key, value ) );
     }
 
     private String createJsonStringFor( final long relationshipId, final String key, final String value )
     {
         return "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"uri\": \""
-               + functionalTestHelper.relationshipUri( relationshipId ) + "\"}";
+                + functionalTestHelper.relationshipUri( relationshipId ) + "\"}";
     }
 
     private JaxRsResponse httpGet( String indexUri )
@@ -183,7 +176,7 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         String indexName = "nosuchindex";
         String indexUri = functionalTestHelper.relationshipIndexUri() + indexName;
-        JaxRsResponse response = request.delete(indexUri);
+        JaxRsResponse response = request.delete( indexUri );
         assertEquals( Status.NOT_FOUND.getStatusCode(), response.getStatus() );
     }
 
@@ -192,48 +185,32 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         final long startNode = helper.createNode();
         final long endNode = helper.createNode();
-
         final String key = "key_get";
         final String value = "value";
-
         final String relationshipName1 = "related-to";
         final String relationshipName2 = "dislikes";
-
         String jsonString = jsonRelationshipCreationSpecification( relationshipName1, endNode, key, value );
-
         JaxRsResponse createRelationshipResponse = httpPostCreateRelationship( startNode, jsonString );
         assertEquals( 201, createRelationshipResponse.getStatus() );
-        String relationshipLocation1 = createRelationshipResponse.getLocation()
-                .toString();
-
+        String relationshipLocation1 = createRelationshipResponse.getLocation().toString();
         jsonString = jsonRelationshipCreationSpecification( relationshipName2, endNode, key, value );
         createRelationshipResponse = httpPostCreateRelationship( startNode, jsonString );
         assertEquals( 201, createRelationshipResponse.getStatus() );
-        String relationshipLocation2 = createRelationshipResponse.getHeaders()
-                .get( HttpHeaders.LOCATION )
-                .get( 0 );
-
+        String relationshipLocation2 = createRelationshipResponse.getHeaders().get( HttpHeaders.LOCATION ).get( 0 );
         String indexName = "matrix";
         JaxRsResponse indexCreationResponse = httpPostIndexRelationshipRoot( "{\"name\":\"" + indexName + "\"}" );
         assertEquals( 201, indexCreationResponse.getStatus() );
-
         JaxRsResponse indexedRelationshipResponse = httpPostIndexRelationshipNameKeyValue( indexName,
                 functionalTestHelper.getRelationshipIdFromUri( relationshipLocation1 ), key, value );
-        String indexLocation1 = indexedRelationshipResponse.getHeaders()
-                .get( HttpHeaders.LOCATION )
-                .get( 0 );
+        String indexLocation1 = indexedRelationshipResponse.getHeaders().get( HttpHeaders.LOCATION ).get( 0 );
         indexedRelationshipResponse = httpPostIndexRelationshipNameKeyValue( indexName,
                 functionalTestHelper.getRelationshipIdFromUri( relationshipLocation2 ), key, value );
-        String indexLocation2 = indexedRelationshipResponse.getHeaders()
-                .get( HttpHeaders.LOCATION )
-                .get( 0 );
-
-        Map<String, String> uriToName = new HashMap<String, String>();
+        String indexLocation2 = indexedRelationshipResponse.getHeaders().get( HttpHeaders.LOCATION ).get( 0 );
+        Map<String, String> uriToName = new HashMap<>();
         uriToName.put( indexLocation1.toString(), relationshipName1 );
         uriToName.put( indexLocation2.toString(), relationshipName2 );
-
-        JaxRsResponse response = RestRequest.req()
-                .get( functionalTestHelper.indexRelationshipUri( indexName, key, value ) );
+        JaxRsResponse response = RestRequest.req().get(
+                functionalTestHelper.indexRelationshipUri( indexName, key, value ) );
         assertEquals( 200, response.getStatus() );
         Collection<?> items = (Collection<?>) JsonHelper.jsonToSingleValue( response.getEntity() );
         int counter = 0;
@@ -251,15 +228,15 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
 
     private JaxRsResponse httpPostCreateRelationship( long startNode, String jsonString )
     {
-        return RestRequest.req()
-                .post( functionalTestHelper.dataUri() + "node/" + startNode + "/relationships", jsonString );
+        return RestRequest.req().post( functionalTestHelper.dataUri() + "node/" + startNode + "/relationships",
+                jsonString );
     }
 
     private String jsonRelationshipCreationSpecification( String relationshipName, long endNode, String key,
             String value )
     {
         return "{\"to\" : \"" + functionalTestHelper.dataUri() + "node/" + endNode + "\"," + "\"type\" : \""
-               + relationshipName + "\", " + "\"data\" : {\"" + key + "\" : \"" + value + "\"}}";
+                + relationshipName + "\", " + "\"data\" : {\"" + key + "\" : \"" + value + "\"}}";
     }
 
     @Test
@@ -267,28 +244,26 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         String indexName = "empty-index";
         helper.createRelationshipIndex( indexName );
-        JaxRsResponse response = RestRequest.req()
-                .get( functionalTestHelper.indexRelationshipUri( indexName, "non-existent-key", "non-existent-value" ) );
+        JaxRsResponse response = RestRequest.req().get(
+                functionalTestHelper.indexRelationshipUri( indexName, "non-existent-key", "non-existent-value" ) );
         assertEquals( 200, response.getStatus() );
     }
 
     @Test
-    public void shouldGet200WhenQueryingIndex() throws PropertyValueException
+    public void shouldGet200WhenQueryingIndex()
     {
         String indexName = "bobTheIndex";
         String key = "bobsKey";
         String value = "bobsValue";
         long relationship = helper.createRelationship( "TYPE" );
         helper.addRelationshipToIndex( indexName, key, value, relationship );
-
-        JaxRsResponse response = RestRequest.req()
-                .get( functionalTestHelper.indexRelationshipUri( indexName ) + "?query=" + key + ":" + value );
-
+        JaxRsResponse response = RestRequest.req().get(
+                functionalTestHelper.indexRelationshipUri( indexName ) + "?query=" + key + ":" + value );
         assertEquals( 200, response.getStatus() );
     }
 
     @Test
-    public void shouldBeAbleToRemoveIndexing() throws JsonParseException
+    public void shouldBeAbleToRemoveIndexing()
     {
         String key1 = "kvkey1";
         String key2 = "kvkey2";
@@ -307,7 +282,8 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         assertEquals( 1, helper.getIndexedRelationships( indexName, key2, value1 ).size() );
         assertEquals( 1, helper.getIndexedRelationships( indexName, key2, value2 ).size() );
         JaxRsResponse response = RestRequest.req().delete(
-                functionalTestHelper.relationshipIndexUri() + indexName + "/" + key1 + "/" + value1 + "/" + relationship );
+                functionalTestHelper.relationshipIndexUri() + indexName + "/" + key1 + "/" + value1 + "/"
+                        + relationship );
         assertEquals( 204, response.getStatus() );
         assertEquals( 0, helper.getIndexedRelationships( indexName, key1, value1 ).size() );
         assertEquals( 1, helper.getIndexedRelationships( indexName, key1, value2 ).size() );
@@ -327,7 +303,6 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         assertEquals( 0, helper.getIndexedRelationships( indexName, key1, value2 ).size() );
         assertEquals( 0, helper.getIndexedRelationships( indexName, key2, value1 ).size() );
         assertEquals( 0, helper.getIndexedRelationships( indexName, key2, value2 ).size() );
-
         // Delete the index
         response = RestRequest.req().delete( functionalTestHelper.indexRelationshipUri( indexName ) );
         assertEquals( 204, response.getStatus() );
@@ -341,13 +316,10 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         final long endNodeId = helper.createNode();
         final String relationshiptype = "tested-together";
         final long relationshipId = helper.createRelationship( relationshiptype, startNodeId, endNodeId );
-
         final String key = "key";
         final String value = "value with   spaces  in it";
-
         final String indexName = "spacey-values";
         helper.createRelationshipIndex( indexName );
-
         JaxRsResponse response = httpPostIndexRelationshipNameKeyValue( indexName, relationshipId, key, value );
         assertEquals( Status.CREATED.getStatusCode(), response.getStatus() );
         URI location = response.getLocation();
@@ -358,9 +330,7 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( responseEntity );
         assertEquals( 1, hits.size() );
         response.close();
-
-        CLIENT.resource( location )
-                .delete();
+        CLIENT.resource( location ).delete();
         response = httpGetIndexRelationshipNameKeyValue( indexName, key, URIHelper.encode( value ) );
         assertEquals( 200, response.getStatus() );
         responseEntity = response.getEntity();
@@ -375,9 +345,8 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         final String indexName = "botherable-index";
         helper.createRelationshipIndex( indexName );
         final String corruptJson = "{[}";
-        JaxRsResponse response = RestRequest.req()
-                .post( functionalTestHelper.indexRelationshipUri( indexName ), corruptJson );
-
+        JaxRsResponse response = RestRequest.req().post( functionalTestHelper.indexRelationshipUri( indexName ),
+                corruptJson );
         assertEquals( 400, response.getStatus() );
     }
 
@@ -396,13 +365,13 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         long end = helper.createNode();
         gen.get()
                 .noGraph()
-           .expectedStatus( 201 /* created */)
-           .payloadType( MediaType.APPLICATION_JSON_TYPE )
-           .payload( "{\"key\": \"" + key + "\", \"value\":\"" + value +
-                     "\", \"start\": \"" + functionalTestHelper.nodeUri( start ) +
-                     "\", \"end\": \"" + functionalTestHelper.nodeUri( end ) +
-                     "\", \"type\": \"" + index + "\"}" )
-           .post( functionalTestHelper.relationshipIndexUri() + index + "/?uniqueness=get_or_create" );
+                .expectedStatus( 201 /* created */)
+                .payloadType( MediaType.APPLICATION_JSON_TYPE )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\":\"" + value + "\", \"start\": \""
+                                + functionalTestHelper.nodeUri( start ) + "\", \"end\": \""
+                                + functionalTestHelper.nodeUri( end ) + "\", \"type\": \"" + index + "\"}" )
+                .post( functionalTestHelper.relationshipIndexUri() + index + "/?uniqueness=get_or_create" );
     }
 
     /**
@@ -419,13 +388,14 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         helper.createRelationshipIndex( index );
         gen.get()
                 .noGraph()
-           .expectedStatus( 201 /* created */)
-           .payloadType( MediaType.APPLICATION_JSON_TYPE )
-           .payload( "{\"key\": \"" + key + "\", \"value\":\"" + value +
-                     "\", \"uri\": \"" + functionalTestHelper.relationshipUri( helper.createRelationship( index ) ) + "\"}" )
-           .post( functionalTestHelper.relationshipIndexUri() + index + "/?uniqueness=get_or_create" );
+                .expectedStatus( 201 /* created */)
+                .payloadType( MediaType.APPLICATION_JSON_TYPE )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\":\"" + value + "\", \"uri\": \""
+                                + functionalTestHelper.relationshipUri( helper.createRelationship( index ) ) + "\"}" )
+                .post( functionalTestHelper.relationshipIndexUri() + index + "/?uniqueness=get_or_create" );
     }
-    
+
     /**
      * Get or create unique relationship (existing).
      * 
@@ -437,40 +407,29 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     @Test
     public void get_or_create_unique_relationship_existing() throws Exception
     {
-     final String index = "rels", key = "name", value = "Peter";
-
+        final String index = "rels", key = "name", value = "Peter";
         GraphDatabaseService graphdb = graphdb();
         helper.createRelationshipIndex( index );
-        
-        Transaction tx = graphdb.beginTx();
-        try
+        try ( Transaction tx = graphdb.beginTx() )
         {
-         
-         Node node1 = graphdb.createNode();
-         Node node2 = graphdb.createNode();
-         Relationship rel = node1.createRelationshipTo(node2, MyRelationshipTypes.KNOWS);
-         
+            Node node1 = graphdb.createNode();
+            Node node2 = graphdb.createNode();
+            Relationship rel = node1.createRelationshipTo( node2, MyRelationshipTypes.KNOWS );
             graphdb.index().forRelationships( index ).add( rel, key, value );
-
             tx.success();
         }
-        finally
-        {
-            tx.finish();
-        }
-       
         gen.get()
                 .noGraph()
                 .expectedStatus( 200 /* conflict */)
                 .payloadType( MediaType.APPLICATION_JSON_TYPE )
-                .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value 
-                                          + "\", \"start\": \"" + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                          + "\", \"end\": \""  + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                          + "\", \"type\":\"" + MyRelationshipTypes.KNOWS + "\"}")
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"start\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"end\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"type\":\""
+                                + MyRelationshipTypes.KNOWS + "\"}" )
                 .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=get_or_create" );
-
     }
-    
+
     /**
     * Create a unique relationship or return fail (create).
     * 
@@ -478,169 +437,143 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     * of an already existing relationship, an error should be returned. In this
     * example, no existing relationship is found and a new relationship is created.
     */
-   @Documented
-   @Test
-   public void create_a_unique_relationship_or_return_fail___create() throws Exception
-   {
-   	final String index = "rels", key = "name", value = "Tobias";
-   	helper.createRelationshipIndex( index );
-   	
-        ResponseEntity response = gen.get()
-                .noGraph()
-                                    .expectedStatus( 201 /* created */)
-                                    .payloadType( MediaType.APPLICATION_JSON_TYPE )
-                                    .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value 
-                                   		 + "\", \"start\": \"" + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                   		 + "\", \"end\": \""  + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                   		 + "\", \"type\":\"" + MyRelationshipTypes.KNOWS + "\"}") 
-                                    .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
-
-       MultivaluedMap<String, String> headers = response.response().getHeaders();
-       Map<String, Object> result = JsonHelper.jsonToMap( response.entity() );
-       assertEquals( result.get( "indexed" ), headers.getFirst( "Location" ) );
-   }
-
-   
-   /**
-    * Create a unique relationship or return fail (fail).
-    * 
-    * Here, in case
-    * of an already existing relationship, an error should be returned. In this
-    * example, an existing relationship is found and an error is returned.
-    */
-   @Documented
-   @Test
-   public void create_a_unique_relationship_or_return_fail___fail() throws Exception
-   {
-   	final String index = "rels", key = "name", value = "Peter";
-
-       GraphDatabaseService graphdb = graphdb();
-       helper.createRelationshipIndex( index );
-       
-       Transaction tx = graphdb.beginTx();
-       try
-       {
-       	
-       	Node node1 = graphdb.createNode();
-       	Node node2 = graphdb.createNode();
-       	Relationship rel = node1.createRelationshipTo(node2, MyRelationshipTypes.KNOWS);
-       	
-           graphdb.index().forRelationships( index ).add( rel, key, value );
-
-           tx.success();
-       }
-       finally
-       {
-           tx.finish();
-       }
-      
-        ResponseEntity response = gen.get()
-                .noGraph()
-               .expectedStatus( 409 /* conflict */)
-               .payloadType( MediaType.APPLICATION_JSON_TYPE )
-               .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value 
-                                   		 + "\", \"start\": \"" + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                   		 + "\", \"end\": \""  + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                   		 + "\", \"type\":\"" + MyRelationshipTypes.KNOWS + "\"}")
-               .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
-
-   }
-   
-   /**
-    * Add a relationship to an index 
-    * unless a node already exists for the given mapping then return fail (case create).
-    */
-   @Documented
-   @Test
-   public void put_relationship_or_fail_if_absent() throws Exception
-   {
-   	
-   	final String index = "rels", key = "name", value = "Peter";
-
-       helper.createRelationshipIndex( index );
-       
-        gen.get()
+    @Documented
+    @Test
+    public void create_a_unique_relationship_or_return_fail___create() throws Exception
+    {
+        final String index = "rels", key = "name", value = "Tobias";
+        helper.createRelationshipIndex( index );
+        ResponseEntity response = gen
+                .get()
                 .noGraph()
                 .expectedStatus( 201 /* created */)
                 .payloadType( MediaType.APPLICATION_JSON_TYPE )
-                .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"uri\":\"" + functionalTestHelper.relationshipUri( helper.createRelationship("KNOWS", helper.createNode(), helper.createNode()) ) + "\"}" )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"start\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"end\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"type\":\""
+                                + MyRelationshipTypes.KNOWS + "\"}" )
                 .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
-   }
-   
-   /**
-    * Add a relationship to an index 
-    * unless a node already exists for the given mapping then return fail (case fail).
-    */
-   @Documented
-   @Test
-   public void put_relationship_if_absent_only_fail() throws Exception
-   {
-   	final String index = "rels", key = "name", value = "Peter";
-       GraphDatabaseService graphdb = graphdb();
-       helper.createRelationshipIndex( index );
-       
-       Relationship rel;
-       Transaction tx = graphdb.beginTx();
-       try
-       {
-	       	Node node1 = graphdb.createNode();
-	       	Node node2 = graphdb.createNode();
-	       	rel = node1.createRelationshipTo(node2, MyRelationshipTypes.KNOWS);
-	       	
-	        graphdb.index().forRelationships( index ).add( rel, key, value );
-	        
-	        tx.success();
-       }
-       finally
-       {
-           tx.finish();
-       }
-       
+        MultivaluedMap<String, String> headers = response.response().getHeaders();
+        Map<String, Object> result = JsonHelper.jsonToMap( response.entity() );
+        assertEquals( result.get( "indexed" ), headers.getFirst( "Location" ) );
+    }
+
+    /**
+     * Create a unique relationship or return fail (fail).
+     * 
+     * Here, in case
+     * of an already existing relationship, an error should be returned. In this
+     * example, an existing relationship is found and an error is returned.
+     */
+    @Documented
+    @Test
+    public void create_a_unique_relationship_or_return_fail___fail() throws Exception
+    {
+        final String index = "rels", key = "name", value = "Peter";
+        GraphDatabaseService graphdb = graphdb();
+        helper.createRelationshipIndex( index );
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            Node node1 = graphdb.createNode();
+            Node node2 = graphdb.createNode();
+            Relationship rel = node1.createRelationshipTo( node2, MyRelationshipTypes.KNOWS );
+            graphdb.index().forRelationships( index ).add( rel, key, value );
+            tx.success();
+        }
         gen.get()
                 .noGraph()
                 .expectedStatus( 409 /* conflict */)
                 .payloadType( MediaType.APPLICATION_JSON_TYPE )
-                .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"uri\":\"" + functionalTestHelper.relationshipUri( rel.getId() ) + "\"}" )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"start\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"end\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"type\":\""
+                                + MyRelationshipTypes.KNOWS + "\"}" )
                 .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
-   }
-   
-   /**
-    * This can be safely removed in version 1.11 an onwards.
-    */
-   @Test
-   public void createUniqueShouldBeBackwardsCompatibleWith1_8() throws Exception
-   {
-    final String index = "rels", key = "name", value = "Peter";
+    }
 
-       GraphDatabaseService graphdb = graphdb();
-       helper.createRelationshipIndex( index );
-       
-       Transaction tx = graphdb.beginTx();
-       try
-       {
-        
-        Node node1 = graphdb.createNode();
-        Node node2 = graphdb.createNode();
-        Relationship rel = node1.createRelationshipTo(node2, MyRelationshipTypes.KNOWS);
-        
-           graphdb.index().forRelationships( index ).add( rel, key, value );
-
-           tx.success();
-       }
-       finally
-       {
-           tx.finish();
-       }
-      
-        ResponseEntity response = gen.get()
+    /**
+     * Add a relationship to an index
+     * unless a node already exists for the given mapping then return fail (case create).
+     */
+    @Documented
+    @Test
+    public void put_relationship_or_fail_if_absent() throws Exception
+    {
+        final String index = "rels", key = "name", value = "Peter";
+        helper.createRelationshipIndex( index );
+        gen.get()
                 .noGraph()
-               .expectedStatus( 200 /* conflict */)
-               .payloadType( MediaType.APPLICATION_JSON_TYPE )
-               .payload( "{\"key\": \"" + key + "\", \"value\": \"" + value 
-                                         + "\", \"start\": \"" + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                         + "\", \"end\": \""  + functionalTestHelper.nodeUri( helper.createNode() ) 
-                                         + "\", \"type\":\"" + MyRelationshipTypes.KNOWS + "\"}")
-               .post( functionalTestHelper.relationshipIndexUri() + index + "?unique" );
+                .expectedStatus( 201 /* created */)
+                .payloadType( MediaType.APPLICATION_JSON_TYPE )
+                .payload(
+                        "{\"key\": \""
+                                + key
+                                + "\", \"value\": \""
+                                + value
+                                + "\", \"uri\":\""
+                                + functionalTestHelper.relationshipUri( helper.createRelationship( "KNOWS",
+                                        helper.createNode(), helper.createNode() ) ) + "\"}" )
+                .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
+    }
 
-   }
+    /**
+     * Add a relationship to an index
+     * unless a node already exists for the given mapping then return fail (case fail).
+     */
+    @Documented
+    @Test
+    public void put_relationship_if_absent_only_fail() throws Exception
+    {
+        final String index = "rels", key = "name", value = "Peter";
+        GraphDatabaseService graphdb = graphdb();
+        helper.createRelationshipIndex( index );
+        Relationship rel;
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            Node node1 = graphdb.createNode();
+            Node node2 = graphdb.createNode();
+            rel = node1.createRelationshipTo( node2, MyRelationshipTypes.KNOWS );
+            graphdb.index().forRelationships( index ).add( rel, key, value );
+            tx.success();
+        }
+        gen.get()
+                .noGraph()
+                .expectedStatus( 409 /* conflict */)
+                .payloadType( MediaType.APPLICATION_JSON_TYPE )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"uri\":\""
+                                + functionalTestHelper.relationshipUri( rel.getId() ) + "\"}" )
+                .post( functionalTestHelper.relationshipIndexUri() + index + "?uniqueness=create_or_fail" );
+    }
+
+    /**
+     * This can be safely removed in version 1.11 an onwards.
+     */
+    @Test
+    public void createUniqueShouldBeBackwardsCompatibleWith1_8() throws Exception
+    {
+        final String index = "rels", key = "name", value = "Peter";
+        GraphDatabaseService graphdb = graphdb();
+        helper.createRelationshipIndex( index );
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            Node node1 = graphdb.createNode();
+            Node node2 = graphdb.createNode();
+            Relationship rel = node1.createRelationshipTo( node2, MyRelationshipTypes.KNOWS );
+            graphdb.index().forRelationships( index ).add( rel, key, value );
+            tx.success();
+        }
+        gen.get()
+                .noGraph()
+                .expectedStatus( 200 /* conflict */)
+                .payloadType( MediaType.APPLICATION_JSON_TYPE )
+                .payload(
+                        "{\"key\": \"" + key + "\", \"value\": \"" + value + "\", \"start\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"end\": \""
+                                + functionalTestHelper.nodeUri( helper.createNode() ) + "\", \"type\":\""
+                                + MyRelationshipTypes.KNOWS + "\"}" )
+                .post( functionalTestHelper.relationshipIndexUri() + index + "?unique" );
+    }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/RelationshipDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RelationshipDocIT.java
@@ -82,16 +82,11 @@ public class RelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         Node node = data.get().get( "I" );
         Relationship relationship;
-        Transaction transaction = node.getGraphDatabase().beginTx();
-        try
+        try ( Transaction transaction = node.getGraphDatabase().beginTx() )
         {
             relationship = node.getSingleRelationship(
                     DynamicRelationshipType.withName( "know" ),
                     Direction.OUTGOING );
-        }
-        finally
-        {
-            transaction.finish();
         }
         String response = gen().expectedStatus(
                 com.sun.jersey.api.client.ClientResponse.Status.OK.getStatusCode() ).get(
@@ -269,14 +264,9 @@ public class RelationshipDocIT extends AbstractRestFunctionalTestBase
     {
         Node romeo = getNode( "Romeo" );
 
-        Transaction transaction = romeo.getGraphDatabase().beginTx();
-        try
+        try ( Transaction transaction = romeo.getGraphDatabase().beginTx() )
         {
             return romeo.getRelationships().iterator().next();
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
@@ -224,7 +224,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
      * Create an index for a label and property key which already exists.
      */
     @Test
-    public void create_existing_constraint() throws PropertyValueException
+    public void create_existing_constraint()
     {
         String labelName = "mylabel", propertyKey = "name";
         createLabelUniquenessPropertyConstraint( labelName, propertyKey );
@@ -244,7 +244,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
      * Creating a compound index should not yet be supported.
      */
     @Test
-    public void create_compound_schema_index() throws PropertyValueException
+    public void create_compound_schema_index()
     {
         Map<String, Object> definition = map( "property_keys", asList( "first", "other" ) );
 
@@ -254,17 +254,12 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
 
     private ConstraintDefinition createLabelUniquenessPropertyConstraint( String labelName, String propertyKey )
     {
-        Transaction tx = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             ConstraintDefinition constraintDefinition = graphdb().schema().constraintFor( label( labelName ) ).unique
                     ().on( propertyKey ).create();
             tx.success();
             return constraintDefinition;
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexDocIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Neo4jMatchers;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -31,8 +32,11 @@ import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.GraphDescription;
 
 import static java.util.Arrays.asList;
+
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.helpers.collection.MapUtil.map;
@@ -127,7 +131,7 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
      * Create an index for a label and property key which already exists.
      */
     @Test
-    public void create_existing_index() throws PropertyValueException
+    public void create_existing_index()
     {
         String labelName = "mylabel", propertyKey = "name";
         createIndex( labelName, propertyKey );
@@ -156,7 +160,7 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
      * Creating a compound index should not yet be supported
      */
     @Test
-    public void create_compound_index() throws PropertyValueException
+    public void create_compound_index()
     {
         Map<String, Object> definition = map( "property_keys", asList( "first", "other" ) );
 
@@ -169,17 +173,12 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
     
     private IndexDefinition createIndex( String labelName, String propertyKey )
     {
-        Transaction tx = graphdb().beginTx();
-        try
+        try ( Transaction tx = graphdb().beginTx() )
         {
             IndexDefinition indexDefinition = graphdb().schema().indexFor( label( labelName ) ).on( propertyKey )
                     .create();
             tx.success();
             return indexDefinition;
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
@@ -394,11 +394,6 @@ public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
         assertErrorCodes( response.<Map<String, Object>>content(), expectedErrors );
     }
 
-    private void assertErrorMessages( Response response, String... expectedMessages )
-    {
-        assertErrorMessages( response.<Map<String, Object>>content(), expectedMessages );
-    }
-
     @SuppressWarnings("unchecked")
     private void assertErrorCodes( Map<String, Object> response, StatusCode... expectedErrors )
     {
@@ -417,29 +412,10 @@ public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void assertErrorMessages( Map<String, Object> response, String... expectedMessages )
-    {
-        Iterator<Map<String, Object>> errors = ((List<Map<String, Object>>) response.get( "errors" )).iterator();
-        Iterator<String> expected = iterator( expectedMessages );
-
-        while ( expected.hasNext() )
-        {
-            assertTrue( errors.hasNext() );
-            assertThat( (String) errors.next().get( "message" ), equalTo( expected.next() ) );
-        }
-        if ( errors.hasNext() )
-        {
-            Map<String, Object> error = errors.next();
-            fail( "Expected no more errors, but got " + error.get( "message" ) + " - '" + error.get( "message" ) + "'." );
-        }
-    }
-
     @SuppressWarnings("WhileLoopReplaceableByForEach")
     private long countNodes()
     {
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction transaction = graphdb().beginTx() )
         {
             long count = 0;
             Iterator<Node> allNodes = GlobalGraphOperations.at( graphdb() ).getAllNodes().iterator();
@@ -449,10 +425,6 @@ public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
                 count++;
             }
             return count;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+
 import javax.ws.rs.core.MediaType;
 
 import org.junit.AfterClass;
@@ -481,9 +482,8 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
 
     private Node createLinkedList( final int listLength, final Database db )
     {
-        Transaction tx = db.getGraph().beginTx();
         Node startNode = null;
-        try
+        try ( Transaction tx = db.getGraph().beginTx() )
         {
             Node previous = null;
             for ( int i = 0; i < listLength; i++ )
@@ -504,10 +504,6 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
             }
             tx.success();
             return startNode;
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
@@ -19,18 +19,12 @@
  */
 package org.neo4j.server.rest.streaming;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.graphdb.Neo4jMatchers.inTx;
-
 import java.util.List;
 import java.util.Map;
 
 import org.json.JSONException;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Neo4jMatchers;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -41,12 +35,21 @@ import org.neo4j.server.rest.PrettyJSON;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
-import org.neo4j.server.rest.repr.formats.StreamingJsonFormat;
+import org.neo4j.server.rest.repr.StreamingFormat;
 import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.GraphDescription.Graph;
 
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.UniformInterfaceException;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 
 public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 {
@@ -100,7 +103,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         String entity = gen.get()
         .expectedType( APPLICATION_JSON_TYPE )
-        .withHeader(StreamingJsonFormat.STREAM_HEADER,"true")
+        .withHeader(StreamingFormat.STREAM_HEADER,"true")
         .payload(jsonString)
         .expectedStatus(200)
         .post( batchUri() ).entity();
@@ -194,7 +197,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         String entity = gen.get()
         .expectedType(APPLICATION_JSON_TYPE)
-        .withHeader(StreamingJsonFormat.STREAM_HEADER, "true")
+        .withHeader(StreamingFormat.STREAM_HEADER, "true")
         .expectedStatus(200)
         .payload( jsonString )
         .post( batchUri() )
@@ -228,7 +231,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         JaxRsResponse response = RestRequest.req()
         .accept(APPLICATION_JSON_TYPE)
-        .header(StreamingJsonFormat.STREAM_HEADER, "true")
+        .header(StreamingFormat.STREAM_HEADER, "true")
         .post(batchUri(), jsonString);
 
         assertEquals(200, response.getStatus());
@@ -253,7 +256,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
     @Test
     public void shouldForwardUnderlyingErrors() throws Exception {
 
-        JaxRsResponse response = RestRequest.req().accept(APPLICATION_JSON_TYPE).header(StreamingJsonFormat.STREAM_HEADER,"true")
+        JaxRsResponse response = RestRequest.req().accept(APPLICATION_JSON_TYPE).header(StreamingFormat.STREAM_HEADER,"true")
 
             .post(batchUri(), new PrettyJSON()
                     .array()
@@ -312,7 +315,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         JaxRsResponse response = RestRequest.req()
                 .accept(APPLICATION_JSON_TYPE)
-                .header(StreamingJsonFormat.STREAM_HEADER, "true")
+                .header(StreamingFormat.STREAM_HEADER, "true")
                 .post(batchUri(), jsonString);
         assertEquals(200, response.getStatus());
         assertTrue(((Map)singleResult( response, 1 ).get("body")).get("message").toString().contains( "java.util.ArrayList cannot be cast to java.util.Map" ));
@@ -343,7 +346,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
         
         String entity = gen.get()
                 .expectedType( APPLICATION_JSON_TYPE )
-                .withHeader( StreamingJsonFormat.STREAM_HEADER,"true" )
+                .withHeader( StreamingFormat.STREAM_HEADER,"true" )
                 .expectedStatus(200)
                 .payload( jsonString )
                 .post( batchUri() )
@@ -381,7 +384,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
         .toString();
         gen.get()
             .expectedType(APPLICATION_JSON_TYPE)
-            .withHeader(StreamingJsonFormat.STREAM_HEADER, "true")
+            .withHeader(StreamingFormat.STREAM_HEADER, "true")
             .expectedStatus( 200 )
             .payload( jsonString )
             .post( batchUri() )
@@ -438,7 +441,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         JaxRsResponse response = RestRequest.req()
                 .accept(APPLICATION_JSON_TYPE)
-                .header(StreamingJsonFormat.STREAM_HEADER, "true")
+                .header(StreamingFormat.STREAM_HEADER, "true")
                 .post(batchUri(), jsonString);
         assertEquals(200, response.getStatus());
         assertEquals(400, singleResult( response,1 ).get("status"));
@@ -471,7 +474,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
 
         JaxRsResponse response = RestRequest.req()
                 .accept( APPLICATION_JSON_TYPE )
-                .header(StreamingJsonFormat.STREAM_HEADER, "true")
+                .header(StreamingFormat.STREAM_HEADER, "true")
                 .post(batchUri(), jsonString);
         assertEquals(200, response.getStatus());
         assertEquals(404, singleResult( response ,1 ).get("status"));
@@ -516,7 +519,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
         
         JaxRsResponse response = RestRequest.req()
                 .accept( APPLICATION_JSON_TYPE )
-                .header(StreamingJsonFormat.STREAM_HEADER, "true")
+                .header(StreamingFormat.STREAM_HEADER, "true")
                 .post(batchUri(), jsonString);
 
         assertEquals(200, response.getStatus());
@@ -614,7 +617,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
         
         JaxRsResponse response = RestRequest.req()
                 .accept( APPLICATION_JSON_TYPE )
-                .header(StreamingJsonFormat.STREAM_HEADER, "true")
+                .header(StreamingFormat.STREAM_HEADER, "true")
                 .post(batchUri(), jsonString);
 
         assertEquals(200, response.getStatus());
@@ -645,14 +648,9 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
     }
     private int countNodes()
     {
-        Transaction transaction = graphdb().beginTx();
-        try
+        try ( Transaction transaction = graphdb().beginTx() )
         {
             return IteratorUtil.count( (Iterable)graphdb().getAllNodes() );
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.shell.kernel;
 
-import static org.neo4j.shell.Variables.PROMPT_KEY;
-
 import java.io.Serializable;
 import java.rmi.RemoteException;
 import java.util.Map;
@@ -42,6 +40,8 @@ import org.neo4j.shell.Welcome;
 import org.neo4j.shell.impl.AbstractAppServer;
 import org.neo4j.shell.impl.BashVariableInterpreter.Replacer;
 import org.neo4j.shell.kernel.apps.TransactionProvidingApp;
+
+import static org.neo4j.shell.Variables.PROMPT_KEY;
 
 /**
  * A {@link ShellServer} which contains common methods to use with a
@@ -143,19 +143,13 @@ public class GraphDatabaseShellServer extends AbstractAppServer
     @Override
     protected String getPrompt( Session session ) throws ShellException
     {
-        org.neo4j.graphdb.Transaction transaction = this.getDb().beginTx();
-
-        try
+        try ( org.neo4j.graphdb.Transaction transaction = this.getDb().beginTx() )
         {
             Object rawCustomPrompt = session.get( PROMPT_KEY );
             String customPrompt = rawCustomPrompt != null ? rawCustomPrompt.toString() : getDefaultPrompt();
             String output = bashInterpreter.interpret( customPrompt, this, session );
             transaction.success();
             return output;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 
@@ -237,17 +231,11 @@ public class GraphDatabaseShellServer extends AbstractAppServer
     @Override
     public Welcome welcome( Map<String, Serializable> initialSession ) throws RemoteException, ShellException
     {
-        org.neo4j.graphdb.Transaction transaction = graphDb.beginTx();
-
-        try
+        try ( org.neo4j.graphdb.Transaction transaction = graphDb.beginTx() )
         {
             Welcome welcome = super.welcome( initialSession );
             transaction.success();
             return welcome;
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
@@ -55,8 +55,8 @@ public class Begin extends NonTransactionProvidingApp
 
         Transaction tx = currentTransaction( getServer() );
 
+        // This is a "begin" app so it will leave a transaction open. Don't close it in here
         getServer().getDb().beginTx();
-            
         Integer txCount = session.getCommitCount();
 
         int count;
@@ -66,12 +66,14 @@ public class Begin extends NonTransactionProvidingApp
             {
                 count = 0;
                 out.println( "Transaction started" );
-            } else
+            }
+            else
             {
                 count = 1;
                 out.println( "Warning: transaction found that was not started by the shell." );
             }
-        } else
+        }
+        else
         {
             count = txCount;
             out.println( String.format( "Nested transaction started (Tx count: %d)", count + 1 ) );
@@ -100,7 +102,8 @@ public class Begin extends NonTransactionProvidingApp
         try
         {
             return server.getDb().getTxManager().getTransaction();
-        } catch ( SystemException e )
+        }
+        catch ( SystemException e )
         {
             throw new ShellException( e.getMessage() );
         }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -225,16 +225,11 @@ public abstract class TransactionProvidingApp extends AbstractApp
     public Continuation execute( AppCommandParser parser, Session session,
         Output out ) throws Exception
     {
-        Transaction tx = getServer().getDb().beginTx();
-        try
+        try ( Transaction tx = getServer().getDb().beginTx() )
         {
             Continuation result = this.exec( parser, session, out );
             tx.success();
             return result;
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 
@@ -724,7 +719,10 @@ public abstract class TransactionProvidingApp extends AbstractApp
         Map<String, Direction> matches = filterMapToTypes( db, defaultDirection, relationshipTypes,
                 caseInsensitiveFilters, looseFilters );
         Expander expander = Traversal.emptyExpander();
-        if ( matches == null ) return EMPTY_EXPANDER;
+        if ( matches == null )
+        {
+            return EMPTY_EXPANDER;
+        }
         for ( Map.Entry<String, Direction> entry : matches.entrySet() )
         {
             expander = expander.add( DynamicRelationshipType.withName( entry.getKey() ),
@@ -767,7 +765,9 @@ public abstract class TransactionProvidingApp extends AbstractApp
     {
         String labelValue = parser.option( "l", null );
         if ( labelValue == null )
+        {
             return EMPTY_LABELS;
+        }
         
         labelValue = labelValue.trim();
         if ( labelValue.startsWith( "[" ) )

--- a/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
@@ -37,6 +38,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.helpers.collection.Iterables.count;
 
 public class TransactionSoakIT
@@ -70,15 +72,18 @@ public class TransactionSoakIT
         stopTesters( testers );
         waitForThreadsToFinish( threads );
 
-        long relationshipCount = count( GlobalGraphOperations.at( db ).getAllRelationships() );
-        int expected = committerCount( testers );
-
-        assertEquals( expected, relationshipCount );
+        try ( Transaction tx = db.beginTx() )
+        {
+            long relationshipCount = count( GlobalGraphOperations.at( db ).getAllRelationships() );
+            int expected = committerCount( testers );
+    
+            assertEquals( expected, relationshipCount );
+        }
     }
 
     private List<Tester> createTesters() throws Exception
     {
-        List<Tester> testers = new ArrayList<Tester>( 20 );
+        List<Tester> testers = new ArrayList<>( 20 );
         for ( int i = 0; i < 20; i++ )
         {
             int x = r.nextInt( 3 );


### PR DESCRIPTION
Have Transaction interface extends AutoCloseable which makes transactions
able to participate in try-with-resource blocks, like:

  try ( Transaction tx = db.beginTx() )
  {
    // db operations
    tx.success();
  }

finish() method has been deprecated but parts of the code still use it.
The focus has been here to convert src/main code, documenting tests and
any code ending up in the manual.
