### PR TITLE
Require parenthesis for bare nodes with labels in patterns

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/ParserPattern.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/legacy/ParserPattern.scala
@@ -88,12 +88,6 @@ trait ParserPattern extends Base with Labels {
       nodeInParenthesis | // (singleNodeDefinition)
       failure("expected an expression that is a node")
 
-  private def labels: Parser[(Seq[KeyToken], Map[String, Expression], Boolean)] = optLabelShortForm ^^ {
-    case labels =>
-      val bare = labels.isEmpty
-      (labels, Map.empty, bare)
-  }
-
   private def labelsAndValues: Parser[(Seq[KeyToken], Map[String, Expression], Boolean)] = optLabelShortForm ~ opt(curlyMap) ^^ {
     case labels ~ optMap =>
       val mapVal = optMap.getOrElse(Map.empty)
@@ -101,10 +95,9 @@ trait ParserPattern extends Base with Labels {
       (labels, mapVal, bare)
   }
 
-  private def singleNodeDefinition = identity ~ labels ^^ {
-    case name ~ labels =>
-      val (labelsVal, mapVal, bare) = labels
-      ParsedEntity(name, Identifier(name), mapVal, labelsVal, bare)
+  private def singleNodeDefinition = identity ^^ {
+    case name =>
+      ParsedEntity(name, Identifier(name), Map.empty, Seq.empty, true)
   }
 
   private def nodeInParenthesis = parens(optionalName ~ labelsAndValues) ^^ {

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Patterns.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Patterns.scala
@@ -107,7 +107,7 @@ trait Patterns extends Parser
 
   private def NodePattern : Rule1[ast.NodePattern] = rule("a node pattern") (
       group("(" ~~ MaybeIdentifier ~~ MaybeNodeLabels ~~ MaybeProperties ~~ ")") ~~> t(toNodePattern _)
-    | group(Identifier ~~ MaybeNodeLabels) ~~> t(ast.NamedNodePattern(_, _, None, _))
+    | Identifier ~~> t(ast.NamedNodePattern(_, Seq(), None, _))
   )
 
   private def MaybeIdentifier : Rule1[Option[ast.Identifier]] = rule("an identifier") {

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
@@ -365,13 +365,13 @@ public class JavaExecutionEngineDocTest
         // END SNIPPET: create_multiple_nodes_from_map
         dumpToFile( "create_multiple_nodes_from_map", query, params );
 
-        ExecutionResult result = engine.execute( "match n:Person where n.name in ['Andres', 'Michael'] and n.position = 'Developer' return n" );
+        ExecutionResult result = engine.execute( "match (n:Person) where n.name in ['Andres', 'Michael'] and n.position = 'Developer' return n" );
         assertThat( count( result ), is( 2 ) );
 
-        result = engine.execute( "match n:Person where n.children = 3 return n" );
+        result = engine.execute( "match (n:Person) where n.children = 3 return n" );
         assertThat( count( result ), is( 1 ) );
 
-        result = engine.execute( "match n:Person where n.awesome = true return n" );
+        result = engine.execute( "match (n:Person) where n.awesome = true return n" );
         assertThat( count( result ), is( 1 ) );
     }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
@@ -34,7 +34,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineHelper with Assertions w
     val b = createNode()
     relate(a, b, "X")
 
-    val result = parseAndExecute("start a = node(1) create unique a-[r:X]->b:FOO return b")
+    val result = parseAndExecute("start a = node(1) create unique a-[r:X]->(b:FOO) return b")
     val createdNode = result.columnAs[Node]("b").toList.head
 
     assertStats(result, relationshipsCreated =  1, nodesCreated = 1, labelsAdded = 1)
@@ -47,7 +47,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineHelper with Assertions w
     val b = createNode()
     relate(a, b, "X")
 
-    val result = parseAndExecute("start b = node(1) create unique a:FOO-[r:X]->b return a")
+    val result = parseAndExecute("start b = node(1) create unique (a:FOO)-[r:X]->b return a")
     val createdNode = result.columnAs[Node]("a").toList.head
 
     assertStats(result, relationshipsCreated =  1, nodesCreated = 1, labelsAdded = 1)

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -99,8 +99,8 @@ class ErrorMessagesTest extends ExecutionEngineHelper with Assertions with Strin
 
   @Test def badMatch5() {
     expectSyntaxError("start p=node(2) match p[:likes]->dude return dude.name",
-      vLegacy ->("expected valid query body", 23),
-      v2_0 ->("Invalid input '[': expected an identifier character, whitespace, '=', node labels, a relationship pattern, ',', USING, WHERE, CREATE, DELETE, SET, REMOVE, RETURN, WITH, UNION, ';' or end of input (line 1, column 24)", 23)
+      vLegacy -> ("expected valid query body", 23),
+      v2_0 -> ("Invalid input '[': expected an identifier character, whitespace, '=', a relationship pattern, ',', USING, WHERE, CREATE, DELETE, SET, REMOVE, RETURN, WITH, UNION, ';' or end of input (line 1, column 24)", 23)
     )
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -2461,7 +2461,7 @@ RETURN x0.name
     relate(a, b2)
 
     // WHEN
-    val result = parseAndExecute(s"START a=node(${nodeId(a)}) MATCH a-[?]->b:foo RETURN b")
+    val result = parseAndExecute(s"START a=node(${nodeId(a)}) MATCH a-[?]->(b:foo) RETURN b")
 
     // THEN
     assert(result.toList === List(Map("b" -> b1)))
@@ -2477,7 +2477,7 @@ RETURN x0.name
     relate(a2, b)
 
     // WHEN
-    val result = parseAndExecute( "START a=node(1,2), b=node(3) MATCH a:bar --> b:foo RETURN a")
+    val result = parseAndExecute( "START a=node(1,2), b=node(3) MATCH (a:bar) --> (b:foo) RETURN a")
 
     // THEN
     assert(result.toList === List(Map("a" -> a1)))
@@ -2650,7 +2650,7 @@ RETURN x0.name
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = parseAndExecute("MATCH n:Person-->() USING INDEX n:Person(name) WHERE n.name = 'Jacob' RETURN n")
+    val result = parseAndExecute("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name = 'Jacob' RETURN n")
     println(result.executionPlanDescription())
 
     //THEN
@@ -2666,7 +2666,7 @@ RETURN x0.name
     relate(jake, createNode())
 
     //WHEN
-    val result = parseAndExecute("MATCH n:Person-->() WHERE n.name = 'Jacob' RETURN n")
+    val result = parseAndExecute("MATCH (n:Person)-->() WHERE n.name = 'Jacob' RETURN n")
 
     //THEN
     assert(result.toList === List(Map("n"->jake)))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -43,7 +43,7 @@ class ExecutionResultTest extends ExecutionEngineHelper with Assertions {
   }
 
   @Test def correctLabelStatisticsForCreate() {
-    val result = parseAndExecute("create n:foo:bar")
+    val result = parseAndExecute("create (n:foo:bar)")
     val stats  = result.queryStatistics()
 
     assert(stats.labelsAdded === 2)

--- a/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
@@ -40,7 +40,9 @@ class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker 
 
   @Test def Creating_nodes_with_literal_labels() {
     assertDoesNotWork("CREATE node :FOO:BAR {name: 'Stefan'}")
-    assertThat("CREATE node :FOO:BAR", List("FOO", "BAR"))
+    assertDoesNotWork("CREATE node :FOO:BAR")
+    assertThat("CREATE node", List())
+    assertThat("CREATE (node :FOO:BAR)", List("FOO", "BAR"))
     assertThat("CREATE (node:FOO:BAR {name: 'Mattias'})", List("FOO", "BAR"))
     assertThat("CREATE (n:Person)-[:OWNS]->(x:Dog) RETURN n AS node", List("Person"))
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -524,7 +524,7 @@ return distinct center""")
 
   @Test
   def should_be_able_to_create_node_with_labels() {
-    val result = parseAndExecute("create n:FOO:BAR return n")
+    val result = parseAndExecute("create (n:FOO:BAR) return n")
     val createdNode = result.columnAs[Node]("n").next()
 
     assertThat(createdNode, inTx(graph, hasLabels("FOO", "BAR")))

--- a/community/cypher/src/test/scala/org/neo4j/cypher/OptionalBehaviourAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/OptionalBehaviourAcceptanceTest.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 class OptionalBehaviourAcceptanceTest extends ExecutionEngineHelper {
   @Test def optional_nodes_with_labels_in_match_clause_should_return_null_when_where_is_no_match() {
     createNode()
-    val result = parseAndExecute("start n=node(1) match n-[r?]-m:Person return r")
+    val result = parseAndExecute("start n=node(1) match n-[r?]-(m:Person) return r")
     assert(result.toList === List(Map("r" -> null)))
   }
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintValidationAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintValidationAcceptanceTest.scala
@@ -55,7 +55,7 @@ class UniqueConstraintValidationAcceptanceTest
 
     // WHEN
     try {
-      parseAndExecute("match node2:Label1 where node2.seq = 2 set node2.key1 = 'value1'")
+      parseAndExecute("match (node2:Label1) where node2.seq = 2 set node2.key1 = 'value1'")
 
       fail("should have thrown exception")
     }
@@ -114,13 +114,13 @@ class UniqueConstraintValidationAcceptanceTest
     {
       // WHEN
       parseAndExecute(
-        "match toRemove:Label1 where toRemove.key1 = 'value1' " +
+        "match (toRemove:Label1) where toRemove.key1 = 'value1' " +
           resolve +
           " create ( toAdd:Label1 { seq: {seq}, key1: 'value1' } )",
         "seq" -> seq)
 
       // THEN
-      val result: ExecutionResult = parseAndExecute("match n:Label1 where n.key1 = 'value1' return n.seq as seq")
+      val result: ExecutionResult = parseAndExecute("match (n:Label1) where n.key1 = 'value1' return n.seq as seq")
       assertEquals(List(seq), result.columnAs[Int]("seq").toList)
       seq += 1
     }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintVerificationAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UniqueConstraintVerificationAcceptanceTest.scala
@@ -73,7 +73,7 @@ class UniqueConstraintVerificationAcceptanceTest
   def should_add_constraint_using_recreated_unique_data() {
     // GIVEN
     parseAndExecute("create (a:Person{name:\"Alistair\"}), (b:Person{name:\"Stefan\"})")
-    parseAndExecute("match n:Person delete n")
+    parseAndExecute("match (n:Person) delete n")
     parseAndExecute("create (a:Person{name:\"Alistair\"}), (b:Person{name:\"Stefan\"})")
 
     // WHEN

--- a/community/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
@@ -51,7 +51,7 @@ class UsingAcceptanceTest extends ExecutionEngineHelper with Assertions with Gra
 
     // WHEN
     intercept[IndexHintException](
-      parseAndExecute("match n:Person-->() using index n:Person(name) where n.name = \"kabam\" return n"))
+      parseAndExecute("match (n:Person)-->() using index n:Person(name) where n.name = \"kabam\" return n"))
   }
 
   @Test
@@ -60,7 +60,7 @@ class UsingAcceptanceTest extends ExecutionEngineHelper with Assertions with Gra
 
     // WHEN
     intercept[IndexHintException](
-      parseAndExecute("match n:Person-->() using index m:Person(name) where n.name = \"kabam\" return n"))
+      parseAndExecute("match (n:Person)-->() using index m:Person(name) where n.name = \"kabam\" return n"))
   }
 
   @Test
@@ -70,7 +70,7 @@ class UsingAcceptanceTest extends ExecutionEngineHelper with Assertions with Gra
 
     // WHEN
     intercept[IndexHintException](
-      parseAndExecute("match n:Person-->() using index n:Person(name) where n.name <> \"kabam\" return n"))
+      parseAndExecute("match (n:Person)-->() using index n:Person(name) where n.name <> \"kabam\" return n"))
   }
 
   @Test
@@ -81,6 +81,6 @@ class UsingAcceptanceTest extends ExecutionEngineHelper with Assertions with Gra
 
     // WHEN
     intercept[IndexHintException](
-      parseAndExecute("match n:Person-->m:Food using index n:Person(name) using index m:Food(name) where n.name = m.name return n"))
+      parseAndExecute("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name = m.name return n"))
   }
 }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/AggregationTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/AggregationTest.scala
@@ -67,7 +67,7 @@ class AggregationTest extends DocumentingTestBase {
     testQuery(
       title = "Count non-null values",
       text = "You can count the non-`null` values by using +count(<identifier>)+.",
-      queryText = "match n:Person return count(n.property)",
+      queryText = "match (n:Person) return count(n.property)",
       returns = "The count of related nodes with the `property` property set is returned by the query.",
       assertions = p => assertEquals(Map("count(n.property)" -> 3), p.toList.head))
   }
@@ -77,7 +77,7 @@ class AggregationTest extends DocumentingTestBase {
       title = "SUM",
       text = "The +SUM+ aggregation function simply sums all the numeric values it encounters. " +
         "Nulls are silently dropped. This is an example of how you can use +SUM+.",
-      queryText = "match n:Person where has(n.property) return sum(n.property)",
+      queryText = "match (n:Person) where has(n.property) return sum(n.property)",
       returns = "This returns the sum of all the values in the property `property`.",
       assertions = p => assertEquals(Map("sum(n.property)" -> (13 + 33 + 44)), p.toList.head))
   }
@@ -86,7 +86,7 @@ class AggregationTest extends DocumentingTestBase {
     testQuery(
       title = "AVG",
       text = "+AVG+ calculates the average of a numeric column.",
-      queryText = "match n:Person where has(n.property) return avg(n.property)",
+      queryText = "match (n:Person) where has(n.property) return avg(n.property)",
       returns = "The average of all the values in the property `property` is returned by the example query.",
       assertions = p => assertEquals(Map("avg(n.property)" -> 30), p.toList.head))
   }
@@ -95,7 +95,7 @@ class AggregationTest extends DocumentingTestBase {
     testQuery(
       title = "MIN",
       text = "+MIN+ takes a numeric property as input, and returns the smallest value in that column.",
-      queryText = "match n:Person where has(n.property) return min(n.property)",
+      queryText = "match (n:Person) where has(n.property) return min(n.property)",
       returns = "This returns the smallest of all the values in the property `property`.",
       assertions = p => assertEquals(Map("min(n.property)" -> 13), p.toList.head))
   }
@@ -103,8 +103,8 @@ class AggregationTest extends DocumentingTestBase {
   @Test def max() {
     testQuery(
       title = "MAX",
-      text = "+MAX+ find the largets value in a numeric column.",
-      queryText = "match n:Person where has(n.property) return max(n.property)",
+      text = "+MAX+ find the largest value in a numeric column.",
+      queryText = "match (n:Person) where has(n.property) return max(n.property)",
       returns = "The largest of all the values in the property `property` is returned.",
       assertions = p => assertEquals(Map("max(n.property)" -> 44), p.toList.head))
   }
@@ -113,7 +113,7 @@ class AggregationTest extends DocumentingTestBase {
     testQuery(
       title = "COLLECT",
       text = "+COLLECT+ collects all the values into a list. It will ignore null values,",
-      queryText = "match n:Person return collect(n.property)",
+      queryText = "match (n:Person) return collect(n.property)",
       returns = "Returns a single row, with all the values collected.",
       assertions = p => assertEquals(Map("collect(n.property)" -> Seq(13, 33, 44)), p.toList.head))
   }
@@ -123,7 +123,7 @@ class AggregationTest extends DocumentingTestBase {
       title = "DISTINCT",
       text = """All aggregation functions also take the +DISTINCT+ modifier, which removes duplicates from the values.
 So, to count the number of unique eye colors from nodes related to `a`, this query can be used: """,
-      queryText = "match a:Person-->b where a.name = 'A' return count(distinct b.eyes)",
+      queryText = "match (a:Person)-->(b) where a.name = 'A' return count(distinct b.eyes)",
       returns = "Returns the number of eye colors.",
       assertions = p => assertEquals(Map("count(distinct b.eyes)" -> 2), p.toList.head))
   }
@@ -159,7 +159,7 @@ an aggregate function.
 
 An example might be helpful:""",
       queryText = "" +
-      		"MATCH me:Person-->friend:Person-->friend_of_friend:Person " +
+      		"MATCH (me:Person)-->(friend:Person)-->(friend_of_friend:Person) " +
           "WHERE me.name = 'A'" +
       		"RETURN count(distinct friend_of_friend), count(friend_of_friend)",
       returns = "In this example we are trying to find all our friends of friends, and count them. The first aggregate function, " +
@@ -173,7 +173,7 @@ An example might be helpful:""",
     testQuery(
       title = "PERCENTILE_DISC",
       text = "+PERCENTILE_DISC+ calculates the percentile of a given value over a group, with a percentile from 0.0 to 1.0. It uses a rounding method, returning the nearest value to the percentile. For interpolated values, see PERCENTILE_CONT.",
-      queryText = "match n:Person where has(n.property) return percentile_disc(n.property, 0.5)",
+      queryText = "match (n:Person) where has(n.property) return percentile_disc(n.property, 0.5)",
       returns = "The 50th percentile of the values in the property `property` is returned by the example query. In this case, 0.5 is the median, or 50th percentile.",
       assertions = p => assertEquals(Map("percentile_disc(n.property, 0.5)" -> 33), p.toList.head))
   }
@@ -182,7 +182,7 @@ An example might be helpful:""",
     testQuery(
       title = "PERCENTILE_CONT",
       text = "+PERCENTILE_CONT+ calculates the percentile of a given value over a group, with a percentile from 0.0 to 1.0. It uses a linear interpolation method, calculating a weighted average between two values, if the desired percentile lies between them. For nearest values using a rounding method, see PERCENTILE_DISC.",
-      queryText = "match n:Person where has(n.property) return percentile_cont(n.property, 0.4)",
+      queryText = "match (n:Person) where has(n.property) return percentile_cont(n.property, 0.4)",
       returns = "The 40th percentile of the values in the property `property` is returned by the example query, calculated with a weighted average.",
       assertions = p => assertEquals(Map("percentile_cont(n.property, 0.4)" -> 29), p.toList.head))
   }

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
@@ -100,7 +100,7 @@ class CreateTest extends DocumentingTestBase with StatisticsChecker {
       title = "Create a relationship between two nodes",
       text = "To create a relationship between two nodes, we first get the two nodes. " +
         "Once the nodes are loaded, we simply create a relationship between them.",
-      queryText = "match a:Person, b:Person where a.name = 'Node A' and b.name = 'Node B' create a-[r:RELTYPE]->b return r",
+      queryText = "match (a:Person), (b:Person) where a.name = 'Node A' and b.name = 'Node B' create a-[r:RELTYPE]->b return r",
       returns = "The created relationship is returned by the query.",
       assertions = (p) => assert(p.size === 1)
     )
@@ -148,7 +148,7 @@ will be created. """,
       title = "Create a relationship and set properties",
       text = "Setting properties on relationships is done in a similar manner to how it's done when creating nodes. " +
         "Note that the values can be any expression.",
-      queryText = "match a:Person, b:Person where a.name = 'Node A' and b.name = 'Node B' create a-[r:RELTYPE {name : a.name + '<->' + b.name }]->b return r",
+      queryText = "match (a:Person), (b:Person) where a.name = 'Node A' and b.name = 'Node B' create a-[r:RELTYPE {name : a.name + '<->' + b.name }]->b return r",
       returns = "The newly created relationship is returned by the example query.",
       assertions = (p) => {
         val result = p.toList

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
@@ -93,7 +93,7 @@ class CreateUniqueTest extends DocumentingTestBase with StatisticsChecker {
       title = "Create labeled node if missing",
       text = "If the pattern described needs a labeled node and there is none with the given labels, " +
              "Cypher will create a new one.",
-      queryText = "match a where a.name = 'A' create unique a-[:KNOWS]-c:blue return c",
+      queryText = "match a where a.name = 'A' create unique (a)-[:KNOWS]-(c:blue) return c",
       returns = "The A node is connected in a `KNOWS` relationship to the c node, but since C doesn't have " +
                 "the `:blue` label, a new node labeled as `:blue` is created along with a `KNOWS` relationship "+
                 "from A to it.",

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -66,7 +66,7 @@ class MatchTest extends DocumentingTestBase {
     testQuery(
       title = "Get all nodes with a label",
       text = "Getting all nodes with a label on them is done with a single node pattern where the node has a label on it.",
-      queryText = """match movie:Movie return movie""",
+      queryText = """match (movie:Movie) return movie""",
       returns = "Returns all the movies in the database.",
       assertions = (p) => assertEquals(nodes("WallStreet", "TheAmericanPresident").toSet, p.columnAs[Node]("movie").toSet)
     )
@@ -299,7 +299,7 @@ Cypher will try to match the relationship where the connected nodes switch sides
     testQuery(
       title = "Match with labels",
       text = "To constrain your pattern with labels on nodes, you add it to your pattern nodes, using the label syntax.",
-      queryText = "match charlie:Person-->movie:Movie where charlie.name='Charlie Sheen' return movie",
+      queryText = "match (charlie:Person)-->(movie:Movie) where charlie.name='Charlie Sheen' return movie",
       returns = "Return any nodes connected with Charlie that are labeled +Movie+.",
       assertions = p => assertEquals(List(node("WallStreet")), p.columnAs[Node]("movie").toList)
     )

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/UnionTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/UnionTest.scala
@@ -48,9 +48,9 @@ class UnionTest extends DocumentingTestBase with StatisticsChecker {
       title = "Union two queries",
       text = "Combining the results from two queries is done using UNION ALL",
       queryText =
-        """match n:Actor return n.name as name
+        """match (n:Actor) return n.name as name
            UNION ALL
-           match n:Movie return n.title as name""",
+           match (n:Movie) return n.title as name""",
       returns = "The combined result is returned.",
       assertions = (p) => assert(p.toList === List(Map("name" -> "Lucy Liu"), Map("name" -> "Kevin Bacon"), Map("name" -> "Cypher")))
     )
@@ -59,11 +59,11 @@ class UnionTest extends DocumentingTestBase with StatisticsChecker {
   @Test def union_between_two_queries_distinct() {
     testQuery(
       title = "Combine two queries and removing duplicates",
-      text = "By not uncluding +ALL+ in the +UNION+, duplicates are removed from the combined result set",
+      text = "By not including +ALL+ in the +UNION+, duplicates are removed from the combined result set",
       queryText =
-        """match n:Actor return n.name as name
+        """match (n:Actor) return n.name as name
            UNION
-           match n:Movie return n.title as name""",
+           match (n:Movie) return n.title as name""",
       returns = "The combined result is returned.",
       assertions = (p) => assert(p.toList === List(Map("name" -> "Lucy Liu"), Map("name" -> "Kevin Bacon"), Map("name" -> "Cypher")))
     )

--- a/community/cypher/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -43,7 +43,7 @@ class UsingTest extends DocumentingTestBase {
     testQuery(
       title = "Query using an index hint",
       text = "To query using an index hint, use +USING+ +INDEX+.",
-      queryText = "match n:Swedish using index n:Swedish(surname) where n.surname = 'Taylor' return n",
+      queryText = "match (n:Swedish) using index n:Swedish(surname) where n.surname = 'Taylor' return n",
       returns = "The query result is returned as usual.",
       assertions = (p) => assert(p.toList === List(Map("n" -> node("Andres"))))
     )
@@ -56,7 +56,7 @@ class UsingTest extends DocumentingTestBase {
     testQuery(
       title = "Query using multiple index hints",
       text = "To query using multiple index hints, use +USING+ +INDEX+.",
-      queryText = "match m:German-->n:Swedish using index m:German(surname) using index n:Swedish(surname) where m.surname = 'Plantikow' and n.surname = 'Taylor' return m",
+      queryText = "match (m:German)-->(n:Swedish) using index m:German(surname) using index n:Swedish(surname) where m.surname = 'Plantikow' and n.surname = 'Taylor' return m",
       returns = "The query result is returned as usual.",
       assertions = (p) => assert(p.toList === List(Map("m" -> node("Stefan"))))
     )
@@ -66,7 +66,7 @@ class UsingTest extends DocumentingTestBase {
     testQuery(
       title = "Hinting a label scan",
       text = "If the best performance is to be had by scanning all nodes in a label and then filtering on that set, use +USING+ +SCAN+.",
-      queryText = "match m:German using scan m:German where m.surname = 'Plantikow' return m",
+      queryText = "match (m:German) using scan m:German where m.surname = 'Plantikow' return m",
       returns = "This query does it's work by finding all `:German` labeled nodes and filtering them by the surname property",
       assertions = (p) => assert(p.toList === List(Map("m" -> node("Stefan"))))
     )

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/CypherParserTest.scala
@@ -1791,7 +1791,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def create_node_with_a_label() {
-    test(vFrom2_0, "create a:FOO",
+    test(vFrom2_0, "create (a:FOO)",
       Query.
         start(CreateNodeStartItem(CreateNode("a", Map(), LabelSupport.labelCollection("FOO"), false))).
         returns()
@@ -1799,7 +1799,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def create_node_with_multiple_labels() {
-    test(vFrom2_0, "create a:FOO:BAR",
+    test(vFrom2_0, "create (a:FOO:BAR)",
       Query.
         start(CreateNodeStartItem(CreateNode("a", Map(), LabelSupport.labelCollection("FOO", "BAR"), false))).
         returns()
@@ -1807,7 +1807,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def create_node_with_multiple_labels_with_spaces() {
-    test(vFrom2_0, "create a :FOO :BAR",
+    test(vFrom2_0, "create (a :FOO :BAR)",
       Query.
         start(CreateNodeStartItem(CreateNode("a", Map(), LabelSupport.labelCollection("FOO", "BAR"), false))).
         returns()
@@ -1815,7 +1815,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def create_nodes_with_labels_and_a_rel() {
-    test(vFrom2_0, "CREATE (n:Person:Husband)-[:FOO]->x:Person",
+    test(vFrom2_0, "CREATE (n:Person:Husband)-[:FOO]->(x:Person)",
       Query.
         start(CreateRelationshipStartItem(CreateRelationship("  UNNAMED25",
         RelationshipEndpoint(Identifier("n"),Map(), LabelSupport.labelCollection("Person", "Husband"), false),
@@ -2810,29 +2810,29 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def match_left_with_single_label() {
-    val query    = "start a = NODE(1) match a:foo -[r:MARRIED]-> () return a"
+    val query    = "start a = NODE(1) match (a:foo) -[r:MARRIED]-> () return a"
     val expected =
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo(SingleNode("a", Seq(UnresolvedLabel("foo"))), SingleNode("  UNNAMED46"), "r", Seq("MARRIED"), Direction.OUTGOING, false)).
+        matches(RelatedTo(SingleNode("a", Seq(UnresolvedLabel("foo"))), SingleNode("  UNNAMED48"), "r", Seq("MARRIED"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("a"), "a"))
 
     test(vFrom2_0, query, expected)
   }
 
   @Test def match_left_with_multiple_labels() {
-    val query    = "start a = NODE(1) match a:foo:bar -[r:MARRIED]-> () return a"
+    val query    = "start a = NODE(1) match (a:foo:bar) -[r:MARRIED]-> () return a"
     val expected =
       Query.
         start(NodeById("a", 1)).
-        matches(RelatedTo(SingleNode("a", Seq(UnresolvedLabel("foo"), UnresolvedLabel("bar"))), SingleNode("  UNNAMED50"), "r", Seq("MARRIED"), Direction.OUTGOING, false)).
+        matches(RelatedTo(SingleNode("a", Seq(UnresolvedLabel("foo"), UnresolvedLabel("bar"))), SingleNode("  UNNAMED52"), "r", Seq("MARRIED"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("a"), "a"))
 
     test(vFrom2_0, query, expected)
   }
 
   @Test def match_right_with_multiple_labels() {
-    val query    = "start a = NODE(1) match () -[r:MARRIED]-> a:foo:bar return a"
+    val query    = "start a = NODE(1) match () -[r:MARRIED]-> (a:foo:bar) return a"
     val expected =
       Query.
         start(NodeById("a", 1)).
@@ -2843,7 +2843,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def match_both_with_labels() {
-    val query    = "start a = NODE(1) match b:foo -[r:MARRIED]-> a:bar return a"
+    val query    = "start a = NODE(1) match (b:foo) -[r:MARRIED]-> (a:bar) return a"
     val expected =
       Query.
         start(NodeById("a", 1)).
@@ -2895,10 +2895,10 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def keywords_in_reltype_and_label() {
-    test(vFrom2_0, "START n=node(0) MATCH n:On-[:WHERE]->() RETURN n",
+    test(vFrom2_0, "START n=node(0) MATCH (n:On)-[:WHERE]->() RETURN n",
       Query.
         start(NodeById("n", 0)).
-        matches(RelatedTo(SingleNode("n", Seq(UnresolvedLabel("On"))), SingleNode("  UNNAMED38"), "  UNNAMED26", Seq("WHERE"), Direction.OUTGOING, false)).
+        matches(RelatedTo(SingleNode("n", Seq(UnresolvedLabel("On"))), SingleNode("  UNNAMED40"), "  UNNAMED28", Seq("WHERE"), Direction.OUTGOING, false)).
         returns(ReturnItem(Identifier("n"), "n"))
     )
   }
@@ -2909,8 +2909,8 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def simple_query_with_index_hint() {
-    test(vFrom2_0, "match n:Person-->() using index n:Person(name) where n.name = 'Andres' return n",
-      Query.matches(RelatedTo(SingleNode("n", Seq(UnresolvedLabel("Person"))), SingleNode("  UNNAMED18"), "  UNNAMED14", Seq(), Direction.OUTGOING, optional = false)).
+    test(vFrom2_0, "match (n:Person)-->() using index n:Person(name) where n.name = 'Andres' return n",
+      Query.matches(RelatedTo(SingleNode("n", Seq(UnresolvedLabel("Person"))), SingleNode("  UNNAMED20"), "  UNNAMED16", Seq(), Direction.OUTGOING, optional = false)).
         where(Equals(Property(Identifier("n"), PropertyKey("name")), Literal("Andres"))).
         using(SchemaIndex("n", "Person", "name", None)).
         returns(ReturnItem(Identifier("n"), "n", renamed = false)))
@@ -2925,7 +2925,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def awesome_single_labeled_node_match_pattern() {
-    test(vFrom2_0, "match s:nostart return s",
+    test(vFrom2_0, "match (s:nostart) return s",
       Query.
         matches(SingleNode("s", Seq(UnresolvedLabel("nostart")))).
         returns(ReturnItem(Identifier("s"), "s")))
@@ -2941,7 +2941,7 @@ class CypherParserTest extends JUnitSuite with Assertions {
   }
 
   @Test def label_scan_hint() {
-    test(vFrom2_0, "match p:Person using scan p:Person return p",
+    test(vFrom2_0, "match (p:Person) using scan p:Person return p",
       Query.
         matches(SingleNode("p", Seq(UnresolvedLabel("Person")))).
         using(NodeByLabel("p", "Person")).

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/legacy/ParserPatternTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/legacy/ParserPatternTest.scala
@@ -49,10 +49,14 @@ class ParserPatternTest extends ParserPattern with ParserTest with Expressions {
     parsing("(n)") shouldGive
       ParsedEntity("n", Identifier("n"), Map.empty, Seq.empty, true)
 
+    parsing("(n:Foo:Bar)") shouldGive
+      ParsedEntity("n", Identifier("n"), Map.empty, Seq(KeyToken.Unresolved("Foo", TokenType.Label), KeyToken.Unresolved("Bar", TokenType.Label)), false)
+
     parsing("(n {name:'Andres'})") shouldGive
       ParsedEntity("n", Identifier("n"), Map("name" -> Literal("Andres")), Seq.empty, false)
 
     assertFails("n {name:'Andres'}")
+    assertFails("n:Foo:Bar")
   }
 
   @Test def paths() {

--- a/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TransactionFunctionalTest.java
@@ -348,7 +348,7 @@ public class TransactionFunctionalTest extends AbstractRestFunctionalTestBase
 
         // when
         Response response = http.POST( "/db/data/transaction/commit", quotedJson(
-                "{ 'statements': [ { 'statement': 'MATCH n:Foo RETURN COLLECT(n)' } ] }" ) );
+                "{ 'statements': [ { 'statement': 'MATCH (n:Foo) RETURN COLLECT(n)' } ] }" ) );
 
         // then
         assertThat( response.status(), equalTo( 200 ) );

--- a/manual/cypherdoc/src/test/resources/hello-world.asciidoc
+++ b/manual/cypherdoc/src/test/resources/hello-world.asciidoc
@@ -27,7 +27,7 @@ Let's find the node we created:
 // output
 [source,cypher]
 ----
-MATCH person:Person
+MATCH (person:Person)
 WHERE person.name = "Adam"
 RETURN person;
 ----

--- a/manual/src/tutorials/cypher/social-movie-db.asciidoc
+++ b/manual/src/tutorials/cypher/social-movie-db.asciidoc
@@ -53,7 +53,7 @@ Let's check if the node is there:
 
 [source,cypher]
 ----
-MATCH me:User
+MATCH (me:User)
 WHERE me.name = "Me"
 RETURN me.name;
 ----
@@ -67,7 +67,7 @@ Add a movie rating:
 
 [source,cypher]
 ----
-MATCH me:User, movie:Movie
+MATCH (me:User), (movie:Movie)
 WHERE me.name = "Me" AND movie.title = "The Matrix"
 CREATE (me)-[:RATED {stars : 5, comment : "I love that movie!"}]->(movie);
 ----
@@ -81,7 +81,7 @@ Which movies did I rate?
 
 [source,cypher]
 ----
-MATCH me:User, (me)-[rating:RATED]->(movie)
+MATCH (me:User), (me)-[rating:RATED]->(movie)
 WHERE me.name = "Me"
 RETURN movie.title, rating.stars, rating.comment;
 ----
@@ -105,7 +105,7 @@ We return the relationship to check that it has not been created several times.
 
 [source,cypher]
 ----
-MATCH me:User, friend:User
+MATCH (me:User), (friend:User)
 WHERE me.name = "Me" AND friend.name = "A Friend"
 CREATE UNIQUE (me)-[friendship:FRIEND]->(friend)
 RETURN friendship;
@@ -121,7 +121,7 @@ Let's update our friendship with a +since+ property:
 
 [source,cypher]
 ----
-MATCH me:User, friend:User, (me)-[friendship:FRIEND]->(friend)
+MATCH (me:User), (friend:User), (me)-[friendship:FRIEND]->(friend)
 WHERE me.name = "Me" AND friend.name = "A Friend"
 SET friendship.since='forever'
 RETURN friendship;
@@ -135,7 +135,7 @@ Let's pretend us being our friend and wanting to see which movies our friends ha
 
 [source,cypher]
 ----
-MATCH me:User, (me)-[:FRIEND]-(friend)-[rating:RATED]->(movie)
+MATCH (me:User), (me)-[:FRIEND]-(friend)-[rating:RATED]->(movie)
 WHERE me.name = "A Friend"
 RETURN movie.title, avg(rating.stars) as stars, collect(rating.comment) as comments, count(*);
 ----
@@ -150,7 +150,7 @@ That's too little data, let's add some more friends and friendships.
 
 [source,cypher]
 ----
-MATCH me:User
+MATCH (me:User)
 WHERE me.name = "Me"
 FOREACH (i in range(1,10) |
   CREATE (friend:User {name: "Friend " + i}), (me)-[:FRIEND]->(friend));
@@ -166,7 +166,7 @@ Show all our friends:
 
 [source,cypher]
 ----
-MATCH me:User, (me)-[r:FRIEND]->(friend)
+MATCH (me:User), (me)-[r:FRIEND]->(friend)
 WHERE me.name = "Me" 
 RETURN type(r) as friendship, friend.name;
 ----


### PR DESCRIPTION
When using labels in patterns, parenthesis must be used.
ie. CREATE (n:Foo:Bar)
