### PR TITLE
fixing rest api such that nodes or relationships are indexed properly, w...

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -988,7 +988,27 @@ public class RestfulGraphDatabase
                             String.valueOf( entityBody.get( "key" ) ),
                             String.valueOf( entityBody.get( "value" ) ), extractNodeIdOrNull( getStringOrNull(
                             entityBody, "uri" ) ), getMapOrNull( entityBody, "properties" ) );
-                    return result.other() ? output.created( result.first() ) : output.conflict( result.first() );
+                    if ( result.other() )
+                    {
+                        return output.created( result.first() );
+                    }
+
+                    String uri = getStringOrNull( entityBody, "uri" );
+
+                    if ( uri == null )
+                    {
+                        return output.conflict( result.first() );
+                    }
+
+                    long idOfNodeToBeIndexed = extractNodeId( uri );
+                    long idOfNodeAlreadyInIndex = extractNodeId( result.first().getIdentity() );
+
+                    if ( idOfNodeToBeIndexed == idOfNodeAlreadyInIndex )
+                    {
+                        return output.created( result.first() );
+                    }
+
+                    return output.conflict( result.first() );
 
                 default:
                     entityBody = input.readMap( postBody, "key", "value", "uri" );
@@ -1058,7 +1078,27 @@ public class RestfulGraphDatabase
                             getStringOrNull( entityBody, "type" ), extractNodeIdOrNull( getStringOrNull( entityBody,
                             "end" ) ),
                             getMapOrNull( entityBody, "properties" ) );
-                    return result.other() ? output.created( result.first() ) : output.conflict( result.first() );
+                    if ( result.other() )
+                    {
+                        return output.created( result.first() );
+                    }
+
+                    String uri = getStringOrNull( entityBody, "uri" );
+
+                    if ( uri == null )
+                    {
+                        return output.conflict( result.first() );
+                    }
+
+                    long idOfRelationshipToBeIndexed = extractRelationshipId( uri );
+                    long idOfRelationshipAlreadyInIndex = extractRelationshipId( result.first().getIdentity() );
+
+                    if ( idOfRelationshipToBeIndexed == idOfRelationshipAlreadyInIndex )
+                    {
+                        return output.created( result.first() );
+                    }
+
+                    return output.conflict( result.first() );
 
                 default:
                     entityBody = input.readMap( postBody, "key", "value", "uri" );


### PR DESCRIPTION
...here before dummy nodes were indexed in their place

changed rest api for create_or_fail semantics: if you request indexing a node under key foo and value bar, and that node or another node is already indexed under foo/ bar, then an error is returned
