### PR TITLE
HA stability fixes.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/FileLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/FileLock.java
@@ -70,7 +70,7 @@ public abstract class FileLock
         {
             FileLock regular = wrapOrNull( channel.tryLock() );
             if ( regular == null )
-                throw new IOException( "Unable to lock " + channel );
+                throw new IOException( "Unable to lock " + channel +" because another process already holds the lock.");
 
             FileLock extra = getLockFileBasedFileLock( fileName.getParentFile() );
             if ( extra == null )
@@ -82,7 +82,10 @@ public abstract class FileLock
         }
         else
         {
-            return wrapOrNull( channel.tryLock() );
+            FileLock regular = wrapOrNull( channel.tryLock() );
+            if ( regular == null )
+                throw new IOException( "Unable to lock " + channel + " because another process already holds the lock." );
+            return regular;
         }
     }
 
@@ -109,7 +112,8 @@ public abstract class FileLock
         if ( fileChannelLock == null )
         {
             fileChannel.close();
-            throw new IOException( "Couldn't create lock file " + lockFile.getAbsolutePath() );
+            throw new IOException( "Couldn't lock lock file " + lockFile.getAbsolutePath()  +
+                    " because another process already holds the lock." );
         }
         return new WindowsFileLock( lockFile, fileChannel, fileChannelLock );
     }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContext.java
@@ -420,8 +420,8 @@ public class MultiPaxosContext
                 .ConfigurationRequestState>();
         private Iterable<URI> joiningInstances;
         private boolean joinDenied;
-        private Set<org.neo4j.cluster.InstanceId> currentlyJoiningInstances = new HashSet<org.neo4j.cluster
-                .InstanceId>();
+        private Map<org.neo4j.cluster.InstanceId, URI> currentlyJoiningInstances =
+                new HashMap<org.neo4j.cluster.InstanceId, URI>();
 
 
         // Cluster API
@@ -607,14 +607,16 @@ public class MultiPaxosContext
             return Iterables.filter( not( in( me ) ), configuration.getMemberIds() );
         }
 
-        public boolean isInstanceWithIdCurrentlyJoining( org.neo4j.cluster.InstanceId joiningId )
+        /** Used to ensure that no other instance is trying to join with the same id from a different machine */
+        public boolean isInstanceJoiningFromDifferentUri( org.neo4j.cluster.InstanceId joiningId, URI uri )
         {
-            return currentlyJoiningInstances.contains( joiningId );
+            return currentlyJoiningInstances.containsKey( joiningId )
+                    && !currentlyJoiningInstances.get( joiningId ).equals(uri);
         }
 
-        public void instanceIsJoining( org.neo4j.cluster.InstanceId joiningId )
+        public void instanceIsJoining( org.neo4j.cluster.InstanceId joiningId, URI uri )
         {
-            currentlyJoiningInstances.add( joiningId );
+            currentlyJoiningInstances.put( joiningId, uri );
         }
 
         public String myName()

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
@@ -150,7 +150,10 @@ public enum ProposerState
                                     PaxosInstance.State.delivered ) )
                             {
                                 // Retry
-                                context.unbookInstance( instance.id );
+                                Message oldMessage = context.unbookInstance( instance.id );
+                                context.getLogger( getClass() ).debug( "Retrying instance " + instance.id +
+                                        " with message " + message.getPayload() +
+                                        ". Previous instance was " + oldMessage );
                                 outgoing.offer( Message.internal( ProposerMessage.propose, message.getPayload() ) );
                             }
                             break;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -85,9 +85,9 @@ public interface ClusterContext
 
     Iterable<InstanceId> getOtherInstances();
 
-    boolean isInstanceWithIdCurrentlyJoining( InstanceId joiningId );
+    boolean isInstanceJoiningFromDifferentUri( InstanceId joiningId, URI joiningUri );
 
-    void instanceIsJoining( InstanceId joiningId );
+    void instanceIsJoining( InstanceId joiningId, URI uri );
 
     String myName();
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.Executor;
+
+import org.junit.Test;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.protocol.atomicbroadcast.ObjectStreamFactory;
+import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
+import org.neo4j.cluster.protocol.election.ElectionRole;
+import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.impl.util.TestLogging;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertFalse;
+import static org.mockito.Mockito.*;
+
+public class MultiPaxosContextTest
+{
+
+    @Test
+    public void shouldNotConsiderInstanceJoiningWithSameIdAndIpAProblem() throws Exception
+    {
+        // Given
+        MultiPaxosContext ctx = new MultiPaxosContext( new InstanceId( 1 ),
+                Collections.<ElectionRole>emptyList(),
+                mock( ClusterConfiguration.class ), mock( Executor.class ),
+                new TestLogging(), new ObjectStreamFactory(),
+                new ObjectStreamFactory(), mock( AcceptorInstanceStore.class ), mock( Timeouts.class ) );
+
+        InstanceId joiningId = new InstanceId( 12 );
+        String joiningUri = "http://127.0.0.1:900";
+
+        // When
+        ctx.getClusterContext().instanceIsJoining( joiningId, new URI( joiningUri ) );
+
+        // Then
+        assertFalse( ctx.getClusterContext().isInstanceJoiningFromDifferentUri( joiningId, new URI( joiningUri ) ));
+        assertTrue( ctx.getClusterContext().isInstanceJoiningFromDifferentUri( joiningId, new URI("http://127.0.0.1:80")));
+        assertFalse( ctx.getClusterContext().isInstanceJoiningFromDifferentUri( new InstanceId( 13 ), new URI( joiningUri ) ) );
+    }
+
+}

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -31,6 +26,10 @@ import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.protocol.omega.MessageArgumentMatcher;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class ProposerStateTest
 {
@@ -38,6 +37,7 @@ public class ProposerStateTest
     public void ifProposingWithClosedInstanceThenRetryWithNextInstance() throws Throwable
     {
         ProposerContext context = Mockito.mock(ProposerContext.class);
+        when(context.getLogger( any(Class.class) )).thenReturn( StringLogger.DEV_NULL );
 
         InstanceId instanceId = new InstanceId( 42 );
         PaxosInstanceStore paxosInstanceStore = new PaxosInstanceStore();


### PR DESCRIPTION
 o Cluster now allows same instance to restart a join cycle, as long as it joins from the same ip+port
 o FileLock gives more debugging details
 o ProposerState now uses value_1 rather than message payload in one incorrectly implemented branch.
