### PR TITLE
[After 2.0 GA] Remove usages of Thread.interrupted()

### DIFF
--- a/advanced/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
+++ b/advanced/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
@@ -196,7 +196,6 @@ public class TestLockManagerBean
             }
             catch ( InterruptedException e )
             {
-                Thread.interrupted();
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -531,15 +531,7 @@ public class IndexingService extends LifecycleAdapter
 
     private void awaitIndexFuture( Future<Void> future ) throws Exception
     {
-        try
-        {
             future.get( 1, MINUTES );
-        }
-        catch ( InterruptedException e )
-        {
-            Thread.interrupted();
-            throw e;
-        }
     }
 
     private void dropRecoveringIndexes(
@@ -567,7 +559,6 @@ public class IndexingService extends LifecycleAdapter
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
             throw new IndexActivationFailedKernelException( e, "Unable to activate index, thread was interrupted." );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MeasureDoNothing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MeasureDoNothing.java
@@ -72,9 +72,8 @@ public class MeasureDoNothing extends Thread
             {
                 this.wait( TIME_TO_WAIT );
             }
-            catch ( InterruptedException e )
+            catch ( InterruptedException ignored )
             {
-                Thread.interrupted();
             }
             long time = System.currentTimeMillis() - start;
             if ( time > TIME_BEFORE_BLOCK )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
@@ -235,9 +235,8 @@ public class IndexManagerImpl implements IndexManager, IndexProviders
                     throw new TransactionFailureException( "Index creation failed for " + indexName +
                             ", " + result.first(), ex.getCause() );
                 }
-                catch ( InterruptedException ex )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                 }
                 finally
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/LockableWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/LockableWindow.java
@@ -101,9 +101,8 @@ abstract class LockableWindow implements PersistenceWindow
             {
                 wait();
             }
-            catch ( InterruptedException e )
+            catch ( InterruptedException ignored )
             {
-                Thread.interrupted();
             }
         }
         locked = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RWLock.java
@@ -564,9 +564,8 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
         {
             wait();
         }
-        catch ( InterruptedException e )
+        catch ( InterruptedException ignored )
         {
-            interrupted();
         }
         ragManager.stopWaitOn( this, tx );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FileUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FileUtils.java
@@ -266,9 +266,8 @@ public class FileUtils
         {
             Thread.sleep( 500 );
         }
-        catch ( InterruptedException ee )
+        catch ( InterruptedException ignored )
         {
-            Thread.interrupted();
         } // ok
         System.gc();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/TestPropertyDataRace.java
@@ -137,9 +137,8 @@ public class TestPropertyDataRace
                             prepare.await();
                             break;
                         }
-                        catch ( InterruptedException e )
+                        catch ( InterruptedException ignored )
                         {
-                            Thread.interrupted(); // reset
                         }
                     }
                     for ( String key : one.getPropertyKeys() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -86,12 +86,7 @@ public class SchemaIndexTestHelper
         {
             return future.get( 10, SECONDS );
         }
-        catch ( InterruptedException e )
-        {
-            Thread.interrupted();
-            throw new RuntimeException( e );
-        }
-        catch ( ExecutionException | TimeoutException e )
+        catch ( InterruptedException | ExecutionException | TimeoutException e )
         {
             throw new RuntimeException( e );
         }
@@ -105,7 +100,6 @@ public class SchemaIndexTestHelper
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
             throw new RuntimeException( e );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationBasic.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationBasic.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
@@ -30,6 +28,8 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestIsolationBasic extends AbstractNeo4jTestCase
 {
@@ -82,13 +82,12 @@ public class TestIsolationBasic extends AbstractNeo4jTestCase
         {
             public void run()
             {
-                Transaction tx = getGraphDb().beginTx();
-                try
+
+                try ( Transaction ignore = getGraphDb().beginTx() )
                 {
                     node1.setProperty( "key", "new" );
                     rel1.setProperty( "key", "new" );
-                    node1.createRelationshipTo( node2, 
-                        DynamicRelationshipType.withName( "TEST" ) );
+                    node1.createRelationshipTo( node2, DynamicRelationshipType.withName( "TEST" ) );
                     assertPropertyEqual( node1, "key", "new" );
                     assertPropertyEqual( rel1, "key", "new" );
                     assertRelationshipCount( node1, 2 );
@@ -101,14 +100,11 @@ public class TestIsolationBasic extends AbstractNeo4jTestCase
                     assertRelationshipCount( node2, 2 );
                     // no tx.success();
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    e.printStackTrace();
-                    Thread.interrupted();
                 }
                 finally
                 {
-                    tx.finish();
                     assertPropertyEqual( node1, "key", "old" );
                     assertPropertyEqual( rel1, "key", "old" );
                     assertRelationshipCount( node1, 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRaceOnMultipleNodeImpl.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRaceOnMultipleNodeImpl.java
@@ -253,7 +253,6 @@ public class TestRaceOnMultipleNodeImpl
             }
             catch ( InterruptedException e )
             {
-                Thread.interrupted();
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestDeadlockDetection.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestDeadlockDetection.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static java.lang.System.currentTimeMillis;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.neo4j.kernel.impl.transaction.LockWorker.newResourceObject;
-
 import java.io.File;
 import java.util.Random;
 import java.util.Stack;
@@ -35,6 +29,12 @@ import javax.transaction.Transaction;
 import org.junit.Test;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.transaction.LockWorker.ResourceObject;
+
+import static java.lang.System.currentTimeMillis;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.impl.transaction.LockWorker.newResourceObject;
 
 public class TestDeadlockDetection
 {
@@ -316,7 +316,6 @@ public class TestDeadlockDetection
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestRWLock.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestRWLock.java
@@ -19,14 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.neo4j.kernel.impl.transaction.LockWorker.newResourceObject;
-
 import java.io.File;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +30,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.transaction.LockWorker.ResourceObject;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.impl.transaction.LockWorker.newResourceObject;
 
 public class TestRWLock
 {
@@ -377,7 +377,6 @@ public class TestRWLock
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/DoubleLatch.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DoubleLatch.java
@@ -79,7 +79,6 @@ public class DoubleLatch
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
             throw new RuntimeException( e );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessStreamHandler.java
@@ -87,19 +87,15 @@ public class ProcessStreamHandler
         {
             out.join();
         }
-        catch( InterruptedException e )
+        catch( InterruptedException ignored )
         {
-            Thread.interrupted();
-            e.printStackTrace();
         }
         try
         {
             err.join();
         }
-        catch( InterruptedException e )
+        catch( InterruptedException ignored )
         {
-            Thread.interrupted();
-            e.printStackTrace();
         }
     }
 
@@ -115,15 +111,11 @@ public class ProcessStreamHandler
         launch();
         try
         {
-            try
-            {
-                return process.waitFor();
-            }
-            catch( InterruptedException e )
-            {
-                Thread.interrupted();
-                return 0;
-            }
+            return process.waitFor();
+        }
+        catch ( InterruptedException e )
+        {
+            return 0;
         }
         finally
         {

--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
@@ -672,9 +672,8 @@ public abstract class SubProcess<T, P> implements Serializable
                 {
                     Thread.sleep( 10 );
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                 }
             }
         }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexCreation.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexCreation.java
@@ -89,8 +89,7 @@ public class TestIndexCreation
                     @Override
                     public void run()
                     {
-                        Transaction tx = db.beginTx();
-                        try
+                        try(Transaction tx = db.beginTx())
                         {
                             latch.await();
                             Index<Node> index = db.index().forNodes( "index" + r );
@@ -98,13 +97,8 @@ public class TestIndexCreation
                             index.add( node, "name", "Name" );
                             tx.success();
                         }
-                        catch ( InterruptedException e )
+                        catch ( InterruptedException ignored )
                         {
-                            Thread.interrupted();
-                        }
-                        finally
-                        {
-                            tx.finish();
                         }
                     }
                 } );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/ServerProcess.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/ServerProcess.java
@@ -55,7 +55,7 @@ public class ServerProcess extends SubProcess<ServerInterface, Pair<String, Stri
             }
             catch ( InterruptedException e )
             {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -73,9 +73,8 @@ public class ServerProcess extends SubProcess<ServerInterface, Pair<String, Stri
                 {
                     Thread.sleep( 100 );
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                 }
                 shutdownProcess();
             }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
@@ -117,7 +117,6 @@ public class ClusterJoin
         }
         catch ( InterruptedException e )
         {
-            Thread.interrupted();
             logger.warn( "Unable to leave cluster, interrupted", e );
         }
     }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/Goal.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/Goal.java
@@ -68,9 +68,8 @@ public class Goal
         {
             Thread.sleep( millis );
         }
-        catch ( InterruptedException e )
+        catch ( InterruptedException ignored )
         {
-            Thread.interrupted();
         }
     }
 

--- a/enterprise/com/src/main/java/org/neo4j/com/ChunkingChannelBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ChunkingChannelBuffer.java
@@ -565,7 +565,6 @@ public class ChunkingChannelBuffer implements ChannelBuffer, ChannelFutureListen
             }
             catch ( InterruptedException e )
             {   // OK
-                Thread.interrupted();
             }
         }
 

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -460,9 +460,8 @@ public abstract class Server<T, R> implements ChannelPipelineFactory, Lifecycle
                 {
                     Thread.sleep( millis );
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                 }
             }
         };

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerProcess.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerProcess.java
@@ -88,9 +88,8 @@ public class MadeUpServerProcess extends SubProcess<ServerInterface, StartupData
                 {
                     Thread.sleep( 100 );
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                 }
                 shutdownProcess();
             }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/MasterTxIdGenerator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/MasterTxIdGenerator.java
@@ -333,9 +333,8 @@ public class MasterTxIdGenerator implements TxIdGenerator, Lifecycle
                 {
                     wait( 2000 /*wait timeout just for safety*/ );
                 }
-                catch ( InterruptedException e )
+                catch ( InterruptedException ignored )
                 {
-                    Thread.interrupted();
                     // Hmm, ok we got interrupted. No biggy I'd guess
                 }
             }


### PR DESCRIPTION
Thread.interrupted() should be used to check if a thread
has been interrupted. When catching InterruptedException,
we already know that the thread has been interrupted, so
no need to check it. Finally, this method also clears the
interrupted flag, which is already cleared by the method
throwing the InterruptedException.
