### PR TITLE
Remove the node title from the prompt in the shell.

### DIFF
--- a/community/shell/src/docs/dev/shell.asciidoc
+++ b/community/shell/src/docs/dev/shell.asciidoc
@@ -157,18 +157,6 @@ An example of a filter could be +.\*url.\*:http.\*neo4j.*,name:Neo4j+.
 The filter option is also accompanied by the options +-i+ and +-l+ which stands for +ignore case+ (ignore casing of the characters) and +loose matching+ (it's considered a match even if the filter value just matches a part of the compared value, not necessarily the entire value).
 So for a case-insensitive, loose filter you can supply a filter with +-f -i -l+ or +-fil+ for short.
 
-[[shell-titles]]
-== Node titles ==
-
-To make it easier to navigate your graph the shell can display a title for each node, f.ex. in +ls -r+.
-It will display the relationships as well as the nodes on the other side of the relationships.
-The title is displayed together with each node and its best suited property value from a list of property keys.
-
-If you're standing on a node which has two +KNOWS+ relationships to other nodes it'd be difficult to know which friend is which.
-The title feature addresses this by reading a list of property keys and grabbing the first existing property value of those keys and displays it as a title for the node.
-So you may specify a list (with or without regular expressions), f.ex: +name,title.\*,caption+ and the title for each node will be the property value of the first existing key in that list.
-The list is defined by the client (you) using the +TITLE_KEYS+ <<shell-env-vars,environment variable>> and the default being +.\*name.\*,.\*title.*+
-
 [[shell-commands]]
 == How to use (individual commands) ==
 

--- a/community/shell/src/main/java/org/neo4j/shell/Session.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Session.java
@@ -161,14 +161,4 @@ public class Session
     {
         setInternal( Variables.TX_COUNT, commitCount );
     }
-
-    public String getTitleKeys() throws ShellException
-    {
-        return ( String ) get( Variables.TITLE_KEYS_KEY );
-    }
-
-    public String getMaxTitleLength() throws ShellException
-    {
-        return ( String ) get( Variables.TITLE_MAX_LENGTH );
-    }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/Variables.java
+++ b/community/shell/src/main/java/org/neo4j/shell/Variables.java
@@ -40,13 +40,6 @@ public class Variables
      */
     public static final String STACKTRACES_KEY = "STACKTRACES";
     /**
-     * When displaying node ids this variable is also used for getting an
-     * appropriate property value from that node to display as the title.
-     * This variable can contain many property keys (w/ regex) separated by
-     * comma prioritized in order.
-     */
-    public static final String TITLE_KEYS_KEY = "TITLE_KEYS";
-    /**
      * The maximum length of titles to be displayed.
      */
     public static final String TITLE_MAX_LENGTH = "TITLE_MAX_LENGTH";

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.rmi.RemoteException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import javax.transaction.Transaction;
 
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
@@ -136,7 +135,6 @@ public class GraphDatabaseShellServer extends AbstractAppServer
     @Override
     protected void initialPopulateSession( Session session ) throws ShellException
     {
-        session.set( Variables.TITLE_KEYS_KEY, ".*name.*,.*title.*" );
         session.set( Variables.TITLE_MAX_LENGTH, "40" );
     }
 

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -377,7 +377,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
         else
         {
             return getDisplayName( server, session, thing.asRelationship(),
-                true, checkForMe );
+                    true, checkForMe );
         }
     }
 
@@ -393,7 +393,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
         throws ShellException
     {
         return getDisplayName( server, session,
-            getThingById( server, typedId ), checkForMe );
+                getThingById( server, typedId ), checkForMe );
     }
 
     /**
@@ -411,52 +411,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
             return getDisplayNameForCurrent( server, session );
         }
 
-        String title = findTitle( session, node );
-        StringBuilder result = new StringBuilder( "(" );
-        result.append( title != null ? title + "," : "" );
-        result.append( node.getId() );
-        result.append( ")" );
-        return result.toString();
-    }
-
-    protected static String findTitle( Session session, Node node ) throws ShellException
-    {
-        String keys = session.getTitleKeys();
-        if ( keys == null )
-        {
-            return null;
-        }
-
-        String[] titleKeys = keys.split( Pattern.quote( "," ) );
-        Pattern[] patterns = new Pattern[ titleKeys.length ];
-        for ( int i = 0; i < titleKeys.length; i++ )
-        {
-            patterns[ i ] = Pattern.compile( titleKeys[ i ] );
-        }
-        for ( Pattern pattern : patterns )
-        {
-            for ( String nodeKey : node.getPropertyKeys() )
-            {
-                if ( matches( pattern, nodeKey, false, false ) )
-                {
-                    return trimLength( session,
-                        format( node.getProperty( nodeKey ), false ) );
-                }
-            }
-        }
-        return null;
-    }
-
-    private static String trimLength( Session session, String string ) throws ShellException
-    {
-        String maxLengthString = session.getMaxTitleLength();
-        int maxLength = maxLengthString != null ?
-            Integer.parseInt( maxLengthString ) : Integer.MAX_VALUE;
-        if ( string.length() > maxLength )
-        {
-            string = string.substring( 0, maxLength ) + "...";
-        }
-        return string;
+        return String.format( "(%d)", node.getId() );
     }
 
     /**
@@ -535,6 +490,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
         return builder.append( "]" ).toString();
     }
 
+    @SafeVarargs
     protected static <T extends Enum<T>> T parseEnum(
         Class<T> enumClass, String name, T defaultValue, Pair<String, T>... additionalPairs )
     {

--- a/community/shell/src/test/java/org/neo4j/shell/TestClientReconnect.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestClientReconnect.java
@@ -19,24 +19,18 @@
  */
 package org.neo4j.shell;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.Serializable;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.shell.impl.CollectingOutput;
+
+import static org.junit.Assert.assertTrue;
 
 public class TestClientReconnect extends AbstractShellTest
 {
-//    private final File storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true );
-//    
-//    @Override
-//    protected GraphDatabaseAPI newDb()
-//    {
-//        return new EmbeddedGraphDatabase( storeDir.getAbsolutePath() );
-//    }
-    
     @Test
     public void remoteClientAbleToReconnectAndContinue() throws Exception
     {
@@ -51,16 +45,15 @@ public class TestClientReconnect extends AbstractShellTest
     }
     
     @Test
-    public void initialSessionValuesSurvivesReconnect() throws Exception
+    public void initialSessionValuesAreEffective() throws Exception
     {
         createRelationshipChain( 2 );
         makeServerRemotelyAvailable();
-        Map<String, Serializable> initialSession = MapUtil.<String, Serializable>genericMap(
-                "TITLE_KEYS", "test" );
+        Map<String, Serializable> initialSession = MapUtil.genericMap( "FOO", "bar" );
         ShellClient client = newRemoteClient( initialSession );
-        String name = "MyTest";
-        client.evaluate( "set test " + name );
-        assertTrue( client.getPrompt().contains( name ) );
+        CollectingOutput output = new CollectingOutput();
+        client.evaluate("env", output);
+        assertTrue( output.asString().contains( "FOO=bar" ) );
         client.shutdown();
     }
 }


### PR DESCRIPTION
Reading properties requires a data transaction. Therefore any transaction
in the shell effectively becomes a data transaction. Since schema changes
are not allowed in the same transaction as data operations, this shell
feature prevents making any schema changes during an explicit transaction.
