### PR TITLE
Improve error logging when sending HTTP error response.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/OutputFormat.java
@@ -171,7 +171,7 @@ public class OutputFormat
                     {
                         throw new WebApplicationException( badRequest( e ) );
                     }
-                    throw new WebApplicationException( serverError( e ) );
+                    throw new WebApplicationException( e, serverError( e ) );
                 }
                 finally
                 {


### PR DESCRIPTION
Ensure that we include the underlying exception as a root cause so
that our server-side logging includes it. Without this fix we just get
a WebApplicationException and its stacktrace with a null message, the
original exception was being returned to the client but thrown away on
the server side.
