### PR TITLE
Add some acceptance tests of profiling OPTIONAL MATCH, MERGE and UNION queries

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineHelper.scala
@@ -49,6 +49,9 @@ trait ExecutionEngineHelper extends GraphDatabaseTestBase with GraphIcing {
   // that individual tests don't need to worry about that.
   def execute(q: String, params: (String, Any)*): ExecutionResult =
     new EagerExecutionResult(engine.execute(q, params.toMap))
+  
+  def profile(q: String, params: (String, Any)*): ExecutionResult =
+    new EagerExecutionResult(engine.profile(q, params.toMap))
 
   def executeLazy(q: String, params: (String, Any)*): ExecutionResult =
     engine.execute(q, params.toMap)


### PR DESCRIPTION
I thought there was a bug hiding somewhere, and that the query with the WITH clause would fail, but apparently it all works just as it should.

Oh well, now the feature also has high-level tests.
