### PR TITLE
Fix for NPE in PersistenceWindowPool

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -230,6 +230,16 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
 
     private StatementOperationParts buildStatementOperations()
     {
+        // Note: There is a smell here, where the storage layer throws unsupportedoperation for half of its methods,
+        // and the caching layer needs special access methods into the storage layer. We should consider redesigning
+        // this. Perhaps, from the point of view of this stack, the caching and storage should be conflated. Or,
+        // perhaps each layer needs it's own interface, rather than all layers sharing the same interface.
+        // Specifically, the bottom three layers (Storage, Cache, Tx State) have very different capabilities.
+        // No writes should go past the Tx state layer, for instance, and the cache layer should be able to partially
+        // solve commands with things from the cache, and delegate to the storage to solve other parts. We probably
+        // want the the bottom two, caching and storage, to implement some other interface than the operations interface
+        // to allow addressing these characteristics.
+
         // Start off with the store layer.
         StoreStatementOperations context = new StoreStatementOperations(
                 propertyKeyTokenHolder, labelTokenHolder, relationshipTypeTokenHolder,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DefaultWindowPoolFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DefaultWindowPoolFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.nioneo.store;
 
 import java.io.File;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.Settings;
@@ -41,7 +42,8 @@ public class DefaultWindowPoolFactory implements WindowPoolFactory
         return new PersistenceWindowPool( storageFileName, recordSize, fileChannel,
                 calculateMappedMemory( configuration, storageFileName ),
                 configuration.get( CommonAbstractStore.Configuration.use_memory_mapped_buffers ),
-                isReadOnly( configuration ) && !isBackupSlave( configuration ), log );
+                isReadOnly( configuration ) && !isBackupSlave( configuration ),
+                new ConcurrentHashMap<Long, PersistenceRow>(), log );
     }
 
     private boolean isBackupSlave( Config configuration )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,8 +52,7 @@ public class PersistenceWindowPool implements WindowPool
     // == recordSize
     private final int blockSize;
     private FileChannel fileChannel;
-    private final ConcurrentMap<Long,PersistenceRow> activeRowWindows =
-        new ConcurrentHashMap<Long,PersistenceRow>();
+    private final ConcurrentMap<Long,PersistenceRow> activeRowWindows;
     private long availableMem = 0;
     private long memUsed = 0;
     private int brickCount = 0;
@@ -82,6 +80,7 @@ public class PersistenceWindowPool implements WindowPool
     /**
      * Create new pool for a store.
      *
+     *
      * @param storeName
      *            Name of store that use this pool
      * @param blockSize
@@ -90,12 +89,16 @@ public class PersistenceWindowPool implements WindowPool
      *            A fileChannel to the store
      * @param mappedMem
      *            Number of bytes dedicated to memory mapped windows
+     * @param activeRowWindows
+     *            Data structure for storing active "row windows", generally just provide a concurrent hash map.
      * @throws UnderlyingStorageException
      *             If unable to create pool
      */
     public PersistenceWindowPool( File storeName, int blockSize,
-        FileChannel fileChannel, long mappedMem,
-        boolean useMemoryMappedBuffers, boolean readOnly, StringLogger log )
+                                  FileChannel fileChannel, long mappedMem,
+                                  boolean useMemoryMappedBuffers, boolean readOnly,
+                                  ConcurrentMap<Long, PersistenceRow> activeRowWindows,
+                                  StringLogger log )
     {
         this.storeName = storeName;
         this.blockSize = blockSize;
@@ -103,6 +106,7 @@ public class PersistenceWindowPool implements WindowPool
         this.availableMem = mappedMem;
         this.useMemoryMapped = useMemoryMappedBuffers;
         this.readOnly = readOnly;
+        this.activeRowWindows = activeRowWindows;
         this.mapMode = readOnly ? MapMode.READ_ONLY : MapMode.READ_WRITE;
         this.log = log;
         setupBricks();
@@ -174,8 +178,12 @@ public class PersistenceWindowPool implements WindowPool
                     // Someone else put it there before us. Close this row
                     // which was unnecessarily opened. The next go in this loop
                     // will get that one instead.
-                    dpw.close();
-                    theBrick.unLock();
+                    dpw.close();;
+                    if(theBrick != null)
+                    {
+                        // theBrick may be null here if brick size is 0.
+                        theBrick.unLock();
+                    }
                 }
             }
             else

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PersistenceRowAndWindowDirtyWriteIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PersistenceRowAndWindowDirtyWriteIT.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Ignore;
@@ -40,6 +39,8 @@ import org.neo4j.test.subprocess.DebuggedThread;
 import org.neo4j.test.subprocess.EnabledBreakpoints;
 import org.neo4j.test.subprocess.ForeignBreakpoints;
 import org.neo4j.test.subprocess.SubProcessTestRunner;
+
+import static org.junit.Assert.*;
 
 @RunWith(SubProcessTestRunner.class)
 @ForeignBreakpoints({
@@ -99,6 +100,7 @@ public class PersistenceRowAndWindowDirtyWriteIT
                         50000, // memory available, must be at least that big for 2 windows to exist
                         true, // memory map?
                         false, // read only?
+                        new ConcurrentHashMap<Long, PersistenceRow>(),
                         StringLogger.DEV_NULL );
 
         Thread theTriggeringOne = new Thread( new Runnable()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestPersistenceWindowPoolContention.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestPersistenceWindowPoolContention.java
@@ -69,7 +69,7 @@ public class TestPersistenceWindowPoolContention
         assertTrue( "delete " + file, file.delete() );
         channel = new RandomAccessFile( file, "rw" ).getChannel();
         write( channel, fileSize );
-        pool = new PersistenceWindowPool( new File("contention test"), recordSize, channel, mappingSize, true, false, StringLogger.DEV_NULL );
+        pool = new PersistenceWindowPool( new File("contention test"), recordSize, channel, mappingSize, true, false, new ConcurrentHashMap<Long, PersistenceRow>(), StringLogger.DEV_NULL );
     }
 
     private void write( FileChannel channel, long bytes ) throws IOException


### PR DESCRIPTION
Fix for NPE in PersistenceWindowPool when concurrently loading non-mapped windows.
