### PR TITLE
Ensure that we remove index entries when labels and properties of a node...

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -325,14 +325,14 @@ public class IndexingService extends LifecycleAdapter
             switch (update.getUpdateMode())
             {
             case ADDED:
-                for (int len = update.getNumberOfLabelsAfter(), i = 0; i < len; i++)
+                for ( int len = update.getNumberOfLabelsAfter(), i = 0; i < len; i++ )
                 {
                     processUpdateIfIndexExists( updaterMap, update, propertyKeyId, update.getLabelAfter( i ) );
                 }
                 break;
 
             case REMOVED:
-                for (int len = update.getNumberOfLabelsBefore(), i = 0; i < len; i++)
+                for ( int len = update.getNumberOfLabelsBefore(), i = 0; i < len; i++ )
                 {
                     processUpdateIfIndexExists( updaterMap, update, propertyKeyId, update.getLabelBefore( i ) );
                 }
@@ -342,7 +342,7 @@ public class IndexingService extends LifecycleAdapter
                 int lenBefore = update.getNumberOfLabelsBefore();
                 int lenAfter = update.getNumberOfLabelsAfter();
 
-                for(int i = 0, j = 0; i < lenBefore && j < lenAfter; i++, j++)
+                for ( int i = 0, j = 0; i < lenBefore && j < lenAfter; )
                 {
                     int labelBefore = update.getLabelBefore( i );
                     int labelAfter = update.getLabelAfter( j );


### PR DESCRIPTION
... are changed in the same transaction

When we build REMOVE NodePropertyUpdates based on node commands we read the before value from
the store. This is incorrect when the property and labels have changed in the same transaction and can cause
IndexingService to not correctly remove index entries.

To side-step this issue, this commit builds a lookup table from (nodeId, pkId) to NodePropertyUpdate
for CHANGE updates in WriteTransaction. These updates contain the correct before value and lead the proper
de-indexing.

A solution that doesn't need a lookup table would be nice but this fixes it for now.
