### PR TITLE
Edit files with Notepad if Desktop.edit fails

### DIFF
--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/windows/WindowsEnvironment.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/windows/WindowsEnvironment.java
@@ -56,13 +56,13 @@ class WindowsEnvironment extends PortableEnvironment
                 e.printStackTrace( System.out );
             }
         }
-
         windowsEditFile( file );
     }
 
     private void windowsEditFile( File file ) throws IOException
     {
-        getRuntime().exec( new String[]{"rundll32", "url.dll,FileProtocolHandler", file.getAbsolutePath()} );
+        String[] cmdarray = { "notepad", file.getAbsolutePath() };
+        getRuntime().exec( cmdarray );
     }
 
     @Override


### PR DESCRIPTION
The previous code, with its clever use of rundll32 url.dll,FileProtocolHandler is not robust across various versions of Windows.
