### PR TITLE
Corrects DiffSets problems

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
+/**
+ * Methods "missing" from {@link Arrays} are provided here.
+ */
+public abstract class ArrayUtil
+{
+    /**
+     * I can't believe this method is missing from {@link Arrays}.
+     * @see Arrays#toString(byte[]) for similar functionality.
+     */
+    public static String toString( Object array )
+    {
+        assert array.getClass().isArray() : array + " is not an array";
+
+        StringBuilder result = new StringBuilder();
+        String separator = "[";
+        for ( int size = Array.getLength( array ), i = 0; i < size; i++ )
+        {
+            result.append( separator ).append( Array.get( array, i ) );
+            separator = ", ";
+        }
+        return result.append( ']' ).toString();
+    }
+
+    public static int hashCode( Object array )
+    {
+        assert array.getClass().isArray() : array + " is not an array";
+
+        int length = Array.getLength( array ), result = length;
+        for ( int i = 0; i < length; i++ )
+        {
+            result = 31 * result + Array.get( array, i ).hashCode();
+        }
+        return result;
+    }
+
+    public interface ArrayEquality
+    {
+        boolean typeEquals( Class<?> firstType, Class<?> otherType );
+
+        boolean itemEquals( Object firstArray, Object otherArray );
+    }
+
+    public static final ArrayEquality DEFAULT_ARRAY_EQUALITY = new ArrayEquality()
+    {
+        @Override
+        public boolean typeEquals( Class<?> firstType, Class<?> otherType )
+        {
+            return firstType == otherType;
+        }
+
+        @Override
+        public boolean itemEquals( Object lhs, Object rhs )
+        {
+            return lhs == rhs || (lhs != null && lhs.equals( rhs ));
+        }
+    };
+
+    public static boolean equals( Object firstArray, Object otherArray )
+    {
+        return equals( firstArray, otherArray, DEFAULT_ARRAY_EQUALITY );
+    }
+
+    /**
+     * I also can't believe this method is missing from {@link Arrays}.
+     * Both arguments must be arrays of some type.
+     *
+     * @param firstArray value to compare to the other value
+     * @param otherArray value to compare to the first value
+     * @param equality equality logic
+     *
+     * @see Arrays#equals(byte[], byte[]) for similar functionality.
+     */
+    public static boolean equals( Object firstArray, Object otherArray, ArrayEquality equality )
+    {
+        assert firstArray.getClass().isArray() : firstArray + " is not an array";
+        assert otherArray.getClass().isArray() : otherArray + " is not an array";
+
+        int length;
+        if ( equality.typeEquals( firstArray.getClass(), otherArray.getClass() )
+                && (length = Array.getLength( firstArray )) == Array.getLength( otherArray ) )
+        {
+            for ( int i = 0; i < length; i++ )
+            {
+                if ( !equality.itemEquals( Array.get( firstArray, i ), Array.get( otherArray, i ) ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public static Object clone( Object array )
+    {
+        if ( array instanceof Object[] )
+        {
+            return ((Object[]) array).clone();
+        }
+        if ( array instanceof boolean[] )
+        {
+            return ((boolean[]) array).clone();
+        }
+        if ( array instanceof byte[] )
+        {
+            return ((byte[]) array).clone();
+        }
+        if ( array instanceof short[] )
+        {
+            return ((short[]) array).clone();
+        }
+        if ( array instanceof char[] )
+        {
+            return ((char[]) array).clone();
+        }
+        if ( array instanceof int[] )
+        {
+            return ((int[]) array).clone();
+        }
+        if ( array instanceof long[] )
+        {
+            return ((long[]) array).clone();
+        }
+        if ( array instanceof float[] )
+        {
+            return ((float[]) array).clone();
+        }
+        if ( array instanceof double[] )
+        {
+            return ((double[]) array).clone();
+        }
+        throw new IllegalArgumentException( "Not an array type: " + array.getClass() );
+    }
+
+    private ArrayUtil()
+    {   // No instances allowed
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanArrayProperty.java
@@ -38,15 +38,15 @@ class BooleanArrayProperty extends FullSizeProperty
     @Override
     public boolean[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof boolean[])
+        if ( value instanceof boolean[] )
         {
-            return Arrays.equals(this.value, (boolean[])value);
+            return Arrays.equals( this.value, (boolean[]) value );
         }
 
         if ( value instanceof Boolean[] )
@@ -79,7 +79,7 @@ class BooleanArrayProperty extends FullSizeProperty
     {
         return Arrays.equals( this.value, ((BooleanArrayProperty)that).value );
     }
-    
+
     @Override
     @Deprecated
     public PropertyData asPropertyDataJustForIntegration()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteArrayProperty.java
@@ -35,15 +35,15 @@ class ByteArrayProperty extends FullSizeProperty
     @Override
     public byte[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof byte[])
+        if ( value instanceof byte[] )
         {
-            return Arrays.equals(this.value, (byte[])value);
+            return Arrays.equals( this.value, (byte[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/CharArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/CharArrayProperty.java
@@ -35,15 +35,15 @@ class CharArrayProperty extends FullSizeProperty
     @Override
     public char[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof char[])
+        if ( value instanceof char[] )
         {
-            return Arrays.equals(this.value, (char[])value);
+            return Arrays.equals( this.value, (char[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleArrayProperty.java
@@ -35,15 +35,15 @@ class DoubleArrayProperty extends FullSizeProperty
     @Override
     public double[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof double[])
+        if ( value instanceof double[] )
         {
-            return Arrays.equals(this.value, (double[])value);
+            return Arrays.equals( this.value, (double[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatArrayProperty.java
@@ -35,15 +35,15 @@ class FloatArrayProperty extends FullSizeProperty
     @Override
     public float[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof float[])
+        if ( value instanceof float[] )
         {
-            return Arrays.equals(this.value, (float[])value);
+            return Arrays.equals( this.value, (float[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntArrayProperty.java
@@ -35,7 +35,7 @@ class IntArrayProperty extends FullSizeProperty
     @Override
     public int[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyProperty.java
@@ -25,7 +25,7 @@ abstract class LazyProperty<T> extends FullSizeProperty
 {
     private volatile Object value;
 
-    LazyProperty( long propertyKeyId, Callable<T> producer )
+    LazyProperty( long propertyKeyId, Callable<? extends T> producer )
     {
         super( propertyKeyId );
         this.value = producer;
@@ -55,22 +55,30 @@ abstract class LazyProperty<T> extends FullSizeProperty
                 }
             }
         }
-        return cast( value );
+        return castAndPrepareForReturn( value );
     }
 
     protected Object produceValue()
     {
         try
         {
-            return ( (Callable<?>) value ).call();
-        } catch ( Exception e )
+            return ((Callable<?>) value).call();
+        }
+        catch ( Exception e )
         {
             throw new RuntimeException( e );
         }
     }
 
+    /**
+     * Casts the internal value to the correct type and makes it ready for returning out,
+     * potentially all the way out to the user.
+     *
+     * @param value the value to cast and prepare.
+     * @return the cast and prepared value.
+     */
     @SuppressWarnings("unchecked")
-    private T cast( Object value )
+    protected T castAndPrepareForReturn( Object value )
     {
         return (T) value;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyStringProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyStringProperty.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api.properties;
 
 import java.util.concurrent.Callable;
 
-public class LazyStringProperty extends LazyProperty<String>
+class LazyStringProperty extends LazyProperty<String>
 {
     LazyStringProperty( long propertyKeyId, Callable<String> producer )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongArrayProperty.java
@@ -35,15 +35,15 @@ class LongArrayProperty extends FullSizeProperty
     @Override
     public long[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof long[])
+        if ( value instanceof long[] )
         {
-            return Arrays.equals(this.value, (long[])value);
+            return Arrays.equals( this.value, (long[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortArrayProperty.java
@@ -35,15 +35,15 @@ class ShortArrayProperty extends FullSizeProperty
     @Override
     public short[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof short[])
+        if ( value instanceof short[] )
         {
-            return Arrays.equals(this.value, (short[])value);
+            return Arrays.equals( this.value, (short[]) value );
         }
         return valueCompare( value, this.value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringArrayProperty.java
@@ -35,15 +35,15 @@ class StringArrayProperty extends FullSizeProperty
     @Override
     public String[] value()
     {
-        return value;
+        return value.clone();
     }
 
     @Override
     public boolean valueEquals( Object value )
     {
-        if ( value instanceof String[])
+        if ( value instanceof String[] )
         {
-            return Arrays.equals(this.value, (String[])value);
+            return Arrays.equals( this.value, (String[]) value );
         }
         return valueCompare( this.value, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DiffApplyingPrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DiffApplyingPrimitiveLongIterator.java
@@ -68,7 +68,7 @@ public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLo
     {
         this.source = source;
         this.addedElements = addedElements;
-        this.addedElementsIterator = addedElements == null ? null : addedElements.iterator();
+        this.addedElementsIterator = addedElements.iterator();
         this.removedElements = removedElements;
         phase = Phase.FILTERED_SOURCE;
 
@@ -87,8 +87,7 @@ public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLo
         {
             long value = source.next();
             next( value );
-            if ( ( removedElements == null || !removedElements.contains( value ) ) &&
-                 ( addedElements == null || !addedElements.contains( value ) ) )
+            if ( !removedElements.contains( value ) && !addedElements.contains( value ) )
             {
                 return;
             }
@@ -99,7 +98,7 @@ public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLo
 
     private void transitionToAddedElements()
     {
-        phase = addedElementsIterator == null ? Phase.NO_ADDED_ELEMENTS : Phase.ADDED_ELEMENTS;
+        phase = !addedElementsIterator.hasNext() ? Phase.NO_ADDED_ELEMENTS : Phase.ADDED_ELEMENTS;
         computeNext();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -83,7 +83,7 @@ public final class TxStateImpl implements TxState
             return new LabelState( id );
         }
     };
-    
+
     private static final StateCreator<NodeState> NODE_STATE_CREATOR = new StateCreator<NodeState>()
     {
         @Override
@@ -92,7 +92,7 @@ public final class TxStateImpl implements TxState
             return new NodeState( id );
         }
     };
-    
+
     private static final StateCreator<RelationshipState> RELATIONSHIP_STATE_CREATOR =
             new StateCreator<RelationshipState>()
     {
@@ -230,7 +230,7 @@ public final class TxStateImpl implements TxState
     {
         return getOrCreateGraphState().propertyDiffSets();
     }
-    
+
     @Override
     public boolean nodeIsAddedInThisTx( long nodeId )
     {
@@ -279,9 +279,12 @@ public final class TxStateImpl implements TxState
             DiffSets<SafeProperty> diffSets = nodePropertyDiffSets( nodeId );
             if ( replacedProperty.isDefined() )
             {
-                diffSets.remove( (SafeProperty)replacedProperty );
+                diffSets.replace( (SafeProperty)replacedProperty, newProperty );
             }
-            diffSets.add( newProperty );
+            else
+            {
+                diffSets.add( newProperty );
+            }
             legacyState.nodeSetProperty( nodeId, newProperty.asPropertyDataJustForIntegration() );
             hasChanges = true;
         }
@@ -295,14 +298,17 @@ public final class TxStateImpl implements TxState
             DiffSets<SafeProperty> diffSets = relationshipPropertyDiffSets( relationshipId );
             if ( replacedProperty.isDefined() )
             {
-                diffSets.remove( (SafeProperty)replacedProperty );
+                diffSets.replace( (SafeProperty)replacedProperty, newProperty );
             }
-            diffSets.add( newProperty );
+            else
+            {
+                diffSets.add( newProperty );
+            }
             legacyState.relationshipSetProperty( relationshipId, newProperty.asPropertyDataJustForIntegration() );
             hasChanges = true;
         }
     }
-    
+
     @Override
     public void graphDoReplaceProperty( Property replacedProperty, SafeProperty newProperty )
     {
@@ -311,9 +317,12 @@ public final class TxStateImpl implements TxState
             DiffSets<SafeProperty> diffSets = graphPropertyDiffSets();
             if ( replacedProperty.isDefined() )
             {
-                diffSets.remove( (SafeProperty)replacedProperty );
+                diffSets.replace( (SafeProperty)replacedProperty, newProperty );
             }
-            diffSets.add( newProperty );
+            else
+            {
+                diffSets.add( newProperty );
+            }
             legacyState.graphSetProperty( newProperty.asPropertyDataJustForIntegration() );
             hasChanges = true;
         }
@@ -351,7 +360,7 @@ public final class TxStateImpl implements TxState
             hasChanges = true;
         }
     }
-    
+
     @Override
     public void nodeDoAddLabel( long labelId, long nodeId )
     {
@@ -388,7 +397,7 @@ public final class TxStateImpl implements TxState
         }
         return UpdateTriState.UNTOUCHED;
     }
-    
+
     @Override
     public Set<Long> nodesWithLabelAdded( long labelId )
     {
@@ -563,7 +572,7 @@ public final class TxStateImpl implements TxState
     {
         return getState( relationshipStatesMap(), relationshipId, RELATIONSHIP_STATE_CREATOR );
     }
-    
+
     private GraphState getOrCreateGraphState()
     {
         if ( graphState == null )
@@ -617,7 +626,7 @@ public final class TxStateImpl implements TxState
             }
         } );
     }
-    
+
     @Override
     public DiffSets<UniquenessConstraint> constraintsChangesForLabel( long labelId )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/properties/LazyPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/properties/LazyPropertyTest.java
@@ -23,7 +23,11 @@ import java.util.concurrent.Callable;
 
 import org.junit.Test;
 
+import org.neo4j.helpers.ArrayUtil;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LazyPropertyTest
 {
@@ -31,8 +35,7 @@ public class LazyPropertyTest
     public void shouldLoadLazyStringProperty() throws Exception
     {
         // given
-        LazyStringProperty property = new LazyStringProperty( 0, value("person") );
-
+        LazyStringProperty property = new LazyStringProperty( 0, value( "person" ) );
         // when / then
         assertEquals( "person", property.value() );
     }
@@ -41,11 +44,83 @@ public class LazyPropertyTest
     public void shouldLoadLazyStringPropertyOnlyOnce() throws Exception
     {
         // given
-        LazyStringProperty property = new LazyStringProperty( 0, value("person") );
-
+        LazyStringProperty property = new LazyStringProperty( 0, value( "person" ) );
         // when / then
         assertEquals( "person", property.value() );
         assertEquals( "person", property.value() );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForBooleanArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new boolean[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForByteArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new byte[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForShortArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new short[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForCharArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new char[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForIntArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new int[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForLongArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new long[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForFloatArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new float[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForDoubleArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new double[] {} );
+    }
+
+    @Test
+    public void shouldExhibitCorrectEqualityForStringArray() throws Exception
+    {
+        verifyCorrectValueEqualityForLazyArrayProperty( new String[] {} );
+    }
+
+    private static void verifyCorrectValueEqualityForLazyArrayProperty( Object array )
+    {
+        // given
+        LazyArrayProperty property = new LazyArrayProperty( 0, value( ArrayUtil.clone( array ) ) );
+        // when/then
+        assertTrue( "value should be reported equal with same type", property.valueEquals( array ) );
+        // when
+        for ( Object value : new Object[] { new boolean[] {}, new byte[] {}, new short[] {}, new char[] {},
+                new int[] {}, new long[] {}, new float[] {}, new double[] {}, new String[] {}, } )
+        {
+            if ( value.getClass() == array.getClass() )
+            {
+                continue;
+            }
+            // then
+            assertFalse( "value should be reported inequal with different type", property.valueEquals( value ) );
+        }
     }
 
     private static <T> Callable<T> value( final T value )
@@ -57,10 +132,7 @@ public class LazyPropertyTest
             @Override
             public T call() throws Exception
             {
-                if ( called )
-                {
-                    throw new AssertionError( "Already called for value: " + value );
-                }
+                assertFalse( "Already called for value: " + value, called );
                 called = true;
                 return value;
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class PropertyTransactionStateTest
+{
+    private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+    }
+
+    @Test
+    public void testUpdateDoubleArrayProperty() throws Exception
+    {
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( "foo", new double[] { 0, 0, 0, 0 } );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 100; i++ )
+            {
+                double[] data = (double[]) node.getProperty( "foo" );
+                data[2] = i;
+                data[3] = i;
+                node.setProperty( "foo", data );
+                assertArrayEquals( new double[] { 0, 0, i, i }, (double[]) node.getProperty( "foo" ), 0.1D );
+            }
+        }
+    }
+
+    @Test
+    public void testStringPropertyUpdate() throws Exception
+    {
+        String key = "foo";
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( key, "one" );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.setProperty( key, "one" );
+            node.setProperty( key, "two" );
+            assertEquals( "two", node.getProperty( key ) );
+        }
+    }
+
+    @Test
+    public void testSetDoubleArrayProperty() throws Exception
+    {
+        db.beginTx();
+        Node node = db.createNode();
+        for ( int i = 0; i < 100; i++ )
+        {
+            node.setProperty( "foo", new double[] { 0, 0, i, i } );
+            assertArrayEquals( new double[] { 0, 0, i, i }, (double[]) node.getProperty( "foo" ), 0.1D );
+        }
+    }
+}


### PR DESCRIPTION
There were problems in how the added/removed parts of DiffSets were
populated and managed in general. The problems were exposed in that
the 'remove' part contained invalid and/or too few entries and the
'added' part contained too many entries. In the property scenario
the diff set was used to remove the old property and add the new.
Add and remove were issued separated from each other, which made those
step on each others toes.

These things were changed:
o Introduced DiffSets#replace which does proper add/remove semantics
  knowing that one value replaces another.
o Removed null from the added/removed sets management by using empty sets
  in place of null. This makes for less checks, less code, more
  intuitive code and actually less objects being created since a set
  may not need to be created to remove something that it doesn't have.
o All *ArrayProperty (extends SafeProperty) classes have their value()
  method return a clone of the actual array. This fixes a problem with the
  initial test used to drive all these changes, where the test changed and
  reused an array property value read from a node.
o Safe equals() on LazyArrayProperty and clearly describes why the type
  member field needs no synchronization or volatility; both for
  readability and for reasoning about potential future changes to
  synchronization thereabout.

co-author: Tobias Lindaaker, @thobe
