### PR TITLE
LabelScanStore files are included when copying store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import org.neo4j.graphdb.ResourceIterator;
+
+public abstract class PrefetchingResourceIterator<T> extends PrefetchingIterator<T> implements ResourceIterator<T>
+{
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/scan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/scan/LabelScanStore.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.kernel.api.scan;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.nioneo.store.UnderlyingStorageException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -68,6 +70,8 @@ public interface LabelScanStore extends Lifecycle
      * @return a {@link Reader} capable of retrieving nodes for labels.
      */
     Reader newReader();
+    
+    ResourceIterator<File> snapshotStoreFiles() throws IOException;
     
     /**
      * Initializes the store. After this has been called recovery updates can be processed.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
@@ -25,8 +25,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.List;
 
 import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.ClosableIterable;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.SchemaCache;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -155,7 +155,7 @@ public class ShutdownXaDataSource extends NeoStoreXaDataSource
     }
 
     @Override
-    public ClosableIterable<File> listStoreFiles( boolean includeLogicalLogs )
+    public ResourceIterator<File> listStoreFiles( boolean includeLogicalLogs )
     {
         throw databaseIsShutdownError();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.ClosableIterable;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 /**
@@ -271,7 +271,7 @@ public abstract class XaDataSource implements Lifecycle
         throw new UnsupportedOperationException( getClass().getName() );
     }
 
-    public ClosableIterable<File> listStoreFiles( boolean includeLogicalLogs ) throws IOException
+    public ResourceIterator<File> listStoreFiles( boolean includeLogicalLogs ) throws IOException
     {
         throw new UnsupportedOperationException( getClass().getName() );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.scan;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,11 +27,14 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.scan.LabelScanStore;
 import org.neo4j.kernel.api.scan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 
 import static java.util.Arrays.binarySearch;
+
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 public class InMemoryLabelScanStore implements LabelScanStore
 {
@@ -130,6 +134,12 @@ public class InMemoryLabelScanStore implements LabelScanStore
             {   // Nothing to close
             }
         };
+    }
+    
+    @Override
+    public ResourceIterator<File> snapshotStoreFiles()
+    {
+        return emptyIterator();
     }
     
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.DefaultTxHook;
@@ -78,6 +79,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
@@ -745,6 +747,12 @@ public class WriteTransactionTest
             return LabelScanStore.EMPTY_READER;
         }
         
+        @Override
+        public ResourceIterator<File> snapshotStoreFiles()
+        {
+            return emptyIterator();
+        }
+
         @Override
         public void init()
         {   // Do nothing

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/MultipleBackupDeletionPolicy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/MultipleBackupDeletionPolicy.java
@@ -25,14 +25,14 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.KeepOnlyLastCommitDeletionPolicy;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 
-class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
+public class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
 {
     static final String SNAPSHOT_ID = "backup";
     
     private IndexCommit snapshot;
     private int snapshotUsers;
 
-    MultipleBackupDeletionPolicy()
+    public MultipleBackupDeletionPolicy()
     {
         super( new KeepOnlyLastCommitDeletionPolicy() );
     }
@@ -53,7 +53,10 @@ class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
     @Override
     public synchronized void release( String id ) throws IOException
     {
-        if ( (--snapshotUsers) > 0 ) return;
+        if ( (--snapshotUsers) > 0 )
+        {
+            return;
+        }
         super.release( id );
         snapshot = null;
         if ( snapshotUsers < 0 )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
 
 import org.neo4j.index.impl.lucene.LuceneDataSource;
+import org.neo4j.index.impl.lucene.MultipleBackupDeletionPolicy;
 
 public class IndexWriterFactories
 {
@@ -39,6 +40,7 @@ public class IndexWriterFactories
             {
                 IndexWriterConfig writerConfig = new IndexWriterConfig( Version.LUCENE_36, LuceneDataSource.KEYWORD_ANALYZER );
                 writerConfig.setMaxBufferedDocs( 100000 ); // TODO figure out depending on environment?
+                writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
                 return new IndexWriter( directory, writerConfig );
             }
         };

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
@@ -21,16 +21,21 @@ package org.neo4j.kernel.api.impl.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.Directory;
 
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.index.impl.lucene.Hits;
 import org.neo4j.kernel.api.scan.LabelScanStore;
 import org.neo4j.kernel.api.scan.NodeLabelUpdate;
@@ -210,6 +215,52 @@ public class LuceneLabelScanStore implements LabelScanStore
         };
     }
     
+    @Override
+    public ResourceIterator<File> snapshotStoreFiles() throws IOException
+    {
+        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getConfig().getIndexDeletionPolicy();
+        return new StoreSnapshot( deletionPolicy );
+    }
+    
+    private class StoreSnapshot extends PrefetchingIterator<File> implements ResourceIterator<File>
+    {
+        private final String ID = "backup";
+        private final SnapshotDeletionPolicy deletionPolicy;
+        private final IndexCommit commit;
+        private final Iterator<String> fileNames;
+
+        StoreSnapshot( SnapshotDeletionPolicy deletionPolicy ) throws IOException
+        {
+            this.deletionPolicy = deletionPolicy;
+            this.commit = deletionPolicy.snapshot( ID );
+            this.fileNames = commit.getFileNames().iterator();
+        }
+
+        @Override
+        protected File fetchNextOrNull()
+        {
+            if ( !fileNames.hasNext() )
+            {
+                return null;
+            }
+            return new File( directoryLocation, fileNames.next() );
+        }
+        
+        @Override
+        public void close()
+        {
+            try
+            {
+                deletionPolicy.release( ID );
+            }
+            catch ( IOException e )
+            {
+                // TODO What to do here?
+                throw new RuntimeException( "Unable to close lucene index snapshot", e );
+            }
+        }
+    }
+
     @Override
     public void init() throws IOException
     {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.impl.index;
 import java.io.File;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.impl.index.LuceneLabelScanStore.Monitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
@@ -36,6 +37,9 @@ import static org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.fullStoreLab
 
 public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<LuceneLabelScanStoreExtension.Dependencies>
 {
+    private final int priority;
+    private final Monitor monitor;
+
     public interface Dependencies
     {
         Config getConfig();
@@ -49,7 +53,14 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
     
     public LuceneLabelScanStoreExtension()
     {
+        this( 10, null );
+    }
+    
+    LuceneLabelScanStoreExtension( int priority, Monitor monitor )
+    {
         super( "lucene");
+        this.priority = priority;
+        this.monitor = monitor;
     }
     
     @Override
@@ -65,8 +76,8 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 
                 dependencies.getFileSystem(), standard(),
                 fullStoreLabelUpdateStream( dependencies.getDataSourceManager() ),
-                loggerMonitor( dependencies.getLogging() ) );
+                monitor != null ? monitor : loggerMonitor( dependencies.getLogging() ) );
         
-        return new LabelScanStoreProvider( scanStore, 10 );
+        return new LabelScanStoreProvider( scanStore, priority );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/index/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/index/LabelScanStoreHaIT.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.ha.ClusterManager;
+import org.neo4j.test.ha.ClusterManager.ManagedCluster;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
+
+public class LabelScanStoreHaIT
+{
+    @Test
+    public void shouldCopyLabelScanStoreToNewSlaves() throws Exception
+    {
+        // THEN
+        assertEquals( "Expected noone to build their label scan store index.",
+                0, monitor.callsTo_noIndex );
+    }
+    
+    private void createSomeLabeledNodes( GraphDatabaseService db, Label[]... labelArrays )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( Label[] labels : labelArrays )
+            {
+                db.createNode( labels );
+            }
+            tx.success();
+        }
+    }
+
+    private static enum Labels implements Label
+    {
+        First,
+        Second;
+    }
+    
+    private final File rootDirectory = TargetDirectory.forTest( getClass() ).directory( "root", true );
+    private ClusterManager clusterManager;
+    private final LifeSupport life = new LifeSupport();
+    private ManagedCluster cluster;
+    private final TestMonitor monitor = new TestMonitor();
+    
+    @Before
+    public void setup()
+    {
+        KernelExtensionFactory<?> testExtension = new LuceneLabelScanStoreExtension( 100, monitor );
+        HighlyAvailableGraphDatabaseFactory factory = new HighlyAvailableGraphDatabaseFactory();
+        factory.addKernelExtensions( Arrays.<KernelExtensionFactory<?>>asList( testExtension ) );
+        clusterManager = new ClusterManager.Builder( rootDirectory ).withStoreDirInitializer(
+                new ClusterManager.StoreDirInitializer()
+        {
+            @Override
+            public void initializeStoreDir( int serverId, File storeDir ) throws IOException
+            {
+                if ( serverId == 1 )
+                {
+                    GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase(
+                            storeDir.getAbsolutePath() );
+                    try
+                    {
+                        createSomeLabeledNodes( db,
+                                new Label[] {Labels.First},
+                                new Label[] {Labels.First, Labels.Second},
+                                new Label[] {Labels.Second} );
+                    }
+                    finally
+                    {
+                        db.shutdown();
+                    }
+                }
+            }
+        } ).build();
+        life.add( clusterManager );
+        life.start();
+        cluster = clusterManager.getDefaultCluster();
+        cluster.await( allSeesAllAsAvailable() );
+    }
+    
+    @After
+    public void teardown()
+    {
+        life.shutdown();
+    }
+    
+    private static class TestMonitor implements LuceneLabelScanStore.Monitor
+    {
+        private volatile int callsTo_noIndex;
+        
+        @Override
+        public void noIndex()
+        {
+            callsTo_noIndex++;
+        }
+
+        @Override
+        public void corruptIndex( IOException e )
+        {
+        }
+
+        @Override
+        public void rebuilding()
+        {
+        }
+
+        @Override
+        public void rebuilt()
+        {
+        }
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
@@ -36,12 +36,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
-import ch.qos.logback.classic.LoggerContext;
-import org.slf4j.impl.StaticLoggerBinder;
-import org.w3c.dom.Document;
 
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.cluster.ClusterSettings;
@@ -73,6 +70,10 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.LogbackService;
 import org.neo4j.kernel.logging.Logging;
 
+import org.slf4j.impl.StaticLoggerBinder;
+import org.w3c.dom.Document;
+import ch.qos.logback.classic.LoggerContext;
+
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 
@@ -87,20 +88,32 @@ public class ClusterManager
     public static class Builder
     {
         private final File root;
-        private Provider provider = clusterOfSize( 3 );
-        private Map<String, String> commonConfig = emptyMap();
-        private Map<Integer, Map<String,String>> instanceConfig = new HashMap<>();
-        private HighlyAvailableGraphDatabaseFactory factory = new HighlyAvailableGraphDatabaseFactory();
-        public File seedDir;
+        private final Provider provider = clusterOfSize( 3 );
+        private final Map<String, String> commonConfig = emptyMap();
+        private final Map<Integer, Map<String,String>> instanceConfig = new HashMap<>();
+        private final HighlyAvailableGraphDatabaseFactory factory = new HighlyAvailableGraphDatabaseFactory();
+        private StoreDirInitializer initializer;
 
         public Builder( File root )
         {
             this.root = root;
         }
 
-        public Builder withSeedDir( File seedDir )
+        public Builder withSeedDir( final File seedDir )
         {
-            this.seedDir = seedDir;
+            return withStoreDirInitializer( new StoreDirInitializer()
+            {
+                @Override
+                public void initializeStoreDir( int serverId, File storeDir ) throws IOException
+                {
+                    copyRecursively( seedDir, storeDir );
+                }
+            } );
+        }
+        
+        public Builder withStoreDirInitializer( StoreDirInitializer initializer )
+        {
+            this.initializer = initializer;
             return this;
         }
 
@@ -108,6 +121,11 @@ public class ClusterManager
         {
             return new ClusterManager( this );
         }
+    }
+    
+    public interface StoreDirInitializer
+    {
+        void initializeStoreDir( int serverId, File storeDir ) throws IOException;
     }
 
     /**
@@ -219,7 +237,7 @@ public class ClusterManager
     private final Map<String, ManagedCluster> clusterMap = new HashMap<>();
     private final Provider clustersProvider;
     private final HighlyAvailableGraphDatabaseFactory dbFactory;
-    private final File seedDir;
+    private final StoreDirInitializer storeDirInitializer;
 
     public ClusterManager( Provider clustersProvider, File root, Map<String, String> commonConfig,
                            Map<Integer, Map<String, String>> instanceConfig,
@@ -230,7 +248,7 @@ public class ClusterManager
         this.commonConfig = commonConfig;
         this.instanceConfig = instanceConfig;
         this.dbFactory = dbFactory;
-        this.seedDir = null;
+        this.storeDirInitializer = null;
     }
 
     private ClusterManager( Builder builder )
@@ -240,7 +258,7 @@ public class ClusterManager
         this.commonConfig = builder.commonConfig;
         this.instanceConfig = builder.instanceConfig;
         this.dbFactory = builder.factory;
-        this.seedDir = builder.seedDir;
+        this.storeDirInitializer = builder.initializer;
     }
 
     public ClusterManager( Provider clustersProvider, File root, Map<String, String> commonConfig,
@@ -467,9 +485,9 @@ public class ClusterManager
             {
                 int haPort = new URI( "cluster://" + member.getHost() ).getPort() + 3000;
                 File storeDir = new File( new File( root, name ), "server" + serverId );
-                if ( seedDir != null)
+                if ( storeDirInitializer != null)
                 {
-                    copyRecursively( seedDir, storeDir );
+                    storeDirInitializer.initializeStoreDir( serverId, storeDir );
                 }
                 GraphDatabaseBuilder graphDatabaseBuilder = dbFactory
                         .newHighlyAvailableDatabaseBuilder( storeDir.getAbsolutePath() ).
@@ -940,7 +958,7 @@ public class ClusterManager
     {
         private final HighlyAvailableGraphDatabase db;
         private final NetworkReceiver receiver;
-        private NetworkSender sender;
+        private final NetworkSender sender;
 
         StartNetworkAgainKit( HighlyAvailableGraphDatabase db, NetworkReceiver receiver, NetworkSender sender )
         {


### PR DESCRIPTION
The store files of the active label scan store is included in the files
streamed from NeoStoreXaDataSource#listStoreFiles() so that the full label
scan store is included in a full database copy.

co-author: Tobias Lindaaker, @thobe 
