### PR TITLE
Keeps explicit state whether a transaction is remotely initialize or not

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -22,6 +22,7 @@ package org.neo4j.helpers;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.Thread.State;
 import java.lang.reflect.InvocationTargetException;
 
 public class Exceptions
@@ -165,6 +166,30 @@ public class Exceptions
             cause.printStackTrace(System.err);
             return "[ERROR: Unable to serialize stacktrace, UTF-8 not supported.]";
         }
+    }
+    
+    public static String stringify( Thread thread, StackTraceElement[] elements )
+    {
+        StringBuilder builder = new StringBuilder(
+                "\"" + thread.getName() + "\" " + (thread.isDaemon() ? "daemon": "") +
+                " prio=" + thread.getPriority() +
+                " tid=" + thread.getId() +
+                " " + thread.getState().name().toLowerCase() + "\n" );
+        builder.append( "   " + State.class.getName() + ": " + thread.getState().name().toUpperCase() + "\n" );
+        for ( StackTraceElement element : elements )
+        {
+            builder.append( "      at " + element.getClassName() + "." + element.getMethodName() ); 
+            if ( element.isNativeMethod() )
+            {
+                builder.append( "(Native method)" );
+            }
+            else
+            {
+                builder.append( "(" + element.getFileName() + ":" + element.getLineNumber() + ")" );
+            }
+            builder.append( "\n" );
+        }
+        return builder.toString();
     }
     
     @SuppressWarnings( "rawtypes" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -37,7 +37,7 @@ import static org.neo4j.helpers.Listeners.notifyListeners;
 public class AvailabilityGuard
 {
     private Iterable<AvailabilityListener> listeners = Listeners.newListeners();
-    private Clock clock;
+    private final Clock clock;
 
     public interface AvailabilityListener
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/CommonFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/CommonFactories.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel;
 
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.DefaultLogBufferFactory;
 import org.neo4j.kernel.impl.transaction.xaframework.LogBufferFactory;
 import org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier;
@@ -43,7 +43,7 @@ public class CommonFactories
         return new DefaultLogBufferFactory();
     }
 
-    public static TxHook defaultTxHook()
+    public static RemoteTxHook defaultTxHook()
     {
         return new DefaultTxHook();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/DefaultTxHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DefaultTxHook.java
@@ -19,26 +19,22 @@
  */
 package org.neo4j.kernel;
 
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 
 /**
  * @deprecated This will be moved to internal packages in the next major release.
  */
 @Deprecated
-public class DefaultTxHook implements TxHook
+public class DefaultTxHook implements RemoteTxHook
 {
     @Override
-    public void initializeTransaction( int eventIdentifier )
+    public void remotelyInitializeTransaction( int eventIdentifier )
     {
         // Do nothing from the ordinary here
     }
 
-    public boolean hasAnyLocks( javax.transaction.Transaction tx )
-    {
-        return false;
-    }
-
-    public void finishTransaction( int eventIdentifier, boolean success )
+    @Override
+    public void remotelyFinishTransaction( int eventIdentifier, boolean success )
     {
         // Do nothing from the ordinary here
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -135,7 +135,7 @@ import org.neo4j.kernel.impl.transaction.RagManager;
 import org.neo4j.kernel.impl.transaction.ReadOnlyTxManager;
 import org.neo4j.kernel.impl.transaction.TransactionManagerProvider;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.TxManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.DefaultLogBufferFactory;
@@ -218,7 +218,7 @@ public abstract class InternalAbstractGraphDatabase
     protected IndexManagerImpl indexManager;
     protected Schema schema;
     protected KernelPanicEventGenerator kernelPanicEventGenerator;
-    protected TxHook txHook;
+    protected RemoteTxHook txHook;
     protected FileSystemAbstraction fileSystem;
     protected XaDataSourceManager xaDataSourceManager;
     protected LockManager lockManager;
@@ -868,7 +868,7 @@ public abstract class InternalAbstractGraphDatabase
         }
     }
 
-    protected TxHook createTxHook()
+    protected RemoteTxHook createTxHook()
     {
         return new DefaultTxHook();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
@@ -26,7 +26,7 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
@@ -170,7 +170,7 @@ public class NoTransactionState implements TransactionState
     }
 
     @Override
-    public TxHook getTxHook()
+    public RemoteTxHook getTxHook()
     {
         return null;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
@@ -90,7 +90,7 @@ public interface TransactionState
 
     boolean hasChanges();
 
-    TxHook getTxHook();
+    RemoteTxHook getTxHook();
 
     TxIdGenerator getTxIdGenerator();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
@@ -38,7 +38,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockType;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
@@ -55,7 +55,7 @@ public class WritableTransactionState implements TransactionState
     private final NodeManager nodeManager;
     private final StringLogger log;
     private final Transaction tx;
-    private final TxHook txHook;
+    private final RemoteTxHook txHook;
     private final TxIdGenerator txIdGenerator;
 
     // State
@@ -262,7 +262,7 @@ public class WritableTransactionState implements TransactionState
     }
 
     public WritableTransactionState( LockManager lockManager,
-            NodeManager nodeManager, Logging logging, Transaction tx, TxHook txHook, TxIdGenerator txIdGenerator )
+            NodeManager nodeManager, Logging logging, Transaction tx, RemoteTxHook txHook, TxIdGenerator txIdGenerator )
     {
         this.lockManager = lockManager;
         this.nodeManager = nodeManager;
@@ -779,7 +779,7 @@ public class WritableTransactionState implements TransactionState
     }
 
     @Override
-    public TxHook getTxHook()
+    public RemoteTxHook getTxHook()
     {
         return txHook;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.kernel.impl.util.StringLogger;
 
@@ -83,7 +83,7 @@ public class NeoStore extends AbstractStore
     private RelationshipTypeTokenStore relTypeStore;
     private LabelTokenStore labelTokenStore;
     private SchemaStore schemaStore;
-    private final TxHook txHook;
+    private final RemoteTxHook txHook;
     private long lastCommittedTx = -1;
     private long latestConstraintIntroducingTx = -1;
 
@@ -92,7 +92,7 @@ public class NeoStore extends AbstractStore
     public NeoStore( File fileName, Config conf,
                      IdGeneratorFactory idGeneratorFactory, WindowPoolFactory windowPoolFactory,
                      FileSystemAbstraction fileSystemAbstraction,
-                     StringLogger stringLogger, TxHook txHook,
+                     StringLogger stringLogger, RemoteTxHook txHook,
                      RelationshipTypeTokenStore relTypeStore, LabelTokenStore labelTokenStore,
                      PropertyStore propStore, RelationshipStore relStore,
                      NodeStore nodeStore, SchemaStore schemaStore )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.UpgradableDatabase;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.util.StringLogger;
 
 /**
@@ -57,7 +57,7 @@ public class StoreFactory
     private final WindowPoolFactory windowPoolFactory;
     private final FileSystemAbstraction fileSystemAbstraction;
     private final StringLogger stringLogger;
-    private final TxHook txHook;
+    private final RemoteTxHook txHook;
 
     public static final String LABELS_PART = ".labels";
     public static final String NAMES_PART = ".names";
@@ -81,7 +81,7 @@ public class StoreFactory
     public static final String SCHEMA_STORE_NAME = ".schemastore.db";
 
     public StoreFactory( Config config, IdGeneratorFactory idGeneratorFactory, WindowPoolFactory windowPoolFactory,
-                         FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger, TxHook txHook )
+                         FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger, RemoteTxHook txHook )
     {
         this.config = config;
         this.idGeneratorFactory = idGeneratorFactory;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RemoteTxHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RemoteTxHook.java
@@ -19,15 +19,14 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import javax.transaction.Transaction;
-
-public interface TxHook
+/**
+ * Hook for remote transaction coordination
+ */
+public interface RemoteTxHook
 {
-    void initializeTransaction( int eventIdentifier );
+    void remotelyInitializeTransaction( int eventIdentifier );
     
-    boolean hasAnyLocks( Transaction tx );
-    
-    void finishTransaction( int eventIdentifier, boolean success );
+    void remotelyFinishTransaction( int eventIdentifier, boolean success );
     
     boolean freeIdsDuringRollback();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionManagerProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionManagerProvider.java
@@ -44,7 +44,7 @@ public abstract class TransactionManagerProvider extends Service
     public abstract AbstractTransactionManager loadTransactionManager( String txLogDir,
     		XaDataSourceManager xaDataSourceManager,
     		KernelPanicEventGenerator kpe, 
-    		TxHook rollbackHook, 
+    		RemoteTxHook rollbackHook, 
     		StringLogger msgLog, 
     		FileSystemAbstraction fileSystem,
     		TransactionStateFactory stateFactory );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionStateFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionStateFactory.java
@@ -32,7 +32,7 @@ public class TransactionStateFactory
     protected LockManager lockManager;
     protected NodeManager nodeManager;
     protected final Logging logging;
-    protected TxHook txHook;
+    protected RemoteTxHook txHook;
     protected TxIdGenerator txIdGenerator;
     
     public TransactionStateFactory( Logging logging )
@@ -41,7 +41,7 @@ public class TransactionStateFactory
     }
     
     public void setDependencies( LockManager lockManager,
-            NodeManager nodeManager, TxHook txHook, TxIdGenerator txIdGenerator )
+            NodeManager nodeManager, RemoteTxHook txHook, TxIdGenerator txIdGenerator )
     {
         this.lockManager = lockManager;
         this.nodeManager = nodeManager;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/JOTMTransactionManager.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/JOTMTransactionManager.java
@@ -64,7 +64,7 @@ public class JOTMTransactionManager extends AbstractTransactionManager
         @Override
         public AbstractTransactionManager loadTransactionManager(
                 String txLogDir, XaDataSourceManager xaDataSourceManager, KernelPanicEventGenerator kpe,
-                TxHook rollbackHook, StringLogger msgLog,
+                RemoteTxHook rollbackHook, StringLogger msgLog,
                 FileSystemAbstraction fileSystem, TransactionStateFactory stateFactory )
         {
             return new JOTMTransactionManager( xaDataSourceManager, stateFactory );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -82,7 +82,7 @@ import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.core.WritableTransactionState;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.TxManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
@@ -230,7 +230,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     }
 
     @Override
-    protected TxHook createTxHook()
+    protected RemoteTxHook createTxHook()
     {
         clusterEventsDelegateInvocationHandler = new DelegateInvocationHandler();
         memberContextDelegateInvocationHandler = new DelegateInvocationHandler();
@@ -340,8 +340,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         paxosLife.add( clusterEvents );
         paxosLife.add( localClusterMemberAvailability );
 
-        DelegateInvocationHandler<TxHook> txHookDelegate = new DelegateInvocationHandler<>();
-        TxHook txHook = (TxHook) Proxy.newProxyInstance( TxHook.class.getClassLoader(), new Class[]{TxHook.class},
+        DelegateInvocationHandler<RemoteTxHook> txHookDelegate = new DelegateInvocationHandler<>();
+        RemoteTxHook txHook = (RemoteTxHook) Proxy.newProxyInstance( RemoteTxHook.class.getClassLoader(), new Class[]{RemoteTxHook.class},
                 txHookDelegate );
         new TxHookModeSwitcher( memberStateMachine, txHookDelegate,
                 master, new TxHookModeSwitcher.RequestContextFactoryResolver()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -34,12 +34,12 @@ import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockManagerImpl;
 import org.neo4j.kernel.impl.transaction.RagManager;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 {
     private final AbstractTransactionManager txManager;
-    private final TxHook txHook;
+    private final RemoteTxHook txHook;
     private final HaXaDataSourceManager xaDsm;
     private final Master master;
     private final RequestContextFactory requestContextFactory;
@@ -49,7 +49,7 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
     public LockManagerModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                     DelegateInvocationHandler<LockManager> delegate,
                                     AbstractTransactionManager txManager,
-                                    TxHook txHook, HaXaDataSourceManager xaDsm, Master master,
+                                    RemoteTxHook txHook, HaXaDataSourceManager xaDsm, Master master,
                                     RequestContextFactory requestContextFactory, AvailabilityGuard availabilityGuard,
                                     Config config )
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -39,14 +39,14 @@ import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockManagerImpl;
 import org.neo4j.kernel.impl.transaction.LockNotFoundException;
 import org.neo4j.kernel.impl.transaction.RagManager;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.info.LockInfo;
 import org.neo4j.kernel.logging.Logging;
 
 public class SlaveLockManager implements LockManager
 {
     private final AbstractTransactionManager txManager;
-    private final TxHook txHook;
+    private final RemoteTxHook txHook;
     private final AvailabilityGuard availabilityGuard;
     private final Configuration config;
     private final RequestContextFactory requestContextFactory;
@@ -59,7 +59,7 @@ public class SlaveLockManager implements LockManager
         long getAvailabilityTimeout();
     }
 
-    public SlaveLockManager( AbstractTransactionManager txManager, TxHook txHook,
+    public SlaveLockManager( AbstractTransactionManager txManager, RemoteTxHook txHook,
                              AvailabilityGuard availabilityGuard, Configuration config,
                              RagManager ragManager, RequestContextFactory requestContextFactory, Master master,
                              HaXaDataSourceManager xaDsm )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
@@ -21,26 +21,23 @@ package org.neo4j.kernel.ha.transaction;
 
 import java.net.URI;
 
-import javax.transaction.TransactionManager;
-
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
-import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
-import org.neo4j.kernel.impl.transaction.TxHook;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 
-public class TxHookModeSwitcher extends AbstractModeSwitcher<TxHook>
+public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
 {
     private final Master master;
     private final RequestContextFactoryResolver requestContextFactory;
     private final DependencyResolver resolver;
 
     public TxHookModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                               DelegateInvocationHandler<TxHook> delegate, Master master,
+                               DelegateInvocationHandler<RemoteTxHook> delegate, Master master,
                                RequestContextFactoryResolver requestContextFactory, DependencyResolver resolver )
     {
         super( stateMachine, delegate );
@@ -50,16 +47,16 @@ public class TxHookModeSwitcher extends AbstractModeSwitcher<TxHook>
     }
 
     @Override
-    protected TxHook getMasterImpl()
+    protected RemoteTxHook getMasterImpl()
     {
         return new MasterTxHook();
     }
 
     @Override
-    protected TxHook getSlaveImpl( URI serverHaUri )
+    protected RemoteTxHook getSlaveImpl( URI serverHaUri )
     {
         return new SlaveTxHook( master, resolver.resolveDependency( HaXaDataSourceManager.class ),
-                requestContextFactory, (AbstractTransactionManager)resolver.resolveDependency( TransactionManager.class ) );
+                requestContextFactory );
     }
 
     public interface RequestContextFactoryResolver


### PR DESCRIPTION
instead of relying on lock information (whether any lock was grabbed or
not). There was a problem where the "old" transaction state was checked
for locks and not the new one (the one in the Kernel API), or preferrably
both should have been checked. But that approach was error prone so an
explicit flag is better and safer.

Also renamed TxHook --> RemoteTxHook because that name and its method
names were so misguiding that it slowed down reasoning around problems
where it was involved.

The fix in this commit is for a regression from 1.9, but may also fix some
other corner cases with remote transaction management.
