### PR TITLE
Uses a snapshot of the reference to Master instead of a proxy

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public LabelTokenCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                                           DelegateInvocationHandler<TokenCreator> delegate,
-                                           HaXaDataSourceManager xaDsm,
-                                           Master master, RequestContextFactory requestContextFactory,
-                                           Logging logging
+                                          DelegateInvocationHandler<TokenCreator> delegate,
+                                          HaXaDataSourceManager xaDsm,
+                                          DelegateInvocationHandler<Master> master,
+                                          RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCre
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLabelTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlaveLabelTokenCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public PropertyKeyCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                                                DelegateInvocationHandler<TokenCreator> delegate,
-                                                HaXaDataSourceManager xaDsm,
-                                                Master master, RequestContextFactory requestContextFactory,
-                                                Logging logging
+                                           DelegateInvocationHandler<TokenCreator> delegate,
+                                           HaXaDataSourceManager xaDsm,
+                                           DelegateInvocationHandler<Master> master,
+                                           RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCr
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlavePropertyTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlavePropertyTokenCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
@@ -23,8 +23,8 @@ import java.net.URI;
 
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
-import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.core.DefaultRelationshipTypeCreator;
 import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.logging.Logging;
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public RelationshipTypeCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                                 DelegateInvocationHandler<TokenCreator> delegate,
                                                 HaXaDataSourceManager xaDsm,
-                                                Master master, RequestContextFactory requestContextFactory,
-                                                Logging logging
+                                                DelegateInvocationHandler<Master> master,
+                                                RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<To
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveRelationshipTypeCreator( master, requestContextFactory, xaDsm );
+        return new SlaveRelationshipTypeCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import java.io.IOException;
-
 import org.jboss.netty.channel.Channel;
 
 import org.neo4j.com.RequestContext;
@@ -39,7 +37,6 @@ public class SlaveServer extends Server<Slave, Void>
     public static final byte APPLICATION_PROTOCOL_VERSION = 1;
 
     public SlaveServer( Slave requestTarget, Configuration config, Logging logging )
-            throws IOException
     {
         super( requestTarget, config, logging, DEFAULT_FRAME_LENGTH, APPLICATION_PROTOCOL_VERSION, ALWAYS_MATCH, 
                 SYSTEM_CLOCK );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -39,7 +39,7 @@ import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final AbstractTransactionManager txManager;
     private final RemoteTxHook remoteTxHook;
@@ -48,7 +48,7 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 
     public LockManagerModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                     DelegateInvocationHandler<LockManager> delegate,
-                                    HaXaDataSourceManager xaDsm, Master master,
+                                    HaXaDataSourceManager xaDsm, DelegateInvocationHandler<Master> master,
                                     RequestContextFactory requestContextFactory, AbstractTransactionManager txManager,
                                     RemoteTxHook remoteTxHook, AvailabilityGuard availabilityGuard, Config config )
     {
@@ -71,8 +71,8 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
     @Override
     protected LockManager getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLockManager( new RagManager(), requestContextFactory, master, xaDsm, txManager, remoteTxHook,
-                availabilityGuard, new SlaveLockManager.Configuration()
+        return new SlaveLockManager( new RagManager(), requestContextFactory, master.cement(), xaDsm, txManager,
+                remoteTxHook, availabilityGuard, new SlaveLockManager.Configuration()
         {
             @Override
             public long getAvailabilityTimeout()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
@@ -33,13 +33,14 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
 {
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactoryResolver requestContextFactory;
     private final StringLogger log;
     private final DependencyResolver resolver;
 
     public TxHookModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                               DelegateInvocationHandler<RemoteTxHook> delegate, Master master,
+                               DelegateInvocationHandler<RemoteTxHook> delegate,
+                               DelegateInvocationHandler<Master> master,
                                RequestContextFactoryResolver requestContextFactory, StringLogger log,
                                DependencyResolver resolver )
     {
@@ -59,7 +60,7 @@ public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
     @Override
     protected RemoteTxHook getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxHook( master, resolver.resolveDependency( HaXaDataSourceManager.class ),
+        return new SlaveTxHook( master.cement(), resolver.resolveDependency( HaXaDataSourceManager.class ),
                 requestContextFactory, log );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
@@ -25,12 +25,12 @@ import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.ha.com.RequestContextFactory;
-import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
-import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -38,16 +38,17 @@ import org.neo4j.kernel.impl.util.StringLogger;
 public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
-    private StringLogger msgLog;
-    private Config config;
-    private Slaves slaves;
+    private final StringLogger msgLog;
+    private final Config config;
+    private final Slaves slaves;
     private final AbstractTransactionManager tm;
 
     public TxIdGeneratorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                       DelegateInvocationHandler<TxIdGenerator> delegate, HaXaDataSourceManager xaDsm,
-                                      Master master, RequestContextFactory requestContextFactory,
+                                      DelegateInvocationHandler<Master> master,
+                                      RequestContextFactory requestContextFactory,
                                       StringLogger msgLog, Config config, Slaves slaves, AbstractTransactionManager tm
     )
     {
@@ -70,7 +71,7 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
     @Override
     protected TxIdGenerator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master,
+        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master.cement(),
                 HighAvailabilityModeSwitcher.getServerId( serverHaUri ), requestContextFactory, xaDsm, tm);
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -45,12 +45,14 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.ha.ClusterManager;
 
+import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
@@ -101,6 +103,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         HighlyAvailableGraphDatabase db = cluster.getAnySlave();
 
         // WHEN
+        HighlyAvailableGraphDatabase theOtherSlave;
         Transaction tx = db.beginTx();
         try
         {
@@ -109,7 +112,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         }
         finally
         {
-            HighlyAvailableGraphDatabase theOtherSlave = cluster.getAnySlave( db );
+            theOtherSlave = cluster.getAnySlave( db );
             takeTheLeadInAnEventualMasterSwitch( theOtherSlave );
             cluster.shutdown( cluster.getMaster() );
             assertFinishGetsTransactionFailure( tx );
@@ -119,6 +122,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
 
         // THEN
         assertFalse( db.isMaster() );
+        assertTrue( theOtherSlave.isMaster() );
         // to prevent a deadlock scenario which occurs if this test exists (and @After starts)
         // before the db has recovered from its KERNEL_PANIC
         awaitFullyOperational( db );
@@ -443,7 +447,8 @@ public class TransactionConstraintsIT extends AbstractClusterTest
 
     private void awaitFullyOperational( GraphDatabaseService db ) throws InterruptedException
     {
-        while ( true )
+        long endTime = currentTimeMillis() + MINUTES.toMillis( 1 );
+        for ( int i = 0; currentTimeMillis() < endTime; i++ )
         {
             try
             {
@@ -452,7 +457,11 @@ public class TransactionConstraintsIT extends AbstractClusterTest
             }
             catch ( Exception e )
             {
-                Thread.sleep( 100 );
+                if ( i > 0 && i%10 == 0 )
+                {
+                    e.printStackTrace();
+                }
+                Thread.sleep( 1000 );
             }
         }
     }


### PR DESCRIPTION
so that the master cannot change all of a sudden in the middle of
operations. This fixes a problem where a service which was instantiated
for one specific master continued to run for a different master after a
sudden master switch. Specifically this resulted in misuse of id ranges,
potentially received from a different master than expected.
