### PR TITLE
1.9 fix logical log rotation threshold docs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -180,8 +180,8 @@ public abstract class GraphDatabaseSettings
     @Description( "Specifies at which file size the logical log will auto-rotate. " +
                   "0 means that no rotation will automatically occur based on file size. " +
                   "Default is 25M" )
-    public static final Setting<Long> logical_log_rotation_threshold = setting( "logical_log_rotation_threshold",
-            Settings.LONG_WITH_OPTIONAL_UNIT, "25M" );
+    public static final GraphDatabaseSetting<Long> logical_log_rotation_threshold = new NumberOfBytesSetting( setting(
+            "logical_log_rotation_threshold", BYTES, "25M" ) );
 
     @Description("Use a quick approach for rebuilding the ID generators. This give quicker recovery time, " +
             "but will limit the ability to reuse the space of deleted entities.")


### PR DESCRIPTION
Make this setting look like the others.
Or should it still be using `Settings.LONG_WITH_OPTIONAL_UNIT` like master does?
The important part is using `GraphDatabaseSetting<Long>`, that's what fixes the docs.
