### PR TITLE
Allow sorting by any deterministic expression.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -35,12 +35,6 @@ class EntityNotFoundException(message: String, cause: Throwable = null) extends 
 
 class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(message, cause)
 
-class IterableRequiredException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  def this(message: String) = this(message, null)
-
-  def this(expression: Expression) = this("Expected " + expression + " to be a collection, but it is not.", null)
-}
-
 class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(message, cause) {
   def this(message: String) = this(message, null)
 }
@@ -56,8 +50,6 @@ class InternalException(message: String, inner: Exception = null) extends Cypher
 class MissingIndexException(indexName: String) extends CypherException("Index `" + indexName + "` does not exist")
 
 class MissingConstraintException() extends CypherException("Constraint not found")
-
-class InvalidAggregateException(message: String) extends CypherException(message)
 
 class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable)
   extends CypherException("Node with id " + nodeId + " still has relationships, and cannot be deleted.")

--- a/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/SortPipe.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/internal/pipes/SortPipe.scala
@@ -45,12 +45,11 @@ class SortPipe(source: Pipe, sortDescription: List[SortItem]) extends PipeWithSo
 }
 
 trait ExecutionContextComparer extends Comparer {
-  def compareBy(a: Map[String, Any], b: Map[String, Any], order: Seq[SortItem])(implicit qtx: QueryState): Boolean = order match {
+  def compareBy(a: ExecutionContext, b: ExecutionContext, order: Seq[SortItem])(implicit qtx: QueryState): Boolean = order match {
     case Nil => false
     case head :: tail => {
-      val key = head.columnName
-      val aVal = a(key)
-      val bVal = b(key)
+      val aVal = head(a)
+      val bVal = head(b)
       signum(compare(aVal, bVal)) match {
         case 1 => !head.ascending
         case -1 => head.ascending


### PR DESCRIPTION
Make it possible to sort by any expression that is deterministic.
Which is to say, any expression that does not contain a call to the rand().

So x+1 will work, but rand()+x or similar will not.
