### PR TITLE
ImpermanentGraphDatabase.cleanup should delete all nodes

### DIFF
--- a/community/cypher/cypher-docs/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
+++ b/community/cypher/cypher-docs/src/test/java/org/neo4j/cypher/javacompat/IntroDocTest.java
@@ -102,7 +102,7 @@ public class IntroDocTest implements GraphHolder
     public static void setup() throws IOException
     {
         graphdb = (ImpermanentGraphDatabase)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        graphdb.cleanContent( false );
+        graphdb.cleanContent();
 
         engine = new ExecutionEngine( graphdb );
     }

--- a/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
+++ b/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
@@ -236,7 +236,7 @@ abstract class ArticleTest extends Assertions with DocumentationHelper {
       newImpermanentDatabaseBuilder().
       newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
 
-    db.asInstanceOf[ImpermanentGraphDatabase].cleanContent(false)
+    db.asInstanceOf[ImpermanentGraphDatabase].cleanContent()
 
     db.inTx {
       nodeIndex = db.index().forNodes("nodes")

--- a/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -277,7 +277,7 @@ abstract class DocumentingTestBase extends Assertions with DocumentationHelper w
       newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
     engine = new ExecutionEngine(db)
 
-    db.asInstanceOf[ImpermanentGraphDatabase].cleanContent(false)
+    db.asInstanceOf[ImpermanentGraphDatabase].cleanContent()
 
     db.inTx {
       nodeIndex = db.index().forNodes("nodes")

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
@@ -217,7 +217,6 @@ public class GetOrCreateDocIT extends AbstractJavaDocTestbase
             catch ( RuntimeException e )
             {
                 failure = e;
-                throw e;
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -176,25 +176,19 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
         return life.add( new SingleLoggingService( StringLogger.loggerDirectory( fileSystem, storeDir ) ) );
     }
 
-    public void cleanContent( boolean retainReferenceNode )
+    public void cleanContent()
     {
         Transaction tx = beginTx();
         try
         {
-            for ( Node node : GlobalGraphOperations.at( this ).getAllNodes() )
+            Iterable<Node> allNodes = GlobalGraphOperations.at(this).getAllNodes();
+            for ( Node node : allNodes)
             {
                 for ( Relationship rel : node.getRelationships( Direction.OUTGOING ) )
                 {
                     rel.delete();
                 }
-                if ( !node.hasRelationship() )
-                {
-                    if(retainReferenceNode && node.getId() == 0)
-                    {
-                        continue;
-                    }
-                    node.delete();
-                }
+                node.delete();
             }
             tx.success();
         }
@@ -207,10 +201,5 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
             //noinspection deprecation
             tx.finish();
         }
-    }
-
-    public void cleanContent()
-    {
-        cleanContent( false );
     }
 }


### PR DESCRIPTION
This fixes a bug where certain graphs could confuse the cleanup method
into leaving some nodes behind.
