### PR TITLE
Uses a snapshot of the reference to Master instead of a proxy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/LazySingleReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/LazySingleReference.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.neo4j.helpers.Thunk;
+
+/**
+ * Manages a lazy initialized single reference that can be {@link #invalidate() invalidated}.
+ * Concurrent {@link #evaluate() access} is supported and only a single instance will be {@link #create() created}.
+ */
+public abstract class LazySingleReference<T> implements Thunk<T>
+{
+    private volatile T reference;
+    
+    /**
+     * @return whether or not the managed reference has been initialized, i.e {@link #evaluate() evaluated}
+     * for the first time, or after {@link #invalidate() invalidated}.
+     */
+    public boolean isCreated()
+    {
+        return reference != null;
+    }
+    
+    /**
+     * Returns the reference, initializing it if need be.
+     */
+    @Override
+    public T evaluate()
+    {
+        T result;
+        if ( (result = reference) == null )
+        {
+            synchronized ( this )
+            {
+                if ( (result = reference) == null )
+                {
+                    result = reference = create();
+                }
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * Invalidates any initialized reference. A future call to {@link #evaluate()} will have it initialized again.
+     */
+    public synchronized void invalidate()
+    {
+        reference = null;
+    }
+    
+    /**
+     * Provides a reference to manage.
+     */
+    protected abstract T create();
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/LazySingleReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/LazySingleReferenceTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.test.OtherThreadExecutor;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.test.DoubleLatch.awaitLatch;
+
+public class LazySingleReferenceTest
+{
+    @Test
+    public void shouldOnlyAllowSingleThreadToInitialize() throws Exception
+    {
+        // GIVEN
+        final CountDownLatch latch = new CountDownLatch( 1 );
+        final AtomicInteger initCalls = new AtomicInteger();
+        LazySingleReference<Integer> ref = new LazySingleReference<Integer>()
+        {
+            @Override
+            protected Integer create()
+            {
+                awaitLatch( latch );
+                return initCalls.incrementAndGet();
+            }
+        };
+        Future<Integer> t1Evaluate = t1.executeDontWait( evaluate( ref ) );
+        t1.waitUntilWaiting();
+        
+        // WHEN
+        Future<Integer> t2Evaluate = t2.executeDontWait( evaluate( ref ) );
+        t2.waitUntilBlocked();
+        latch.countDown();
+        int e1 = t1Evaluate.get();
+        int e2 = t2Evaluate.get();
+        
+        // THEN
+        assertEquals( "T1 evaluation", 1, e1 );
+        assertEquals( "T2 evaluation", 1, e2 );
+    }
+    
+    @Test
+    public void shouldMutexAccessBetweenInvalidateAndEvaluate() throws Exception
+    {
+        // GIVEN
+        final CountDownLatch latch = new CountDownLatch( 1 );
+        final AtomicInteger initCalls = new AtomicInteger();
+        LazySingleReference<Integer> ref = new LazySingleReference<Integer>()
+        {
+            @Override
+            protected Integer create()
+            {
+                awaitLatch( latch );
+                return initCalls.incrementAndGet();
+            }
+        };
+        Future<Integer> t1Evaluate = t1.executeDontWait( evaluate( ref ) );
+        t1.waitUntilWaiting();
+        
+        // WHEN
+        Future<Void> t2Invalidate = t2.executeDontWait( invalidate( ref ) );
+        t2.waitUntilBlocked();
+        latch.countDown();
+        int e = t1Evaluate.get();
+        t2Invalidate.get();
+        
+        // THEN
+        assertEquals( "Evaluation", 1, e );
+    }
+    
+    @Test
+    public void shouldInitializeAgainAfterInvalidated() throws Exception
+    {
+        // GIVEN
+        final AtomicInteger initCalls = new AtomicInteger();
+        LazySingleReference<Integer> ref = new LazySingleReference<Integer>()
+        {
+            @Override
+            protected Integer create()
+            {
+                return initCalls.incrementAndGet();
+            }
+        };
+        assertEquals( "First evaluation", 1, ref.evaluate().intValue() );
+        
+        // WHEN
+        ref.invalidate();
+        int e2 = ref.evaluate();
+        
+        // THEN
+        assertEquals( "Second evaluation", 2, e2 );
+    }
+    
+    @Test
+    public void shouldRespondToIsInitialized() throws Exception
+    {
+        // GIVEN
+        LazySingleReference<Integer> ref = new LazySingleReference<Integer>()
+        {
+            @Override
+            protected Integer create()
+            {
+                return 1;
+            }
+        };
+        
+        // WHEN
+        boolean firstResult = ref.isCreated();
+        ref.evaluate();
+        boolean secondResult = ref.isCreated();
+        ref.invalidate();
+        boolean thirdResult = ref.isCreated();
+        ref.evaluate();
+        boolean fourthResult = ref.isCreated();
+        
+        // THEN
+        assertFalse( "Should not start off as initialized", firstResult );
+        assertTrue( "Should be initialized after an evaluation", secondResult );
+        assertFalse( "Should not be initialized after invalidated", thirdResult );
+        assertTrue( "Should be initialized after a re-evaluation", fourthResult );
+    }
+    
+    private OtherThreadExecutor<Void> t1, t2;
+    
+    @Before
+    public void before()
+    {
+        t1 = new OtherThreadExecutor<>( "T1", null );
+        t2 = new OtherThreadExecutor<>( "T2", null );
+    }
+
+    @After
+    public void after()
+    {
+        t2.close();
+        t1.close();
+    }
+
+    private WorkerCommand<Void,Integer> evaluate( final LazySingleReference<Integer> ref )
+    {
+        return new WorkerCommand<Void,Integer>()
+        {
+            @Override
+            public Integer doWork( Void state ) throws Exception
+            {
+                return ref.evaluate();
+            }
+        };
+    }
+    
+    private WorkerCommand<Void,Void> invalidate( final LazySingleReference<Integer> ref )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                ref.invalidate();
+                return null;
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -178,6 +178,11 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Visitor<LineLogger
         waitUntilThreadState( Thread.State.WAITING );
     }
 
+    public void waitUntilBlocked() throws TimeoutException
+    {
+        waitUntilThreadState( Thread.State.BLOCKED );
+    }
+    
     public void waitUntilThreadState( Thread.State... possibleStates ) throws TimeoutException
     {
         Set<Thread.State> stateSet = new HashSet<>( asList( possibleStates ) );
@@ -217,6 +222,7 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Visitor<LineLogger
         return thread;
     }
 
+    @Override
     public void close()
     {
         commandExecutor.shutdown();

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -25,22 +25,67 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.kernel.impl.util.LazySingleReference;
 
 /**
  * InvocationHandler for dynamic proxies that delegate calls to a given backing implementation. This is mostly
  * used to present a single object to others, while being able to switch implementation at runtime.
- *
- * @param <T>
+ * 
+ * There are concepts of {@link #snapshot(Object)} and {@link #cement(Object)} in here, which serves different purposes:
+ * <ol>
+ * <li>{@link #snapshot(Object)}: acquire the actual delegate at this particular point in time, pulling it out
+ * from the proxy and using it directly. This is used for acquiring a snapshot and keep using that particular
+ * instance, even if a new delegate is assigned for this handler.</li>
+ * <li>{@link #cement(Object)}: acquire a proxy that will have its delegate assigned the next call to
+ * {@link #setDelegate(Object)}. This is useful if one {@link DelegateInvocationHandler} depends on
+ * another which will have its delegate set later than this one.</li>
+ * </ol>
  */
 public class DelegateInvocationHandler<T> implements InvocationHandler
 {
     private volatile T delegate;
+    
+    // A concrete version of delegate, where a user can request to cement this delegate so that it gets concrete
+    // the next call to setDelegate and will never change since.
+    private final LazySingleReference<T> concrete;
+    
+    public DelegateInvocationHandler( final Class<T> interfaceClass )
+    {
+        concrete = new LazySingleReference<T>()
+        {
+            @SuppressWarnings( "unchecked" )
+            @Override
+            protected T create()
+            {
+                return (T) Proxy.newProxyInstance( DelegateInvocationHandler.class.getClassLoader(),
+                        new Class[] {interfaceClass}, new Concrete<>() );
+            }
+        };
+    }
 
+    /**
+     * Updates the delegate for this handler, also {@link #harden() hardens} instances
+     * {@link #cement(Object) cemented} from the last call to {@link #setDelegate(Object)}.
+     * @param delegate the new delegate to set.
+     */
     public void setDelegate( T delegate )
     {
         this.delegate = delegate;
+        harden();
     }
 
+    /**
+     * Updates {@link #cement(Object) cemented} delegates with the current delegate, making it concrete.
+     * Callers of {@link #cement(Object)} in between this call and the previous call to {@link #setDelegate(Object)}
+     * will see the current delegate.
+     */
+    @SuppressWarnings( "unchecked" )
+    public void harden()
+    {
+        ((Concrete<T>)Proxy.getInvocationHandler( concrete.evaluate() )).set( delegate );
+        concrete.invalidate();
+    }
+    
     @Override
     public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
     {
@@ -48,6 +93,12 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
         {
             throw new TransactionFailureException( "Instance state changed after this transaction started." );
         }
+        return proxyInvoke( delegate, method, args );
+    }
+
+    private static Object proxyInvoke( Object delegate, Method method, Object[] args )
+            throws Throwable
+    {
         try
         {
             return method.invoke( delegate, args );
@@ -58,10 +109,56 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
         }
     }
     
+    /**
+     * Cements this delegate, i.e. returns an instance which will have its delegate assigned and hardened
+     * later on so that it never will change after that point.
+     */
+    public T cement()
+    {
+        return concrete.evaluate();
+    }
+    
+    /**
+     * Takes a snapshot of the current delegate and returns that.
+     */
+    @SuppressWarnings( "unchecked" )
     public static <T> T snapshot( T proxiedInstance )
     {
-        @SuppressWarnings( "unchecked" )
-        DelegateInvocationHandler<T> delegateHandler = (DelegateInvocationHandler<T>) Proxy.getInvocationHandler( proxiedInstance );
+        DelegateInvocationHandler<T> delegateHandler =
+                (DelegateInvocationHandler<T>) Proxy.getInvocationHandler( proxiedInstance );
         return delegateHandler.delegate;
+    }
+    
+    @Override
+    public String toString()
+    {
+        return "Delegate[" + delegate + "]";
+    }
+    
+    private static class Concrete<T> implements InvocationHandler
+    {
+        private volatile T delegate;
+        
+        void set( T delegate )
+        {
+            this.delegate = delegate;
+        }
+        
+        @Override
+        public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
+        {
+            if ( delegate == null )
+            {
+                throw new IllegalStateException( "Cement hasn't hardened yet" );
+            }
+            
+            return proxyInvoke( delegate, method, args );
+        }
+        
+        @Override
+        public String toString()
+        {
+            return "Concrete[" + delegate + "]";
+        }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public LabelTokenCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                                           DelegateInvocationHandler<TokenCreator> delegate,
-                                           HaXaDataSourceManager xaDsm,
-                                           Master master, RequestContextFactory requestContextFactory,
-                                           Logging logging
+                                          DelegateInvocationHandler<TokenCreator> delegate,
+                                          HaXaDataSourceManager xaDsm,
+                                          DelegateInvocationHandler<Master> master,
+                                          RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCre
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLabelTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlaveLabelTokenCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public PropertyKeyCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                                                DelegateInvocationHandler<TokenCreator> delegate,
-                                                HaXaDataSourceManager xaDsm,
-                                                Master master, RequestContextFactory requestContextFactory,
-                                                Logging logging
+                                           DelegateInvocationHandler<TokenCreator> delegate,
+                                           HaXaDataSourceManager xaDsm,
+                                           DelegateInvocationHandler<Master> master,
+                                           RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCr
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlavePropertyTokenCreator( master, requestContextFactory, xaDsm );
+        return new SlavePropertyTokenCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
@@ -23,8 +23,8 @@ import java.net.URI;
 
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
-import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.core.DefaultRelationshipTypeCreator;
 import org.neo4j.kernel.impl.core.TokenCreator;
 import org.neo4j.kernel.logging.Logging;
@@ -32,15 +32,15 @@ import org.neo4j.kernel.logging.Logging;
 public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<TokenCreator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final Logging logging;
 
     public RelationshipTypeCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                                 DelegateInvocationHandler<TokenCreator> delegate,
                                                 HaXaDataSourceManager xaDsm,
-                                                Master master, RequestContextFactory requestContextFactory,
-                                                Logging logging
+                                                DelegateInvocationHandler<Master> master,
+                                                RequestContextFactory requestContextFactory, Logging logging
     )
     {
         super( stateMachine, delegate );
@@ -59,6 +59,6 @@ public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<To
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveRelationshipTypeCreator( master, requestContextFactory, xaDsm );
+        return new SlaveRelationshipTypeCreator( master.cement(), requestContextFactory, xaDsm );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import java.io.IOException;
-
 import org.jboss.netty.channel.Channel;
 
 import org.neo4j.com.RequestContext;
@@ -39,7 +37,6 @@ public class SlaveServer extends Server<Slave, Void>
     public static final byte APPLICATION_PROTOCOL_VERSION = 1;
 
     public SlaveServer( Slave requestTarget, Configuration config, Logging logging )
-            throws IOException
     {
         super( requestTarget, config, logging, DEFAULT_FRAME_LENGTH, APPLICATION_PROTOCOL_VERSION, ALWAYS_MATCH, 
                 SYSTEM_CLOCK );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -39,7 +39,7 @@ import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
     private final AbstractTransactionManager txManager;
     private final RemoteTxHook remoteTxHook;
@@ -48,7 +48,7 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
 
     public LockManagerModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                     DelegateInvocationHandler<LockManager> delegate,
-                                    HaXaDataSourceManager xaDsm, Master master,
+                                    HaXaDataSourceManager xaDsm, DelegateInvocationHandler<Master> master,
                                     RequestContextFactory requestContextFactory, AbstractTransactionManager txManager,
                                     RemoteTxHook remoteTxHook, AvailabilityGuard availabilityGuard, Config config )
     {
@@ -71,8 +71,8 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<LockManager>
     @Override
     protected LockManager getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLockManager( new RagManager(), requestContextFactory, master, xaDsm, txManager, remoteTxHook,
-                availabilityGuard, new SlaveLockManager.Configuration()
+        return new SlaveLockManager( new RagManager(), requestContextFactory, master.cement(), xaDsm, txManager,
+                remoteTxHook, availabilityGuard, new SlaveLockManager.Configuration()
         {
             @Override
             public long getAvailabilityTimeout()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxHookModeSwitcher.java
@@ -33,13 +33,14 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
 {
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactoryResolver requestContextFactory;
     private final StringLogger log;
     private final DependencyResolver resolver;
 
     public TxHookModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
-                               DelegateInvocationHandler<RemoteTxHook> delegate, Master master,
+                               DelegateInvocationHandler<RemoteTxHook> delegate,
+                               DelegateInvocationHandler<Master> master,
                                RequestContextFactoryResolver requestContextFactory, StringLogger log,
                                DependencyResolver resolver )
     {
@@ -59,7 +60,7 @@ public class TxHookModeSwitcher extends AbstractModeSwitcher<RemoteTxHook>
     @Override
     protected RemoteTxHook getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxHook( master, resolver.resolveDependency( HaXaDataSourceManager.class ),
+        return new SlaveTxHook( master.cement(), resolver.resolveDependency( HaXaDataSourceManager.class ),
                 requestContextFactory, log );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TxIdGeneratorModeSwitcher.java
@@ -25,12 +25,12 @@ import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.ha.com.RequestContextFactory;
-import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
-import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -38,16 +38,17 @@ import org.neo4j.kernel.impl.util.StringLogger;
 public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerator>
 {
     private final HaXaDataSourceManager xaDsm;
-    private final Master master;
+    private final DelegateInvocationHandler<Master> master;
     private final RequestContextFactory requestContextFactory;
-    private StringLogger msgLog;
-    private Config config;
-    private Slaves slaves;
+    private final StringLogger msgLog;
+    private final Config config;
+    private final Slaves slaves;
     private final AbstractTransactionManager tm;
 
     public TxIdGeneratorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                       DelegateInvocationHandler<TxIdGenerator> delegate, HaXaDataSourceManager xaDsm,
-                                      Master master, RequestContextFactory requestContextFactory,
+                                      DelegateInvocationHandler<Master> master,
+                                      RequestContextFactory requestContextFactory,
                                       StringLogger msgLog, Config config, Slaves slaves, AbstractTransactionManager tm
     )
     {
@@ -70,7 +71,7 @@ public class TxIdGeneratorModeSwitcher extends AbstractModeSwitcher<TxIdGenerato
     @Override
     protected TxIdGenerator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master,
+        return new SlaveTxIdGenerator( config.get( ClusterSettings.server_id ), master.cement(),
                 HighAvailabilityModeSwitcher.getServerId( serverHaUri ), requestContextFactory, xaDsm, tm);
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -45,12 +45,14 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.ha.ClusterManager;
 
+import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
@@ -101,6 +103,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         HighlyAvailableGraphDatabase db = cluster.getAnySlave();
 
         // WHEN
+        HighlyAvailableGraphDatabase theOtherSlave;
         Transaction tx = db.beginTx();
         try
         {
@@ -109,7 +112,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         }
         finally
         {
-            HighlyAvailableGraphDatabase theOtherSlave = cluster.getAnySlave( db );
+            theOtherSlave = cluster.getAnySlave( db );
             takeTheLeadInAnEventualMasterSwitch( theOtherSlave );
             cluster.shutdown( cluster.getMaster() );
             assertFinishGetsTransactionFailure( tx );
@@ -119,6 +122,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
 
         // THEN
         assertFalse( db.isMaster() );
+        assertTrue( theOtherSlave.isMaster() );
         // to prevent a deadlock scenario which occurs if this test exists (and @After starts)
         // before the db has recovered from its KERNEL_PANIC
         awaitFullyOperational( db );
@@ -443,7 +447,8 @@ public class TransactionConstraintsIT extends AbstractClusterTest
 
     private void awaitFullyOperational( GraphDatabaseService db ) throws InterruptedException
     {
-        while ( true )
+        long endTime = currentTimeMillis() + MINUTES.toMillis( 1 );
+        for ( int i = 0; currentTimeMillis() < endTime; i++ )
         {
             try
             {
@@ -452,7 +457,11 @@ public class TransactionConstraintsIT extends AbstractClusterTest
             }
             catch ( Exception e )
             {
-                Thread.sleep( 100 );
+                if ( i > 0 && i%10 == 0 )
+                {
+                    e.printStackTrace();
+                }
+                Thread.sleep( 1000 );
             }
         }
     }

--- a/enterprise/ha/src/test/java/org/neo4j/test/AbstractClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/AbstractClusterTest.java
@@ -19,15 +19,13 @@
  */
 package org.neo4j.test;
 
-import static org.neo4j.cluster.ClusterSettings.default_timeout;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
-
 import java.io.File;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -35,9 +33,15 @@ import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.ha.ClusterManager.Provider;
 
+import static org.neo4j.cluster.ClusterSettings.default_timeout;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
+import static org.neo4j.test.ha.ClusterManager.masterAvailable;
+
 public abstract class AbstractClusterTest
 {
-    private final File dir = TargetDirectory.forTest( getClass() ).directory( "dbs", true );
+    public @Rule TestName testName = new TestName();
+    private File dir;
     protected LifeSupport life = new LifeSupport();
     private final Provider provider;
     protected ClusterManager clusterManager;
@@ -56,6 +60,7 @@ public abstract class AbstractClusterTest
     @Before
     public void before() throws Exception
     {
+        dir = TargetDirectory.forTest( getClass() ).directory( testName.getMethodName(), true );
         clusterManager = life.add( new ClusterManager( provider, dir, stringMap( default_timeout.name(), "1s" ) )
         {
             @Override


### PR DESCRIPTION
so that the master cannot change all of a sudden in the middle of
operations. This fixes a problem where a service which was instantiated
for one specific master continued to run for a different master after a
sudden master switch. Specifically this resulted in misuse of id ranges,
potentially received from a different master than expected.
