### PR TITLE
Improve the error message for MERGE statements with map property parameters

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/MergeAst.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/commands/MergeAst.scala
@@ -52,7 +52,10 @@ case class MergeAst(patterns: Seq[AbstractPattern], onActions: Seq[OnAction]) {
 
         val labelActions = labelsNames.map(labelName => LabelAction(Identifier(name), LabelSetOp, Seq(labelName)))
         val propertyActions = props.map {
-          case (propertyKey, expression) => PropertySetAction(Property(Identifier(name), PropertyKey(propertyKey)), expression)
+          case (propertyKey, expression) => {
+            if (propertyKey == "*") throw new PatternException("MERGE does not support map parameters")
+            PropertySetAction(Property(Identifier(name), PropertyKey(propertyKey)), expression)
+          }
         }
 
         val actionsFromOnCreateClause = actionsMap.get((name, On.Create)).getOrElse(Set.empty)


### PR DESCRIPTION
This change has the desired effect. Running the query [here](https://github.com/neo4j/neo4j/issues/975) now gives a helpful error message.

But the implementation seems a bit hacky, depending on the special value "*" for the property key. Is there a better way of doing this? Should the key have its own type to carry this information more securely?

@systay, @boggle, @thobe: thoughts?
