### PR TITLE
Up the minimum heap size example to 16M

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -31,7 +31,7 @@ wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
 # Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=3
+#wrapper.java.initmemory=16
 
 # Maximum Java Heap Size (in MB)
 #wrapper.java.maxmemory=64

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -31,7 +31,7 @@ wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
 # Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=3
+#wrapper.java.initmemory=16
 
 # Maximum Java Heap Size (in MB)
 #wrapper.java.maxmemory=64


### PR DESCRIPTION
`wrapper.java.initmemory` was already 16 MBs in the community wrapper.conf.
