### PR TITLE
Fix for recovery of constraint indexes.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
@@ -87,7 +87,7 @@ import static org.neo4j.kernel.extension.KernelExtensionUtil.servicesClassPathEn
  *
  * <h3>Online operation</h3>
  *
- * Once the index is online, the database will move to using the {@link #getOnlineAccessor(long,IndexConfiguration) online accessor} to
+ * Once the index is online, the database will move to using the {@link #getOnlineAccessor(boolean, boolean) online accessor} to
  * write to the index.
  */
 public abstract class SchemaIndexProvider extends LifecycleAdapter implements Comparable<SchemaIndexProvider>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
@@ -20,10 +20,12 @@
 package org.neo4j.kernel.impl.nioneo.store;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.neo4j.kernel.impl.nioneo.store.labels.InlineNodeLabels.parseInlined;
 
 public class NodeRecord extends PrimitiveRecord
 {
@@ -94,7 +96,7 @@ public class NodeRecord extends PrimitiveRecord
                 .append( ",used=" ).append( inUse() )
                 .append( ",rel=" ).append( nextRel )
                 .append( ",prop=" ).append( getNextProp() )
-                .append( ",labels=" ).append( getLabelField() )
+                .append( ",labels=" ).append( Arrays.toString(parseInlined( getLabelField() )) )
                 .append( "," ).append( isLight ? "light" : "heavy" );
         if ( !isLight && !dynamicLabelRecords.isEmpty() )
         {
@@ -117,6 +119,7 @@ public class NodeRecord extends PrimitiveRecord
         clone.nextRel = nextRel;
         clone.labels = labels;
         clone.isLight = isLight;
+        clone.setInUse( inUse() );
 
         if( dynamicLabelRecords.size() > 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
@@ -118,7 +118,7 @@ public class InlineNodeLabels implements NodeLabels
         return true;
     }
 
-    private static long[] parseInlined( long labelField )
+    public static long[] parseInlined( long labelField )
     {
         byte numberOfLabels = labelCount( labelField );
         if ( numberOfLabels == 0 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
@@ -812,10 +812,16 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
             Collection<NodeLabelUpdate> labelUpdates = new ArrayList<>();
             gatherPropertyAndLabelUpdates( propertyUpdates, labelUpdates );
 
-            indexes.updateIndexes( propertyUpdates );
-            updateLabelScanStore( labelUpdates );
+            if(propertyUpdates.size() > 0)
+            {
+                indexes.updateIndexes( propertyUpdates );
+            }
 
-            cacheAccess.applyLabelUpdates( labelUpdates );
+            if(labelUpdates.size() > 0)
+            {
+                updateLabelScanStore( labelUpdates );
+                cacheAccess.applyLabelUpdates( labelUpdates );
+            }
 
             // schema rules. Execute these after generating the property updates so. If executed
             // before and we've got a transaction that sets properties/labels as well as creating an index

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/NodeRecordTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/NodeRecordTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+public class NodeRecordTest
+{
+
+    @Test
+    public void cloneShouldProduceExactCopy() throws Exception
+    {
+        // Given
+        long relId = 1337l;
+        long propId = 1338l;
+        long inlinedLabels = 12l;
+
+        NodeRecord node = new NodeRecord( 1l, relId, propId );
+        node.setLabelField( inlinedLabels, asList( new DynamicRecord( 1l ), new DynamicRecord( 2l ) ) );
+        node.setInUse( true );
+
+        // When
+        NodeRecord clone = node.clone();
+
+        // Then
+        assertEquals(node.inUse(), clone.inUse());
+        assertEquals(node.getLabelField(), clone.getLabelField());
+        assertEquals(node.getNextProp(), clone.getNextProp());
+        assertEquals(node.getNextRel(), clone.getNextRel());
+
+        assertThat( clone.getDynamicLabelRecords(), equalTo(node.getDynamicLabelRecords()) );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
@@ -26,20 +26,12 @@ import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
 
 public class EphemeralFileSystemRule extends ExternalResource
 {
-    private EphemeralFileSystemAbstraction fs;
-
-    @Override
-    protected void before() throws Throwable
-    {
-        super.before();
-        fs = new EphemeralFileSystemAbstraction();
-    }
+    private EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
 
     @Override
     protected void after()
     {
         fs.shutdown();
-        super.after();
     }
 
     public EphemeralFileSystemAbstraction get()

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
@@ -44,21 +44,15 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor implements UniquePro
     @Override
     public IndexUpdater newUpdater( final IndexUpdateMode mode ) throws IOException
     {
-        return new UniquePropertyIndexUpdater( this ) {
-
-            final IndexUpdater delegate = UniqueLuceneIndexAccessor.super.newUpdater( mode );
-
-            @Override
-            protected void flushUpdates( Iterable<NodePropertyUpdate> updates )
-                    throws IOException, IndexEntryConflictException
-            {
-                for ( NodePropertyUpdate update : updates )
-                {
-                    delegate.process( update );
-                    delegate.close();
-                }
-            }
-        };
+        if(mode != IndexUpdateMode.RECOVERY)
+        {
+            return new LuceneUniquePropertyIndexUpdater( super.newUpdater( mode ) );
+        }
+        else
+        {
+            /* If we are in recovery, don't handle the business logic of validating uniqueness. */
+            return super.newUpdater( mode );
+        }
     }
 
     public Long currentlyIndexedNode( Object value ) throws IOException
@@ -78,5 +72,57 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor implements UniquePro
             searcherManager.release( searcher );
         }
         return null;
+    }
+
+    /* The fact that this is here is a sign of a design error, and we should revisit and
+     * remove this later on. Specifically, this is here because the unique indexes do validation
+     * of uniqueness, which they really shouldn't be doing. In fact, they shouldn't exist, the unique
+     * indexes are just indexes, and the logic of how they are used is not the responsibility of the
+     * storage system to handle, that should go in the kernel layer.
+     *
+     * Anyway, where was I.. right: The kernel depends on the unique indexes to handle the business
+     * logic of verifying domain uniqueness, and if they did not do that, race conditions appear for
+     * index creation (not online operations, note) where concurrent violation of a currently created
+     * index may break uniqueness.
+     *
+     * Phew. So, unique indexes currently have to pick up the slack here. The problem is that while
+     * they serve the role of business logic execution, they also happen to be indexes, which is part
+     * of the storage layer. There is one golden rule in the storage layer, which must never ever be
+     * violated: Operations are idempotent. All operations against the storage layer have to be
+     * executable over and over and have the same result, this is the basis of data recovery and
+     * system consistency.
+     *
+     * Clearly, the uniqueness indexes don't do this, and so they fail in fulfilling their primary
+     * contract in order to pick up the slack for the kernel not fulfilling it's contract. We hack
+     * around this issue by tracking state - we know that probably the only time the idempotent
+     * requirement will be invoked is during recovery, and we know that by happenstance, recovery is
+     * single-threaded. As such, when we are in recovery, we turn off the business logic part and
+     * correctly fulfill our actual contract. As soon as the database is online, we flip back to
+     * running business logic in the storage layer and incorrectly implementing the storage layer
+     * contract.
+     *
+     * One day, we should fix this.
+     */
+    private class LuceneUniquePropertyIndexUpdater extends UniquePropertyIndexUpdater
+    {
+
+        final IndexUpdater delegate;
+
+        public LuceneUniquePropertyIndexUpdater( IndexUpdater delegate ) throws IOException
+        {
+            super( UniqueLuceneIndexAccessor.this );
+            this.delegate = delegate;
+        }
+
+        @Override
+        protected void flushUpdates( Iterable<NodePropertyUpdate> updates )
+                throws IOException, IndexEntryConflictException
+        {
+            for ( NodePropertyUpdate update : updates )
+            {
+                delegate.process( update );
+                delegate.close();
+            }
+        }
     }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -538,7 +538,7 @@ public class TestApps extends AbstractShellTest
         }
         catch ( ShellException e )
         {
-            assertThat( e.getStackTraceAsString(), containsString( "Node record Node[0,used=false,rel=0,prop=-1,labels=0,light] still has relationships" ) );
+            assertThat( e.getStackTraceAsString(), containsString( "Node record Node[0,used=false,rel=0,prop=-1,labels=[],light] still has relationships" ) );
         }
     }
 


### PR DESCRIPTION
o Constraint indexes do no longer verify uniqueness during recovery.
  They should not verify uniquneness at all, but that is a larger change.
o NodeRecord now correctly copies inUse flag for clone()
o NodeRecord now prints out the inlined labels it contains as a list, rather
  than as the long they are packed into.
