### PR TITLE
Remove 350 calls to Transaction#finish().

### DIFF
--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
@@ -28,6 +28,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -97,7 +98,7 @@ public class IntroDocTest implements GraphHolder
         fw.append( AsciiDocGenerator.dumpToSeparateFileWithType( new File( DOCS_TARGET ), "intro.result",
                 createQueryResultSnippet( engine.execute( query ).dumpToString() ) ) );
         fw.close();
-        tx.finish();
+        tx.close();
     }
 
     @BeforeClass

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaExecutionEngineDocTest.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.cypher.javacompat;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.neo4j.cypher.javacompat.RegularExpressionMatcher.matchesPattern;
-import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
-import static org.neo4j.helpers.collection.IteratorUtil.count;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,14 +28,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectWriter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -55,6 +43,19 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.AsciiDocGenerator;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.cypher.javacompat.RegularExpressionMatcher.matchesPattern;
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
 
 public class JavaExecutionEngineDocTest
 {
@@ -92,7 +93,7 @@ public class JavaExecutionEngineDocTest
         index( michaelaNode );
 
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @After
@@ -110,8 +111,7 @@ public class JavaExecutionEngineDocTest
         db.index().forNodes( "people" ).add( n, "name", n.getProperty( "name" ) );
     }
 
-    public static String parametersToAsciidoc( final Object params ) throws JsonGenerationException,
-            JsonMappingException, IOException
+    public static String parametersToAsciidoc( final Object params ) throws IOException
     {
         StringBuffer sb = new StringBuffer( 2048 );
         String prettifiedJson = WRITER.writeValueAsString( params );
@@ -179,7 +179,7 @@ public class JavaExecutionEngineDocTest
             db.createNode();
         }
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -444,6 +444,6 @@ public class JavaExecutionEngineDocTest
         Transaction tx = db.beginTx();
         a.createRelationshipTo( b, DynamicRelationshipType.withName( "friend" ) );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 }

--- a/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQuery.java
+++ b/community/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaQuery.java
@@ -84,7 +84,7 @@ public class JavaQuery
             nodeResult = node + ": " + node.getProperty( "name" );
         }
         // END SNIPPET: items
-        tx.finish();
+        tx.close();
         // the result is now empty, get a new one
         result = engine.execute( "start n=node(*) where n.name = 'my node' return n, n.name" );
         // START SNIPPET: rows

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
@@ -26,6 +26,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphalgo.CommonEvaluators;
 import org.neo4j.graphalgo.EstimateEvaluator;
 import org.neo4j.graphalgo.GraphAlgoFactory;
@@ -73,7 +74,7 @@ public class PathFindingDocTest
     public void doAfter()
     {
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @AfterClass

--- a/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
@@ -41,6 +41,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.SillyUtils.nonNull;
 
 /**
@@ -83,7 +84,7 @@ public abstract class Neo4jAlgoTestCase
     {
         graph.clear();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     public static void deleteFileOrDirectory( File file )

--- a/community/graph-matching/src/test/java/matching/TestMatchingOfCircularPattern.java
+++ b/community/graph-matching/src/test/java/matching/TestMatchingOfCircularPattern.java
@@ -19,11 +19,6 @@
  */
 package matching;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -33,6 +28,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -48,6 +44,12 @@ import org.neo4j.graphmatching.PatternMatcher;
 import org.neo4j.graphmatching.PatternNode;
 import org.neo4j.helpers.collection.IteratorWrapper;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class TestMatchingOfCircularPattern
 {
@@ -213,7 +215,7 @@ public class TestMatchingOfCircularPattern
     @After
     public void verifyCount()
     {
-        tx.finish();
+        tx.close();
         tx = null;
         assertEquals( EXPECTED_VISIBLE_MESSAGE_COUNT, count );
     }

--- a/community/graph-matching/src/test/java/matching/TestPatternMatching.java
+++ b/community/graph-matching/src/test/java/matching/TestPatternMatching.java
@@ -19,11 +19,6 @@
  */
 package matching;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,6 +33,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -53,9 +49,14 @@ import org.neo4j.graphmatching.PatternRelationship;
 import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphHolder;
-import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestData;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestPatternMatching implements GraphHolder
 {
@@ -103,7 +104,7 @@ public class TestPatternMatching implements GraphHolder
     @After
     public void tearDownTx()
     {
-        tx.finish();
+        tx.close();
     }
 
     @AfterClass
@@ -164,8 +165,8 @@ public class TestPatternMatching implements GraphHolder
         Node a1 = createInstance( "a1" );
         Node b1 = createInstance( "b1" );
 
-        Relationship rel = a1.createRelationshipTo( b1, R1 );
-        rel = a1.createRelationshipTo( b1, R2 );
+        a1.createRelationshipTo( b1, R1 );
+        Relationship rel = a1.createRelationshipTo( b1, R2 );
         rel.setProperty( "musthave", true );
 
         PatternNode pA = new PatternNode();
@@ -768,12 +769,6 @@ public class TestPatternMatching implements GraphHolder
             assertTrue( "Unexpected node matched: " + matchedNode.getProperty( "name" ), remove );
         }
         assertTrue( "Not all nodes were found", expected.isEmpty() );
-    }
-
-    private void execAndWait( String... args ) throws Exception
-    {
-        Process process = Runtime.getRuntime().exec( args );
-        new ProcessStreamHandler( process, true ).waitForResult();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -238,7 +238,7 @@ public class IndexingAcceptanceTest
         firstNode.delete();
         long sizeAfterDelete = count( beansAPI.findNodesByLabelAndProperty( MY_LABEL, "name", "Mattias" ) );
 
-        tx.finish();
+        tx.close();
 
         // THEN
         assertThat( sizeBeforeDelete, equalTo(1l) );
@@ -260,7 +260,7 @@ public class IndexingAcceptanceTest
         firstNode.delete();
         long sizeAfterDelete = count( beansAPI.findNodesByLabelAndProperty( MY_LABEL, "name", "Mattias" ) );
 
-        tx.finish();
+        tx.close();
 
         // THEN
         assertThat( sizeBeforeDelete, equalTo(1l) );
@@ -282,13 +282,14 @@ public class IndexingAcceptanceTest
         createNode( beansAPI, map( "name", "Mattias" ), MY_LABEL );
         long sizeAfterDelete = count( beansAPI.findNodesByLabelAndProperty( MY_LABEL, "name", "Mattias" ) );
 
-        tx.finish();
+        tx.close();
 
         // THEN
         assertThat( sizeBeforeDelete, equalTo(1l) );
         assertThat( sizeAfterDelete, equalTo(2l) );
     }
 
+    @SuppressWarnings("RedundantCast")
     @Test
     public void shouldBeAbleToQuerySupportedPropertyTypes() throws Exception
     {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -352,7 +352,7 @@ public class LabelsAcceptanceTest
         Node node = beansAPI.createNode();
         node.addLabel( Labels.MY_LABEL );
         tx.success();
-        tx.finish();
+        tx.close();
 
         // THEN
         assertThat(glops, inTx( beansAPI, hasNodes( Labels.MY_LABEL, node )));
@@ -434,7 +434,7 @@ public class LabelsAcceptanceTest
             node.addLabel( label );
             node.setProperty( "name", "bla" );
             tx.success();
-            tx.finish();
+            tx.close();
         }
 
         // WHEN
@@ -446,7 +446,7 @@ public class LabelsAcceptanceTest
                 node.delete(); // ... and afterwards the node
             }
             tx.success();
-            tx.finish(); // here comes the exception
+            tx.close(); // here comes the exception
         }
 
         // THEN

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -144,7 +144,7 @@ public class SchemaAcceptanceTest
         Schema schema = db.schema();
         schema.indexFor( label ).on( propertyKey ).create();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         ConstraintViolationException caught = null;

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaIndexWaitingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaIndexWaitingAcceptanceTest.java
@@ -66,7 +66,7 @@ public class SchemaIndexWaitingAcceptanceTest
         Transaction tx = db.beginTx();
         IndexDefinition index = db.schema().indexFor( DynamicLabel.label( "Person" ) ).on( "name" ).create();
         tx.success();
-        tx.finish();
+        tx.close();
 
         latch.awaitStart();
         tx = db.beginTx();
@@ -101,7 +101,7 @@ public class SchemaIndexWaitingAcceptanceTest
         Transaction tx = db.beginTx();
         db.schema().indexFor( DynamicLabel.label( "Person" ) ).on( "name" ).create();
         tx.success();
-        tx.finish();
+        tx.close();
 
         latch.awaitStart();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/GuardPerformanceImpact.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GuardPerformanceImpact.java
@@ -118,7 +118,7 @@ public class GuardPerformanceImpact
                 db.createNode();
             }
             tx.success();
-            tx.finish();
+            tx.close();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
@@ -35,6 +35,7 @@ import org.junit.ClassRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -146,7 +147,7 @@ public abstract class AbstractNeo4jTestCase
     {
         if ( tx != null )
         {
-            tx.finish();
+            tx.close();
         }
 
         if ( restartGraphDbBetweenTests() )
@@ -178,7 +179,7 @@ public abstract class AbstractNeo4jTestCase
         if ( tx != null )
         {
             tx.success();
-            tx.finish();
+            tx.close();
         }
         tx = graphDb.beginTx();
         return tx;
@@ -189,7 +190,7 @@ public abstract class AbstractNeo4jTestCase
         if ( tx != null )
         {
             tx.success();
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }
@@ -198,7 +199,7 @@ public abstract class AbstractNeo4jTestCase
     {
         if ( tx != null )
         {
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }
@@ -208,7 +209,7 @@ public abstract class AbstractNeo4jTestCase
         if ( tx != null )
         {
             tx.failure();
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/SchemaLoggingIT.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.api.index.IndexPopulationJob;
@@ -62,11 +63,11 @@ public class SchemaLoggingIT
         Transaction tx = db.beginTx();
         db.schema().indexFor( label( labelName ) ).on( property ).create();
         tx.success();
-        tx.finish();
+        tx.close();
         tx = db.beginTx();
         db.schema().awaitIndexesOnline( 1, TimeUnit.MINUTES );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -484,7 +484,7 @@ public class IndexPopulationJobTest
         statement.schemaWriteOperations().labelGetOrCreateForName( SECOND.name() );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRestartIt.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRestartIt.java
@@ -167,7 +167,7 @@ public class IndexRestartIt
         Transaction tx = db.beginTx();
         IndexDefinition index = db.schema().indexFor( myLabel ).on( "number_of_bananas_owned" ).create();
         tx.success();
-        tx.finish();
+        tx.close();
         return index;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -153,7 +153,7 @@ public class KernelIT extends KernelIntegrationTest
         int labelId = statement.dataWriteOperations().labelGetOrCreateForName( "labello" );
         statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
         statement.close();
-        tx.finish();
+        tx.close();
 
         // THEN
         tx = db.beginTx();
@@ -167,7 +167,7 @@ public class KernelIT extends KernelIntegrationTest
         {
             // Yay!
         }
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -183,7 +183,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.close();
         tx.failure();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // THEN
         tx = db.beginTx();
@@ -197,7 +197,7 @@ public class KernelIT extends KernelIntegrationTest
         {
             // Yay!
         }
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -215,7 +215,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId2 );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // THEN
         tx = db.beginTx();
@@ -223,7 +223,7 @@ public class KernelIT extends KernelIntegrationTest
 
         assertEquals( asSet( labelId1 ), asSet( statement.readOperations().nodeGetLabels( node.getId() ) ) );
 
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -246,7 +246,7 @@ public class KernelIT extends KernelIntegrationTest
 
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -262,7 +262,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId2 );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
         tx = db.beginTx();
         statement = statementContextProvider.statement();
 
@@ -276,7 +276,7 @@ public class KernelIT extends KernelIntegrationTest
         assertEquals( asSet( labelId1 ), labels );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -290,7 +290,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId1 );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -298,7 +298,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId1 );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // THEN
         tx = db.beginTx();
@@ -306,7 +306,7 @@ public class KernelIT extends KernelIntegrationTest
         PrimitiveIntIterator labels = statement.readOperations().nodeGetLabels( node.getId() );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         assertThat( asSet( labels ), equalTo( Collections.<Integer>emptySet() ) );
     }
@@ -322,7 +322,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -331,7 +331,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         assertFalse( "Shouldn't have been added now", added );
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -344,7 +344,7 @@ public class KernelIT extends KernelIntegrationTest
         int labelId = statement.dataWriteOperations().labelGetOrCreateForName( "mylabel" );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -353,7 +353,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         assertTrue( "Should have been added now", added );
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -367,7 +367,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -376,7 +376,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         assertTrue( "Should have been removed now", removed );
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -389,7 +389,7 @@ public class KernelIT extends KernelIntegrationTest
         int labelId = statement.dataWriteOperations().labelGetOrCreateForName( "mylabel" );
         statement.close();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -398,7 +398,7 @@ public class KernelIT extends KernelIntegrationTest
 
         // THEN
         assertFalse( "Shouldn't have been removed now", removed );
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -409,7 +409,7 @@ public class KernelIT extends KernelIntegrationTest
         Label label = label( "labello" );
         Node node = db.createNode( label );
         tx.success();
-        tx.finish();
+        tx.close();
 
         tx = db.beginTx();
         Statement statement = statementContextProvider.statement();
@@ -426,7 +426,7 @@ public class KernelIT extends KernelIntegrationTest
         statement.close();
 
         tx.success();
-        tx.finish();
+        tx.close();
 
         assertEquals( emptySetOf( Long.class ), nodes );
         assertEquals( emptySetOf( Integer.class ), labels );
@@ -441,13 +441,13 @@ public class KernelIT extends KernelIntegrationTest
         Label label = label( "labello" );
         Node node = db.createNode( label );
         tx.success();
-        tx.finish();
+        tx.close();
 
         // AND GIVEN I DELETE IT
         tx = db.beginTx();
         node.delete();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // WHEN
         tx = db.beginTx();
@@ -456,7 +456,7 @@ public class KernelIT extends KernelIntegrationTest
         PrimitiveLongIterator nodes = statement.readOperations().nodesGetForLabel( labelId );
         Set<Long> nodeSet = asSet( nodes );
         tx.success();
-        tx.finish();
+        tx.close();
 
         // THEN
         assertThat( nodeSet, equalTo( Collections.<Long>emptySet() ) );
@@ -521,7 +521,7 @@ public class KernelIT extends KernelIntegrationTest
             }
         } );
         tx.success();
-        tx.finish();
+        tx.close();
         return state;
     }
 
@@ -540,7 +540,7 @@ public class KernelIT extends KernelIntegrationTest
             }
         } );
         tx.success();
-        tx.finish();
+        tx.close();
         return result.get();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigJumpingStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigJumpingStoreIT.java
@@ -143,7 +143,7 @@ public class BigJumpingStoreIT
         }
 
         tx.success();
-        tx.finish();
+        tx.close();
 
         // Verify
         tx = db.beginTx();
@@ -161,7 +161,7 @@ public class BigJumpingStoreIT
             db.getNodeManager().clearCache();
         }
         assertEquals( numberOfRels, relCount );
-        tx.finish();
+        tx.close();
 
         // Remove stuff
         tx = db.beginTx();
@@ -218,7 +218,7 @@ public class BigJumpingStoreIT
             }
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         // Verify again
         tx = db.beginTx();
@@ -272,7 +272,7 @@ public class BigJumpingStoreIT
             }
             db.getNodeManager().clearCache();
         }
-        tx.finish();
+        tx.close();
     }
 
     private void setPropertyOnAll( Iterable<Relationship> relationships, String key,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
@@ -48,9 +48,11 @@ import org.neo4j.kernel.IdType;
 
 import static java.lang.Math.pow;
 import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
@@ -158,12 +160,12 @@ public class BigStoreIT implements RelationshipType
             if ( i % 100 == 0 && i > 0 )
             {
                 tx.success();
-                tx.finish();
+                tx.close();
                 tx = db.beginTx();
             }
         }
         tx.success();
-        tx.finish();
+        tx.close();
         
         db.shutdown();
         db = new GraphDatabaseFactory().newEmbeddedDatabase( PATH );
@@ -262,7 +264,7 @@ public class BigStoreIT implements RelationshipType
         assertEquals( stringPropertyValue, nodeAboveTheLine.getProperty( propertyKey ) );
         assertTrue( Arrays.equals( arrayPropertyValue, (long[]) relBelowTheLine.getProperty( propertyKey ) ) );
         tx.success();
-        tx.finish();
+        tx.close();
 
         for ( int i = 0; i < 2; i++ )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -178,7 +178,7 @@ public class ManyPropertyKeysIT
         public Void doWork( WorkerState state )
         {
             state.tx.success();
-            state.tx.finish();
+            state.tx.close();
             return null;
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -98,7 +98,7 @@ public class NodeManagerTest
         node.removeProperty( "wut" );
         node.delete();
         tx.success();
-        tx.finish();
+        tx.close();
 
         //THEN prop is removed only once
         assertThat( tracker.removed, is( "1:wut" ) );
@@ -132,13 +132,13 @@ public class NodeManagerTest
         Node secondCommittedNode = db.createNode();
         Node thirdCommittedNode = db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         
         // Second one deleted, just to create a hole
         tx = db.beginTx();
         secondCommittedNode.delete();
         tx.success();
-        tx.finish();
+        tx.close();
         
         // WHEN
         tx = db.beginTx();
@@ -147,7 +147,7 @@ public class NodeManagerTest
         thirdCommittedNode.delete();
         List<Node> allNodes = addToCollection( getNodeManager().getAllNodes(), new ArrayList<Node>() );
         Set<Node> allNodesSet = new HashSet<>( allNodes );
-        tx.finish();
+        tx.close();
 
         // THEN
         assertEquals( allNodes.size(), allNodesSet.size() );
@@ -164,12 +164,12 @@ public class NodeManagerTest
         Relationship secondCommittedRelationship = createRelationshipAssumingTxWith( "committed", 2 );
         Relationship thirdCommittedRelationship = createRelationshipAssumingTxWith( "committed", 3 );
         tx.success();
-        tx.finish();
+        tx.close();
         
         tx = db.beginTx();
         secondCommittedRelationship.delete();
         tx.success();
-        tx.finish();
+        tx.close();
         
         // WHEN
         tx = db.beginTx();
@@ -179,7 +179,7 @@ public class NodeManagerTest
         List<Relationship> allRelationships = addToCollection( getNodeManager().getAllRelationships(),
                 new ArrayList<Relationship>() );
         Set<Relationship> allRelationshipsSet = new HashSet<>( allRelationships );
-        tx.finish();
+        tx.close();
 
         // THEN
         assertEquals( allRelationships.size(), allRelationshipsSet.size() );
@@ -196,7 +196,7 @@ public class NodeManagerTest
             db.createNode();
             db.createNode();
             tx.success();
-            tx.finish();
+            tx.close();
         }
 
         // WHEN iterator is started
@@ -234,7 +234,7 @@ public class NodeManagerTest
         Relationship relationship1 = createRelationshipAssumingTxWith( "key", 1 );
         Relationship relationship2 = createRelationshipAssumingTxWith( "key", 2 );
         tx.success();
-        tx.finish();
+        tx.close();
         
         // WHEN
         tx = db.beginTx();
@@ -245,7 +245,7 @@ public class NodeManagerTest
         assertEquals( asList( relationship1, relationship2, relationship3 ),
                 addToCollection( allRelationships, new ArrayList<Relationship>() ) );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private void delete( Relationship relationship )
@@ -253,7 +253,7 @@ public class NodeManagerTest
         Transaction tx = db.beginTx();
         relationship.delete();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private Node createNodeWith( String key, Object value )
@@ -262,7 +262,7 @@ public class NodeManagerTest
         Node node = db.createNode();
         node.setProperty( key, value );
         tx.success();
-        tx.finish();
+        tx.close();
         return node;
     }
 
@@ -272,7 +272,7 @@ public class NodeManagerTest
         Transaction tx = db.beginTx();
         Relationship relationship = createRelationshipAssumingTxWith( key, value );
         tx.success();
-        tx.finish();
+        tx.close();
         return relationship;
     }
 
@@ -290,7 +290,7 @@ public class NodeManagerTest
         Transaction tx = db.beginTx();
         node.delete();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private class NodeLoggingTracker implements PropertyTracker<Node>

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ProveFiveBillionIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ProveFiveBillionIT.java
@@ -19,15 +19,12 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static java.lang.Math.pow;
-import static org.neo4j.helpers.collection.MapUtil.map;
-import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
-
 import java.io.File;
 import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -36,6 +33,11 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
+
+import static java.lang.Math.pow;
+
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
 
 @Ignore( "Requires a lot of disk space" )
 public class ProveFiveBillionIT
@@ -87,7 +89,7 @@ public class ProveFiveBillionIT
             if ( i % 100000 == 0 )
             {
                 tx.success();
-                tx.finish();
+                tx.close();
                 System.out.println( (i/1000000) + "M" );
                 tx = db.beginTx();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestChangingOfLogFormat.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestChangingOfLogFormat.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.fail;
-import static org.neo4j.kernel.impl.nioneo.store.TestXa.copyLogicalLog;
-import static org.neo4j.kernel.impl.nioneo.store.TestXa.renameCopiedLogicalLog;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -32,12 +28,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.fail;
+
+import static org.neo4j.kernel.impl.nioneo.store.TestXa.copyLogicalLog;
+import static org.neo4j.kernel.impl.nioneo.store.TestXa.renameCopiedLogicalLog;
 
 public class TestChangingOfLogFormat
 {
@@ -50,7 +52,7 @@ public class TestChangingOfLogFormat
         Transaction tx = db.beginTx();
         db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         
         Pair<Pair<File, File>, Pair<File, File>> copy = copyLogicalLog( fs.get(), logBaseFileName );
         decrementLogFormat( copy.other().other() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentModificationOfRelationshipChains.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentModificationOfRelationshipChains.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -136,7 +137,7 @@ public class TestConcurrentModificationOfRelationshipChains
         Transaction tx = db.beginTx();
         toDelete.delete();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private void deleteRelationshipInDifferentThread( final GraphDatabaseAPI db, final Relationship toDelete ) throws
@@ -167,7 +168,7 @@ public class TestConcurrentModificationOfRelationshipChains
             node1.createRelationshipTo( node2, relType );
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
         Transaction transaction = db.beginTx();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
@@ -26,6 +26,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -34,7 +35,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.Settings.TRUE;
 
 public class TestExceptionTypeOnInvalidIds
@@ -85,7 +87,7 @@ public class TestExceptionTypeOnInvalidIds
     @After
     public void endTransaction()
     {
-        tx.finish();
+        tx.close();
         tx = null;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationMultipleThreads.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationMultipleThreads.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
@@ -58,7 +59,7 @@ public class TestIsolationMultipleThreads
         }
 
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @After
@@ -387,7 +388,7 @@ public class TestIsolationMultipleThreads
                 for (int round = 0; round < 100; round++)
                 {
                     int deadLocks = 0;
-                    DeadlockDetectedException ex = null;
+                    DeadlockDetectedException ex;
                     do
                     {
                         ex = null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
@@ -19,15 +19,12 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Iterator;
 import java.util.Random;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -38,6 +35,10 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestNeo4j extends AbstractNeo4jTestCase
 {
@@ -69,15 +70,12 @@ public class TestNeo4j extends AbstractNeo4jTestCase
     @Test
     public void testBasicNodeRelationships()
     {
-        Node firstNode = null;
-        Node secondNode = null;
-        Relationship rel = null;
         // Create nodes and a relationship between them
-        firstNode = getGraphDb().createNode();
+        Node firstNode = getGraphDb().createNode();
         assertNotNull( "Failure creating first node", firstNode );
-        secondNode = getGraphDb().createNode();
+        Node secondNode = getGraphDb().createNode();
         assertNotNull( "Failure creating second node", secondNode );
-        rel = firstNode.createRelationshipTo( secondNode, MyRelTypes.TEST );
+        Relationship rel = firstNode.createRelationshipTo( secondNode, MyRelTypes.TEST );
         assertNotNull( "Relationship is null", rel );
         RelationshipType relType = rel.getType();
         assertNotNull( "Relationship's type is is null", relType );
@@ -87,7 +85,7 @@ public class TestNeo4j extends AbstractNeo4jTestCase
         assertTrue( firstNode.getRelationships( relType ).iterator().hasNext() );
         assertTrue( secondNode.getRelationships( relType ).iterator().hasNext() );
 
-        Iterable<Relationship> allRels = null;
+        Iterable<Relationship> allRels;
 
         // Verify that both nodes return the relationship we created above
         allRels = firstNode.getRelationships();
@@ -200,7 +198,7 @@ public class TestNeo4j extends AbstractNeo4jTestCase
     public void testNodeChangePropertyArray() throws Exception
     {
         Transaction tx = getTransaction();
-        tx.finish();
+        tx.close();
         tx = getGraphDb().beginTx();
         Node node;
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
@@ -19,13 +19,10 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -36,6 +33,11 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestNeo4jApiExceptions
 {
@@ -194,7 +196,7 @@ public class TestNeo4jApiExceptions
         if ( tx != null )
         {
             tx.success();
-            tx.finish();
+            tx.close();
         }
         tx = graph.beginTx();
     }
@@ -204,7 +206,7 @@ public class TestNeo4jApiExceptions
         if ( tx != null )
         {
             tx.success();
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,12 +26,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
 import javax.transaction.TransactionManager;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -46,6 +42,10 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
 {
@@ -80,7 +80,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
  //       assertTrue( node1.getProperty( key1 ).equals( 1 ) );
         Transaction tx = getTransaction();
         tx.success();
-        tx.finish();
+        tx.close();
         clearCache();
         tx = getGraphDb().beginTx();
 //        node1.getPropertyKeys().iterator().next();
@@ -280,7 +280,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
         clearCache();
         nodeA.createRelationshipTo( nodeB, MyRelTypes.TEST );
         int count = 0;
-        for ( Relationship relToB : nodeA.getRelationships( MyRelTypes.TEST ) )
+        for ( Relationship ignored : nodeA.getRelationships( MyRelTypes.TEST ) )
         {
             count++;
         }
@@ -298,7 +298,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
         getTransaction().finish();
         newTransaction();
         count = 0;
-        for ( Relationship relToB : nodeA.getRelationships( MyRelTypes.TEST ) )
+        for ( Relationship ignored : nodeA.getRelationships( MyRelTypes.TEST ) )
         {
             count++;
         }
@@ -452,7 +452,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
         node2.createRelationshipTo( node1, MyRelTypes.TEST2 );
         node1.createRelationshipTo( node2, MyRelTypes.TEST_TRAVERSAL );
         tx.success();
-        tx.finish();
+        tx.close();
         tx = graphDb.beginTx();
         Set<Relationship> rels = new HashSet<Relationship>();
         RelationshipType types[] = new RelationshipType[] { 
@@ -519,7 +519,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
         assertEquals( 2, rels.size() );
         
         tx.success();
-        tx.finish();
+        tx.close();
         graphDb.shutdown();
     }
 
@@ -577,7 +577,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
             totalOneDirection++;
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         tx = graphDb.beginTx();
         Set<Relationship> rels = new HashSet<Relationship>();
@@ -659,7 +659,7 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
         rels.clear();
 
         tx.success();
-        tx.finish();
+        tx.close();
         graphDb.shutdown();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jConstrains.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jConstrains.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.core;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -57,7 +58,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             node.delete();
         }
         tx.success();
-        tx.finish();
+        tx.close();
         tx = getGraphDb().beginTx();
         // the DB should be empty
         // long numNodesPost = getNodeManager().getNumberOfIdsInUse( Node.class
@@ -77,7 +78,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             // should be thrown
         }
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -91,7 +92,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         {
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Should not validate" );
         }
         catch ( Exception e )
@@ -113,7 +114,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         {
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Should not validate" );
         }
         catch ( Exception e )
@@ -136,7 +137,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         rel0.delete();
         Transaction tx = getTransaction();
         tx.success();
-        tx.finish();
+        tx.close();
         setTransaction( getGraphDb().beginTx() );
         node2.delete();
         rel1.delete();
@@ -150,7 +151,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         Node node2 = getGraphDb().createNode();
         Transaction tx = getTransaction();
         tx.success();
-        tx.finish();
+        tx.close();
         tx = getGraphDb().beginTx();
         node1.delete();
         clearCache(); 
@@ -165,7 +166,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         try
         {
             tx.failure();
-            tx.finish();
+            tx.close();
             // fail( "Transaction should be marked rollback" );
         }
         catch ( Exception e )
@@ -203,7 +204,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             node.removeProperty( key );
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Change property on deleted node should not validate" );
         }
         catch ( Exception e )
@@ -223,7 +224,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             node.setProperty( key, 2 );
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Change property on deleted node should not validate" );
         }
         catch ( Exception e )
@@ -244,7 +245,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             rel.setProperty( key, 1 );
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Add property on deleted rel should not validate" );
         }
         catch ( Exception e )
@@ -267,7 +268,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             rel.removeProperty( key );
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Remove property on deleted rel should not validate" );
         }
         catch ( Exception e )
@@ -291,7 +292,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             rel.setProperty( key, 2 );
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Change property on deleted rel should not validate" );
         }
         catch ( Exception e )
@@ -312,7 +313,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             node1.delete();
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Should not validate" );
         }
         catch ( Exception e )
@@ -335,7 +336,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
             rel.delete();
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Should not validate" );
         }
         catch ( Exception e )
@@ -359,7 +360,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         {
             Transaction tx = getTransaction();
             tx.failure();
-            tx.finish();
+            tx.close();
         }
         setTransaction( getGraphDb().beginTx() );
         try
@@ -387,7 +388,7 @@ public class TestNeo4jConstrains extends AbstractNeo4jTestCase
         {
             Transaction tx = getTransaction();
             tx.success();
-            tx.finish();
+            tx.close();
             fail( "Shouldn't validate" );
         }
         catch ( Exception e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNode.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNode.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.helpers.Exceptions.launderedException;
-
 import java.lang.Thread.State;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,6 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -39,19 +34,25 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
 public class TestNode extends AbstractNeo4jTestCase
 {
     @Test
     public void testNodeCreateAndDelete()
     {
-        long nodeId = -1;
         Node node = getGraphDb().createNode();
-        nodeId = node.getId();
+        long nodeId = node.getId();
         getGraphDb().getNodeById( nodeId );
         node.delete();
         Transaction tx = getTransaction();
         tx.success();
-        tx.finish();
+        tx.close();
         setTransaction( getGraphDb().beginTx() );
         try
         {
@@ -321,12 +322,12 @@ public class TestNode extends AbstractNeo4jTestCase
         node.setProperty( "test", "test" );
         Transaction tx = getTransaction();
         tx.success();
-        tx.finish();
+        tx.close();
         tx = getGraphDb().beginTx();
         node.setProperty( "test2", "test2" );
         node.delete();
         tx.success();
-        tx.finish();
+        tx.close();
         setTransaction( getGraphDb().beginTx() );
     }
     

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
@@ -80,7 +80,7 @@ public class TestReadOnlyNeo4j
         {
             // good
         }
-        tx.finish();
+        tx.close();
         readGraphDb.shutdown();
     }
     
@@ -99,7 +99,7 @@ public class TestReadOnlyNeo4j
             rel.setProperty( "since", System.currentTimeMillis() );
         }
         tx.success();
-        tx.finish();
+        tx.close();
         DbRepresentation result = DbRepresentation.of( db );
         db.shutdown();
         return result;
@@ -118,7 +118,7 @@ public class TestReadOnlyNeo4j
         node1.setProperty( "key1", "value1" );
         rel.setProperty( "key1", "value1" );
         tx.success();
-        tx.finish();
+        tx.close();
         
         // make sure write operations still throw exception
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.count;
-import static org.neo4j.kernel.impl.MyRelTypes.TEST;
-import static org.neo4j.tooling.GlobalGraphOperations.at;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,6 +26,7 @@ import java.util.Set;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -47,16 +38,22 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.kernel.impl.MyRelTypes.TEST;
+import static org.neo4j.tooling.GlobalGraphOperations.at;
+
 public class TestRelationship extends AbstractNeo4jTestCase
 {
     private String key1 = "key1";
     private String key2 = "key2";
     private String key3 = "key3";
-
-    private enum RelType implements RelationshipType
-    {
-        TYPE_GENERIC
-    }
 
     @Test
     public void testSimple()
@@ -64,9 +61,9 @@ public class TestRelationship extends AbstractNeo4jTestCase
         Node node1 = getGraphDb().createNode();
         Node node2 = getGraphDb().createNode();
         Relationship rel1 = node1.createRelationshipTo( node2,
-            MyRelTypes.TEST );
-        Relationship rel2 = node1.createRelationshipTo( node2,
-            MyRelTypes.TEST );
+                MyRelTypes.TEST );
+        node1.createRelationshipTo( node2,
+                MyRelTypes.TEST );
         rel1.delete();
         newTransaction();
         assertTrue( node1.getRelationships().iterator().hasNext() );
@@ -91,9 +88,8 @@ public class TestRelationship extends AbstractNeo4jTestCase
         Node n2 = db.createNode();
         n1.createRelationshipTo( n2, TEST );
         tx.success();
-        tx.finish();
+        tx.close();
         db.getConfig().getGraphDbModule().getNodeManager().clearCache();
-        // n1.getSingleRelationship( RelType.TYPE_GENERIC, Direction.BOTH );
         for ( Node n : db.getAllNodes() )
         {
             for ( Relationship rel : n.getRelationships() )
@@ -232,20 +228,13 @@ public class TestRelationship extends AbstractNeo4jTestCase
     {
         countRelationships( 9, node.getRelationships() );
         countRelationships( 9, node.getRelationships( dir ) );
-        countRelationships( 9, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 6, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2 } ) );
-        countRelationships( 6, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 6, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 3, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST } ) );
-        countRelationships( 3, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2 } ) );
-        countRelationships( 3, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST_TRAVERSAL } ) );
+        countRelationships( 9, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 6, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2 ) );
+        countRelationships( 6, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 6, node.getRelationships( MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 3, node.getRelationships( MyRelTypes.TEST ) );
+        countRelationships( 3, node.getRelationships( MyRelTypes.TEST2 ) );
+        countRelationships( 3, node.getRelationships( MyRelTypes.TEST_TRAVERSAL ) );
         countRelationships( 3, node.getRelationships( MyRelTypes.TEST, dir ) );
         countRelationships( 3, node.getRelationships( MyRelTypes.TEST2, dir ) );
         countRelationships( 3, node.getRelationships(
@@ -256,20 +245,13 @@ public class TestRelationship extends AbstractNeo4jTestCase
     {
         countRelationships( 3, node.getRelationships() );
         countRelationships( 3, node.getRelationships( dir ) );
-        countRelationships( 3, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2 } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 1, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST } ) );
-        countRelationships( 1, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2 } ) );
-        countRelationships( 1, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST_TRAVERSAL } ) );
+        countRelationships( 3, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2 ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 1, node.getRelationships( MyRelTypes.TEST ) );
+        countRelationships( 1, node.getRelationships( MyRelTypes.TEST2 ) );
+        countRelationships( 1, node.getRelationships( MyRelTypes.TEST_TRAVERSAL ) );
         countRelationships( 1, node.getRelationships( MyRelTypes.TEST, dir ) );
         countRelationships( 1, node.getRelationships( MyRelTypes.TEST2, dir ) );
         countRelationships( 1, node.getRelationships(
@@ -280,20 +262,13 @@ public class TestRelationship extends AbstractNeo4jTestCase
     {
         countRelationships( 6, node.getRelationships() );
         countRelationships( 6, node.getRelationships( dir ) );
-        countRelationships( 6, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 4, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST2 } ) );
-        countRelationships( 4, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 4, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST2 } ) );
-        countRelationships( 2, node.getRelationships( new RelationshipType[] {
-            MyRelTypes.TEST_TRAVERSAL } ) );
+        countRelationships( 6, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 4, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST2 ) );
+        countRelationships( 4, node.getRelationships( MyRelTypes.TEST, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 4, node.getRelationships( MyRelTypes.TEST2, MyRelTypes.TEST_TRAVERSAL ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST2 ) );
+        countRelationships( 2, node.getRelationships( MyRelTypes.TEST_TRAVERSAL ) );
         countRelationships( 2, node.getRelationships( MyRelTypes.TEST, dir ) );
         countRelationships( 2, node.getRelationships( MyRelTypes.TEST2, dir ) );
         countRelationships( 2, node.getRelationships(
@@ -304,7 +279,7 @@ public class TestRelationship extends AbstractNeo4jTestCase
         Iterable<Relationship> rels )
     {
         int count = 0;
-        for ( Relationship r : rels )
+        for ( Relationship ignored : rels )
         {
             count++;
         }
@@ -368,8 +343,8 @@ public class TestRelationship extends AbstractNeo4jTestCase
         // do some evil stuff
         Node node1 = getGraphDb().createNode();
         Node node2 = getGraphDb().createNode();
-        Relationship relationship = node1.createRelationshipTo( node2,
-            MyRelTypes.TEST );
+        node1.createRelationshipTo( node2,
+                MyRelTypes.TEST );
         node1.delete();
         node2.delete();
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipConcurrentDeleteAndLoadCachePoisoning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipConcurrentDeleteAndLoadCachePoisoning.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -49,6 +50,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.Predicates.stringContains;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.qa.tooling.DumpProcessInformation.doThreadDump;
@@ -102,7 +104,7 @@ public class TestRelationshipConcurrentDeleteAndLoadCachePoisoning
             first.createRelationshipTo( db.createNode(), DynamicRelationshipType.withName( "AC" ) );
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         // This is required, otherwise relChainPosition is never consulted, everything will already be in mem.
         db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
@@ -115,7 +117,7 @@ public class TestRelationshipConcurrentDeleteAndLoadCachePoisoning
                 Transaction tx = db.beginTx();
                 theOneAfterTheGap.delete();
                 tx.success();
-                tx.finish();
+                tx.close();
             }
         };
 
@@ -194,6 +196,7 @@ public class TestRelationshipConcurrentDeleteAndLoadCachePoisoning
     {
     }
 
+    @SuppressWarnings("UnusedParameters")
     @BreakpointHandler( "readDone" )
     public static void onReadDone( BreakPoint self, DebugInterface di )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipGrabSize.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipGrabSize.java
@@ -36,8 +36,10 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.String.valueOf;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.kernel.impl.MyRelTypes.TEST;
@@ -71,7 +73,7 @@ public class TestRelationshipGrabSize
     private void finishTx( boolean success )
     {
         if ( success ) tx.success();
-        tx.finish();
+        tx.close();
     }
     
     private void clearCache()
@@ -143,7 +145,7 @@ public class TestRelationshipGrabSize
             node1.createRelationshipTo( node2, type );
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         db.getNodeManager().clearCache();
 
@@ -152,20 +154,20 @@ public class TestRelationshipGrabSize
         node1.getRelationships().iterator().next().delete();
         node1.setProperty( "foo", "bar" );
         int relCount = 0;
-        for ( Relationship rel : node2.getRelationships() )
+        for ( Relationship ignored : node2.getRelationships() )
         {
             relCount++;
         }
         assertEquals( relCount, GRAB_SIZE + 1 );
         relCount = 0;
-        for (Relationship rel : node1.getRelationships())
+        for (Relationship ignored : node1.getRelationships())
         {
             relCount++;
         }
         assertEquals( relCount, GRAB_SIZE + 1 );
         assertEquals( "bar", node1.getProperty( "foo" ) );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -218,7 +220,7 @@ public class TestRelationshipGrabSize
             count++;
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         clearCacheAndCreateDeleteCount( db, node1, node2, type1, type2, count );
         clearCacheAndCreateDeleteCount( db, node1, node2, type2, type1, count );
@@ -239,11 +241,11 @@ public class TestRelationshipGrabSize
         assertEquals( expectedCount, count( node1.getRelationships() ) );
         assertEquals( expectedCount, count( node2.getRelationships() ) );
         tx.success();
-        tx.finish();
+        tx.close();
 
         tx = db.beginTx();
         assertEquals( expectedCount, count( node1.getRelationships() ) );
         assertEquals( expectedCount, count( node2.getRelationships() ) );
-        tx.finish();
+        tx.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestTxApplicationSynchronization.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestTxApplicationSynchronization.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -78,7 +79,7 @@ public class TestTxApplicationSynchronization
         nodeId = node.getId();
         node.setProperty( "propName", "propValue" );
         tx.success();
-        tx.finish();
+        tx.close();
 
         targetDb = (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabase( dir.directory( "target", true ).getAbsolutePath() );
         applyTransactions( baseDb, targetDb );
@@ -104,7 +105,7 @@ public class TestTxApplicationSynchronization
         Transaction tx = baseDb.beginTx();
         baseDb.getNodeById( nodeId ).removeProperty( "propName" );
         tx.success();
-        tx.finish();
+        tx.close();
 
         final CountDownLatch localLatch = new CountDownLatch( 1 );
 
@@ -163,12 +164,14 @@ public class TestTxApplicationSynchronization
     private static DebuggedThread updater;
     private static final CountDownLatch latch = new CountDownLatch( 1 );
 
+    @SuppressWarnings("UnusedParameters")
     @BreakpointHandler("waitForSuspend")
     public static void suspendHandler( BreakPoint self, DebugInterface di ) throws Exception
     {
         latch.await();
     }
 
+    @SuppressWarnings("UnusedParameters")
     @BreakpointHandler("resumeAll")
     public static void resumeAllHandler( BreakPoint self, DebugInterface di )
     {
@@ -197,7 +200,7 @@ public class TestTxApplicationSynchronization
     }
 
     @BreakpointHandler("execute")
-    public static void handleExecute( BreakPoint self, DebugInterface di )
+    public static void handleExecute( @SuppressWarnings("UnusedParameters") BreakPoint self, DebugInterface di )
     {
         updater = di.thread();
         updater.suspend( null );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/ProduceUncleanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/ProduceUncleanStore.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -30,7 +26,6 @@ import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.test.ProcessStreamHandler;
 
 public class ProduceUncleanStore
 {
@@ -54,18 +49,7 @@ public class ProduceUncleanStore
         node.setProperty( "name", "Something" );
         if ( setGraphProperty ) ((GraphDatabaseAPI)db).getNodeManager().getGraphProperties().setProperty( "prop", "Some value" );
         tx.success();
-        tx.finish();
+        tx.close();
         System.exit( 0 );
-    }
-
-    public static void atPath( File path ) throws Exception
-    {
-        Process process = Runtime.getRuntime()
-            .exec( new String[]{
-                "java", "-cp", System.getProperty( "java.class.path" ),
-                ProduceUncleanStore.class.getName(), path.getAbsolutePath()
-            } );
-        int ret = new ProcessStreamHandler(process, true).waitForResult();
-        assertEquals( "ProduceUncleanStore terminated unsuccessfully", 0, ret );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestGraphProperties.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
@@ -50,6 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.getPropertyKeys;
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
@@ -79,7 +81,7 @@ public class TestGraphProperties
         graphProperties.setProperty( "test", "yo" );
         assertEquals( "yo", graphProperties.getProperty( "test" ) );
         tx.success();
-        tx.finish();
+        tx.close();
         assertThat( graphProperties, inTx( db, hasProperty( "test" ).withValue( "yo" ) ) );
         tx = db.beginTx();
         assertNull( graphProperties.removeProperty( "something non existent" ) );
@@ -89,7 +91,7 @@ public class TestGraphProperties
         assertEquals( 10, graphProperties.getProperty( "other" ) );
         graphProperties.setProperty( "new", "third" );
         tx.success();
-        tx.finish();
+        tx.close();
         assertThat( graphProperties, inTx( db, not( hasProperty( "test" ) ) ) );
         assertThat( graphProperties, inTx( db, hasProperty( "other" ).withValue( 10 ) ) );
         assertThat( getPropertyKeys( db, graphProperties ), containsOnly( "other", "new" ) );
@@ -97,7 +99,7 @@ public class TestGraphProperties
         tx = db.beginTx();
         graphProperties.setProperty( "rollback", true );
         assertEquals( true, graphProperties.getProperty( "rollback" ) );
-        tx.finish();
+        tx.close();
         assertThat( graphProperties, inTx( db, not( hasProperty( "rollback" ) ) ) );
         db.shutdown();
     }
@@ -116,7 +118,7 @@ public class TestGraphProperties
             properties( db ).setProperty( "key" + i, values[i % values.length] );
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         for ( int i = 0; i < count; i++ )
         {
@@ -144,7 +146,7 @@ public class TestGraphProperties
         properties( db ).setProperty( key, array );
         assertThat( properties( db ), hasProperty( key ).withValue( array ) );
         tx.success();
-        tx.finish();
+        tx.close();
 
         assertThat( properties( db ), inTx( db, hasProperty( key ).withValue( array ) ) );
         db.getNodeManager().clearCache();
@@ -166,14 +168,14 @@ public class TestGraphProperties
         Node node = db.createNode();
         node.setProperty( "name", "Yo" );
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
 
         db = (GraphDatabaseAPI) factory.newImpermanentDatabase( storeDir );
         tx = db.beginTx();
         db.getNodeManager().getGraphProperties().setProperty( "test", "something" );
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
 
         NeoStore neoStore = new StoreFactory( new Config( Collections.<String, String>emptyMap(),
@@ -241,7 +243,7 @@ public class TestGraphProperties
         Node node = db.createNode();
         node.setProperty( "name", "Something" );
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
 
         removeLastNeoStoreRecord( fileSystem, storeDir );
@@ -252,7 +254,7 @@ public class TestGraphProperties
         tx = db.beginTx();
         properties.setProperty( "a property", "a value" );
         tx.success();
-        tx.finish();
+        tx.close();
         db.getNodeManager().clearCache();
         assertThat( properties, inTx( db, hasProperty( "a property" ).withValue( "a value" ) ) );
         db.shutdown();
@@ -366,7 +368,7 @@ public class TestGraphProperties
                 public Void doWork( State state )
                 {
                     state.tx.success();
-                    state.tx.finish();
+                    state.tx.close();
                     return null;
                 }
             } );
@@ -408,7 +410,7 @@ public class TestGraphProperties
         node.setProperty( "name", "Something" );
         ((GraphDatabaseAPI)db).getNodeManager().getGraphProperties().setProperty( "prop", "Some value" );
         tx.success();
-        tx.finish();
+        tx.close();
         EphemeralFileSystemAbstraction snapshot = fileSystem.snapshot();
         db.shutdown();
         return snapshot;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGenerator.java
@@ -19,14 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-import static org.neo4j.helpers.collection.IteratorUtil.lastOrNull;
-import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,6 +33,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -53,6 +46,15 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.IteratorUtil.lastOrNull;
+import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 
 public class TestIdGenerator
 {
@@ -444,7 +446,6 @@ public class TestIdGenerator
     @Test
     public void testRandomTest()
     {
-        int numberOfCloses = 0;
         java.util.Random random = new java.util.Random( System.currentTimeMillis() );
         int capacity = random.nextInt( 1024 ) + 1024;
         int grabSize = random.nextInt( 128 ) + 128;
@@ -474,7 +475,6 @@ public class TestIdGenerator
                     closeIdGenerator( idGenerator );
                     grabSize = random.nextInt( 128 ) + 128;
                     idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, 0 );
-                    numberOfCloses++;
                 }
             }
             closeIdGenerator( idGenerator );
@@ -643,7 +643,7 @@ public class TestIdGenerator
             }
         }
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
 
         // After a clean shutdown, create new nodes and relationships and see so
@@ -665,7 +665,7 @@ public class TestIdGenerator
             }
         }
         tx.success();
-        tx.finish();
+        tx.close();
 
         // Verify by loading everything from scratch
         ((GraphDatabaseAPI) db).getNodeManager().clearCache();
@@ -674,7 +674,7 @@ public class TestIdGenerator
         {
             lastOrNull( node.getRelationships() );
         }
-        tx.finish();
+        tx.close();
         db.shutdown();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestOsSpecificLocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestOsSpecificLocks.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
-
 import java.io.File;
 import java.nio.channels.FileChannel;
 
@@ -33,6 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -40,6 +34,13 @@ import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.StoreLocker;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 public class TestOsSpecificLocks
 {
@@ -91,7 +92,7 @@ public class TestOsSpecificLocks
         Transaction tx = db.beginTx();
         db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         assertTrue( new File( path, "lock" ).exists() );
         try
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorIT.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -60,6 +61,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;
@@ -217,7 +219,7 @@ public class StoreMigratorIT
                 currentNode = relationship.getEndNode();
             }
             tx.success();
-            tx.finish();
+            tx.close();
             assertEquals( 500, traversalCount );
         }
 
@@ -234,7 +236,7 @@ public class StoreMigratorIT
                 }
             }
             tx.success();
-            tx.finish();
+            tx.close();
             assertEquals( 501, nodeCount );
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
@@ -19,19 +19,14 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
-import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
-
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.transaction.xa.Xid;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -43,6 +38,12 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.LogTestUtils.LogHookAdapter;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
 
 public class TestInjectMultipleStartEntries
 {
@@ -95,7 +96,7 @@ public class TestInjectMultipleStartEntries
         tx.success();
         try
         {
-            tx.finish();
+            tx.close();
             fail( "This transaction shouldn't be successful" );
         }
         catch ( TransactionFailureException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestManualAcquireLock.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestManualAcquireLock.java
@@ -19,18 +19,20 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.fail;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.test.OtherThreadExecutor;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.junit.Assert.fail;
 
 public class TestManualAcquireLock extends AbstractNeo4jTestCase
 {
@@ -112,7 +114,7 @@ public class TestManualAcquireLock extends AbstractNeo4jTestCase
         }
         commit();
         tx.success();
-        tx.finish();
+        tx.close();
         worker.finishTx();
     }
     
@@ -155,7 +157,7 @@ public class TestManualAcquireLock extends AbstractNeo4jTestCase
                 public Void doWork( State state )
                 {
                     state.tx.success();
-                    state.tx.finish();
+                    state.tx.close();
                     return null;
                 }
             } );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestApplyTransactions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestApplyTransactions.java
@@ -50,7 +50,7 @@ public class TestApplyTransactions
         Transaction tx = origin.beginTx();
         origin.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         XaDataSource originNeoDataSource = origin.getXaDataSourceManager().getXaDataSource(
                 NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
         int latestTxId = (int) originNeoDataSource.getLastCommittedTxId();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestPartialTransactionCopier.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestPartialTransactionCopier.java
@@ -19,28 +19,16 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static java.nio.ByteBuffer.allocate;
-import static org.junit.Assert.assertThat;
-import static org.neo4j.kernel.impl.nioneo.xa.CommandMatchers.nodeCommandEntry;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils.readLogHeader;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils.writeLogHeader;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.containsExactly;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.doneEntry;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.logEntries;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.onePhaseCommitEntry;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.startEntry;
-import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.transaction.xa.Xid;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -51,6 +39,20 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.LogTestUtils;
 import org.neo4j.test.LogTestUtils.LogHookAdapter;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.nio.ByteBuffer.allocate;
+
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.kernel.impl.nioneo.xa.CommandMatchers.nodeCommandEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils.readLogHeader;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils.writeLogHeader;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.containsExactly;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.doneEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.logEntries;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.onePhaseCommitEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.startEntry;
+import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
 
 public class TestPartialTransactionCopier
 {
@@ -135,7 +137,7 @@ public class TestPartialTransactionCopier
             Transaction tx = db.beginTx();
             db.createNode();
             tx.success();
-            tx.finish();
+            tx.close();
         }
         db.shutdown();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestTxEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestTxEntries.java
@@ -19,15 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import java.util.Random;
-
 import javax.transaction.xa.Xid;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -37,6 +34,9 @@ import org.neo4j.kernel.impl.transaction.xaframework.LogEntry.Start;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class TestTxEntries
 {
@@ -130,7 +130,7 @@ public class TestTxEntries
         node1.createRelationshipTo( node2,
                 DynamicRelationshipType.withName( "relType1" ) );
         tx.success();
-        tx.finish();
+        tx.close();
 
         tx = db.beginTx();
         node1.delete();
@@ -138,7 +138,7 @@ public class TestTxEntries
         try
         {
             // Will throw exception, causing the tx to be rolledback.
-            tx.finish();
+            tx.close();
         }
         catch ( Exception nothingToSeeHereMoveAlong )
         {
@@ -152,6 +152,6 @@ public class TestTxEntries
         tx = db.beginTx();
         node1.setProperty( "foo", "bar" );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestTxTimestamps.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestTxTimestamps.java
@@ -73,7 +73,7 @@ public class TestTxTimestamps
             Node node = db.createNode();
             node.setProperty( "name", "Mattias " + i );
             tx.success();
-            tx.finish();
+            tx.close();
             expectedCommitTimestamps[i] = System.currentTimeMillis();
         }
         db.getXaDataSourceManager().getNeoStoreDataSource().rotateLogicalLog();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthOneTraversalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/DepthOneTraversalTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 
@@ -43,7 +44,7 @@ public class DepthOneTraversalTest extends TraversalTestBase
     @After
     public void tearDown()
     {
-        tx.finish();
+        tx.close();
     }
     
     private void shouldGetBothNodesOnDepthOne( TraversalDescription description )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SpecificDepthTraversalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/SpecificDepthTraversalTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
@@ -42,7 +43,7 @@ public class SpecificDepthTraversalTest extends TraversalTestBase
     @After
     public void tearDown()
     {
-        tx.finish();
+        tx.close();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
@@ -43,7 +44,9 @@ import org.neo4j.kernel.Traversal;
 import org.neo4j.kernel.Uniqueness;
 
 import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.graphdb.traversal.Evaluators.includeIfContainsAll;
@@ -69,7 +72,7 @@ public class TestBidirectionalTraversal extends TraversalTestBase
     @After
     public void tearDown()
     {
-        tx.finish();
+        tx.close();
     }
     
     @Test( expected = IllegalArgumentException.class )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestEvaluators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestEvaluators.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
@@ -65,7 +66,7 @@ public class TestEvaluators extends TraversalTestBase
     @After
     public void tearDown()
     {
-        tx.finish();
+        tx.close();
     }
     
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiPruneEvaluators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultiPruneEvaluators.java
@@ -77,7 +77,7 @@ public class TestMultiPruneEvaluators extends TraversalTestBase
             assertTrue( name + " shouldn't have been returned", expectedNodes.remove( name ) );
         }
         tx.success();
-        tx.finish();
+        tx.close();
         assertTrue( expectedNodes.isEmpty() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -60,7 +61,7 @@ public class TestMultipleFilters extends TraversalTestBase
     @After
     public void tearDown()
     {
-         tx.finish();
+         tx.close();
     }
     
     private static class MustBeConnectedToNodeFilter implements Predicate<Path>, Evaluator

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -33,6 +34,7 @@ import org.neo4j.kernel.Uniqueness;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
 import static org.neo4j.graphdb.traversal.Evaluators.atDepth;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.Traversal.bidirectionalTraversal;
@@ -60,7 +62,7 @@ public class TestPath extends TraversalTestBase
     @After
     public void tearDown()
     {
-        tx.finish();
+        tx.close();
     }
     
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestSorting.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestSorting.java
@@ -24,11 +24,14 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
 import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.graphdb.traversal.Evaluators.excludeStartPosition;
 import static org.neo4j.graphdb.traversal.Sorting.endNodeProperty;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
@@ -66,7 +69,7 @@ public class TestSorting extends TraversalTestBase
         assertEquals( nodes, asCollection( traversal().evaluator( excludeStartPosition() )
                 .sort( endNodeProperty( "name" ) ).traverse( getNodeWithName( me ) ).nodes() ) );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private List<Node> asNodes( String abraham, String george, String dan, String zack, String andreas,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TreeGraphTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TreeGraphTest.java
@@ -187,7 +187,7 @@ public class TreeGraphTest extends TraversalTestBase
             assertEquals( expectedDepth( ( 12 - i++ ) ), pos.length() );
         }
         tx.success();
-        tx.finish();
+        tx.close();
         assertEquals( 13, i );
 
         assertTrue( encounteredNodes.indexOf( "5" ) < encounteredNodes.indexOf( "2" ) );

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -91,6 +91,6 @@ public class TestImpermanentGraphDatabase
         Transaction tx = db.beginTx();
         db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/BatchTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/BatchTransaction.java
@@ -28,25 +28,15 @@ public class BatchTransaction
 
     public static BatchTransaction beginBatchTx( GraphDatabaseService db )
     {
-        return new BatchTransaction( db, MAX_SIZE );
-    }
-    
-    public static BatchTransaction beginBatchTx( GraphDatabaseService db, int maxSize )
-    {
-        return new BatchTransaction( db, maxSize );
+        return new BatchTransaction( db );
     }
     
     private final GraphDatabaseService db;
     private Transaction tx;
-    private int txSize;
-    private int total;
-    private boolean printProgress;
-    private final int maxSize;
-    
-    private BatchTransaction( GraphDatabaseService db, int maxSize )
+
+    private BatchTransaction( GraphDatabaseService db )
     {
         this.db = db;
-        this.maxSize = maxSize;
         beginTx();
     }
 
@@ -54,35 +44,7 @@ public class BatchTransaction
     {
         this.tx = db.beginTx();
     }
-    
-    public GraphDatabaseService getDb()
-    {
-        return db;
-    }
-    
-    public boolean increment()
-    {
-        return increment( 1 );
-    }
-    
-    public boolean increment( int count )
-    {
-        txSize += count;
-        total++;
-        if ( txSize >= MAX_SIZE )
-        {
-            if ( printProgress )
-            {
-                System.out.println( total );
-            }
-            txSize = 0;
-            finish();
-            beginTx();
-            return true;
-        }
-        return false;
-    }
-    
+
     public void restart()
     {
         finish();
@@ -92,26 +54,11 @@ public class BatchTransaction
     public void finish()
     {
         tx.success();
-        tx.finish();
+        tx.close();
     }
-    
-    public int size()
-    {
-        return txSize;
-    }
-    
+
     public int limit()
     {
         return MAX_SIZE;
-    }
-    
-    public int total()
-    {
-        return total;
-    }
-    
-    public void printProgress( boolean value )
-    {
-        printProgress = value;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/GraphTransactionRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphTransactionRule.java
@@ -20,6 +20,7 @@
 package org.neo4j.test;
 
 import org.junit.rules.ExternalResource;
+
 import org.neo4j.graphdb.Transaction;
 
 /**
@@ -59,12 +60,12 @@ public class GraphTransactionRule
     public void success()
     {
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     public void failure()
     {
         tx.failure();
-        tx.finish();
+        tx.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
@@ -145,14 +145,14 @@ public class TestBatchInsert
 
     private BatchInserter newBatchInserterWithSchemaIndexProvider( KernelExtensionFactory<?> provider )
     {
-        List<KernelExtensionFactory<?>> extensions = Arrays.<KernelExtensionFactory<?>>asList(
+        List<KernelExtensionFactory<?>> extensions = Arrays.asList(
                 provider, new InMemoryLabelScanStoreExtension() );
         return BatchInserters.inserter( "neo-batch-db", fs.get(), stringMap(), extensions );
     }
 
     private BatchInserter newBatchInserterWithLabelScanStore( KernelExtensionFactory<?> provider )
     {
-        List<KernelExtensionFactory<?>> extensions = Arrays.<KernelExtensionFactory<?>>asList(
+        List<KernelExtensionFactory<?>> extensions = Arrays.asList(
                 new InMemoryIndexProviderFactory(), provider );
         return BatchInserters.inserter( "neo-batch-db", fs.get(), stringMap(), extensions );
     }
@@ -778,7 +778,7 @@ public class TestBatchInsert
         }
         node.delete();
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
     }
 

--- a/community/lucene-index/src/test/java/examples/ImdbDocTest.java
+++ b/community/lucene-index/src/test/java/examples/ImdbDocTest.java
@@ -188,7 +188,7 @@ public class ImdbDocTest
     @After
     public void finishTx()
     {
-        tx.finish();
+        tx.close();
     }
 
     private void rollbackTx()
@@ -582,7 +582,7 @@ public class ImdbDocTest
         // Note that to use a compound query, we can't combine committed
         // and uncommitted index entries, so we'll commit before querying:
         tx.success();
-        tx.finish();
+        tx.close();
 
         // and now we can search for it:
         try ( Transaction tx = graphDb.beginTx() )

--- a/community/lucene-index/src/test/java/examples/LuceneIndexSiteExamples.java
+++ b/community/lucene-index/src/test/java/examples/LuceneIndexSiteExamples.java
@@ -53,7 +53,7 @@ public class LuceneIndexSiteExamples
     public void finishTx()
     {
         tx.success();
-        tx.finish();
+        tx.close();
     }
     
     @Test

--- a/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
@@ -36,6 +36,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.SillyUtils.nonNull;
 
 public abstract class Neo4jTestCase
@@ -80,7 +81,7 @@ public abstract class Neo4jTestCase
         {
             tx.success();
         }
-        tx.finish();
+        tx.close();
         tx = null;
     }
     

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractLuceneIndexTest
             {
                 tx.success();
             }
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTestIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTestIT.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -74,7 +75,7 @@ public abstract class AbstractLuceneIndexTestIT
             {
                 tx.success();
             }
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AddRelToIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AddRelToIndex.java
@@ -40,7 +40,7 @@ public class AddRelToIndex
         Relationship relationship = db.getReferenceNode().createRelationshipTo( node, DynamicRelationshipType.withName( "KNOWS" ) );
         index.add( relationship, "key", "value" );
         tx.success();
-        tx.finish();
+        tx.close();
         // Skip shutdown
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/CommitCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/CommitCommand.java
@@ -27,7 +27,7 @@ public class CommitCommand implements WorkerCommand<CommandState, Void>
     public Void doWork( CommandState state )
     {
         state.tx.success();
-        state.tx.finish();
+        state.tx.close();
         return null;
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RollbackCommand.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RollbackCommand.java
@@ -27,7 +27,7 @@ public class RollbackCommand implements WorkerCommand<CommandState, Void>
     public Void doWork( CommandState state )
     {
         state.tx.failure();
-        state.tx.finish();
+        state.tx.close();
         state.tx = null;
         return null;
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestAutoIndexing.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestAutoIndexing.java
@@ -56,7 +56,7 @@ public class TestAutoIndexing
         if ( tx != null )
         {
             tx.success();
-            tx.finish();
+            tx.close();
         }
         tx = graphDb.beginTx();
     }
@@ -82,7 +82,7 @@ public class TestAutoIndexing
     {
         if ( tx != null )
         {
-            tx.finish();
+            tx.close();
         }
         if ( graphDb != null )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDeletion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDeletion.java
@@ -41,6 +41,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.index.Neo4jTestCase.assertContains;
 import static org.neo4j.index.impl.lucene.Contains.contains;
 
@@ -92,7 +93,7 @@ public class TestIndexDeletion
             {
                 tx.success();
             }
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexNames.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexNames.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.index.Neo4jTestCase.assertContains;
 
 public class TestIndexNames
@@ -66,7 +67,7 @@ public class TestIndexNames
             {
                 tx.success();
             }
-            tx.finish();
+            tx.close();
             tx = null;
         }
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.index.timeline;
 
-import static java.util.Collections.sort;
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -31,6 +27,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -44,6 +41,12 @@ import org.neo4j.helpers.Pair;
 import org.neo4j.index.lucene.LuceneTimeline;
 import org.neo4j.index.lucene.TimelineIndex;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.util.Collections.sort;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 
 public class TestTimeline
 {
@@ -70,7 +73,7 @@ public class TestTimeline
     private void commitTx()
     {
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private interface EntityCreator<T extends PropertyContainer>

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexRecoveryIT.java
@@ -266,11 +266,11 @@ public class LuceneIndexRecoveryIT
         Transaction tx = db.beginTx();
         IndexDefinition definition = db.schema().indexFor( label ).on( NUM_BANANAS_KEY ).create();
         tx.success();
-        tx.finish();
+        tx.close();
 
         tx = db.beginTx();
         db.schema().awaitIndexOnline( definition, 10, TimeUnit.SECONDS );
-        tx.finish();
+        tx.close();
     }
 
     private Set<Node> doIndexLookup( Label myLabel, Object value )
@@ -279,7 +279,7 @@ public class LuceneIndexRecoveryIT
         Iterable<Node> iter = db.findNodesByLabelAndProperty( myLabel, NUM_BANANAS_KEY, value );
         Set<Node> nodes = asUniqueSet( iter );
         tx.success();
-        tx.finish();
+        tx.close();
         return nodes;
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -35,6 +36,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 
 import static org.junit.Assert.assertThat;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.createIndex;
@@ -56,7 +58,7 @@ public class SchemaIndexAcceptanceTest
         Node node2 = createNode( label, "name", "Two" );
         Node node3 = createNode( label, "name", "Three" );
         tx.success();
-        tx.finish();
+        tx.close();
 
         createIndex( db, label, propertyKey );
 
@@ -75,7 +77,7 @@ public class SchemaIndexAcceptanceTest
         Transaction tx = db.beginTx();
         Node node1 = createNode( label, propertyKey, arrayPropertyValue );
         tx.success();
-        tx.finish();
+        tx.close();
 
         restart();
 
@@ -93,7 +95,7 @@ public class SchemaIndexAcceptanceTest
         Transaction tx = db.beginTx();
         Node node1 = createNode( label, propertyKey, arrayPropertyValue );
         tx.success();
-        tx.finish();
+        tx.close();
 
         restart();
 
@@ -111,7 +113,7 @@ public class SchemaIndexAcceptanceTest
         Transaction tx = db.beginTx();
         Node node1 = createNode( label, propertyKey, arrayPropertyValue );
         tx.success();
-        tx.finish();
+        tx.close();
 
         createIndex( db, label, propertyKey );
 
@@ -192,7 +194,7 @@ public class SchemaIndexAcceptanceTest
         Transaction tx = db.beginTx();
         indexDefinition.drop();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private static void doStuff( GraphDatabaseService db, Label label, String propertyKey )

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
@@ -54,6 +55,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -316,7 +318,7 @@ public class TestLuceneBatchInsert
         assertTrue(db.index().getNodeAutoIndexer().getAutoIndex().get( "name", "peter" ).hasNext());
         assertTrue(db.index().getNodeAutoIndexer().getAutoIndex().get( "name", "bob" ).hasNext());
         assertFalse(db.index().getNodeAutoIndexer().getAutoIndex().get( "name", "joe" ).hasNext());
-        tx.finish();
+        tx.close();
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseMetadataServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseMetadataServiceTest.java
@@ -34,6 +34,7 @@ import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class DatabaseMetadataServiceTest
@@ -48,7 +49,7 @@ public class DatabaseMetadataServiceTest
         node.createRelationshipTo( db.createNode(), withName( "b" ) );
         node.createRelationshipTo( db.createNode(), withName( "c" ) );
         tx.success();
-        tx.finish();
+        tx.close();
         
         Database database = new WrappedDatabase( db );
         DatabaseMetadataService service = new DatabaseMetadataService( database );
@@ -60,7 +61,7 @@ public class DatabaseMetadataServiceTest
         List<Map<String, Object>> jsonList = JsonHelper.jsonToList( response.getEntity()
                 .toString() );
         assertEquals( 3, jsonList.size() );
-        tx.finish();
+        tx.close();
         database.stop();
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rrd/NodeIdsInUseSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/NodeIdsInUseSampleableTest.java
@@ -62,7 +62,7 @@ public class NodeIdsInUseSampleableTest
         Transaction tx = db.beginTx();
         db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Before

--- a/community/server/src/test/java/org/neo4j/server/rrd/PropertyCountSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/PropertyCountSampleableTest.java
@@ -52,7 +52,7 @@ public class PropertyCountSampleableTest
         Transaction tx = db.getGraph().beginTx();
         referenceNodeId = db.getGraph().createNode().getId();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Test
@@ -90,7 +90,7 @@ public class PropertyCountSampleableTest
         } );
 
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     private void addPropertyToReferenceNode()
@@ -99,7 +99,7 @@ public class PropertyCountSampleableTest
         Node n = db.getGraph().getNodeById( referenceNodeId );
         n.setProperty( "monkey", "rock!" );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @After

--- a/community/server/src/test/java/org/neo4j/server/rrd/RelationshipCountSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/RelationshipCountSampleableTest.java
@@ -31,6 +31,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class RelationshipCountSampleableTest
@@ -59,7 +60,7 @@ public class RelationshipCountSampleableTest
         Node node2 = db.createNode();
         node1.createRelationshipTo( node2, withName( "friend" ) );
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     @Before

--- a/community/shell/src/test/java/org/neo4j/shell/AbstractShellTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AbstractShellTest.java
@@ -19,15 +19,6 @@
  */
 package org.neo4j.shell;
 
-import static java.lang.Integer.parseInt;
-import static java.util.regex.Pattern.compile;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
-import static org.neo4j.shell.ShellLobby.NO_INITIAL_SESSION;
-import static org.neo4j.shell.ShellLobby.remoteLocation;
-
 import java.io.Serializable;
 import java.rmi.RemoteException;
 import java.util.Collections;
@@ -37,19 +28,31 @@ import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.shell.impl.SimpleAppServer;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.RemoteClient;
 import org.neo4j.shell.impl.SameJvmClient;
+import org.neo4j.shell.impl.SimpleAppServer;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.lang.Integer.parseInt;
+import static java.util.regex.Pattern.compile;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.shell.ShellLobby.NO_INITIAL_SESSION;
+import static org.neo4j.shell.ShellLobby.remoteLocation;
 
 public abstract class AbstractShellTest
 {
@@ -151,7 +154,7 @@ public abstract class AbstractShellTest
         assert tx != null;
         if ( success )
             tx.success();
-        tx.finish();
+        tx.close();
         tx = null;
     }
 
@@ -338,7 +341,7 @@ public abstract class AbstractShellTest
             firstNode = secondNode;
         }
         tx.success();
-        tx.finish();
+        tx.close();
         return rels;
     }
 
@@ -347,7 +350,7 @@ public abstract class AbstractShellTest
         Transaction tx = db.beginTx();
         relationship.delete();
         tx.success();
-        tx.finish();
+        tx.close();
     }
 
     protected void setProperty( Node node, String key, Object value )
@@ -355,7 +358,7 @@ public abstract class AbstractShellTest
         Transaction tx = db.beginTx();
         node.setProperty( key, value );
         tx.success();
-        tx.finish();
+        tx.close();
     }
     
     protected Node getCurrentNode() throws RemoteException, ShellException

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -324,7 +324,7 @@ public class TestApps extends AbstractShellTest
         String name = "Test";
         node.setProperty( "name", name );
         tx.success();
-        tx.finish();
+        tx.close();
 
         GraphDatabaseShellServer server = new GraphDatabaseShellServer( db );
         ShellClient client = newShellClient( server );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
@@ -42,6 +42,7 @@ import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.helpers.Settings.osIsWindows;
 
 public class BackupEmbeddedIT
@@ -69,7 +70,7 @@ public class BackupEmbeddedIT
         node.setProperty( "name", "Neo" );
         db.getReferenceNode().createRelationshipTo( node, DynamicRelationshipType.withName( "KNOWS" ) );
         tx.success();
-        tx.finish();
+        tx.close();
         return DbRepresentation.of( db );
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
@@ -92,7 +92,7 @@ public class IncrementalBackupTests
                 DynamicRelationshipType.withName( "LOVES" ) );
         knows.setProperty( "since", 1940 );
         tx.success();
-        tx.finish();
+        tx.close();
         DbRepresentation result = DbRepresentation.of( db );
         db.shutdown();
         return result;
@@ -109,7 +109,7 @@ public class IncrementalBackupTests
                 DynamicRelationshipType.withName( "HATES" ) );
         hates.setProperty( "since", 1948 );
         tx.success();
-        tx.finish();
+        tx.close();
         DbRepresentation result = DbRepresentation.of( db );
         db.shutdown();
         return result;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
@@ -335,7 +335,7 @@ public class TestBackup
         db.getReferenceNode().createRelationshipTo( node,
                 DynamicRelationshipType.withName( "LOVES" ) );
         tx.success();
-        tx.finish();
+        tx.close();
         DbRepresentation result = DbRepresentation.of( db );
         db.shutdown();
         return result;
@@ -361,7 +361,7 @@ public class TestBackup
         db.getReferenceNode().createRelationshipTo( node,
                 DynamicRelationshipType.withName( "KNOWS" ) );
         tx.success();
-        tx.finish();
+        tx.close();
         DbRepresentation result = DbRepresentation.of( db );
         db.shutdown();
         return result;
@@ -381,7 +381,7 @@ public class TestBackup
             Index<Node> index = db.index().forNodes( "yo" );
             index.add( db.createNode(), "justTo", "commitATx" );
             tx.success();
-            tx.finish();
+            tx.close();
 
             OnlineBackup backup = OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() );
             backup.full( backupPath.getPath() );
@@ -393,7 +393,7 @@ public class TestBackup
                 Node node = db.createNode();
                 index.add( node, "key", "value" + i );
                 tx.success();
-                tx.finish();
+                tx.close();
                 backup.incremental( backupPath.getPath() );
                 assertEquals( lastCommittedTxForLucene + i + 1,
                         getLastCommittedTx( backupPath.getPath() ) );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/FinishTx.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/FinishTx.java
@@ -39,7 +39,7 @@ public class FinishTx implements WorkerCommand<HighlyAvailableGraphDatabase, Voi
     {
         if ( successful )
             tx.success();
-        tx.finish();
+        tx.close();
         return null;
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/MultipleClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/MultipleClusterTest.java
@@ -72,7 +72,7 @@ public class MultipleClusterTest
                 cluster1NodeId = node.getId();
                 logging.getLogger().info( "CREATED NODE" );
                 tx.success();
-                tx.finish();
+                tx.close();
             }
 
             ManagedCluster cluster2 = clusterManager.getCluster( "neo4j.ha2" );
@@ -86,7 +86,7 @@ public class MultipleClusterTest
                 cluster2NodeId = node.getId();
                 logging.getLogger().info( "CREATED NODE" );
                 tx.success();
-                tx.finish();
+                tx.close();
             }
 
             // Verify properties in all cluster nodes

--- a/enterprise/ha/src/test/java/org/neo4j/ha/PullStormIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/PullStormIT.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
@@ -37,6 +35,10 @@ import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
  * This is a test for the Neo4j HA self-inflicted DDOS "pull storm" phenomenon. In a 2 instance setup, whereby
@@ -82,7 +84,7 @@ public class PullStormIT
                     master.createNode().setProperty( "foo", "bar" );
                 }
                 tx.success();
-                tx.finish();
+                tx.close();
             }
 
             // Slave goes down
@@ -102,7 +104,7 @@ public class PullStormIT
                         master.createNode().setProperty( "foo", "bar" );
                     }
                     tx.success();
-                    tx.finish();
+                    tx.close();
                 }
             }
 
@@ -127,7 +129,7 @@ public class PullStormIT
                         Transaction tx = master.beginTx();
                         master.createNode().setProperty( "foo", "bar" );
                         tx.success();
-                        tx.finish(); // This should cause lots of concurrent calls to pullUpdate()
+                        tx.close(); // This should cause lots of concurrent calls to pullUpdate()
                     }
                 } );
             }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/QuorumWritesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/QuorumWritesIT.java
@@ -278,7 +278,7 @@ public class QuorumWritesIT
         Transaction tx = db.beginTx();
         Node node = db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         return node;
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -35,6 +35,7 @@ import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.SillyUtils.nonNull;
 
 public class TestBranchedData
@@ -89,7 +90,7 @@ public class TestBranchedData
         Transaction tx = db.beginTx();
         db.createNode();
         tx.success();
-        tx.finish();
+        tx.close();
         db.shutdown();
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestPartialPullUpdates.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestPartialPullUpdates.java
@@ -19,14 +19,12 @@
  */
 package org.neo4j.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -42,6 +40,9 @@ import org.neo4j.test.subprocess.DebugInterface;
 import org.neo4j.test.subprocess.EnabledBreakpoints;
 import org.neo4j.test.subprocess.ForeignBreakpoints;
 import org.neo4j.test.subprocess.SubProcessTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /*
  * This test fails. What it tries to assert is that when a slave pulls updates from the master they are applied
@@ -78,7 +79,7 @@ public class TestPartialPullUpdates
         node.setProperty( "uuid", "123" );
         master.index().forNodes( "auto" ).add( node, "uuid", "123" );
         tx.success();
-        tx.finish();
+        tx.close();
 
         slave1 = (HighlyAvailableGraphDatabase) new HighlyAvailableGraphDatabaseFactory().
                 newHighlyAvailableDatabaseBuilder( TargetDirectory.forTest( TestPartialPullUpdates.class ).directory(
@@ -111,7 +112,7 @@ public class TestPartialPullUpdates
         master.index().forNodes( "auto" ).remove( toRemove );
         toRemove.delete();
         tx.success();
-        tx.finish();
+        tx.close();
 
         // Do the update pulling in a different thread so we can kill it.
         Thread t = new Thread( new Runnable()

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.ha;
 
-import static java.lang.System.currentTimeMillis;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
-import static org.neo4j.test.ha.ClusterManager.masterSeesSlavesAsAvailable;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +26,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -47,6 +41,15 @@ import org.neo4j.shell.ShellLobby;
 import org.neo4j.shell.ShellSettings;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
+
+import static java.lang.System.currentTimeMillis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
+import static org.neo4j.test.ha.ClusterManager.masterAvailable;
+import static org.neo4j.test.ha.ClusterManager.masterSeesSlavesAsAvailable;
 
 public class TestPullUpdates
 {
@@ -146,13 +149,12 @@ public class TestPullUpdates
                     .newGraphDatabase();
             slave.shutdown();
 
-            long nodeId = -1;
             Transaction tx = master.beginTx();
             Node node = master.createNode();
             node.setProperty( "from", "master" );
-            nodeId = node.getId();
+            long nodeId = node.getId();
             tx.success();
-            tx.finish();
+            tx.close();
 
             // Store is already in place, should pull updates
             slave = new HighlyAvailableGraphDatabaseFactory().
@@ -206,7 +208,7 @@ public class TestPullUpdates
             for ( HighlyAvailableGraphDatabase db : cluster.getAllMembers() )
             {
                 Object value = db.getReferenceNode().getProperty( "i", null );
-                if ( value == null || (Integer) value != i )
+                if ( value == null || value != i )
                 {
                     ok = false;
                 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
@@ -106,7 +106,7 @@ public class TestSlaveOnlyCluster
             node.setProperty( "foo", "bar" );
             long nodeId = node.getId();
             tx.success();
-            tx.finish();
+            tx.close();
 
             Transaction transaction = master.beginTx();
             try

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
@@ -51,6 +52,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
 import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
@@ -457,7 +459,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         }
         finally
         {
-            tx.finish();
+            tx.close();
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +30,14 @@ import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
 
 public class ConcurrentInstanceStartupIT
 {
@@ -119,7 +120,7 @@ public class ConcurrentInstanceStartupIT
             }
             Transaction tx = db.beginTx();
             db.createNode();
-            tx.success(); tx.finish();
+            tx.success(); tx.close();
         }
 
         assertTrue( masterDone );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.member.paxos.MemberIsAvailable;
@@ -47,6 +43,12 @@ import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.tooling.GlobalGraphOperations;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class HardKillIT
 {
@@ -191,7 +193,7 @@ public class HardKillIT
                 .setConfig( HaSettings.tx_push_factor, "0" );
         HighlyAvailableGraphDatabase db = (HighlyAvailableGraphDatabase) builder.newGraphDatabase();
         Transaction tx = db.beginTx();
-        tx.finish();
+        tx.close();
         try
         {
             Thread.sleep( 2000 );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestTxPush.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestTxPush.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.neo4j.test.TargetDirectory.forTest;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.test.TargetDirectory.forTest;
 
 @Ignore("Need to properly setup instances with priorities such that slave only instances are present")
 public class TestTxPush
@@ -52,7 +54,7 @@ public class TestTxPush
             long nodeId = node.getId();
             node.setProperty( "foo", "bar" );
             tx.success();
-            tx.finish();
+            tx.close();
 
             try
             {
@@ -101,7 +103,7 @@ public class TestTxPush
             long nodeId = node.getId();
             node.setProperty( "foo", "bar" );
             tx.success();
-            tx.finish();
+            tx.close();
 
             /*
              * This is the slave only, it will not get transactions pushed at even though it is in higher prio and

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
@@ -64,7 +64,7 @@ public class ClusterTest
             long nodeId = node.getId();
             node.setProperty( "foo", "bar" );
             tx.success();
-            tx.finish();
+            tx.close();
 
 
             HighlyAvailableGraphDatabase slave = clusterManager.getDefaultCluster().getAnySlave();
@@ -99,7 +99,7 @@ public class ClusterTest
             Transaction tx = master.beginTx();
             master.createNode();
             tx.success();
-            tx.finish();
+            tx.close();
         }
         finally
         {
@@ -216,7 +216,7 @@ public class ClusterTest
             master.createNode();
             logging.getLogger().info( "CREATED NODE" );
             tx.success();
-            tx.finish();
+            tx.close();
 
             logging.getLogger().info( "STOPPING CLUSTER" );
         }

--- a/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
+++ b/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
@@ -19,15 +19,10 @@
  */
 package slavetest;
 
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.com.ServerUtil.rotateLogs;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.test.TargetDirectory.forTest;
-
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -36,6 +31,13 @@ import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.com.ServerUtil.rotateLogs;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.TargetDirectory.forTest;
 
 /*
  * This test case ensures that instances with the same store id but very old txids
@@ -113,13 +115,8 @@ public class TestInstanceJoin
         Node node = db.createNode();
         node.setProperty( key, value );
         tx.success();
-        tx.finish();
+        tx.close();
         return node.getId();
-    }
-
-    private static HighlyAvailableGraphDatabase start( String storeDir, int i )
-    {
-        return start( storeDir, i, stringMap() );
     }
 
     private static HighlyAvailableGraphDatabase start( String storeDir, int i, Map<String, String> additionalConfig )


### PR DESCRIPTION
Because this touches so many files, it also includes a mass of other warning removals.
