### PR TITLE
[Browser] fixes links to correct version of neo4j-manual

### DIFF
--- a/community/browser/app/content/guides/cypher.jade
+++ b/community/browser/app/content/guides/cypher.jade
@@ -142,5 +142,5 @@ article.guide
             a(href='http://www.neo4j.org/develop/drivers') Download
             |  a driver for your language of choice
           li
-            a(href='http://docs.neo4j.org/chunked/@@neo4j.version@@/') Read
+            a(href='http://docs.neo4j.org/chunked/{{neo4j.version}}/') Read
             |  the Neo4j manual for details

--- a/community/browser/app/content/guides/explore.jade
+++ b/community/browser/app/content/guides/explore.jade
@@ -45,7 +45,7 @@ article.guide
     img(src='/content/help/guides/img/books.png')
     ul
       li
-        a.external(href='http://docs.neo4j.org/chunked/@@neo4j.version@@/') Neo4j Manual
+        a.external(href='http://docs.neo4j.org/chunked/{{neo4j.version}}/') Neo4j Manual
         | - the official reference
       li
         a.external(href='http://graphdatabases.com/') Graph Databases


### PR DESCRIPTION
removed maven properties for neo4j version, instead relying on version reported by REST API
