### PR TITLE
LabelScanStore files are included when copying store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingResourceIterator.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import org.neo4j.graphdb.ResourceIterator;
+
+public abstract class PrefetchingResourceIterator<T> extends PrefetchingIterator<T> implements ResourceIterator<T>
+{
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/scan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/scan/LabelScanStore.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.kernel.api.scan;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.nioneo.store.UnderlyingStorageException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
@@ -64,6 +66,8 @@ public interface LabelScanStore extends Lifecycle
      * @return a {@link LabelScanReader} capable of retrieving nodes for labels.
      */
     LabelScanReader newReader();
+    
+    ResourceIterator<File> snapshotStoreFiles() throws IOException;
     
     /**
      * Initializes the store. After this has been called recovery updates can be processed.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -103,6 +103,8 @@ public class LabelScanStoreProvider extends LifecycleAdapter implements Comparab
     public static interface FullStoreChangeStream extends Iterable<NodeLabelUpdate>
     {
         PrimitiveLongIterator labelIds();
+        
+        long highestNodeId();
     }
 
     public static FullStoreChangeStream fullStoreLabelUpdateStream( final XaDataSourceManager dataSourceManager )
@@ -165,6 +167,13 @@ public class LabelScanStoreProvider extends LifecycleAdapter implements Comparab
                         }
                     }
                 };
+            }
+
+            @Override
+            public long highestNodeId()
+            {
+                return dataSourceManager.getNeoStoreDataSource()
+                        .getNeoStore().getNodeStore().getHighestPossibleIdInUse();
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ShutdownXaDataSource.java
@@ -25,8 +25,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.List;
 
 import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.ClosableIterable;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.SchemaCache;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -155,7 +155,7 @@ public class ShutdownXaDataSource extends NeoStoreXaDataSource
     }
 
     @Override
-    public ClosableIterable<File> listStoreFiles( boolean includeLogicalLogs )
+    public ResourceIterator<File> listStoreFiles( boolean includeLogicalLogs )
     {
         throw databaseIsShutdownError();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.collection.ClosableIterable;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 /**
@@ -271,7 +271,7 @@ public abstract class XaDataSource implements Lifecycle
         throw new UnsupportedOperationException( getClass().getName() );
     }
 
-    public ClosableIterable<File> listStoreFiles( boolean includeLogicalLogs ) throws IOException
+    public ResourceIterator<File> listStoreFiles( boolean includeLogicalLogs ) throws IOException
     {
         throw new UnsupportedOperationException( getClass().getName() );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.scan;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,12 +27,15 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.scan.LabelScanReader;
 import org.neo4j.kernel.api.scan.LabelScanStore;
 import org.neo4j.kernel.api.scan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 
 import static java.util.Arrays.binarySearch;
+
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 public class InMemoryLabelScanStore implements LabelScanStore
 {
@@ -131,6 +135,12 @@ public class InMemoryLabelScanStore implements LabelScanStore
             {   // Nothing to close
             }
         };
+    }
+    
+    @Override
+    public ResourceIterator<File> snapshotStoreFiles()
+    {
+        return emptyIterator();
     }
     
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.DefaultTxHook;
@@ -78,6 +79,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
@@ -745,6 +747,12 @@ public class WriteTransactionTest
             return LabelScanReader.EMPTY;
         }
         
+        @Override
+        public ResourceIterator<File> snapshotStoreFiles()
+        {
+            return emptyIterator();
+        }
+
         @Override
         public void init()
         {   // Do nothing

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/MultipleBackupDeletionPolicy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/MultipleBackupDeletionPolicy.java
@@ -25,14 +25,14 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.KeepOnlyLastCommitDeletionPolicy;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 
-class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
+public class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
 {
     static final String SNAPSHOT_ID = "backup";
     
     private IndexCommit snapshot;
     private int snapshotUsers;
 
-    MultipleBackupDeletionPolicy()
+    public MultipleBackupDeletionPolicy()
     {
         super( new KeepOnlyLastCommitDeletionPolicy() );
     }
@@ -53,7 +53,10 @@ class MultipleBackupDeletionPolicy extends SnapshotDeletionPolicy
     @Override
     public synchronized void release( String id ) throws IOException
     {
-        if ( (--snapshotUsers) > 0 ) return;
+        if ( (--snapshotUsers) > 0 )
+        {
+            return;
+        }
         super.release( id );
         snapshot = null;
         if ( snapshotUsers < 0 )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
 
 import org.neo4j.index.impl.lucene.LuceneDataSource;
+import org.neo4j.index.impl.lucene.MultipleBackupDeletionPolicy;
 
 public class IndexWriterFactories
 {
@@ -39,6 +40,7 @@ public class IndexWriterFactories
             {
                 IndexWriterConfig writerConfig = new IndexWriterConfig( Version.LUCENE_36, LuceneDataSource.KEYWORD_ANALYZER );
                 writerConfig.setMaxBufferedDocs( 100000 ); // TODO figure out depending on environment?
+                writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
                 return new IndexWriter( directory, writerConfig );
             }
         };

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.impl.index;
 import java.io.File;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.impl.index.LuceneLabelScanStore.Monitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
@@ -36,6 +37,9 @@ import static org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.fullStoreLab
 
 public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<LuceneLabelScanStoreExtension.Dependencies>
 {
+    private final int priority;
+    private final Monitor monitor;
+
     public interface Dependencies
     {
         Config getConfig();
@@ -49,7 +53,14 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
     
     public LuceneLabelScanStoreExtension()
     {
+        this( 10, null );
+    }
+    
+    LuceneLabelScanStoreExtension( int priority, Monitor monitor )
+    {
         super( "lucene");
+        this.priority = priority;
+        this.monitor = monitor;
     }
     
     @Override
@@ -65,8 +76,8 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 
                 dependencies.getFileSystem(), standard(),
                 fullStoreLabelUpdateStream( dependencies.getDataSourceManager() ),
-                loggerMonitor( dependencies.getLogging() ) );
+                monitor != null ? monitor : loggerMonitor( dependencies.getLogging() ) );
         
-        return new LabelScanStoreProvider( scanStore, 10 );
+        return new LabelScanStoreProvider( scanStore, priority );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/index/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/index/LabelScanStoreHaIT.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.ha.ClusterManager;
+import org.neo4j.test.ha.ClusterManager.ManagedCluster;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
+
+public class LabelScanStoreHaIT
+{
+    @Test
+    public void shouldCopyLabelScanStoreToNewSlaves() throws Exception
+    {
+        // This check is here o check so that the extension provided by this test is selected.
+        // It can be higher than 3 (number of cluster members) since some members may restart
+        // some services to switch role.
+        assertTrue( monitor.callsTo_init >= 3 );
+        
+        // GIVEN
+        // An HA cluster where the master started with initial data consisting
+        // of a couple of nodes, each having one or more properties.
+        // The cluster starting up should have the slaves copy their stores from the master
+        // and get the label scan store with it.
+        
+        // THEN
+        assertEquals( "Expected noone to build their label scan store index.",
+                0, monitor.timesRebuiltWithData );
+        for ( GraphDatabaseService db : cluster.getAllMembers() )
+        {
+            assertEquals( 2, numberOfNodesHavingLabel( db, Labels.First ) );
+            assertEquals( 2, numberOfNodesHavingLabel( db, Labels.First ) );
+        }
+    }
+    
+    private int numberOfNodesHavingLabel( GraphDatabaseService db, Label label )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            int count = count( GlobalGraphOperations.at( db ).getAllNodesWithLabel( label ) );
+            tx.success();
+            return count;
+        }
+    }
+
+    private void createSomeLabeledNodes( GraphDatabaseService db, Label[]... labelArrays )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( Label[] labels : labelArrays )
+            {
+                db.createNode( labels );
+            }
+            tx.success();
+        }
+    }
+
+    private static enum Labels implements Label
+    {
+        First,
+        Second;
+    }
+    
+    private final File rootDirectory = TargetDirectory.forTest( getClass() ).directory( "root", true );
+    private ClusterManager clusterManager;
+    private final LifeSupport life = new LifeSupport();
+    private ManagedCluster cluster;
+    private final TestMonitor monitor = new TestMonitor();
+    
+    @Before
+    public void setup()
+    {
+        KernelExtensionFactory<?> testExtension = new LuceneLabelScanStoreExtension( 100, monitor );
+        HighlyAvailableGraphDatabaseFactory factory = new HighlyAvailableGraphDatabaseFactory();
+        factory.addKernelExtensions( Arrays.<KernelExtensionFactory<?>>asList( testExtension ) );
+        clusterManager = new ClusterManager.Builder( rootDirectory )
+                .withDbFactory( factory )
+                .withStoreDirInitializer( new ClusterManager.StoreDirInitializer()
+        {
+            @Override
+            public void initializeStoreDir( int serverId, File storeDir ) throws IOException
+            {
+                if ( serverId == 1 )
+                {
+                    GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase(
+                            storeDir.getAbsolutePath() );
+                    try
+                    {
+                        createSomeLabeledNodes( db,
+                                new Label[] {Labels.First},
+                                new Label[] {Labels.First, Labels.Second},
+                                new Label[] {Labels.Second} );
+                    }
+                    finally
+                    {
+                        db.shutdown();
+                    }
+                }
+            }
+        } ).build();
+        life.add( clusterManager );
+        life.start();
+        cluster = clusterManager.getDefaultCluster();
+        cluster.await( allSeesAllAsAvailable() );
+    }
+    
+    @After
+    public void teardown()
+    {
+        life.shutdown();
+    }
+    
+    private static class TestMonitor implements LuceneLabelScanStore.Monitor
+    {
+        private volatile int callsTo_init;
+        private volatile int timesRebuiltWithData;
+        
+        @Override
+        public void init()
+        {
+            callsTo_init++;
+        }
+        
+        @Override
+        public void noIndex()
+        {
+        }
+
+        @Override
+        public void corruptIndex( IOException e )
+        {
+        }
+
+        @Override
+        public void rebuilding()
+        {
+        }
+
+        @Override
+        public void rebuilt( long roughNodeCount )
+        {
+            // In HA each slave database will startup with an empty database before realizing that
+            // it needs to copy a store from its master, let alone find its master.
+            // So we're expecting one call to this method from each slave with node count == 0. Ignore those.
+            // We're tracking number of times we're rebuilding the index where there's data to rebuild,
+            // i.e. after the db has been copied from the master.
+            if ( roughNodeCount > 0 )
+            {
+                timesRebuiltWithData++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The store files of the active label scan store is included in the files
streamed from NeoStoreXaDataSource#listStoreFiles() so that the full label
scan store is included in a full database copy.

co-author: Tobias Lindaaker, @thobe
