### PR TITLE
Adds serverId to the globalId part of a Xid

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static org.neo4j.kernel.impl.nioneo.store.AbstractNameStore.NAME_STORE_BLOCK_SIZE;
-
 import java.io.IOException;
 
 import javax.transaction.xa.Xid;
@@ -38,6 +36,12 @@ import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.transaction.xaframework.LogBuffer;
 import org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils;
 
+import static java.lang.System.currentTimeMillis;
+
+import static org.neo4j.kernel.impl.nioneo.store.AbstractNameStore.NAME_STORE_BLOCK_SIZE;
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
+
 /**
  * This class lives here instead of somewhere else in order to be able to access the {@link Command} implementations.
  *
@@ -46,11 +50,13 @@ import org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils;
 public class TransactionWriter
 {
     private final LogBuffer buffer;
+    private final int identifier;
     private final int localId;
 
-    public TransactionWriter( LogBuffer buffer, int localId )
+    public TransactionWriter( LogBuffer buffer, int identifier, int localId )
     {
         this.buffer = buffer;
+        this.identifier = identifier;
         this.localId = localId;
     }
 
@@ -58,13 +64,13 @@ public class TransactionWriter
 
     public void start( int masterId, int myId ) throws IOException
     {
-        start( XidImpl.getNewGlobalId(), masterId, myId, System.currentTimeMillis() );
+        start( getNewGlobalId( DEFAULT_SEED, localId ), masterId, myId, currentTimeMillis() );
     }
 
     public void start( byte[] globalId, int masterId, int myId, long startTimestamp ) throws IOException
     {
         Xid xid = new XidImpl( globalId, NeoStoreXaDataSource.BRANCH_ID );
-        LogIoUtils.writeStart( buffer, this.localId, xid, masterId, myId, startTimestamp );
+        LogIoUtils.writeStart( buffer, this.identifier, xid, masterId, myId, startTimestamp );
     }
 
     public void prepare() throws IOException
@@ -74,7 +80,7 @@ public class TransactionWriter
 
     public void prepare( long prepareTimestamp ) throws IOException
     {
-        LogIoUtils.writePrepare( buffer, localId, prepareTimestamp );
+        LogIoUtils.writePrepare( buffer, identifier, prepareTimestamp );
     }
 
     public void commit( boolean twoPhase, long txId ) throws IOException
@@ -84,12 +90,12 @@ public class TransactionWriter
 
     public void commit( boolean twoPhase, long txId, long commitTimestamp ) throws IOException
     {
-        LogIoUtils.writeCommit( twoPhase, buffer, localId, txId, commitTimestamp );
+        LogIoUtils.writeCommit( twoPhase, buffer, identifier, txId, commitTimestamp );
     }
 
     public void done() throws IOException
     {
-        LogIoUtils.writeDone( buffer, localId );
+        LogIoUtils.writeDone( buffer, identifier );
     }
 
     // Transaction data
@@ -198,7 +204,7 @@ public class TransactionWriter
 
     private void write( Command command ) throws IOException
     {
-        LogIoUtils.writeCommand( buffer, localId, command );
+        LogIoUtils.writeCommand( buffer, identifier, command );
     }
 
     private static <T extends AbstractNameRecord> T withName( T record, int[] dynamicIds, String name )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTransactionImpl.java
@@ -57,13 +57,13 @@ class ReadOnlyTransactionImpl implements Transaction
     private final int eventIdentifier;
 
     private final ReadOnlyTxManager txManager;
-    private StringLogger logger;
+    private final StringLogger logger;
 
-    ReadOnlyTransactionImpl( ReadOnlyTxManager txManager, StringLogger logger )
+    ReadOnlyTransactionImpl( byte[] xidGlobalId, ReadOnlyTxManager txManager, StringLogger logger )
     {
         this.txManager = txManager;
         this.logger = logger;
-        globalId = XidImpl.getNewGlobalId();
+        globalId = xidGlobalId;
         eventIdentifier = txManager.getNextEventIdentifier();
     }
 
@@ -94,6 +94,7 @@ class ReadOnlyTransactionImpl implements Transaction
         return txString.toString();
     }
 
+    @Override
     public synchronized void commit() throws RollbackException,
         HeuristicMixedException, IllegalStateException
     {
@@ -106,6 +107,7 @@ class ReadOnlyTransactionImpl implements Transaction
         return globalStartRecordWritten;
     }
 
+    @Override
     public synchronized void rollback() throws IllegalStateException,
         SystemException
     {
@@ -113,6 +115,7 @@ class ReadOnlyTransactionImpl implements Transaction
         txManager.rollback();
     }
 
+    @Override
     public synchronized boolean enlistResource( XAResource xaRes )
         throws RollbackException, IllegalStateException
     {
@@ -193,6 +196,7 @@ class ReadOnlyTransactionImpl implements Transaction
             + txManager.getTxStatusAsString( status ) );
     }
 
+    @Override
     public synchronized boolean delistResource( XAResource xaRes, int flag )
         throws IllegalStateException
     {
@@ -248,6 +252,7 @@ class ReadOnlyTransactionImpl implements Transaction
     }
 
     // TODO: figure out if this needs syncrhonization or make status volatile
+    @Override
     public int getStatus() // throws SystemException
     {
         return status;
@@ -262,6 +267,7 @@ class ReadOnlyTransactionImpl implements Transaction
     private List<Synchronization> syncHooksAdded =
         new ArrayList<Synchronization>();
 
+    @Override
     public synchronized void registerSynchronization( Synchronization s )
         throws RollbackException, IllegalStateException
     {
@@ -348,6 +354,7 @@ class ReadOnlyTransactionImpl implements Transaction
         syncHooks = null; // help gc
     }
 
+    @Override
     public void setRollbackOnly() throws IllegalStateException
     {
         if ( status == Status.STATUS_ACTIVE ||

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/ReadOnlyTxManager.java
@@ -29,6 +29,7 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 
 import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.Factory;
 import org.neo4j.kernel.impl.core.ReadOnlyDbException;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.transaction.xaframework.XaResource;
@@ -46,9 +47,13 @@ public class ReadOnlyTxManager extends AbstractTransactionManager
     private XaDataSourceManager xaDsManager = null;
     private final StringLogger logger;
 
-    public ReadOnlyTxManager( XaDataSourceManager xaDsManagerToUse, StringLogger logger )
+    private final Factory<byte[]> xidGlobalIdFactory;
+
+    public ReadOnlyTxManager( XaDataSourceManager xaDsManagerToUse, Factory<byte[]> xidGlobalIdFactory,
+            StringLogger logger )
     {
         xaDsManager = xaDsManagerToUse;
+        this.xidGlobalIdFactory = xidGlobalIdFactory;
         this.logger = logger;
     }
 
@@ -80,7 +85,6 @@ public class ReadOnlyTxManager extends AbstractTransactionManager
     {
     }
 
-
     @Override
     public void begin() throws NotSupportedException
     {
@@ -89,7 +93,7 @@ public class ReadOnlyTxManager extends AbstractTransactionManager
             throw new NotSupportedException(
                     "Nested transactions not supported" );
         }
-        txThreadMap.set( new ReadOnlyTransactionImpl( this, logger ) );
+        txThreadMap.set( new ReadOnlyTransactionImpl( xidGlobalIdFactory.newInstance(), this, logger ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -65,18 +65,19 @@ class TransactionImpl implements Transaction
     private final int eventIdentifier;
 
     private final TxManager txManager;
-    private StringLogger logger;
+    private final StringLogger logger;
     private final ForceMode forceMode;
     private Thread owner;
 
     private final TransactionState state;
 
-    TransactionImpl( TxManager txManager, ForceMode forceMode, TransactionStateFactory stateFactory, StringLogger logger )
+    TransactionImpl( byte[] xidGlobalId, TxManager txManager, ForceMode forceMode,
+            TransactionStateFactory stateFactory, StringLogger logger )
     {
         this.txManager = txManager;
         this.logger = logger;
         this.state = stateFactory.create( this );
-        globalId = XidImpl.getNewGlobalId();
+        globalId = xidGlobalId;
         eventIdentifier = txManager.getNextEventIdentifier();
         this.forceMode = forceMode;
         owner = Thread.currentThread();
@@ -186,7 +187,9 @@ class TransactionImpl implements Transaction
                     }
                     // TODO ties HA to our TxManager
                     if ( !hasAnyLocks() )
+                    {
                         getState().getTxHook().initializeTransaction( eventIdentifier );
+                    }
                     return true;
                 }
                 Xid sameRmXid = null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/XidImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/XidImpl.java
@@ -20,25 +20,45 @@
 package org.neo4j.kernel.impl.transaction;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Random;
 
 import javax.transaction.xa.Xid;
 
+import static java.nio.ByteBuffer.wrap;
+
 public class XidImpl implements Xid
 {
-    // Neo4j ('N' 'E'  'O') format identifier
-    private static final int FORMAT_ID = 0x4E454E31; 
+    interface Seed
+    {
+        long nextRandomLong();
+        
+        long nextSequenceId();
+    }
+    
+    public static final Seed DEFAULT_SEED = new Seed()
+    {
+        private long nextSequenceId = 0;
+        private final Random r = new Random();
+
+        @Override
+        public synchronized long nextSequenceId()
+        {
+            return nextSequenceId++;
+        }
+        
+        @Override
+        public long nextRandomLong()
+        {
+            return r.nextLong();
+        }
+    };
+    
+    // Neo4j ('N' 'E' 'O') format identifier
+    private static final int FORMAT_ID = 0x4E454E31;
 
     private static final byte INSTANCE_ID[] = new byte[] { 'N', 'E', 'O', 'K',
         'E', 'R', 'N', 'L', '\0' };
-
-    private static long nextSequenceId = 0;
-
-    // next sequence number for global tx id
-    private synchronized static long getNextSequenceId()
-    {
-        return nextSequenceId++;
-    }
 
     // INSTANCE_ID + millitime(long) + seqnumber(long)
     private final byte globalId[];
@@ -46,19 +66,24 @@ public class XidImpl implements Xid
     private final byte branchId[];
     private final int formatId;
     
-    private static final Random r = new Random( System.currentTimeMillis() );
-
-    // resourceId.length = 4, unique for each XAResource
-    public static byte[] getNewGlobalId()
+    /**
+     * Generates a new global id byte[] for use as one part that makes up a Xid. A global id is made up of:
+     * - INSTANCE_ID: fixed number of bytes and content
+     * - 8b: current time millis
+     * - 8b: sequence id, incremented for each new generated global id
+     * - 4b: local id, an id fixed for and local to the instance generating this global id
+     * 
+     * resourceId.length = 4, unique for each XAResource
+     * @param localId
+     * @return
+     */
+    public static byte[] getNewGlobalId( Seed seed, int localId )
     {
-        // create new global id ( [INSTANCE_ID][time][sequence] )
-        byte globalId[] = new byte[INSTANCE_ID.length + 16];
-        System.arraycopy( INSTANCE_ID, 0, globalId, 0, INSTANCE_ID.length );
-        ByteBuffer byteBuf = ByteBuffer.wrap( globalId );
-        byteBuf.position( INSTANCE_ID.length );
-        long time = r.nextLong(); // System.currentTimeMillis();
-        long sequence = getNextSequenceId();
-        byteBuf.putLong( time ).putLong( sequence );
+        byte globalId[] = Arrays.copyOf( INSTANCE_ID, INSTANCE_ID.length + 20 );
+        wrap( globalId, INSTANCE_ID.length, 20 )
+               .putLong( seed.nextRandomLong() )
+               .putLong( seed.nextSequenceId() )
+               .putInt( localId );
         return globalId;
     }
 
@@ -101,55 +126,39 @@ public class XidImpl implements Xid
         this.formatId = formatId;
     }
 
+    @Override
     public byte[] getGlobalTransactionId()
     {
         return globalId.clone();
     }
 
+    @Override
     public byte[] getBranchQualifier()
     {
         return branchId.clone();
     }
 
+    @Override
     public int getFormatId()
     {
         return FORMAT_ID;
     }
 
+    @Override
     public boolean equals( Object o )
     {
         if ( !(o instanceof Xid) )
         {
             return false;
         }
-        byte otherGlobalId[] = ((Xid) o).getGlobalTransactionId();
-        byte otherBranchId[] = ((Xid) o).getBranchQualifier();
-
-        if ( globalId.length != otherGlobalId.length || 
-            branchId.length != otherBranchId.length )
-        {
-            return false;
-        }
-
-        for ( int i = 0; i < globalId.length; i++ )
-        {
-            if ( globalId[i] != otherGlobalId[i] )
-            {
-                return false;
-            }
-        }
-        for ( int i = 0; i < branchId.length; i++ )
-        {
-            if ( branchId[i] != otherBranchId[i] )
-            {
-                return false;
-            }
-        }
-        return true;
+        
+        return Arrays.equals( globalId, ((Xid) o).getGlobalTransactionId() ) &&
+               Arrays.equals( branchId, ((Xid) o).getBranchQualifier() );
     }
 
     private volatile int hashCode = 0;
 
+    @Override
     public int hashCode()
     {
         if ( hashCode == 0 )
@@ -168,10 +177,12 @@ public class XidImpl implements Xid
         return hashCode;
     }
 
+    @Override
     public String toString()
     {
         StringBuffer buf = new StringBuffer( "GlobalId[" );
-        if ( globalId.length == (INSTANCE_ID.length + 8 + 8) )
+        int baseLength = INSTANCE_ID.length + 8 + 8;
+        if ( globalId.length == baseLength || globalId.length == baseLength+4 )
         {
             for ( int i = 0; i < INSTANCE_ID.length - 1; i++ )
             {
@@ -185,6 +196,13 @@ public class XidImpl implements Xid
             buf.append( time );
             buf.append( '|' );
             buf.append( sequence );
+            
+            /* MP 2013-11-27: 4b added to the globalId, consisting of the serverId value. This if-statement
+             * keeps things backwards compatible and nice. */
+            if ( byteBuf.hasRemaining() )
+            {
+                buf.append( '|' ).append( byteBuf.getInt() );
+            }
         }
         else
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriterTest.java
@@ -33,6 +33,7 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.internal.matchers.TypeSafeMatcher;
 import org.mockito.InOrder;
+
 import org.neo4j.kernel.impl.nioneo.store.AbstractBaseRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
@@ -55,7 +56,7 @@ public class TransactionWriterTest
     {
         // given
         InMemoryLogBuffer buffer = new InMemoryLogBuffer();
-        TransactionWriter writer = new TransactionWriter( buffer, 1 );
+        TransactionWriter writer = new TransactionWriter( buffer, 1, -1 );
 
         NodeRecord node = new NodeRecord( 0, -1, -1 );
         RelationshipRecord relationship = new RelationshipRecord( 0, 1, 1, 6 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestTransactionImpl.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestTransactionImpl.java
@@ -19,19 +19,24 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
+import javax.transaction.RollbackException;
+import javax.transaction.Synchronization;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
+import org.neo4j.kernel.impl.util.MultipleCauseException;
+import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.logging.SystemOutLogging;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-
-import org.junit.Test;
-import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
-import org.neo4j.kernel.impl.util.MultipleCauseException;
-import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.kernel.logging.SystemOutLogging;
+import static org.neo4j.kernel.impl.transaction.TransactionStateFactory.noStateFactory;
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
 
 public class TestTransactionImpl
 {
@@ -40,7 +45,9 @@ public class TestTransactionImpl
             throws IllegalStateException, RollbackException
     {
         TxManager mockedTxManager = mock( TxManager.class );
-        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced, TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), new SystemOutLogging().getMessagesLog( TxManager.class ) );
+        TransactionImpl tx = new TransactionImpl( getNewGlobalId( DEFAULT_SEED, 0 ), mockedTxManager, ForceMode.forced,
+                noStateFactory( new DevNullLoggingService() ),
+                new SystemOutLogging().getMessagesLog( TxManager.class ) );
 
         // Evil synchronizations
         final RuntimeException firstException = new RuntimeException( "Ex1" );
@@ -94,7 +101,9 @@ public class TestTransactionImpl
             RollbackException
     {
         TxManager mockedTxManager = mock( TxManager.class );
-        TransactionImpl tx = new TransactionImpl( mockedTxManager, ForceMode.forced, TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), new SystemOutLogging().getMessagesLog( TxManager.class ) );
+        TransactionImpl tx = new TransactionImpl( getNewGlobalId( DEFAULT_SEED, 0 ), mockedTxManager, ForceMode.forced,
+                noStateFactory( new DevNullLoggingService() ),
+                new SystemOutLogging().getMessagesLog( TxManager.class ) );
 
         // Evil synchronizations
         final RuntimeException firstException = new RuntimeException( "Ex1" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
@@ -19,22 +19,23 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-
 import java.io.File;
 
 import javax.transaction.SystemException;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.kernel.KernelEventHandlers;
 import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class TxManagerTest
 {
@@ -45,7 +46,7 @@ public class TxManagerTest
         XaDataSourceManager mockXaManager = mock( XaDataSourceManager.class );
         File txLogDir = TargetDirectory.forTest( fs.get(), getClass() ).directory( "log", true );
         TxManager txm = new TxManager( txLogDir, mockXaManager, new KernelPanicEventGenerator(
-                new KernelEventHandlers() ), StringLogger.DEV_NULL, fs.get(), null );
+                new KernelEventHandlers() ), StringLogger.DEV_NULL, fs.get(), null, null );
         txm.doRecovery(); // Make the txm move to an ok state
 
         String msg = "These kinds of throwables, breaking our transaction managers, are why we can't have nice things.";

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/XidImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/XidImplTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import java.util.Arrays;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static java.util.Arrays.copyOf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
+
+public class XidImplTest
+{
+    @Test
+    public void fixedSeedDifferentLocalIdShouldMakeUnequal() throws Exception
+    {
+        // WHEN
+        byte[] globalIdZero = getNewGlobalId( fixedSeed, 0 );
+        byte[] globalIdOne = getNewGlobalId( fixedSeed, 1 );
+        
+        // THEN
+        assertFalse( Arrays.equals( globalIdZero, globalIdOne ) );
+    }
+    
+    @Test
+    public void fixedSeedSameLocalIdShouldMakeEqual() throws Exception
+    {
+        // WHEN
+        byte[] globalIdZero = getNewGlobalId( fixedSeed, 0 );
+        byte[] otherGlobalIdZero = getNewGlobalId( fixedSeed, 0 );
+        
+        // THEN
+        assertTrue( Arrays.equals( globalIdZero, otherGlobalIdZero ) );
+    }
+    
+    @Test
+    public void defaultSeedDifferentLocalIdShouldMakeUnequal() throws Exception
+    {
+        // WHEN
+        byte[] globalIdZero = getNewGlobalId( DEFAULT_SEED, 0 );
+        byte[] globalIdOne = getNewGlobalId( DEFAULT_SEED, 1 );
+        
+        // THEN
+        assertFalse( Arrays.equals( globalIdZero, globalIdOne ) );
+    }
+    
+    @Test
+    public void defaultSeedSameLocalIdShouldMakeUnequal() throws Exception
+    {
+        // WHEN
+        byte[] globalIdZero = getNewGlobalId( DEFAULT_SEED, 0 );
+        byte[] otherGlobalIdZero = getNewGlobalId( DEFAULT_SEED, 0 );
+        
+        // THEN
+        assertFalse( Arrays.equals( globalIdZero, otherGlobalIdZero ) );
+    }
+    
+    @Test
+    public void shouldProduceShortXidToStringForOldGlobalIdFormat() throws Exception
+    {
+        // GIVEN
+        XidImpl xid = new XidImpl( shorten( getNewGlobalId( DEFAULT_SEED, 10 ), 4 ), "test".getBytes() );
+        
+        // WHEN
+        String toString = xid.toString();
+        
+        // THEN
+        assertThat( toString, CoreMatchers.containsString( "NEOKERNL" ) );
+        assertEquals( 2, occurencesOf( '|', toString ) );
+    }
+
+    @Test
+    public void shouldProduceLongerXidToStringForNewGlobalIdFormat() throws Exception
+    {
+        // GIVEN
+        XidImpl xid = new XidImpl( getNewGlobalId( DEFAULT_SEED, 10 ), "test".getBytes() );
+        
+        // WHEN
+        String toString = xid.toString();
+        
+        // THEN
+        assertThat( toString, CoreMatchers.containsString( "NEOKERNL" ) );
+        assertEquals( 3, occurencesOf( '|', toString ) );
+    }
+    
+    private byte[] shorten( byte[] newGlobalId, int byHowMuch )
+    {
+        return copyOf( newGlobalId, newGlobalId.length-byHowMuch );
+    }
+    
+    private int occurencesOf( char c, String inString )
+    {
+        int count = 0;
+        for ( int i = 0; i < inString.length(); i++ )
+        {
+            if ( c == inString.charAt( i ) )
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /*
+     * The fixed seed is not a normal seed, it mimics many seed instances having the exact same start condition,
+     * for example if two database instances would start and by chance get the same seed.
+     */
+    private final XidImpl.Seed fixedSeed = new XidImpl.Seed()
+    {
+        @Override
+        public long nextSequenceId()
+        {
+            return 1;
+        }
+        
+        @Override
+        public long nextRandomLong()
+        {
+            return 14; // soo random
+        }
+    };
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestLogPruneStrategy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestLogPruneStrategy.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -38,11 +32,22 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.transaction.xaframework.LogExtractor.LogLoader;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
 
 public class TestLogPruneStrategy
 {
@@ -169,7 +174,9 @@ public class TestLogPruneStrategy
             {
                 assertLogRangeByTimestampExists( log, millisToKeep, lastTimestamp );
                 if ( System.currentTimeMillis() > end )
+                {
                     break;
+                }
             }
         }
     }
@@ -219,7 +226,9 @@ public class TestLogPruneStrategy
         {
             Long firstTimestamp = log.getFirstStartRecordTimestamp( version+1 );
             if ( firstTimestamp == null )
+            {
                 break;
+            }
             assertTrue( "Log " + version + " should've been deleted by now. first of " + (version+1) + ":" + firstTimestamp + ", highestVersion:" +
                     log.getHighestLogVersion() + ", lowerLimit:" + lowerLimit + ", timestamp:" + lastTimestamp,
                     firstTimestamp >= lowerLimit );
@@ -235,8 +244,10 @@ public class TestLogPruneStrategy
     {
         assertTrue( log.getHighestLogVersion() >= to );
         for ( long i = 0; i < from; i++ )
+        {
             assertFalse( "Log v" + i + " shouldn't exist when highest version is " + log.getHighestLogVersion() +
                     " and prune strategy " + log.pruning, FS.fileExists( log.getFileName( i ) ) );
+        }
         
         for ( long i = from; i <= to; i++ )
         {
@@ -249,8 +260,10 @@ public class TestLogPruneStrategy
                 empty.remove( i );
             }
             else
+            {
                 assertTrue( "Log v" + i + " should be at least size " + log.getLogSize(),
                         FS.getFileSize( file ) >= log.getLogSize() );
+            }
         }
         assertTrue( "Expected to find empty logs: " + empty, empty.isEmpty() );
     }
@@ -259,7 +272,9 @@ public class TestLogPruneStrategy
     {
         Set<Long> result = new HashSet<Long>();
         for ( long item : items )
+        {
             result.add( item );
+        }
         return result;
     }
 
@@ -340,16 +355,21 @@ public class TestLogPruneStrategy
         public boolean addTransaction( int commandSize, long date ) throws IOException
         {
             InMemoryLogBuffer tempLogBuffer = new InMemoryLogBuffer();
-            LogIoUtils.writeStart( tempLogBuffer, identifier, new XidImpl( XidImpl.getNewGlobalId(), RESOURCE_XID ), -1, -1, date );
+            LogIoUtils.writeStart( tempLogBuffer, identifier, new XidImpl( getNewGlobalId( DEFAULT_SEED, 0 ),
+                    RESOURCE_XID ), -1, -1, date );
             LogIoUtils.writeCommand( tempLogBuffer, identifier, new TestXaCommand( commandSize ) );
             LogIoUtils.writeCommit( false, tempLogBuffer, identifier, ++tx, date );
             LogIoUtils.writeDone( tempLogBuffer, identifier );
             tempLogBuffer.read( activeBuffer );
             if ( !timestamps.containsKey( version ) )
+             {
                 timestamps.put( version, date ); // The first tx timestamp for this version
+            }
             boolean rotate = (activeBuffer.capacity() - activeBuffer.remaining()) >= logSize;
             if ( rotate )
+            {
                 rotate();
+            }
             return rotate;
         }
         
@@ -362,7 +382,9 @@ public class TestLogPruneStrategy
             while ( true )
             {
                 if ( addTransaction( size, System.currentTimeMillis() ) )
+                {
                     return;
+                }
                 size = Math.max( 10, (size + 7)%100 );
             }
         }
@@ -387,7 +409,9 @@ public class TestLogPruneStrategy
             finally
             {
                 if ( channel != null )
+                {
                     channel.close();
+                }
             }
         }
         
@@ -398,9 +422,13 @@ public class TestLogPruneStrategy
             {
                 File file = getFileName( version );
                 if ( FS.fileExists( file ) )
+                {
                     size += FS.getFileSize( file );
+                }
                 else
+                {
                     break;
+                }
             }
             return size;
         }
@@ -408,16 +436,22 @@ public class TestLogPruneStrategy
         public int getTotalTransactionCountOfAllExistingLogFiles()
         {
             if ( getHighestLogVersion() == 0 )
+            {
                 return 0;
+            }
             long upper = getHighestLogVersion()-1;
             long lower = upper;
             while ( lower >= 0 )
             {
                 File file = getFileName( lower-1 );
                 if ( !FS.fileExists( file ) )
+                {
                     break;
+                }
                 else
+                {
                     lower--;
+                }
             }
             return (int) (getLastCommittedTxId() - getFirstCommittedTxId( lower ));
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestLogPruning.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-
 import org.junit.After;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.test.ImpermanentGraphDatabase;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class TestLogPruning
 {
@@ -39,7 +41,9 @@ public class TestLogPruning
     public void after() throws Exception
     {
         if ( db != null )
+        {
             db.shutdown();
+        }
     }
     
     @Test
@@ -58,7 +62,7 @@ public class TestLogPruning
     @Test
     public void pruneByFileSize() throws Exception
     {
-        int size = 1000;
+        int size = 1050;
         newDb( size + " size" );
         
         doTransaction();
@@ -98,7 +102,9 @@ public class TestLogPruning
         for ( int i = 0; i < transactionsToKeep/txsPerLog*3; i++ )
         {
             for ( int j = 0; j < txsPerLog; j++ )
+            {
                 doTransaction();
+            }
             rotate();
             assertEquals( Math.min( i+1, transactionsToKeep/txsPerLog ), logCount() );
         }
@@ -144,9 +150,13 @@ public class TestLogPruning
         for ( long i = log.getHighestLogVersion()-1; i >= 0; i-- )
         {
             if ( fs.fileExists( log.getFileName( i ) ) )
+            {
                 count++;
+            }
             else
+            {
                 break;
+            }
         }
         return count;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
@@ -19,15 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -55,6 +46,17 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.FailureOutput;
 import org.neo4j.test.TargetDirectory;
 
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
 import static org.neo4j.kernel.impl.transaction.xaframework.ForceMode.forced;
 import static org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies.NO_PRUNING;
 
@@ -114,7 +116,7 @@ public class XaLogicalLogTest
         // -- set the log up with 10 transactions (with no commands, just start and commit)
         for ( int txId = 1; txId <= 10; txId++ )
         {
-            int identifier = xaLogicalLog.start( new XidImpl( XidImpl.getNewGlobalId(), RESOURCE_ID ), -1, 0 );
+            int identifier = xaLogicalLog.start( new XidImpl( getNewGlobalId( DEFAULT_SEED, 0 ), RESOURCE_ID ), -1, 0 );
             xaLogicalLog.writeStartEntry( identifier );
             xaLogicalLog.commitOnePhase( identifier, txId, ForceMode.forced );
             xaLogicalLog.done( identifier );
@@ -160,7 +162,7 @@ public class XaLogicalLogTest
     
     private static class FixedSizeXaCommand extends XaCommand
     {
-        private byte[] data;
+        private final byte[] data;
 
         FixedSizeXaCommand( int payloadSize )
         {

--- a/community/kernel/src/test/java/org/neo4j/test/GraphStoreFixture.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphStoreFixture.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -38,8 +39,10 @@ import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.StoreAccess;
 import org.neo4j.kernel.impl.nioneo.xa.TransactionWriter;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
-import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.transaction.xaframework.InMemoryLogBuffer;
+
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
 
 public abstract class GraphStoreFixture implements TestRule
 {
@@ -68,15 +71,15 @@ public abstract class GraphStoreFixture implements TestRule
     public static abstract class Transaction
     {
         public final long startTimestamp = System.currentTimeMillis();
-        public final byte[] globalId = XidImpl.getNewGlobalId();
+        public final byte[] globalId = getNewGlobalId( DEFAULT_SEED, 0 );
 
         protected abstract void transactionData( TransactionDataBuilder tx, IdGenerator next );
 
-        private ReadableByteChannel write( IdGenerator idGenerator, int localId, int masterId, int myId, Long txId )
+        private ReadableByteChannel write( IdGenerator idGenerator, int identifier, int masterId, int myId, Long txId )
                 throws IOException
         {
             InMemoryLogBuffer buffer = new InMemoryLogBuffer();
-            TransactionWriter writer = new TransactionWriter( buffer, localId );
+            TransactionWriter writer = new TransactionWriter( buffer, identifier, 0 );
             writer.start( globalId, masterId, myId, startTimestamp );
 
             transactionData( new TransactionDataBuilder( writer ), idGenerator );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -20,8 +20,6 @@
 package org.neo4j.kernel.ha.cluster;
 
 import java.net.URI;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This to make it impossible that two instances may produce the same random
seed for its Xid generator and happen to generate the same ID for
different transactions.

Also uses the default constructor of Random() because it's a more random
seed than just current time.
