### PR TITLE
Passes correct payload for phase1Timeout messages

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContext.java
@@ -312,6 +312,10 @@ public class MultiPaxosContext
         @Override
         public void bookInstance( InstanceId instanceId, Message message )
         {
+            if ( message.getPayload() == null )
+            {
+                throw new IllegalArgumentException( "null payload for booking instance: " + message );
+            }
             bookedInstances.put( instanceId, message );
         }
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
@@ -94,10 +94,7 @@ public class PaxosInstance
 
     public void ready( Object value, boolean clientValue )
     {
-        if ( value == null )
-        {
-            throw new IllegalArgumentException( "value null" );
-        }
+        assertNotNull( value );
         
         state = State.p1_ready;
         promises.clear();
@@ -141,10 +138,7 @@ public class PaxosInstance
 
     public void closed( Object value, String conversationIdHeader )
     {
-        if ( value == null )
-        {
-            throw new IllegalArgumentException( "value null" );
-        }
+        assertNotNull( value );
         
         value_2 = value;
         state = State.closed;
@@ -152,6 +146,14 @@ public class PaxosInstance
         rejectedAccepts.clear();
         acceptors = null;
         this.conversationIdHeader = conversationIdHeader;
+    }
+
+    private void assertNotNull( Object value )
+    {
+        if ( value == null )
+        {
+            throw new IllegalArgumentException( "value null" );
+        }
     }
 
     public void delivered()

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
@@ -103,9 +103,10 @@ public enum ProposerState
                                             InstanceId.INSTANCE ) );
                                 }
                                 // This will reset the phase1Timeout if existing
+                                // TODO no payload associated with the phase1Timeout here.
+                                //      but what payload to use? instance.value_2?
                                 context.setTimeout( instanceId, message.copyHeadersTo( Message.timeout(
-                                        ProposerMessage
-                                                .phase1Timeout, message ), InstanceId.INSTANCE ) );
+                                        ProposerMessage.phase1Timeout, message ), InstanceId.INSTANCE ) );
                             }
                             break;
                         }
@@ -142,8 +143,8 @@ public enum ProposerState
                                                 InstanceId.INSTANCE ) );
                                     }
                                     context.setTimeout( instanceId, message.copyHeadersTo( Message.timeout(
-                                            ProposerMessage
-                                                    .phase1Timeout, message ), InstanceId.INSTANCE ) );
+                                            ProposerMessage.phase1Timeout, message, message.getPayload() ),
+                                            InstanceId.INSTANCE ) );
                                 }
                             }
                             else if ( instance.isState( PaxosInstance.State.closed ) || instance.isState(
@@ -286,7 +287,7 @@ public enum ProposerState
                                 }
 
                                 context.setTimeout( instanceId, message.copyHeadersTo( Message.timeout(
-                                        ProposerMessage.phase1Timeout, message ), InstanceId.INSTANCE ) );
+                                        ProposerMessage.phase1Timeout, message, message.getPayload() ), InstanceId.INSTANCE ) );
                             }
                             break;
                         }
@@ -427,8 +428,8 @@ public enum ProposerState
                         ballot ) ).setHeader( InstanceId.INSTANCE, instanceId.toString() ) );
             }
 
-            context.setTimeout( instanceId, Message.timeout( ProposerMessage.phase1Timeout, message )
-                    .setHeader( InstanceId.INSTANCE, instanceId.toString() ) );
+            context.setTimeout( instanceId, Message.timeout( ProposerMessage.phase1Timeout, message,
+                    message.getPayload() ).setHeader( InstanceId.INSTANCE, instanceId.toString() ) );
         }
         else
         {

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/TrackingMessageHolder.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/TrackingMessageHolder.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.com.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.helpers.collection.IteratorUtil;
+
+public class TrackingMessageHolder implements MessageHolder
+{
+    private final List<Message> messages = new ArrayList<>();
+    
+    @Override
+    public void offer( Message<? extends MessageType> message )
+    {
+        messages.add( message );
+    }
+    
+    public <T extends MessageType> Message<T> single()
+    {
+        return IteratorUtil.single( messages );
+    }
+
+    public <T extends MessageType> Message<T> first()
+    {
+        return IteratorUtil.first( messages );
+    }
+}

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -20,10 +20,8 @@
 package org.neo4j.cluster.protocol.cluster;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -31,8 +29,8 @@ import org.mockito.ArgumentMatcher;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
-import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.com.message.TrackingMessageHolder;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationRequestState;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationResponseState;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -48,7 +46,6 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.cluster.com.message.Message.to;
 import static org.neo4j.cluster.protocol.cluster.ClusterMessage.configurationRequest;
 import static org.neo4j.cluster.protocol.cluster.ClusterMessage.joinDenied;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
 
 public class ClusterStateTest
 {
@@ -70,8 +67,7 @@ public class ClusterStateTest
         ClusterState.entered.handle( context, message, outgoing );
         
         // THEN assert that the responding instance sends its configuration along with the response
-        @SuppressWarnings( "unchecked" )
-        Message<ClusterMessage> response = (Message<ClusterMessage>) single( outgoing.messages );
+        Message<ClusterMessage> response = outgoing.single();
         assertTrue( response.getPayload() instanceof ConfigurationResponseState );
         ConfigurationResponseState responseState = response.getPayload();
         assertEquals( existingMembers, responseState.getMembers() );
@@ -113,7 +109,7 @@ public class ClusterStateTest
                 .setHeader( Message.CONVERSATION_ID, "bla" ), outgoing );
         
         // THEN assert that the failure contains the received configuration
-        Message<? extends MessageType> response = single( outgoing.messages );
+        Message<? extends MessageType> response = outgoing.single();
         ClusterEntryDeniedException deniedException = response.getPayload();
         assertEquals( existingMembers, deniedException.getConfigurationResponseState().getMembers() );
     }
@@ -149,17 +145,6 @@ public class ClusterStateTest
     private URI uri( int i )
     {
         return URI.create( "http://localhost:" + (6000+i) + "?serverId=" + i );
-    }
-
-    public static class TrackingMessageHolder implements MessageHolder
-    {
-        private final List<Message<? extends MessageType>> messages = new ArrayList<>();
-        
-        @Override
-        public void offer( Message<? extends MessageType> message )
-        {
-            messages.add( message );
-        }
     }
 
     private static class ConfigurationResponseStateMatcher extends ArgumentMatcher<ConfigurationResponseState>

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/omega/MessageArgumentMatcher.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/omega/MessageArgumentMatcher.java
@@ -24,6 +24,7 @@ import java.net.URI;
 
 import org.hamcrest.Description;
 import org.mockito.ArgumentMatcher;
+
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageType;
 
@@ -80,6 +81,8 @@ public class MessageArgumentMatcher<T extends MessageType> extends ArgumentMatch
     @Override
     public void describeTo( Description description )
     {
-        description.appendText( theMessageType.name()+"{from="+from+", to="+to+", payload="+payload+"}" );
+        description.appendText(
+                (theMessageType != null ? theMessageType.name() : "<no particular message type>") +
+                "{from=" + from + ", to=" + to + ", payload=" + payload + "}" );
     }
 }


### PR DESCRIPTION
There was an issue where a phase1Timeout occured, but no payload passed
with it. The consumer of such a timeout used the payload and made it
available for later usage even, which then would unexpectedly fail.

Now, wherever applicable, the correct payload is sent with such timeout
messages.
