### PR TITLE
Ensures tx manager gets called in KernelTransaction#commit no matter what

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionForcefullyRolledBackException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionForcefullyRolledBackException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions;
+
+/**
+ * Thrown when there's a transaction wanting to commit, but was unable to and was therefore
+ * forced to roll back instead.
+ */
+public class TransactionForcefullyRolledBackException extends TransactionFailureException
+{
+    public TransactionForcefullyRolledBackException( RuntimeException cause )
+    {
+        super( cause );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
@@ -170,11 +170,6 @@ public class NoTransactionState implements TransactionState
     }
 
     @Override
-    public void setRollbackOnly()
-    {
-    }
-
-    @Override
     public TxHook getTxHook()
     {
         return null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
@@ -88,8 +88,6 @@ public interface TransactionState
 
     boolean hasChanges();
 
-    void setRollbackOnly();
-
     TxHook getTxHook();
 
     TxIdGenerator getTxIdGenerator();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.Transaction;
@@ -774,27 +775,6 @@ public class WritableTransactionState implements TransactionState
         public void afterCompletion( int status )
         {
             releaseLocks();
-        }
-    }
-
-    @Override
-    public void setRollbackOnly()
-    {
-        try
-        {
-            tx.setRollbackOnly();
-        }
-        catch ( IllegalStateException e )
-        {
-            // this exception always get generated in a finally block and
-            // when it happens another exception has already been thrown
-            // (most likley NotInTransactionException)
-            log.warn( "Failed to set transaction rollback only", e );
-        }
-        catch ( javax.transaction.SystemException se )
-        {
-            // our TM never throws this exception
-            log.warn( "Failed to set transaction rollback only", se );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTxManager.java
@@ -163,7 +163,7 @@ public class ReadOnlyTxManager extends AbstractTransactionManager
         txThreadMap.remove();
         tx.setStatus( Status.STATUS_NO_TRANSACTION );
         throw new RollbackException(
-                "Failed to commit, transaction rolledback" );
+                "Failed to commit, transaction rolled back" );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.RollbackException;
@@ -32,6 +33,7 @@ import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -110,6 +112,10 @@ class TransactionImpl implements Transaction
                 eventIdentifier, owner.getName(), txManager.getTxStatusAsString( status ), resourceList.size() );
     }
 
+    /**
+     * This implementation assumes this call hierarchy:
+     * {@link TransactionImpl#commit()} --> {@link KernelTransaction#commit()} --> {@link TransactionManager#commit()}
+     */
     @Override
     public synchronized void commit() throws RollbackException,
             HeuristicMixedException, HeuristicRollbackException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.NotSupportedException;
@@ -247,8 +248,10 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     synchronized void setTmNotOk( Throwable cause )
     {
         if ( !tmOk )
+        {
             return;
-        
+        }
+
         tmOk = false;
         tmNotOkCause = cause;
         log.logMessage( "setting TM not OK", cause );
@@ -499,13 +502,13 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
                 if ( commitFailureCause == null )
                 {
                     throw logAndReturn( "TM error tx commit", new HeuristicRollbackException(
-                            "Failed to commit, transaction rolledback ---> "
+                            "Failed to commit, transaction rolled back ---> "
                                     + "error code was: " + xaErrorCode ) );
                 }
                 else
                 {
                     throw logAndReturn( "TM error tx commit", Exceptions.withCause( new HeuristicRollbackException(
-                            "Failed to commit, transaction rolledback ---> " +
+                            "Failed to commit, transaction rolled back ---> " +
                                     commitFailureCause ), commitFailureCause ) );
                 }
             }
@@ -566,7 +569,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         }
         tx.setStatus( Status.STATUS_NO_TRANSACTION );
         RollbackException rollbackException = new RollbackException(
-                "Failed to commit, transaction rolledback" );
+                "Failed to commit, transaction rolled back" );
         ExceptionCauseSetter.setCause( rollbackException, tx.getRollbackCause() );
         throw rollbackException;
     }
@@ -659,7 +662,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         assertTmOk();
         return txThreadMap.get();
     }
-    
+
     @Override
     public void resume( Transaction tx ) throws IllegalStateException,
             SystemException
@@ -949,7 +952,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
     {
         this.kernel = kernel;
     }
-    
+
     @Override
     @SuppressWarnings("deprecation")
     public KernelTransaction getKernelTransaction()
@@ -965,7 +968,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         }
         return tx != null ? ((TransactionImpl)tx).getTransactionContext() : null;
     }
-    
+
     private class TxManagerDataSourceRegistrationListener implements DataSourceRegistrationListener
     {
         @Override

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.shell.kernel.apps;
 
-import static org.neo4j.shell.ShellException.wrapCause;
-
 import java.rmi.RemoteException;
 
 import javax.transaction.SystemException;
@@ -34,6 +32,8 @@ import org.neo4j.shell.Output;
 import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.Variables;
+
+import static org.neo4j.shell.ShellException.wrapCause;
 
 @Service.Implementation(App.class)
 public class Commit extends NonTransactionProvidingApp
@@ -49,9 +49,9 @@ public class Commit extends NonTransactionProvidingApp
     {
         try
         {
-
             return getServer().getDb().getTxManager().getTransaction();
-        } catch ( SystemException e )
+        }
+        catch ( SystemException e )
         {
             throw wrapCause( e );
         }
@@ -76,7 +76,8 @@ public class Commit extends NonTransactionProvidingApp
             {
                 out.println( "Warning: committing a transaction not started by the shell" );
                 txCount = 1;
-            } else
+            }
+            else
             {
                 throw new ShellException( "Not in a transaction" );
             }
@@ -95,11 +96,13 @@ public class Commit extends NonTransactionProvidingApp
                 session.remove( Variables.TX_COUNT );
                 out.println( "Transaction committed" );
                 return Continuation.INPUT_COMPLETE;
-            } catch ( Exception e )
+            }
+            catch ( Exception e )
             {
                 throw fail( session, e.getMessage() );
             }
-        } else
+        }
+        else
         {
             session.set( Variables.TX_COUNT, --txCount );
             out.println( String.format( "Nested transaction committed (Tx count: %d)", txCount ) );


### PR DESCRIPTION
Calling KernelTransaction#commit must end up calling transaction manager
commit so that the transaction will get finished properly. This is done by
having any operations done before it performed in a try with the tx
manager delegation in its finally clause.
