### PR TITLE
Fix a bug where PropertyRecords could get more than one PropertyBlock for a key

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
@@ -119,7 +119,9 @@ public class PropertyBlock implements Cloneable
 
     public void setValueBlocks( long[] blocks )
     {
-        assert ( blocks == null || blocks.length <= PropertyType.getPayloadSizeLongs() ) : ( "i was given an array of size " + blocks.length );
+        int expectedPayloadSize = PropertyType.getPayloadSizeLongs();
+        assert ( blocks == null || blocks.length <= expectedPayloadSize) : (
+                "I was given an array of size " + blocks.length +", but I wanted it to be " + expectedPayloadSize );
         this.valueBlocks = blocks;
         valueRecords.clear();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyRecord.java
@@ -133,27 +133,8 @@ public class PropertyRecord extends Abstract64BitRecord
 
     public void setPropertyBlock( PropertyBlock block )
     {
-        int index = getIndexOf( block );
-
-        if ( index != -1 )
-        {
-            removePropertyBlock( index );
-        }
-
+        removePropertyBlock( block.getKeyIndexId() );
         addPropertyBlock( block );
-    }
-
-    private int getIndexOf( PropertyBlock block )
-    {
-        for ( int i = 0; i < blockRecords.size(); i++ )
-        {
-            if ( blockRecords.get( i ).getKeyIndexId() == block.getKeyIndexId() )
-            {
-                return i;
-            }
-        }
-
-        return -1;
     }
 
     public PropertyBlock getPropertyBlock( int keyIndex )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PropertyRecordTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PropertyRecordTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class PropertyRecordTest
+{
+    @Test
+    public void addingDuplicatePropertyBlockShouldOverwriteExisting()
+    {
+        // Given these things...
+        PropertyRecord record = new PropertyRecord( 1 );
+        PropertyBlock blockA = new PropertyBlock();
+        blockA.setValueBlocks( new long[1] );
+        blockA.setKeyIndexId( 2 );
+        PropertyBlock blockB = new PropertyBlock();
+        blockB.setValueBlocks( new long[1] );
+        blockB.setKeyIndexId( 2 ); // also 2, thus a duplicate
+
+        // When we set the property block twice that have the same key
+        record.setPropertyBlock( blockA );
+        record.setPropertyBlock( blockB );
+
+        // Then the record should only contain a single block, because blockB overwrote blockA
+        List<PropertyBlock> propertyBlocks = record.getPropertyBlocks();
+        assertThat( propertyBlocks, hasItem( blockB ));
+        assertThat( propertyBlocks, hasSize( 1 ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -82,7 +81,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;


### PR DESCRIPTION
The problem was that setPropertyBlock did not properly remove the exising blocks that it found.
It did correctly find the existing blocks, by their index, but then tried to remove those blocks
by understanding their index as their key.

The fix is to use the index as an index and remove the blocks by that index.
