### PR TITLE
Prohibit equality comparison of incomparable values

### DIFF
--- a/community/cypher/cypher-commons/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher-commons/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -74,4 +74,5 @@ class MergeConstraintConflictException(message: String) extends CypherException(
 
 class ArithmeticException(message: String) extends CypherException(message)
 
-class IllegalValueException(message: String) extends CypherException(message)
+class IncomparableValuesException(lhs: String, rhs: String)
+  extends SyntaxException(s"Don't know how to compare that. Left: ${lhs}; Right: ${rhs}")

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/Comparer.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/Comparer.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_0
 
 import java.math.BigDecimal
 import java.lang.Character
-import org.neo4j.cypher.SyntaxException
+import org.neo4j.cypher.IncomparableValuesException
 import org.neo4j.cypher.internal.compiler.v2_0.commands.expressions.StringHelper
 import org.neo4j.cypher.internal.compiler.v2_0.pipes.QueryState
 
@@ -41,10 +41,7 @@ trait Comparer extends StringHelper {
     case (null, null) => 0
     case (null, _) => 1
     case (_, null) => -1
-    case (left, right) => {
-      def txt(x: Any) = text(x, qtx.query) + " (" + x.getClass.getSimpleName + ")"
-      throw new SyntaxException("Don't know how to compare that. Left: " + txt(left) + "; Right: " + txt(right))
-    }
+    case (left, right) => throw new IncomparableValuesException(textWithType(left), textWithType(right))
   }
 
   private def areComparableOfSameType(l: AnyRef, r: AnyRef): Boolean =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/StringFunctions.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/StringFunctions.scala
@@ -71,6 +71,8 @@ trait StringHelper {
     case x                  => x.toString
   }
 
+  protected def textWithType(x: Any)(implicit qs: QueryState) = s"${text(x, qs.query)} (${x.getClass.getSimpleName})"
+
   private def makeString(m: QueryContext => Map[String, Any], qtx: QueryContext) = m(qtx).map {
     case (k, v) => k + " -> " + text(v, qtx)
   }.mkString("{", ", ", "}")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EqualsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EqualsTest.scala
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.commands
+
+import org.junit.Test
+import org.scalatest._
+import org.neo4j.cypher.{IncomparableValuesException, ExecutionEngineHelper}
+
+class EqualsTest extends ExecutionEngineHelper with Matchers {
+
+  @Test
+  def should_prohibit_equals_between_node_and_parameter() {
+    // given
+    createLabeledNode("Person")
+
+    evaluating {
+      execute("MATCH (b) WHERE b = {param} RETURN b", "param" -> Map("name" -> "John Silver"))
+    } should produce[IncomparableValuesException]
+  }
+
+  @Test
+  def should_prohibit_equals_between_parameter_and_node() {
+    // given
+    createLabeledNode("Person")
+
+    evaluating {
+      execute("MATCH (b) WHERE {param} = b RETURN b", "param" -> Map("name" -> "John Silver"))
+    } should produce[IncomparableValuesException]
+  }
+
+  @Test
+  def should_allow_equals_between_node_and_node() {
+    // given
+    createLabeledNode("Person")
+
+    // when
+    val result = executeScalar[Number]("MATCH (a) WITH a MATCH (b) WHERE a = b RETURN count(b)")
+
+    // then
+    result should be (1)
+  }
+
+  @Test
+  def should_reject_equals_between_node_and_property() {
+    // given
+    createLabeledNode(Map("val"->17), "Person")
+
+    evaluating {
+      execute("MATCH (a) WHERE a = a.val RETURN count(a)")
+    } should produce[IncomparableValuesException]
+  }
+
+  @Test
+  def should_allow_equals_between_relationship_and_relationship() {
+    // given
+    relate(createLabeledNode("Person"), createLabeledNode("Person"))
+
+    // when
+    val result = executeScalar[Number]("MATCH ()-[a]->() WITH a MATCH ()-[b]->() WHERE a = b RETURN count(b)")
+
+    // then
+    result should be (1)
+  }
+
+
+  @Test
+  def should_reject_equals_between_node_and_relationship() {
+    // given
+    relate(createLabeledNode("Person"), createLabeledNode("Person"))
+
+    evaluating {
+      execute("MATCH (a)-[b]->() RETURN a = b")
+    } should produce[IncomparableValuesException]
+  }
+
+  @Test
+  def should_reject_equals_between_relationship_and_node() {
+    // given
+    relate(createLabeledNode("Person"), createLabeledNode("Person"))
+
+    evaluating {
+      execute("MATCH (a)-[b]->() RETURN b = a")
+    } should produce[IncomparableValuesException]
+  }
+}


### PR DESCRIPTION
This ensures that nodes can only be equality compared against nodes, and relationships only against relationships (particularly prohibits comparing entities against map parameters)
