### PR TITLE
Fixes #1099 configurable shell server host

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.fail;
  */
 public abstract class KernelExtensionFactoryContractTest
 {
-    private final Class<? extends KernelExtensionFactory<?>> extClass;
+    protected final Class<? extends KernelExtensionFactory<?>> extClass;
     private final String key;
     private final TargetDirectory target;
 

--- a/community/shell/src/main/java/org/neo4j/shell/ShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellServer.java
@@ -89,12 +89,21 @@ public interface ShellServer extends Remote
 	void shutdown() throws RemoteException;
 	
 	/**
-	 * Makes this server available for clients to connect to via RMI.
+	 * Makes this server available at {@code localhost} for clients to connect to via RMI.
 	 * @param port the RMI port.
 	 * @param name the RMI name.
 	 * @throws RemoteException RMI error.
 	 */
 	void makeRemotelyAvailable( int port, String name ) throws RemoteException;
+	
+	/**
+	 * Makes this server available at the specific {@code host} for clients to connect to via RMI.
+	 * @param host the host to make this server available at.
+	 * @param port the RMI port.
+	 * @param name the RMI name.
+	 * @throws RemoteException RMI error.
+	 */
+	void makeRemotelyAvailable( String host, int port, String name ) throws RemoteException;
 	
 	/**
 	 * @return all the available commands one can issue to this server.

--- a/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
@@ -35,12 +35,15 @@ import static org.neo4j.helpers.Settings.setting;
 /**
  * Settings for the shell extension
  */
-@Description("Settings for the remote shell extension")
+@Description( "Settings for the remote shell extension" )
 public class ShellSettings
 {
     @Description("Enable a remote shell server which shell clients can log in to")
     public static final Setting<Boolean> remote_shell_enabled = setting( "remote_shell_enabled", BOOLEAN, FALSE );
 
+    public static final Setting<String> remote_shell_host = setting( "remote_shell_host", STRING, "localhost",
+            illegalValueMessage( "must be a valid name", matches( ANY ) ) );
+    
     public static final Setting<Integer> remote_shell_port = setting( "remote_shell_port", INTEGER, "1337", port );
 
     public static final Setting<Boolean> remote_shell_read_only = setting( "remote_shell_read_only", BOOLEAN, FALSE );

--- a/community/shell/src/main/java/org/neo4j/shell/impl/AbstractAppServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/AbstractAppServer.java
@@ -50,7 +50,7 @@ import org.neo4j.shell.TextUtil;
 public abstract class AbstractAppServer extends SimpleAppServer
 	implements AppShellServer
 {
-    private final Map<String, App> apps = new TreeMap<String, App>();
+    private final Map<String, App> apps = new TreeMap<>();
 
 	/**
 	 * Constructs a new server.
@@ -102,7 +102,9 @@ public abstract class AbstractAppServer extends SimpleAppServer
 	{
         Session session = getClientSession( clientId );
 		if ( line == null || line.trim().length() == 0 )
-			return new Response( getPrompt( session ), Continuation.INPUT_COMPLETE );
+        {
+            return new Response( getPrompt( session ), Continuation.INPUT_COMPLETE );
+        }
 
         try
         {
@@ -125,7 +127,7 @@ public abstract class AbstractAppServer extends SimpleAppServer
     protected String replaceAlias( String line, Session session )
     {
 	    boolean changed = true;
-	    Set<String> appNames = new HashSet<String>();
+	    Set<String> appNames = new HashSet<>();
 	    while ( changed )
 	    {
 	        changed = false;
@@ -177,7 +179,7 @@ public abstract class AbstractAppServer extends SimpleAppServer
 
     private static List<String> quote( List<String> candidates )
     {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         for ( String candidate : candidates )
         {
             candidate = candidate.replaceAll( " ", "\\\\ " );

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
@@ -95,8 +95,13 @@ class RemotelyAvailableServer extends UnicastRemoteObject implements ShellServer
     @Override
     public void makeRemotelyAvailable( int port, String name ) throws RemoteException
     {
-        RmiLocation location = RmiLocation.location( "localhost", port, name );
-        location.bind( this );
+        makeRemotelyAvailable( "localhost", port, name );
+    }
+    
+    @Override
+    public void makeRemotelyAvailable( String host, int port, String name ) throws RemoteException
+    {
+        RmiLocation.location( host, port, name ).bind( this );
     }
 
     @Override

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
@@ -37,6 +37,7 @@ import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 public class ShellBootstrap implements Serializable
 {
     private final boolean enable;
+    private String host;
     private final int port;
     private final String name;
     private final boolean read_only;
@@ -44,6 +45,7 @@ public class ShellBootstrap implements Serializable
     ShellBootstrap( Config config )
     {
         this.enable = config.get( ShellSettings.remote_shell_enabled );
+        this.host = config.get( ShellSettings.remote_shell_host );
         this.port = config.get( ShellSettings.remote_shell_port );
         this.name = config.get( ShellSettings.remote_shell_name );
         this.read_only = config.get( ShellSettings.remote_shell_read_only );
@@ -119,7 +121,7 @@ public class ShellBootstrap implements Serializable
 
     public GraphDatabaseShellServer enable( GraphDatabaseShellServer server ) throws RemoteException
     {
-        server.makeRemotelyAvailable( port, name );
+        server.makeRemotelyAvailable( host, port, name );
         return server;
     }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/impl/SimpleAppServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/SimpleAppServer.java
@@ -52,7 +52,7 @@ public abstract class SimpleAppServer implements ShellServer
 	 */
 	public static final int DEFAULT_PORT = 1337;
 	
-	private final Map<Serializable, Session> clientSessions = new ConcurrentHashMap<Serializable, Session>();
+	private final Map<Serializable, Session> clientSessions = new ConcurrentHashMap<>();
 	
 	private final AtomicInteger nextClientId = new AtomicInteger();
 	
@@ -88,7 +88,9 @@ public abstract class SimpleAppServer implements ShellServer
     {
 	    Serializable clientId = newClientId();
 	    if ( clientSessions.containsKey( clientId ) )
-	        throw new IllegalStateException( "Client " + clientId + " already initialized" );
+        {
+            throw new IllegalStateException( "Client " + clientId + " already initialized" );
+        }
 	    Session session = newSession( clientId, initialSession );
         clientSessions.put( clientId, session );
 		try
@@ -121,12 +123,14 @@ public abstract class SimpleAppServer implements ShellServer
 	    Session session = new Session( id );
 	    initialPopulateSession( session );
 	    for ( Map.Entry<String, Serializable> entry : initialSession.entrySet() )
-	        session.set( entry.getKey(), entry.getValue() );
+        {
+            session.set( entry.getKey(), entry.getValue() );
+        }
 	    return session;
     }
 
     protected void initialPopulateSession( Session session ) throws ShellException
-    {
+    {   // No initial session by default
     }
 
     /**
@@ -151,7 +155,9 @@ public abstract class SimpleAppServer implements ShellServer
     {
         Session session = clientSessions.get( clientID );
         if ( session == null )
+        {
             throw new IllegalStateException( "Client " + clientID + " not initialized" );
+        }
         return session;
     }
     
@@ -161,7 +167,9 @@ public abstract class SimpleAppServer implements ShellServer
         // TODO how about clients not properly leaving?
         
         if ( clientSessions.remove( clientID ) == null )
+        {
             throw new IllegalStateException( "Client " + clientID + " not initialized" );
+        }
     }
 
     @Override
@@ -178,10 +186,23 @@ public abstract class SimpleAppServer implements ShellServer
     public synchronized void makeRemotelyAvailable( int port, String name )
 		throws RemoteException
 	{
-	    if ( remoteEndPoint == null )
-	        remoteEndPoint = new RemotelyAvailableServer( this );
-	    remoteEndPoint.makeRemotelyAvailable( port, name );
+	    remoteEndPoint().makeRemotelyAvailable( port, name );
 	}
+	
+	@Override
+	public synchronized void makeRemotelyAvailable( String host, int port, String name ) throws RemoteException
+	{
+        remoteEndPoint().makeRemotelyAvailable( host, port, name );
+	}
+
+    private ShellServer remoteEndPoint() throws RemoteException
+    {
+        if ( remoteEndPoint == null )
+        {
+            remoteEndPoint = new RemotelyAvailableServer( this );
+        }
+        return remoteEndPoint;
+    }
 	
 	@Override
     public String[] getAllAvailableCommands()
@@ -190,7 +211,6 @@ public abstract class SimpleAppServer implements ShellServer
 	}
 
 	public TabCompletion tabComplete( String partOfLine, Session session )
-	        throws ShellException, RemoteException
 	{
 	    return new TabCompletion( Collections.<String>emptyList(), 0 );
 	}

--- a/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2002-2013 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.shell.impl;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.shell.ShellSettings;
+import org.neo4j.shell.kernel.GraphDatabaseShellServer;
+
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.valueOf;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class ShellBootstrapTest
+{
+    @Test
+    public void shouldPickUpAllConfigOptions() throws Exception
+    {
+        // GIVEN
+        String host = "test";
+        int port = 1234;
+        String name = "my shell";
+        Config config = new Config( stringMap(
+                ShellSettings.remote_shell_host.name(), host,
+                ShellSettings.remote_shell_port.name(), valueOf( port ),
+                ShellSettings.remote_shell_name.name(), name,
+                ShellSettings.remote_shell_enabled.name(), TRUE.toString() ) );
+        GraphDatabaseShellServer server = mock( GraphDatabaseShellServer.class );
+        
+        // WHEN
+        server = new ShellBootstrap( config ).enable( server );
+        
+        // THEN
+        verify( server ).makeRemotelyAvailable( host, port, name );
+    }
+}


### PR DESCRIPTION
Fixes #1099 adding a configuration option 'remote_shell_host' that
dictates which host to make the remote shell server available at in a
scenario where a server has more than one IP. Defaults to "localhost".
