### PR TITLE
Quote javacmd

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -189,14 +189,14 @@ startit() {
     CONSOLE_LOG="$NEO4J_LOG/console.log"
 
     if [ $UID == 0 ] ; then
-      su $NEO4J_USER -c "$JAVACMD -cp '$CLASSPATH' $JAVA_OPTS \
+      su $NEO4J_USER -c "\"$JAVACMD\" -cp '$CLASSPATH' $JAVA_OPTS \
         -Dneo4j.home=\"${NEO4J_HOME}\" -Dneo4j.instance=\"${NEO4J_INSTANCE}\" \
         -Dfile.encoding=UTF-8 \
         org.neo4j.server.Bootstrapper >> \"${CONSOLE_LOG}\" 2>&1 & echo \$! > \"$PID_FILE\" "
     else
       checkwriteaccess
       echo "WARNING: not changing user"
-      $JAVACMD -cp "${CLASSPATH}" $JAVA_OPTS  \
+      "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS  \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
         -Dfile.encoding=UTF-8 \
         org.neo4j.server.Bootstrapper >> "${CONSOLE_LOG}" 2>&1 & echo $! > "${PID_FILE}"
@@ -273,7 +273,7 @@ console() {
 
     echo "Using additional JVM arguments: " $JAVA_OPTS
 
-    $JAVACMD -cp "${CLASSPATH}" $JAVA_OPTS \
+    "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
         -Dfile.encoding=UTF-8 \
         org.neo4j.server.Bootstrapper


### PR DESCRIPTION
Quoting JAVACMD so that people will be able to set a JAVA_HOME with spaces in it (e.g. the default JRE installation location on the Mac)
