### PR TITLE
Fix array storage corruption in batch inserter.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/TargetDirectory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TargetDirectory.java
@@ -47,6 +47,11 @@ public class TargetDirectory
             this.clean = clean;
         }
 
+        public String absolutePath()
+        {
+            return directory().getAbsolutePath();
+        }
+
         public File directory()
         {
             if ( subdir == null ) throw new IllegalStateException( "Not initialized" );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
@@ -60,6 +60,7 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -140,6 +141,34 @@ public class TestBatchInsert
     private GraphDatabaseService newBatchGraphDatabase()
     {
         return BatchInserters.batchDatabase( "neo-batch-db", fs.get() );
+    }
+
+    @Test
+    public void shouldUpdateStringArrayPropertiesOnNodesUsingBatchInserter1()
+    {
+        // Given
+        BatchInserter batchInserter = newBatchInserter();
+
+        String[] array1 = { "1" };
+        String[] array2 = { "a" };
+
+        long id1 = batchInserter.createNode(map("array", array1));
+        long id2 = batchInserter.createNode(map());
+
+        // When
+        batchInserter.getNodeProperties( id1 ).get( "array" );
+        batchInserter.setNodeProperty( id1, "array", array1 );
+        batchInserter.setNodeProperty( id2, "array", array2 );
+
+        batchInserter.getNodeProperties( id1 ).get( "array" );
+        batchInserter.setNodeProperty( id1, "array", array1 );
+        batchInserter.setNodeProperty( id2, "array", array2 );
+
+        // Then
+        assertThat( (String[])batchInserter.getNodeProperties( id1 ).get( "array" ), equalTo(array1) );
+
+        batchInserter.shutdown();
+
     }
 
     @Test


### PR DESCRIPTION
This addresses an issue where, when changing an array property from one array to another array of the same size,
the dynamic record storing the original value would get marked as not in use twice, putting it's id in the list
of reclaimed ids twice. That in turn would, obviously, allocate the same dynamic record twice to two different
properties.
