### PR TITLE
Performance optimizations for best-first selector

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
@@ -19,10 +19,8 @@
  */
 package org.neo4j.graphalgo.impl.util;
 
-import static org.neo4j.kernel.StandardExpander.toPathExpander;
-
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.neo4j.graphalgo.impl.util.PriorityMap.Converter;
 import org.neo4j.graphalgo.impl.util.PriorityMap.Entry;
@@ -33,30 +31,78 @@ import org.neo4j.graphdb.traversal.BranchOrderingPolicy;
 import org.neo4j.graphdb.traversal.BranchSelector;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
+import org.neo4j.helpers.Function2;
+
+import static org.neo4j.kernel.StandardExpander.toPathExpander;
 
 public abstract class BestFirstSelectorFactory<P extends Comparable<P>, D>
         implements BranchOrderingPolicy
 {
+    private final Function2<Visit<P>, P, Boolean> interestPredicate;
+
+    public BestFirstSelectorFactory( boolean forMultiplePaths )
+    {
+        // If we are interested in multiple paths then we must keep around branches that have the same
+        // cost to any same end node, but if we're only interested in a single path then we can skip
+        // branches that have the same cost to any given end node and only keep one of the lowest cost branches.
+        this.interestPredicate = forMultiplePaths ?
+                new Function2<Visit<P>,P,Boolean>()
+                {
+                    @Override
+                    public Boolean apply( Visit<P> from1, P from2 )
+                    {
+                        return from1.compareTo( from2 ) >= 0;
+                    }
+                }
+                :
+                new Function2<Visit<P>,P,Boolean>()
+                {
+                    @Override
+                    public Boolean apply( Visit<P> from1, P from2 )
+                    {
+                        return from1.compareTo( from2 ) > 0;
+                    }
+                };
+    }
+
+    @Override
     public BranchSelector create( TraversalBranch startSource, PathExpander expander )
     {
         return new BestFirstSelector( startSource, getStartData(), expander );
     }
-    
+
     public BranchSelector create( TraversalBranch startSource, RelationshipExpander expander )
     {
         return new BestFirstSelector( startSource, getStartData(), toPathExpander( expander ) );
     }
-    
+
     protected abstract P getStartData();
+
+    private static class Visit<P extends Comparable<P>> implements Comparable<P>
+    {
+        private P cost;
+        private boolean visited;
+
+        public Visit( P cost )
+        {
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo( P o )
+        {
+            return cost.compareTo( o );
+        }
+    }
 
     public final class BestFirstSelector implements BranchSelector
     {
-        private PriorityMap<TraversalBranch, Node, P> queue =
+        private final PriorityMap<TraversalBranch, Node, P> queue =
                 PriorityMap.withNaturalOrder( CONVERTER );
         private TraversalBranch current;
         private P currentAggregatedValue;
-        private final Set<Long> visitedNodes = new HashSet<Long>();
         private final PathExpander expander;
+        private final Map<Long, Visit<P>> visits = new HashMap<Long, Visit<P>>();
 
         public BestFirstSelector( TraversalBranch source, P startData, PathExpander expander )
         {
@@ -65,34 +111,47 @@ public abstract class BestFirstSelectorFactory<P extends Comparable<P>, D>
             this.expander = expander;
         }
 
+        @Override
         public TraversalBranch next( TraversalContext metadata )
         {
             // Exhaust current if not already exhausted
             while ( true )
             {
                 TraversalBranch next = current.next( expander, metadata );
-                if ( next != null )
-                {
-                    if ( !visitedNodes.contains( next.endNode().getId() ) )
-                    {
-                        P newPriority = addPriority( next, currentAggregatedValue,
-                                calculateValue( next ) );
-                        queue.put( next, newPriority );
-                    }
-                }
-                else
+                if ( next == null )
                 {
                     break;
                 }
+
+                long endNodeId = next.endNode().getId();
+                Visit<P> stay = visits.get( endNodeId );
+                if ( stay == null || !stay.visited )
+                {
+                    D cost = calculateValue( next );
+                    P newPriority = addPriority( next, currentAggregatedValue, cost );
+
+                    boolean newStay = stay == null;
+                    if ( newStay )
+                    {
+                        stay = new Visit<P>( newPriority );
+                        visits.put( endNodeId, stay );
+                    }
+                    if ( newStay || interestPredicate.apply( stay, newPriority ) )
+                    {   // If the priority map already contains a traversal branch with this end node with
+                        // a lower cost, then don't bother adding it to the priority map
+                        queue.put( next, newPriority );
+                        stay.cost = newPriority;
+                    }
+                }
             }
-            
+
             // Pop the top from priorityMap
             Entry<TraversalBranch, P> entry = queue.pop();
             if ( entry != null )
             {
                 current = entry.getEntity();
                 currentAggregatedValue = entry.getPriority();
-                visitedNodes.add( current.endNode().getId() );
+                visits.get( current.endNode().getId() ).visited = true;
                 return current;
             }
             return null;
@@ -101,12 +160,13 @@ public abstract class BestFirstSelectorFactory<P extends Comparable<P>, D>
 
     protected abstract P addPriority( TraversalBranch source,
             P currentAggregatedValue, D value );
-    
+
     protected abstract D calculateValue( TraversalBranch next );
-    
+
     public static final Converter<Node, TraversalBranch> CONVERTER =
             new Converter<Node, TraversalBranch>()
     {
+        @Override
         public Node convert( TraversalBranch source )
         {
             return source.endNode();

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/PathExplosionIT.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/PathExplosionIT.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphalgo.path;
+
+import java.io.IOException;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphalgo.CostEvaluator;
+import org.neo4j.graphalgo.EstimateEvaluator;
+import org.neo4j.graphalgo.GraphAlgoFactory;
+import org.neo4j.graphalgo.PathFinder;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.util.FileUtils;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.lang.System.currentTimeMillis;
+
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.helpers.collection.Iterables.toList;
+import static org.neo4j.kernel.Traversal.pathExpanderForAllTypes;
+
+@Ignore( "Not a test, merely a performance measurement. Convert into a proper performance benchmark at some point" )
+public class PathExplosionIT
+{
+    private static final boolean FIND_MULTIPLE_PATHS = false;
+    private static final int MIN_PATH_LENGTH = 2;
+    private static final int MAX_PATH_LENGTH = 10;
+    private static final int MIN_PATH_WIDTH = 2;
+    private static final int MAX_PATH_WIDTH = 6;
+    private static final int WARMUP_RUNS = 2;
+    private static final long TOLERATED_DURATION = 10000;
+    
+    @Test
+    public void aStarShouldFinishWithinToleratedDuration() throws IOException
+    {
+        assertPathFinderCompletesWithinToleratedDuration( TOLERATED_DURATION,
+                GraphAlgoFactory.aStar( expander, constantEvaluator, estimateEvaluator ) );
+    }
+
+    @Test
+    public void dijkstraShouldFinishWithinToleratedDuration() throws IOException
+    {
+        assertPathFinderCompletesWithinToleratedDuration( TOLERATED_DURATION,
+                GraphAlgoFactory.dijkstra( expander, constantEvaluator ) );
+    }
+
+    @Test
+    public void shortestPathShouldFinishWithinToleratedDuration() throws IOException
+    {
+        assertPathFinderCompletesWithinToleratedDuration( TOLERATED_DURATION,
+                GraphAlgoFactory.shortestPath( expander, Integer.MAX_VALUE ) );
+    }
+
+    @Rule
+    public TargetDirectory.TestDirectory testDir = TargetDirectory.testDirForTest( getClass() );
+
+    void assertPathFinderCompletesWithinToleratedDuration( long toleratedRuntime, PathFinder<? extends Path> pathFinder )
+            throws IOException
+    {
+        for ( int pathWidth = MIN_PATH_WIDTH; pathWidth <= MAX_PATH_WIDTH; pathWidth++ )
+        {
+            for ( int pathLength = MIN_PATH_LENGTH; pathLength <= MAX_PATH_LENGTH; pathLength++ )
+            {
+                FileUtils.deleteRecursively( testDir.directory() );
+                GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+                try
+                {
+                    long[] startEndNodeIds = createPathGraphAndReturnStartAndEnd( pathLength, pathWidth, db );
+                    long runTime = findPath( startEndNodeIds[0], startEndNodeIds[1], db, pathFinder, WARMUP_RUNS );
+                    System.out.println( String.format( "Runtime[pathWidth:%s, pathLength:%s] = %s", pathWidth, pathLength,
+                            runTime ) );
+                    assertTrue( runTime < toleratedRuntime );
+                }
+                finally
+                {
+                    db.shutdown();
+                }
+            }
+        }
+    }
+
+    long findPath( long startId, long endId, GraphDatabaseService db, PathFinder<? extends Path> pathFinder,
+                   int warmUpRuns )
+    {
+        long runTime = -1;
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node startNode = db.getNodeById( startId );
+            Node endNode = db.getNodeById( endId );
+            for ( int run = 0; run < warmUpRuns; run++ )
+            {
+                runPathOnce( startNode, endNode, db, pathFinder );
+            }
+            runTime = runPathOnce( startNode, endNode, db, pathFinder );
+            tx.success();
+        }
+        catch ( Exception e )
+        {
+            tx.failure();
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            tx.finish();
+        }
+        return runTime;
+    }
+
+    long runPathOnce( Node startNode, Node endNode, GraphDatabaseService db, PathFinder<? extends Path> pathFinder )
+    {
+        long startTime = currentTimeMillis();
+        
+        Path path = FIND_MULTIPLE_PATHS ?
+                // call findAllPaths, but just grab the first one
+                toList( pathFinder.findAllPaths( startNode, endNode ) ).get( 0 ) :
+                // call findinglePath
+                pathFinder.findSinglePath( startNode, endNode );
+
+        // iterate through the path
+        count( path );
+        
+        return currentTimeMillis() - startTime;
+    }
+
+    long[] createPathGraphAndReturnStartAndEnd( int length, int width, GraphDatabaseService db )
+    {
+        long startId = -1;
+        long endId = -1;
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node startNode = null;
+            Node endNode = db.createNode();
+            startId = endNode.getId();
+            for ( int l = 0; l < length; l++ )
+            {
+                startNode = endNode;
+                endNode = db.createNode();
+                for ( int w = 0; w < width; w++ )
+                {
+                    startNode.createRelationshipTo( endNode, RelTypes.SomeRelType );
+                }
+            }
+            endId = endNode.getId();
+            tx.success();
+        }
+        finally
+        {
+            tx.finish();
+        }
+        return new long[] { startId, endId };
+    }
+
+    private enum RelTypes implements RelationshipType
+    {
+        SomeRelType
+    }
+    
+    private final PathExpander<?> expander = pathExpanderForAllTypes( Direction.BOTH );
+    private final CostEvaluator<Double> constantEvaluator = new CostEvaluator<Double>()
+    {
+        @Override
+        public Double getCost( Relationship relationship, Direction direction )
+        {
+            return 1D;
+        }
+    };
+    private final EstimateEvaluator<Double> estimateEvaluator = new EstimateEvaluator<Double>()
+    {
+        @Override
+        public Double getCost( Node node, Node goal )
+        {
+            return 1D;
+        }
+    };
+}


### PR DESCRIPTION
Mostly revolving around finding single paths. This gives a good
improvement when calling PathFinder#findSinglePath for those graph
algorithms using the traversal framework and more specifically the
BestFirstSelector. Currently this will benefit Dijkstra and A_, although
the default implementation of A_ is a custom non-traversal-framework
version that only supports single paths anyways so already has got a
similar performance behaviour. Look at TraversalAStar for a A\* version
that uses the traversal framework.

Observed performance improvements of Dijkstra findSinglePath for graphs that saw performance problems previously is around two orders of magnitude, but depends on the graph layout.
