### PR TITLE
Cypher-docs: note requirement of a bound node when creating

### DIFF
--- a/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
+++ b/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
@@ -188,7 +188,9 @@ For more information on parameters, see <<cypher-parameters>>.""",
         """match (charlie:Person {name:'Charlie Sheen'}), (wallStreet:Movie {title:'Wall Street'})
 merge (charlie)-[r:ACTED_IN]->(wallStreet)
 return r""",
-      returns = "Charlie Sheen had already been marked as acting on Wall Street, so the existing relationship is found and returned",
+      returns = "Charlie Sheen had already been marked as acting on Wall Street, so the existing relationship is found " +
+        "and returned. Note that in order to match or create a relationship when using +MERGE+, at least one bound node " +
+        "must be specified, which is done via the +MATCH+ clause in the above example.",
       assertions = (p) => assertStats(p, relationshipsCreated = 0)
     )
   }


### PR DESCRIPTION
relationships with MERGE clause.

Related code change: #1548
