### PR TITLE
Initialize transactions on master as late as possible.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/DefaultTxHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DefaultTxHook.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 
 /**
@@ -28,7 +29,7 @@ import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 public class DefaultTxHook implements RemoteTxHook
 {
     @Override
-    public void remotelyInitializeTransaction( int eventIdentifier )
+    public void remotelyInitializeTransaction( int eventIdentifier, TransactionState state )
     {
         // Do nothing from the ordinary here
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -149,6 +149,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
 import org.neo4j.kernel.impl.traversal.BidirectionalTraversalDescriptionImpl;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
 import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.Monitors;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.info.DiagnosticsManager;
@@ -249,6 +250,7 @@ public abstract class InternalAbstractGraphDatabase
     protected JobScheduler jobScheduler;
     protected UpdateableSchemaState updateableSchemaState;
     protected CleanupService cleanupService;
+    protected Monitors monitors;
 
     protected final LifeSupport life = new LifeSupport();
     private final Map<String, CacheProvider> cacheProviders;
@@ -394,6 +396,9 @@ public abstract class InternalAbstractGraphDatabase
 
         // Create logger
         this.logging = createLogging();
+
+        // Component monitoring
+        this.monitors = new Monitors( logging.getMessagesLog( Monitors.class ) );
 
         // Apply autoconfiguration for memory settings
         AutoConfigurator autoConfigurator = new AutoConfigurator( fileSystem,
@@ -1368,6 +1373,14 @@ public abstract class InternalAbstractGraphDatabase
             else if ( IdGeneratorFactory.class.isAssignableFrom( type ) )
             {
                 return type.cast( idGeneratorFactory );
+            }
+            else if ( Monitors.class.isAssignableFrom( type ) )
+            {
+                return type.cast( monitors );
+            }
+            else if ( RemoteTxHook.class.isAssignableFrom( type ) )
+            {
+                return type.cast( txHook );
             }
             else if ( DependencyResolver.class.equals( type ) )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
@@ -198,4 +198,15 @@ public class NoTransactionState implements TransactionState
     {
         return Iterables.empty();
     }
+
+    @Override
+    public boolean isRemotelyInitialized()
+    {
+        return false;
+    }
+
+    @Override
+    public void markAsRemotelyInitialized()
+    {
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
@@ -44,6 +44,8 @@ import org.neo4j.kernel.impl.util.RelIdArray;
  */
 public interface TransactionState
 {
+    TransactionState NO_STATE = new NoTransactionState();
+
     LockElement acquireWriteLock( Object resource );
 
     LockElement acquireReadLock( Object resource );
@@ -101,5 +103,57 @@ public interface TransactionState
     // Tech debt, this is here waiting for transaction state to move to the TxState class
     Iterable<WritableTransactionState.CowNodeElement> getChangedNodes();
 
-    TransactionState NO_STATE = new NoTransactionState();
+    /**
+     * A history of slave transactions and their cultural impact on Graph Databases.
+     *
+     *
+     * Acknowledgments
+     *
+     * I would like to thank both Mattias and Chris for their excellent input on this subject, without their eye
+     * witness accounts of the actual events, none of this would be possible.
+     *
+     *
+     * Chapter I
+     * Humble Beginnings
+     *
+     * Once upon a time, when a slave asked the master to perform an action, this used to imply something, a bond.
+     * The master recognized the slaves need for a transaction, and would implicitly create one. It was a time of peace
+     * and of reconciliation. Alas, this soon led to confusion as untrustworthy networks would cause master switches.
+     * A new master might receive a message intended for another, and would out of the kindness of his kernel create a
+     * new transaction for the slave. While a beautiful gesture, it shouldn't have done this because now it had tore
+     * transaction state into two transactions, a most vile abomination.
+     *
+     * So it was decided that the trust the masters had in their slaves must be revoked. Instead slaves had to
+     * explicitly ask the masters to create a transaction. All was now consistent - but now an additional network hop
+     * was required, and slaves begin transactions on the masters for the most simple of requests. Read only operations
+     * would suddenly pull updates. The universe was in disarray.
+     *
+     *
+     * Chapter II
+     * A hack
+     *
+     * Pulling updates on read operations is very bad, because it voids the databases contracts for when updates should
+     * be pulled, and makes read scaling perform very poorly. It was soon recognized that, while correct, the new
+     * regimen could not be allowed to stand. A hack was devised, whereupon the slave would wait to initialize the
+     * transaction on the master until the first write lock was required. A clear signal that a write was about to
+     * happen.
+     *
+     * This very hack is why the below methods exist.
+     *
+     *
+     * Chapter III
+     * A new dawn
+     *
+     * Once all Neo4j operations are contained in the Kernel component, the kernel will be able to get a clear view of
+     * all running transactions, and clear entry points for all running operations within those transactions. With that,
+     * a new rein of trust can be implemented. As soon as a slave sees a new master, it will be able to void all running
+     * transactions, and start new with the new master. This will allow a return to the days of implicit transactions,
+     * where network communication is done only just when it is needed, and removing the additional network hop.
+     *
+     * The End.
+     *
+     */
+    boolean isRemotelyInitialized();
+
+    void markAsRemotelyInitialized();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
@@ -62,6 +62,8 @@ public class WritableTransactionState implements TransactionState
     private List<LockElement> lockElements;
     private PrimitiveElement primitiveElement;
 
+    private boolean isRemotelyInitialized = false;
+
     public static class PrimitiveElement
     {
         PrimitiveElement()
@@ -788,5 +790,17 @@ public class WritableTransactionState implements TransactionState
     public TxIdGenerator getTxIdGenerator()
     {
         return txIdGenerator;
+    }
+
+    @Override
+    public boolean isRemotelyInitialized()
+    {
+        return isRemotelyInitialized;
+    }
+
+    @Override
+    public void markAsRemotelyInitialized()
+    {
+        isRemotelyInitialized = true;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConnectionBroker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConnectionBroker.java
@@ -59,6 +59,7 @@ public abstract class IndexConnectionBroker<T extends XaConnection>
                                                 + con.getXaResource() + "' in "
                                                 + tx );
                 }
+
                 tx.registerSynchronization( new TxCommitHook( tx ) );
                 txConnectionMap.put( tx, con );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/AbstractTransactionManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/AbstractTransactionManager.java
@@ -40,12 +40,23 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public abstract class AbstractTransactionManager implements TransactionManager, Lifecycle
 {
+    public abstract void doRecovery() throws Throwable;
+
+    /**
+     * Returns the {@link TransactionState} associated with the current transaction.
+     * If no transaction is active for the current thread {@link TransactionState#NO_STATE}
+     * should be returned.
+     *
+     * @return state associated with the current transaction for this thread.
+     */
+    public abstract TransactionState getTransactionState();
+
+    public abstract int getEventIdentifier();
+
     public void begin( ForceMode forceMode ) throws NotSupportedException, SystemException
     {
         begin();
     }
-
-    public abstract void doRecovery() throws Throwable;
 
     /**
      * @return which {@link ForceMode} the transaction tied to the calling
@@ -55,17 +66,6 @@ public abstract class AbstractTransactionManager implements TransactionManager, 
     {
         return ForceMode.forced;
     }
-    
-    /**
-     * Returns the {@link TransactionState} associated with the current transaction.
-     * If no transaction is active for the current thread {@link TransactionState#NO_STATE}
-     * should be returned.
-     * 
-     * @return state associated with the current transaction for this thread.
-     */
-    public abstract TransactionState getTransactionState();
-
-    public abstract int getEventIdentifier();
 
     /**
      * @return the error that happened during recovery, if recovery has taken place, null otherwise.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RemoteTxHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RemoteTxHook.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
+import org.neo4j.kernel.impl.core.TransactionState;
+
 /**
  * Hook for remote transaction coordination
  */
 public interface RemoteTxHook
 {
-    void remotelyInitializeTransaction( int eventIdentifier );
+    void remotelyInitializeTransaction( int eventIdentifier, TransactionState state );
     
     void remotelyFinishTransaction( int eventIdentifier, boolean success );
     

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Monitors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Monitors.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.lang.reflect.Proxy.newProxyInstance;
+
+/**
+ * This allows injecting monitoring listeners into a running component. It works by a component declaring a Monitor
+ * interface, which contains methods that it will call at various interesting parts of it's regular operations. The
+ * component asks for an implementation of the interface from this service, and uses that implementation to call
+ * the various hook methods.
+ *
+ * An external stakeholder can then register listeners through this monitor service, which will receive calls from the
+ * original component as long as it is registered.
+ */
+public class Monitors
+{
+    private final ConcurrentMap<Class<?>, MonitorProxy> proxies = new ConcurrentHashMap<>();
+    private final StringLogger logger;
+
+    public Monitors(StringLogger logger)
+    {
+        this.logger = logger;
+    }
+
+    /**
+     * Get a new monitor instance, used by the component being monitored.
+     */
+    public <T> T newMonitor( Class<T> monitorInterface )
+    {
+        MonitorProxy<T> monitorProxy = proxyFor( monitorInterface );
+        return monitorProxy.instance();
+    }
+
+    /**
+     * Add a listener. The listener will recieve calls for all valid monitor interfaces it implements.
+     */
+    public void addListener( Object listener )
+    {
+        for ( Class<?> monitorInterface : listener.getClass().getInterfaces() )
+        {
+            if( validMonitorInterface( monitorInterface ))
+            {
+                proxyFor(monitorInterface).addListener( listener );
+            }
+        }
+    }
+
+    /**
+     * Add a listener. The listener will recieve calls for all valid monitor interfaces it implements.
+     */
+    public void removeListener( Object listener )
+    {
+        for ( Class<?> monitorInterface : listener.getClass().getInterfaces() )
+        {
+            if( validMonitorInterface( monitorInterface ))
+            {
+                proxyFor(monitorInterface).removeListener( listener );
+            }
+        }
+    }
+
+    private static final class MonitorProxy<T> implements InvocationHandler
+    {
+        private final Class<T> monitorInterface;
+        private final Set<T> listeners = new HashSet<>();
+        private final T proxyInstance;
+        private final StringLogger logger;
+
+        private MonitorProxy(Class<T> monitorInterface, StringLogger logger)
+        {
+            this.monitorInterface = monitorInterface;
+            this.logger = logger;
+            assertValidMonitorInterface( monitorInterface );
+            proxyInstance = (T) newProxyInstance( getClass().getClassLoader(), new Class[]{monitorInterface}, this );
+        }
+
+        public T instance()
+        {
+            return proxyInstance;
+        }
+
+        @Override
+        public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
+        {
+            for ( T listener : listeners )
+            {
+                try
+                {
+                    method.invoke( listener, args );
+                }
+                catch(Exception e)
+                {
+                    logger.error( "Monitor listener failure.", e );
+                }
+            }
+
+            return null;
+        }
+
+        public void addListener( Object rawListener )
+        {
+            listeners.add(monitorInterface.cast( rawListener ));
+        }
+
+        public void removeListener( Object rawListener )
+        {
+            listeners.remove(monitorInterface.cast( rawListener ));
+        }
+    }
+
+    private <T> MonitorProxy<T> proxyFor( Class<T> monitorInterface )
+    {
+        if(!proxies.containsKey( monitorInterface ))
+        {
+            proxies.putIfAbsent( monitorInterface, new MonitorProxy(monitorInterface, logger) );
+        }
+
+        return proxies.get( monitorInterface );
+    }
+
+    private static void assertValidMonitorInterface( Class<?> monitorInterface )
+    {
+        if(!validMonitorInterface( monitorInterface ))
+        {
+            throw new IllegalArgumentException( "Only void methods are allowed in monitor interfaces: "
+                    + monitorInterface );
+        }
+    }
+
+    private static boolean validMonitorInterface( Class<?> monitorInterface )
+    {
+        for ( Method method : monitorInterface.getDeclaredMethods() )
+        {
+            if(method.getReturnType() != void.class)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/MonitorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/MonitorsTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class MonitorsTest
+{
+    interface MyMonitor
+    {
+        void aVoid();
+        void takesArgs( String arg1, long arg2, Object ... moreArgs );
+    }
+
+    @Test
+    public void shouldProvideNoOpDelegate() throws Exception
+    {
+        // Given
+        Monitors monitors = new Monitors(StringLogger.DEV_NULL);
+
+        // When
+        MyMonitor monitor = monitors.newMonitor( MyMonitor.class );
+
+        // Then those should be no-ops
+        monitor.aVoid();
+        monitor.takesArgs( "ha", 12, new Object() );
+    }
+
+    @Test
+    public void shouldRegister() throws Exception
+    {
+        // Given
+        Monitors monitors = new Monitors(StringLogger.DEV_NULL);
+
+        MyMonitor listener = mock( MyMonitor.class );
+        MyMonitor monitor = monitors.newMonitor( MyMonitor.class );
+        Object obj = new Object();
+
+        // When
+        monitors.addListener( listener );
+        monitor.aVoid();
+        monitor.takesArgs( "ha", 12, obj );
+
+        // Then
+        verify(listener).aVoid();
+        verify(listener).takesArgs( "ha", 12, obj );
+    }
+
+    @Test
+    public void shouldUnregister() throws Exception
+    {
+        // Given
+        Monitors monitors = new Monitors(StringLogger.DEV_NULL);
+
+        MyMonitor listener = mock( MyMonitor.class );
+        MyMonitor monitor = monitors.newMonitor( MyMonitor.class );
+        Object obj = new Object();
+
+        monitors.addListener( listener );
+
+        // When
+        monitors.removeListener( listener );
+        monitor.aVoid();
+        monitor.takesArgs( "ha", 12, obj );
+
+        // Then
+        verifyNoMoreInteractions( listener );
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/ConnectionBroker.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/ConnectionBroker.java
@@ -27,8 +27,8 @@ public class ConnectionBroker extends IndexConnectionBroker<LuceneXaConnection>
 {
     private final LuceneDataSource xaDs;
 
-    public ConnectionBroker(TransactionManager transactionManager,
-                            LuceneDataSource dataSource)
+    public ConnectionBroker( TransactionManager transactionManager,
+                             LuceneDataSource dataSource )
     {
         super( transactionManager );
         this.xaDs = dataSource;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -377,7 +377,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 xaDataSourceManager, logging, config.get( HaSettings.com_chunk_size ).intValue() ) ) );
 
         new TxIdGeneratorModeSwitcher( memberStateMachine, txIdGeneratorDelegate,
-                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory, msgLog, config, slaves );
+                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory, msgLog, config, slaves,
+                txManager );
         return txIdGenerator;
     }
 
@@ -387,7 +388,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         idGeneratorFactory = new HaIdGeneratorFactory( master, logging );
         highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher( clusterClient, masterDelegateInvocationHandler,
                 clusterMemberAvailability, memberStateMachine, this, (HaIdGeneratorFactory) idGeneratorFactory,
-                config, logging, updateableSchemaState, kernelExtensions.listFactories() );
+                config, logging, updateableSchemaState, kernelExtensions.listFactories(), monitors );
         /*
          * We always need the mode switcher and we need it to restart on switchover.
          */
@@ -411,7 +412,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 (LockManager) Proxy.newProxyInstance( LockManager.class.getClassLoader(),
                         new Class[]{LockManager.class}, lockManagerDelegate );
         new LockManagerModeSwitcher( memberStateMachine, lockManagerDelegate,
-                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory );
+                (HaXaDataSourceManager) xaDataSourceManager, master, requestContextFactory, txManager, txHook,
+                availabilityGuard, config );
         return lockManager;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -86,6 +86,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.NoSuchLogVersionException;
 import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
 import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
 import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.Monitors;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -143,6 +144,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
 
     private final UpdateableSchemaState updateableSchemaState;
     private final Iterable<KernelExtensionFactory<?>> kernelExtensions;
+    private final Monitors monitors;
 
     private volatile URI me;
 
@@ -151,7 +153,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                                          HighAvailabilityMemberStateMachine stateHandler, GraphDatabaseAPI graphDb,
                                          HaIdGeneratorFactory idGeneratorFactory, Config config, Logging logging,
                                          UpdateableSchemaState updateableSchemaState,
-                                         Iterable<KernelExtensionFactory<?>> kernelExtensions )
+                                         Iterable<KernelExtensionFactory<?>> kernelExtensions, Monitors monitors )
     {
         this.bindingNotifier = bindingNotifier;
         this.delegateHandler = delegateHandler;
@@ -162,6 +164,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         this.logging = logging;
         this.updateableSchemaState = updateableSchemaState;
         this.kernelExtensions = kernelExtensions;
+        this.monitors = monitors;
         this.msgLog = logging.getMessagesLog( getClass() );
         this.life = new LifeSupport();
         this.stateHandler = stateHandler;
@@ -288,7 +291,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                         .resolveDependency( TransactionManager.class );
                 MasterImpl.SPI spi = new DefaultMasterImplSPI( graphDb, logging, txManager );
 
-                MasterImpl masterImpl = new MasterImpl( spi, logging, config );
+                MasterImpl masterImpl = new MasterImpl( spi, monitors, logging, config );
 
                 MasterServer masterServer = new MasterServer( masterImpl, logging, serverConfig(),
                         new BranchDetectingTxVerifier( graphDb ) );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.StringLogger;
 
@@ -42,11 +43,12 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
     private StringLogger msgLog;
     private Config config;
     private Slaves slaves;
+    private final AbstractTransactionManager tm;
 
     public TxIdGeneratorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                       DelegateInvocationHandler<TxIdGenerator> delegate, HaXaDataSourceManager xaDsm,
                                       Master master, RequestContextFactory requestContextFactory,
-                                      StringLogger msgLog, Config config, Slaves slaves
+                                      StringLogger msgLog, Config config, Slaves slaves, AbstractTransactionManager tm
     )
     {
         super( stateMachine, delegate );
@@ -56,6 +58,7 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
         this.msgLog = msgLog;
         this.config = config;
         this.slaves = slaves;
+        this.tm = tm;
     }
 
     @Override
@@ -68,6 +71,6 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
     protected TxIdGenerator getSlaveImpl( URI serverHaUri )
     {
         return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master,
-                HighAvailabilityModeSwitcher.getServerId( serverHaUri ), requestContextFactory, xaDsm );
+                HighAvailabilityModeSwitcher.getServerId( serverHaUri ), requestContextFactory, xaDsm, tm);
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
@@ -51,7 +51,6 @@ import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 
 public class UniqueConstraintHaIT
 {
-
     @Rule
     public ClusterRule clusterRule = new ClusterRule( getClass() );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.ha.com.master.MasterImpl;
+import org.neo4j.kernel.impl.util.Monitors;
+import org.neo4j.test.ha.ClusterManager;
+import org.neo4j.test.ha.ClusterRule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.neo4j.helpers.collection.Iterables.count;
+
+/**
+ * Determines when slaves should initialize a transaction on the master. This is particularly relevant for read operations
+ * where we want slaves to be fast, and preferably not go to the master at all.
+ */
+public class WhenToInitializeTransactionOnMasterFromSlaveIT
+{
+    @Rule
+    public ClusterRule clusterRule = new ClusterRule(getClass());
+
+    private GraphDatabaseService slave;
+    private ClusterManager.ManagedCluster cluster;
+
+    private MasterImpl.Monitor masterMonitor = mock(MasterImpl.Monitor.class);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        cluster = clusterRule.startCluster();
+        slave = cluster.getAnySlave();
+
+        // Create some basic data
+        try(Transaction tx = slave.beginTx())
+        {
+            Node node = slave.createNode( DynamicLabel.label( "Person" ) );
+            node.setProperty( "name", "Bob" );
+            node.createRelationshipTo( slave.createNode(), DynamicRelationshipType.withName( "KNOWS" ));
+
+            tx.success();
+        }
+
+        // And now monitor the master for incoming calls
+        cluster.getMaster().getDependencyResolver().resolveDependency( Monitors.class ).addListener( masterMonitor );
+    }
+
+    @Test
+    public void shouldNotInitializeTxOnReadOnlyOpsOnNeoXaDS() throws Exception
+    {
+        long nodeId = 0l;
+
+        try(Transaction transaction = slave.beginTx())
+        {
+            // When
+            Node node = slave.getNodeById( nodeId );
+
+            // Then
+            assertDidntStartMasterTx();
+
+
+            // When
+            count(node.getLabels());
+
+            // Then
+            assertDidntStartMasterTx();
+
+
+            // When
+            readAllRels( node );
+
+            // Then
+            assertDidntStartMasterTx();
+
+
+            // When
+            readEachProperty(node);
+
+            // Then
+            assertDidntStartMasterTx();
+
+            transaction.success();
+        }
+
+        // Finally
+        assertDidntStartMasterTx();
+    }
+
+    private void assertDidntStartMasterTx()
+    {
+        verifyNoMoreInteractions( masterMonitor );
+    }
+
+    private void readAllRels( Node node )
+    {
+        for ( Relationship relationship : node.getRelationships() )
+        {
+            readEachProperty( relationship );
+        }
+    }
+
+    private void readEachProperty( PropertyContainer entity )
+    {
+        for ( String k : entity.getPropertyKeys() )
+        {
+            entity.getProperty( k );
+        }
+    }
+
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -32,6 +32,8 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
+import org.neo4j.kernel.impl.util.Monitors;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 
 import static org.mockito.Mockito.*;
@@ -47,7 +49,7 @@ public class HighAvailabilityModeSwitcherTest
                 mock( DelegateInvocationHandler.class ), availability,
                 mock( HighAvailabilityMemberStateMachine.class),  mock( GraphDatabaseAPI.class ),
                 mock( HaIdGeneratorFactory.class ), mock( Config.class ), mock( Logging.class ), mock(
-                UpdateableSchemaState.class), Iterables.<KernelExtensionFactory<?>>empty() );
+                UpdateableSchemaState.class), Iterables.<KernelExtensionFactory<?>>empty(), new Monitors( StringLogger.DEV_NULL) );
 
         // When
         toTest.masterIsElected( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.MASTER,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -30,6 +30,8 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.impl.util.Monitors;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.Logging;
 
@@ -41,6 +43,8 @@ import static org.mockito.Mockito.*;
 
 public class MasterImplTest
 {
+    private final Monitors monitors = new Monitors( StringLogger.DEV_NULL);
+
     @Test
     public void givenStartedAndInaccessibleWhenInitializeTxThenThrowException() throws Throwable
     {
@@ -53,7 +57,7 @@ public class MasterImplTest
 
         when( spi.isAccessible() ).thenReturn( false );
 
-        MasterImpl instance = new MasterImpl( spi, logging, config );
+        MasterImpl instance = new MasterImpl( spi, monitors , logging, config );
         instance.start();
 
         // When
@@ -81,7 +85,7 @@ public class MasterImplTest
         when( spi.isAccessible() ).thenReturn( true );
         when( spi.beginTx() ).thenReturn( mock( Transaction.class ) );
 
-        MasterImpl instance = new MasterImpl( spi, logging, config );
+        MasterImpl instance = new MasterImpl( spi, monitors, logging, config );
         instance.start();
 
         // When
@@ -106,7 +110,7 @@ public class MasterImplTest
         when( spi.isAccessible() ).thenReturn( true );
         when( spi.beginTx() ).thenThrow( new SystemException("Nope") );
 
-        MasterImpl instance = new MasterImpl( spi, new DevNullLoggingService(), config );
+        MasterImpl instance = new MasterImpl( spi, monitors, new DevNullLoggingService(), config );
         instance.start();
 
         // When


### PR DESCRIPTION
o Remote transaction is no longer created on enlist, because read transactions are now enlisted as well, plummeting performance.
  Instead, the slave tracks a flag for whether the remote transaction is initialized or not, and then only initializes on two points,
  either when the first lock is grabbed, or right before the transaction is pushed to the master.

o This part of the code can be further refactored once JTA becomes an orthogonal concern and the domain logic for HA is all contained
  in one data source. Until then, this will hold the fort. For an intro to the conundrum here, see the comment in TransactionState around
  the methods tracking if the remote tranasction is initialized.

o Added Monitors and test for HA slaves pull update behavior.
## 
