### PR TITLE
Fix for inability to remove constraints in HA.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -114,7 +114,7 @@ public interface TxState
 
         void visitRemovedIndex( IndexDescriptor element, boolean isConstraintIndex );
 
-        void visitAddedConstraint( UniquenessConstraint element, long indexId );
+        void visitAddedConstraint( UniquenessConstraint element );
 
         void visitRemovedConstraint( UniquenessConstraint element );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -159,7 +159,7 @@ public final class TxStateImpl implements TxState
                 @Override
                 public void visitAdded( UniquenessConstraint element )
                 {
-                    visitor.visitAddedConstraint( element, createdConstraintIndexesByConstraint().get( element ) );
+                    visitor.visitAddedConstraint( element );
                 }
 
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/ReadTransaction.java
@@ -31,6 +31,7 @@ import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
@@ -373,7 +374,7 @@ class ReadTransaction implements NeoStoreTransaction
     }
 
     @Override
-    public void dropSchemaRule( long id )
+    public void dropSchemaRule( SchemaRule rule )
     {
         throw readOnlyException();
     }
@@ -398,7 +399,7 @@ class ReadTransaction implements NeoStoreTransaction
     }
 
     @Override
-    public void setConstraintIndexOwner( long constraintIndexId, long constraintId )
+    public void setConstraintIndexOwner( IndexRule constraintIndex, long constraintId )
     {
         throw readOnlyException();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
@@ -143,22 +143,22 @@ public class TransactionWriter
         update( relationship );
     }
 
-    public void createSchema( Collection<DynamicRecord> records ) throws IOException
+    public void createSchema( Collection<DynamicRecord> beforeRecord, Collection<DynamicRecord> afterRecord ) throws IOException
     {
-        for ( DynamicRecord record : records )
+        for ( DynamicRecord record : afterRecord )
         {
             record.setCreated();
         }
-        updateSchema( records );
+        updateSchema( beforeRecord, afterRecord );
     }
 
-    public void updateSchema( Collection<DynamicRecord> records ) throws IOException
+    public void updateSchema(Collection<DynamicRecord> beforeRecords, Collection<DynamicRecord> afterRecords) throws IOException
     {
-        for ( DynamicRecord record : records )
+        for ( DynamicRecord record : afterRecords )
         {
             record.setInUse( true );
         }
-        addSchema( records );
+        addSchema( beforeRecords, afterRecords );
     }
 
     public void update( RelationshipRecord relationship ) throws IOException
@@ -184,23 +184,23 @@ public class TransactionWriter
         update( before, property );
     }
 
-    public void update( PropertyRecord before, PropertyRecord property ) throws IOException
+    public void update( PropertyRecord before, PropertyRecord after ) throws IOException
     {
-        property.setInUse( true );
-        add( before, property );
+        after.setInUse(true);
+        add( before, after );
     }
 
-    public void delete( PropertyRecord before, PropertyRecord property ) throws IOException
+    public void delete( PropertyRecord before, PropertyRecord after ) throws IOException
     {
-        property.setInUse( false );
-        add( before, property );
+        after.setInUse(false);
+        add( before, after );
     }
 
     // Internals
 
-    private void addSchema( Collection<DynamicRecord> records ) throws IOException
+    private void addSchema( Collection<DynamicRecord> beforeRecords, Collection<DynamicRecord> afterRecords ) throws IOException
     {
-        write( new Command.SchemaRuleCommand( null, null, null, records, null, Long.MAX_VALUE ) );
+        write( new Command.SchemaRuleCommand( null, null, null, beforeRecords, afterRecords, null, Long.MAX_VALUE ) );
     }
 
     public void add( NodeRecord before, NodeRecord after ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/NeoStoreTransaction.java
@@ -27,6 +27,7 @@ import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
@@ -274,7 +275,7 @@ public interface NeoStoreTransaction
 
     void createSchemaRule( SchemaRule schemaRule );
 
-    void dropSchemaRule( long id );
+    void dropSchemaRule( SchemaRule rule );
 
     void addLabelToNode( int labelId, long nodeId );
 
@@ -282,7 +283,7 @@ public interface NeoStoreTransaction
 
     PrimitiveLongIterator getLabelsForNode( long nodeId );
 
-    void setConstraintIndexOwner( long constraintIndexId, long constraintId );
+    void setConstraintIndexOwner( IndexRule constraintIndex, long constraintId );
 
     public interface PropertyReceiver
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.core.TransactionEventsSyncHook;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.core.TxEventSyncHookFactory;
+import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
@@ -308,14 +309,14 @@ public class PersistenceManager
         }
     }
 
-    public void dropSchemaRule( long ruleId )
+    public void dropSchemaRule( SchemaRule rule )
     {
-        getResource( true ).dropSchemaRule( ruleId );
+        getResource( true ).dropSchemaRule( rule );
     }
 
-    public void setConstraintIndexOwner( long constraintIndexId, long constraintId )
+    public void setConstraintIndexOwner( IndexRule constraintIndex, long constraintId )
     {
-        getResource( true ).setConstraintIndexOwner( constraintIndexId, constraintId );
+        getResource( true ).setConstraintIndexOwner( constraintIndex, constraintId );
     }
 
     private class TxCommitHook implements Synchronization

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -89,14 +89,13 @@ import static org.neo4j.test.AllItemsMatcher.matchesAll;
 
 public class WriteTransactionTest
 {
-
     public static final String LONG_STRING = "string value long enough not to be stored as a short string";
 
     @Test
     public void shouldValidateConstraintIndexAsPartOfPrepare() throws Exception
     {
         // GIVEN
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
 
         final long indexId = neoStore.getSchemaStore().nextId();
         final long constraintId = neoStore.getSchemaStore().nextId();
@@ -107,14 +106,14 @@ public class WriteTransactionTest
         writeTransaction.prepare();
 
         // THEN
-        verify( MOCK_INDEXING ).validateIndex( indexId );
+        verify( mockIndexing ).validateIndex( indexId );
     }
 
     @Test
     public void shouldAddSchemaRuleToCacheWhenApplyingTransactionThatCreatesOne() throws Exception
     {
         // GIVEN
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
 
         // WHEN
         final long ruleId = neoStore.getSchemaStore().nextId();
@@ -140,10 +139,10 @@ public class WriteTransactionTest
             schemaStore.updateRecord( record );
         }
         long ruleId = first( records ).getId();
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
 
         // WHEN
-        writeTransaction.dropSchemaRule( ruleId );
+        writeTransaction.dropSchemaRule( rule );
         writeTransaction.prepare();
         writeTransaction.commit();
 
@@ -155,7 +154,7 @@ public class WriteTransactionTest
     public void shouldRemoveSchemaRuleWhenRollingBackTransaction() throws Exception
     {
         // GIVEN
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
 
         // WHEN
         final long ruleId = neoStore.getSchemaStore().nextId();
@@ -191,7 +190,7 @@ public class WriteTransactionTest
         };
 
         // GIVEN
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING, verifier );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing, verifier );
         int nodeId = 1;
         writeTransaction.setCommitTxId( nodeId );
         writeTransaction.nodeCreate( nodeId );
@@ -235,7 +234,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         int nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2;
         Object value1 = "first", value2 = 4;
         writeTransaction.nodeCreate( nodeId );
@@ -264,7 +263,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         int nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2;
         Object value1 = "first", value2 = 4;
         writeTransaction.nodeCreate( nodeId );
@@ -292,7 +291,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         long nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2, labelId = 3;
         long[] labelIds = new long[] {labelId};
         Object value1 = LONG_STRING, value2 = LONG_STRING.getBytes();
@@ -320,7 +319,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         long nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2, labelId1 = 3, labelId2 = 4;
         Object value1 = "first", value2 = 4;
         writeTransaction.nodeCreate( nodeId );
@@ -349,7 +348,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         long nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2, labelId = 3;
         long[] labelIds = new long[] {labelId};
         Object value1 = "first", value2 = 4;
@@ -378,7 +377,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         long nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2, labelId1 = 3, labelId2 = 4;
         Object value1 = "first", value2 = 4;
         writeTransaction.nodeCreate( nodeId );
@@ -408,7 +407,7 @@ public class WriteTransactionTest
     {
         // GIVEN
         long nodeId = 1;
-        WriteTransaction writeTransaction = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction writeTransaction = newWriteTransaction( mockIndexing );
         int propertyKey1 = 1, propertyKey2 = 2, labelId1 = 3, labelId2 = 4;
         Object value1 = "first", value2 = 4;
         writeTransaction.nodeCreate( nodeId );
@@ -437,7 +436,7 @@ public class WriteTransactionTest
     public void shouldUpdateHighIdsOnRecoveredTransaction() throws Exception
     {
         // GIVEN
-        WriteTransaction tx = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction tx = newWriteTransaction( mockIndexing );
         int nodeId = 5, relId = 10, relationshipType = 3, propertyKeyId = 4, ruleId = 8;
 
         // WHEN
@@ -477,7 +476,7 @@ public class WriteTransactionTest
         Visitor<XaCommand, RuntimeException> verifier = heavySchemaRuleVerifier();
 
         // GIVEN
-        WriteTransaction tx = newWriteTransaction( MOCK_INDEXING, verifier );
+        WriteTransaction tx = newWriteTransaction( mockIndexing, verifier );
         long ruleId = 0;
         int labelId = 5, propertyKeyId = 7;
         SchemaRule rule = indexRule( ruleId, labelId, propertyKeyId, PROVIDER_DESCRIPTOR );
@@ -506,7 +505,7 @@ public class WriteTransactionTest
          */
 
         // GIVEN
-        WriteTransaction tx = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction tx = newWriteTransaction( mockIndexing );
         int nodeId = 0;
         tx.nodeCreate( nodeId );
         int index = 0;
@@ -541,7 +540,7 @@ public class WriteTransactionTest
                 }
             }
         };
-        tx = newWriteTransaction( MOCK_INDEXING, verifier );
+        tx = newWriteTransaction( mockIndexing, verifier );
         int index2 = 1;
         tx.nodeAddProperty( nodeId, index2, string( 40 ) ); // will require a block of size 4
         prepareAndCommit( tx );
@@ -560,7 +559,7 @@ public class WriteTransactionTest
 
         // -- an index
         long ruleId = 0;
-        WriteTransaction tx = newWriteTransaction( MOCK_INDEXING );
+        WriteTransaction tx = newWriteTransaction( mockIndexing );
         SchemaRule rule = indexRule( ruleId, labelId, propertyKeyId, PROVIDER_DESCRIPTOR );
         tx.createSchemaRule( rule );
         prepareAndCommit( tx );
@@ -654,7 +653,7 @@ public class WriteTransactionTest
         }
     }
 
-    static IndexingService MOCK_INDEXING = mock( IndexingService.class );
+    private final IndexingService mockIndexing = mock( IndexingService.class );
 
     private WriteTransaction newWriteTransaction( IndexingService indexing )
     {
@@ -711,7 +710,7 @@ public class WriteTransactionTest
             @Override
             public boolean visit( XaCommand element )
             {
-                for ( DynamicRecord record : ((SchemaRuleCommand) element).getRecords() )
+                for ( DynamicRecord record : ((SchemaRuleCommand) element).getRecordsAfter() )
                 {
                     assertFalse( record + " should have been heavy", record.isLight() );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestIndexProviderFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestIndexProviderFactory.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexConfiguration;
+import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+public class TestIndexProviderFactory extends KernelExtensionFactory<TestIndexProviderFactory.Dependencies>
+{
+    public static final String KEY = "test";
+
+    public static final SchemaIndexProvider.Descriptor PROVIDER_DESCRIPTOR =
+            new SchemaIndexProvider.Descriptor( KEY, "1.0" );
+
+    private final SchemaIndexProvider indexProvider;
+
+    public static class TestIndexProvider extends SchemaIndexProvider
+    {
+
+        public TestIndexProvider()
+        {
+            super( PROVIDER_DESCRIPTOR, 10 );
+        }
+
+        @Override
+        public IndexPopulator getPopulator( long indexId, IndexConfiguration config )
+        {
+            return mock(IndexPopulator.class);
+        }
+
+        @Override
+        public IndexAccessor getOnlineAccessor( long indexId, IndexConfiguration config ) throws IOException
+        {
+            return mock(IndexAccessor.class);
+        }
+
+        @Override
+        public String getPopulationFailure( long indexId ) throws IllegalStateException
+        {
+            return null;
+        }
+
+        @Override
+        public InternalIndexState getInitialState( long indexId )
+        {
+            return InternalIndexState.FAILED;
+        }
+    }
+
+    public interface Dependencies
+    {
+    }
+
+    public TestIndexProviderFactory( SchemaIndexProvider singleProvider )
+    {
+        super( KEY );
+        if ( singleProvider == null )
+        {
+            throw new IllegalArgumentException( "Null provider" );
+        }
+        this.indexProvider = singleProvider;
+    }
+
+    @Override
+    public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
+    {
+        return indexProvider;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/GraphStoreFixture.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphStoreFixture.java
@@ -155,11 +155,11 @@ public abstract class GraphStoreFixture implements TestRule
             this.writer = writer;
         }
 
-        public void createSchema( Collection<DynamicRecord> records )
+        public void createSchema( Collection<DynamicRecord> beforeRecords, Collection<DynamicRecord> afterRecords )
         {
             try
             {
-                writer.createSchema( records );
+                writer.createSchema( beforeRecords, afterRecords );
             }
             catch ( IOException e )
             {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
@@ -19,13 +19,16 @@
  */
 package org.neo4j.kernel.api;
 
+import java.io.File;
 import javax.transaction.xa.XAException;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.InvalidTransactionTypeException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.UniquenessConstraintDefinition;
+import org.neo4j.kernel.PropertyUniqueConstraintDefinition;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.transaction.TxManager;
@@ -33,12 +36,18 @@ import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
 
 import static java.util.Arrays.asList;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
 
 public class UniqueConstraintHaIT
@@ -85,7 +94,7 @@ public class UniqueConstraintHaIT
         HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
 
         // when
-        try ( Transaction tx = slave.beginTx() )
+        try ( Transaction ignored = slave.beginTx() )
         {
             slave.schema().constraintFor( label( "Label1" ) ).on( "key1" ).unique().create();
             fail( "We expected to not be able to create a constraint on a slave in a cluster." );
@@ -93,6 +102,44 @@ public class UniqueConstraintHaIT
         catch ( Exception e )
         {
             assertThat(e, instanceOf(InvalidTransactionTypeException.class));
+        }
+    }
+
+    @Test
+    public void shouldRemoveConstraints() throws Exception
+    {
+        // given
+        ClusterManager.ManagedCluster cluster = clusterRule.startCluster();
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+
+        try ( Transaction tx = master.beginTx() )
+        {
+            master.schema().constraintFor( label( "User" ) ).on( "name" ).unique().create();
+            tx.success();
+        }
+        cluster.sync();
+
+        // and given I have some data for the constraint
+        createUser( cluster.getAnySlave(), "Bob" );
+
+        // when
+        try ( Transaction tx = master.beginTx() )
+        {
+            single( master.schema().getConstraints() ).drop();
+            tx.success();
+        }
+        cluster.sync();
+
+        // then the constraint should be gone, and not be enforced anymore
+        for ( HighlyAvailableGraphDatabase clusterMember : cluster.getAllMembers() )
+        {
+            try ( Transaction tx = clusterMember.beginTx() )
+            {
+                assertEquals( count(clusterMember.schema().getConstraints()), 0);
+                assertEquals( count(clusterMember.schema().getIndexes()), 0);
+                createUser( clusterMember, "Bob" );
+                tx.success();
+            }
         }
     }
 
@@ -143,6 +190,41 @@ public class UniqueConstraintHaIT
         // And then I should be able to perform new write transactions, on both master and slave
         createUser( slave, "Steven" );
         createUser( master, "Caroline" );
+    }
+
+    @Test
+    public void newSlaveJoiningClusterShouldNotAcceptOperationsUntilConstraintIsOnline() throws Throwable
+    {
+        // Given
+        ClusterManager.ManagedCluster cluster = clusterRule.startCluster();
+
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+        File slaveStoreDirectory = cluster.getStoreDir( slave );
+
+        // Crash the slave
+        ClusterManager.RepairKit shutdownSlave = cluster.shutdown( slave );
+        deleteRecursively( slaveStoreDirectory );
+
+        try(Transaction tx = master.beginTx())
+        {
+            master.schema().constraintFor( label("User") ).on( "name" ).unique().create();
+            tx.success();
+        }
+
+        // When
+        slave = shutdownSlave.repair();
+
+        // Then
+        try( Transaction ignored = slave.beginTx() )
+        {
+            assertThat(single( slave.schema().getConstraints() ), instanceOf(PropertyUniqueConstraintDefinition.class));
+            PropertyUniqueConstraintDefinition constraint =
+                    (PropertyUniqueConstraintDefinition)single(slave.schema().getConstraints());
+            assertThat(single(constraint.getPropertyKeys()), equalTo("name"));
+            assertThat(constraint.getLabel(), equalTo(label("User")));
+        }
     }
 
     private void createUser( HighlyAvailableGraphDatabase db, String name )


### PR DESCRIPTION
 o Added test that verifies database does not block writes while populating constraint index.
 o Verifies that constraint deletion works in HA clusters.
 o Added test to verify new slave joining cluster properly initializes constraints
 o Added before/after records for schema commands to allow deleting schema rules from
   logical log.
