### PR TITLE
Use %~dps0 instead of %~dp0.

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jBackup.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jBackup.bat
@@ -60,7 +60,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+set BASEDIR=%~dps0\..
 
 :repoSetup
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jInstaller.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jInstaller.bat
@@ -67,7 +67,7 @@ goto :main %1
   set javaPath=%javaPath:###"=%
   set javaPath=%javaPath:###=%
 
-  set binPath="\"%javaPath%\bin\java.exe\" %loggingProperties% -DworkingDir="%~dp0.." -DconfigFile=%configFile% %classpath% %mainclass% -Dorg.neo4j.cluster.logdirectory="%~dps0..\data\log" -jar %~dps0%wrapperJarFilename%  %serviceName%"
+  set binPath="\"%javaPath%\bin\java.exe\" %loggingProperties% -DworkingDir="%~dps0.." -DconfigFile=%configFile% %classpath% %mainclass% -Dorg.neo4j.cluster.logdirectory="%~dps0..\data\log" -jar %~dps0%wrapperJarFilename%  %serviceName%"
 
   sc create "%serviceName%" binPath= %binPath% DisplayName= "%serviceDisplayName:"=%" start= %serviceStartType%
   sc start %serviceName%

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jShell.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jShell.bat
@@ -60,7 +60,7 @@ set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
-set BASEDIR=%~dp0\..
+set BASEDIR=%~dps0\..
 
 :repoSetup
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
@@ -133,7 +133,7 @@ goto:eof
   goto :eof
 
 :console
-  "%javapath%\bin\java.exe" -DworkingDir="%~dp0.." -Djava.util.logging.config.file=conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar %~dps0%wrapperJarFilename%
+  "%javapath%\bin\java.exe" -DworkingDir="%~dps0.." -Djava.util.logging.config.file=conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar %~dps0%wrapperJarFilename%
   goto :eof
 
 :help


### PR DESCRIPTION
For consistency, use short path everywhere.

Raised from #1753.

I can't think of any negative impact of using short-path everywhere, but this needs some thorough testing on Windows before merging.
