### PR TITLE
Uses a snapshot of the reference to Master instead of a proxy

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Map;
+
 import javax.transaction.Transaction;
 
 import org.jboss.netty.logging.InternalLoggerFactory;
@@ -143,7 +144,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     protected void create()
     {
         life.add( new BranchedDataMigrator( storeDir ) );
-        masterDelegateInvocationHandler = new DelegateInvocationHandler();
+        masterDelegateInvocationHandler = new DelegateInvocationHandler( Master.class );
         master = (Master) Proxy.newProxyInstance( Master.class.getClassLoader(), new Class[]{Master.class},
                 masterDelegateInvocationHandler );
 
@@ -243,9 +244,9 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected RemoteTxHook createTxHook()
     {
-        clusterEventsDelegateInvocationHandler = new DelegateInvocationHandler();
-        memberContextDelegateInvocationHandler = new DelegateInvocationHandler();
-        clusterMemberAvailabilityDelegateInvocationHandler = new DelegateInvocationHandler();
+        clusterEventsDelegateInvocationHandler = new DelegateInvocationHandler( ClusterMemberEvents.class );
+        memberContextDelegateInvocationHandler = new DelegateInvocationHandler( HighAvailabilityMemberContext.class );
+        clusterMemberAvailabilityDelegateInvocationHandler = new DelegateInvocationHandler( ClusterMemberAvailability.class );
 
         clusterEvents = (ClusterMemberEvents) Proxy.newProxyInstance( ClusterMemberEvents.class.getClassLoader(),
                 new Class[]{ClusterMemberEvents.class, Lifecycle.class}, clusterEventsDelegateInvocationHandler );
@@ -349,7 +350,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         paxosLife.add( clusterEvents );
         paxosLife.add( localClusterMemberAvailability );
 
-        DelegateInvocationHandler<RemoteTxHook> txHookDelegate = new DelegateInvocationHandler<>();
+        DelegateInvocationHandler<RemoteTxHook> txHookDelegate = new DelegateInvocationHandler<>( RemoteTxHook.class );
         RemoteTxHook txHook = (RemoteTxHook) Proxy.newProxyInstance( RemoteTxHook.class.getClassLoader(), new Class[]{RemoteTxHook.class},
                 txHookDelegate );
         new TxHookModeSwitcher( memberStateMachine, txHookDelegate,
@@ -378,7 +379,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected TxIdGenerator createTxIdGenerator()
     {
-        DelegateInvocationHandler<TxIdGenerator> txIdGeneratorDelegate = new DelegateInvocationHandler<>();
+        DelegateInvocationHandler<TxIdGenerator> txIdGeneratorDelegate =
+                new DelegateInvocationHandler<>( TxIdGenerator.class );
         TxIdGenerator txIdGenerator =
                 (TxIdGenerator) Proxy.newProxyInstance( TxIdGenerator.class.getClassLoader(),
                         new Class[]{TxIdGenerator.class}, txIdGeneratorDelegate );
@@ -417,7 +419,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected LockManager createLockManager()
     {
-        DelegateInvocationHandler<LockManager> lockManagerDelegate = new DelegateInvocationHandler<>();
+        DelegateInvocationHandler<LockManager> lockManagerDelegate = new DelegateInvocationHandler<>( LockManager.class );
         LockManager lockManager =
                 (LockManager) Proxy.newProxyInstance( LockManager.class.getClassLoader(),
                         new Class[]{LockManager.class}, lockManagerDelegate );
@@ -431,7 +433,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     protected TokenCreator createRelationshipTypeCreator()
     {
         DelegateInvocationHandler<TokenCreator> relationshipTypeCreatorDelegate =
-                new DelegateInvocationHandler<>();
+                new DelegateInvocationHandler<>( TokenCreator.class );
         TokenCreator relationshipTypeCreator =
                 (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
                         new Class[]{TokenCreator.class}, relationshipTypeCreatorDelegate );
@@ -444,7 +446,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     protected TokenCreator createPropertyKeyCreator()
     {
         DelegateInvocationHandler<TokenCreator> propertyKeyCreatorDelegate =
-                new DelegateInvocationHandler<>();
+                new DelegateInvocationHandler<>( TokenCreator.class );
         TokenCreator propertyTokenCreator =
                 (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
                         new Class[]{TokenCreator.class}, propertyKeyCreatorDelegate );
@@ -457,7 +459,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     protected TokenCreator createLabelIdCreator()
     {
         DelegateInvocationHandler<TokenCreator> labelIdCreatorDelegate =
-                new DelegateInvocationHandler<>();
+                new DelegateInvocationHandler<>( TokenCreator.class );
         TokenCreator labelIdCreator =
                 (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
                         new Class[]{TokenCreator.class}, labelIdCreatorDelegate );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
@@ -29,6 +29,8 @@ import org.neo4j.kernel.impl.core.DefaultLabelIdCreator;
 import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.logging.Logging;
 
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+
 public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
@@ -59,6 +61,6 @@ public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCre
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLabelTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlaveLabelTokenCreator( snapshot( master ), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
@@ -29,6 +29,8 @@ import org.neo4j.kernel.impl.core.DefaultPropertyTokenCreator;
 import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.logging.Logging;
 
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+
 public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
@@ -59,6 +61,6 @@ public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCr
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlavePropertyTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlavePropertyTokenCreator( snapshot( master ), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
@@ -23,11 +23,13 @@ import java.net.URI;
 
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
-import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.core.DefaultRelationshipTypeCreator;
 import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
 
 public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
@@ -59,6 +61,6 @@ public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<To
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveRelationshipTypeCreator( master, requestContextFactory, xaDsm );
+        return new SlaveRelationshipTypeCreator( snapshot( master ), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.impl.transaction.LockManagerImpl;
 import org.neo4j.kernel.impl.transaction.RagManager;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 {
     private final HaXaDataSourceManager xaDsm;
@@ -71,8 +73,8 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
     @Override
     protected LockManager getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLockManager( new RagManager(), requestContextFactory, master, xaDsm, txManager, remoteTxHook,
-                availabilityGuard, new SlaveLockManager.Configuration()
+        return new SlaveLockManager( new RagManager(), requestContextFactory, snapshot( master ), xaDsm, txManager,
+                remoteTxHook, availabilityGuard, new SlaveLockManager.Configuration()
         {
             @Override
             public long getAvailabilityTimeout()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
@@ -31,6 +31,8 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+
 public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
 {
     private final Master master;
@@ -59,7 +61,7 @@ public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
     @Override
     protected RemoteTxHook getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxHook( master, resolver.resolveDependency( HaXaDataSourceManager.class ),
+        return new SlaveTxHook( snapshot( master ), resolver.resolveDependency( HaXaDataSourceManager.class ),
                 requestContextFactory, log );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
@@ -25,24 +25,26 @@ import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.ha.com.RequestContextFactory;
-import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
-import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
 
 public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerator>
 {
     private final HaXaDataSourceManager xaDsm;
     private final Master master;
     private final RequestContextFactory requestContextFactory;
-    private StringLogger msgLog;
-    private Config config;
-    private Slaves slaves;
+    private final StringLogger msgLog;
+    private final Config config;
+    private final Slaves slaves;
     private final AbstractTransactionManager tm;
 
     public TxIdGeneratorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
@@ -70,7 +72,7 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
     @Override
     protected TxIdGenerator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master,
+        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), snapshot( master ),
                 HighAvailabilityModeSwitcher.getServerId( serverHaUri ), requestContextFactory, xaDsm, tm);
     }
 }


### PR DESCRIPTION
so that the master cannot change all of a sudden in the middle of
operations. This fixes a problem where a service which was instantiated
for one specific master continued to run for a different master after a
sudden master switch. Specifically this resulted in misuse of id ranges,
potentially received from a different master than expected.
