### PR TITLE
Lucene label scan store can be used in batch insertion

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -31,7 +31,6 @@ import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
-import org.neo4j.kernel.impl.nioneo.xa.IntegrityValidator;
 import org.neo4j.kernel.impl.storemigration.ConfigMapUpgradeConfiguration;
 import org.neo4j.kernel.impl.storemigration.DatabaseFiles;
 import org.neo4j.kernel.impl.storemigration.StoreMigrator;
@@ -52,7 +51,7 @@ public class StoreFactory
         public static final Setting<Integer> array_block_size = GraphDatabaseSettings.array_block_size;
         public static final Setting<Integer> label_block_size = GraphDatabaseSettings.label_block_size;
     }
-    
+
     private final Config config;
     private final IdGeneratorFactory idGeneratorFactory;
     private final WindowPoolFactory windowPoolFactory;
@@ -80,7 +79,7 @@ public class StoreFactory
     public static final String LABEL_TOKEN_STORE_NAME = ".labeltokenstore.db";
     public static final String LABEL_TOKEN_NAMES_STORE_NAME = LABEL_TOKEN_STORE_NAME + NAMES_PART;
     public static final String SCHEMA_STORE_NAME = ".schemastore.db";
-    
+
     public StoreFactory( Config config, IdGeneratorFactory idGeneratorFactory, WindowPoolFactory windowPoolFactory,
                          FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger, TxHook txHook )
     {
@@ -153,7 +152,7 @@ public class StoreFactory
         return new SchemaStore( file, config, IdType.SCHEMA, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger );
     }
-    
+
     private DynamicStringStore newDynamicStringStore(File fileName, IdType nameIdType)
     {
         return new DynamicStringStore( fileName, config, nameIdType, idGeneratorFactory, windowPoolFactory,
@@ -229,12 +228,15 @@ public class StoreFactory
         createRelationshipTypeStore(new File( fileName.getPath() + RELATIONSHIP_TYPE_TOKEN_STORE_NAME ));
         createLabelTokenStore( new File( fileName.getPath() + LABEL_TOKEN_STORE_NAME ) );
         createSchemaStore(new File( fileName.getPath() + SCHEMA_STORE_NAME));
-        
+
         NeoStore neoStore = newNeoStore( fileName );
         /*
         *  created time | random long | backup version | tx id | store version | next prop
         */
-        for ( int i = 0; i < 6; i++ ) neoStore.nextId();
+        for ( int i = 0; i < 6; i++ )
+        {
+            neoStore.nextId();
+        }
         neoStore.setCreationTime( storeId.getCreationTime() );
         neoStore.setRandomNumber( storeId.getRandomId() );
         neoStore.setVersion( 0 );
@@ -255,7 +257,7 @@ public class StoreFactory
     public void createNodeStore( File fileName )
     {
         createNodeLabelsStore( new File( fileName.getPath() + LABELS_PART ) );
-        
+
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( NodeStore.TYPE_DESCRIPTOR ) );
         NodeStore store = newNodeStore( fileName );
         NodeRecord nodeRecord = new NodeRecord( store.nextId(), Record.NO_NEXT_RELATIONSHIP.intValue(), Record.NO_NEXT_PROPERTY.intValue() );
@@ -335,14 +337,14 @@ public class StoreFactory
     private void createPropertyKeyTokenStore( File fileName )
     {
         createEmptyStore( fileName, buildTypeDescriptorAndVersion( PropertyKeyTokenStore.TYPE_DESCRIPTOR ));
-        createDynamicStringStore(new File( fileName.getPath() + KEYS_PART), PropertyKeyTokenStore.NAME_STORE_BLOCK_SIZE, IdType.PROPERTY_KEY_TOKEN_NAME );
+        createDynamicStringStore(new File( fileName.getPath() + KEYS_PART), TokenStore.NAME_STORE_BLOCK_SIZE, IdType.PROPERTY_KEY_TOKEN_NAME );
     }
 
     public void createDynamicArrayStore( File fileName, int blockSize)
     {
         createEmptyDynamicStore(fileName, blockSize, DynamicArrayStore.VERSION, IdType.ARRAY_BLOCK);
     }
-    
+
     public void createSchemaStore( File fileName )
     {
         createEmptyDynamicStore( fileName, SchemaStore.BLOCK_SIZE, SchemaStore.VERSION, IdType.SCHEMA );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.DependencyResolver.Adapter;
 import org.neo4j.graphdb.Node;
@@ -60,8 +61,8 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
-import org.neo4j.kernel.impl.cache.Cache;
 import org.neo4j.kernel.impl.cache.AutoLoadingCache;
+import org.neo4j.kernel.impl.cache.Cache;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
@@ -88,8 +89,12 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class TestNeoStore
@@ -1144,6 +1149,6 @@ public class TestNeoStore
 
         // then the value should have been stored
         assertEquals( 10l, neoStore.getLatestConstraintIntroducingTx() );
-
+        neoStore.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestXaFramework.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestXaFramework.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
@@ -50,7 +51,6 @@ import org.neo4j.kernel.impl.core.NoTransactionState;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.xaframework.DefaultLogBufferFactory;
-import org.neo4j.kernel.impl.transaction.xaframework.InjectedTransactionValidator;
 import org.neo4j.kernel.impl.transaction.xaframework.LogBuffer;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies;
 import org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier;
@@ -74,6 +74,7 @@ import org.neo4j.kernel.logging.DevNullLoggingService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.kernel.impl.transaction.xaframework.InjectedTransactionValidator.ALLOW_ALL;
 
 public class TestXaFramework extends AbstractNeo4jTestCase
@@ -266,7 +267,7 @@ public class TestXaFramework extends AbstractNeo4jTestCase
                         };
                     }
                 };
-                
+
                 map.put( "store_dir", path().getPath() );
                 xaContainer = xaFactory.newXaContainer( this, resourceFile(),
                         new DummyCommandFactory(),
@@ -510,7 +511,10 @@ public class TestXaFramework extends AbstractNeo4jTestCase
         boolean allDeleted = true;
         for ( File file : files )
         {
-            if ( !file.delete() ) allDeleted = false;
+            if ( !file.delete() )
+            {
+                allDeleted = false;
+            }
         }
         assertTrue( "delete all files starting with " + prefix, allDeleted );
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
@@ -30,9 +30,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.lucene.store.LockObtainFailedException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.api.scan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
@@ -43,9 +45,13 @@ import org.neo4j.test.TargetDirectory;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.collection.IteratorUtil.emptyPrimitiveLongIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
@@ -294,7 +300,7 @@ public class LuceneLabelScanStoreTest
 
     private static class TrackingMonitor implements LuceneLabelScanStore.Monitor
     {
-        boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled, corruptIndexCalled;
+        boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled;
 
         @Override
         public void noIndex()
@@ -303,9 +309,13 @@ public class LuceneLabelScanStoreTest
         }
 
         @Override
+        public void lockedIndex( LockObtainFailedException e )
+        {
+        }
+
+        @Override
         public void corruptIndex( IOException corruptionException )
         {
-            corruptIndexCalled = true;
         }
 
         @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/RestRepresentationWriter.java
@@ -21,7 +21,6 @@ package org.neo4j.server.rest.transactional;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 
 import org.codehaus.jackson.JsonGenerator;


### PR DESCRIPTION
This fixes a problem where the LuceneLabelScanStore couldn't be used in
batch insertion due one of its dependencies (Dependencies#getLogging())
couldn't be resolved by the batch inserter's dependency resolver. Tests
didn't catch this since the test-only in-memory label scan store was
selected instead due to being available.
