### PR TITLE
Faster initial population of label scan store.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdateNodeIdComparator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdateNodeIdComparator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.labelscan;
+
+import java.util.Comparator;
+
+public class NodeLabelUpdateNodeIdComparator implements Comparator<NodeLabelUpdate>
+{
+    @Override public int compare( NodeLabelUpdate o1, NodeLabelUpdate o2 )
+    {
+        long nodeId1 = o1.getNodeId();
+        long nodeId2 = o2.getNodeId();
+
+        if ( nodeId1 > nodeId2 )
+        {
+            return 1;
+        }
+        else if ( nodeId1 == nodeId2 )
+        {
+            return 0;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+
+public interface LabelScanWriter extends Closeable
+{
+    /**
+     * Store a {@link NodeLabelUpdate}. Calls to this method MUST be ordered by ascending node id.
+     */
+    void write( NodeLabelUpdate update ) throws IOException;
+
+    /**
+     * Close this writer and flush pending changes to the store.
+     */
+    void close() throws IOException;
+
+    LabelScanWriter EMPTY = new LabelScanWriter()
+    {
+        @Override
+        public void write( NodeLabelUpdate update ) throws IOException
+        {
+            // do nothing
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            // nothing to close
+        }
+    };
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdateNodeIdComparatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/labelscan/NodeLabelUpdateNodeIdComparatorTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.labelscan;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class NodeLabelUpdateNodeIdComparatorTest
+{
+    @Test
+    public void shouldCompareNodeLabelUpdatesByNodeId() throws Exception
+    {
+        assertEquals( comparator().compare( updateWithId( 1 ), updateWithId( 1 ) ), 0);
+        assertEquals( comparator().compare( updateWithId( 2 ), updateWithId( 1 ) ), 1);
+        assertEquals( comparator().compare( updateWithId( 0 ), updateWithId( 1 ) ), -1);
+    }
+
+    private NodeLabelUpdateNodeIdComparator comparator()
+    {
+        return new NodeLabelUpdateNodeIdComparator();
+    }
+
+    private NodeLabelUpdate updateWithId( int nodeId )
+    {
+        return NodeLabelUpdate.labelChanges( nodeId, new long[]{}, new long[]{} );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -76,11 +76,20 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaCommand;
 import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
 import org.neo4j.kernel.logging.SingleLoggingService;
 import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
@@ -958,8 +967,15 @@ public class WriteTransactionTest
     public static final LabelScanStore NO_LABEL_SCAN_STORE = new LabelScanStore()
     {
         @Override
-        public void updateAndCommit( Iterator<NodeLabelUpdate> updates )
-        {   // Do nothing
+        public LabelScanReader newReader()
+        {
+            return LabelScanReader.EMPTY;
+        }
+
+        @Override
+        public LabelScanWriter newWriter()
+        {
+            return LabelScanWriter.EMPTY;
         }
 
         @Override
@@ -980,12 +996,6 @@ public class WriteTransactionTest
         @Override
         public void recover( Iterator<NodeLabelUpdate> updates )
         {   // Do nothing
-        }
-
-        @Override
-        public LabelScanReader newReader()
-        {
-            return LabelScanReader.EMPTY;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/TestBatchInsert.java
@@ -1172,12 +1172,6 @@ public class TestBatchInsert
     {
         private final List<NodeLabelUpdate> allUpdates = new ArrayList<>();
 
-        @Override
-        public void updateAndCommit( Iterator<NodeLabelUpdate> updates ) throws IOException
-        {
-            addToCollection( updates, allUpdates );
-        }
-
         public void assertRecivedUpdate( long node, long... labels )
         {
             for ( NodeLabelUpdate update : allUpdates )
@@ -1239,6 +1233,23 @@ public class TestBatchInsert
         @Override
         public void shutdown() throws IOException
         {
+        }
+
+        @Override public LabelScanWriter newWriter()
+        {
+            return new LabelScanWriter()
+            {
+                @Override
+                public void write( NodeLabelUpdate update ) throws IOException
+                {
+                    addToCollection( Collections.singletonList( update ).iterator(), allUpdates );
+                }
+
+                @Override
+                public void close() throws IOException
+                {
+                }
+            };
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/BitmapDocumentFormat.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/BitmapDocumentFormat.java
@@ -54,7 +54,7 @@ public enum BitmapDocumentFormat
         }
     };
 
-    static final String RANGE = "range", LABEL = "label";
+    public static final String RANGE = "range", LABEL = "label";
     private final BitmapFormat format;
 
     private BitmapDocumentFormat( BitmapFormat format )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
@@ -28,18 +28,18 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
 
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
-import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
+import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 public interface LabelScanStorageStrategy
 {
-    void applyUpdates( StorageService storage, Iterator<NodeLabelUpdate> updates ) throws IOException;
-
     PrimitiveLongIterator nodesWithLabel( IndexSearcher searcher, int labelId );
 
     AllEntriesLabelScanReader newNodeLabelReader( SearcherManager searcher );
 
     Iterator<Long> labelsForNode( IndexSearcher searcher, long nodeId );
+
+    LabelScanWriter acquireWriter( StorageService storage );
 
     interface StorageService
     {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanWriter.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Fieldable;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+
+import org.neo4j.kernel.api.impl.index.bitmaps.Bitmap;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.unsafe.batchinsert.LabelScanWriter;
+
+public class LuceneLabelScanWriter implements LabelScanWriter
+{
+    private final LabelScanStorageStrategy.StorageService storage;
+    private final BitmapDocumentFormat format;
+    private final IndexSearcher searcher;
+
+    private List<NodeLabelUpdate> updates;
+    private long currentRange;
+
+    public LuceneLabelScanWriter( LabelScanStorageStrategy.StorageService storage,
+                                  BitmapDocumentFormat format )
+    {
+        this.storage = storage;
+        this.format = format;
+        currentRange = -1;
+        updates = new ArrayList<>( format.bitmapFormat().rangeSize() );
+        searcher = storage.acquireSearcher();
+    }
+
+    @Override
+    public void write( NodeLabelUpdate update ) throws IOException
+    {
+        long range = format.bitmapFormat().rangeOf( update.getNodeId() );
+
+        if ( range != currentRange )
+        {
+            if ( range < currentRange )
+            {
+                throw new IllegalArgumentException( "NodeLabelUpdates must be supplied in order of ascending node id" );
+            }
+
+            flush();
+            currentRange = range;
+        }
+
+        updates.add( update );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        flush();
+        storage.releaseSearcher( searcher );
+        storage.refreshSearcher();
+    }
+
+    private Map<Long/*range*/, Bitmap> readLabelBitMapsInRange( IndexSearcher searcher, long range ) throws IOException
+    {
+        Map<Long/*label*/, Bitmap> fields = new HashMap<>();
+        Term documentTerm = format.rangeTerm( range );
+        TopDocs docs = searcher.search( new TermQuery( documentTerm ), 1 );
+        if ( docs != null && docs.totalHits != 0 )
+        {
+            Document document = searcher.doc( docs.scoreDocs[0].doc );
+            for ( Fieldable field : document.getFields() )
+            {
+                if ( !format.isRangeField( field ) )
+                {
+                    Long label = Long.valueOf( field.name() );
+                    fields.put( label, format.readBitmap( field ) );
+                }
+            }
+        }
+        return fields;
+    }
+
+
+    private void flush() throws IOException
+    {
+        if ( currentRange < 0 )
+        {
+            return;
+        }
+
+        Map<Long/*label*/, Bitmap> fields = readLabelBitMapsInRange( searcher, currentRange );
+        updateFields( updates, fields );
+
+        Document document = new Document();
+        document.add( format.rangeField( currentRange ) );
+
+        for ( Map.Entry<Long/*label*/, Bitmap> field : fields.entrySet() )
+        {
+            // one field per label
+            Bitmap value = field.getValue();
+            if ( value.hasContent() )
+            {
+                format.addLabelField( document, field.getKey(), value );
+            }
+        }
+
+        if ( isEmpty( document ) )
+        {
+            storage.deleteDocuments( format.rangeTerm( document ) );
+        }
+        else
+        {
+            storage.updateDocument( format.rangeTerm( document ), document );
+        }
+        updates.clear();
+    }
+
+    private boolean isEmpty( Document document )
+    {
+        for ( Fieldable fieldable : document.getFields() )
+        {
+            if ( !format.isRangeField( fieldable ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void updateFields( Iterable<NodeLabelUpdate> updates, Map<Long/*label*/, Bitmap> fields )
+    {
+        for ( NodeLabelUpdate update : updates )
+        {
+            clearLabels( fields, update );
+            setLabels( fields, update );
+        }
+    }
+
+    private void clearLabels( Map<Long, Bitmap> fields, NodeLabelUpdate update )
+    {
+        for ( Bitmap bitmap : fields.values() )
+        {
+            format.bitmapFormat().set( bitmap, update.getNodeId(), false );
+        }
+    }
+
+    private void setLabels( Map<Long, Bitmap> fields, NodeLabelUpdate update )
+    {
+        for ( long label : update.getLabelsAfter() )
+        {
+            Bitmap bitmap = fields.get( label );
+            if ( bitmap == null )
+            {
+                fields.put( label, bitmap = new Bitmap() );
+            }
+            format.bitmapFormat().set( bitmap, update.getNodeId(), true );
+        }
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/bitmaps/BitmapFormat.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/bitmaps/BitmapFormat.java
@@ -32,6 +32,10 @@ public enum BitmapFormat
         this.mask = mask;
     }
 
+    public int rangeSize() {
+        return 1 << shift;
+    }
+
     public long rangeOf( long id )
     {
         return id >> shift;
@@ -59,7 +63,7 @@ public enum BitmapFormat
     }
 
     // Returns true if the label exists on the given node for the given bitmap
-    public boolean peek( long bitmap, long nodeId )
+    public boolean hasLabel( long bitmap, long nodeId )
     {
         long normalizedNodeId = nodeId % (1L << shift);
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreWriterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreWriterTest.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.junit.Test;
+
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+
+import static java.lang.Long.parseLong;
+import static java.lang.String.valueOf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.kernel.api.impl.index.BitmapDocumentFormat.RANGE;
+
+public class LuceneLabelScanStoreWriterTest
+{
+
+    public static final BitmapDocumentFormat FORMAT = BitmapDocumentFormat._32;
+
+    @Test
+    public void shouldComplainIfNodesSuppliedOutOfRangeOrder() throws Exception
+    {
+        // given
+        int nodeId1 = 1;
+        int nodeId2 = 33;
+
+        long node1Range = FORMAT.bitmapFormat().rangeOf( nodeId1 );
+        long node2Range = FORMAT.bitmapFormat().rangeOf( nodeId2 );
+        assertNotEquals( node1Range, node2Range );
+
+        // when
+        LuceneLabelScanWriter writer = new LuceneLabelScanWriter( new StubStorageService(), FORMAT );
+        writer.write( NodeLabelUpdate.labelChanges( nodeId2, new long[]{}, new long[]{} ) );
+        try
+        {
+            writer.write( NodeLabelUpdate.labelChanges( nodeId1, new long[]{}, new long[]{} ) );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldStoreDocumentWithNodeIdsAndLabelsInIt() throws Exception
+    {
+        // given
+        int nodeId = 1;
+        int label1 = 201;
+        int label2 = 202;
+        StubStorageService storage = new StubStorageService();
+
+        // when
+        LuceneLabelScanWriter writer = new LuceneLabelScanWriter( storage, FORMAT );
+
+        writer.write( NodeLabelUpdate.labelChanges( nodeId, new long[]{}, new long[]{label1, label2} ) );
+        writer.close();
+
+        // then
+        long range = FORMAT.bitmapFormat().rangeOf( nodeId );
+        Document document = storage.getDocument( new Term( RANGE, valueOf( range ) ) );
+
+        assertTrue( FORMAT.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label1 ) ) ),
+                nodeId ) );
+        assertTrue( FORMAT.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label2 ) ) ), nodeId ) );
+    }
+
+    @Test
+    public void shouldStoreDocumentWithNodeIdsInTheSameRange() throws Exception
+    {
+        // given
+        int nodeId1 = 1;
+        int nodeId2 = 3;
+        int label1 = 201;
+        int label2 = 202;
+        StubStorageService storage = new StubStorageService();
+        BitmapDocumentFormat format = BitmapDocumentFormat._32;
+        long range = format.bitmapFormat().rangeOf( nodeId1 );
+        assertEquals( range, format.bitmapFormat().rangeOf( nodeId2 ) );
+
+        // when
+        LuceneLabelScanWriter writer = new LuceneLabelScanWriter( storage, format );
+
+        writer.write( NodeLabelUpdate.labelChanges( nodeId1, new long[]{}, new long[]{label1} ) );
+        writer.write( NodeLabelUpdate.labelChanges( nodeId2, new long[]{}, new long[]{label2} ) );
+        writer.close();
+
+        // then
+        Document document = storage.getDocument( new Term( RANGE, valueOf( range ) ) );
+
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label1 ) ) ), nodeId1 ) );
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label2 ) ) ), nodeId2 ) );
+    }
+
+    @Test
+    public void shouldStoreDocumentWithNodeIdsInADifferentRange() throws Exception
+    {
+        // given
+        int nodeId1 = 1;
+        int nodeId2 = 33;
+        int label1 = 201;
+        int label2 = 202;
+        StubStorageService storage = new StubStorageService();
+        BitmapDocumentFormat format = BitmapDocumentFormat._32;
+
+        long node1Range = format.bitmapFormat().rangeOf( nodeId1 );
+        long node2Range = format.bitmapFormat().rangeOf( nodeId2 );
+        assertNotEquals( node1Range, node2Range );
+
+        // when
+        LuceneLabelScanWriter writer = new LuceneLabelScanWriter( storage, format );
+
+        writer.write( NodeLabelUpdate.labelChanges( nodeId1, new long[]{}, new long[]{label1} ) );
+        writer.write( NodeLabelUpdate.labelChanges( nodeId2, new long[]{}, new long[]{label2} ) );
+        writer.close();
+
+        // then
+        Document document1 = storage.getDocument( new Term( RANGE, valueOf( node1Range ) ) );
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document1.get( valueOf( label1 ) ) ), nodeId1 ) );
+
+        Document document2 = storage.getDocument( new Term( RANGE, valueOf( node2Range ) ) );
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document2.get( valueOf( label2 ) ) ), nodeId2 ) );
+    }
+
+    @Test
+    public void shouldUpdateExistingDocumentWithNodesInTheSameRange() throws Exception
+    {
+        // given
+        int nodeId1 = 1;
+        int nodeId2 = 3;
+        int label1 = 201;
+        int label2 = 202;
+        StubStorageService storage = new StubStorageService();
+        BitmapDocumentFormat format = BitmapDocumentFormat._32;
+
+        long range = format.bitmapFormat().rangeOf( nodeId1 );
+        assertEquals( range, format.bitmapFormat().rangeOf( nodeId2 ) );
+
+        // node already indexed
+        LuceneLabelScanWriter writer = new LuceneLabelScanWriter( storage, format );
+        writer.write( NodeLabelUpdate.labelChanges( nodeId1, new long[]{}, new long[]{label1} ) );
+        writer.close();
+
+        // when
+        writer = new LuceneLabelScanWriter( storage, format );
+        writer.write( NodeLabelUpdate.labelChanges( nodeId2, new long[]{}, new long[]{label2} ) );
+        writer.close();
+
+        // then
+        Document document = storage.getDocument( new Term( RANGE, valueOf( range ) ) );
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label1 ) ) ), nodeId1 ) );
+        assertTrue( format.bitmapFormat().hasLabel( parseLong( document.get( valueOf( label2 ) ) ), nodeId2 ) );
+    }
+
+    private class StubStorageService implements LabelScanStorageStrategy.StorageService
+    {
+        private Map<Term, Document> storage = new HashMap<>();
+
+        @Override
+        public void updateDocument( Term term, Document document ) throws IOException
+        {
+            storage.put( term, document );
+        }
+
+        @Override
+        public void deleteDocuments( Term term ) throws IOException
+        {
+            storage.remove( term );
+        }
+
+        @Override
+        public IndexSearcher acquireSearcher()
+        {
+            return new IndexSearcher( mock( IndexReader.class ) )
+            {
+                private Map<Integer, Document> docIds = new HashMap<>();
+
+                @Override
+                public TopDocs search( Query query, int n )
+                {
+                    Document document = storage.get( ((TermQuery) query).getTerm() );
+                    if ( document == null )
+                    {
+                        return new TopDocs( 0, new ScoreDoc[0], 0 );
+                    }
+
+                    int docId = new Random().nextInt();
+                    docIds.put( docId, document );
+                    int score = 10;
+                    return new TopDocs( 1, new ScoreDoc[]{new ScoreDoc( docId, score )}, score );
+                }
+
+                @Override
+                public Document doc( int docID )
+                {
+                    return docIds.get( docID );
+                }
+            };
+        }
+
+        @Override
+        public void releaseSearcher( IndexSearcher searcher ) throws IOException
+        {
+        }
+
+        @Override
+        public void refreshSearcher() throws IOException
+        {
+        }
+
+        public Document getDocument( Term term )
+        {
+            return storage.get( term );
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/bitmaps/BitmapFormatTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/bitmaps/BitmapFormatTest.java
@@ -135,10 +135,10 @@ public class BitmapFormatTest
             // when
             BitmapFormat._32.set( bitmap, input, true );
             // then
-            assertThat( BitmapFormat._32.peek( bitmap.bitmap(), input ), is( true ) );
+            assertThat( BitmapFormat._32.hasLabel( bitmap.bitmap(), input ), is( true ) );
             for ( int check = 0; check < 32; check++ )
             {
-                assertThat( BitmapFormat._32.peek( bitmap.bitmap(), check ), is( input == check ) );
+                assertThat( BitmapFormat._32.hasLabel( bitmap.bitmap(), check ), is( input == check ) );
             }
         }
     }
@@ -153,10 +153,10 @@ public class BitmapFormatTest
             // when
             BitmapFormat._64.set( bitmap, input, true );
             // then
-            assertThat( BitmapFormat._64.peek( bitmap.bitmap(), input ), is( true ) );
+            assertThat( BitmapFormat._64.hasLabel( bitmap.bitmap(), input ), is( true ) );
             for ( int check = 0; check < 64; check++ )
             {
-                assertThat( BitmapFormat._64.peek( bitmap.bitmap(), check ), is( input == check ) );
+                assertThat( BitmapFormat._64.hasLabel( bitmap.bitmap(), check ), is( input == check ) );
             }
         }
     }


### PR DESCRIPTION
Improve write performance by refreshing the lucene searcher less often.
Refreshing less often is possible if writes are ordered so that we never
need to read our own writes during a single batch of writes, and we can
consider initial population as one very large batch.

A new facade LabelScanWriter expresses the batching of writes, repolacing
LabelScanStore#updateAndCommit. It also mirrors the way we use LabelScanReader.
