### PR TITLE
Fixes AStar algo shortcoming and thereby #887

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AStar.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/AStar.java
@@ -19,22 +19,18 @@
  */
 package org.neo4j.graphalgo.impl.path;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.EstimateEvaluator;
 import org.neo4j.graphalgo.PathFinder;
 import org.neo4j.graphalgo.WeightedPath;
 import org.neo4j.graphalgo.impl.util.PathImpl;
+import org.neo4j.graphalgo.impl.util.PriorityMap;
+import org.neo4j.graphalgo.impl.util.PriorityMap.Entry;
 import org.neo4j.graphalgo.impl.util.WeightedPathImpl;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -48,6 +44,8 @@ import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.graphdb.traversal.TraversalMetadata;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 
+import static org.neo4j.graphalgo.impl.util.PriorityMap.withSelfKeyNaturalOrder;
+import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.kernel.StandardExpander.toPathExpander;
 
 public class AStar implements PathFinder<WeightedPath>
@@ -56,13 +54,13 @@ public class AStar implements PathFinder<WeightedPath>
     private final CostEvaluator<Double> lengthEvaluator;
     private final EstimateEvaluator<Double> estimateEvaluator;
     private Metadata lastMetadata;
-    
+
     public AStar( RelationshipExpander expander,
             CostEvaluator<Double> lengthEvaluator, EstimateEvaluator<Double> estimateEvaluator )
     {
         this( toPathExpander( expander ), lengthEvaluator, estimateEvaluator );
     }
-    
+
     public AStar( PathExpander<?> expander,
             CostEvaluator<Double> lengthEvaluator, EstimateEvaluator<Double> estimateEvaluator )
     {
@@ -70,27 +68,28 @@ public class AStar implements PathFinder<WeightedPath>
         this.lengthEvaluator = lengthEvaluator;
         this.estimateEvaluator = estimateEvaluator;
     }
-    
+
+    @Override
     public WeightedPath findSinglePath( Node start, Node end )
     {
         lastMetadata = new Metadata();
-        Doer doer = new Doer( start, end );
-        while ( doer.hasNext() )
+        AStarIterator iterator = new AStarIterator( start, end );
+        while ( iterator.hasNext() )
         {
-            Node node = doer.next();
+            Node node = iterator.next();
             GraphDatabaseService graphDb = node.getGraphDatabase();
             if ( node.equals( end ) )
             {
                 // Hit, return path
-                double weight = doer.score.get( node.getId() ).wayLength;
+                double weight = iterator.visitData.get( node.getId() ).wayLength;
                 LinkedList<Relationship> rels = new LinkedList<Relationship>();
-                Relationship rel = graphDb.getRelationshipById( doer.cameFrom.get( node.getId() ) );
+                Relationship rel = graphDb.getRelationshipById( iterator.visitData.get( node.getId() ).cameFromRelationship );
                 while ( rel != null )
                 {
                     rels.addFirst( rel );
                     node = rel.getOtherNode( node );
-                    Long nextRelId = doer.cameFrom.get( node.getId() );
-                    rel = nextRelId == null ? null : graphDb.getRelationshipById( nextRelId );
+                    long nextRelId = iterator.visitData.get( node.getId() ).cameFromRelationship;
+                    rel = nextRelId == -1 ? null : graphDb.getRelationshipById( nextRelId );
                 }
                 Path path = toPath( start, rels );
                 lastMetadata.paths++;
@@ -99,19 +98,19 @@ public class AStar implements PathFinder<WeightedPath>
         }
         return null;
     }
-    
-    public Iterable<WeightedPath> findAllPaths( Node node, Node end )
+
+    @Override
+    public Iterable<WeightedPath> findAllPaths( final Node node, final Node end )
     {
-        WeightedPath path = findSinglePath( node, end );
-        return path != null ? Arrays.asList( path ) : Collections.<WeightedPath>emptyList();
+        return option( findSinglePath( node, end ) );
     }
-    
+
     @Override
     public TraversalMetadata metadata()
     {
         return lastMetadata;
     }
-    
+
     private Path toPath( Node start, LinkedList<Relationship> rels )
     {
         PathImpl.Builder builder = new PathImpl.Builder( start );
@@ -121,100 +120,81 @@ public class AStar implements PathFinder<WeightedPath>
         }
         return builder.build();
     }
-    
-    private static class Data
+
+    private static class Visit
     {
-        private double wayLength; // acumulated cost to get here (g)
+        private double wayLength; // accumulated cost to get here (g)
         private double estimate; // heuristic estimate of cost to reach end (h)
-        
+        private long cameFromRelationship;
+        private boolean visited;
+        private boolean next;
+
+        Visit( long cameFromRelationship, double wayLength, double estimate )
+        {
+            update( cameFromRelationship, wayLength, estimate );
+        }
+
+        void update( long cameFromRelationship, double wayLength, double estimate )
+        {
+            this.cameFromRelationship = cameFromRelationship;
+            this.wayLength = wayLength;
+            this.estimate = estimate;
+        }
+
         double getFscore()
         {
             return wayLength + estimate;
         }
     }
 
-    private class Doer extends PrefetchingIterator<Node> implements Path
+    private class AStarIterator extends PrefetchingIterator<Node> implements Path
     {
+        private final Node start;
         private final Node end;
         private Node lastNode;
-        private boolean expand;
-        private final Set<Long> visitedNodes = new HashSet<Long>();
-        private final Set<Node> nextNodesSet = new HashSet<Node>();
-        private final TreeMap<Double, Collection<Node>> nextNodes =
-                new TreeMap<Double, Collection<Node>>();
-        private final Map<Long, Long> cameFrom = new HashMap<Long, Long>();
-        private final Map<Long, Data> score = new HashMap<Long, Data>();
-        private final Node start;
-        
-        Doer( Node start, Node end )
+        private final PriorityMap<Node, Node, Double> nextPrioritizedNodes = withSelfKeyNaturalOrder();
+        private final Map<Long, Visit> visitData = new HashMap<Long, Visit>();
+
+        AStarIterator( Node start, Node end )
         {
             this.start = start;
             this.end = end;
-            
-            Data data = new Data();
-            data.wayLength = 0;
-            data.estimate = estimateEvaluator.getCost( start, end );
-            addNext( start, data.getFscore() );
-            this.score.put( start.getId(), data );
+
+            Visit visit = new Visit( -1, 0, estimateEvaluator.getCost( start, end ) );
+            addNext( start, visit.getFscore(), visit );
+            this.visitData.put( start.getId(), visit );
         }
-        
-        private void addNext( Node node, double fscore )
+
+        private void addNext( Node node, double fscore, Visit visit )
         {
-            Collection<Node> nodes = this.nextNodes.get( fscore );
-            if ( nodes == null )
-            {
-                nodes = new HashSet<Node>();
-                this.nextNodes.put( fscore, nodes );
-            }
-            nodes.add( node );
-            this.nextNodesSet.add( node );
+            nextPrioritizedNodes.put( node, fscore );
+            visit.next = true;
         }
 
         private Node popLowestScoreNode()
         {
-            Iterator<Map.Entry<Double, Collection<Node>>> itr =
-                    this.nextNodes.entrySet().iterator();
-            if ( !itr.hasNext() )
+            Entry<Node, Double> top = nextPrioritizedNodes.pop();
+            if ( top == null )
             {
                 return null;
             }
-            
-            Map.Entry<Double, Collection<Node>> entry = itr.next();
-            Node node = entry.getValue().isEmpty() ? null : entry.getValue().iterator().next();
-            if ( node == null )
-            {
-                return null;
-            }
-            
-            if ( node != null )
-            {
-                entry.getValue().remove( node );
-                this.nextNodesSet.remove( node );
-                if ( entry.getValue().isEmpty() )
-                {
-                    this.nextNodes.remove( entry.getKey() );
-                }
-                this.visitedNodes.add( node.getId() );
-            }
+
+            Node node = top.getEntity();
+            Visit visit = visitData.get( node.getId() );
+            visit.visited = true;
+            visit.next = false;
             return node;
         }
 
         @Override
         protected Node fetchNextOrNull()
         {
-            // FIXME
-            if ( !this.expand )
-            {
-                this.expand = true;
-            }
-            else
+            if ( lastNode != null )
             {
                 expand();
             }
-            
-            Node node = popLowestScoreNode();
-            this.lastNode = node;
-            return node;
+
+            return (lastNode = popLowestScoreNode());
         }
 
         @SuppressWarnings( "unchecked" )
@@ -223,34 +203,30 @@ public class AStar implements PathFinder<WeightedPath>
             for ( Relationship rel : expander.expand( this, BranchState.NO_STATE ) )
             {
                 lastMetadata.rels++;
-                Node node = rel.getOtherNode( this.lastNode );
-                if ( this.visitedNodes.contains( node.getId() ) )
+                Node node = rel.getOtherNode( lastNode );
+                Visit visit = visitData.get( node.getId() );
+                if ( visit != null && visit.visited )
                 {
                     continue;
                 }
-                
-                Data lastNodeData = this.score.get( this.lastNode.getId() );
-                double tentativeGScore = lastNodeData.wayLength +
+
+                Visit lastVisit = visitData.get( lastNode.getId() );
+                double tentativeGScore = lastVisit.wayLength +
                         lengthEvaluator.getCost( rel, Direction.OUTGOING );
-                boolean isBetter = false;
-                double estimate = estimateEvaluator.getCost( node, this.end );
-                if ( !this.nextNodesSet.contains( node ) )
+                double estimate = estimateEvaluator.getCost( node, end );
+
+                if ( visit == null || !visit.next || tentativeGScore < visit.wayLength )
                 {
-                    addNext( node, estimate + tentativeGScore );
-                    isBetter = true;
-                }
-                else if ( tentativeGScore < this.score.get( node.getId() ).wayLength )
-                {
-                    isBetter = true;
-                }
-                
-                if ( isBetter )
-                {
-                    this.cameFrom.put( node.getId(), rel.getId() );
-                    Data data = new Data();
-                    data.wayLength = tentativeGScore;
-                    data.estimate = estimate;
-                    this.score.put( node.getId(), data );
+                    if ( visit == null )
+                    {
+                        visit = new Visit( rel.getId(), tentativeGScore, estimate );
+                        visitData.put( node.getId(), visit );
+                    }
+                    else
+                    {
+                        visit.update( rel.getId(), tentativeGScore, estimate );
+                    }
+                    addNext( node, estimate + tentativeGScore, visit );
                 }
             }
         }
@@ -284,13 +260,13 @@ public class AStar implements PathFinder<WeightedPath>
         {
             throw new UnsupportedOperationException();
         }
-        
+
         @Override
         public Iterable<Node> nodes()
         {
             throw new UnsupportedOperationException();
         }
-        
+
         @Override
         public Iterable<Node> reverseNodes()
         {
@@ -309,12 +285,12 @@ public class AStar implements PathFinder<WeightedPath>
             throw new UnsupportedOperationException();
         }
     }
-    
+
     private static class Metadata implements TraversalMetadata
     {
         private int rels;
         private int paths;
-        
+
         @Override
         public int getNumberOfPathsReturned()
         {

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.PriorityQueue;
 
-class PriorityMap<E, K, P>
+public class PriorityMap<E, K, P>
 {
     public interface Converter<T, S>
     {
@@ -61,6 +61,7 @@ class PriorityMap<E, K, P>
     @SuppressWarnings( "unchecked" )
     private static final Converter SELF_KEY = new Converter()
     {
+        @Override
         public Object convert( Object source )
         {
             return source;
@@ -83,6 +84,7 @@ class PriorityMap<E, K, P>
             this.reversed = reversed;
         }
 
+        @Override
         public int compare( P o1, P o2 )
         {
             if ( reversed )
@@ -167,7 +169,7 @@ class PriorityMap<E, K, P>
         }
         return result;
     }
-    
+
     private void put( E entity, P priority, K key )
     {
         Node<E, P> node = new Node<E, P>( entity, priority );
@@ -184,7 +186,10 @@ class PriorityMap<E, K, P>
     public P get( K key )
     {
         Node<E, P> node = map.get( key );
-        if ( node == null ) return null;
+        if ( node == null )
+        {
+            return null;
+        }
         return node.priority;
     }
 
@@ -214,7 +219,7 @@ class PriorityMap<E, K, P>
         }
         return result;
     }
-    
+
     public Entry<E, P> peek()
     {
         Node<E, P> node = queue.peek();
@@ -231,6 +236,7 @@ class PriorityMap<E, K, P>
     private final PriorityQueue<Node<E, P>> queue = new PriorityQueue<Node<E, P>>(
             11, new Comparator<Node<E, P>>()
             {
+                @Override
                 public int compare( Node<E, P> o1, Node<E, P> o2 )
                 {
                     return order.compare( o1.priority, o2.priority );

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
@@ -19,12 +19,16 @@
  */
 package org.neo4j.graphalgo.impl.util;
 
+import org.junit.Test;
+
+import org.neo4j.graphalgo.impl.util.PriorityMap.Entry;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.neo4j.graphalgo.impl.util.PriorityMap.Entry;
+import static org.neo4j.graphalgo.impl.util.PriorityMap.withSelfKeyNaturalOrder;
 
 public class TestPriorityMap
 {
@@ -65,6 +69,24 @@ public class TestPriorityMap
         map.put( y, 8d );
         // get x
 //        map.put(
+    }
+
+    @Test
+    public void shouldReplaceIfBetter() throws Exception
+    {
+        // GIVEN
+        PriorityMap<Integer, Integer, Double> map = withSelfKeyNaturalOrder();
+        map.put( 1, 2d );
+
+        // WHEN
+        boolean putResult = map.put( 1, 1.5d );
+
+        // THEN
+        assertTrue( putResult );
+        Entry<Integer, Double> top = map.pop();
+        assertNull( map.peek() );
+        assertEquals( 1, top.getEntity().intValue() );
+        assertEquals( 1.5d, top.getPriority().doubleValue(), 0d );
     }
 
     private void assertEntry( Entry<Integer, Double> entry, Integer entity,

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/AStarPerformanceIT.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/AStarPerformanceIT.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphalgo.path;
+
+import java.io.File;
+import java.util.Random;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.neo4j.graphalgo.PathFinder;
+import org.neo4j.graphalgo.WeightedPath;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
+import static java.lang.System.currentTimeMillis;
+
+import static org.neo4j.graphalgo.CommonEvaluators.doubleCostEvaluator;
+import static org.neo4j.graphalgo.GraphAlgoFactory.aStar;
+import static org.neo4j.kernel.Traversal.pathExpanderForAllTypes;
+import static org.neo4j.test.TargetDirectory.forTest;
+
+@Ignore( "Not a test, just nice to have" )
+public class AStarPerformanceIT
+{
+    private static final boolean REBUILD = true;
+
+    @Test
+    public void somePerformanceTesting() throws Exception
+    {
+        // GIVEN
+        int numberOfNodes = 200000;
+        if ( REBUILD )
+        {
+            Random random = new Random();
+            GeoDataGenerator generator = new GeoDataGenerator( numberOfNodes, 5d, 1000, 1000 );
+            generator.generate( directory );
+        }
+
+        // WHEN
+        long[][] points = new long[][] {
+                new long[] {9415, 158154},
+                new long[] {89237, 192863},
+                new long[] {68072, 150484},
+                new long[] {186309, 194495},
+                new long[] {152097, 99289},
+                new long[] {92150, 161182},
+                new long[] {188446, 115873},
+                new long[] {85033, 7772},
+                new long[] {291, 86707},
+                new long[] {188345, 158468}
+        };
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( directory.getAbsolutePath() );
+        PathFinder<WeightedPath> algo = aStar( pathExpanderForAllTypes(),
+                doubleCostEvaluator( "weight", 0 ), GeoDataGenerator.estimateEvaluator() );
+        for ( int i = 0; i < 10; i++ )
+        {
+            System.out.println( "----- " + i );
+            for ( long[] p : points )
+            {
+                Transaction tx = db.beginTx();
+                try
+                {
+                    Node start = db.getNodeById( p[0] );
+                    Node end = db.getNodeById( p[1] );
+                    long time = currentTimeMillis();
+                    WeightedPath path = algo.findSinglePath( start, end );
+                    time = currentTimeMillis() - time;
+                    System.out.println( "time: " + time + ", len:" + path.length() + ", weight:" + path.weight() );
+                    tx.success();
+                }
+                finally
+                {
+                    tx.finish();
+                }
+            }
+        }
+
+        // THEN
+        db.shutdown();
+    }
+
+    private final File directory = forTest( getClass() ).graphDbDir( REBUILD );
+}

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/GeoDataGenerator.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/GeoDataGenerator.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphalgo.path;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.neo4j.graphalgo.EstimateEvaluator;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+
+import static java.lang.Math.abs;
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
+
+import static org.neo4j.unsafe.batchinsert.BatchInserters.inserter;
+
+/**
+ * Data generator that can generate geographic graph data. The generated data is not realistic in terms of how
+ * roads or connections would be built, but holds true to geographical aspects in general in terms of location
+ * and connection weights.
+ */
+public class GeoDataGenerator
+{
+    private final Random random = new Random();
+    private final int numberOfNodes;
+    private final int numberOfConnections;
+    private final int width, height;
+    private int maxDistance = 3;
+    private double neighborConnectionFactor = 0.6;
+
+    public GeoDataGenerator( int numberOfNodes, double connectionDensity, int width, int height )
+    {
+        this.numberOfNodes = numberOfNodes;
+        this.numberOfConnections = (int) (numberOfNodes * connectionDensity);
+        this.width = width;
+        this.height = height;
+    }
+
+    public GeoDataGenerator withMaxNeighborDistance( int maxDistance, double neighborConnectionFactor )
+    {
+        this.maxDistance = maxDistance;
+        this.neighborConnectionFactor = neighborConnectionFactor;
+        return this;
+    }
+
+    public void generate( File storeDir )
+    {
+        BatchInserter inserter = inserter( storeDir.getAbsolutePath() );
+        Grid grid = new Grid();
+        try
+        {
+            for ( int i = 0; i < numberOfNodes; i++ )
+            {
+                grid.createNodeAtRandomLocation( random, inserter );
+            }
+
+            for ( int i = 0; i < numberOfConnections; i++ )
+            {
+                grid.createConnection( random, inserter );
+            }
+        }
+        finally
+        {
+            inserter.shutdown();
+        }
+    }
+
+    private static class PositionedNode
+    {
+        private final long node;
+        private final double x, y;
+
+        PositionedNode( long node, double x, double y )
+        {
+            this.node = node;
+            this.x = x;
+            this.y = y;
+        }
+
+        public double distanceTo( PositionedNode other )
+        {
+            return sqrt( pow( abs( x - other.x ), 2 ) + pow( abs( y - other.y ), 2 ) );
+        }
+    }
+
+    private static class Cell
+    {
+        private final List<PositionedNode> nodes = new ArrayList<PositionedNode>();
+
+        void add( PositionedNode node )
+        {
+            nodes.add( node );
+        }
+
+        PositionedNode get( Random random )
+        {
+            return nodes.get( random.nextInt( nodes.size() ) );
+        }
+    }
+
+    private class Grid
+    {
+        private final int cellsX, cellsY;
+        private final double sizeX, sizeY;
+        private final Cell[][] cells;
+        private final Map<String, Object> nodePropertyScratchMap = new HashMap<String, Object>();
+        private final Map<String, Object> relationshipPropertyScratchMap = new HashMap<String, Object>();
+
+        Grid()
+        {
+            this.cellsX = 100;
+            this.cellsY = 100;
+            this.sizeX = (double)width / cellsX;
+            this.sizeY = (double)height / cellsY;
+            this.cells = new Cell[cellsX][cellsY];
+            for ( int x = 0; x < cellsX; x++ )
+            {
+                for ( int y = 0; y < cellsY; y++ )
+                {
+                    cells[x][y] = new Cell();
+                }
+            }
+        }
+
+        void createNodeAtRandomLocation( Random random, BatchInserter inserter )
+        {
+            double x = random.nextInt( width-1 ) + random.nextFloat();
+            double y = random.nextInt( height-1 ) + random.nextFloat();
+            nodePropertyScratchMap.put( "x", x );
+            nodePropertyScratchMap.put( "y", y );
+            long node = inserter.createNode( nodePropertyScratchMap );
+            cells[(int)(x/sizeX)][(int)(y/sizeY)].add( new PositionedNode( node, x, y ) );
+        }
+
+        void createConnection( Random random, BatchInserter inserter )
+        {
+            // pick a cell
+            int firstCellX = random.nextInt( cellsX );
+            int firstCellY = random.nextInt( cellsY );
+            int otherCellX = vicinity( random, firstCellX, cellsX );
+            int otherCellY = vicinity( random, firstCellY, cellsY );
+
+            // pick another cell at max distance 3
+            Cell firstCell = cells[firstCellX][firstCellY];
+            Cell otherCell = cells[otherCellX][otherCellY];
+
+            // connect a random node from the first to a random node to the other
+            // with a reasonable weight (roughly distance +/- random)
+            PositionedNode firstNode = firstCell.get( random );
+            PositionedNode otherNode = otherCell.get( random );
+            relationshipPropertyScratchMap.put( "weight", factor( random, firstNode.distanceTo( otherNode ), 0.5d ) );
+            inserter.createRelationship( firstNode.node, otherNode.node, RelationshipTypes.CONNECTION,
+                    relationshipPropertyScratchMap );
+        }
+
+        private int vicinity( Random random, int position, int maxPosition )
+        {
+            int distance = distance( random, maxDistance );
+            int result = position + distance * (random.nextBoolean() ? 1 : -1);
+            if ( result < 0 )
+            {
+                result = 0;
+            }
+            if ( result >= maxPosition )
+            {
+                result = maxPosition-1;
+            }
+            return result;
+        }
+
+        private int distance( Random random, int max )
+        {
+            for ( int i = 0; i < max; i++ )
+            {
+                if ( random.nextFloat() < neighborConnectionFactor )
+                {
+                    return i;
+                }
+            }
+            return max;
+        }
+
+        private double factor( Random random, double value, double maxDivergence )
+        {
+            double divergence = random.nextDouble()*maxDivergence;
+            divergence = random.nextBoolean() ? 1d - divergence : 1d + divergence;
+            return value * divergence;
+        }
+    }
+
+    public static enum RelationshipTypes implements RelationshipType
+    {
+        CONNECTION;
+    }
+
+    public static EstimateEvaluator<Double> estimateEvaluator()
+    {
+        return new FlatEstimateEvaluator();
+    }
+
+    private static class FlatEstimateEvaluator implements EstimateEvaluator<Double>
+    {
+        private double[] cachedGoal;
+
+        @Override
+        public Double getCost( Node node, Node goal )
+        {
+            if ( cachedGoal == null )
+            {
+                cachedGoal = new double[] {
+                        (Double)goal.getProperty( "x" ),
+                        (Double)goal.getProperty( "y" )
+                };
+            }
+
+            double x = (Double)node.getProperty( "x" ), y = (Double)node.getProperty( "y" );
+            double deltaX = abs( x - cachedGoal[0] ), deltaY = abs( y - cachedGoal[1] );
+            return sqrt( pow( deltaX, 2 ) + pow( deltaY, 2 ) );
+        }
+    };
+}


### PR DESCRIPTION
Some graphs would have the AStar algorithm not select the cheapest path,
specifically if there were multiple paths through the same node.

While doing this fix there were a number of low-hanging optimizations that
were done as well, which resulted in less memory usage and faster
algorithm, measured to roughly 15% performance increase.

This commit also includes a very crude geo data generator this may not be
very realistic, but holds reasonably true to geographic aspects.
