### PR TITLE
Removed lock striping when loading nodes/relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel;
 
-import java.util.Iterator;
-
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Expander;
 import org.neo4j.graphdb.Node;
@@ -53,6 +51,7 @@ import org.neo4j.kernel.impl.traversal.TraversalDescriptionImpl;
  * {@link org.neo4j.graphdb.traversal.BranchOrderingPolicies},
  * {@link org.neo4j.graphdb.traversal.BranchCollisionPolicies} and {@link org.neo4j.graphdb.traversal.Uniqueness}
  */
+@Deprecated
 public class Traversal
 {
     /**
@@ -65,6 +64,7 @@ public class Traversal
      * @return a new {@link TraversalDescription} with default values.
      * @deprecated See {@link org.neo4j.graphdb.GraphDatabaseService#traversalDescription}
      */
+    @Deprecated
     public static TraversalDescription description()
     {
         return new TraversalDescriptionImpl();
@@ -76,6 +76,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.GraphDatabaseService#traversalDescription}
      */
+    @Deprecated
     public static TraversalDescription traversal()
     {
         return new TraversalDescriptionImpl();
@@ -84,6 +85,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.GraphDatabaseService#traversalDescription}
      */
+    @Deprecated
     public static TraversalDescription traversal( UniquenessFactory uniqueness )
     {
         return new TraversalDescriptionImpl().uniqueness( uniqueness );
@@ -92,6 +94,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.GraphDatabaseService#traversalDescription}
      */
+    @Deprecated
     public static TraversalDescription traversal( UniquenessFactory uniqueness, Object optionalUniquenessParameter )
     {
         return new TraversalDescriptionImpl().uniqueness( uniqueness, optionalUniquenessParameter );
@@ -100,6 +103,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.GraphDatabaseService#bidirectionalTraversalDescription}
      */
+    @Deprecated
     public static BidirectionalTraversalDescription bidirectionalTraversal()
     {
         return new BidirectionalTraversalDescriptionImpl();
@@ -113,6 +117,7 @@ public class Traversal
      *
      * @deprecated because InitialStateFactory is deprecated.
      */
+    @Deprecated
     public static <STATE> InitialStateFactory<STATE> initialState( final STATE initialState )
     {
         return new InitialStateFactory<STATE>()
@@ -135,12 +140,13 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypeAndDirection}
      */
+    @Deprecated
     public static Expander expanderForTypes( RelationshipType type,
             Direction dir )
     {
         return StandardExpander.create( type, dir );
     }
-    
+
     /**
      * Creates a new {@link PathExpander} which is set to expand
      * relationships with {@code type} and {@code direction}.
@@ -151,12 +157,13 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypeAndDirection}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> pathExpanderForTypes( RelationshipType type, Direction dir )
     {
         return StandardExpander.create( type, dir );
     }
-    
+
     /**
      * Creates a new {@link RelationshipExpander} which is set to expand
      * relationships with {@code type} in any direction.
@@ -166,6 +173,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forType}
      */
+    @Deprecated
     public static Expander expanderForTypes( RelationshipType type )
     {
         return StandardExpander.create( type, Direction.BOTH );
@@ -180,12 +188,13 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forType}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> pathExpanderForTypes( RelationshipType type )
     {
         return StandardExpander.create( type, Direction.BOTH );
     }
-    
+
     /**
      * Returns an empty {@link Expander} which, if not modified, will expand
      * all relationships when asked to expand a {@link Node}. Criterias
@@ -195,6 +204,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#allTypesAndDirections}
      */
+    @Deprecated
     public static Expander emptyExpander()
     {
         return StandardExpander.DEFAULT; // TODO: should this be a PROPER empty?
@@ -209,12 +219,13 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#allTypesAndDirections}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> emptyPathExpander()
     {
         return StandardExpander.DEFAULT; // TODO: should this be a PROPER empty?
     }
-    
+
     /**
      * Creates a new {@link RelationshipExpander} which is set to expand
      * relationships with two different types and directions.
@@ -227,6 +238,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypesAndDirections}
      */
+    @Deprecated
     public static Expander expanderForTypes( RelationshipType type1,
             Direction dir1, RelationshipType type2, Direction dir2 )
     {
@@ -245,13 +257,14 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypesAndDirections}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> pathExpanderForTypes( RelationshipType type1,
             Direction dir1, RelationshipType type2, Direction dir2 )
     {
         return StandardExpander.create( type1, dir1, type2, dir2 );
     }
-    
+
     /**
      * Creates a new {@link RelationshipExpander} which is set to expand
      * relationships with multiple types and directions.
@@ -265,6 +278,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypesAndDirections}
      */
+    @Deprecated
     public static Expander expanderForTypes( RelationshipType type1,
             Direction dir1, RelationshipType type2, Direction dir2,
             Object... more )
@@ -285,6 +299,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forTypesAndDirections}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> pathExpanderForTypes( RelationshipType type1,
             Direction dir1, RelationshipType type2, Direction dir2,
@@ -292,7 +307,7 @@ public class Traversal
     {
         return StandardExpander.create( type1, dir1, type2, dir2, more );
     }
-    
+
     /**
      * Returns a {@link RelationshipExpander} which expands relationships
      * of all types and directions.
@@ -300,6 +315,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#allTypesAndDirections}
      */
+    @Deprecated
     public static Expander expanderForAllTypes()
     {
         return expanderForAllTypes( Direction.BOTH );
@@ -312,11 +328,12 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#allTypesAndDirections}
      */
+    @Deprecated
     public static <STATE> PathExpander<STATE> pathExpanderForAllTypes()
     {
         return pathExpanderForAllTypes( Direction.BOTH );
     }
-    
+
     /**
      * Returns a {@link RelationshipExpander} which expands relationships
      * of all types in the given {@code direction}.
@@ -325,11 +342,12 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forDirection}
      */
+    @Deprecated
     public static Expander expanderForAllTypes( Direction direction )
     {
         return StandardExpander.create( direction );
     }
-    
+
     /**
      * Returns a {@link PathExpander} which expands relationships
      * of all types in the given {@code direction}.
@@ -338,12 +356,13 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.PathExpanders#forDirection}
      */
+    @Deprecated
     @SuppressWarnings( "unchecked" )
     public static <STATE> PathExpander<STATE> pathExpanderForAllTypes( Direction direction )
     {
         return StandardExpander.create( direction );
     }
-    
+
     public static Expander expander( PathExpander expander )
     {
         if ( expander instanceof Expander )
@@ -352,7 +371,7 @@ public class Traversal
         }
         return StandardExpander.wrap( expander );
     }
-    
+
     /**
      * Returns a {@link RelationshipExpander} wrapped as an {@link Expander}.
      * @param expander {@link RelationshipExpander} to wrap.
@@ -377,6 +396,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.traversal.BranchOrderingPolicies#PREORDER_DEPTH_FIRST}
      */
+    @Deprecated
     public static BranchOrderingPolicy preorderDepthFirst()
     {
         return CommonBranchOrdering.PREORDER_DEPTH_FIRST;
@@ -393,6 +413,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.traversal.BranchOrderingPolicies#POSTORDER_DEPTH_FIRST}
      */
+    @Deprecated
     public static BranchOrderingPolicy postorderDepthFirst()
     {
         return CommonBranchOrdering.POSTORDER_DEPTH_FIRST;
@@ -408,6 +429,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.traversal.BranchOrderingPolicies#PREORDER_BREADTH_FIRST}
      */
+    @Deprecated
     public static BranchOrderingPolicy preorderBreadthFirst()
     {
         return CommonBranchOrdering.PREORDER_BREADTH_FIRST;
@@ -424,6 +446,7 @@ public class Traversal
      *
      * @deprecated See {@link org.neo4j.graphdb.traversal.BranchOrderingPolicies#POSTORDER_BREADTH_FIRST}
      */
+    @Deprecated
     public static BranchOrderingPolicy postorderBreadthFirst()
     {
         return CommonBranchOrdering.POSTORDER_BREADTH_FIRST;
@@ -432,6 +455,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.traversal.SideSelectorPolicies#ALTERNATING}
      */
+    @Deprecated
     public static SideSelectorPolicy alternatingSelectorOrdering()
     {
         return SideSelectorPolicies.ALTERNATING;
@@ -440,6 +464,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.traversal.SideSelectorPolicies#LEVEL}
      */
+    @Deprecated
     public static SideSelectorPolicy levelSelectorOrdering()
     {
         return SideSelectorPolicies.LEVEL;
@@ -448,6 +473,7 @@ public class Traversal
     /**
      * @deprecated See {@link org.neo4j.graphdb.traversal.BranchCollisionPolicies#SHORTEST_PATH}
      */
+    @Deprecated
     public static BranchCollisionDetector shortestPathsCollisionDetector( int maxDepth )
     {
         return new ShortestPathsBranchCollisionDetector( Evaluators.toDepth( maxDepth ) );
@@ -480,7 +506,7 @@ public class Traversal
         String relationshipRepresentation( T path, Node from,
                 Relationship relationship );
     }
-    
+
     /**
      * The default {@link PathDescriptor} used in common toString()
      * representations in classes implementing {@link Path}.
@@ -488,11 +514,13 @@ public class Traversal
      */
     public static class DefaultPathDescriptor<T extends Path> implements PathDescriptor<T>
     {
+        @Override
         public String nodeRepresentation( Path path, Node node )
         {
             return "(" + node.getId() + ")";
         }
 
+        @Override
         public String relationshipRepresentation( Path path,
                 Node from, Relationship relationship )
         {
@@ -592,7 +620,7 @@ public class Traversal
             }
         } );
     }
-    
+
     public static PathDescription path()
     {
         return new PathDescription();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/PersistenceCache.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.state.NodeState;
 import org.neo4j.kernel.impl.api.state.TxState;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.GraphPropertiesImpl;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.Primitive;
@@ -68,13 +68,13 @@ public class PersistenceCache
             relationshipCache.updateSize( (RelationshipImpl) entity, size );
         }
     };
-    private final LockStripedCache<NodeImpl> nodeCache;
-    private final LockStripedCache<RelationshipImpl> relationshipCache;
+    private final AutoLoadingCache<NodeImpl> nodeCache;
+    private final AutoLoadingCache<RelationshipImpl> relationshipCache;
     private final Thunk<GraphPropertiesImpl> graphProperties;
 
     public PersistenceCache(
-            LockStripedCache<NodeImpl> nodeCache,
-            LockStripedCache<RelationshipImpl> relationshipCache,
+            AutoLoadingCache<NodeImpl> nodeCache,
+            AutoLoadingCache<RelationshipImpl> relationshipCache,
             Thunk<GraphPropertiesImpl> graphProperties )
     {
         this.nodeCache = nodeCache;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/AutoLoadingCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/AutoLoadingCache.java
@@ -20,11 +20,14 @@
 package org.neo4j.kernel.impl.cache;
 
 import java.util.Collection;
-import java.util.concurrent.locks.ReentrantLock;
 
-public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E>
+/**
+ * Cache that know itself how to load entities into the cache when requested.
+ *
+ * @param <E> type of entity objects in the cache.
+ */
+public class AutoLoadingCache<E extends EntityWithSizeObject> implements Cache<E>
 {
-    private final ReentrantLock locks[];
     private final Cache<E> actual;
     private final Loader<E> loader;
 
@@ -36,15 +39,10 @@ public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E
         E loadById( long id );
     }
 
-    public LockStripedCache( Cache<E> actual, int stripeCount, Loader<E> loader )
+    public AutoLoadingCache( Cache<E> actual, Loader<E> loader )
     {
         this.loader = loader;
-        this.locks = new ReentrantLock[stripeCount];
         this.actual = actual;
-        for ( int i = 0; i < locks.length; i++ )
-        {
-            locks[i] = new ReentrantLock();
-        }
     }
 
     @Override
@@ -54,9 +52,9 @@ public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E
     }
 
     @Override
-    public void put( E value )
+    public E put( E value )
     {
-        actual.put( value );
+        return actual.put( value );
     }
 
     @Override
@@ -74,39 +72,35 @@ public class LockStripedCache<E extends EntityWithSizeObject> implements Cache<E
             return result;
         }
 
-        ReentrantLock lock = lockId( key );
-        try
+        /* MP/JS | A note about locking:
+         * Previously this block of code below was wrapped in a lock, striped on the key where there were
+         * an arbitrary number of stripes. The lock would prevent multiple threads to load the same entity
+         * at the same time, or more specifically prevent multiple threads to put two versions of the same entity
+         * into the cache at the same time.
+         *   So without the lock there can be thread T1 loading an entity into an entity object E1 at the same time
+         * as thread T2 loading the same entity into another entity object E2. E1 and E2 represent the same entity E.
+         * This race would have one of the threads win and have its version put in the cache last,
+         * the other overwritten. Consider the similarities of that race with cache eviction coming into play,
+         * where T1 loads E1 and puts it in cache and returns it. After that and before T2 comes in
+         * and wants that same entity there has been an eviction of E1. T2 would then load E2 and
+         * put into cache resulting in two "live" versions of E as well. It would seem that having the lock would
+         * reduce the chance for this happening, but not prevent it.
+         *   There doesn't seem to be any reason as to why having two versions of the same entity object would cause
+         * problems (keep in mind that there will only be one version in the cache). Also, the overhead of
+         * locking grows with the number of threads/cores to eventually become a bottle neck.
+         *
+         * Based on that the locking was removed. */
+        result = loader.loadById( key );
+        if ( result == null )
         {
-            result = loader.loadById( key );
-            if ( result == null )
-            {
-                return null;
-            }
-            actual.put( result );
-            return result;
+            return null;
         }
-        finally
-        {
-            lock.unlock();
-        }
+        return actual.put( result );
     }
 
     public E getIfCached( long key )
     {
         return actual.get( key );
-    }
-
-    private ReentrantLock lockId( long id )
-    {
-        // TODO: Change stripe mod for new 4B+
-        int stripe = (int) (id / 32768) % locks.length;
-        if ( stripe < 0 )
-        {
-            stripe *= -1;
-        }
-        ReentrantLock lock = locks[stripe];
-        lock.lock();
-        return lock;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/Cache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/Cache.java
@@ -31,12 +31,13 @@ public interface Cache<E extends EntityWithSizeObject>
     String getName();
 
     /**
-     * Adds <CODE>element</CODE> to cache.
+     * Adds {@code element} to the cache. This operation is atomic and will not put the element into the cache
+     * if there were a previous element with the same {@link EntityWithSizeObject#getId() id}, but instead
+     * then return that element.
      *
-     * @param value
-     *            the element to cache
+     * @param value the element to cache.
      */
-    void put( E value );
+    E put( E value );
 
     /**
      * Removes the element for <CODE>key</CODE> from cache and returns it. If
@@ -79,6 +80,6 @@ public interface Cache<E extends EntityWithSizeObject>
     long missCount();
 
     void updateSize( E entity, int newSize );
-    
+
     void printStatistics();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/NoCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/NoCache.java
@@ -33,20 +33,25 @@ public class NoCache<E extends EntityWithSizeObject> implements Cache<E>
         this.name = name;
     }
 
-    public void put( E value )
+    @Override
+    public E put( E value )
     {
+        return value;
     }
 
+    @Override
     public void putAll( Collection<E> values )
     {
     }
 
+    @Override
     public E get( long key )
     {
         MISSES.incrementAndGet();
         return null;
     }
 
+    @Override
     public E remove( long key )
     {
         return null;
@@ -64,15 +69,18 @@ public class NoCache<E extends EntityWithSizeObject> implements Cache<E>
         return 0;
     }
 
+    @Override
     public long size()
     {
         return 0;
     }
 
+    @Override
     public void clear()
     {
     }
 
+    @Override
     public String getName()
     {
         return name;
@@ -83,7 +91,7 @@ public class NoCache<E extends EntityWithSizeObject> implements Cache<E>
     {
         // do nothing
     }
-    
+
     @Override
     public void printStatistics()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/StrongReferenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/StrongReferenceCache.java
@@ -25,27 +25,28 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class StrongReferenceCache<E extends EntityWithSizeObject> implements Cache<E>
 {
+    private final ConcurrentHashMap<Long,E> cache = new ConcurrentHashMap<>();
     private final String name;
-    private final ConcurrentHashMap<Long,E> cache = new ConcurrentHashMap<Long,E>();
-
     private final HitCounter counter = new HitCounter();
-
 
     public StrongReferenceCache( String name )
     {
         this.name = name;
     }
 
+    @Override
     public void clear()
     {
         cache.clear();
     }
 
+    @Override
     public E get( long key )
     {
         return counter.count( cache.get( key ) );
     }
 
+    @Override
     public String getName()
     {
         return name;
@@ -56,9 +57,11 @@ public class StrongReferenceCache<E extends EntityWithSizeObject> implements Cac
         return Integer.MAX_VALUE;
     }
 
-    public void put( E value )
+    @Override
+    public E put( E value )
     {
-        cache.put( value.getId(), value );
+        E previous = cache.putIfAbsent( value.getId(), value );
+        return previous != null ? previous : value;
     }
 
     public void putAll( List<E> list )
@@ -69,6 +72,7 @@ public class StrongReferenceCache<E extends EntityWithSizeObject> implements Cac
         }
     }
 
+    @Override
     public E remove( long key )
     {
         return cache.remove( key );
@@ -86,6 +90,7 @@ public class StrongReferenceCache<E extends EntityWithSizeObject> implements Cac
         return counter.getMissCount();
     }
 
+    @Override
     public long size()
     {
         return cache.size();
@@ -105,7 +110,7 @@ public class StrongReferenceCache<E extends EntityWithSizeObject> implements Cac
     {
         // do nothing
     }
-    
+
     @Override
     public void printStatistics()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeManager.java
@@ -46,9 +46,9 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.kernel.ThreadToStatementContextBridge;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.cache.Cache;
 import org.neo4j.kernel.impl.cache.CacheProvider;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
@@ -76,8 +76,8 @@ public class NodeManager implements Lifecycle, EntityFactory
 
     private final StringLogger logger;
     private final GraphDatabaseService graphDbService;
-    private final LockStripedCache<NodeImpl> nodeCache;
-    private final LockStripedCache<RelationshipImpl> relCache;
+    private final AutoLoadingCache<NodeImpl> nodeCache;
+    private final AutoLoadingCache<RelationshipImpl> relCache;
     private final CacheProvider cacheProvider;
     private final AbstractTransactionManager transactionManager;
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
@@ -94,10 +94,9 @@ public class NodeManager implements Lifecycle, EntityFactory
     private final List<PropertyTracker<Node>> nodePropertyTrackers;
     private final List<PropertyTracker<Relationship>> relationshipPropertyTrackers;
 
-    private static final int LOCK_STRIPE_COUNT = 32;
     private GraphPropertiesImpl graphProperties;
 
-    private final LockStripedCache.Loader<NodeImpl> nodeLoader = new LockStripedCache.Loader<NodeImpl>()
+    private final AutoLoadingCache.Loader<NodeImpl> nodeLoader = new AutoLoadingCache.Loader<NodeImpl>()
     {
         @Override
         public NodeImpl loadById( long id )
@@ -111,7 +110,7 @@ public class NodeManager implements Lifecycle, EntityFactory
         }
     };
 
-    private final LockStripedCache.Loader<RelationshipImpl> relLoader = new LockStripedCache.Loader<RelationshipImpl>()
+    private final AutoLoadingCache.Loader<RelationshipImpl> relLoader = new AutoLoadingCache.Loader<RelationshipImpl>()
     {
         @Override
         public RelationshipImpl loadById( long id )
@@ -150,8 +149,8 @@ public class NodeManager implements Lifecycle, EntityFactory
 
         this.cacheProvider = cacheProvider;
         this.statementCtxProvider = statementCtxProvider;
-        this.nodeCache = new LockStripedCache<>( nodeCache, LOCK_STRIPE_COUNT, nodeLoader );
-        this.relCache = new LockStripedCache<>( relCache, LOCK_STRIPE_COUNT, relLoader );
+        this.nodeCache = new AutoLoadingCache<>( nodeCache, nodeLoader );
+        this.relCache = new AutoLoadingCache<>( relCache, relLoader );
         this.xaDsm = xaDsm;
         nodePropertyTrackers = new LinkedList<>();
         relationshipPropertyTrackers = new LinkedList<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -60,7 +60,7 @@ import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.GraphPropertiesImpl;
 import org.neo4j.kernel.impl.core.NodeImpl;
@@ -297,8 +297,8 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
         final NodeManager nodeManager = dependencyResolver.resolveDependency( NodeManager.class );
         Iterator<? extends Cache<?>> caches = nodeManager.caches().iterator();
         persistenceCache = new PersistenceCache(
-                (LockStripedCache<NodeImpl>)caches.next(),
-                (LockStripedCache<RelationshipImpl>)caches.next(), new Thunk<GraphPropertiesImpl>()
+                (AutoLoadingCache<NodeImpl>)caches.next(),
+                (AutoLoadingCache<RelationshipImpl>)caches.next(), new Thunk<GraphPropertiesImpl>()
         {
             @Override
             public GraphPropertiesImpl evaluate()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import org.neo4j.helpers.Thunk;
 import org.neo4j.kernel.api.KernelStatement;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.RelationshipImpl;
 
@@ -69,7 +69,7 @@ public class PersistenceCacheTest
     }
 
     private PersistenceCache persistenceCache;
-    private LockStripedCache<NodeImpl> nodeCache;
+    private AutoLoadingCache<NodeImpl> nodeCache;
     private final long nodeId = 1;
     private final KernelStatement state = mock( KernelStatement.class );
 
@@ -77,8 +77,8 @@ public class PersistenceCacheTest
     @Before
     public void init()
     {
-        nodeCache = mock( LockStripedCache.class );
-        LockStripedCache<RelationshipImpl> relCache = mock( LockStripedCache.class );
+        nodeCache = mock( AutoLoadingCache.class );
+        AutoLoadingCache<RelationshipImpl> relCache = mock( AutoLoadingCache.class );
         persistenceCache = new PersistenceCache( nodeCache, relCache, mock( Thunk.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/CacheTypesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/CacheTypesIT.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+public class CacheTypesIT extends AbstractNeo4jTestCase
+{
+    private GraphDatabaseAPI newDb( String cacheType )
+    {
+        return (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig( GraphDatabaseSettings.cache_type.name(), cacheType ).newGraphDatabase();
+    }
+
+    @Test
+    public void testDefaultCache()
+    {
+        GraphDatabaseAPI db = newDb( null );
+        assertEquals( SoftCacheProvider.NAME, db.getNodeManager().getCacheType().getName() );
+        db.shutdown();
+    }
+
+    @Test
+    public void testWeakRefCache()
+    {
+        GraphDatabaseAPI db = newDb( WeakCacheProvider.NAME );
+        assertEquals( WeakCacheProvider.NAME, db.getNodeManager().getCacheType().getName() );
+        db.shutdown();
+    }
+
+    @Test
+    public void testSoftRefCache()
+    {
+        GraphDatabaseAPI db = newDb( SoftCacheProvider.NAME );
+        assertEquals( SoftCacheProvider.NAME, db.getNodeManager().getCacheType().getName() );
+        db.shutdown();
+    }
+
+    @Test
+    public void testNoCache()
+    {
+        GraphDatabaseAPI db = newDb( NoCacheProvider.NAME );
+        assertEquals( NoCacheProvider.NAME, db.getNodeManager().getCacheType().getName() );
+        db.shutdown();
+    }
+
+    @Test
+    public void testStrongCache()
+    {
+        GraphDatabaseAPI db = newDb( StrongCacheProvider.NAME );
+        assertEquals( StrongCacheProvider.NAME, db.getNodeManager().getCacheType().getName() );
+        db.shutdown();
+    }
+    
+    @Test
+    public void testInvalidCache()
+    {
+        // invalid cache type should fail
+        GraphDatabaseAPI db = null;
+        try
+        {
+            db = newDb( "whatever" );
+            fail( "Wrong cache type should not be allowed" );
+        }
+        catch( Exception e )
+        {
+            // Ok
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -59,7 +59,7 @@ import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
@@ -173,8 +173,8 @@ public class TestNeoStore
         NodeManager nodeManager = mock(NodeManager.class);
         @SuppressWarnings( "rawtypes" )
         List caches = Arrays.asList(
-                (Cache) mock( LockStripedCache.class ),
-                (Cache) mock( LockStripedCache.class ) );
+                (Cache) mock( AutoLoadingCache.class ),
+                (Cache) mock( AutoLoadingCache.class ) );
         when( nodeManager.caches() ).thenReturn( caches );
 
         ds = new NeoStoreXaDataSource(config, sf, StringLogger.DEV_NULL,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
@@ -58,7 +58,7 @@ import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.Cache;
-import org.neo4j.kernel.impl.cache.LockStripedCache;
+import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
@@ -366,8 +366,8 @@ public class TestXa
         NodeManager nodeManager = mock(NodeManager.class);
         @SuppressWarnings( "rawtypes" )
         List caches = Arrays.asList(
-                (Cache) mock( LockStripedCache.class ),
-                (Cache) mock( LockStripedCache.class ) );
+                (Cache) mock( AutoLoadingCache.class ),
+                (Cache) mock( AutoLoadingCache.class ) );
         when( nodeManager.caches() ).thenReturn( caches );
 
         NeoStoreXaDataSource neoStoreXaDataSource = new NeoStoreXaDataSource( config, sf,


### PR DESCRIPTION
Previously, loading a node or relationships had the loading code wrapped in a lock, striped on the key
where there were an arbitrary number of stripes. The lock would prevent multiple threads to load the
same entity at the same time, or more specifically prevent multiple threads to put two versions of the
same entity into the cache at the same time.

So without the lock there can be thread T1 loading an entity into an entity object E1 at the same time
as thread T2 loading the same entity into another entity object E2. E1 and E2 represent the same entity E.
This race would have one of the threads win and have its version put in the cache last,
the other overwritten. Consider the similarities of that race with cache eviction coming into play,
where T1 loads E1 and puts it in cache and returns it. After that and before T2 comes in
and wants that same entity there has been an eviction of E1. T2 would then load E2 and
put into cache resulting in two "live" versions of E. It seems that having the lock would merely
reduce the chance for this happening, not prevent it.

There doesn't seem to be any reason as to why having two versions of the same entity object would cause
problems (keep in mind that there will only be one version in the cache). Also, the overhead of locking
grows with the number of threads/cores to eventually become a bottle neck.

Based on that the locking was removed.

Also, to support this the Cache#put contract and method signature has
changed to return any existing element with the same ID instead of
overwriting what's there.

co-author: Johan Svensson, @johan-neo
