### PR TITLE
traversal for constant direction

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/PathExpanders.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/PathExpanders.java
@@ -80,27 +80,36 @@ public abstract class PathExpanders
     /**
      * An expander forcing constant relationship direction
      */
-    public static <STATE> PathExpander<STATE> forConstantDirectionWithTypes( final RelationshipType... types) {
-        return new PathExpander<STATE>() {
+    public static <STATE> PathExpander<STATE> forConstantDirectionWithTypes( final RelationshipType... types )
+    {
+        return new PathExpander<STATE>()
+        {
             @Override
-            public Iterable<Relationship> expand(Path path, BranchState<STATE> state) {
-                if (path.length()==0) {
-                    return path.endNode().getRelationships(types);
-                } else {
-                    Direction direction = getDirectionOfLastRelationship(path);
-                    return path.endNode().getRelationships(direction, types);
+            public Iterable<Relationship> expand( Path path, BranchState<STATE> state )
+            {
+                if ( path.length() == 0 )
+                {
+                    return path.endNode().getRelationships( types );
+                }
+                else
+                {
+                    Direction direction = getDirectionOfLastRelationship( path );
+                    return path.endNode().getRelationships( direction, types );
                 }
             }
 
             @Override
-            public PathExpander<STATE> reverse() {
+            public PathExpander<STATE> reverse()
+            {
                 return this;
             }
 
-            private Direction getDirectionOfLastRelationship(Path path) {
+            private Direction getDirectionOfLastRelationship( Path path )
+            {
                 assert path.length() > 0;
                 Direction direction = Direction.INCOMING;
-                if (path.endNode().equals(path.lastRelationship().getEndNode())) {
+                if ( path.endNode().equals( path.lastRelationship().getEndNode() ) )
+                {
                     direction = Direction.OUTGOING;
                 }
                 return direction;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestConstantDirectionExpander.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestConstantDirectionExpander.java
@@ -22,51 +22,57 @@ package org.neo4j.kernel.impl.traversal;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 
-public class TestConstantDirectionExpander extends TraversalTestBase {
-    private static enum Types implements RelationshipType {
+public class TestConstantDirectionExpander extends TraversalTestBase
+{
+    private static enum Types implements RelationshipType
+    {
         A, B
     }
 
     private Transaction tx;
 
     @Before
-    public void createGraph() {
+    public void createGraph()
+    {
         /*
          *   (l)--[A]-->(m)--[A]-->(n)<--[A]--(o)<--[B]--(p)<--[B]--(q)
          */
-        createGraph("l A m", "m A n", "o A n", "p B o", "q B p");
+        createGraph( "l A m", "m A n", "o A n", "p B o", "q B p" );
         tx = beginTx();
     }
 
     @After
-    public void tearDown() {
+    public void tearDown()
+    {
         tx.close();
     }
 
     @Test
-    public void pathWithConstantDirection() {
-        Node l = getNodeWithName("l");
-        expectPaths(getGraphDb().traversalDescription()
+    public void pathWithConstantDirection()
+    {
+        Node l = getNodeWithName( "l" );
+        expectPaths( getGraphDb().traversalDescription()
                 .expand(
-                        PathExpanders.forConstantDirectionWithTypes(Types.A))
-                .traverse(l), "l", "l,m", "l,m,n");
+                        PathExpanders.forConstantDirectionWithTypes( Types.A ) )
+                .traverse( l ), "l", "l,m", "l,m,n" );
 
-        Node n = getNodeWithName("n");
-        expectPaths(getGraphDb().traversalDescription()
+        Node n = getNodeWithName( "n" );
+        expectPaths( getGraphDb().traversalDescription()
                 .expand(
-                        PathExpanders.forConstantDirectionWithTypes(Types.A))
-                .traverse(n), "n", "n,m", "n,m,l", "n,o");
+                        PathExpanders.forConstantDirectionWithTypes( Types.A ) )
+                .traverse( n ), "n", "n,m", "n,m,l", "n,o" );
 
-        Node q = getNodeWithName("q");
-        expectPaths(getGraphDb().traversalDescription()
+        Node q = getNodeWithName( "q" );
+        expectPaths( getGraphDb().traversalDescription()
                 .expand(
-                        PathExpanders.forConstantDirectionWithTypes(Types.B))
-                .traverse(q), "q", "q,p", "q,p,o");
+                        PathExpanders.forConstantDirectionWithTypes( Types.B ) )
+                .traverse( q ), "q", "q,p", "q,p,o" );
 
     }
 }


### PR DESCRIPTION
Implementing a PathExpander ensuring that relationship direction will be constant along the path.
The first relationship determines the direction to follow for all subsequent steps.
Relates to http://stackoverflow.com/questions/20654988/directed-paths-in-neo4j
