### PR TITLE
Prevents local slave lock acquisition waiting after granted on master

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -171,7 +171,7 @@ public class Exceptions
     public static String stringify( Thread thread, StackTraceElement[] elements )
     {
         StringBuilder builder = new StringBuilder(
-                "\"" + thread.getName() + "\" " + (thread.isDaemon() ? "daemon": "") +
+                "\"" + thread.getName() + "\"" + (thread.isDaemon() ? " daemon": "") +
                 " prio=" + thread.getPriority() +
                 " tid=" + thread.getId() +
                 " " + thread.getState().name().toLowerCase() + "\n" );
@@ -182,6 +182,10 @@ public class Exceptions
             if ( element.isNativeMethod() )
             {
                 builder.append( "(Native method)" );
+            }
+            else if ( element.getFileName() == null )
+            {
+                builder.append( "(Unknown source)" );
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockManager.java
@@ -27,29 +27,124 @@ import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.info.LockInfo;
 import org.neo4j.kernel.logging.Logging;
 
+/**
+ * The LockManager can lock resources for reading or writing. By doing this one
+ * may achieve different transaction isolation levels. A resource can for now be
+ * any object (but null).
+ * <p>
+ * Acquiring locks must be released after usage. Failure to do so will result in
+ * the resource being blocked to all other transactions. Put all locks in a try -
+ * finally block.
+ * <p>
+ * Multiple locks on the same resource held by the same transaction requires the
+ * transaction to invoke the release lock method multiple times. If a tx has
+ * invoked {@link #getReadLock(Object, Transaction)} on the same resource x times in
+ * a row it must invoke {@link #releaseReadLock(Object, Transaction)} x times to release
+ * all the locks. Same for write locks correspondingly.
+ * <p>
+ * LockManager just maps locks to resources and they do all the hard work
+ * together with a {@link RagManager resource allocation graph}.
+ */
 public interface LockManager
 {
+    /**
+     * Tries to acquire read lock on {@code resource} for a given
+     * transaction. If read lock can't be acquired the transaction will wait for
+     * the transaction until it can acquire it. If waiting leads to dead lock a
+     * {@link DeadlockDetectedException} will be thrown.
+     *
+     * @param resource the resource to lock
+     * @throws DeadlockDetectedException if a deadlock is detected, or prevented rather
+     * @throws IllegalResourceException if an illegal resource is supplied
+     */
     void getReadLock( Object resource, Transaction tx )
-                throws DeadlockDetectedException, IllegalResourceException;
+            throws DeadlockDetectedException, IllegalResourceException;
 
+    /**
+     * Tries to acquire read lock on {@code resource} for a given
+     * transaction. If read lock can't be acquired {@code false} will be returned
+     * and no lock will have been acquired.
+     *
+     * @param resource the resource
+     * @throws IllegalResourceException if an illegal resource is supplied
+     */
+    boolean tryReadLock( Object resource, Transaction tx )
+            throws IllegalResourceException;
+    
+    /**
+     * Tries to acquire write lock on <CODE>resource</CODE> for a given
+     * transaction. If write lock can't be acquired the transaction will wait
+     * for the lock until it can acquire it. If waiting leads to dead lock a
+     * {@link DeadlockDetectedException} will be thrown.
+     *
+     * @param resource the resource
+     * @throws DeadlockDetectedException if a deadlock is detected, or prevented rather
+     * @throws IllegalResourceException if an illegal resource is supplied
+     */
     void getWriteLock( Object resource, Transaction tx )
-                            throws DeadlockDetectedException, IllegalResourceException;
+            throws DeadlockDetectedException, IllegalResourceException;
+    
+    /**
+     * Tries to acquire write lock on {@code resource} for a given
+     * transaction. If write lock can't be acquired {@code false} will be returned
+     * and no lock will have been acquired.
+     *
+     * @param resource the resource
+     * @throws IllegalResourceException if an illegal resource is supplied
+     */
+    boolean tryWriteLock( Object resource, Transaction tx )
+            throws IllegalResourceException;
 
+    /**
+     * Releases a read lock held by the given transaction on {@code resource}.
+     *
+     * @param resource the resource
+     * @throws IllegalResourceException if an illegal resource is supplied
+     * @throws LockNotFoundException if given transaction don't have read lock on the given {@code resource}.
+     */
     void releaseReadLock( Object resource, Transaction tx )
-                                throws LockNotFoundException, IllegalResourceException;
+            throws LockNotFoundException, IllegalResourceException;
 
+    /**
+     * Releases a write lock held by the given transaction on {@code resource}.
+     *
+     * @param resource the resource
+     * @throws IllegalResourceException if an illegal resource is supplied
+     * @throws LockNotFoundException if given transaction don't have read lock on the given {@code resource}.
+     */
     void releaseWriteLock( Object resource, Transaction tx )
-                                    throws LockNotFoundException, IllegalResourceException;
+            throws LockNotFoundException, IllegalResourceException;
 
+    /**
+     * @return number of deadlocks that have been detected and prevented.
+     * @see #getWriteLock(Object, Transaction) and {@link #getReadLock(Object, Transaction)}.
+     */
     long getDetectedDeadlockCount();
 
+    /**
+     * Utility method for debugging. Dumps info to {@code logging} about txs having locks on resources.
+     */
     void dumpLocksOnResource( Object resource, Logging logging );
 
+    /**
+     * @return a {@link List} of all locks currently active.
+     */
     List<LockInfo> getAllLocks();
 
+    /**
+     * Returns info about locks that have been awaited for {@code minWaitTime} milliseconds.
+     * @param minWaitTime the threshold time in milliseconds for inclusion in the resulting {@link List}.
+     * @return locks that have been awaited for at least {@code minWaitTime} milliseconds.
+     */
     List<LockInfo> getAwaitedLocks( long minWaitTime );
 
+    /**
+     * Utility method for debugging. Dumps the resource allocation graph to {@code logging}.
+     */
     void dumpRagStack( Logging logging );
 
+    /**
+     * Utility method for debugging. Dumps info about each lock to {@code logging}.
+     */
     void dumpAllLocks( Logging logging );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/LockNotFoundException.java
@@ -25,9 +25,4 @@ public class LockNotFoundException extends LockException
     {
         super( message );
     }
-
-    public LockNotFoundException( String s, Throwable throwable )
-    {
-        super(s, throwable);
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RWLock.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.ListIterator;
 import java.util.Set;
 
 import javax.transaction.Transaction;
@@ -37,6 +38,12 @@ import org.neo4j.kernel.info.LockInfo;
 import org.neo4j.kernel.info.LockingTransaction;
 import org.neo4j.kernel.info.ResourceType;
 import org.neo4j.kernel.info.WaitingThread;
+
+import static java.lang.Thread.currentThread;
+import static java.lang.Thread.interrupted;
+
+import static org.neo4j.kernel.impl.transaction.LockType.READ;
+import static org.neo4j.kernel.impl.transaction.LockType.WRITE;
 
 /**
  * A read/write lock is a lock that will allow many transactions to acquire read
@@ -66,19 +73,15 @@ import org.neo4j.kernel.info.WaitingThread;
  */
 class RWLock implements Visitor<LineLogger, RuntimeException>
 {
-    private int writeCount = 0; // total writeCount
-    private int readCount = 0; // total readCount
-    private int marked = 0; // synch helper in LockManager
-
-    private final Object resource; // the resource for this RWLock
-
-    private final LinkedList<WaitElement> waitingThreadList =
-        new LinkedList<WaitElement>();
-
-    private final ArrayMap<Transaction,TxLockElement> txLockElementMap =
-        new ArrayMap<Transaction,TxLockElement>( (byte)5, false, true );
-
+    private final Object resource; // the resource this RWLock locks
+    private final LinkedList<WaitElement> waitingThreadList = new LinkedList<>();
+    private final ArrayMap<Transaction,TxLockElement> txLockElementMap = new ArrayMap<>( (byte)5, false, true );
     private final RagManager ragManager;
+    
+    // access to these is guarded by synchronized blocks
+    private int totalReadCount;
+    private int totalWriteCount;
+    private int marked; // synch helper in LockManager
 
     RWLock( Object resource, RagManager ragManager )
     {
@@ -89,25 +92,31 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
     // keeps track of a transactions read and write lock count on this RWLock
     private static class TxLockElement
     {
-        final Transaction tx;
-        int readCount = 0;
-        int writeCount = 0;
-
-        private boolean movedOn = false;
+        private final Transaction tx;
+        
+        // access to these is guarded by synchronized blocks
+        private int readCount;
+        private int writeCount;
+        private boolean movedOn;
 
         TxLockElement( Transaction tx )
         {
             this.tx = tx;
+        }
+        
+        boolean isFree()
+        {
+            return readCount == 0 && writeCount == 0;
         }
     }
 
     // keeps track of what type of lock a thread is waiting for
     private static class WaitElement
     {
-        final TxLockElement element;
-        final LockType lockType;
-        final Thread waitingThread;
-        final long since = System.currentTimeMillis();
+        private final TxLockElement element;
+        private final LockType lockType;
+        private final Thread waitingThread;
+        private final long since = System.currentTimeMillis();
 
         WaitElement( TxLockElement element, LockType lockType, Thread thread )
         {
@@ -139,52 +148,52 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
      * @throws DeadlockDetectedException
      *             if a deadlock is detected
      */
-    synchronized void acquireReadLock(Transaction tx) throws DeadlockDetectedException
+    synchronized void acquireReadLock( Transaction tx ) throws DeadlockDetectedException
     {
-        assertTransaction( tx );
-        TxLockElement tle = txLockElementMap.get( tx );
-        if ( tle == null )
-        {
-            tle = new TxLockElement( tx );
-        }
+        TxLockElement tle = getOrCreateLockElement( tx );
 
         try
         {
             tle.movedOn = false;
-            while ( writeCount > tle.writeCount )
+            while ( totalWriteCount > tle.writeCount )
             {
-                ragManager.checkWaitOn( this, tx );
-                waitingThreadList.addFirst( new WaitElement( tle,
-                    LockType.READ, Thread.currentThread() ) );
-                try
-                {
-                    wait();
-                }
-                catch ( InterruptedException e )
-                {
-                    Thread.interrupted();
-                }
-                ragManager.stopWaitOn( this, tx );
+                deadlockGuardedWait( tx, tle, READ );
             }
 
-            if ( tle.readCount == 0 && tle.writeCount == 0 )
-            {
-                ragManager.lockAcquired( this, tx );
-            }
-            readCount++;
-            tle.readCount++;
-            tle.movedOn = true;
-            // TODO: this put could be optimized?
-            txLockElementMap.put( tx, tle );
+            registerReadLockAcquired( tx, tle );
         }
         finally
         {
             // if deadlocked, remove marking so lock is removed when empty
+            tle.movedOn = true;
             marked--;
         }
     }
 
-	/**
+    synchronized boolean tryAcquireReadLock( Transaction tx )
+    {
+        TxLockElement tle = getOrCreateLockElement( tx );
+
+        try
+        {
+            tle.movedOn = false;
+            if ( totalWriteCount > tle.writeCount )
+            {
+                return false;
+            }
+
+            registerReadLockAcquired( tx, tle );
+            return true;
+        }
+        finally
+        {
+            // if deadlocked, remove marking so lock is removed when empty
+            tle.movedOn = true;
+            marked--;
+        }
+    }
+
+    /**
 	 * Releases the read lock held by the provided transaction. If it is null then
 	 * an attempt to acquire the current transaction will be made. This is to
 	 * make safe calling the method from the context of an
@@ -193,24 +202,18 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
 	 * transactions in the queue they will be interrupted if they can acquire
 	 * the lock.
 	 */
-    synchronized void releaseReadLock(Transaction tx) throws LockNotFoundException
+    synchronized void releaseReadLock( Transaction tx ) throws LockNotFoundException
     {
-        assertTransaction( tx );
-        TxLockElement tle = txLockElementMap.get( tx );
-        if ( tle == null )
-        {
-            throw new LockNotFoundException(
-                "No transaction lock element found for " + tx );
-        }
+        TxLockElement tle = getLockElement( tx );
 
         if ( tle.readCount == 0 )
         {
             throw new LockNotFoundException( "" + tx + " don't have readLock" );
         }
 
-        readCount--;
+        totalReadCount--;
         tle.readCount--;
-        if ( tle.readCount == 0 && tle.writeCount == 0 )
+        if ( tle.isFree() )
         {
             if ( !this.isMarked() )
             {
@@ -230,7 +233,7 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
                 // locks, if none of these are found it means that there
                 // is a (are) thread(s) that will release read lock(s) in the
                 // near future...
-                if ( readCount == we.element.readCount )
+                if ( totalReadCount == we.element.readCount )
                 {
                     // found a write lock with all read locks
                     waitingThreadList.removeLast();
@@ -241,16 +244,14 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
                 }
                 else
                 {
-                    java.util.ListIterator<WaitElement> listItr =
-                        waitingThreadList.listIterator(
+                    ListIterator<WaitElement> listItr = waitingThreadList.listIterator(
                             waitingThreadList.lastIndexOf( we ) );
                     // hm am I doing the first all over again?
                     // think I am if cursor is at lastIndex + 0.5 oh well...
                     while ( listItr.hasPrevious() )
                     {
                         we = listItr.previous();
-                        if ( we.lockType == LockType.WRITE
-                            && readCount == we.element.readCount )
+                        if ( we.lockType == LockType.WRITE && totalReadCount == we.element.readCount )
                         {
                             // found a write lock with all read locks
                             listItr.remove();
@@ -277,8 +278,8 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
             {
                 // some thread may have the write lock and released a read lock
                 // if writeCount is down to zero we can interrupt the waiting
-                // readlock
-                if ( writeCount == 0 )
+                // read lock
+                if ( totalWriteCount == 0 )
                 {
                     waitingThreadList.removeLast();
                     if ( !we.element.movedOn )
@@ -288,12 +289,6 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
                 }
             }
         }
-    }
-
-    private void assertTransaction( Transaction tx )
-    {
-        if ( tx == null )
-            throw new IllegalArgumentException();
     }
 
     /**
@@ -319,52 +314,52 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
      * @throws DeadlockDetectedException
      *             if a deadlock is detected
      */
-    synchronized void acquireWriteLock(Transaction tx) throws DeadlockDetectedException
+    synchronized void acquireWriteLock( Transaction tx ) throws DeadlockDetectedException
     {
-        assertTransaction( tx );
-        TxLockElement tle = txLockElementMap.get( tx );
-        if ( tle == null )
-        {
-            tle = new TxLockElement( tx );
-        }
+        TxLockElement tle = getOrCreateLockElement( tx );
 
         try
         {
             tle.movedOn = false;
-            while ( writeCount > tle.writeCount || readCount > tle.readCount )
+            while ( totalWriteCount > tle.writeCount || totalReadCount > tle.readCount )
             {
-                ragManager.checkWaitOn( this, tx );
-                waitingThreadList.addFirst( new WaitElement( tle,
-                    LockType.WRITE, Thread.currentThread() ) );
-                try
-                {
-                    wait();
-                }
-                catch ( InterruptedException e )
-                {
-                    Thread.interrupted();
-                }
-                ragManager.stopWaitOn( this, tx );
+                deadlockGuardedWait( tx, tle, WRITE );
             }
 
-            if ( tle.readCount == 0 && tle.writeCount == 0 )
-            {
-                ragManager.lockAcquired( this, tx );
-            }
-            writeCount++;
-            tle.writeCount++;
-            tle.movedOn = true;
-            // TODO optimize this put?
-            txLockElementMap.put( tx, tle );
+            registerWriteLockAcquired( tx, tle );
         }
         finally
         {
             // if deadlocked, remove marking so lock is removed when empty
+            tle.movedOn = true;
             marked--;
         }
     }
 
-	/**
+    synchronized boolean tryAcquireWriteLock( Transaction tx )
+    {
+        TxLockElement tle = getOrCreateLockElement( tx );
+
+        try
+        {
+            tle.movedOn = false;
+            if ( totalWriteCount > tle.writeCount || totalReadCount > tle.readCount )
+            {
+                return false;
+            }
+
+            registerWriteLockAcquired( tx, tle );
+            return true;
+        }
+        finally
+        {
+            // if deadlocked, remove marking so lock is removed when empty
+            tle.movedOn = true;
+            marked--;
+        }
+    }
+    
+    /**
 	 * Releases the write lock held by the provided tx. If it is null then an
 	 * attempt to acquire the current transaction from the transaction manager
 	 * will be made. This is to make safe calling this method as an
@@ -373,24 +368,18 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
 	 * transactions in the queue they will be interrupted if they can acquire
 	 * the lock.
 	 */
-    synchronized void releaseWriteLock(Transaction tx) throws LockNotFoundException
+    synchronized void releaseWriteLock( Transaction tx ) throws LockNotFoundException
     {
-        assertTransaction( tx );
-        TxLockElement tle = txLockElementMap.get( tx );
-        if ( tle == null )
-        {
-            throw new LockNotFoundException(
-                "No transaction lock element found for " + tx );
-        }
+        TxLockElement tle = getLockElement( tx );
 
         if ( tle.writeCount == 0 )
         {
             throw new LockNotFoundException( "" + tx + " don't have writeLock" );
         }
 
-        writeCount--;
+        totalWriteCount--;
         tle.writeCount--;
-        if ( tle.readCount == 0 && tle.writeCount == 0 )
+        if ( tle.isFree() )
         {
             if ( !this.isMarked() )
             {
@@ -404,7 +393,7 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
         // (that is: If writeCount > 0 a waiting thread in the queue cannot be
         // the thread that holds the write locks because then it would never
         // have been put into wait mode)
-        if ( writeCount == 0 && waitingThreadList.size() > 0 )
+        if ( totalWriteCount == 0 && waitingThreadList.size() > 0 )
         {
             // wake elements in queue until a write lock is found or queue is
             // empty
@@ -426,12 +415,12 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
 
     int getWriteCount()
     {
-        return writeCount;
+        return totalWriteCount;
     }
 
     int getReadCount()
     {
-        return readCount;
+        return totalReadCount;
     }
 
     synchronized int getWaitingThreadsCount()
@@ -442,8 +431,8 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
     @Override
     public synchronized boolean visit( LineLogger logger )
     {
-        logger.logLine( "Total lock count: readCount=" + readCount
-            + " writeCount=" + writeCount + " for " + resource );
+        logger.logLine( "Total lock count: readCount=" + totalReadCount
+            + " writeCount=" + totalWriteCount + " for " + resource );
 
         logger.logLine( "Waiting list:" );
         Iterator<WaitElement> wElements = waitingThreadList.iterator();
@@ -476,8 +465,8 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
 
     synchronized LockInfo info()
     {
-        Set<LockingTransaction> lockingTxs = new HashSet<LockingTransaction>();
-        Set<WaitingThread> waitingTxs = new HashSet<WaitingThread>();
+        Set<LockingTransaction> lockingTxs = new HashSet<>();
+        Set<WaitingThread> waitingTxs = new HashSet<>();
         for ( TxLockElement tle : txLockElementMap.values() )
         {
             lockingTxs.add( new LockingTransaction( tle.tx.toString(), tle.readCount, tle.writeCount ) );
@@ -505,14 +494,18 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
             type = ResourceType.OTHER;
             id = resource.toString();
         }
-        return new LockInfo( type, id, readCount, writeCount, new ArrayList<LockingTransaction>( lockingTxs ), new ArrayList<WaitingThread>( waitingTxs ) );
+        return new LockInfo( type, id, totalReadCount, totalWriteCount,
+                new ArrayList<>( lockingTxs ), new ArrayList<>( waitingTxs ) );
     }
 
     synchronized boolean acceptVisitorIfWaitedSinceBefore( Visitor<LockInfo, RuntimeException> visitor, long waitStart )
     {
         for ( WaitElement thread : waitingThreadList )
         {
-            if ( thread.since < waitStart ) return visitor.visit( info() );
+            if ( thread.since < waitStart )
+            {
+                return visitor.visit( info() );
+            }
         }
         return false;
     }
@@ -521,5 +514,71 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
     public String toString()
     {
         return "RWLock[" + resource + "]";
+    }
+
+    private void registerReadLockAcquired( Transaction tx, TxLockElement tle )
+    {
+        registerLockAcquired( tx, tle );
+        totalReadCount++;
+        tle.readCount++;
+    }
+
+    private void registerWriteLockAcquired( Transaction tx, TxLockElement tle )
+    {
+        registerLockAcquired( tx, tle );
+        totalWriteCount++;
+        tle.writeCount++;
+    }
+
+    private void registerLockAcquired( Transaction tx, TxLockElement tle )
+    {
+        if ( tle.isFree() )
+        {
+            ragManager.lockAcquired( this, tx );
+        }
+    }
+
+    private TxLockElement getLockElement( Transaction tx )
+    {
+        TxLockElement tle = txLockElementMap.get( tx );
+        if ( tle == null )
+        {
+            throw new LockNotFoundException( "No transaction lock element found for " + tx );
+        }
+        return tle;
+    }
+
+    private void assertTransaction( Transaction tx )
+    {
+        if ( tx == null )
+        {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private void deadlockGuardedWait( Transaction tx, TxLockElement tle, LockType lockType )
+    {   // given: we must be in a synchronized block here
+        ragManager.checkWaitOn( this, tx );
+        waitingThreadList.addFirst( new WaitElement( tle, lockType, currentThread() ) );
+        try
+        {
+            wait();
+        }
+        catch ( InterruptedException e )
+        {
+            interrupted();
+        }
+        ragManager.stopWaitOn( this, tx );
+    }
+
+    private TxLockElement getOrCreateLockElement( Transaction tx )
+    {
+        assertTransaction( tx );
+        TxLockElement tle = txLockElementMap.get( tx );
+        if ( tle == null )
+        {
+            txLockElementMap.put( tx, tle = new TxLockElement( tx ) );
+        }
+        return tle;
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -81,8 +81,8 @@ import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.core.WritableTransactionState;
 import org.neo4j.kernel.impl.transaction.LockManager;
-import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
+import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.impl.transaction.TxManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
@@ -410,8 +410,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         LockManager lockManager =
                 (LockManager) Proxy.newProxyInstance( LockManager.class.getClassLoader(),
                         new Class[]{LockManager.class}, lockManagerDelegate );
-        new LockManagerModeSwitcher( memberStateMachine, lockManagerDelegate, txManager, txHook,
-                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory, availabilityGuard, config );
+        new LockManagerModeSwitcher( memberStateMachine, lockManagerDelegate,
+                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory );
         return lockManager;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -128,7 +128,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
 
     public static final int UNFINISHED_TRANSACTION_CLEANUP_DELAY = 1;
 
-    private SPI spi;
+    private final SPI spi;
     private final StringLogger msgLog;
     private final Config config;
 
@@ -239,7 +239,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
 
     private void resumeTransaction( RequestContext txId )
     {
-        spi.resumeTransaction(getTx(txId));
+        spi.resumeTransaction( getTx( txId ) );
     }
 
     private void suspendTransaction( RequestContext context )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LocalDeadlockDetectedException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LocalDeadlockDetectedException.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.lock;
+
+import javax.transaction.Transaction;
+
+import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.impl.transaction.LockManager;
+import org.neo4j.kernel.impl.transaction.LockType;
+import org.neo4j.kernel.info.LockInfo;
+
+import static java.lang.String.format;
+
+/**
+ * Temporary exception to aid in driving out a nasty "lock get stuck" issue in HA. Since it's subclasses
+ * {@link DeadlockDetectedException} it will be invisible to users and code that already handle such
+ * deadlock exceptions and retry. This exception is thrown instead of awaiting a lock locally on a slave
+ * after it was acquired on the master, since applying a lock locally after master granted it should succeed,
+ * or fail; it cannot wait for another condition.
+ * 
+ * While this work-around is in place there is more breathing room to figure out the real problem preventing
+ * some local locks to be grabbed.
+ * 
+ * @author Mattias Persson
+ */
+public class LocalDeadlockDetectedException extends DeadlockDetectedException
+{
+    public LocalDeadlockDetectedException( LockManager lockManager, Transaction tx, Object resource,
+            LockType type )
+    {
+        super( constructHelpfulDiagnosticsMessage( lockManager, tx, resource, type ) );
+    }
+
+    private static String constructHelpfulDiagnosticsMessage( LockManager lockManager,
+            Transaction tx, Object resource, LockType type )
+    {
+        StringBuilder builder = new StringBuilder( format(
+                "%s tried to apply local %s lock on %s after acquired on master. Currently these locks exist:%n",
+                tx, type, resource ) );
+        for ( LockInfo lock : lockManager.getAllLocks() )
+        {
+            if ( lock.getReadCount() > 0 || lock.getWriteCount() > 0 )
+            {
+                builder.append( format( lock.toString() /*lock.toString includes a %n at the end*/ ) );
+            }
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
A slave in an HA cluster acquires locks by first acquiring it on its
master, and if granted go and acquire it locally. Given that the master is
the authorative instances w/ regards to locks in the cluster it is
expected that acquiring a lock that the master just granted should not
have to await any condition - it's expected to be free to acquire. However
that is apparently not the case since sometimes the slave comes back from
the master having just acquired it and it goes and blocks, awaiting the
lock to be free since some other transactions holds it presumably.

The problem described above in many cases results in such a lock being
stuck forever on the master, where the only way to release it would be to
restart that database.

This commit doesn't fix the issue that is the confusion that the master is
not the single authorative entity of locks. The fix here is to prevent a
local lock acquisition, after master acquired such, to go and wait for that
lock to be free locally. If that would happen then it will not wait, but
instead throw a DeadlockDetectedException (actually a subclass thereof)
containing diagnostics about which locks are present in the local lock
manager. These deadlock detected exceptions will walk and quack the same
way a "real" such deadlock and a normal retry of the transaction will put
things right again.

The root cause will have to be fixed, but having a few more deadlock
detected exceptions thrown to the client instead of leaving unreleasable
locks on the master behind is a massive improvement.

For reference, this issue caused many unexpected BlockingReadTimeoutExceptions
to be thrown, exceptions of which there should be much less of after this commit.
