### PR TITLE
Collapse Kernel.TransactionImplementation into KernelTransactionImplemen...

### DIFF
--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundExecutionContextTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/spi/gdsimpl/TransactionBoundExecutionContextTest.scala
@@ -39,7 +39,7 @@ class TransactionBoundExecutionContextTest extends JUnitSuite with Assertions wi
   def init() {
     graph = new ImpermanentGraphDatabase
     outerTx = mock[Transaction]
-    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null)
+    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, null, null)
   }
 
   @Test def should_mark_transaction_successful_if_successful() {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelStatement.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexReader;
+import org.neo4j.kernel.api.operations.LegacyKernelOperations;
 import org.neo4j.kernel.api.scan.LabelScanReader;
 import org.neo4j.kernel.api.scan.LabelScanStore;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
@@ -42,14 +43,15 @@ public class KernelStatement implements TxState.Holder, Statement
 
     public KernelStatement( KernelTransactionImplementation transaction, IndexReaderFactory indexReaderFactory,
                             LabelScanStore labelScanStore,
-                            TxState.Holder txStateHolder, LockHolder lockHolder )
+                            TxState.Holder txStateHolder, LockHolder lockHolder, LegacyKernelOperations
+                            legacyKernelOperations, StatementOperationParts operations )
     {
         this.transaction = transaction;
         this.lockHolder = lockHolder;
         this.indexReaderFactory = indexReaderFactory;
         this.txStateHolder = txStateHolder;
         this.labelScanStore = labelScanStore;
-        this.facade = new OperationsFacade(transaction, this);
+        this.facade = new OperationsFacade( this, legacyKernelOperations, operations);
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 
 /**
@@ -49,7 +48,4 @@ public interface KernelTransaction
 
     /** Roll back this transaction, undoing any changes that have been made. */
     void rollback() throws TransactionFailureException;
-
-    <RESULT, FAILURE extends KernelException> RESULT execute( MicroTransaction<RESULT, FAILURE> transaction )
-            throws FAILURE;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/OperationsFacade.java
@@ -58,54 +58,57 @@ import static org.neo4j.helpers.collection.IteratorUtil.emptyPrimitiveLongIterat
 
 public class OperationsFacade implements ReadOperations, DataWriteOperations, SchemaWriteOperations
 {
-    private final KernelTransactionImplementation transaction;
     final KernelStatement statement;
+    private final LegacyKernelOperations legacyKernelOperations;
+    private final StatementOperationParts operations;
 
-    OperationsFacade( KernelTransactionImplementation transaction, KernelStatement statement )
+    OperationsFacade( KernelStatement statement, LegacyKernelOperations legacyKernelOperations,
+                      StatementOperationParts operations )
     {
-        this.transaction = transaction;
         this.statement = statement;
+        this.legacyKernelOperations = legacyKernelOperations;
+        this.operations = operations;
     }
 
     // <DataRead>
     final KeyReadOperations tokenRead()
     {
-        return transaction.operations.keyReadOperations();
+        return operations.keyReadOperations();
     }
 
     final KeyWriteOperations tokenWrite()
     {
-        return transaction.operations.keyWriteOperations();
+        return operations.keyWriteOperations();
     }
 
     final EntityReadOperations dataRead()
     {
-        return transaction.operations.entityReadOperations();
+        return operations.entityReadOperations();
     }
 
     final EntityWriteOperations dataWrite()
     {
-        return transaction.operations.entityWriteOperations();
+        return operations.entityWriteOperations();
     }
 
     final SchemaReadOperations schemaRead()
     {
-        return transaction.operations.schemaReadOperations();
+        return operations.schemaReadOperations();
     }
 
     final org.neo4j.kernel.api.operations.SchemaWriteOperations schemaWrite()
     {
-        return transaction.operations.schemaWriteOperations();
+        return operations.schemaWriteOperations();
     }
 
     final SchemaStateOperations schemaState()
     {
-        return transaction.operations.schemaStateOperations();
+        return operations.schemaStateOperations();
     }
 
     final LegacyKernelOperations legacyOps()
     {
-        return transaction.legacyKernelOperations;
+        return legacyKernelOperations;
     }
 
     // <DataRead>
@@ -265,6 +268,13 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     {
         statement.assertOpen();
         return schemaRead().uniqueIndexesGetForLabel( statement, labelId );
+    }
+
+    @Override
+    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    {
+        statement.assertOpen();
+        return schemaRead().indexGetOwningUniquenessConstraintId( statement, index );
     }
 
     @Override
@@ -518,6 +528,12 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     {
         statement.assertOpen();
         schemaWrite().constraintDrop( statement, constraint );
+    }
+
+    @Override
+    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException
+    {
+        schemaWrite().uniqueIndexDrop( statement, descriptor );
     }
     // </SchemaWrite>
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
@@ -73,4 +73,9 @@ interface SchemaRead
      * for the time being.
      */
     Iterator<UniquenessConstraint> constraintsGetAll();
+
+    /**
+     * Get the owning constraint for a constraint index. Returns null if the index does not have an owning constraint.
+     */
+    Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
@@ -44,4 +44,10 @@ interface SchemaWrite
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
 
     void constraintDrop( UniquenessConstraint constraint ) throws DropConstraintFailureException;
+
+    /**
+     * This should not be used, it is exposed to allow an external job to clean up constraint indexes.
+     * That external job should become an internal job, at which point this operation should go away.
+     */
+    void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Transactor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Transactor.java
@@ -35,7 +35,7 @@ public class Transactor
 {
     public interface Work<RESULT, FAILURE extends KernelException>
     {
-        RESULT perform( StatementOperationParts statementContext, KernelStatement statement ) throws FAILURE;
+        RESULT perform( Statement statement ) throws FAILURE;
     }
 
     private final AbstractTransactionManager txManager;
@@ -57,7 +57,11 @@ public class Transactor
             boolean success = false;
             try
             {
-                RESULT result = tx.execute( new MicroTransaction<>( work ) );
+                RESULT result;
+                try ( Statement statement = tx.acquireStatement() )
+                {
+                    result = work.perform( statement );
+                }
                 success = true;
                 return result;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.api.exceptions;
 
-import org.neo4j.kernel.api.exceptions.KernelException;
-
 public class InvalidTransactionTypeKernelException extends KernelException
 {
     public InvalidTransactionTypeKernelException(String message)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -115,6 +115,27 @@ class TransactionImpl implements Transaction
     /**
      * This implementation assumes this call hierarchy:
      * {@link TransactionImpl#commit()} --> {@link KernelTransaction#commit()} --> {@link TransactionManager#commit()}
+     *
+     *
+     * TransactionImpl#commit -> TransactionManaager#commit -> KernelTransaction#commit
+     *
+     * Now:
+     *   Kernel does:
+     *     #commit()
+     *       -> Prepare commands for commit
+     *       -> call txmanager#commit()
+     *       -> roll back if failure
+     *       -> in any case, release locks
+     *
+     * TxManager does:
+     *   KernelTx#prepare()
+     *     -> prepare commands
+     *   We commit
+     *   or Kernel -> rollback
+     *     -> drop created indexes
+     *     -> release locks
+     *   or Kernel -> commit
+     *     -> release locks
      */
     @Override
     public synchronized void commit() throws RollbackException,

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/DataStatementArgumentVerificationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/DataStatementArgumentVerificationTest.java
@@ -99,6 +99,6 @@ public class DataStatementArgumentVerificationTest
 
     private OperationsFacade stubStatement()
     {
-        return new OperationsFacade( mock( KernelTransactionImplementation.class ), mock( KernelStatement.class ) );
+        return new OperationsFacade( mock( KernelStatement.class ), null, null );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -22,32 +22,18 @@ package org.neo4j.kernel.api;
 import org.mockito.Mockito;
 
 import org.neo4j.kernel.api.operations.LegacyKernelOperations;
-import org.neo4j.kernel.impl.api.IndexReaderFactory;
+import org.neo4j.kernel.impl.api.SchemaWriteGuard;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 
 import static org.mockito.Mockito.mock;
 
-public class StubKernelTransaction extends KernelTransactionImplementation
+public class KernelTransactionFactory
 {
-    public StubKernelTransaction()
+    static KernelTransaction kernelTransaction()
     {
-        super( Mockito.mock( StatementOperationParts.class ), Mockito.mock( LegacyKernelOperations.class ) );
-    }
-
-    @Override
-    protected void doCommit()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    protected void doRollback()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    protected KernelStatement newStatement()
-    {
-        return new KernelStatement(this, mock( IndexReaderFactory.class ), null, null, null);
+        return new KernelTransactionImplementation( Mockito.mock( StatementOperationParts.class ),
+                Mockito.mock( LegacyKernelOperations.class ) , false, mock( SchemaWriteGuard.class ), null, null, null,
+                mock( AbstractTransactionManager.class ), null, null, null, null, null, mock( NeoStore.class ));
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/StatementLifecycleTest.java
@@ -33,7 +33,8 @@ public class StatementLifecycleTest
     {
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
-        KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null, null );
+        KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null,
+                null, null, null );
         statement.acquire();
 
         // when
@@ -48,7 +49,8 @@ public class StatementLifecycleTest
     {
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
-        KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null, null );
+        KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null,
+                null, null, null );
         statement.acquire();
         statement.acquire();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
@@ -25,13 +25,15 @@ import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import static org.neo4j.kernel.api.KernelTransactionFactory.*;
+
 public class TransactionStatementSequenceTest
 {
     @Test
     public void shouldAllowReadStatementAfterReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().readOperations();
 
         // when / then
@@ -42,7 +44,7 @@ public class TransactionStatementSequenceTest
     public void shouldAllowDataStatementAfterReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().readOperations();
 
         // when / then
@@ -53,7 +55,7 @@ public class TransactionStatementSequenceTest
     public void shouldAllowSchemaStatementAfterReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().readOperations();
 
         // when / then
@@ -64,7 +66,7 @@ public class TransactionStatementSequenceTest
     public void shouldRejectSchemaStatementAfterDataStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().dataWriteOperations();
 
         // when
@@ -86,7 +88,7 @@ public class TransactionStatementSequenceTest
     public void shouldRejectDataStatementAfterSchemaStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().schemaWriteOperations();
 
         // when
@@ -108,7 +110,7 @@ public class TransactionStatementSequenceTest
     public void shouldAllowDataStatementAfterDataStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().dataWriteOperations();
 
         // when / then
@@ -119,7 +121,7 @@ public class TransactionStatementSequenceTest
     public void shouldAllowSchemaStatementAfterSchemaStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().schemaWriteOperations();
 
         // when / then
@@ -130,7 +132,7 @@ public class TransactionStatementSequenceTest
     public void shouldAllowReadStatementAfterDataStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().dataWriteOperations();
 
         // when / then
@@ -141,11 +143,10 @@ public class TransactionStatementSequenceTest
     public void shouldAllowReadStatementAfterSchemaStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         tx.acquireStatement().schemaWriteOperations();
 
         // when / then
         tx.acquireStatement().readOperations();
     }
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
@@ -24,13 +24,15 @@ import org.junit.Test;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
+import static org.neo4j.kernel.api.KernelTransactionFactory.kernelTransaction;
+
 public class TransactionStatementSharingTest
 {
     @Test
     public void shouldShareStatementStateForConcurrentReadStatementAndReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         ReadOperations stmt1 = tx.acquireStatement().readOperations();
 
         // when
@@ -44,7 +46,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentReadStatementAndDataStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         ReadOperations stmt1 = tx.acquireStatement().readOperations();
 
         // when
@@ -58,7 +60,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentReadStatementAndSchemaStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         ReadOperations stmt1 = tx.acquireStatement().readOperations();
 
         // when
@@ -72,7 +74,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentDataStatementAndReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         DataWriteOperations stmt1 = tx.acquireStatement().dataWriteOperations();
 
         // when
@@ -86,7 +88,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentDataStatementAndDataStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         DataWriteOperations stmt1 = tx.acquireStatement().dataWriteOperations();
 
         // when
@@ -100,7 +102,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentSchemaStatementAndReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         SchemaWriteOperations stmt1 = tx.acquireStatement().schemaWriteOperations();
 
         // when
@@ -114,7 +116,7 @@ public class TransactionStatementSharingTest
     public void shouldShareStatementStateForConcurrentSchemaStatementAndSchemaStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         SchemaWriteOperations stmt1 = tx.acquireStatement().schemaWriteOperations();
 
         // when
@@ -128,7 +130,7 @@ public class TransactionStatementSharingTest
     public void shouldNotShareStateForSequentialReadStatementAndReadStatement() throws Exception
     {
         // given
-        KernelTransactionImplementation tx = new StubKernelTransaction();
+        KernelTransaction tx = kernelTransaction();
         Statement statement = tx.acquireStatement();
         ReadOperations ops1 = statement.readOperations();
         statement.close();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
@@ -300,7 +300,8 @@ public class StoreStatementOperationsTest
                 neoStore,
                 resolver.resolveDependency( PersistenceManager.class ),
                 indexingService );
-        this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ), labelScanStore, null, null );
+        this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ), labelScanStore, null,
+                null, null, null );
     }
 
     @After

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -23,9 +23,7 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.MicroTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.transaction.TxManager;
 
@@ -58,13 +56,6 @@ class TransitionalTxManagementKernelTransaction implements KernelTransaction
     public void rollback() throws TransactionFailureException
     {
         ctx.rollback();
-    }
-
-    @Override
-    public <RESULT, FAILURE extends KernelException> RESULT execute( MicroTransaction<RESULT, FAILURE> transaction )
-            throws FAILURE
-    {
-        return ctx.execute( transaction );
     }
 
     public void suspendSinceTransactionsAreStillThreadBound()


### PR DESCRIPTION
...tation.

o In order to make Transactor testable we have removed the MicroTransaction
   execution concern form KernelTransaction. To do this we had to expose some
   more schema operations from Statement.
