### PR TITLE
Cope with version check of very short store files.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.storemigration.ConfigMapUpgradeConfiguration;
 import org.neo4j.kernel.impl.storemigration.DatabaseFiles;
 import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
+import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.UpgradableDatabase;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
@@ -111,7 +112,7 @@ public class StoreFactory
     private void tryToUpgradeStores( File fileName )
     {
         new StoreUpgrader(config, stringLogger, new ConfigMapUpgradeConfiguration(config),
-                new UpgradableDatabase( fileSystemAbstraction ),
+                new UpgradableDatabase( new StoreVersionCheck( fileSystemAbstraction ) ),
                 new StoreMigrator( new VisibleMigrationProgressMonitor( stringLogger, System.out ) ),
                 new DatabaseFiles( fileSystemAbstraction ),
                 idGeneratorFactory, fileSystemAbstraction ).attemptUpgrade( fileName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.neo4j.helpers.UTF8;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+
+public class StoreVersionCheck
+{
+    private FileSystemAbstraction fs;
+
+    public StoreVersionCheck( FileSystemAbstraction fs )
+    {
+        this.fs = fs;
+    }
+
+    public boolean hasVersion( File storeFile, String expectedVersion )
+    {
+        FileChannel fileChannel = null;
+        byte[] expectedVersionBytes = UTF8.encode( expectedVersion );
+        try
+        {
+            if ( !fs.fileExists( storeFile ) )
+            {
+                return false;
+            }
+
+            fileChannel = fs.open( storeFile, "r" );
+            if ( fileChannel.size() < expectedVersionBytes.length )
+            {
+                return false;
+            }
+
+            String actualVersion = readVersion( fileChannel, expectedVersionBytes.length );
+            if ( !expectedVersion.equals( actualVersion ) )
+            {
+                return false;
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+        finally
+        {
+            if ( fileChannel != null )
+            {
+                try
+                {
+                    fileChannel.close();
+                }
+                catch ( IOException e )
+                {
+                    // Ignore exception on close
+                }
+            }
+        }
+        return true;
+    }
+
+    private String readVersion( FileChannel fileChannel, int bytesToRead ) throws IOException
+    {
+        fileChannel.position( fileChannel.size() - bytesToRead );
+        byte[] foundVersionBytes = new byte[bytesToRead];
+        fileChannel.read( ByteBuffer.wrap( foundVersionBytes ) );
+        return UTF8.decode( foundVersionBytes );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/CurrentDatabaseTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/CurrentDatabaseTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CurrentDatabaseTest
+{
+    @Test
+    public void shouldRejectStoreWhereOneFileHasTheWrongVersion() throws Exception
+    {
+        File workingDirectory = new File( "target/" + CurrentDatabaseTest.class.getSimpleName() );
+
+        StoreVersionCheck storeVersionCheck = mock( StoreVersionCheck.class );
+        when( storeVersionCheck.hasVersion( eq( new File( workingDirectory, "neostore.nodestore.db" ) ), anyString() ) )
+                .thenReturn( false );
+        when( storeVersionCheck.hasVersion( not( eq( new File( workingDirectory, "neostore.nodestore.db" ) ) ),
+                anyString() ) )
+                .thenReturn( true );
+
+        assertFalse( new CurrentDatabase( storeVersionCheck ).storeFilesAtCurrentVersion( workingDirectory ) );
+    }
+
+    @Test
+    public void shouldAcceptStoreWhenAllFilesHaveTheCorrectVersion()
+    {
+        File workingDirectory = new File( "target/" + CurrentDatabaseTest.class.getSimpleName() );
+
+        StoreVersionCheck storeVersionCheck = mock( StoreVersionCheck.class );
+        when( storeVersionCheck.hasVersion( any( File.class ), anyString() ) ).thenReturn( true );
+
+        assertTrue( new CurrentDatabase( storeVersionCheck ).storeFilesAtCurrentVersion( workingDirectory ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderInterruptionTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderInterruptionTestIT.java
@@ -82,7 +82,7 @@ public class StoreUpgraderInterruptionTestIT
     
     private StoreUpgrader newUpgrader( StoreMigrator migrator, DatabaseFiles files )
     {
-        return new StoreUpgrader( defaultConfig(), StringLogger.DEV_NULL, alwaysAllowed(), new UpgradableDatabase(fileSystem), migrator,
+        return new StoreUpgrader( defaultConfig(), StringLogger.DEV_NULL, alwaysAllowed(), new UpgradableDatabase( new StoreVersionCheck( fileSystem ) ), migrator,
                 files, defaultIdGeneratorFactory(), defaultFileSystemAbstraction() );        
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTestIT.java
@@ -177,7 +177,7 @@ public class StoreUpgraderTestIT
 
     private StoreUpgrader newUpgrader( UpgradeConfiguration config, StoreMigrator migrator, DatabaseFiles files )
     {
-        return new StoreUpgrader( defaultConfig(), StringLogger.DEV_NULL, config, new UpgradableDatabase( fs.get() ), migrator,
+        return new StoreUpgrader( defaultConfig(), StringLogger.DEV_NULL, config, new UpgradableDatabase( new StoreVersionCheck( fs.get() ) ), migrator,
                 files, new DefaultIdGeneratorFactory(), fs.get() );
     }
     

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Test;
+
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StoreVersionCheckTest
+{
+    @Test
+    public void shouldReportMissingFileDoesNotHaveSpecifiedVersion()
+    {
+        // given
+        File missingFile = new File("/you/will/never/find/me");
+        StoreVersionCheck storeVersionCheck = new StoreVersionCheck(new EphemeralFileSystemAbstraction());
+
+        // then
+        assertFalse( storeVersionCheck.hasVersion( missingFile, "version" ) );
+    }
+
+    @Test
+    public void shouldReportShortFileDoesNotHaveSpecifiedVersion() throws IOException
+    {
+        // given
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        File shortFile = fileContaining( fs, "a" );
+
+        StoreVersionCheck storeVersionCheck = new StoreVersionCheck( fs );
+
+        // then
+        assertFalse( storeVersionCheck.hasVersion( shortFile, "version" ) );
+    }
+
+    @Test
+    public void shouldReportFileWithIncorrectVersion() throws IOException
+    {
+        // given
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        File shortFile = fileContaining( fs, "versionWhichIsIncorrect" );
+
+        StoreVersionCheck storeVersionCheck = new StoreVersionCheck( fs );
+
+        // then
+        assertFalse( storeVersionCheck.hasVersion( shortFile, "correctVersion" ) );
+    }
+
+    @Test
+    public void shouldReportFileWithCorrectVersion() throws IOException
+    {
+        // given
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        File shortFile = fileContaining( fs, "correctVersion" );
+
+        StoreVersionCheck storeVersionCheck = new StoreVersionCheck( fs );
+
+        // then
+        assertTrue( storeVersionCheck.hasVersion( shortFile, "correctVersion" ) );
+    }
+
+    private File fileContaining( EphemeralFileSystemAbstraction fs, String content ) throws IOException
+    {
+        File shortFile = new File( "shortFile" );
+        OutputStream outputStream = fs.openAsOutputStream( shortFile, true );
+        outputStream.write( content.getBytes() );
+        outputStream.close();
+        return shortFile;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
@@ -57,7 +57,7 @@ public class UpgradableDatabaseTestIT
 
         copyRecursively( resourceDirectory, workingDirectory );
 
-        assertTrue( new UpgradableDatabase(fileSystem).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
+        assertTrue( new UpgradableDatabase( new StoreVersionCheck( fileSystem ) ).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
     }
 
     @Test
@@ -74,7 +74,7 @@ public class UpgradableDatabaseTestIT
 
         changeVersionNumber( fileSystem, new File( workingDirectory, "neostore.nodestore.db" ), "v0.9.5" );
 
-        assertFalse( new UpgradableDatabase(fileSystem).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
+        assertFalse( new UpgradableDatabase( new StoreVersionCheck( fileSystem ) ).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
     }
 
     @Test
@@ -91,7 +91,7 @@ public class UpgradableDatabaseTestIT
 
         truncateFile( fileSystem, new File( workingDirectory, "neostore.nodestore.db" ), "StringPropertyStore v0.9.9" );
 
-        assertFalse( new UpgradableDatabase(fileSystem).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
+        assertFalse( new UpgradableDatabase( new StoreVersionCheck( fileSystem ) ).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
     }
 
     @Test
@@ -110,7 +110,7 @@ public class UpgradableDatabaseTestIT
         assertTrue( shortFileLength < UTF8.encode( "StringPropertyStore v0.9.9" ).length );
         truncateToFixedLength( fileSystem, new File( workingDirectory, "neostore.relationshiptypestore.db" ), shortFileLength );
 
-        assertFalse( new UpgradableDatabase(fileSystem).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
+        assertFalse( new UpgradableDatabase( new StoreVersionCheck( fileSystem ) ).storeFilesUpgradeable( new File( workingDirectory, "neostore" ) ) );
     }
 
     private final FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();

--- a/community/server/src/main/java/org/neo4j/server/preflight/PerformUpgradeIfNecessary.java
+++ b/community/server/src/main/java/org/neo4j/server/preflight/PerformUpgradeIfNecessary.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.storemigration.CurrentDatabase;
 import org.neo4j.kernel.impl.storemigration.DatabaseFiles;
 import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
+import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.UpgradableDatabase;
 import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
@@ -66,7 +67,7 @@ public class PerformUpgradeIfNecessary implements PreflightTask
             String dbLocation = new File( config.getString( Configurator.DATABASE_LOCATION_PROPERTY_KEY ) )
                     .getAbsolutePath();
 
-            if ( new CurrentDatabase().storeFilesAtCurrentVersion( new File( dbLocation ) ) )
+            if ( new CurrentDatabase(new StoreVersionCheck( new DefaultFileSystemAbstraction() ) ).storeFilesAtCurrentVersion( new File( dbLocation ) ) )
             {
                 return true;
             }
@@ -76,7 +77,7 @@ public class PerformUpgradeIfNecessary implements PreflightTask
             dbConfig.put( "neo_store", store.getPath() );
 
             FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
-            UpgradableDatabase upgradableDatabase = new UpgradableDatabase( fileSystem );
+            UpgradableDatabase upgradableDatabase = new UpgradableDatabase( new StoreVersionCheck( fileSystem ) );
             if ( !upgradableDatabase.storeFilesUpgradeable( store ) )
             {
                 return true;


### PR DESCRIPTION
Fixes a bug where the server would be unable to start if specific store files were
very short and where the database had not been shutdown cleanly.

Paired with @apcj on this one.
