### PR TITLE
Extract SchemaRule logic from SchemaStore.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/ProcessFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ProcessFailureException.java
@@ -72,7 +72,7 @@ public class ProcessFailureException extends Exception
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     private static Throwable cause( List<Entry> causes )
     {
-        return causes.size() == 1 ? causes.get( 0 ).failure : null;
+        return causes.size() >= 1 ? causes.get( 0 ).failure : null;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionImplementation.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.api;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.transaction.RollbackException;
 
 import org.neo4j.helpers.Exceptions;
@@ -38,8 +37,6 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.operations.LegacyKernelOperations;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
 import org.neo4j.kernel.impl.api.LockHolder;
-import org.neo4j.kernel.impl.api.PersistenceCache;
-import org.neo4j.kernel.impl.api.SchemaStorage;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.constraints.ConstraintIndexCreator;
@@ -54,6 +51,7 @@ import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
@@ -70,7 +68,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private final LabelScanStore labelScanStore;
     private final SchemaStorage schemaStorage;
     private final ConstraintIndexCreator constraintIndexCreator;
-    private final PersistenceCache persistenceCache;
     private final PersistenceManager persistenceManager;
     private final SchemaIndexProviderMap providerMap;
     private final UpdateableSchemaState schemaState;
@@ -88,7 +85,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             SchemaWriteGuard schemaWriteGuard, LabelScanStore labelScanStore,
                                             IndexingService indexService,
                                             AbstractTransactionManager transactionManager, NodeManager nodeManager,
-                                            PersistenceCache persistenceCache, UpdateableSchemaState schemaState,
+                                            UpdateableSchemaState schemaState,
                                             LockHolder lockHolder, PersistenceManager persistenceManager,
                                             SchemaIndexProviderMap providerMap, NeoStore neoStore,
                                             TransactionState legacyTxState )
@@ -100,7 +97,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.labelScanStore = labelScanStore;
         this.indexService = indexService;
         this.providerMap = providerMap;
-        this.persistenceCache = persistenceCache;
         this.schemaState = schemaState;
         this.persistenceManager = persistenceManager;
         this.lockHolder = lockHolder;
@@ -150,11 +146,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             {
                 dropCreatedConstraintIndexes();
             }
-            catch ( IllegalStateException e )
-            {
-                throw new TransactionFailureException( e );
-            }
-            catch ( SecurityException e )
+            catch ( IllegalStateException | SecurityException e )
             {
                 throw new TransactionFailureException( e );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.LockManager;
@@ -176,7 +177,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     {
         checkIfShutdown();
         return new KernelTransactionImplementation( statementOperations, legacyKernelOperations, readOnly,
-                schemaWriteGuard, labelScanStore, indexService, transactionManager, nodeManager, persistenceCache,
+                schemaWriteGuard, labelScanStore, indexService, transactionManager, nodeManager,
                 schemaState, new LockHolderImpl( lockManager, getJTATransaction(), nodeManager ),
                 persistenceManager, providerMap, neoStore, getLegacyTxState() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StoreStatementOperations.java
@@ -70,6 +70,7 @@ import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DelegatingRecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DelegatingRecordStore.java
@@ -54,6 +54,18 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
     }
 
     @Override
+    public long getHighestPossibleIdInUse()
+    {
+        return delegate.getHighestPossibleIdInUse();
+    }
+
+    @Override
+    public long nextId()
+    {
+        return delegate.nextId();
+    }
+
+    @Override
     public R getRecord( long id )
     {
         return delegate.getRecord( id );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RecordStore.java
@@ -29,13 +29,15 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.kernel.IdType;
 
-public interface RecordStore<R extends AbstractBaseRecord>
+public interface RecordStore<R extends AbstractBaseRecord> extends IdSequence
 {
     File getStorageFileName();
 
     WindowPoolStats getWindowPoolStats();
 
     long getHighId();
+
+    long getHighestPossibleIdInUse();
 
     R getRecord( long id );
 
@@ -101,7 +103,8 @@ public interface RecordStore<R extends AbstractBaseRecord>
             processRecord( PropertyRecord.class, store, property );
         }
 
-        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string, IdType idType ) throws FAILURE
+        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string,
+                                   @SuppressWarnings( "deprecation") IdType idType ) throws FAILURE
         {
             processDynamic( store, string );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -37,8 +37,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.helpers.Function;
-import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.Thunk;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.Visitor;
@@ -74,6 +72,7 @@ import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.Store;
 import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
@@ -101,9 +100,6 @@ import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
-
-import static org.neo4j.helpers.collection.Iterables.filter;
-import static org.neo4j.helpers.collection.Iterables.map;
 
 /**
  * A <CODE>NeoStoreXaDataSource</CODE> is a factory for
@@ -260,7 +256,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
      */
     public NeoStoreXaDataSource( Config config, StoreFactory sf,
                                  StringLogger stringLogger, XaFactory xaFactory, TransactionStateFactory stateFactory,
-                                 TransactionInterceptorProviders providers,
+                                 @SuppressWarnings("deprecation") TransactionInterceptorProviders providers,
                                  JobScheduler scheduler, Logging logging,
                                  UpdateableSchemaState updateableSchemaState,
                                  TokenNameLookup tokenNameLookup,
@@ -692,21 +688,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
 
     private Iterator<IndexRule> loadIndexRules()
     {
-        return map( new Function<SchemaRule, IndexRule>()
-        {
-            @Override
-            public IndexRule apply( SchemaRule schemaRule )
-            {
-                return (IndexRule) schemaRule;
-            }
-        }, filter( new Predicate<SchemaRule>()
-        {
-            @Override
-            public boolean accept( SchemaRule item )
-            {
-                return item.getKind().isIndex();
-            }
-        }, neoStore.getSchemaStore().loadAllSchemaRules() ) );
+        return new SchemaStorage( neoStore.getSchemaStore() ).allIndexRules();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/graphdb/Neo4jMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/Neo4jMatchers.java
@@ -466,6 +466,7 @@ public class Neo4jMatchers
 
     }
 
+    @SafeVarargs
     public static <T> TypeSafeDiagnosingMatcher<Neo4jMatchers.Deferred<T>> containsOnly( final T... expectedObjects )
     {
         return new TypeSafeDiagnosingMatcher<Neo4jMatchers.Deferred<T>>()
@@ -529,7 +530,7 @@ public class Neo4jMatchers
                     Schema.IndexState currentState = db.schema().getIndexState( current );
                     if ( !currentState.equals( expectedState ) )
                     {
-                        description.appendText( current.toString() );
+                        description.appendValue( current ).appendText( " has state " ).appendValue( currentState );
                         return false;
                     }
                 }
@@ -544,6 +545,7 @@ public class Neo4jMatchers
         };
     }
 
+    @SafeVarargs
     public static <T> TypeSafeDiagnosingMatcher<Neo4jMatchers.Deferred<T>> contains( final T... expectedObjects )
     {
         return new TypeSafeDiagnosingMatcher<Neo4jMatchers.Deferred<T>>()

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -34,6 +34,6 @@ public class KernelTransactionFactory
     {
         return new KernelTransactionImplementation( Mockito.mock( StatementOperationParts.class ),
                 Mockito.mock( LegacyKernelOperations.class ) , false, mock( SchemaWriteGuard.class ), null, null,
-                mock( AbstractTransactionManager.class ), null, null, null, null, null, null, mock( NeoStore.class ), null );
+                mock( AbstractTransactionManager.class ), null, null, null, null, null, mock( NeoStore.class ), null );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -20,12 +20,13 @@
 package org.neo4j.kernel.api;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.impl.api.LockHolder;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class KernelTransactionImplementationTest
 {
@@ -37,7 +38,7 @@ public class KernelTransactionImplementationTest
     {
         // given
         KernelTransactionImplementation tx = new KernelTransactionImplementation( null, null, false, null, null,
-                null, txm, null, null, null, mock(LockHolder.class), null, null, mock( NeoStore.class ),
+                null, txm, null, null, mock(LockHolder.class), null, null, mock( NeoStore.class ),
                 mock(TransactionState.class) );
         // when
         tx.prepare();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StoreStatementOperationsTest.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -277,12 +278,13 @@ public class StoreStatementOperationsTest
         }
     }
 
-    private GraphDatabaseAPI db;
+    @SuppressWarnings("deprecation") private GraphDatabaseAPI db;
     private final Label label1 = label( "first-label" ), label2 = label( "second-label" );
     private final String propertyKey = "name";
     private KernelStatement state;
     private StoreStatementOperations statement;
 
+    @SuppressWarnings("deprecation")
     @Before
     public void before()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintsCreationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintsCreationIT.java
@@ -20,13 +20,13 @@
 package org.neo4j.kernel.impl.api.integrationtest;
 
 import java.util.Iterator;
-
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.Transaction;
 import javax.transaction.xa.XAException;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.helpers.Function;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
@@ -36,16 +36,21 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
-import org.neo4j.kernel.impl.api.SchemaStorage;
 import org.neo4j.kernel.impl.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule;
 import org.neo4j.kernel.impl.transaction.TxManager;
 
 import static java.util.Collections.singletonList;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.nioneo.store.AbstractBaseRecord;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
-import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.StoreAccess;
 
 import static java.lang.String.format;
@@ -87,7 +87,7 @@ public class ConsistencyCheckTasks
         tasks.add( create( nativeStores.getSchemaStore() ));
 
         // PASS 2: Rule integrity and obligation build up
-        final SchemaRecordCheck schemaCheck = new SchemaRecordCheck( (SchemaStore) nativeStores.getSchemaStore() );
+        final SchemaRecordCheck schemaCheck = new SchemaRecordCheck( new SchemaStorage( nativeStores.getSchemaStore() ) );
         tasks.add( new SchemaStoreProcessorTask<>(
                 nativeStores.getSchemaStore(), "check_rules", schemaCheck, progress, order,
                 processor, processor ) );

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/schema/IndexRules.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/schema/IndexRules.java
@@ -19,39 +19,24 @@
  */
 package org.neo4j.consistency.checking.schema;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Iterator;
 
-import org.neo4j.kernel.api.exceptions.schema.MalformedSchemaRuleException;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
-import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
-import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 
 public class IndexRules
 {
-    @SuppressWarnings("unchecked")
-    public static List<IndexRule> loadAllIndexRules( final RecordStore<DynamicRecord> schemaStore )
-            throws MalformedSchemaRuleException
+    public static Iterable<IndexRule> loadAllIndexRules( final RecordStore<DynamicRecord> schemaStore )
     {
-        final List<IndexRule> indexRules = new ArrayList<>();
-        new RecordStore.Processor<MalformedSchemaRuleException>()
+        return new Iterable<IndexRule>()
         {
             @Override
-            public void processSchema( RecordStore<DynamicRecord> store,
-                                       DynamicRecord record ) throws MalformedSchemaRuleException
+            public Iterator<IndexRule> iterator()
             {
-                if ( record.inUse() && record.isStartRecord() )
-                {
-                    SchemaRule schemaRule = ((SchemaStore) schemaStore).loadSingleSchemaRule( record.getId() );
-                    if ( schemaRule instanceof IndexRule  )
-                    {
-                        indexRules.add( (IndexRule) schemaRule );
-                    }
-                }
+                return new SchemaStorage( schemaStore ).allIndexRules();
             }
-        }.applyFiltered( schemaStore );
-        return indexRules;
+        };
     }
 }

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
@@ -114,6 +114,18 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
     }
 
     @Override
+    public long getHighestPossibleIdInUse()
+    {
+        return Math.max( highId, actual.getHighestPossibleIdInUse() );
+    }
+
+    @Override
+    public long nextId()
+    {
+        return actual.nextId();
+    }
+
+    @Override
     public R getRecord( long id )
     {
         return getRecord( id, false );
@@ -224,7 +236,8 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
         }
 
         @Override
-        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string, IdType idType ) throws FAILURE
+        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string,
+                                   @SuppressWarnings( "deprecation") IdType idType ) throws FAILURE
         {
             processor.processString( (RecordStore<DynamicRecord>) diffStore, string, idType );
         }

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRecordCheckTest.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/SchemaRecordCheckTest.java
@@ -25,13 +25,12 @@ import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.store.RecordAccessStub;
 import org.neo4j.kernel.api.exceptions.schema.MalformedSchemaRuleException;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.impl.nioneo.store.AbstractDynamicStore;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
-import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
+import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule;
 
 import static org.mockito.Mockito.mock;
@@ -44,17 +43,13 @@ public class SchemaRecordCheckTest
 {
     public SchemaRecordCheckTest()
     {
-        super( new SchemaRecordCheck( configureSchemaStore() ), ConsistencyReport.SchemaConsistencyReport.class );
+        super( new SchemaRecordCheck( configureSchemaStore() ),
+                ConsistencyReport.SchemaConsistencyReport.class );
     }
 
-
-    public static SchemaStore configureSchemaStore()
+    public static SchemaStorage configureSchemaStore()
     {
-        @SuppressWarnings( "unchecked" )
-        SchemaStore mock = mock( SchemaStore.class );
-        when( mock.getRecordSize() ).thenReturn( SchemaStore.BLOCK_SIZE + AbstractDynamicStore.BLOCK_HEADER_SIZE );
-        when( mock.getRecordHeaderSize() ).thenReturn( AbstractDynamicStore.BLOCK_HEADER_SIZE );
-        return mock;
+        return mock( SchemaStorage.class );
     }
 
     @Test


### PR DESCRIPTION
Since the record type of SchemaStore isn't SchemaRule, but rather
DynamicRecord that then encode the SchemaRule, it becomes tedious and
leads to broken abstractions to have the logic for converting these
DynamicRecords to SchemaRule objects in the SchemaStore. It is instead
moved to the SchemaStorage class that encapsulates a SchemaStore and
handles the conversion to SchemaRule objects.
