### PR TITLE
Fix for problem with index lookups against properties

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/package.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/package.scala
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.executionplan
+
+import org.neo4j.graphdb.PropertyContainer
+import org.neo4j.cypher.internal.compiler.v2_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v2_0.commands.StartItem
+import org.neo4j.cypher.internal.compiler.v2_0.symbols.SymbolTable
+import org.neo4j.cypher.internal.compiler.v2_0.pipes.EntityProducer
+
+package object builders {
+  // TODO added 2013-12-06
+  // These types are ugly and should move into a tiny case class given the fields readable names
+  // To minimize the changes, I didn't do it the first time around.
+  type MaybeProducerOf[T <: PropertyContainer] = PartialFunction[(PlanContext, StartItem, Option[SymbolTable]), EntityProducer[T]]
+
+}

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/EntityProducerFactoryTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/EntityProducerFactoryTest.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_0.executionplan.builders
 
 import org.neo4j.cypher.internal.compiler.v2_0._
-import commands.{AnyIndex, NodeByLabel, SchemaIndex}
-import commands.expressions.Literal
+import org.neo4j.cypher.internal.compiler.v2_0.commands.{AnyIndex, NodeByLabel, SchemaIndex}
+import org.neo4j.cypher.internal.compiler.v2_0.commands.expressions.{Identifier, Literal}
 import pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v2_0.spi.{QueryContext, PlanContext}
 import org.neo4j.cypher.IndexHintException
@@ -30,11 +30,13 @@ import org.junit.{Before, Test}
 import org.mockito.Mockito._
 import org.scalatest.Assertions
 import org.neo4j.kernel.api.index.IndexDescriptor
+import org.neo4j.cypher.internal.compiler.v2_0.symbols.SymbolTable
 
 class EntityProducerFactoryTest extends MockitoSugar with Assertions {
   var planContext: PlanContext = null
   var factory: EntityProducerFactory = null
   val context = ExecutionContext.empty
+  val emptySymbolTable = Some(new SymbolTable())
 
   @Before
   def init() {
@@ -50,7 +52,7 @@ class EntityProducerFactoryTest extends MockitoSugar with Assertions {
     when(planContext.getIndexRule(label, prop)).thenReturn(None)
 
     //WHEN
-    intercept[IndexHintException](factory.nodeByIndexHint(planContext, SchemaIndex("id", label, prop, AnyIndex, None)))
+    intercept[IndexHintException](factory.nodeByIndexHint(planContext, SchemaIndex("id", label, prop, AnyIndex, None), emptySymbolTable))
   }
 
   @Test
@@ -67,7 +69,7 @@ class EntityProducerFactoryTest extends MockitoSugar with Assertions {
     val state = QueryStateHelper.empty.copy(inner = queryContext)
 
     //WHEN
-    val func = factory.nodeByIndexHint(planContext, SchemaIndex("id", label, prop, AnyIndex, Some(Literal(value))))
+    val func = factory.nodeByIndexHint(planContext, SchemaIndex("id", label, prop, AnyIndex, Some(Literal(value))), emptySymbolTable)
     assert(func(context, state) === indexResult)
   }
 
@@ -81,7 +83,7 @@ class EntityProducerFactoryTest extends MockitoSugar with Assertions {
     val state = QueryStateHelper.empty.copy(inner = queryContext)
 
     // when
-    val func = factory.nodeByLabel(planContext, NodeByLabel("id", label))
+    val func = factory.nodeByLabel(planContext, NodeByLabel("id", label), None)
     assert(func(context, state) === Iterator.empty)
 
     // then
@@ -95,7 +97,7 @@ class EntityProducerFactoryTest extends MockitoSugar with Assertions {
     val propertyKey = "prop"
     val index: IndexDescriptor = new IndexDescriptor(123, 456)
     when(planContext.getIndexRule(labelName, propertyKey)).thenReturn(Some(index))
-    val producer = factory.nodeByIndexHint(planContext, SchemaIndex("x", labelName, propertyKey, AnyIndex, Some(Literal(Seq(1,2,3)))))
+    val producer = factory.nodeByIndexHint(planContext, SchemaIndex("x", labelName, propertyKey, AnyIndex, Some(Literal(Seq(1,2,3)))), emptySymbolTable)
     val queryContext: QueryContext = mock[QueryContext]
     val state = QueryStateHelper.empty.copy(inner = queryContext)
 
@@ -104,5 +106,20 @@ class EntityProducerFactoryTest extends MockitoSugar with Assertions {
 
     //THEN
     verify(queryContext, times(1)).exactIndexSearch(index, Array(1,2,3))
+  }
+
+  @Test
+  def should_not_accept_an_index_hint_query_with_missing_dependencies_in_the_expression() {
+    //GIVEN
+    val labelName = "Label"
+    val propertyKey = "prop"
+    val symbolTable = new SymbolTable()
+    val index: IndexDescriptor = new IndexDescriptor(123, 456)
+    when(planContext.getIndexRule(labelName, propertyKey)).thenReturn(Some(index))
+    val indexStartItem = SchemaIndex("x", labelName, propertyKey, AnyIndex, Some(Identifier("a")))
+
+    // Then
+    val message = "Should not accept index lookups when dependencies are not met"
+    assert(!factory.nodeByIndexHint.isDefinedAt((planContext, indexStartItem, Some(symbolTable))), message)
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/StartPipePlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/StartPipePlanDescriptionTest.scala
@@ -32,6 +32,7 @@ import org.neo4j.cypher.PlanDescription
 import org.neo4j.cypher.internal.compiler.v2_0.commands.SchemaIndex
 import org.neo4j.cypher.internal.compiler.v2_0.commands.NodeByIndex
 import org.neo4j.kernel.api.index.IndexDescriptor
+import org.neo4j.cypher.internal.compiler.v2_0.symbols.SymbolTable
 
 
 class StartPipePlanDescriptionTest extends MockitoSugar {
@@ -122,7 +123,7 @@ class StartPipePlanDescriptionTest extends MockitoSugar {
   }
 
   private def createPlanDescription(startItem: StartItem): PlanDescription = {
-    val producer = factory.nodeStartItems((planContext, startItem))
+    val producer = factory.nodeStartItems((planContext, startItem, Some(new SymbolTable())))
     val pipe = new NodeStartPipe(NullPipe(), "n", producer)
     pipe.executionPlanDescription
   }


### PR DESCRIPTION
Index lookups use expressions to dynamically produce the value
being searched for. The expressions might have symbol table
dependencies that are not met, and in these cases Cypher should
not use index seeks. This commit makes it so.
