### PR TITLE
Allow both escaped ' and " chars in string literals

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Strings.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/parser/v2_0/rules/Strings.scala
@@ -25,17 +25,18 @@ import org.parboiled.Context
 trait Strings extends Base {
 
   protected def StringCharacters(c: Char): Rule1[String] = {
-    push(new StringBuilder) ~ zeroOrMore(EscapedChar(c) | NormalChar(c)) ~~> (_.toString())
+    push(new StringBuilder) ~ zeroOrMore(EscapedChar | NormalChar(c)) ~~> (_.toString())
   }
 
   protected def NormalChar(c: Char) = {
     !(ch('\\') | ch(c)) ~ ANY ~:% withContext(appendToStringBuffer(_)(_))
   }
 
-  protected def EscapedChar(c: Char) = {
+  protected def EscapedChar = {
     "\\" ~ (
       ch('\\') ~:% withContext(appendToStringBuffer(_)(_))
-        | ch(c) ~:% withContext(appendToStringBuffer(_)(_))
+        | ch('\'') ~:% withContext(appendToStringBuffer(_)(_))
+        | ch('"') ~:% withContext(appendToStringBuffer(_)(_))
         | ch('b') ~ appendToStringBuffer('\b')
         | ch('f') ~ appendToStringBuffer('\f')
         | ch('n') ~ appendToStringBuffer('\n')

--- a/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/CypherParserTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/internal/parser/v2_0/CypherParserTest.scala
@@ -55,10 +55,16 @@ class CypherParserTest extends JUnitSuite with Assertions {
 
   @Test def should_return_string_literal_with_escaped_sequence_in() {
     test(
-      "start s = node(1) return \"a\\tp\\\"a\"",
+      "start s = node(1) return \"a\\tp\\\"a\\\'b\"",
       Query.
         start(NodeById("s", 1)).
-        returns(ReturnItem(Literal("a\tp\"a"), "\"a\\tp\\\"a\"")))
+        returns(ReturnItem(Literal("a\tp\"a\'b"), "\"a\\tp\\\"a\\\'b\"")))
+
+    test(
+      "start s = node(1) return \'a\\tp\\\'a\\\"b\'",
+      Query.
+        start(NodeById("s", 1)).
+        returns(ReturnItem(Literal("a\tp\'a\"b"), "\'a\\tp\\\'a\\\"b\'")))
   }
 
   @Test def allTheNodes() {


### PR DESCRIPTION
Regardless of the quote type used to represent the string literal. Fixes #1291.
