### PR TITLE
Fold semantic checking over collections

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Expression.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Expression.scala
@@ -45,7 +45,7 @@ object Expression {
 
   implicit class SemanticCheckableExpressionTraversable[A <: Expression](traversable: TraversableOnce[A]) extends SemanticChecking {
     def semanticCheck(ctx: SemanticContext) : SemanticCheck =
-      traversable.foldLeft(SemanticCheckResult.success) { (f, o) => f then o.semanticCheck(ctx) }
+      traversable.foldSemanticCheck { _.semanticCheck(ctx) }
   }
 
   implicit class InferrableTypeTraversableOnce[A <: Expression](traversable: TraversableOnce[A]) {
@@ -53,9 +53,7 @@ object Expression {
       (state: SemanticState) => traversable.map { _.types(state) } reduce { _ mergeDown _ }
 
     def constrainType(possibleType: CypherType, possibleTypes: CypherType*) : SemanticCheck =
-      traversable.foldLeft(SemanticCheckResult.success) {
-        (f, e) => f then e.constrainType(possibleType, possibleTypes:_*)
-      }
+      traversable.foldSemanticCheck { _.constrainType(possibleType, possibleTypes:_*) }
   }
 }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
@@ -43,11 +43,8 @@ import Pattern._
 
 case class Pattern(patternParts: Seq[PatternPart], token: InputToken) extends AstNode {
   def semanticCheck(ctx: SemanticContext): SemanticCheck =
-    semanticCheckPatternParts(_.declareIdentifiers(ctx)) then
-    semanticCheckPatternParts(_.semanticCheck(ctx))
-
-  private def semanticCheckPatternParts(check: PatternPart => SemanticCheck) =
-    patternParts.foldLeft(SemanticCheckResult.success) { (f, p) => f then check(p) }
+    patternParts.foldSemanticCheck(_.declareIdentifiers(ctx)) then
+    patternParts.foldSemanticCheck(_.semanticCheck(ctx))
 
   def toLegacyPatterns: Seq[commands.Pattern] = patternParts.flatMap(_.toLegacyPatterns)
   def toLegacyNamedPaths: Seq[commands.NamedPath] = patternParts.flatMap(_.toLegacyNamedPath)

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReturnItem.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReturnItem.scala
@@ -30,12 +30,11 @@ sealed trait ReturnItems extends AstNode with SemanticCheckable {
 case class ListedReturnItems(items: Seq[ReturnItem], token: InputToken) extends ReturnItems {
   def semanticCheck = items.semanticCheck
 
-  def declareIdentifiers(currentState: SemanticState) = {
-    items.foldLeft(SemanticCheckResult.success)((sc, item) => item.alias match {
-      case Some(identifier) => sc then identifier.declare(item.expression.types(currentState))
-      case None => sc
+  def declareIdentifiers(currentState: SemanticState) =
+    items.foldSemanticCheck(item => item.alias match {
+      case Some(identifier) => identifier.declare(item.expression.types(currentState))
+      case None             => SemanticCheckResult.success
     })
-  }
 
   def toCommands = items.map(_.toCommand)
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/package.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/package.scala
@@ -27,43 +27,47 @@ package object v2_0 {
   type TypeGenerator = SemanticState => TypeSet
 
   // Allows joining of two (SemanticState => SemanticCheckResult) funcs together (using then)
-  implicit def chainableSemanticCheck(check: SemanticCheck) = ChainableSemanticCheck(check)
+  implicit def chainableSemanticCheck(check: SemanticCheck) = new ChainableSemanticCheck(check)
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Either[SemanticError, SemanticState]) func
-  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]) = ChainableSemanticCheck(func)
+  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]) = new ChainableSemanticCheck(func)
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Seq[SemanticError]) func
-  implicit def chainableSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]) = ChainableSemanticCheck(func)
+  implicit def chainableSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]) = new ChainableSemanticCheck(func)
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Option[SemanticError]) func
-  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticError]) = ChainableSemanticCheck(func)
+  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticError]) = new ChainableSemanticCheck(func)
 
   // Allows using a (SemanticState => Either[SemanticError, SemanticState]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]) : SemanticCheck = state => {
+  implicit def liftSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]): SemanticCheck = state => {
     func(state).fold(error => SemanticCheckResult.error(state, error), s => SemanticCheckResult.success(s))
   }
   // Allows using a (SemanticState => Seq[SemanticError]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]) : SemanticCheck = state => {
+  implicit def liftSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]): SemanticCheck = state => {
     SemanticCheckResult(state, func(state))
   }
   // Allows using a (SemanticState => Option[SemanticError]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorFunc(func: SemanticState => Option[SemanticError]) : SemanticCheck = state => {
+  implicit def liftSemanticErrorFunc(func: SemanticState => Option[SemanticError]): SemanticCheck = state => {
     SemanticCheckResult.error(state, func(state))
   }
 
   // Allows using a sequence of SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrors(errors: Seq[SemanticError]) : SemanticCheck = SemanticCheckResult(_, errors)
+  implicit def liftSemanticErrors(errors: Seq[SemanticError]): SemanticCheck = SemanticCheckResult(_, errors)
   // Allows using a single SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticError(error: SemanticError) : SemanticCheck = SemanticCheckResult.error(_, error)
+  implicit def liftSemanticError(error: SemanticError): SemanticCheck = SemanticCheckResult.error(_, error)
   // Allows using an optional SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorOption(error: Option[SemanticError]) : SemanticCheck = SemanticCheckResult.error(_, error)
+  implicit def liftSemanticErrorOption(error: Option[SemanticError]): SemanticCheck = SemanticCheckResult.error(_, error)
 
   // Allows starting with a sequence of SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorsAndChain(errors: Seq[SemanticError]) : ChainableSemanticCheck = liftSemanticErrors(errors)
+  implicit def liftSemanticErrorsAndChain(errors: Seq[SemanticError]): ChainableSemanticCheck = liftSemanticErrors(errors)
   // Allows starting with a single SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorAndChain(error: SemanticError) : ChainableSemanticCheck = liftSemanticError(error)
+  implicit def liftSemanticErrorAndChain(error: SemanticError): ChainableSemanticCheck = liftSemanticError(error)
   // Allows starting with an optional SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorOptionAndChain(error: Option[SemanticError]) : ChainableSemanticCheck = liftSemanticErrorOption(error)
+  implicit def liftSemanticErrorOptionAndChain(error: Option[SemanticError]): ChainableSemanticCheck = liftSemanticErrorOption(error)
+
+  // Allows folding a semantic checking func over a collection
+  implicit def optionSemanticChecking[A](option: Option[A]) = new OptionSemanticChecking(option)
+  implicit def traversableOnceSemanticChecking[A](traversable: TraversableOnce[A]) = new TraversableOnceSemanticChecking(traversable)
 
   // Allows calling semanticCheck on an optional SemanticCheckable object
-  implicit def semanticCheckableOption[A <: SemanticCheckable](option: Option[A]) = SemanticCheckableOption(option)
+  implicit def semanticCheckableOption[A <: SemanticCheckable](option: Option[A]) = new SemanticCheckableOption(option)
   // Allows calling semanticCheck on a traversable sequence of SemanticCheckable objects
-  implicit def semanticCheckableTraversableOnce[A <: SemanticCheckable](traversable: TraversableOnce[A]) = SemanticCheckableTraversableOnce(traversable)
+  implicit def semanticCheckableTraversableOnce[A <: SemanticCheckable](traversable: TraversableOnce[A]) = new SemanticCheckableTraversableOnce(traversable)
 }


### PR DESCRIPTION
Rather than using the fold to build a chain of semantic check functions.
This reduces the stack requirements for semantic checking.
