### PR TITLE
Rationalize example JVM parameters.

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -2,7 +2,10 @@ wrapper.java.additional=-Dorg.neo4j.server.properties=conf/neo4j-server.properti
 wrapper.java.additional=-Djava.util.logging.config.file=conf/logging.properties
 wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 
-# Java Additional Parameters
+#********************************************************************
+# JVM Parameters
+#********************************************************************
+
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 
@@ -28,20 +31,25 @@ wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 #wrapper.java.additional=-XX:+PrintGCDetails
 #wrapper.java.additional=-XX:+PrintGCDateStamps
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
-# Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=16
+# Uncomment the following lines to enable JVM startup diagnostics
+#wrapper.java.additional=-XX:+PrintFlagsFinal
+#wrapper.java.additional=-XX:+PrintFlagsInitial
 
-# Maximum Java Heap Size (in MB)
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=16
 #wrapper.java.maxmemory=64
 
-# Application parameters.  Add parameters as needed starting from 1
-wrapper.java.app.mainclass=org.neo4j.server.Bootstrapper
-
-# both pidfile and lockfile are relative to the bin dir
+#********************************************************************
+# Wrapper settings
+#********************************************************************
+# path is relative to the bin dir
 wrapper.pidfile=../data/neo4j-server.pid
-wrapper.lockfile=../data/neo4j-server.lck
 
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -5,7 +5,7 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 #********************************************************************
 # JVM Parameters
 #********************************************************************
- 
+
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 
@@ -14,20 +14,25 @@ wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 #wrapper.java.additional=-XX:+PrintGCDetails
 #wrapper.java.additional=-XX:+PrintGCDateStamps
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
-# Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=16
+# Uncomment the following lines to enable JVM startup diagnostics
+#wrapper.java.additional=-XX:+PrintFlagsFinal
+#wrapper.java.additional=-XX:+PrintFlagsInitial
 
-# Maximum Java Heap Size (in MB)
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=16
 #wrapper.java.maxmemory=64
 
 #********************************************************************
 # Wrapper settings
 #********************************************************************
-# Override default pidfile and lockfile 
-#wrapper.pidfile=../data/neo4j-server.pid
-#wrapper.lockfile=../data/neo4j-server.lck
+# path is relative to the bin dir
+wrapper.pidfile=../data/neo4j-server.pid
 
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/arbiter-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/arbiter-wrapper.conf
@@ -3,18 +3,15 @@ wrapper.java.additional.1=-Dorg.neo4j.server.properties=conf/neo4j-server.proper
 wrapper.java.additional.2=-Dneo4j.home=..
 wrapper.java.additional.3=-Dorg.neo4j.cluster.logdirectory=../data/log
 
-# Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=3
-
-# Maximum Java Heap Size (in MB)
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=16
 #wrapper.java.maxmemory=64
 
-# Application parameters.  Add parameters as needed starting from 1
-# wrapper.app.parameter.1=...
-
-# both pidfile and lockfile are relative to the bin dir
-wrapper.pidfile=../data/neo4j-arbiter.pid
-wrapper.lockfile=../data/neo4j-arbiter.lck
+# path is relative to the bin dir
+wrapper.pidfile=../data/neo4j-server.pid
 
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -2,7 +2,10 @@ wrapper.java.additional=-Dorg.neo4j.server.properties=conf/neo4j-server.properti
 wrapper.java.additional=-Djava.util.logging.config.file=conf/logging.properties
 wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 
-# Java Additional Parameters
+#********************************************************************
+# JVM Parameters
+#********************************************************************
+
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 
@@ -28,20 +31,25 @@ wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 #wrapper.java.additional=-XX:+PrintGCDetails
 #wrapper.java.additional=-XX:+PrintGCDateStamps
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
-# Initial Java Heap Size (in MB)
-#wrapper.java.initmemory=16
+# Uncomment the following lines to enable JVM startup diagnostics
+#wrapper.java.additional=-XX:+PrintFlagsFinal
+#wrapper.java.additional=-XX:+PrintFlagsInitial
 
-# Maximum Java Heap Size (in MB)
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=16
 #wrapper.java.maxmemory=64
 
-# Application parameters.  Add parameters as needed starting from 1
-wrapper.java.app.mainclass=org.neo4j.server.Bootstrapper
-
-# both pidfile and lockfile are relative to the bin dir
+#********************************************************************
+# Wrapper settings
+#********************************************************************
+# path is relative to the bin dir
 wrapper.pidfile=../data/neo4j-server.pid
-wrapper.lockfile=../data/neo4j-server.lck
 
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties


### PR DESCRIPTION
Add additional sensible example parameters:
  -XX:+PrintPromotionFailure
  -XX:+PrintFlagsFinal
  -XX:+PrintFlagsInitial

Explain that default heap size is dynamically calculated to avoid
confusion with example hard-coded sizes.

Remove legacy parameters that don't apply anymore, such as:
  wrapper.lockfile
  wrapper.java.app.mainclass

@sarmbruster could you take a look and confirm that these changes seem reasonable?
