### PR TITLE
Ignores TransactionNotPresentOnMasterExceptions

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -441,11 +441,6 @@ public abstract class Server<T, R> implements ChannelPipelineFactory, Lifecycle
                 {
                     finishOffChannel( null, slave );
                 }
-                catch ( TransactionNotPresentOnMasterException e )
-                {
-                    // It's ok, there is nothing to finish anyway, since this is thrown when the transaction was not
-                    // found
-                }
                 catch ( Throwable e )
                 {
                     // Introduce some delay here. it becomes like a busy wait if it never succeeds
@@ -468,7 +463,7 @@ public abstract class Server<T, R> implements ChannelPipelineFactory, Lifecycle
         };
     }
 
-    protected void handleRequest( ChannelBuffer buffer, final Channel channel ) throws IOException
+    protected void handleRequest( ChannelBuffer buffer, final Channel channel )
     {
         Byte continuation = readContinuationHeader( buffer, channel );
         if ( continuation == null )
@@ -615,7 +610,7 @@ public abstract class Server<T, R> implements ChannelPipelineFactory, Lifecycle
         targetBuffer.writeBytes( storeId.serialize() );
     }
 
-    private static void writeTransactionStreams( TransactionStream txStream, ChannelBuffer buffer ) throws IOException
+    private static void writeTransactionStreams( TransactionStream txStream, ChannelBuffer buffer )
     {
         if ( !txStream.hasNext() )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -33,6 +33,7 @@ import org.neo4j.com.Protocol;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Server;
+import org.neo4j.com.TransactionNotPresentOnMasterException;
 import org.neo4j.com.TxChecksumVerifier;
 import org.neo4j.kernel.ha.HaRequestType20;
 import org.neo4j.kernel.ha.MasterClient20;
@@ -65,7 +66,15 @@ public class MasterServer extends Server<Master, Void>
     @Override
     protected void finishOffChannel( Channel channel, RequestContext context )
     {
-        getRequestTarget().finishTransaction( context, false );
+        try
+        {
+            getRequestTarget().finishTransaction( context, false );
+        }
+        catch ( TransactionNotPresentOnMasterException e )
+        {
+            // This is OK. This method has been called due to some connection problem or similar,
+            // it's a best-effort to finish of a channel and transactions associated with it.
+        }
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockManagerImpl;
 import org.neo4j.kernel.impl.transaction.RagManager;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
-import org.neo4j.kernel.impl.transaction.TxManager;
 
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 {


### PR DESCRIPTION
This was done already but not for all cases. Puts that catching in one
place so that all code paths benefit.

Sits in a PR due to problems relying on HA tests locally.
