### PR TITLE
Fix nullpointer on PersistenceWindowPool.acquire when accessing brickArray

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
@@ -120,7 +120,7 @@ public class PersistenceWindowPool implements WindowPool
      * @return A locked window encapsulating the position
      */
     @Override
-    public PersistenceWindow acquire( long position, OperationType operationType )
+    public synchronized PersistenceWindow acquire( long position, OperationType operationType )
     {
         LockableWindow window = null;
         if ( brickMiss >= REFRESH_BRICK_COUNT )
@@ -254,7 +254,7 @@ public class PersistenceWindowPool implements WindowPool
         }
     }
 
-    private void applyChangesToWindowIfNecessary( PersistenceRow dpw )
+    private synchronized void applyChangesToWindowIfNecessary( PersistenceRow dpw )
     {
         int brickIndex = positionToBrickIndex( dpw.position() );
         LockableWindow existingBrickWindow = brickIndex < brickArray.length ?
@@ -420,7 +420,7 @@ public class PersistenceWindowPool implements WindowPool
      * 
      * @param nr the number of windows to free.
      */
-    private void freeWindows( int nr )
+    private synchronized void freeWindows( int nr )
     {
         // Only called from expandBricks, so we're under a lock here
         if ( brickSize <= 0 )
@@ -542,7 +542,7 @@ public class PersistenceWindowPool implements WindowPool
      * 
      * @return all bricks in this pool divided into mapped and unmapped.
      */
-    private Pair<List<BrickElement>, List<BrickElement>> gatherMappedVersusUnmappedWindows()
+    private synchronized Pair<List<BrickElement>, List<BrickElement>> gatherMappedVersusUnmappedWindows()
     {
         List<BrickElement> mappedBricks = new ArrayList<BrickElement>();
         List<BrickElement> unmappedBricks = new ArrayList<BrickElement>();


### PR DESCRIPTION
We see this nullpointer when using 2.0.0-M05:

```
java.lang.NullPointerException
    at org.neo4j.kernel.impl.nioneo.store.PersistenceWindowPool.acquire(PersistenceWindowPool.java:180)
    at org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore.acquireWindow(CommonAbstractStore.java:437)
    at org.neo4j.kernel.impl.nioneo.store.AbstractDynamicStore.forceGetRecord(AbstractDynamicStore.java:397)
    at org.neo4j.kernel.impl.nioneo.store.SchemaStore$1.fetchNextOrNull(SchemaStore.java:88)
    at org.neo4j.kernel.impl.nioneo.store.SchemaStore$1.fetchNextOrNull(SchemaStore.java:77)
    at org.neo4j.helpers.collection.PrefetchingIterator.hasNext(PrefetchingIterator.java:55)
    at org.neo4j.helpers.collection.Iterables$FilterIterable$FilterIterator.moveToNextValid(Iterables.java:697)
    at org.neo4j.helpers.collection.Iterables$FilterIterable$FilterIterator.hasNext(Iterables.java:741)
    at org.neo4j.helpers.collection.Iterables$MapIterable$MapIterator.hasNext(Iterables.java:639)
    at org.neo4j.kernel.api.operations.ConstraintEnforcingEntityWriteOperations.nodeAddLabel(ConstraintEnforcingEntityWriteOperations.java:59)
    at org.neo4j.kernel.impl.api.LockingStatementOperations.nodeAddLabel(LockingStatementOperations.java:74)
    at org.neo4j.kernel.api.DataStatement.nodeAddLabel(DataStatement.java:70)
    at org.neo4j.kernel.impl.core.NodeProxy.addLabel(NodeProxy.java:459)
```

From the code it looks the brickArray is not always consistently locked causing this problem.
