### PR TITLE
Only return same relationship once.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -891,4 +891,18 @@ public class TestRelationship extends AbstractNeo4jTestCase
         clearCache();
         assertEquals( "Test", node.getProperty( "name" ) );
     }
+
+    @Test
+    public void shouldNotGetTheSameRelationshipMoreThanOnceWhenAskingForTheSameTypeMultipleTimes() throws Exception
+    {
+        // given
+        Node node = getGraphDb().createNode();
+        node.createRelationshipTo( getGraphDb().createNode(), withName( "FOO" ) );
+
+        // when
+        int relationships = count( node.getRelationships( withName( "FOO" ), withName( "FOO" ) ) );
+
+        // then
+        assertEquals( 1, relationships );
+    }
 }


### PR DESCRIPTION
If providing the same RelationshipType more than once to the
getRelationships() method of Node, one would get relationships of that
type more than once. This change deduplicates the types, ensuring that
each relationship is returned no more than once.

This fixes #1477.
