### PR TITLE
Fixes a recovery issue with deleted nodes

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestRecoveryScenarios.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestRecoveryScenarios.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.recovery;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.test.EphemeralFileSystemRule.shutdownDb;
+
+/**
+ * Arbitrary recovery scenarios boiled down to as small tests as possible
+ */
+public class TestRecoveryScenarios
+{
+    @Test
+    public void shouldRecoverTransactionWhereNodeIsDeletedInTheFuture() throws Exception
+    {
+        // GIVEN
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode( label );
+            node.setProperty( "key", "value" );
+            tx.success();
+        }
+        rotateLog();
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.setProperty( "other-key", 1 );
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.delete();
+            tx.success();
+        }
+        flushAll();
+
+        // WHEN
+        FileSystemAbstraction uncleanFs = fsRule.snapshot( shutdownDb( db ) );
+        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().setFileSystem( uncleanFs ).newImpermanentDatabase();
+
+        // THEN
+        // -- really the problem was that recovery threw exception, so mostly assert that.
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.getNodeById( node.getId() );
+            fail( "Should not exist" );
+        }
+        catch ( NotFoundException e )
+        {
+            assertEquals( "Node " + node.getId() + " not found", e.getMessage() );
+        }
+    }
+
+    public final @Rule EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private final Label label = label( "label" );
+    private GraphDatabaseAPI db;
+
+    @Before
+    public void before()
+    {
+        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
+            .setFileSystem( fsRule.get() ).newImpermanentDatabase();
+    }
+
+    @After
+    public void after()
+    {
+        db.shutdown();
+    }
+
+    private void rotateLog()
+    {
+        db.getDependencyResolver().resolveDependency( XaDataSourceManager.class ).rotateLogicalLogs();
+    }
+
+    private void flushAll()
+    {
+        db.getDependencyResolver().resolveDependency(
+                XaDataSourceManager.class ).getNeoStoreDataSource().getNeoStore().flushAll();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestApplyTransactions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestApplyTransactions.java
@@ -33,6 +33,8 @@ import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.neo4j.test.EphemeralFileSystemRule.shutdownDb;
+
 public class TestApplyTransactions
 {
     @Test
@@ -63,14 +65,7 @@ public class TestApplyTransactions
                 NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
         destNeoDataSource.applyCommittedTransaction( latestTxId, theTx );
         origin.shutdown();
-        EphemeralFileSystemAbstraction snapshot = fs.snapshot( new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                dest.shutdown();
-            }
-        } );
+        EphemeralFileSystemAbstraction snapshot = fs.snapshot( shutdownDb( dest ) );
 
         /*
          * Open crashed db, try to extract the transaction it reports as latest. It should be there.
@@ -84,6 +79,6 @@ public class TestApplyTransactions
         long extractedTxId = destNeoDataSource.getLogExtractor( latestTxId, latestTxId ).extractNext( theTx );
         assertEquals( latestTxId, extractedTxId );
     }
-    
+
     @Rule public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 }

--- a/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
@@ -20,12 +20,14 @@
 package org.neo4j.test;
 
 import org.junit.rules.ExternalResource;
+
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 
 public class EphemeralFileSystemRule extends ExternalResource
 {
     private EphemeralFileSystemAbstraction fs;
-    
+
     @Override
     protected void before() throws Throwable
     {
@@ -39,12 +41,12 @@ public class EphemeralFileSystemRule extends ExternalResource
         fs.shutdown();
         super.after();
     }
-    
+
     public EphemeralFileSystemAbstraction get()
     {
         return fs;
     }
-    
+
     public EphemeralFileSystemAbstraction snapshot( Runnable action )
     {
         EphemeralFileSystemAbstraction snapshot = fs.snapshot();
@@ -58,5 +60,17 @@ public class EphemeralFileSystemRule extends ExternalResource
             fs = snapshot;
         }
         return fs;
+    }
+
+    public static Runnable shutdownDb( final GraphDatabaseService db )
+    {
+        return new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                db.shutdown();
+            }
+        };
     }
 }


### PR DESCRIPTION
There was an issue where this scenario might happen:
- TX1: Node N exists and has property record P
- rotate log
- TX2: P gets changed
- TX3: N gets deleted (also P, but that's irrelevant for this scenario)
- N is persisted to disk for some reason
- crash
- recover
- TX2: P has changed and updates to indexes are gathered. As
  part of that it tries to read the labels of N (which does not
  exist a.t.m.)

We can actually just assume that if this happens and we're in
recovery mode that the node in question will be deleted in an
upcoming transaction, so just skip this update.
