### PR TITLE
Removed lock striping when loading nodes/relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.state.NodeState;
 import org.neo4j.kernel.impl.api.state.TxState;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.GraphPropertiesImpl;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.Primitive;
@@ -68,13 +68,13 @@ public class PersistenceCache
             relationshipCache.updateSize( (RelationshipImpl) entity, size );
         }
     };
-    private final LockStripedCache<NodeImpl> nodeCache;
-    private final LockStripedCache<RelationshipImpl> relationshipCache;
+    private final AutoLoadingCache<NodeImpl> nodeCache;
+    private final AutoLoadingCache<RelationshipImpl> relationshipCache;
     private final Thunk<GraphPropertiesImpl> graphProperties;
 
     public PersistenceCache(
-            LockStripedCache<NodeImpl> nodeCache,
-            LockStripedCache<RelationshipImpl> relationshipCache,
+            AutoLoadingCache<NodeImpl> nodeCache,
+            AutoLoadingCache<RelationshipImpl> relationshipCache,
             Thunk<GraphPropertiesImpl> graphProperties )
     {
         this.nodeCache = nodeCache;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/AutoLoadingCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/AutoLoadingCache.java
@@ -20,11 +20,14 @@
 package org.neo4j.kernel.impl.cache;
 
 import java.util.Collection;
-import java.util.concurrent.locks.ReentrantLock;
 
-public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E>
+/**
+ * Cache that know itself how to load entities into the cache when requested.
+ *
+ * @param <E> type of entity objects in the cache.
+ */
+public class AutoLoadingCache<E extends EntityWithSizeObject> implements Cache<E>
 {
-    private final ReentrantLock locks[];
     private final Cache<E> actual;
     private final Loader<E> loader;
 
@@ -36,15 +39,10 @@ public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E
         E loadById( long id );
     }
 
-    public LockStripedCache( Cache<E> actual, int stripeCount, Loader<E> loader )
+    public AutoLoadingCache( Cache<E> actual, Loader<E> loader )
     {
         this.loader = loader;
-        this.locks = new ReentrantLock[stripeCount];
         this.actual = actual;
-        for ( int i = 0; i < locks.length; i++ )
-        {
-            locks[i] = new ReentrantLock();
-        }
     }
 
     @Override
@@ -74,39 +72,36 @@ public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E
             return result;
         }
 
-        ReentrantLock lock = lockId( key );
-        try
+        /* MP/JS | A note about locking:
+         * Previously this block of code below was wrapped in a lock, striped on the key where there were
+         * an arbitrary number of stripes. The lock would prevent multiple threads to load the same entity
+         * at the same time, or more specifically prevent multiple threads to put two versions of the same entity
+         * into the cache at the same time.
+         *   So without the lock there can be thread T1 loading an entity into an entity object E1 at the same time
+         * as thread T2 loading the same entity into another entity object E2. E1 and E2 represent the same entity E.
+         * This race would have one of the threads win and have its version put in the cache last,
+         * the other overwritten. Consider the similarities of that race with cache eviction coming into play,
+         * where T1 loads E1 and puts it in cache and returns it. After that and before T2 comes in
+         * and wants that same entity there has been an eviction of E1. T2 would then load E2 and
+         * put into cache resulting in two "live" versions of E as well. It would seem that having the lock would
+         * reduce the chance for this happening, but not prevent it.
+         *   There doesn't seem to be any reason as to why having two versions of the same entity object would cause
+         * problems (keep in mind that there will only be one version in the cache). Also, the overhead of
+         * locking grows with the number of threads/cores to eventually become a bottle neck.
+         *
+         * Based on that the locking was removed. */
+        result = loader.loadById( key );
+        if ( result == null )
         {
-            result = loader.loadById( key );
-            if ( result == null )
-            {
-                return null;
-            }
-            actual.put( result );
-            return result;
+            return null;
         }
-        finally
-        {
-            lock.unlock();
-        }
+        actual.put( result );
+        return result;
     }
 
     public E getIfCached( long key )
     {
         return actual.get( key );
-    }
-
-    private ReentrantLock lockId( long id )
-    {
-        // TODO: Change stripe mod for new 4B+
-        int stripe = (int) (id / 32768) % locks.length;
-        if ( stripe < 0 )
-        {
-            stripe *= -1;
-        }
-        ReentrantLock lock = locks[stripe];
-        lock.lock();
-        return lock;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeManager.java
@@ -46,9 +46,9 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.cache.Cache;
 import org.neo4j.kernel.impl.cache.CacheProvider;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
@@ -76,8 +76,8 @@ public class NodeManager implements Lifecycle, EntityFactory
 
     private final StringLogger logger;
     private final GraphDatabaseService graphDbService;
-    private final LockStripedCache<NodeImpl> nodeCache;
-    private final LockStripedCache<RelationshipImpl> relCache;
+    private final AutoLoadingCache<NodeImpl> nodeCache;
+    private final AutoLoadingCache<RelationshipImpl> relCache;
     private final CacheProvider cacheProvider;
     private final AbstractTransactionManager transactionManager;
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
@@ -94,10 +94,9 @@ public class NodeManager implements Lifecycle, EntityFactory
     private final List<PropertyTracker<Node>> nodePropertyTrackers;
     private final List<PropertyTracker<Relationship>> relationshipPropertyTrackers;
 
-    private static final int LOCK_STRIPE_COUNT = 32;
     private GraphPropertiesImpl graphProperties;
 
-    private final LockStripedCache.Loader<NodeImpl> nodeLoader = new LockStripedCache.Loader<NodeImpl>()
+    private final AutoLoadingCache.Loader<NodeImpl> nodeLoader = new AutoLoadingCache.Loader<NodeImpl>()
     {
         @Override
         public NodeImpl loadById( long id )
@@ -111,7 +110,7 @@ public class NodeManager implements Lifecycle, EntityFactory
         }
     };
 
-    private final LockStripedCache.Loader<RelationshipImpl> relLoader = new LockStripedCache.Loader<RelationshipImpl>()
+    private final AutoLoadingCache.Loader<RelationshipImpl> relLoader = new AutoLoadingCache.Loader<RelationshipImpl>()
     {
         @Override
         public RelationshipImpl loadById( long id )
@@ -150,8 +149,8 @@ public class NodeManager implements Lifecycle, EntityFactory
 
         this.cacheProvider = cacheProvider;
         this.statementCtxProvider = statementCtxProvider;
-        this.nodeCache = new LockStripedCache<>( nodeCache, LOCK_STRIPE_COUNT, nodeLoader );
-        this.relCache = new LockStripedCache<>( relCache, LOCK_STRIPE_COUNT, relLoader );
+        this.nodeCache = new AutoLoadingCache<>( nodeCache, nodeLoader );
+        this.relCache = new AutoLoadingCache<>( relCache, relLoader );
         this.xaDsm = xaDsm;
         nodePropertyTrackers = new LinkedList<>();
         relationshipPropertyTrackers = new LinkedList<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -60,7 +60,7 @@ import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.GraphPropertiesImpl;
 import org.neo4j.kernel.impl.core.NodeImpl;
@@ -297,8 +297,8 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
         final NodeManager nodeManager = dependencyResolver.resolveDependency( NodeManager.class );
         Iterator<? extends Cache<?>> caches = nodeManager.caches().iterator();
         persistenceCache = new PersistenceCache(
-                (LockStripedCache<NodeImpl>)caches.next(),
-                (LockStripedCache<RelationshipImpl>)caches.next(), new Thunk<GraphPropertiesImpl>()
+                (AutoLoadingCache<NodeImpl>)caches.next(),
+                (AutoLoadingCache<RelationshipImpl>)caches.next(), new Thunk<GraphPropertiesImpl>()
         {
             @Override
             public GraphPropertiesImpl evaluate()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import org.neo4j.helpers.Thunk;
 import org.neo4j.kernel.api.KernelStatement;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.RelationshipImpl;
 
@@ -69,7 +69,7 @@ public class PersistenceCacheTest
     }
 
     private PersistenceCache persistenceCache;
-    private LockStripedCache<NodeImpl> nodeCache;
+    private AutoLoadingCache<NodeImpl> nodeCache;
     private final long nodeId = 1;
     private final KernelStatement state = mock( KernelStatement.class );
 
@@ -77,8 +77,8 @@ public class PersistenceCacheTest
     @Before
     public void init()
     {
-        nodeCache = mock( LockStripedCache.class );
-        LockStripedCache<RelationshipImpl> relCache = mock( LockStripedCache.class );
+        nodeCache = mock( AutoLoadingCache.class );
+        AutoLoadingCache<RelationshipImpl> relCache = mock( AutoLoadingCache.class );
         persistenceCache = new PersistenceCache( nodeCache, relCache, mock( Thunk.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -59,7 +59,7 @@ import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
@@ -174,8 +174,8 @@ public class TestNeoStore
         NodeManager nodeManager = mock(NodeManager.class);
         @SuppressWarnings( "rawtypes" )
         List caches = Arrays.asList(
-                (Cache) mock( LockStripedCache.class ),
-                (Cache) mock( LockStripedCache.class ) );
+                (Cache) mock( AutoLoadingCache.class ),
+                (Cache) mock( AutoLoadingCache.class ) );
         when( nodeManager.caches() ).thenReturn( caches );
 
         ds = new NeoStoreXaDataSource(config, sf, StringLogger.DEV_NULL,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
@@ -58,7 +58,7 @@ import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
@@ -366,8 +366,8 @@ public class TestXa
         NodeManager nodeManager = mock(NodeManager.class);
         @SuppressWarnings( "rawtypes" )
         List caches = Arrays.asList(
-                (Cache) mock( LockStripedCache.class ),
-                (Cache) mock( LockStripedCache.class ) );
+                (Cache) mock( AutoLoadingCache.class ),
+                (Cache) mock( AutoLoadingCache.class ) );
         when( nodeManager.caches() ).thenReturn( caches );
 
         NeoStoreXaDataSource neoStoreXaDataSource = new NeoStoreXaDataSource( config, sf,


### PR DESCRIPTION
Previously, loading a node or relationships had the loading code wrapped in a lock, striped on the key
where there were an arbitrary number of stripes. The lock would prevent multiple threads to load the
same entity at the same time, or more specifically prevent multiple threads to put two versions of the
same entity into the cache at the same time.

So without the lock there can be thread T1 loading an entity into an entity object E1 at the same time
as thread T2 loading the same entity into another entity object E2. E1 and E2 represent the same entity E.
This race would have one of the threads win and have its version put in the cache last,
the other overwritten. Consider the similarities of that race with cache eviction coming into play,
where T1 loads E1 and puts it in cache and returns it. After that and before T2 comes in
and wants that same entity there has been an eviction of E1. T2 would then load E2 and
put into cache resulting in two "live" versions of E. It seems that having the lock would merely
reduce the chance for this happening, not prevent it.

There doesn't seem to be any reason as to why having two versions of the same entity object would cause
problems (keep in mind that there will only be one version in the cache).
Also, the overhead of locking grows with the number of threads/cores to eventually become a bottle neck.

Based on that the locking was removed.

co-author: Johan Svensson, @johan-neo
