### PR TITLE
Fixes a race condition between index population and incoming updates

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -1113,10 +1113,24 @@ public abstract class IteratorUtil
 
     public static Set<Long> asSet( PrimitiveLongIterator iterator )
     {
+        return internalAsSet( iterator, false );
+    }
+
+    public static Set<Long> asSetAllowDuplicates( PrimitiveLongIterator iterator )
+    {
+        return internalAsSet( iterator, true );
+    }
+
+    private static Set<Long> internalAsSet( PrimitiveLongIterator iterator, boolean allowDuplicates )
+    {
         Set<Long> set = new HashSet<>();
         while ( iterator.hasNext() )
         {
-            set.add( iterator.next() );
+            long value = iterator.next();
+            if ( !set.add( value ) && !allowDuplicates )
+            {
+                throw new IllegalStateException( "Duplicates found. Tried to add " + value + " to " + set );
+            }
         }
         return set;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/NodePropertyUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/NodePropertyUpdate.java
@@ -24,6 +24,10 @@ import java.util.Arrays;
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.api.UpdateMode;
 
+import static org.neo4j.kernel.impl.api.UpdateMode.ADDED;
+import static org.neo4j.kernel.impl.api.UpdateMode.CHANGED;
+import static org.neo4j.kernel.impl.api.UpdateMode.REMOVED;
+
 public class NodePropertyUpdate
 {
     private final long nodeId;
@@ -34,8 +38,8 @@ public class NodePropertyUpdate
     private final long[] labelsBefore;
     private final long[] labelsAfter;
 
-    public NodePropertyUpdate( long nodeId, int propertyKeyId, Object valueBefore, long[] labelsBefore,
-                               Object valueAfter, long[] labelsAfter )
+    private NodePropertyUpdate( long nodeId, int propertyKeyId, Object valueBefore, long[] labelsBefore,
+                               Object valueAfter, long[] labelsAfter, UpdateMode updateMode )
     {
         this.nodeId = nodeId;
         this.propertyKeyId = propertyKeyId;
@@ -43,26 +47,7 @@ public class NodePropertyUpdate
         this.labelsBefore = labelsBefore;
         this.valueAfter = valueAfter;
         this.labelsAfter = labelsAfter;
-        this.updateMode = figureOutUpdateMode( valueBefore, valueAfter );
-    }
-
-    private UpdateMode figureOutUpdateMode( Object valueBefore, Object valueAfter )
-    {
-        boolean beforeSet = valueBefore != null;
-        boolean afterSet = valueAfter != null;
-        if ( !beforeSet && afterSet )
-        {
-            return UpdateMode.ADDED;
-        }
-        if ( beforeSet && afterSet )
-        {
-            return UpdateMode.CHANGED;
-        }
-        if ( beforeSet )
-        {
-            return UpdateMode.REMOVED;
-        }
-        throw new IllegalArgumentException( "Neither before or after set" );
+        this.updateMode = updateMode;
     }
 
     public long getNodeId()
@@ -214,17 +199,18 @@ public class NodePropertyUpdate
 
     public static NodePropertyUpdate add( long nodeId, int propertyKeyId, Object value, long[] labels )
     {
-        return new NodePropertyUpdate( nodeId, propertyKeyId, null, EMPTY_LONG_ARRAY, value, labels );
+        return new NodePropertyUpdate( nodeId, propertyKeyId, null, EMPTY_LONG_ARRAY, value, labels, ADDED );
     }
 
     public static NodePropertyUpdate change( long nodeId, int propertyKeyId, Object valueBefore, long[] labelsBefore,
             Object valueAfter, long[] labelsAfter )
     {
-        return new NodePropertyUpdate( nodeId, propertyKeyId, valueBefore, labelsBefore, valueAfter, labelsAfter );
+        return new NodePropertyUpdate( nodeId, propertyKeyId, valueBefore, labelsBefore, valueAfter, labelsAfter,
+                CHANGED );
     }
 
     public static NodePropertyUpdate remove( long nodeId, int propertyKeyId, Object value, long[] labels )
     {
-        return new NodePropertyUpdate( nodeId, propertyKeyId, value, labels, null, EMPTY_LONG_ARRAY );
+        return new NodePropertyUpdate( nodeId, propertyKeyId, value, labels, null, EMPTY_LONG_ARRAY, REMOVED );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -48,7 +48,7 @@ import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
 /**
  * Represents one job of initially populating an index over existing data in the database.
  * Scans the store directly.
- * 
+ *
  * @author Mattias Persson
  */
 public class IndexPopulationJob implements Runnable
@@ -88,7 +88,7 @@ public class IndexPopulationJob implements Runnable
         this.failureDelegate = failureDelegateFactory;
         this.log = logging.getMessagesLog( getClass() );
     }
-    
+
     @Override
     public void run()
     {
@@ -106,8 +106,10 @@ public class IndexPopulationJob implements Runnable
 
                 indexAllNodes();
                 if ( cancelled )
+                {
                     // We remain in POPULATING state
                     return;
+                }
 
                 Callable<Void> duringFlip = new Callable<Void>()
                 {
@@ -236,20 +238,22 @@ public class IndexPopulationJob implements Runnable
             cancelled = true;
             storeScan.stop();
         }
-        
+
         return latchGuardedValue( NO_VALUE, doneSignal );
     }
 
     /**
-     * A transaction happened that produced the given updates. Let this job incorporate its data
-     * into, feeding it to the {@link IndexPopulator}.
+     * A transaction happened that produced the given updates. Let this job incorporate its data,
+     * feeding it to the {@link IndexPopulator}.
      */
     public void update( Iterable<NodePropertyUpdate> updates )
     {
         for ( NodePropertyUpdate update : updates )
+        {
             queue.add( update );
+        }
     }
-    
+
     @Override
     public String toString()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -53,13 +53,14 @@ class HashBasedIndex extends InMemoryIndexImplementation
     }
 
     @Override
-    void doAdd( Object propertyValue, long nodeId )
+    void doAdd( Object propertyValue, long nodeId, boolean applyIdempotently )
     {
         Set<Long> nodes = data.get( propertyValue );
         if ( nodes == null )
         {
             data.put( propertyValue, nodes = new HashSet<>() );
         }
+        // In this implementation we don't care about idempotency.
         nodes.add( nodeId );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -66,9 +66,9 @@ class InMemoryIndex
         return indexData.lookup( propertyValue );
     }
 
-    protected void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+    protected void add( long nodeId, Object propertyValue, boolean applyIdempotently ) throws IndexEntryConflictException, IOException
     {
-        indexData.add( nodeId, propertyValue );
+        indexData.add( nodeId, propertyValue, applyIdempotently );
     }
 
     protected void remove( long nodeId, Object propertyValue )
@@ -76,18 +76,19 @@ class InMemoryIndex
         indexData.remove( nodeId, propertyValue );
     }
 
-    protected void update( Iterable<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
+    protected void update( Iterable<NodePropertyUpdate> updates, boolean applyIdempotently )
+            throws IndexEntryConflictException, IOException
     {
         for ( NodePropertyUpdate update : updates )
         {
             switch ( update.getUpdateMode() )
             {
             case ADDED:
-                add( update.getNodeId(), update.getValueAfter() );
+                add( update.getNodeId(), update.getValueAfter(), applyIdempotently );
                 break;
             case CHANGED:
                 remove( update.getNodeId(), update.getValueBefore() );
-                add( update.getNodeId(), update.getValueAfter() );
+                add( update.getNodeId(), update.getValueAfter(), applyIdempotently );
                 break;
             case REMOVED:
                 remove( update.getNodeId(), update.getValueBefore() );
@@ -114,13 +115,13 @@ class InMemoryIndex
         @Override
         public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
         {
-            InMemoryIndex.this.add( nodeId, propertyValue );
+            InMemoryIndex.this.add( nodeId, propertyValue, false );
         }
 
         @Override
         public void update( Iterable<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
         {
-            InMemoryIndex.this.update( updates );
+            InMemoryIndex.this.update( updates, true );
         }
 
         @Override
@@ -153,7 +154,7 @@ class InMemoryIndex
         {
             try
             {
-                update( updates );
+                update( updates, true );
             }
             catch ( IndexEntryConflictException e )
             {
@@ -165,7 +166,7 @@ class InMemoryIndex
         public void updateAndCommit( Iterable<NodePropertyUpdate> updates )
                 throws IOException, IndexEntryConflictException
         {
-            InMemoryIndex.this.update( updates );
+            InMemoryIndex.this.update( updates, false );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexImplementation.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexImplementation.java
@@ -33,9 +33,9 @@ abstract class InMemoryIndexImplementation implements IndexReader
         return doLookup( encode( value ) );
     }
 
-    final void add( long nodeId, Object propertyValue )
+    final void add( long nodeId, Object propertyValue, boolean applyIdempotently )
     {
-        doAdd( encode( propertyValue ), nodeId );
+        doAdd( encode( propertyValue ), nodeId, applyIdempotently );
     }
 
     final void remove( long nodeId, Object propertyValue )
@@ -45,7 +45,7 @@ abstract class InMemoryIndexImplementation implements IndexReader
 
     abstract PrimitiveLongIterator doLookup( Object propertyValue );
 
-    abstract void doAdd( Object propertyValue, long nodeId );
+    abstract void doAdd( Object propertyValue, long nodeId, boolean applyIdempotently );
 
     abstract void doRemove( Object propertyValue, long nodeId );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/ListBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/ListBasedIndex.java
@@ -44,8 +44,12 @@ class ListBasedIndex extends InMemoryIndexImplementation
     }
 
     @Override
-    void doAdd( Object propertyValue, long nodeId )
+    void doAdd( Object propertyValue, long nodeId, boolean applyIdempotently )
     {
+        if ( applyIdempotently && find( data.iterator(), propertyValue ).hasNext() )
+        {
+            return;
+        }
         data.add( new Entry( propertyValue, nodeId ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -30,18 +30,20 @@ import org.neo4j.kernel.impl.api.index.PropertyUpdateUniquenessValidator;
 class UniqueInMemoryIndex extends InMemoryIndex implements PropertyUpdateUniquenessValidator.Lookup
 {
     @Override
-    protected void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+    protected void add( long nodeId, Object propertyValue, boolean applyIdempotently )
+            throws IndexEntryConflictException, IOException
     {
         PrimitiveLongIterator nodes = lookup( propertyValue );
         if ( nodes.hasNext() )
         {
             throw new PreexistingIndexEntryConflictException( propertyValue, nodes.next(), nodeId );
         }
-        super.add( nodeId, propertyValue );
+        super.add( nodeId, propertyValue, applyIdempotently );
     }
 
     @Override
-    protected void update( Iterable<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
+    protected void update( Iterable<NodePropertyUpdate> updates, boolean applyIdempotently )
+            throws IndexEntryConflictException, IOException
     {
         PropertyUpdateUniquenessValidator.validateUniqueness( updates, UniqueInMemoryIndex.this );
         for ( NodePropertyUpdate update : updates )
@@ -59,7 +61,7 @@ class UniqueInMemoryIndex extends InMemoryIndex implements PropertyUpdateUniquen
             {
             case ADDED:
             case CHANGED:
-                add( update.getNodeId(), update.getValueAfter() );
+                add( update.getNodeId(), update.getValueAfter(), applyIdempotently );
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexLookupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexLookupIT.java
@@ -149,9 +149,10 @@ public class NodeGetUniqueFromIndexLookupIT extends KernelIntegrationTest
                 latch.awaitStart();
                 try ( Transaction tx = db.beginTx() )
                 {
-                    Statement statement = statementContextProvider.statement();
-                    statement.readOperations().nodeGetUniqueFromIndexLookup( index, value );
-                    statement.close();
+                    try ( Statement statement = statementContextProvider.statement() )
+                    {
+                        statement.readOperations().nodeGetUniqueFromIndexLookup( index, value );
+                    }
                     tx.success();
                 }
                 catch ( IndexNotFoundKernelException | IndexBrokenKernelException e )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
@@ -31,7 +31,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
 {
     static final int DEFAULT_QUEUE_THRESHOLD = 10000;
     private final int queueThreshold;
-    private final List<NodePropertyUpdate> updates = new ArrayList<NodePropertyUpdate>();
+    private final List<NodePropertyUpdate> updates = new ArrayList<>();
 
     NonUniqueLuceneIndexPopulator( int queueThreshold, LuceneDocumentStructure documentStructure,
                                    LuceneIndexWriterFactory indexWriterFactory,
@@ -71,16 +71,17 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
             long nodeId = update.getNodeId();
             switch ( update.getUpdateMode() )
             {
-            case ADDED:
-                writer.addDocument( documentStructure.newDocumentRepresentingProperty( nodeId, update.getValueAfter() ) );
-                break;
-            case CHANGED:
+            case ADDED: case CHANGED:
+                // We don't look at the "before" value, so adding and changing idempotently is done the same way.
                 writer.updateDocument( documentStructure.newQueryForChangeOrRemove( nodeId ),
-                                       documentStructure.newDocumentRepresentingProperty( nodeId, update.getValueAfter() ) );
+                                       documentStructure.newDocumentRepresentingProperty( nodeId,
+                                               update.getValueAfter() ) );
                 break;
             case REMOVED:
                 writer.deleteDocuments( documentStructure.newQueryForChangeOrRemove( nodeId ) );
                 break;
+            default:
+                throw new IllegalStateException( "Unknown update mode " + update.getUpdateMode() );
             }
         }
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
@@ -54,7 +54,7 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
 
     private HashMap<Object, Long> newBatchMap()
     {
-        return new HashMap<Object, Long>( (int) (batchSize / LOAD_FACTOR), LOAD_FACTOR );
+        return new HashMap<>( (int) (batchSize / LOAD_FACTOR), LOAD_FACTOR );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.servlet.ServletException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
@@ -37,7 +38,6 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.map.ObjectMapper;
-
 import org.neo4j.server.rest.web.InternalJettyServletRequest;
 import org.neo4j.server.rest.web.InternalJettyServletResponse;
 import org.neo4j.server.web.WebServer;


### PR DESCRIPTION
where the index could end up having duplicates (or more) for any given
entry.

Solution is to change (and clearly document) the contract of the
IndexPopulator#update method in that all updates must be applied in an
idempotent manner. This will incur an overhead in the index population,
but it's a background process and updates comes in in batches so the
overhead is somewhat minimized. Data coming in via IndexPopulator#add does
not have to be checked for idempotency and that fact was clarified a bit
in the javadocs as well.
