### PR TITLE
Better error messages when upgrading unclean store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFile.java
@@ -66,6 +66,14 @@ public enum StoreFile
     {
         return typeDescriptor + " " + LegacyStore.LEGACY_VERSION;
     }
+
+    /**
+     * The first part of the version String.
+     */
+    public String typeDescriptor()
+    {
+        return typeDescriptor;
+    }
     
     public String storeFileName()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -151,4 +151,36 @@ public class StoreUpgrader
             super( message );
         }
     }
+
+    public static class UpgradeMissingStoreFilesException extends UnableToUpgradeException
+    {
+        private static final String MESSAGE = "Missing required store file '%s'.";
+
+        public UpgradeMissingStoreFilesException( String filenameExpectedToExist )
+        {
+            super( String.format( MESSAGE, filenameExpectedToExist ) );
+        }
+    }
+
+    public static class UpgradingStoreVersionNotFoundException extends UnableToUpgradeException
+    {
+        private static final String MESSAGE =
+                "'%s' does not contain a store version, please ensure that the original database was shut down in a clean state.";
+
+        public UpgradingStoreVersionNotFoundException( String filenameWithoutStoreVersion )
+        {
+            super( String.format( MESSAGE, filenameWithoutStoreVersion ) );
+        }
+    }
+
+    public static class UnexpectedUpgradingStoreVersionException extends UnableToUpgradeException
+    {
+        private static final String MESSAGE =
+                "'%s' has a store version number that we cannot upgrade from. Expected '%s' but file is version '%s'.";
+
+        public UnexpectedUpgradingStoreVersionException( String filename, String expectedVersion, String actualVersion )
+        {
+            super( String.format( MESSAGE, filename, expectedVersion, actualVersion ) );
+        }
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgradeIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgradeIntegrationTest.java
@@ -82,7 +82,8 @@ public class StoreUpgradeIntegrationTest
         }
         catch ( RuntimeException e )
         {
-            assertThat( Exceptions.rootCause( e ), Matchers.instanceOf( UnableToUpgradeException.class ) );
+            assertThat( Exceptions.rootCause( e ), Matchers.instanceOf(
+                    StoreUpgrader.UpgradingStoreVersionNotFoundException.class ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTestIT.java
@@ -135,7 +135,7 @@ public class StoreUpgraderTestIT
                     new DatabaseFiles( fileSystem ) ).attemptUpgrade( new File( dbDirectory, NeoStore.DEFAULT_NAME ) );
             fail( "Should throw exception" );
         }
-        catch ( StoreUpgrader.UnableToUpgradeException e )
+        catch ( StoreUpgrader.UnexpectedUpgradingStoreVersionException e )
         {
             // expected
         }
@@ -159,7 +159,7 @@ public class StoreUpgraderTestIT
                     new DatabaseFiles( fileSystem ) ).attemptUpgrade( new File( dbDirectory, NeoStore.DEFAULT_NAME ) );
             fail( "Should throw exception" );
         }
-        catch ( StoreUpgrader.UnableToUpgradeException e )
+        catch ( StoreUpgrader.UpgradingStoreVersionNotFoundException e )
         {
             // expected
         }
@@ -183,7 +183,7 @@ public class StoreUpgraderTestIT
                     new DatabaseFiles( fileSystem ) ).attemptUpgrade( new File( dbDirectory, NeoStore.DEFAULT_NAME ) );
             fail( "Should throw exception" );
         }
-        catch ( StoreUpgrader.UnableToUpgradeException e )
+        catch ( StoreUpgrader.UpgradingStoreVersionNotFoundException e )
         {
             // expected
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
@@ -138,7 +138,7 @@ public class UpgradableDatabaseTestIT
             new UpgradableDatabase( fileSystem ).checkUpgradeable( new File( workingDirectory, "neostore" ) );
             fail( "should not have been able to upgrade" );
         }
-        catch (StoreUpgrader.UnableToUpgradeException e)
+        catch (StoreUpgrader.UnexpectedUpgradingStoreVersionException e)
         {
             assertThat( e.getMessage(), is("'neostore.nodestore.db' has a store version number that we cannot upgrade " +
                     "from. Expected 'NodeStore " + LEGACY_VERSION + "' but file is version 'NodeStore v0.9.5'.") );


### PR DESCRIPTION
Now produces more helpful error messages when people attempt to upgrade store files
that have not been shut down cleanly. We don't tell people that we cannot upgrade
from some weird binary string of a version number, but instead correctly tell them
that the store file has not been shut down properly. When this happens, they should
open the store again in the old version, shut it down properly, and then try
upgrading it again. That should do the trick.
