### PR TITLE
Throws specific exception for denied entry to a cluster

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterEntryDeniedException.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterEntryDeniedException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.cluster;
+
+import org.neo4j.cluster.InstanceId;
+
+public class ClusterEntryDeniedException extends IllegalStateException
+{
+    public ClusterEntryDeniedException( InstanceId me, ClusterConfiguration configuration )
+    {
+        super( "I was denied entry. I am " + me + ", configuration:" + configuration );
+    }
+}

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.cluster.protocol.cluster;
 
-import static org.neo4j.cluster.com.message.Message.internal;
-import static org.neo4j.cluster.com.message.Message.respond;
-import static org.neo4j.cluster.com.message.Message.timeout;
-import static org.neo4j.cluster.com.message.Message.to;
-import static org.neo4j.helpers.collection.Iterables.count;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +33,12 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMess
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.statemachine.State;
 import org.neo4j.helpers.collection.Iterables;
+
+import static org.neo4j.cluster.com.message.Message.internal;
+import static org.neo4j.cluster.com.message.Message.respond;
+import static org.neo4j.cluster.com.message.Message.timeout;
+import static org.neo4j.cluster.com.message.Message.to;
+import static org.neo4j.helpers.collection.Iterables.count;
 
 /**
  * State machine for the Cluster API
@@ -196,7 +196,7 @@ public enum ClusterState
                             if ( context.hasJoinBeenDenied() )
                             {
                                 outgoing.offer( internal( ClusterMessage.joinFailure,
-                                        new IllegalStateException( "i was denied entry" ) ) );
+                                        new ClusterEntryDeniedException( context.me, context.configuration ) ) );
                                 return start;
                             }
                             ClusterMessage.ConfigurationTimeoutState state = message.getPayload();
@@ -315,7 +315,7 @@ public enum ClusterState
                         case joinDenied:
                         {
 //                            outgoing.offer( internal( ClusterMessage.joinFailure,
-//                                    new IllegalStateException( "i was denied entry" ) ) );
+//                                    new ClusterEntryDeniedException( context.me, context.configuration ) ) );
 //                            return start;
                             context.joinDenied();
                             return this;
@@ -364,7 +364,7 @@ public enum ClusterState
                             if ( context.hasJoinBeenDenied() )
                             {
                                 outgoing.offer( internal( ClusterMessage.joinFailure,
-                                    new IllegalStateException( "i was denied entry" ) ) );
+                                    new ClusterEntryDeniedException( context.me, context.configuration ) ) );
                                 return start;
                             }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
@@ -38,6 +38,7 @@ import org.neo4j.cluster.member.ClusterMemberListener;
 import org.neo4j.cluster.member.paxos.PaxosClusterMemberEvents;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectStreamFactory;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
+import org.neo4j.cluster.protocol.cluster.ClusterEntryDeniedException;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
 import org.neo4j.helpers.Args;
@@ -176,7 +177,7 @@ public final class HaBackupProvider extends BackupExtensionService
         {
             Throwable ex = Exceptions.peel( e, Exceptions.exceptionsOfType( LifecycleException.class ) );
 
-            if (ex != null && ex instanceof IllegalStateException)
+            if (ex != null && ex instanceof ClusterEntryDeniedException)
             {
                 // Someone else is doing a backup
                 throw new RuntimeException( "Another backup client is currently performing backup; concurrent backups are not allowed" );


### PR DESCRIPTION
Throws ClusterEntryDeniedException instead of the more generic
IllegalStateException, where CEDE extends ISE. This is so that it can be
caught specifically without resorting to looking at exception message.
