### PR TITLE
Coerce collections to a common type

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/GraphElementPropertyFunctions.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/mutation/GraphElementPropertyFunctions.scala
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.mutation
+
+import org.neo4j.cypher.CypherTypeException
+import org.neo4j.cypher.internal.symbols._
+import org.neo4j.cypher.internal.pipes.QueryState
+
+import java.util.{Map => JavaMap}
+import scala.collection.JavaConverters._
+import collection.Map
+import org.neo4j.cypher.internal.helpers.{CastSupport, CollectionSupport}
+import org.neo4j.cypher.internal.commands.expressions.Expression
+import org.neo4j.graphdb.{Node, Relationship, PropertyContainer}
+import org.neo4j.cypher.internal.ExecutionContext
+
+trait GraphElementPropertyFunctions extends CollectionSupport {
+
+  implicit class RichMap(m: Map[String, Expression]) {
+    def rewrite(f: (Expression) => Expression): Map[String, Expression] = m.map {
+      case (k, v) => k -> v.rewrite(f)
+    }
+
+    def throwIfSymbolsMissing(symbols: SymbolTable) {
+      m.values.foreach(_.throwIfSymbolsMissing(symbols))
+    }
+
+    def symboltableDependencies: Set[String] = m.values.flatMap(_.symbolTableDependencies).toSet
+  }
+
+  def setProperties(pc: PropertyContainer, props: Map[String, Expression], context: ExecutionContext, state: QueryState) {
+    props.foreach {
+      case ("*", expression) => setAllMapKeyValues(expression, context, pc, state)
+      case (key, expression) => setSingleValue(expression, context, pc, key, state)
+    }
+  }
+
+  def getMapFromExpression(v: Any): Map[String, Any] = {
+    v match {
+      case _: collection.Map[_, _] => v.asInstanceOf[collection.Map[String, Any]].toMap
+      case _: JavaMap[_, _]        => v.asInstanceOf[JavaMap[String, Any]].asScala.toMap
+      case _                       => throw new CypherTypeException(s"Don't know how to extract parameters from this type: ${v.getClass.getName}")
+    }
+  }
+
+  private def setAllMapKeyValues(expression: Expression, context: ExecutionContext, pc: PropertyContainer, state: QueryState) {
+    val map = getMapFromExpression(expression(context)(state))
+
+    pc match {
+      case n: Node => map.foreach {
+        case (key, value) =>
+          state.query.nodeOps.setProperty(n, state.query.getOrCreatePropertyKeyId(key), makeValueNeoSafe(value))
+      }
+
+      case r: Relationship => map.foreach {
+        case (key, value) =>
+          state.query.relationshipOps.setProperty(r, state.query.getOrCreatePropertyKeyId(key), makeValueNeoSafe(value))
+      }
+    }
+  }
+
+  private def setSingleValue(expression: Expression, context: ExecutionContext, pc: PropertyContainer, key: String, state: QueryState) {
+    val value = makeValueNeoSafe(expression(context)(state))
+    pc match {
+      case n: Node =>
+        state.query.nodeOps.setProperty(n, state.query.getOrCreatePropertyKeyId(key), value)
+
+      case r: Relationship =>
+        state.query.relationshipOps.setProperty(r, state.query.getOrCreatePropertyKeyId(key), value)
+    }
+  }
+
+  def makeValueNeoSafe(a: Any): Any = if (isCollection(a)) {
+    transformTraversableToArray(makeTraversable(a))
+  } else {
+    a
+  }
+
+
+  private def transformTraversableToArray(a: Any): Any = {
+    val seq: Seq[Any] = a.asInstanceOf[Traversable[_]].toSeq
+
+    if (seq.size == 0) {
+      Array[String]()
+    } else {
+      val typeValue = seq.reduce(CastSupport.merge)
+      val converter = CastSupport.getConverter(typeValue)
+
+      converter.arrayConverter(seq.map(converter.valueConverter))
+    }
+  }
+}

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/mutation/GraphElementPropertyFunctionsTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/mutation/GraphElementPropertyFunctionsTest.scala
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.mutation
+
+import org.junit.Test
+import org.scalatest.Assertions
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.util
+
+@RunWith(value = classOf[Parameterized])
+class GraphElementPropertyFunctionsTest(given: List[_], expected: Array[_]) extends GraphElementPropertyFunctions with Assertions {
+
+  @Test def test_it() {
+    assert(makeValueNeoSafe(given) === expected)
+  }
+}
+
+object GraphElementPropertyFunctionsTest {
+
+  val byte: Byte = 1
+  val short: Short = 1
+  val int: Int = 1
+  val long: Long = 1
+  val float: Float = 1
+  val double: Double = 1
+
+  @Parameters(name = "{0}")
+  def parameters: util.Collection[Array[AnyRef]] = {
+    val list = new util.ArrayList[Array[AnyRef]]()
+    def add(expected: Array[_],
+            values: Any*) {
+      list.add(Array(values.toList, expected))
+    }
+
+    add(Array[Byte](1, 1), byte, byte)
+    add(Array[Short](1, 1), byte, short)
+    add(Array[Int](1, 1), byte, int)
+    add(Array[Long](1, 1), byte, long)
+    add(Array[Float](1, 1), byte, float)
+    add(Array[Double](1, 1), byte, double)
+
+    add(Array[Short](1, 1), short, byte)
+    add(Array[Short](1, 1), short, short)
+    add(Array[Int](1, 1), short, int)
+    add(Array[Long](1, 1), short, long)
+    add(Array[Float](1, 1), short, float)
+    add(Array[Double](1, 1), short, double)
+
+    add(Array[Int](1, 1), int, byte)
+    add(Array[Int](1, 1), int, short)
+    add(Array[Int](1, 1), int, int)
+    add(Array[Long](1, 1), int, long)
+    add(Array[Float](1, 1), int, float)
+    add(Array[Double](1, 1), int, double)
+
+    add(Array[Long](1, 1), long, byte)
+    add(Array[Long](1, 1), long, short)
+    add(Array[Long](1, 1), long, int)
+    add(Array[Long](1, 1), long, long)
+    add(Array[Float](1, 1), long, float)
+    add(Array[Double](1, 1), long, double)
+
+    add(Array[Float](1, 1), float, byte)
+    add(Array[Float](1, 1), float, short)
+    add(Array[Float](1, 1), float, int)
+    add(Array[Float](1, 1), float, long)
+    add(Array[Float](1, 1), float, float)
+    add(Array[Double](1, 1), float, double)
+
+    add(Array[Double](1, 1), double, byte)
+    add(Array[Double](1, 1), double, short)
+    add(Array[Double](1, 1), double, int)
+    add(Array[Double](1, 1), double, long)
+    add(Array[Double](1, 1), double, float)
+    add(Array[Double](1, 1), float, double)
+
+    list
+  }
+}


### PR DESCRIPTION
When saving collections as properties, they must be turned into arrays.
This commit changes how this is done for numeric types. Now Cypher
finds a common type to use, and coerces all numeric values into a
common numeric type.
