### PR TITLE
Allow OPTIONAL MATCH to be recognised in Cypher

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Clauses.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Clauses.scala
@@ -37,9 +37,10 @@ trait Clauses extends Parser
   }
 
   def Match : Rule1[ast.Match] = rule("MATCH") {
-    group(
-      keyword("MATCH") ~~ Pattern ~~ zeroOrMore(Hint, separator = WS) ~~ optional(Where)
-    ) ~>> token ~~> ast.Match
+    group((
+        keyword("OPTIONAL", "MATCH") ~ push(true)
+      | keyword("MATCH") ~ push(false)
+    ) ~~ Pattern ~~ zeroOrMore(Hint, separator = WS) ~~ optional(Where)) ~>> token ~~> ast.Match
   }
 
   def Merge : Rule1[ast.Merge] = rule("MERGE") {

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/SemanticErrorTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/SemanticErrorTest.scala
@@ -299,6 +299,11 @@ class SemanticErrorTest extends ExecutionEngineHelper with Assertions {
     test(
       "MERGE (n:Person) ON MATCH n SET x.foo = 1",
       "x not defined (line 1, column 33)"
+
+  @Test def shouldFailIfUsingOptionalMatch() {
+    test(
+      "optional match (n:Person) return n",
+      "OPTIONAL MATCH is not currently supported (line 1, column 1)"
     )
   }
 


### PR DESCRIPTION
Currently returns an "unsupported" semantic error
