### PR TITLE
This moves population and eviction of the "Persistence Cache" into Write...

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/BridgingCacheAccess.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel;
 
+import java.util.Collection;
+
+import org.neo4j.kernel.api.scan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.PersistenceCache;
 import org.neo4j.kernel.impl.api.SchemaCache;
 import org.neo4j.kernel.impl.api.SchemaState;
@@ -105,5 +108,11 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     {
         nodeManager.patchDeletedRelationshipNodes( relId, firstNodeId, firstNodeNextRelId, secondNodeId,
                 secondNodeNextRelId );
+    }
+
+    @Override
+    public void applyLabelUpdates( Collection<NodeLabelUpdate> labelUpdates )
+    {
+        persistenceCache.apply( labelUpdates );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionImplementation.java
@@ -128,26 +128,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         try
         {
-            try
-            {
-                // TODO: This should be done by log application, not by this level of the stack.
-                if ( hasTxStateWithChanges() )
-                {
-                    persistenceCache.apply( this.txState() );
-                }
-            }
-            finally
-            {
-                try
-                {
-                    lockHolder.releaseLocks();
-                }
-                catch ( ReleaseLocksFailedKernelException e )
-                {
-                    throw new TransactionFailureException( new RuntimeException(e.getMessage(), e) );
-                }
-            }
+            lockHolder.releaseLocks();
             close();
+        }
+        catch ( ReleaseLocksFailedKernelException e )
+        {
+            throw new TransactionFailureException( new RuntimeException(e.getMessage(), e) );
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import java.util.Collection;
+
+import org.neo4j.kernel.api.scan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
 
 public interface CacheAccessBackDoor
@@ -40,6 +43,8 @@ public interface CacheAccessBackDoor
     void addLabelToken( Token labelId );
 
     void addPropertyKeyToken( Token index );
+
+    void applyLabelUpdates( Collection<NodeLabelUpdate> labelUpdates );
 
     /**
      * Patches the relationship chain loading parts of the start and end nodes of deleted relationships. This is

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.NotFoundException;
@@ -50,7 +49,6 @@ import org.neo4j.kernel.impl.util.RelIdIterator;
 
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.binarySearch;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.REFERENCE_SIZE;
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverheadIncludingReferences;
@@ -727,31 +725,9 @@ public class NodeImpl extends ArrayBasedPrimitive
         return binarySearch( labels, labelId ) >= 0;
     }
 
-    public synchronized void commitLabels( Set<Integer> added, Set<Integer> removed )
+    public synchronized void commitLabels( int[] labels )
     {
-        if ( labels != null )
-        {
-            int estimatedDelta = added.size() - removed.size();
-            int[] newLabels = new int[labels.length+estimatedDelta];
-            int cursor = 0;
-
-            // Remove the removed
-            for ( int label : labels )
-            {
-                if ( !removed.contains( label ) )
-                {
-                    newLabels[cursor++] = label;
-                }
-            }
-
-            // Add the added
-            for ( int label : added )
-            {
-                newLabels[cursor++] = label;
-            }
-            Arrays.sort( newLabels );
-            labels = newLabels;
-        }
+        this.labels = labels;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
@@ -815,6 +815,8 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
             indexes.updateIndexes( propertyUpdates );
             updateLabelScanStore( labelUpdates );
 
+            cacheAccess.applyLabelUpdates( labelUpdates );
+
             // schema rules. Execute these after generating the property updates so. If executed
             // before and we've got a transaction that sets properties/labels as well as creating an index
             // we might end up with this corner-case:

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PersistenceCacheTest.java
@@ -21,18 +21,16 @@ package org.neo4j.kernel.impl.api;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.helpers.Thunk;
 import org.neo4j.kernel.api.KernelStatement;
 import org.neo4j.kernel.impl.cache.AutoLoadingCache;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.RelationshipImpl;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.neo4j.kernel.api.scan.NodeLabelUpdate.labelChanges;
 
 public class PersistenceCacheTest
 {
@@ -66,6 +64,20 @@ public class PersistenceCacheTest
 
         // THEN
         verify( nodeCache, times( 1 ) ).remove( nodeId );
+    }
+
+    @Test
+    public void shouldApplyUpdates() throws Exception
+    {
+        // GIVEN
+        NodeImpl node = mock(NodeImpl.class);
+        when( nodeCache.getIfCached( nodeId ) ).thenReturn( node );
+
+        // WHEN
+        persistenceCache.apply(asList( labelChanges( nodeId, new long[]{2l}, new long[]{1l} )));
+
+        // THEN
+        verify(node).commitLabels( new int[]{1} );
     }
 
     private PersistenceCache persistenceCache;


### PR DESCRIPTION
...Transaction.

o Takes advantage of the fact that the exhaustive list of labels is known now, so replaces complex sorting/insert with simple replace.
o Does not address, but works around, the fact that labels are still longs in WriteTransaction. This needs to be addressed in a separate commit.
