### PR TITLE
Copy indexes on copy store in HA.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
@@ -70,7 +70,7 @@ public abstract class FutureAdapter<V> implements Future<V>
         }
     };
     
-    public static final Future<Void> VOID = new Present<Void>( null );
+    public static final Future<Void> VOID = new Present<>( null );
     
     public static <T> Future<T> latchGuardedValue( final ValueGetter<T> value, final CountDownLatch guardedByLatch )
     {

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/CombiningIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/CombiningIterator.java
@@ -56,9 +56,8 @@ public class CombiningIterator<T> extends PrefetchingIterator<T>
     {
         if ( currentIterator == null || !currentIterator.hasNext() )
         {
-            while ( iterators.hasNext() )
+            while ( (currentIterator = nextIteratorOrNull()) != null )
             {
-                currentIterator = iterators.next();
                 if ( currentIterator.hasNext() )
                 {
                     break;
@@ -66,6 +65,15 @@ public class CombiningIterator<T> extends PrefetchingIterator<T>
             }
         }
         return currentIterator != null && currentIterator.hasNext() ? currentIterator.next() : null;
+    }
+
+    protected Iterator<T> nextIteratorOrNull()
+    {
+        if(iterators.hasNext())
+        {
+            return iterators.next();
+        }
+        return null;
     }
 
     protected Iterator<T> currentIterator()

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/CombiningResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/CombiningResourceIterator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.neo4j.graphdb.ResourceIterator;
+
+public class CombiningResourceIterator<T> extends CombiningIterator<T> implements ResourceIterator<T>
+{
+    private final Iterator<ResourceIterator<T>> iterators;
+    private final Collection<ResourceIterator<T>> seenIterators = new ArrayList<>();
+    private ResourceIterator<T> currentIterator;
+
+    public CombiningResourceIterator( Iterator<ResourceIterator<T>> iterators )
+    {
+        super(iterators);
+        this.iterators = iterators;
+    }
+
+    @Override
+    protected Iterator<T> nextIteratorOrNull()
+    {
+        if(iterators.hasNext())
+        {
+            currentIterator = iterators.next();
+            seenIterators.add( currentIterator );
+            return currentIterator;
+        }
+        return null;
+    }
+
+    @Override
+    public void close()
+    {
+        for ( ResourceIterator<T> seenIterator : seenIterators )
+        {
+            seenIterator.close();
+        }
+
+        while(iterators.hasNext())
+        {
+            iterators.next().close();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -466,6 +466,11 @@ public final class Iterables
         return concat( Arrays.asList( (Iterator<T>[]) iterables ).iterator() );
     }
 
+    public static <T> ResourceIterator<T> concatResourceIterators( Iterator<ResourceIterator<T>> iterators )
+    {
+        return new CombiningResourceIterator<>(iterators);
+    }
+
     public static <T> Iterator<T> concat( Iterator<Iterator<T>> iterators )
     {
         return new CombiningIterator<>(iterators);

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.util.Iterator;
+
+import org.neo4j.graphdb.ResourceIterator;
+
+class WrappingResourceIterator<T> implements ResourceIterator<T>
+{
+    private final Iterator<T> iterator;
+    boolean hasNext;
+
+    public WrappingResourceIterator( Iterator<T> iterator )
+    {
+        this.iterator = iterator;
+        hasNext = iterator.hasNext();
+    }
+
+    @Override
+    public void close()
+    {
+        hasNext = false;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return hasNext;
+    }
+
+    @Override
+    public T next()
+    {
+        assertHasNext();
+        T result = iterator.next();
+        hasNext = iterator.hasNext();
+        return result;
+    }
+
+    @Override
+    public void remove()
+    {
+        assertHasNext();
+        try
+        {
+            iterator.remove();
+        }
+        finally
+        {
+            hasNext = iterator.hasNext();
+        }
+    }
+
+    private void assertHasNext()
+    {
+        if ( ! hasNext )
+        {
+            throw new IllegalArgumentException( "Iterator already closed" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -196,9 +196,10 @@ public abstract class InternalAbstractGraphDatabase
     protected File storeDir;
     protected Map<String, String> params;
     private final TransactionInterceptorProviders transactionInterceptorProviders;
-    private final KernelExtensions kernelExtensions;
     protected StoreId storeId;
     private final TransactionBuilder defaultTxBuilder = new TransactionBuilderImpl( this, ForceMode.forced );
+
+    protected final KernelExtensions kernelExtensions;
 
     protected Config config;
 
@@ -874,7 +875,7 @@ public abstract class InternalAbstractGraphDatabase
                 xaFactory, stateFactory, transactionInterceptorProviders, jobScheduler, logging,
                 updateableSchemaState, new NonTransactionalTokenNameLookup( labelTokenHolder, propertyKeyTokenHolder ),
                 dependencyResolver, txManager, propertyKeyTokenHolder, labelTokenHolder, relationshipTypeTokenHolder,
-                persistenceManager, lockManager, nodeManager, this );
+                persistenceManager, lockManager, this );
         xaDataSourceManager.registerDataSource( neoDataSource );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -19,10 +19,14 @@
  */
 package org.neo4j.kernel.api.index;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.SwallowingIndexUpdater;
+
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 /**
  * Used for online operation of an index.
@@ -70,6 +74,13 @@ public interface IndexAccessor
      */
     IndexReader newReader();
 
+    /**
+     * Should return a full listing of all files needed by this index accessor to work with the index. The files
+     * need to remain available until the resource iterator returned here is closed. This is used to duplicate created
+     * indexes across clusters, among other things.
+     */
+    ResourceIterator<File> snapshotFiles() throws IOException;
+
     class Adapter implements IndexAccessor
     {
         @Override
@@ -97,6 +108,12 @@ public interface IndexAccessor
         public IndexReader newReader()
         {
             return IndexReader.EMPTY;
+        }
+
+        @Override
+        public ResourceIterator<File> snapshotFiles()
+        {
+            return emptyIterator();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
@@ -215,6 +215,11 @@ public class KernelExtensions extends DependencyResolver.Adapter implements Life
                 new KernelExtensionHandler() );
     }
 
+    public Iterable<KernelExtensionFactory<?>> listFactories()
+    {
+        return kernelExtensionFactories;
+    }
+
     private static class TypeFilter<T> implements Predicate
     {
         private final Class<T> type;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
@@ -117,5 +119,11 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     public String toString()
     {
         return String.format( "%s -> %s", getClass().getSimpleName(), getDelegate().toString() );
+    }
+
+    @Override
+    public ResourceIterator<File> snapshotFiles() throws IOException
+    {
+        return getDelegate().snapshotFiles();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
@@ -19,15 +19,18 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 
 import static org.neo4j.helpers.FutureAdapter.VOID;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 public class FailedIndexProxy extends AbstractSwallowingIndexProxy
 {
@@ -72,5 +75,11 @@ public class FailedIndexProxy extends AbstractSwallowingIndexProxy
     public void validate() throws IndexPopulationFailedKernelException
     {
         throw getPopulationFailure().asIndexPopulationFailure( getDescriptor(), indexUserDescription );
+    }
+
+    @Override
+    public ResourceIterator<File> snapshotFiles()
+    {
+        return emptyIterator();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.ExceptionDuringFlipKernelException;
 import org.neo4j.kernel.api.exceptions.index.FlipFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
@@ -227,7 +229,21 @@ public class FlippableIndexProxy implements IndexProxy
             lock.readLock().unlock();
         }
     }
-    
+
+    @Override
+    public ResourceIterator<File> snapshotFiles() throws IOException
+    {
+        lock.readLock().lock();
+        try
+        {
+            return delegate.snapshotFiles();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
     @Override
     public IndexPopulationFailure getPopulationFailure() throws IllegalStateException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
@@ -96,4 +98,6 @@ public interface IndexProxy
     void activate() throws IndexActivationFailedKernelException;
 
     void validate() throws ConstraintVerificationFailedKernelException, IndexPopulationFailedKernelException;
+
+    ResourceIterator<File> snapshotFiles() throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexReader;
@@ -123,6 +125,12 @@ public class OnlineIndexProxy implements IndexProxy
     public IndexPopulationFailure getPopulationFailure() throws IllegalStateException
     {
         throw new IllegalStateException( this + " is ONLINE" );
+    }
+
+    @Override
+    public ResourceIterator<File> snapshotFiles() throws IOException
+    {
+        return accessor.snapshotFiles();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -36,6 +38,8 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 
 public class PopulatingIndexProxy implements IndexProxy
@@ -157,7 +161,13 @@ public class PopulatingIndexProxy implements IndexProxy
     {
         throw new IllegalStateException( "Cannot validate index while it is still populating." );
     }
-    
+
+    @Override
+    public ResourceIterator<File> snapshotFiles()
+    {
+        return emptyIterator();
+    }
+
     @Override
     public IndexPopulationFailure getPopulationFailure() throws IllegalStateException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveringIndexProxy.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -56,6 +58,12 @@ public class RecoveringIndexProxy extends AbstractSwallowingIndexProxy
     public void validate()
     {
         throw new UnsupportedOperationException( "Cannot validate recovering index." );
+    }
+
+    @Override
+    public ResourceIterator<File> snapshotFiles()
+    {
+        throw new UnsupportedOperationException( "Cannot snapshot a recovering index." );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListing.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.api.scan.LabelScanStore;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.index.IndexStore;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.xaframework.XaContainer;
+
+import static org.neo4j.helpers.SillyUtils.nonNull;
+
+public class NeoStoreFileListing
+{
+    private final XaContainer xaContainer;
+    private final File storeDir;
+    private final LabelScanStore labelScanStore;
+    private final IndexingService indexingService;
+
+    public NeoStoreFileListing(XaContainer xaContainer, File storeDir, LabelScanStore labelScanStore, IndexingService indexingService)
+    {
+        this.xaContainer = xaContainer;
+        this.storeDir = storeDir;
+        this.labelScanStore = labelScanStore;
+        this.indexingService = indexingService;
+    }
+
+    public ResourceIterator<File> listStoreFiles( boolean includeLogicalLogs ) throws IOException
+    {
+        Collection<File> files = new ArrayList<>();
+        gatherNeoStoreFiles( includeLogicalLogs, files );
+        Closeable labelScanStoreSnapshot = gatherLabelScanStoreFiles( files );
+        Closeable schemaIndexSnapshots = gatherSchemaIndexFiles(files);
+
+        return new StoreSnapshot( files.iterator(), labelScanStoreSnapshot, schemaIndexSnapshots );
+    }
+
+    private Closeable gatherSchemaIndexFiles(Collection<File> targetFiles) throws IOException
+    {
+        ResourceIterator<File> snapshot = indexingService.snapshotStoreFiles();
+        IteratorUtil.addToCollection(snapshot, targetFiles);
+        // Intentionally don't close the snapshot here, return it for closing by the consumer of
+        // the targetFiles list.
+        return snapshot;
+    }
+
+    private Closeable gatherLabelScanStoreFiles( Collection<File> targetFiles ) throws IOException
+    {
+        ResourceIterator<File> snapshot = labelScanStore.snapshotStoreFiles();
+        IteratorUtil.addToCollection(snapshot, targetFiles);
+        // Intentionally don't close the snapshot here, return it for closing by the consumer of
+        // the targetFiles list.
+        return snapshot;
+    }
+
+    private void gatherNeoStoreFiles( boolean includeLogicalLogs, final Collection<File> targetFiles )
+    {
+        File neostoreFile = null;
+        Pattern logFilePattern = xaContainer.getLogicalLog().getHistoryFileNamePattern();
+        for ( File dbFile : nonNull( storeDir.listFiles() ) )
+        {
+            String name = dbFile.getName();
+            // To filter for "neostore" is quite future proof, but the "index.db" file
+            // maybe should be
+            if ( dbFile.isFile() )
+            {
+                if ( name.equals( NeoStore.DEFAULT_NAME ) )
+                {
+                    neostoreFile = dbFile;
+                }
+                else if ( (name.startsWith( NeoStore.DEFAULT_NAME ) ||
+                        name.equals( IndexStore.INDEX_DB_FILE_NAME )) && !name.endsWith( ".id" ) )
+                {   // Store files
+                    targetFiles.add( dbFile );
+                }
+                else if ( includeLogicalLogs && logFilePattern.matcher( dbFile.getName() ).matches() )
+                {   // Logs
+                    targetFiles.add( dbFile );
+                }
+            }
+        }
+        targetFiles.add( neostoreFile );
+    }
+
+    private static class StoreSnapshot extends PrefetchingIterator<File> implements ResourceIterator<File>
+    {
+        private final Iterator<File> files;
+        private final Closeable[] thingsToCloseWhenDone;
+
+        StoreSnapshot( Iterator<File> files, Closeable ... thingsToCloseWhenDone )
+        {
+            this.files = files;
+            this.thingsToCloseWhenDone = thingsToCloseWhenDone;
+        }
+
+        @Override
+        protected File fetchNextOrNull()
+        {
+            return files.hasNext() ? files.next() : null;
+        }
+
+        @Override
+        public void close()
+        {
+            try
+            {
+                for ( Closeable closeable : thingsToCloseWhenDone )
+                {
+                    closeable.close();
+                }
+            }
+            catch ( IOException e )
+            {
+                // The underlying closeable is currently actually a ResourceIterator, so
+                // the close() method doesn't actually throw IOException.
+                throw new RuntimeException( e );
+            }
+        }
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import org.junit.Test;
+import org.neo4j.graphdb.ResourceIterator;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
+import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+
+public class CombiningResourceIteratorTest
+{
+
+    @Test
+    public void shouldNotCloseDuringIteration() throws Exception
+    {
+        // Given
+        ResourceIterator<Long> it1 = spy( asResourceIterator( iterator( 1l, 2l, 3l ) ) );
+        ResourceIterator<Long> it2 = spy( asResourceIterator( iterator( 5l, 6l, 7l ) ) );
+        CombiningResourceIterator<Long> combingIterator = new CombiningResourceIterator<>( iterator(it1, it2) );
+
+        // When I iterate through it, things come back in the right order
+        assertThat( IteratorUtil.asList( combingIterator ), equalTo(asList(1l,2l,3l,5l,6l,7l)) );
+
+        // Then
+        verify(it1, never()).close();
+        verify(it2, never()).close();
+    }
+
+    @Test
+    public void closesAllIteratorsOnShutdown() throws Exception
+    {
+        // Given
+        ResourceIterator<Long> it1 = spy( asResourceIterator( iterator( 1l, 2l, 3l ) ) );
+        ResourceIterator<Long> it2 = spy( asResourceIterator( iterator( 5l, 6l, 7l ) ) );
+        CombiningResourceIterator<Long> combingIterator = new CombiningResourceIterator<>( iterator(it1, it2) );
+
+        // Given I iterate through half of it
+        int iterations = 4;
+        while( iterations --> 0 ) combingIterator.next();
+
+        // When
+        combingIterator.close();
+
+        // Then
+        verify(it1).close();
+        verify(it2).close();
+    }
+
+    @Test
+    public void shouldHandleSingleItemIterators() throws Exception
+    {
+        // Given
+        ResourceIterator<Long> it1 = asResourceIterator( iterator( 1l) );
+        ResourceIterator<Long> it2 = asResourceIterator( iterator( 5l, 6l, 7l ) );
+        CombiningResourceIterator<Long> combingIterator = new CombiningResourceIterator<>( iterator(it1, it2) );
+
+        // When I iterate through it, things come back in the right order
+        assertThat( IteratorUtil.asList( combingIterator ), equalTo(asList(1l,5l,6l,7l)) );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -19,14 +19,17 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.File;
 import java.util.concurrent.Future;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 
 import static org.neo4j.helpers.FutureAdapter.VOID;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 public class IndexProxyAdapter implements IndexProxy
 {
@@ -96,6 +99,12 @@ public class IndexProxyAdapter implements IndexProxy
     @Override
     public void validate()
     {
+    }
+
+    @Override
+    public ResourceIterator<File> snapshotFiles()
+    {
+        return emptyIterator();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -26,19 +26,17 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Ignore;
-
 import org.neo4j.helpers.FutureAdapter;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @Ignore( "This is not a test" )
 public class SchemaIndexTestHelper
@@ -51,6 +49,7 @@ public class SchemaIndexTestHelper
     
     public interface SingleInstanceSchemaIndexProviderFactoryDependencies
     {
+        Config config();
     }
     
     private static class SingleInstanceSchemaIndexProviderFactory

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.kernel.impl.api.index.inmemory;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -32,6 +34,7 @@ import org.neo4j.kernel.impl.api.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 
 import static java.lang.Boolean.getBoolean;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 
 class InMemoryIndex
 {
@@ -154,6 +157,12 @@ class InMemoryIndex
         public IndexReader newReader()
         {
             return indexData;
+        }
+
+        @Override
+        public ResourceIterator<File> snapshotFiles()
+        {
+            return emptyIterator();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -199,7 +199,7 @@ public class TestNeoStore
                 dependencyResolverForNoIndexProvider( nodeManager ), mock( AbstractTransactionManager.class),
                 mock( PropertyKeyTokenHolder.class ), mock(LabelTokenHolder.class),
                 mock( RelationshipTypeTokenHolder.class), mock(PersistenceManager.class), mock(LockManager.class),
-                nodeManager, mock( SchemaWriteGuard.class));
+                mock( SchemaWriteGuard.class));
         ds.init();
         ds.start();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
@@ -384,7 +384,7 @@ public class TestXa
                 dependencyResolverForNoIndexProvider( nodeManager ), txManager,
                 mock( PropertyKeyTokenHolder.class ), mock(LabelTokenHolder.class),
                 mock( RelationshipTypeTokenHolder.class), mock(PersistenceManager.class), mock(LockManager.class),
-                nodeManager, mock( SchemaWriteGuard.class));
+                mock( SchemaWriteGuard.class));
         neoStoreXaDataSource.init();
         neoStoreXaDataSource.start();
         return neoStoreXaDataSource;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListingTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.scan.LabelScanStore;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.transaction.xaframework.XaContainer;
+import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog.getHistoryFileNamePattern;
+
+public class NeoStoreFileListingTest
+{
+    private XaContainer xaContainer;
+    private LabelScanStore labelScanStore;
+    private IndexingService indexingService;
+    private File storeDir;
+
+    private final static String[] STANDARD_STORE_DIR_FILES = new String[]{
+           "active_tx_log",
+           "lock",
+           "messages.log",
+           "neostore",
+           "neostore.id",
+           "neostore.labeltokenstore.db",
+           "neostore.labeltokenstore.db.id",
+           "neostore.labeltokenstore.db.names",
+           "neostore.labeltokenstore.db.names.id",
+           "neostore.nodestore.db",
+           "neostore.nodestore.db.id",
+           "neostore.nodestore.db.labels",
+           "neostore.nodestore.db.labels.id",
+           "neostore.propertystore.db",
+           "neostore.propertystore.db.arrays",
+           "neostore.propertystore.db.arrays.id",
+           "neostore.propertystore.db.id",
+           "neostore.propertystore.db.index",
+           "neostore.propertystore.db.index.id",
+           "neostore.propertystore.db.index.keys",
+           "neostore.propertystore.db.index.keys.id",
+           "neostore.propertystore.db.strings",
+           "neostore.propertystore.db.strings.id",
+           "neostore.relationshipstore.db",
+           "neostore.relationshipstore.db.id",
+           "neostore.relationshiptypestore.db",
+           "neostore.relationshiptypestore.db.id",
+           "neostore.relationshiptypestore.db.names",
+           "neostore.relationshiptypestore.db.names.id",
+           "neostore.schemastore.db",
+           "neostore.schemastore.db.id",
+           "nioneo_logical.log.1",
+           "nioneo_logical.log.active",
+           "nioneo_logical.log.v0",
+           "nioneo_logical.log.v1",
+           "nioneo_logical.log.v2",
+           "store_lock",
+           "tm_tx_log.1"};
+
+    private final static String[] STANDARD_STORE_DIR_DIRECTORIES = new String[]{ "schema", "index", "branched"};
+
+    @Before
+    public void setUp() throws IOException
+    {
+        xaContainer = mock( XaContainer.class );
+        labelScanStore = mock( LabelScanStore.class );
+        indexingService = mock( IndexingService.class );
+        storeDir = mock( File.class );
+
+        XaLogicalLog xaLogicalLog = mock( XaLogicalLog.class );
+        when( xaLogicalLog.getHistoryFileNamePattern()).thenReturn( getHistoryFileNamePattern( "nioneo_logical.log" ) );
+        when( xaContainer.getLogicalLog() ).thenReturn( xaLogicalLog );
+
+        // Defaults, overridden in individual tests
+        filesInStoreDirAre( new String[]{}, new String[]{} );
+        scanStoreFilesAre( new String[]{} );
+        indexFilesAre( new String[]{} );
+    }
+
+    @Test
+    public void shouldListNeoStoreFiles() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        // When
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
+
+        // Then
+        assertThat( asSetOfPaths( result ), equalTo( asSet(
+                "neostore.labeltokenstore.db",
+                "neostore.labeltokenstore.db.names",
+                "neostore.nodestore.db",
+                "neostore.nodestore.db.labels",
+                "neostore.propertystore.db",
+                "neostore.propertystore.db.arrays",
+                "neostore.propertystore.db.index",
+                "neostore.propertystore.db.index.keys",
+                "neostore.propertystore.db.strings",
+                "neostore.relationshipstore.db",
+                "neostore.relationshiptypestore.db",
+                "neostore.relationshiptypestore.db.names",
+                "neostore.schemastore.db",
+                "neostore" ) ) );
+    }
+
+    @Test
+    public void shouldListNeoStoreFilesAndLogicalLogs() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        // When
+        ResourceIterator<File> result = fileListing.listStoreFiles( true );
+
+        // Then
+        assertThat( asSetOfPaths( result ), equalTo(asSet(
+                "neostore.labeltokenstore.db",
+                "neostore.labeltokenstore.db.names",
+                "neostore.nodestore.db",
+                "neostore.nodestore.db.labels",
+                "neostore.propertystore.db",
+                "neostore.propertystore.db.arrays",
+                "neostore.propertystore.db.index",
+                "neostore.propertystore.db.index.keys",
+                "neostore.propertystore.db.strings",
+                "neostore.relationshipstore.db",
+                "neostore.relationshiptypestore.db",
+                "neostore.relationshiptypestore.db.names",
+                "neostore.schemastore.db",
+                "neostore",
+                "nioneo_logical.log.v0",
+                "nioneo_logical.log.v1",
+                "nioneo_logical.log.v2" )));
+    }
+
+    @Test
+    public void shouldListLabelScanStoreAndSchemaIndexes() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        scanStoreFilesAre( new String[]{"blah/scan.store", "scan.more"} );
+        indexFilesAre( new String[]{"schema/index/my.index", "schema/index/their.index"} );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        // When
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
+
+        // Then
+        assertThat( asSetOfPaths( result ), equalTo(asSet(
+                "blah/scan.store",
+                "scan.more",
+                "schema/index/my.index",
+                "schema/index/their.index",
+                "neostore.labeltokenstore.db",
+                "neostore.labeltokenstore.db.names",
+                "neostore.nodestore.db",
+                "neostore.nodestore.db.labels",
+                "neostore.propertystore.db",
+                "neostore.propertystore.db.arrays",
+                "neostore.propertystore.db.index",
+                "neostore.propertystore.db.index.keys",
+                "neostore.propertystore.db.strings",
+                "neostore.relationshipstore.db",
+                "neostore.relationshiptypestore.db",
+                "neostore.relationshiptypestore.db.names",
+                "neostore.schemastore.db",
+                "neostore")));
+    }
+
+    @Test
+    public void shouldCloseIndexAndLabelScanSnapshots() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        ResourceIterator<File> scanSnapshot = scanStoreFilesAre( new String[]{"blah/scan.store", "scan.more"} );
+        ResourceIterator<File> indexSnapshot = indexFilesAre( new String[]{"schema/index/my.index" } );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
+
+        // When
+        result.close();
+
+        // Then
+        verify( scanSnapshot ).close();
+        verify( indexSnapshot ).close();
+    }
+
+    private NeoStoreFileListing newFileListing()
+    {
+        return new NeoStoreFileListing( xaContainer, storeDir, labelScanStore, indexingService );
+    }
+
+    private Set<String> asSetOfPaths( ResourceIterator<File> result )
+    {
+        List<String> fnames = new ArrayList<>();
+        while(result.hasNext())
+        {
+            fnames.add( result.next().getPath() );
+        }
+        return asUniqueSet( fnames );
+    }
+
+    private void filesInStoreDirAre( String[] filenames, String[] dirs )
+    {
+        ArrayList<File> files = new ArrayList<>();
+        mockFiles( filenames, files, false );
+        mockFiles( dirs, files, true );
+        when(storeDir.listFiles()).thenReturn( files.toArray( new File[files.size()] ) );
+    }
+
+    private ResourceIterator<File> scanStoreFilesAre( String[] fileNames ) throws IOException
+    {
+        ArrayList<File> files = new ArrayList<>();
+        mockFiles( fileNames, files, false );
+        ResourceIterator<File> snapshot = spy( asResourceIterator( files.iterator() ) );
+        when(labelScanStore.snapshotStoreFiles()).thenReturn( snapshot );
+        return snapshot;
+    }
+
+    private ResourceIterator<File> indexFilesAre( String[] fileNames ) throws IOException
+    {
+        ArrayList<File> files = new ArrayList<>();
+        mockFiles( fileNames, files, false );
+        ResourceIterator<File> snapshot = spy(asResourceIterator( files.iterator() ));
+        when(indexingService.snapshotStoreFiles()).thenReturn( snapshot );
+        return snapshot;
+    }
+
+    private void mockFiles( String[] filenames, ArrayList<File> files, boolean isDirectories )
+    {
+        for ( String filename : filenames )
+        {
+            File file = mock( File.class );
+
+            String[] fileNameParts = filename.split( "/" );
+            when(file.getName()).thenReturn( fileNameParts[fileNameParts.length-1] );
+
+            when(file.isFile()).thenReturn( !isDirectories );
+            when(file.isDirectory()).thenReturn( isDirectories );
+            when(file.exists()).thenReturn( true );
+            when(file.getPath()).thenReturn( filename );
+            files.add( file );
+        }
+    }
+
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
@@ -30,6 +31,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -47,12 +49,14 @@ abstract class LuceneIndexAccessor implements IndexAccessor
     protected final IndexWriter writer;
     private final IndexWriterStatus writerStatus;
     private final Directory dir;
+    private final File dirFile;
 
     LuceneIndexAccessor( LuceneDocumentStructure documentStructure, LuceneIndexWriterFactory indexWriterFactory,
                          IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile )
             throws IOException
     {
         this.documentStructure = documentStructure;
+        this.dirFile = dirFile;
         this.dir = dirFactory.open( dirFile );
         this.writer = indexWriterFactory.create( dir );
         this.writerStatus = writerStatus;
@@ -107,6 +111,12 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         return new LuceneIndexAccessorReader( searcherManager, documentStructure );
     }
 
+    @Override
+    public ResourceIterator<File> snapshotFiles() throws IOException
+    {
+        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getConfig().getIndexDeletionPolicy();
+        return new LuceneStoreSnapshot( dirFile, deletionPolicy );
+    }
 
     private void addRecovered( long nodeId, Object value ) throws IOException
     {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -37,7 +36,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockObtainFailedException;
 
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.api.scan.LabelScanReader;
 import org.neo4j.kernel.api.scan.LabelScanStore;
 import org.neo4j.kernel.api.scan.NodeLabelUpdate;
@@ -224,46 +222,7 @@ public class LuceneLabelScanStore implements LabelScanStore, LabelScanStorageStr
     public ResourceIterator<File> snapshotStoreFiles() throws IOException
     {
         SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getConfig().getIndexDeletionPolicy();
-        return new StoreSnapshot( deletionPolicy );
-    }
-
-    private class StoreSnapshot extends PrefetchingIterator<File> implements ResourceIterator<File>
-    {
-        private final String ID = "backup";
-        private final SnapshotDeletionPolicy deletionPolicy;
-        private final IndexCommit commit;
-        private final Iterator<String> fileNames;
-
-        StoreSnapshot( SnapshotDeletionPolicy deletionPolicy ) throws IOException
-        {
-            this.deletionPolicy = deletionPolicy;
-            this.commit = deletionPolicy.snapshot( ID );
-            this.fileNames = commit.getFileNames().iterator();
-        }
-
-        @Override
-        protected File fetchNextOrNull()
-        {
-            if ( !fileNames.hasNext() )
-            {
-                return null;
-            }
-            return new File( directoryLocation, fileNames.next() );
-        }
-
-        @Override
-        public void close()
-        {
-            try
-            {
-                deletionPolicy.release( ID );
-            }
-            catch ( IOException e )
-            {
-                // TODO What to do here?
-                throw new RuntimeException( "Unable to close lucene index snapshot", e );
-            }
-        }
+        return new LuceneStoreSnapshot( directoryLocation, deletionPolicy );
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneStoreSnapshot.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneStoreSnapshot.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
+
+class LuceneStoreSnapshot extends PrefetchingIterator<File> implements ResourceIterator<File>
+{
+    private final static String ID = "backup";
+    public static final String NO_INDEX_COMMIT_TO_SNAPSHOT = "No index commit to snapshot";
+    private final File indexDirectory;
+    private final SnapshotDeletionPolicy deletionPolicy;
+    private IndexCommit commit;
+    private Iterator<String> fileNames;
+
+    LuceneStoreSnapshot( File indexDirectory, SnapshotDeletionPolicy deletionPolicy ) throws IOException
+    {
+        this.indexDirectory = indexDirectory;
+        this.deletionPolicy = deletionPolicy;
+
+        attemptSnapshotAndListFilenames();
+    }
+
+    private void attemptSnapshotAndListFilenames() throws IOException
+    {
+        try
+        {
+            this.commit = deletionPolicy.snapshot( ID );
+            this.fileNames = commit.getFileNames().iterator();
+        }
+        catch(IllegalStateException e)
+        {
+            if(e.getMessage().equals( NO_INDEX_COMMIT_TO_SNAPSHOT ))
+            {
+                // Nothing in the index yet
+                this.commit = null;
+                this.fileNames = emptyIterator();
+            }
+            else
+            {
+                throw new IllegalStateException( e );
+            }
+        }
+    }
+
+    @Override
+    protected File fetchNextOrNull()
+    {
+        if ( !fileNames.hasNext() )
+        {
+            return null;
+        }
+        return new File( indexDirectory, fileNames.next() );
+    }
+
+    @Override
+    public void close()
+    {
+        try
+        {
+            deletionPolicy.release( ID );
+        }
+        catch ( IOException e )
+        {
+            // TODO What to do here?
+            throw new RuntimeException( "Unable to close lucene index snapshot", e );
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -34,9 +33,7 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 
 import static java.util.Arrays.asList;
-
-import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
@@ -122,7 +119,7 @@ public class LuceneIndexAccessorTest
         assertEquals( asSet( nodeId2 ), asUniqueSet( reader.lookup( value ) ) );
         reader.close();
     }
-    
+
     private final long nodeId = 1, nodeId2 = 2;
     private final Object value = "value", value2 = 40;
     private final LuceneDocumentStructure documentLogic = new LuceneDocumentStructure();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.test.TargetDirectory;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
+import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+
+public class LuceneIndexIT
+{
+    @Test
+    public void shouldProvideStoreSnapshot() throws Exception
+    {
+        // Given
+        updateAndCommit( asList(
+                add( nodeId, value ),
+                add( nodeId2, value ) ) );
+        accessor.force();
+
+        // When & Then
+        assertThat( asUniqueSetOfNames( accessor.snapshotFiles() ), equalTo( asSet(
+                "_0.nrm",
+                "_0.tis",
+                "_0.fnm",
+                "_0.tii",
+                "segments_1",
+                "_0.frq",
+                "_0.fdx",
+                "_0.fdt" ) ) );
+    }
+
+    @Test
+    public void shouldProvideStoreSnapshotWhenThereAreNoCommits() throws Exception
+    {
+        // Given
+        // A completely un-used index
+
+        // When & Then
+        assertThat( asUniqueSetOfNames( accessor.snapshotFiles() ), equalTo( emptySetOf( String.class ) ) );
+    }
+
+    private Set<String> asUniqueSetOfNames( ResourceIterator<File> files )
+    {
+        ArrayList<String> out = new ArrayList<>();
+        while(files.hasNext())
+            out.add( files.next().getName() );
+        return asUniqueSet( out );
+    }
+
+    private final long nodeId = 1, nodeId2 = 2;
+    private final Object value = "value";
+    private final LuceneDocumentStructure documentLogic = new LuceneDocumentStructure();
+    private final IndexWriterStatus writerLogic = new IndexWriterStatus();
+    private LuceneIndexAccessor accessor;
+    private DirectoryFactory dirFactory;
+
+    @Rule
+    public TargetDirectory.TestDirectory testDir = TargetDirectory.cleanTestDirForTest( getClass() );
+
+    @Before
+    public void before() throws Exception
+    {
+        dirFactory = DirectoryFactory.PERSISTENT;
+        accessor = new NonUniqueLuceneIndexAccessor( documentLogic, standard(), writerLogic, dirFactory, testDir.directory() );
+    }
+
+    @After
+    public void after()
+    {
+        dirFactory.close();
+    }
+
+    private NodePropertyUpdate add( long nodeId, Object value )
+    {
+        return NodePropertyUpdate.add( nodeId, 0, value, new long[0] );
+    }
+
+    private void updateAndCommit( List<NodePropertyUpdate> nodePropertyUpdates )
+            throws IOException, IndexEntryConflictException
+    {
+        try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
+        {
+            for ( NodePropertyUpdate update : nodePropertyUpdates )
+            {
+                updater.process( update );
+            }
+        }
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ToFileStoreWriter.java
@@ -42,6 +42,7 @@ public class ToFileStoreWriter implements StoreWriter
         {
             temporaryBuffer.clear();
             File file = new File( basePath, path );
+
             RandomAccessFile randomAccessFile = null;
             try
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityConsoleLogger.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighAvailabilityConsoleLogger.java
@@ -188,6 +188,6 @@ public class HighAvailabilityConsoleLogger
 
     private String printId( InstanceId id )
     {
-        return id+(id.equals(myId)?" (this server) ":" ");
+        return id+(id != null && id.equals(myId)?" (this server) ":" ");
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -201,7 +201,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         // can server (possibly quite outdated) read requests.
         if (!accessGuard.await( stateSwitchTimeoutMillis ))
         {
-            throw new TransactionFailureException( "Timeout waiting for cluster to elect master" );
+            throw new TransactionFailureException( "Timeout waiting to join cluster, or for cluster to elect master" );
         }
 
         return super.beginTx( forceMode );
@@ -436,7 +436,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         idGeneratorFactory = new HaIdGeneratorFactory( master, logging );
         highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher( masterDelegateInvocationHandler,
                 clusterMemberAvailability, memberStateMachine, this, (HaIdGeneratorFactory) idGeneratorFactory,
-                config, logging, updateableSchemaState );
+                config, logging, updateableSchemaState, kernelExtensions.listFactories() );
         /*
          * We always need the mode switcher and we need it to restart on switchover. So:
          * 1) if in compatibility mode, it must be added in all 3 - to start on start and restart on switchover

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveStoreWriter.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveStoreWriter.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -40,6 +38,7 @@ import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
@@ -48,18 +47,22 @@ import org.neo4j.kernel.impl.util.FileUtils;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.ConsoleLogger;
 
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+
 public class SlaveStoreWriter
 {
     public static final String COPY_FROM_MASTER_TEMP = "temp-copy";
     private final Config config;
+    private final Iterable<KernelExtensionFactory<?>> kernelExtensions;
     private final ConsoleLogger console;
 
     // TODO Should be accepted as a dependency
     private final FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
 
-    public SlaveStoreWriter( Config config, ConsoleLogger console )
+    public SlaveStoreWriter( Config config, Iterable<KernelExtensionFactory<?>> kernelExtensions, ConsoleLogger console )
     {
         this.config = config;
+        this.kernelExtensions = kernelExtensions;
         this.console = console;
     }
 
@@ -84,13 +87,16 @@ public class SlaveStoreWriter
         {
             NeoStore.setVersion( fileSystem, tempStore, highestLogVersion + 1 );
         }
-        GraphDatabaseAPI copiedDb = (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(
-                tempStore.getAbsolutePath() ).setConfig(
-                GraphDatabaseSettings.keep_logical_logs, Settings.TRUE ).setConfig(
-                GraphDatabaseSettings.allow_store_upgrade,
-                config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() ).
 
-                newGraphDatabase();
+        GraphDatabaseAPI copiedDb = (GraphDatabaseAPI) new GraphDatabaseFactory()
+                .setKernelExtensions( kernelExtensions )
+                .newEmbeddedDatabaseBuilder(tempStore.getAbsolutePath() )
+                .setConfig(
+                    GraphDatabaseSettings.keep_logical_logs, Settings.TRUE ).setConfig(
+                    GraphDatabaseSettings.allow_store_upgrade,
+                    config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
+
+                .newGraphDatabase();
 
         // Apply pending transactions
         try

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -28,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -39,31 +39,33 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema.IndexState;
+import org.neo4j.kernel.api.impl.index.DirectoryFactory;
+import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProvider;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.ha.UpdatePuller;
-import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
+import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.DoubleLatch;
+import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.ha.ClusterRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
-import static org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper.singleInstanceSchemaIndexProviderFactory;
+import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
 import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
@@ -141,6 +143,137 @@ public class SchemaIndexHaIT
             awaitIndexOnline( index, newMaster, data );
             tx.success();
         }
+    }
+
+    @Test
+    public void populatingSchemaIndicesOnMasterShouldBeBroughtOnlineOnSlavesAfterStoreCopy() throws Throwable
+    {
+        /*
+        The master has an index that is currently populating.
+        Then a slave comes online and contacts the master to get copies of the store files.
+        Because the index is still populating, it won't be copied. Instead the slave will build its own.
+        We want to observe that the slave builds an index that eventually comes online.
+         */
+
+        // GIVEN
+        ControlledGraphDatabaseFactory dbFactory = new ControlledGraphDatabaseFactory(
+        );
+
+        ManagedCluster cluster = clusterRule.startCluster( dbFactory );
+        cluster.await( allSeesAllAsAvailable() );
+
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+
+        // All slaves in the cluster, except the one I care about, proceed as normal
+        dontBlockIndexPopulationOnAllSlavesExcept( dbFactory, cluster, slave );
+
+        // A slave is offline, and has no store files
+        ClusterManager.RepairKit slaveDown = bringSlaveOfflineAndRemoveStoreFiles( cluster, slave );
+
+        // And I create an index on the master, and wait for population to start
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        Map<Object, Node> data = createSomeData(master);
+        createIndex( master );
+        dbFactory.awaitPopulationStarted( master );
+
+
+        // WHEN the slave comes online before population has finished on the master
+        slave = slaveDown.repair();
+        cluster.await( allSeesAllAsAvailable() );
+        cluster.sync();
+
+
+        // THEN, population should finish successfully on both master and slave
+        dbFactory.triggerFinish( master );
+        dbFactory.triggerFinish( slave );
+
+        // Check master
+        IndexDefinition index = null;
+        try ( Transaction tx = master.beginTx())
+        {
+            index = single( master.schema().getIndexes() );
+            awaitIndexOnline( index, master, data );
+            tx.success();
+        }
+
+        // Check slave
+        try ( Transaction tx = slave.beginTx() )
+        {
+            awaitIndexOnline( index, slave, data );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void onlineSchemaIndicesOnMasterShouldBeBroughtOnlineOnSlavesAfterStoreCopy() throws Throwable
+    {
+        /*
+        The master has an index that is online.
+        Then a slave comes online and contacts the master to get copies of the store files.
+        Because the index is online, it should be copied, and the slave should successfully bring the index online.
+         */
+
+        // GIVEN
+        ControlledGraphDatabaseFactory dbFactory = new ControlledGraphDatabaseFactory(
+        );
+
+        ManagedCluster cluster = clusterRule.startCluster( dbFactory );
+        cluster.await( allSeesAllAsAvailable() );
+
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+
+        // All slaves in the cluster, except the one I care about, proceed as normal
+        dontBlockIndexPopulationOnAllSlavesExcept( dbFactory, cluster, slave );
+
+        // A slave is offline, and has no store files
+        ClusterManager.RepairKit slaveDown = bringSlaveOfflineAndRemoveStoreFiles( cluster, slave );
+
+        // And I create an index on the master, and wait for population to start
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        Map<Object, Node> data = createSomeData(master);
+        createIndex( master );
+        dbFactory.awaitPopulationStarted( master );
+
+        // And the population finishes
+        dbFactory.triggerFinish( master );
+        IndexDefinition index = null;
+        try ( Transaction tx = master.beginTx())
+        {
+            index = single( master.schema().getIndexes() );
+            awaitIndexOnline( index, master, data );
+            tx.success();
+        }
+
+
+        // WHEN the slave comes online after population has finished on the master
+        slave = slaveDown.repair();
+        cluster.await( allSeesAllAsAvailable() );
+        cluster.sync();
+
+
+        // THEN the index should work on the slave
+        dbFactory.triggerFinish( slave );
+        try ( Transaction tx = slave.beginTx() )
+        {
+            awaitIndexOnline( index, slave, data );
+            tx.success();
+        }
+    }
+
+    private void dontBlockIndexPopulationOnAllSlavesExcept( ControlledGraphDatabaseFactory dbFactory, ManagedCluster cluster, HighlyAvailableGraphDatabase slave )
+    {
+        HighlyAvailableGraphDatabase irrelevantSlave = cluster.getAnySlave(slave);
+        dbFactory.triggerFinish( irrelevantSlave );
+    }
+
+    private ClusterManager.RepairKit bringSlaveOfflineAndRemoveStoreFiles( ManagedCluster cluster, HighlyAvailableGraphDatabase slave ) throws IOException
+    {
+        ClusterManager.RepairKit slaveDown = cluster.shutdown(slave);
+
+        File storeDir = new File( slave.getStoreDir() );
+        deleteRecursively( storeDir );
+        storeDir.mkdir();
+        return slaveDown;
     }
 
     @Rule
@@ -242,30 +375,54 @@ public class SchemaIndexHaIT
         }
     }
     
-    private static class ControlledIndexPopulator extends IndexPopulator.Adapter
+    private static class ControlledIndexPopulator implements IndexPopulator
     {
         private final DoubleLatch latch;
-        private final IndexPopulator inMemoryDelegate;
+        private final IndexPopulator delegate;
 
-        public ControlledIndexPopulator( IndexPopulator inMemoryDelegate, DoubleLatch latch )
+        public ControlledIndexPopulator( IndexPopulator delegate, DoubleLatch latch )
         {
-            this.inMemoryDelegate = inMemoryDelegate;
+            this.delegate = delegate;
             this.latch = latch;
+        }
+
+        @Override
+        public void create() throws IOException
+        {
+            delegate.create();
+        }
+
+        @Override
+        public void drop() throws IOException
+        {
+            delegate.drop();
         }
 
         @Override
         public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
         {
-            inMemoryDelegate.add( nodeId, propertyValue );
+            delegate.add(nodeId, propertyValue);
             latch.startAndAwaitFinish();
         }
-        
+
+        @Override
+        public IndexUpdater newPopulatingUpdater() throws IOException
+        {
+            return delegate.newPopulatingUpdater();
+        }
+
         @Override
         public void close( boolean populationCompletedSuccessfully ) throws IOException
         {
-            inMemoryDelegate.close( populationCompletedSuccessfully );
-            assertTrue( populationCompletedSuccessfully );
+            delegate.close(populationCompletedSuccessfully);
+            assertTrue( "Expected population to succeed :(", populationCompletedSuccessfully );
             latch.finish();
+        }
+
+        @Override
+        public void markAsFailed( String failure ) throws IOException
+        {
+            delegate.markAsFailed( failure );
         }
     }
 
@@ -275,79 +432,95 @@ public class SchemaIndexHaIT
 
     private static class ControlledSchemaIndexProvider extends SchemaIndexProvider
     {
-        private final SchemaIndexProvider inMemoryDelegate = new InMemoryIndexProvider();
+        private final SchemaIndexProvider delegate;
         private final DoubleLatch latch = new DoubleLatch();
         
-        public ControlledSchemaIndexProvider()
+        public ControlledSchemaIndexProvider(SchemaIndexProvider delegate)
         {
             super( CONTROLLED_PROVIDER_DESCRIPTOR, 100 /*we want it to always win*/ );
+            this.delegate = delegate;
         }
         
         @Override
         public IndexPopulator getPopulator( long indexId, IndexConfiguration config )
         {
-            return new ControlledIndexPopulator( inMemoryDelegate.getPopulator( indexId, config ), latch );
+            return new ControlledIndexPopulator( delegate.getPopulator( indexId, config ), latch );
         }
 
         @Override
         public IndexAccessor getOnlineAccessor( long indexId, IndexConfiguration config ) throws IOException
         {
-            return inMemoryDelegate.getOnlineAccessor( indexId, config );
+            return delegate.getOnlineAccessor(indexId, config);
         }
 
         @Override
         public InternalIndexState getInitialState( long indexId )
         {
-            return inMemoryDelegate.getInitialState( indexId );
+            return delegate.getInitialState(indexId);
         }
 
         @Override
         public String getPopulationFailure( long indexId ) throws IllegalStateException
         {
-            return inMemoryDelegate.getPopulationFailure( indexId );
+            return delegate.getPopulationFailure( indexId );
+        }
+    }
+
+    interface IndexProviderDependencies
+    {
+        GraphDatabaseService db();
+        Config config();
+    }
+
+    public static class ControllingIndexProviderFactory extends KernelExtensionFactory<IndexProviderDependencies>
+    {
+
+        private final Map<GraphDatabaseService, SchemaIndexProvider> perDbIndexProvider;
+
+        public ControllingIndexProviderFactory( Map<GraphDatabaseService, SchemaIndexProvider> perDbIndexProvider )
+        {
+            super( CONTROLLED_PROVIDER_DESCRIPTOR.getKey() );
+            this.perDbIndexProvider = perDbIndexProvider;
+        }
+
+        @Override
+        public Lifecycle newKernelExtension( SchemaIndexHaIT.IndexProviderDependencies deps ) throws Throwable
+        {
+
+            ControlledSchemaIndexProvider provider = new ControlledSchemaIndexProvider(
+                    new LuceneSchemaIndexProvider( DirectoryFactory.PERSISTENT, deps.config() ) );
+            perDbIndexProvider.put( deps.db(), provider );
+            return provider;
         }
     }
 
     private static class ControlledGraphDatabaseFactory extends HighlyAvailableGraphDatabaseFactory
     {
-        final Map<GraphDatabaseService,ControlledSchemaIndexProvider> perDbIndexProvider = new ConcurrentHashMap<>();
-        
-        @Override
-        public GraphDatabaseBuilder newHighlyAvailableDatabaseBuilder( String path )
+        final Map<GraphDatabaseService,SchemaIndexProvider> perDbIndexProvider = new ConcurrentHashMap<>();
+        private final KernelExtensionFactory<?> factory;
+
+        public ControlledGraphDatabaseFactory()
         {
-            ControlledSchemaIndexProvider provider = new ControlledSchemaIndexProvider();
-            KernelExtensionFactory<?> factory = singleInstanceSchemaIndexProviderFactory( "controlled", provider );
+            factory = new ControllingIndexProviderFactory(perDbIndexProvider);
+        }
+
+        @Override
+        public GraphDatabaseBuilder newHighlyAvailableDatabaseBuilder(String path)
+        {
             getCurrentState().addKernelExtensions( Arrays.<KernelExtensionFactory<?>>asList( factory ) );
-            return dbReferenceCapturingBuilder( perDbIndexProvider, provider,
-                    super.newHighlyAvailableDatabaseBuilder( path ) );
+            return super.newHighlyAvailableDatabaseBuilder( path );
         }
         
         void awaitPopulationStarted( GraphDatabaseService db )
         {
-            DoubleLatch latch = perDbIndexProvider.get( db ).latch;
+            DoubleLatch latch = ((ControlledSchemaIndexProvider)perDbIndexProvider.get( db )).latch;
             latch.awaitStart();
         }
 
         void triggerFinish( GraphDatabaseService db )
         {
-            ControlledSchemaIndexProvider provider = perDbIndexProvider.get( db );
+            ControlledSchemaIndexProvider provider = (ControlledSchemaIndexProvider) perDbIndexProvider.get( db );
             provider.latch.finish();
         }
-    }
-    
-    protected static GraphDatabaseBuilder dbReferenceCapturingBuilder(
-            final Map<GraphDatabaseService, ControlledSchemaIndexProvider> perDbIndexProvider,
-            final ControlledSchemaIndexProvider provider, GraphDatabaseBuilder actual )
-    {
-        return new GraphDatabaseBuilder.Delegator( actual )
-        {
-            @Override
-            public GraphDatabaseService newGraphDatabase()
-            {
-                GraphDatabaseService db = super.newGraphDatabase();
-                perDbIndexProvider.put( db, provider );
-                return db;
-            }
-        };
     }
  }

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -20,7 +20,6 @@
 package org.neo4j.test.ha;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.rules.ExternalResource;
@@ -60,14 +59,14 @@ public class ClusterRule extends ExternalResource
         return startCluster( databaseFactory, stringMap() );
     }
 
-    public ClusterManager.ManagedCluster startCluster( HighlyAvailableGraphDatabaseFactory databaseFactory, Map<String, String> config )
-            throws Exception
+    public ClusterManager.ManagedCluster startCluster( HighlyAvailableGraphDatabaseFactory databaseFactory,
+                                                       Map<String, String> config ) throws Exception
     {
         config.putAll(stringMap(
                 default_timeout.name(), "1s",
-                tx_push_factor.name(), "0" ));
-        clusterManager = new ClusterManager( provider, storeDirectory,
-                config, new HashMap<Integer, Map<String,String>>(), databaseFactory );
+                tx_push_factor.name(), "0"));
+        clusterManager = new ClusterManager.Builder( storeDirectory )
+                .withDbFactory(databaseFactory).build();
         try
         {
             clusterManager.start();

--- a/enterprise/ha/src/test/java/slavetest/TestStoreCopy.java
+++ b/enterprise/ha/src/test/java/slavetest/TestStoreCopy.java
@@ -171,8 +171,7 @@ public class TestStoreCopy extends AbstractClusterTest
 
     private void assertNodeAndIndexingExists( HighlyAvailableGraphDatabase db, long nodeId, String key, Object value )
     {
-        Transaction transaction = db.beginTx();
-        try
+        try (Transaction tx = db.beginTx())
         {
             Node node = db.getNodeById( nodeId );
             assertEquals( "Property '" + key + "'='" + value + "' mismatch on " + node + " for " + db,
@@ -180,10 +179,6 @@ public class TestStoreCopy extends AbstractClusterTest
             assertTrue( "Index '" + key + "' not found for " + db, db.index().existsForNodes( key ) );
             assertEquals( "Index '" + key + "'='" + value + "' mismatch on " + node + " for " + db,
                     node, db.index().forNodes( key ).get( key, value ).getSingle() );
-        }
-        finally
-        {
-            transaction.finish();
         }
     }
 }


### PR DESCRIPTION
o Indexes are now included in the file listing for files to copy in HA and backup.
o Refactored out the logic for listing store files into its own class, and added tests for that.
o Don't copy populating indices in HA
o Integration tests for multiple use cases related to this.
