### PR TITLE
Use tx diff to reclaim unused records.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+
+import org.junit.Test;
+import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
+import org.neo4j.kernel.impl.nioneo.store.NeoStoreRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.transaction.xaframework.LogBuffer;
+import org.neo4j.kernel.impl.transaction.xaframework.XaCommand;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.*;
+
+/**
+ * At any point, a power outage may stop us from writing to the log, which means that, at any point, all our commands
+ * need to be able to handl the log ending mid-way through reading it.
+ */
+public class LogTruncationTest
+{
+    InMemoryLogBuffer inMemoryBuffer = new InMemoryLogBuffer();
+
+    @Test
+    public void testSerializationInFaceOfLogTruncation() throws Exception
+    {
+        // TODO: add support for other commands and permutations as well...
+        assertHandlesLogTruncation( new Command.NodeCommand( null,
+                                                             new NodeRecord( 12l, 13l, 13l ),
+                                                             new NodeRecord( 0,0,0 ) ) );
+        assertHandlesLogTruncation( new Command.LabelTokenCommand( null, new LabelTokenRecord( 1 )) );
+
+        assertHandlesLogTruncation( new Command.NeoStoreCommand( null, new NeoStoreRecord() ) );
+//        assertHandlesLogTruncation( new Command.PropertyCommand( null,
+//                new PropertyRecord( 1, true, new NodeRecord(1, 12, 12, true) ),
+//                new PropertyRecord( 1, true, new NodeRecord(1, 12, 12, true) ) ) );
+    }
+
+    private void assertHandlesLogTruncation( XaCommand cmd ) throws IOException
+    {
+        inMemoryBuffer.reset();
+        cmd.writeToFile( inMemoryBuffer );
+
+        int bytesSuccessfullyWritten = inMemoryBuffer.bytesWritten();
+        assertEquals( cmd, Command.readCommand( null, null, inMemoryBuffer, ByteBuffer.allocate( 100 ) ));
+
+        bytesSuccessfullyWritten--;
+
+        while(bytesSuccessfullyWritten --> 0)
+        {
+            inMemoryBuffer.reset();
+            cmd.writeToFile( inMemoryBuffer );
+            inMemoryBuffer.truncateTo( bytesSuccessfullyWritten );
+
+            Command deserialized = Command.readCommand( null, null, inMemoryBuffer, ByteBuffer.allocate( 100 ) );
+
+            assertNull( "Deserialization did not detect log truncation! Record: " + cmd +
+                        ", deserialized: " + deserialized, deserialized );
+        }
+    }
+
+    public class InMemoryLogBuffer implements LogBuffer, ReadableByteChannel
+    {
+        private byte[] bytes = new byte[1000];
+        private int writeIndex;
+        private int readIndex;
+        private ByteBuffer bufferForConversions = ByteBuffer.wrap( new byte[100] );
+
+        public InMemoryLogBuffer()
+        {
+        }
+
+        public void reset()
+        {
+            writeIndex = readIndex = 0;
+        }
+
+        public void truncateTo( int bytes )
+        {
+            writeIndex = bytes;
+        }
+
+        public int bytesWritten()
+        {
+            return writeIndex;
+        }
+
+        private void ensureArrayCapacityPlus( int plus )
+        {
+            while ( writeIndex+plus > bytes.length )
+            {
+                byte[] tmp = bytes;
+                bytes = new byte[bytes.length*2];
+                System.arraycopy( tmp, 0, bytes, 0, tmp.length );
+            }
+        }
+
+        private LogBuffer flipAndPut()
+        {
+            ensureArrayCapacityPlus( bufferForConversions.limit() );
+            System.arraycopy( bufferForConversions.flip().array(), 0, bytes, writeIndex,
+                              bufferForConversions.limit() );
+            writeIndex += bufferForConversions.limit();
+            return this;
+        }
+
+        public LogBuffer put( byte b ) throws IOException
+        {
+            ensureArrayCapacityPlus( 1 );
+            bytes[writeIndex++] = b;
+            return this;
+        }
+
+        public LogBuffer putShort( short s ) throws IOException
+        {
+            ((ByteBuffer) bufferForConversions.clear()).putShort( s );
+            return flipAndPut();
+        }
+
+        public LogBuffer putInt( int i ) throws IOException
+        {
+            ((ByteBuffer) bufferForConversions.clear()).putInt( i );
+            return flipAndPut();
+        }
+
+        public LogBuffer putLong( long l ) throws IOException
+        {
+            ((ByteBuffer) bufferForConversions.clear()).putLong( l );
+            return flipAndPut();
+        }
+
+        public LogBuffer putFloat( float f ) throws IOException
+        {
+            ((ByteBuffer) bufferForConversions.clear()).putFloat( f );
+            return flipAndPut();
+        }
+
+        public LogBuffer putDouble( double d ) throws IOException
+        {
+            ((ByteBuffer) bufferForConversions.clear()).putDouble( d );
+            return flipAndPut();
+        }
+
+        public LogBuffer put( byte[] bytes ) throws IOException
+        {
+            ensureArrayCapacityPlus( bytes.length );
+            System.arraycopy( bytes, 0, this.bytes, writeIndex, bytes.length );
+            writeIndex += bytes.length;
+            return this;
+        }
+
+        public LogBuffer put( char[] chars ) throws IOException
+        {
+            ensureConversionBufferCapacity( chars.length*2 );
+            bufferForConversions.clear();
+            for ( char ch : chars )
+            {
+                bufferForConversions.putChar( ch );
+            }
+            return flipAndPut();
+        }
+
+        private void ensureConversionBufferCapacity( int length )
+        {
+            if ( bufferForConversions.capacity() < length )
+            {
+                bufferForConversions = ByteBuffer.wrap( new byte[length*2] );
+            }
+        }
+
+        @Override
+        public void writeOut() throws IOException
+        {
+        }
+
+        public void force() throws IOException
+        {
+        }
+
+        public long getFileChannelPosition() throws IOException
+        {
+            return this.readIndex;
+        }
+
+        public FileChannel getFileChannel()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public boolean isOpen()
+        {
+            return true;
+        }
+
+        public void close() throws IOException
+        {
+        }
+
+        public int read( ByteBuffer dst ) throws IOException
+        {
+            if ( readIndex >= writeIndex )
+            {
+                return -1;
+            }
+
+            int actualLengthToRead = Math.min( dst.limit(), writeIndex-readIndex );
+            try
+            {
+                dst.put( bytes, readIndex, actualLengthToRead );
+                return actualLengthToRead;
+            }
+            finally
+            {
+                readIndex += actualLengthToRead;
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NodeCommandTest.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.DefaultTxHook;
 import org.neo4j.kernel.configuration.Config;
@@ -44,8 +45,10 @@ import org.neo4j.test.EphemeralFileSystemRule;
 
 import static java.nio.ByteBuffer.allocate;
 import static java.util.Arrays.asList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+
 import static org.neo4j.kernel.impl.nioneo.store.DynamicRecord.dynamicRecord;
 import static org.neo4j.kernel.impl.nioneo.store.ShortArray.LONG;
 import static org.neo4j.kernel.impl.nioneo.store.labels.DynamicNodeLabels.dynamicPointer;
@@ -132,12 +135,8 @@ public class NodeCommandTest
     }
 
     @Test
-    public void shouldSerializeDynamicRecordsWhenWholeNodeIsRemoved() throws Exception
+    public void shouldSerializeDynamicRecordsRemoved() throws Exception
     {
-        // Note: This is in relation to a bug where serialization would skip the dynamic records if the node was not in
-        // use. In the HA and in the recovery case, that meant that slaves would not update their dynamic label records
-        // appropriately when a node was deleted.
-
         // Given
         NodeRecord before = new NodeRecord( 12, 1, 2 );
         before.setInUse( true );
@@ -145,7 +144,7 @@ public class NodeCommandTest
         before.setLabelField( dynamicPointer( beforeDyn ), beforeDyn );
 
         NodeRecord after = new NodeRecord( 12, 2, 1 );
-        after.setInUse( false );
+        after.setInUse( true );
         List<DynamicRecord> dynamicRecords = asList( dynamicRecord( 0, false, true, -1l, LONG.intValue(), new byte[]{1,2,3,4,5,6,7,8}));
         after.setLabelField( dynamicPointer( dynamicRecords ), dynamicRecords );
 
@@ -201,6 +200,7 @@ public class NodeCommandTest
     @Before
     public void before() throws Exception
     {
+        @SuppressWarnings("deprecation")
         StoreFactory storeFactory = new StoreFactory( new Config(), new DefaultIdGeneratorFactory(),
                 new DefaultWindowPoolFactory(), fs.get(), StringLogger.DEV_NULL, new DefaultTxHook() );
         File storeFile = new File( "nodestore" );


### PR DESCRIPTION
This is a suggestion for a different way of making sure that dynamic records for labels get reclaimed.

Instead of recording dynamic records for labels as deleted in the
transaction log, use the fact that we store both the state before the
transaction and the state after, to only require storing the used ones.
The set of unused records can be computed as the difference between the
set of records used before and the set of records used after.

In effect reverts (most of) 069edcfe7dcbb07f43599c91ec76c154f49b1934, and has the same effect without changing the log format, and thus with less overhead.

If this is an approach we like, we can take the same approach in other places, such as the property records.
