### PR TITLE
Adds documentation for neo4j-installer and updates it for neo4j

### DIFF
--- a/community/server/src/docs/man/neo4j-installer.1.asciidoc
+++ b/community/server/src/docs/man/neo4j-installer.1.asciidoc
@@ -1,0 +1,65 @@
+= NEO4J-INSTALLER(1) =
+:author: The Neo4j Team
+
+NAME
+----
+neo4j-installer - Neo4j Server installation and removal
+
+[[neo4j-installer-manpage]]
+SYNOPSIS
+--------
+
+*neo4j-installer* <command>
+
+[[neo4j-installer-manpage-description]]
+DESCRIPTION
+-----------
+
+Neo4j is a graph database, perfect for working with highly connected data.
+
+The preferred way to install Neo4j on Linux systems is by using prebuilt installation packages, but there's also the possibility to use the `neo4j-installer` command to install or remove it as a system service.
+For information regarding Windows, see below.
+
+Use the `neo4j` command to control the Neo4j Server.
+
+[[neo4j-installer-manpage-commands]]
+COMMANDS
+--------
+
+*install*::
+  Installs the server as a platform-appropriate system service.
+
+*remove*::
+  Uninstalls the system service.
+
+[[neo4j-installer-manpage-usage-windows]]
+Usage - Windows
+---------------
+
+To just control the Neo4j Server, use the `Neo4j.bat` command.
+
+*Neo4jInstaller.bat install/remove*
+
+Neo4j can be installed and run as a Windows Service, running without a console
+window. You'll need to run the scripts with Administrator privileges.
+Just use the `Neo4jInstaller.bat` script with the proper argument:
+
+* Neo4jInstaller.bat install - install as a Windows service
+** will install the service 
+* Neo4jInstaller.bat remove - remove the Neo4j service
+** will stop and remove the Neo4j service
+
+[[neo4j-installer-manpage-files]]
+FILES
+-----
+
+*conf/neo4j-server.properties*::
+  Server configuration.
+
+*conf/neo4j-wrapper.conf*::
+  Configuration for service wrapper.
+
+*conf/neo4j.properties*::
+  Tuning configuration for the database.
+
+

--- a/community/server/src/docs/man/neo4j.1.asciidoc
+++ b/community/server/src/docs/man/neo4j.1.asciidoc
@@ -4,7 +4,7 @@ NEO4J(1)
 
 NAME
 ----
-neo4j - Neo4j Server control and management
+neo4j - Neo4j Server control
 
 [[neo4j-manpage]]
 SYNOPSIS
@@ -17,13 +17,17 @@ DESCRIPTION
 -----------
 
 Neo4j is a graph database, perfect for working with highly connected data.
+The `neo4j` command is used to control the Neo4j Server.
+
+The preferred way to install Neo4j on Linux systems is by using prebuilt installation packages, but there's also the possibility to use the `neo4j-installer` command to install or remove it as a system service.
+For information regarding Windows, see below.
 
 [[neo4j-manpage-commands]]
 COMMANDS
 --------
 
 *console*::
-  Start the server as an application, running as a foreground proces. Stop the server using `CTRL-C`.
+  Start the server as an application, running as a foreground process. Stop the server using `CTRL-C`.
 
 *start*::
   Start server as daemon, running as a background process.
@@ -37,12 +41,6 @@ COMMANDS
 *status*::
   Current running state of the server.
 
-*install*::
-  Installs the server as a platform-appropriate system service.
-
-*remove*::
-  Uninstalls the system service.
-
 *info*::
   Displays configuration information, such as the current NEO4J_HOME and CLASSPATH.
 
@@ -55,16 +53,8 @@ Usage - Windows
 Double-clicking on the Neo4j.bat script will start the server in a console.
 To quit, just press `control-C` in the console window.
 
-*Neo4j.bat install/remove*
+For installing the Neo4j Server as a service, use the `Neo4jInstaller.bat` command.
 
-Neo4j can be installed and run as a Windows Service, running without a console
-window. You'll need to run the scripts with Administrator priveleges.
-Just use the Neo4j.bat script with the proper argument:
-
-* Neo4j.bat install - install as a Windows service
-** will install the service 
-* Neo4j.bat remove - remove the Neo4j service
-** will stop and remove the Neo4j service
 * Neo4j.bat start - will start the Neo4j service
 ** will start the Neo4j service if installed or a console
 ** session otherwise.

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -14,4 +14,4 @@ make_dir                   = $(tools_dir)/make
 
 include $(make_dir)/context-manual.make
 
-manpage_list = "neo4j server" "neo4j-arbiter server" "neo4j-coordinator server" "neo4j-coordinator-shell server" "neo4j-shell shell" "neo4j-backup backup"
+manpage_list = "neo4j server" "neo4j-installer server" "neo4j-arbiter server" "neo4j-coordinator server" "neo4j-coordinator-shell server" "neo4j-shell shell" "neo4j-backup backup"

--- a/manual/assemblies/manpages-enterprise.xml
+++ b/manual/assemblies/manpages-enterprise.xml
@@ -34,6 +34,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>neo4j.*</include>
+        <include>neo4j-installer.*</include>
         <include>neo4j-shell.*</include>
         <include>neo4j-backup.*</include>
         <include>neo4j-arbiter.*</include>

--- a/manual/assemblies/manpages.xml
+++ b/manual/assemblies/manpages.xml
@@ -34,6 +34,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>neo4j.*</include>
+        <include>neo4j-installer.*</include>
         <include>neo4j-shell.*</include>
       </includes>
     </fileSet>

--- a/manual/src/manpages.asciidoc
+++ b/manual/src/manpages.asciidoc
@@ -6,6 +6,7 @@ Manpages
 The Neo4j Unix manual pages are included on the following pages.
 
 * <<neo4j-manpage,neo4j>>
+* <<neo4j-installer-manpage,neo4j-installer>>
 * <<shell-manpage,neo4j-shell>>
 * <<neo4j-backup-manpage,neo4j-backup>>
 * <<neo4j-arbiter-manpage,neo4j-arbiter>>
@@ -16,6 +17,7 @@ The Neo4j Unix manual pages are included on the following pages.
 [subs="none"]
 ++++++++++++++++++++++++++++++++++++++
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j.1.xml"></xi:include> 
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-installer.1.xml"></xi:include> 
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-shell.1.xml"></xi:include> 
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-backup.1.xml"></xi:include> 
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-arbiter.1.xml"></xi:include>

--- a/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/neo4j-advanced.manpages
+++ b/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/neo4j-advanced.manpages
@@ -1,2 +1,1 @@
-manpages/neo4j.1.gz
 manpages/neo4j-shell.1.gz

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.manpages
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.manpages
@@ -1,2 +1,1 @@
-manpages/neo4j.1.gz
 manpages/neo4j-shell.1.gz

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.manpages
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.manpages
@@ -1,3 +1,2 @@
-manpages/neo4j.1.gz
 manpages/neo4j-shell.1.gz
 manpages/neo4j-backup.1.gz


### PR DESCRIPTION
- The docs on neo4j-installer goes into the zip packages as text files in the documentation dir, but not into the deb packages.
- The neo4j-installer manpage is visible in the manual as well.
- I removed the neo4j manpage from the deb packages as the command doesn't get installed on the system anyhow.
- Tells Linux users to use prebuilt installation packages if they can.
- Updated windows information to be in sync with the installation guide.
