### PR TITLE
ExcpetionHandlingIterable no longer uses Unsafe.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -132,7 +132,7 @@ public class Exceptions
         // no instances
     }
 
-    public static final Throwable rootCause( Throwable caughtException )
+    public static Throwable rootCause( Throwable caughtException )
     {
         if ( null == caughtException )
         {


### PR DESCRIPTION
It was an ugly hack before, and it's still an ugly hack, but now
it is an ugly hack that does not use the Unsafe. So a small
improvement.

Really though, we should do something about the fact that we expect
checked exceptions through the Iterable methods. Who throws
checked exceptions through those methods anyway? Some scala code?
