### PR TITLE
Update style.css so that the bottom of the console is readable in Firefo...

### DIFF
--- a/community/server/src/main/resources/webadmin-html/css/style.css
+++ b/community/server/src/main/resources/webadmin-html/css/style.css
@@ -1,4 +1,3 @@
-
 @import url(jquery.ui.css);
 @import url(jquery.notify.css);
 @import url(buttons.css);
@@ -60,7 +59,7 @@ body {
 /* CONTENTS */
 
 #contents { 
-  bottom: 20px;
+  bottom: 24px;
   left: 0;
   position: absolute;
   right: 0;
@@ -138,6 +137,7 @@ body {
 /* FOOTER */
 
 #footer {
+  height:24px; /* must be equal to #contents "bottom" */
   background: none repeat scroll 0 0 #fff;
   border-top: 1px solid #CCC;
   bottom: 0;


### PR DESCRIPTION
...x

Once the Console is full of lines, Firefox displays only half of the active line at the bottom because the height of #footer depends of the font. I suggest to set an explicit height of 24px on #footer's height (which seems to be the actual computed size), and to rise #contents's "bottom" value from 20px to 24px.
