### PR TITLE
Update Cypher test dependencies

### DIFF
--- a/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -235,7 +235,7 @@ class FunctionsTest extends DocumentingTestBase {
       text = """Returns all nodes in a path.""",
       queryText = """match p=a-->b-->c where a.name='Alice' and c.name='Eskil' return NODES(p)""",
       returns = """All the nodes in the path `p` are returned by the example query.""",
-      assertions = (p) => assert(List(node("A"), node("B"), node("E")) === p.columnAs[List[Node]]("NODES(p)").toList.head)
+      assertions = (p) => assert(List(node("A"), node("B"), node("E")) === p.columnAs[Seq[Node]]("NODES(p)").toList.head)
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
@@ -23,8 +23,10 @@ import org.junit.Test
 import collection.JavaConverters._
 import org.scalatest.Assertions
 import org.neo4j.graphdb.{Path, Node, Relationship}
+import org.scalautils.LegacyTripleEquals
 
-class CreateUniqueAcceptanceTest extends ExecutionEngineHelper with Assertions with StatisticsChecker {
+class CreateUniqueAcceptanceTest
+  extends ExecutionEngineHelper with Assertions with StatisticsChecker with LegacyTripleEquals {
 
   val stats = QueryStatistics()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -30,8 +30,9 @@ import util.Random
 import java.util.concurrent.TimeUnit
 import org.neo4j.cypher.internal.PathImpl
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
+import org.scalautils.LegacyTripleEquals
 
-class ExecutionEngineTest extends ExecutionEngineHelper with StatisticsChecker {
+class ExecutionEngineTest extends ExecutionEngineHelper with StatisticsChecker with LegacyTripleEquals {
 
   @Ignore
   @Test def assignToPathInsideForeachShouldWork() {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -26,8 +26,11 @@ import java.util.concurrent.TimeUnit
 import java.io.{FileOutputStream, File}
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.graphdb.GraphDatabaseService
+import org.scalautils.LegacyTripleEquals
 
-class IndexOpAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker with Assertions {
+class IndexOpAcceptanceTest extends ExecutionEngineHelper
+  with StatisticsChecker with Assertions with LegacyTripleEquals {
+
   @Test def createIndex() {
     // WHEN
     execute("CREATE INDEX ON :Person(name)")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LabelsAcceptanceTest.scala
@@ -24,8 +24,10 @@ import org.junit.Test
 import org.scalatest.Assertions
 import org.neo4j.test.ImpermanentGraphDatabase
 import org.neo4j.graphdb.Node
+import org.scalautils.LegacyTripleEquals
 
-class LabelsAcceptanceTest extends ExecutionEngineHelper with StatisticsChecker with Assertions with CollectionSupport {
+class LabelsAcceptanceTest extends ExecutionEngineHelper
+  with StatisticsChecker with Assertions with CollectionSupport with LegacyTripleEquals {
 
   @Test def Adding_single_literal_label() {
     assertThat("create (n {}) set n:FOO", List("FOO"))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeAcceptanceTest.scala
@@ -22,9 +22,10 @@ package org.neo4j.cypher
 import org.scalatest.Assertions
 import org.junit.Test
 import org.neo4j.graphdb.Node
+import org.scalautils.LegacyTripleEquals
 
 class MergeAcceptanceTest
-  extends ExecutionEngineHelper with Assertions with StatisticsChecker {
+  extends ExecutionEngineHelper with Assertions with StatisticsChecker with LegacyTripleEquals {
 
   @Test
   def merge_node_when_no_nodes_exist() {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -28,8 +28,10 @@ import org.neo4j.graphdb._
 import java.util.HashMap
 import org.neo4j.graphdb.Neo4jMatchers._
 import org.neo4j.tooling.GlobalGraphOperations
+import org.scalautils.LegacyTripleEquals
 
-class MutatingIntegrationTest extends ExecutionEngineHelper with Assertions with StatisticsChecker {
+class MutatingIntegrationTest extends ExecutionEngineHelper
+  with Assertions with StatisticsChecker with LegacyTripleEquals {
 
   val stats = QueryStatistics()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/CreateNodeActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/CreateNodeActionTest.scala
@@ -24,8 +24,9 @@ import org.scalatest.Assertions
 import org.neo4j.cypher.ExecutionEngineHelper
 import org.junit.Test
 import org.neo4j.cypher.internal.compiler.v2_0.mutation.CreateNode
+import org.scalautils.LegacyTripleEquals
 
-class CreateNodeActionTest extends ExecutionEngineHelper with Assertions {
+class CreateNodeActionTest extends ExecutionEngineHelper with Assertions with LegacyTripleEquals {
 
   @Test def mixed_types_are_not_ok() {
     val action = CreateNode("id", Map("*" -> Literal(Map("name" -> "Andres", "age" -> 37))), Seq.empty)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/MutationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/MutationTest.scala
@@ -28,8 +28,9 @@ import org.scalatest.Assertions
 import org.junit.Test
 import collection.mutable.{Map => MutableMap}
 import org.neo4j.cypher.internal.compiler.v2_0.pipes.{QueryState, ExecuteUpdateCommandsPipe, NullPipe}
+import org.scalautils.LegacyTripleEquals
 
-class MutationTest extends ExecutionEngineHelper with Assertions {
+class MutationTest extends ExecutionEngineHelper with Assertions with LegacyTripleEquals {
 
   def createQueryState = QueryStateHelper.queryStateFrom(graph)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/TrailDecomposeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/TrailDecomposeTest.scala
@@ -26,8 +26,9 @@ import org.neo4j.cypher.GraphDatabaseTestBase
 import org.junit.Test
 import org.neo4j.graphdb.Direction
 import org.scalatest.Assertions
+import org.scalautils.LegacyTripleEquals
 
-class TrailDecomposeTest extends GraphDatabaseTestBase with Assertions  {
+class TrailDecomposeTest extends GraphDatabaseTestBase with Assertions with LegacyTripleEquals {
   @Test def decompose_simple_path() {
     val nodeA = createNode("A")
     val nodeB = createNode("B")

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -43,6 +43,14 @@
     <module>cypher-docs</module>
   </modules>
 
+  <repositories>
+    <repository>
+      <id>oss.sonatype.org</id>
+      <name>releases</name>
+      <url>http://oss.sonatype.org/content/repositories/releases</url>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
 
@@ -181,6 +189,8 @@
       <artifactId>scala-library</artifactId>
     </dependency>
 
+    <!-- testing -->
+
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.10</artifactId>
@@ -192,10 +202,23 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <!-- testing -->
-
     <dependency>
+      <groupId>org.scalautils</groupId>
+      <artifactId>scalautils_2.10</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>scala-library</artifactId>
+          <groupId>org.scala-lang</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.scalacheck</groupId>
+      <artifactId>scalacheck_2.10</artifactId>
+      <scope>test</scope>
+    </dependency>
+   <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <exclusions>
@@ -234,10 +257,13 @@
         <artifactId>scala-library</artifactId>
         <version>${scala.version}</version>
       </dependency>
+
+      <!-- testing -->
+
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_2.10</artifactId>
-        <version>2.0.RC1-SNAP4</version>
+        <version>2.0</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -245,6 +271,24 @@
             <groupId>org.scala-lang</groupId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.scalautils</groupId>
+        <artifactId>scalautils_2.10</artifactId>
+        <version>2.0</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>scala-library</artifactId>
+            <groupId>org.scala-lang</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.scalacheck</groupId>
+        <artifactId>scalacheck_2.10</artifactId>
+        <version>1.11.0</version>
+        <scope>test</scope>
       </dependency>
 
       <!-- neo4j -->


### PR DESCRIPTION
o ScalaTest_2.10 2.0 has been released
o Add ScalaUtils_2.10 2.0 (=== operator now lives in separate artifact)
o Add ScalaCheck_2.10 1.11.0 (we want to work with it)
