### PR TITLE
Fixes bit-fiddling issues with node label field

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
@@ -101,7 +101,7 @@ public class InlineNodeLabels implements NodeLabels
         }
 
         byte bitsPerLabel = (byte) (ids.length > 0 ? (LABEL_BITS / ids.length) : LABEL_BITS);
-        long limit = 1 << bitsPerLabel;
+        long limit = 1L << bitsPerLabel;
         Bits bits = bits( 5 );
         for ( long id : ids )
         {
@@ -139,7 +139,8 @@ public class InlineNodeLabels implements NodeLabels
 
     private static long combineLabelCountAndLabelStorage( byte labelCount, long labelBits )
     {
-        return (((long) labelCount << 36) | labelBits);
+        long labelCountAsLong = labelCount;
+        return ((labelCountAsLong << 36) | labelBits);
     }
 
     private static byte labelCount( long labelField )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.xa.XAException;
@@ -1151,7 +1153,7 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
                                              "] since it has already been deleted." );
         }
         nodeRecord.setInUse( false );
-        nodeRecord.setLabelField( 0 );
+        nodeRecord.setLabelField( 0, Collections.<DynamicRecord>emptyList() );
         return getAndDeletePropertyChain( nodeRecord );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/NodeStoreTest.java
@@ -19,16 +19,30 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
+import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.DefaultTxHook;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
 import static java.util.Arrays.asList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.kernel.impl.nioneo.store.DynamicArrayStore.allocateFromNumbers;
 import static org.neo4j.kernel.impl.nioneo.store.NodeStore.readOwnerFromDynamicLabelsRecord;
+import static org.neo4j.kernel.impl.nioneo.store.Record.NO_NEXT_PROPERTY;
+import static org.neo4j.kernel.impl.nioneo.store.Record.NO_NEXT_RELATIONSHIP;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class NodeStoreTest
 {
@@ -81,5 +95,66 @@ public class NodeStoreTest
 
         // THEN
         assertEquals( expectedId, firstId );
+    }
+
+    @Test
+    public void shouldCombineProperFiveByteLabelField() throws Exception
+    {
+        // GIVEN
+        // -- a store
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        Config config = new Config();
+        IdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory();
+        WindowPoolFactory windowPoolFactory = new DefaultWindowPoolFactory();
+        StoreFactory factory = new StoreFactory( config, idGeneratorFactory, windowPoolFactory, fs, DEV_NULL, new DefaultTxHook() );
+        File nodeStoreFileName = new File( "nodestore" );
+        factory.createNodeStore( nodeStoreFileName );
+        NodeStore nodeStore = factory.newNodeStore( nodeStoreFileName );
+
+        // -- a record with the msb carrying a negative value
+        long nodeId = 0, labels = 0x8000000001L;
+        NodeRecord record = new NodeRecord( nodeId, NO_NEXT_RELATIONSHIP.intValue(), NO_NEXT_PROPERTY.intValue() );
+        record.setInUse( true );
+        record.setLabelField( labels, Collections.<DynamicRecord>emptyList() );
+        nodeStore.updateRecord( record );
+
+        // WHEN
+        // -- reading that record back
+        NodeRecord readRecord = nodeStore.getRecord( nodeId );
+
+        // THEN
+        // -- the label field must be the same
+        assertEquals( labels, readRecord.getLabelField() );
+
+        // CLEANUP
+        nodeStore.close();
+        fs.shutdown();
+    }
+
+    @Test
+    public void shouldKeepRecordLightWhenSettingLabelFieldWithoutDynamicRecords() throws Exception
+    {
+        // GIVEN
+        NodeRecord record = new NodeRecord( 0, NO_NEXT_RELATIONSHIP.intValue(), NO_NEXT_PROPERTY.intValue() );
+
+        // WHEN
+        record.setLabelField( 0, Collections.<DynamicRecord>emptyList() );
+
+        // THEN
+        assertTrue( record.isLight() );
+    }
+
+    @Test
+    public void shouldMarkRecordHeavyWhenSettingLabelFieldWithDynamicRecords() throws Exception
+    {
+        // GIVEN
+        NodeRecord record = new NodeRecord( 0, NO_NEXT_RELATIONSHIP.intValue(), NO_NEXT_PROPERTY.intValue() );
+
+        // WHEN
+        DynamicRecord dynamicRecord = new DynamicRecord( 1 );
+        record.setLabelField( 0x8000000001L, asList( dynamicRecord ) );
+
+        // THEN
+        assertFalse( record.isLight() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelsFieldTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeLabelsFieldTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -71,6 +72,21 @@ public class NodeLabelsFieldTest
     {
         // GIVEN
         long labelId = 10;
+        NodeRecord node = nodeRecordWithInlinedLabels();
+        NodeLabels nodeLabels = NodeLabelsField.parseLabelsField( node );
+
+        // WHEN
+        nodeLabels.add( labelId, null );
+
+        // THEN
+        assertEquals( inlinedLabelsLongRepresentation( labelId ), node.getLabelField() );
+    }
+
+    @Test
+    public void shouldInlineOneLabelWithHighId() throws Exception
+    {
+        // GIVEN
+        long labelId = 10000;
         NodeRecord node = nodeRecordWithInlinedLabels();
         NodeLabels nodeLabels = NodeLabelsField.parseLabelsField( node );
 
@@ -452,7 +468,7 @@ public class NodeLabelsFieldTest
         NodeRecord node = new NodeRecord( 0, 0, 0 );
         if ( labels.length > 0 )
         {
-            node.setLabelField( inlinedLabelsLongRepresentation( labels ) );
+            node.setLabelField( inlinedLabelsLongRepresentation( labels ), Collections.<DynamicRecord>emptyList() );
         }
         return node;
     }


### PR DESCRIPTION
Node labels are stored in their respective node records. If all labels can
be compacted and inlined into the node record itself (5 bytes) then so be it.
Otherwise it will spill over to a dynamic record. There is some bit-fiddling
involved in doing this and there were a couple of problems thereabout:

o The limit for how big (position of msb) an inlined label id could be was calculated
  wrongly where an int could be shifted more than 32 steps to the left,
  overflowing. Had that value be a long from the beginning to prevent that.
o Reading the 5 bytes that make up the label field and combining those
  requires reading one int and one byte. If the byte was negative it would
  incurr lots of bits unexpectedly set to one when expanded into a long.
o Reading a node command might leave a node record which referred to
  labels in one or more dynamic records as marked as heavy even if that
  node already had references to dynamic records, changed in a transaction,
  but had no labels on that node changed within that same transaction.
  Now defensively only marks as heavy if there were one or more dynamic
  records provided when providing the record object with the label field
  value. This would give the opportuniy to load the dynamic records the
  next time that record would be ensured heavy.

All the above problems have been fixed.
