### PR TITLE
Avoids some use of synchronized map in PersistenceManager

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_0/TransactionBoundExecutionContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_0/TransactionBoundExecutionContextTest.scala
@@ -40,7 +40,7 @@ class TransactionBoundExecutionContextTest extends JUnitSuite with Assertions wi
   def init() {
     graph = new ImpermanentGraphDatabase
     outerTx = mock[Transaction]
-    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, null, null)
+    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, null, null, null)
   }
 
   @Test def should_mark_transaction_successful_if_successful() {

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
@@ -20,8 +20,6 @@ package org.neo4j.examples;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
@@ -18,16 +18,14 @@
  */
 package org.neo4j.examples;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertNotNull;
 
 public class StartWithConfigurationDocTest
 {

--- a/community/kernel/src/main/java/org/neo4j/helpers/Pair.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Pair.java
@@ -27,6 +27,15 @@ package org.neo4j.helpers;
  */
 public abstract class Pair<T1, T2>
 {
+    @SuppressWarnings( "rawtypes" )
+    private static final Pair EMPTY = Pair.of( null, null );
+    
+    @SuppressWarnings( "unchecked" )
+    public static <T1, T2> Pair<T1, T2> empty()
+    {
+        return EMPTY;
+    }
+    
     /**
      * Create a new pair of objects.
      *
@@ -82,7 +91,10 @@ public abstract class Pair<T1, T2>
     @Override
     public boolean equals( Object obj )
     {
-        if ( this == obj ) return true;
+        if ( this == obj )
+        {
+            return true;
+        }
         if ( obj instanceof Pair )
         {
             @SuppressWarnings( "rawtypes" ) Pair that = (Pair) obj;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -25,12 +25,11 @@ import javax.transaction.Transaction;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.impl.core.Transactor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
-import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
+import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
+import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.api.store.CacheLayer;
 import org.neo4j.kernel.impl.api.store.DiskLayer;
@@ -42,6 +41,7 @@ import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.TransactionState;
+import org.neo4j.kernel.impl.core.Transactor;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
@@ -245,8 +245,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
         // + Transaction state handling
         StateHandlingStatementOperations stateHandlingContext = new StateHandlingStatementOperations(
                 storeLayer, legacyPropertyTrackers,
-                new ConstraintIndexCreator( new Transactor( transactionManager, persistenceManager ), indexService ),
-                persistenceManager );
+                new ConstraintIndexCreator( new Transactor( transactionManager, persistenceManager ), indexService ) );
 
         StatementOperationParts parts = new StatementOperationParts( stateHandlingContext, stateHandlingContext,
                 stateHandlingContext, stateHandlingContext, stateHandlingContext, stateHandlingContext,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
 import org.neo4j.kernel.impl.api.state.TxState;
+import org.neo4j.kernel.impl.persistence.NeoStoreTransaction;
 
 public class KernelStatement implements TxState.Holder, Statement
 {
@@ -41,6 +42,8 @@ public class KernelStatement implements TxState.Holder, Statement
     protected final TxState.Holder txStateHolder;
     protected final IndexReaderFactory indexReaderFactory;
     protected final LabelScanStore labelScanStore;
+    protected final NeoStoreTransaction neoStoreTransaction;
+    
     private LabelScanReader labelScanReader;
     private int referenceCount;
     private final OperationsFacade facade;
@@ -49,14 +52,16 @@ public class KernelStatement implements TxState.Holder, Statement
     public KernelStatement( KernelTransactionImplementation transaction, IndexReaderFactory indexReaderFactory,
                             LabelScanStore labelScanStore,
                             TxState.Holder txStateHolder, LockHolder lockHolder, LegacyKernelOperations
-                            legacyKernelOperations, StatementOperationParts operations )
+                            legacyKernelOperations, StatementOperationParts operations,
+                            NeoStoreTransaction neoStoreTransaction )
     {
         this.transaction = transaction;
         this.lockHolder = lockHolder;
         this.indexReaderFactory = indexReaderFactory;
         this.txStateHolder = txStateHolder;
         this.labelScanStore = labelScanStore;
-        this.facade = new OperationsFacade( this, legacyKernelOperations, operations);
+        this.neoStoreTransaction = neoStoreTransaction;
+        this.facade = new OperationsFacade( this, legacyKernelOperations, operations );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -21,13 +21,13 @@ package org.neo4j.kernel.impl.api;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.transaction.RollbackException;
 
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.impl.core.Transactor;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDatabaseKernelException;
@@ -36,19 +36,20 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.TransactionalException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
-import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
+import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
+import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.OldTxStateBridge;
 import org.neo4j.kernel.impl.api.state.OldTxStateBridgeImpl;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.api.state.TxStateImpl;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.TransactionState;
+import org.neo4j.kernel.impl.core.Transactor;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
@@ -179,8 +180,9 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         assertOpen();
         if ( currentStatement == null )
         {
-            currentStatement = new KernelStatement( this, new IndexReaderFactory.Caching( indexService ),labelScanStore,
-                    this, lockHolder, legacyKernelOperations, operations );
+            currentStatement = new KernelStatement( this, new IndexReaderFactory.Caching( indexService ),
+                    labelScanStore, this, lockHolder, legacyKernelOperations, operations,
+                    persistenceManager.getResource() );
         }
         currentStatement.acquire();
         return currentStatement;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -39,23 +39,22 @@ import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.impl.api.operations.KeyWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
-import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.properties.Property;
-import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
-import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.util.DiffSets;
 import org.neo4j.kernel.impl.util.PrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
@@ -81,16 +80,14 @@ public class StateHandlingStatementOperations implements
     private final StoreReadLayer storeLayer;
     private final LegacyPropertyTrackers legacyPropertyTrackers;
     private final ConstraintIndexCreator constraintIndexCreator;
-    private final PersistenceManager persistenceManager;
 
     public StateHandlingStatementOperations(
             StoreReadLayer storeLayer, LegacyPropertyTrackers propertyTrackers,
-            ConstraintIndexCreator constraintIndexCreator, PersistenceManager writeTransactionProxy )
+            ConstraintIndexCreator constraintIndexCreator )
     {
         this.storeLayer = storeLayer;
         this.legacyPropertyTrackers = propertyTrackers;
         this.constraintIndexCreator = constraintIndexCreator;
-        this.persistenceManager = writeTransactionProxy;
     }
 
     @Override
@@ -518,12 +515,12 @@ public class StateHandlingStatementOperations implements
         if ( !existingProperty.isDefined() )
         {
             legacyPropertyTrackers.nodeAddStoreProperty( nodeId, property );
-            persistenceManager.nodeAddProperty( nodeId, property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.nodeAddProperty( nodeId, property.propertyKeyId(), property.value() );
         }
         else
         {
             legacyPropertyTrackers.nodeChangeStoreProperty( nodeId, (DefinedProperty) existingProperty, property );
-            persistenceManager.nodeChangeProperty( nodeId, property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.nodeChangeProperty( nodeId, property.propertyKeyId(), property.value() );
         }
         state.txState().nodeDoReplaceProperty( nodeId, existingProperty, property );
         return existingProperty;
@@ -537,13 +534,13 @@ public class StateHandlingStatementOperations implements
         if ( !existingProperty.isDefined() )
         {
             legacyPropertyTrackers.relationshipAddStoreProperty( relationshipId, property );
-            persistenceManager.relAddProperty( relationshipId, property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.relAddProperty( relationshipId, property.propertyKeyId(), property.value() );
         }
         else
         {
             legacyPropertyTrackers.relationshipChangeStoreProperty( relationshipId, (DefinedProperty)
                     existingProperty, property );
-            persistenceManager.relChangeProperty( relationshipId, property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.relChangeProperty( relationshipId, property.propertyKeyId(), property.value() );
         }
         state.txState().relationshipDoReplaceProperty( relationshipId, existingProperty, property );
         return existingProperty;
@@ -555,11 +552,11 @@ public class StateHandlingStatementOperations implements
         Property existingProperty = graphGetProperty( state, property.propertyKeyId() );
         if ( !existingProperty.isDefined() )
         {
-            persistenceManager.graphAddProperty( property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.graphAddProperty( property.propertyKeyId(), property.value() );
         }
         else
         {
-            persistenceManager.graphChangeProperty( property.propertyKeyId(), property.value() );
+            state.neoStoreTransaction.graphChangeProperty( property.propertyKeyId(), property.value() );
         }
         state.txState().graphDoReplaceProperty( existingProperty, property );
         return existingProperty;
@@ -573,7 +570,7 @@ public class StateHandlingStatementOperations implements
         if ( existingProperty.isDefined() )
         {
             legacyPropertyTrackers.nodeRemoveStoreProperty( nodeId, (DefinedProperty) existingProperty );
-            persistenceManager.nodeRemoveProperty( nodeId, propertyKeyId );
+            state.neoStoreTransaction.nodeRemoveProperty( nodeId, propertyKeyId );
         }
         state.txState().nodeDoRemoveProperty( nodeId, existingProperty );
         return existingProperty;
@@ -588,7 +585,7 @@ public class StateHandlingStatementOperations implements
         {
             legacyPropertyTrackers.relationshipRemoveStoreProperty( relationshipId, (DefinedProperty)
                     existingProperty );
-            persistenceManager.relRemoveProperty( relationshipId, propertyKeyId );
+            state.neoStoreTransaction.relRemoveProperty( relationshipId, propertyKeyId );
         }
         state.txState().relationshipDoRemoveProperty( relationshipId, existingProperty );
         return existingProperty;
@@ -600,7 +597,7 @@ public class StateHandlingStatementOperations implements
         Property existingProperty = graphGetProperty( state, propertyKeyId );
         if ( existingProperty.isDefined() )
         {
-            persistenceManager.graphRemoveProperty( propertyKeyId );
+            state.neoStoreTransaction.graphRemoveProperty( propertyKeyId );
         }
         state.txState().graphDoRemoveProperty( existingProperty );
         return existingProperty;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
@@ -76,6 +76,6 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter implements 
     {
         checkIfShutdown();
         // Contract: Persistence manager throws NotInTransactionException if we are not in a transaction.
-        persistenceManager.currentKernelTransaction();
+        persistenceManager.getCurrentTransaction();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/persistence/PersistenceManager.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.core.TransactionEventsSyncHook;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.core.TxEventSyncHookFactory;
@@ -45,6 +44,7 @@ import org.neo4j.kernel.impl.persistence.NeoStoreTransaction.PropertyReceiver;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
 import org.neo4j.kernel.impl.util.ArrayMap;
+import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.StringLogger;
 
@@ -206,46 +206,46 @@ public class PersistenceManager
         getResource().createRelationshipTypeToken( id, name );
     }
 
-    private NeoStoreTransaction getResource()
+    public NeoStoreTransaction getResource()
     {
         Transaction tx = this.getCurrentTransaction();
-        if ( tx == null )
-        {
-            throw new NotInTransactionException();
-        }
         NeoStoreTransaction con = txConnectionMap.get( tx );
         if ( con == null )
         {
-            try
-            {
-                XaConnection xaConnection = persistenceSource.getXaDataSource().getXaConnection();
-                XAResource xaResource = xaConnection.getXaResource();
-                if ( !tx.enlistResource( xaResource ) )
-                {
-                    throw new ResourceAcquisitionFailedException(
-                        "Unable to enlist '" + xaResource + "' in " + "transaction" );
-                }
-                con = persistenceSource.createTransaction( xaConnection );
-
-                TransactionState state = transactionManager.getTransactionState();
-                tx.registerSynchronization( new TxCommitHook( tx, state ) );
-
-                registerTransactionEventHookIfNeeded( tx );
-
-                txConnectionMap.put( tx, con );
-            }
-            catch ( RollbackException re )
-            {
-                String msg = "The transaction is marked for rollback only.";
-                throw new ResourceAcquisitionFailedException( msg, re );
-            }
-            catch ( SystemException se )
-            {
-                String msg = "TM encountered an unexpected error condition.";
-                throw new ResourceAcquisitionFailedException( msg, se );
-            }
+            txConnectionMap.put( tx, con = createResource( tx ) );
         }
         return con;
+    }
+
+    private NeoStoreTransaction createResource( Transaction tx )
+    {
+        try
+        {
+            XaConnection xaConnection = persistenceSource.getXaDataSource().getXaConnection();
+            XAResource xaResource = xaConnection.getXaResource();
+            if ( !tx.enlistResource( xaResource ) )
+            {
+                throw new ResourceAcquisitionFailedException(
+                    "Unable to enlist '" + xaResource + "' in " + "transaction" );
+            }
+            NeoStoreTransaction con = persistenceSource.createTransaction( xaConnection );
+
+            TransactionState state = transactionManager.getTransactionState();
+            tx.registerSynchronization( new TxCommitHook( tx, state ) );
+
+            registerTransactionEventHookIfNeeded( tx );
+            return con;
+        }
+        catch ( RollbackException re )
+        {
+            String msg = "The transaction is marked for rollback only.";
+            throw new ResourceAcquisitionFailedException( msg, re );
+        }
+        catch ( SystemException se )
+        {
+            String msg = "TM encountered an unexpected error condition.";
+            throw new ResourceAcquisitionFailedException( msg, se );
+        }
     }
 
     private void registerTransactionEventHookIfNeeded( Transaction tx )
@@ -258,12 +258,17 @@ public class PersistenceManager
         }
     }
 
-    private Transaction getCurrentTransaction()
+    public Transaction getCurrentTransaction()
         throws NotInTransactionException
     {
         try
         {
-            return transactionManager.getTransaction();
+            Transaction tx = transactionManager.getTransaction();
+            if ( tx == null )
+            {
+                throw new NotInTransactionException();
+            }
+            return tx;
         }
         catch ( SystemException se )
         {
@@ -329,10 +334,6 @@ public class PersistenceManager
     void delistResourcesForTransaction() throws NotInTransactionException
     {
         Transaction tx = this.getCurrentTransaction();
-        if ( tx == null )
-        {
-            throw new NotInTransactionException();
-        }
         NeoStoreTransaction con = txConnectionMap.get( tx );
         if ( con != null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -38,6 +38,7 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
@@ -142,83 +143,36 @@ class TransactionImpl implements Transaction
         {
             throw new IllegalArgumentException( "Null xa resource" );
         }
-        if ( status == Status.STATUS_ACTIVE ||
-                status == Status.STATUS_PREPARING )
+        if ( status == Status.STATUS_ACTIVE || status == Status.STATUS_PREPARING )
         {
             try
             {
                 if ( resourceList.size() == 0 )
-                {
-                    if ( !globalStartRecordWritten )
-                    {
-                        txManager.writeStartRecord( globalId );
-                        globalStartRecordWritten = true;
-                    }
-                    //
-                    byte branchId[] = txManager.getBranchId( xaRes );
-                    Xid xid = new XidImpl( globalId, branchId );
-                    resourceList.add( new ResourceElement( xid, xaRes ) );
-                    xaRes.start( xid, XAResource.TMNOFLAGS );
-                    try
-                    {
-                        txManager.getTxLog().addBranch( globalId, branchId );
-                    }
-                    catch ( IOException e )
-                    {
-                        logger.error( "Error writing transaction log", e );
-                        txManager.setTmNotOk( e );
-                        throw Exceptions.withCause( new SystemException( "TM encountered a problem, "
-                                + " error writing transaction log" ), e );
-                    }
-
-                    return true;
-                }
-                Xid sameRmXid = null;
-                for ( ResourceElement re : resourceList )
-                {
-                    if ( sameRmXid == null && re.getResource().isSameRM( xaRes ) )
-                    {
-                        sameRmXid = re.getXid();
-                    }
-                    if ( xaRes == re.getResource() )
-                    {
-                        if ( re.getStatus() == RS_SUSPENDED )
-                        {
-                            xaRes.start( re.getXid(), XAResource.TMRESUME );
-                        }
-                        else
-                        {
-                            // either enlisted or delisted
-                            // is TMJOIN correct then?
-                            xaRes.start( re.getXid(), XAResource.TMJOIN );
-                        }
-                        re.setStatus( RS_ENLISTED );
-                        return true;
-                    }
-                }
-                if ( sameRmXid != null ) // should we join?
-                {
-                    addResourceToList( sameRmXid, xaRes );
-                    xaRes.start( sameRmXid, XAResource.TMJOIN );
+                {   // This is the first enlisted resource
+                    ensureGlobalTxStartRecordWritten();
+                    registerAndStartResource( xaRes );
                 }
                 else
-                // new branch
-                {
-                    // ResourceElement re = resourceList.getFirst();
-                    byte branchId[] = txManager.getBranchId( xaRes );
-                    Xid xid = new XidImpl( globalId, branchId );
-                    addResourceToList( xid, xaRes );
-                    xaRes.start( xid, XAResource.TMNOFLAGS );
-                    try
-                    {
-                        txManager.getTxLog().addBranch( globalId, branchId );
+                {   // There are other enlisted resources. We have to check if any of them have the same Xid
+                    Pair<Xid,ResourceElement> similarResource = findAlreadyRegisteredSimilarResource( xaRes );
+                    if ( similarResource.other() != null )
+                    {   // This exact resource is already enlisted
+                        ResourceElement resource = similarResource.other();
+                        
+                        // TODO either enlisted or delisted. is TMJOIN correct then?
+                        xaRes.start( resource.getXid(), resource.getStatus() == RS_SUSPENDED ?
+                                XAResource.TMRESUME : XAResource.TMJOIN );
+                        resource.setStatus( RS_ENLISTED );
                     }
-                    catch ( IOException e )
+                    else if ( similarResource.first() != null )
+                    {   // A similar resource, but not the exact same instance is already registered
+                        Xid xid = similarResource.first();
+                        addResourceToList( xid, xaRes );
+                        xaRes.start( xid, XAResource.TMJOIN );
+                    }
+                    else
                     {
-                        logger.error( "Error writing transaction log", e );
-                        txManager.setTmNotOk( e );
-                        throw Exceptions.withCause( new SystemException( "TM encountered a problem, "
-                                + " error writing transaction log" ), e );
+                        registerAndStartResource( xaRes );
                     }
                 }
                 return true;
@@ -234,11 +188,56 @@ class TransactionImpl implements Transaction
                 status == Status.STATUS_ROLLEDBACK ||
                 status == Status.STATUS_MARKED_ROLLBACK )
         {
-            throw new RollbackException( "Tx status is: "
-                    + txManager.getTxStatusAsString( status ) );
+            throw new RollbackException( "Tx status is: " + txManager.getTxStatusAsString( status ) );
         }
-        throw new IllegalStateException( "Tx status is: "
-                + txManager.getTxStatusAsString( status ) );
+        throw new IllegalStateException( "Tx status is: " + txManager.getTxStatusAsString( status ) );
+    }
+
+    private Pair<Xid, ResourceElement> findAlreadyRegisteredSimilarResource( XAResource xaRes ) throws XAException
+    {
+        Xid sameXid = null;
+        ResourceElement sameResource = null;
+        for ( ResourceElement re : resourceList )
+        {
+            if ( sameXid == null && re.getResource().isSameRM( xaRes ) )
+            {
+                sameXid = re.getXid();
+            }
+            if ( xaRes == re.getResource() )
+            {
+                sameResource = re;
+            }
+        }
+        return sameXid == null && sameResource == null ?
+                Pair.<Xid,ResourceElement>empty() : Pair.of( sameXid, sameResource );
+    }
+
+    private void registerAndStartResource( XAResource xaRes ) throws XAException, SystemException
+    {
+        byte branchId[] = txManager.getBranchId( xaRes );
+        Xid xid = new XidImpl( globalId, branchId );
+        addResourceToList( xid, xaRes );
+        xaRes.start( xid, XAResource.TMNOFLAGS );
+        try
+        {
+            txManager.getTxLog().addBranch( globalId, branchId );
+        }
+        catch ( IOException e )
+        {
+            logger.error( "Error writing transaction log", e );
+            txManager.setTmNotOk( e );
+            throw Exceptions.withCause( new SystemException( "TM encountered a problem, "
+                    + " error writing transaction log" ), e );
+        }
+    }
+
+    private void ensureGlobalTxStartRecordWritten() throws SystemException
+    {
+        if ( !globalStartRecordWritten )
+        {
+            txManager.writeStartRecord( globalId );
+            globalStartRecordWritten = true;
+        }
     }
 
     private void addResourceToList( Xid xid, XAResource xaRes )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -19,13 +19,12 @@
  */
 package org.neo4j.kernel.api;
 
-import org.mockito.Mockito;
-
-import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
+import org.neo4j.kernel.impl.api.operations.LegacyKernelOperations;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 
 import static org.mockito.Mockito.mock;
@@ -34,8 +33,9 @@ public class KernelTransactionFactory
 {
     static KernelTransaction kernelTransaction()
     {
-        return new KernelTransactionImplementation( Mockito.mock( StatementOperationParts.class ),
-                Mockito.mock( LegacyKernelOperations.class ) , false, mock( SchemaWriteGuard.class ), null, null,
-                mock( AbstractTransactionManager.class ), null, null, null, null, null, mock( NeoStore.class ), null );
+        return new KernelTransactionImplementation( mock( StatementOperationParts.class ),
+                mock( LegacyKernelOperations.class ) , false, mock( SchemaWriteGuard.class ), null, null,
+                mock( AbstractTransactionManager.class ), null, null, null, mock( PersistenceManager.class ),
+                null, mock( NeoStore.class ), null );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -20,11 +20,15 @@
 package org.neo4j.kernel.impl.api;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class KernelStatementTest
 {
@@ -39,7 +43,7 @@ public class KernelStatementTest
         KernelStatement statement =
             new KernelStatement(
                 mock( KernelTransactionImplementation.class ),
-                mock( IndexReaderFactory.class ), scanStore, null, null, null, null );
+                mock( IndexReaderFactory.class ), scanStore, null, null, null, null, null );
 
         statement.acquire();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -46,7 +46,7 @@ public class LockingStatementOperationsTest
     private final SchemaWriteOperations schemaWriteOps;
     private final LockHolder locks = mock( LockHolder.class );
     private final InOrder order;
-    private final KernelStatement state = new KernelStatement( null, null, null, null, locks, null, null );
+    private final KernelStatement state = new KernelStatement( null, null, null, null, locks, null, null, null );
 
     public LockingStatementOperationsTest()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.api;
 
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class StatementLifecycleTest
 {
@@ -31,7 +31,7 @@ public class StatementLifecycleTest
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
         KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null,
-                null, null, null );
+                null, null, null, null );
         statement.acquire();
 
         // when
@@ -47,7 +47,7 @@ public class StatementLifecycleTest
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
         KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null, null,
-                null, null, null );
+                null, null, null, null );
         statement.acquire();
         statement.acquire();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -25,13 +25,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.util.DiffSets;
@@ -379,7 +379,7 @@ public class IndexQueryTransactionStateTest
                 mock( TxState.IdGeneration.class ) );
         state = StatementOperationsTestHelper.mockedState( txState );
         txContext = new StateHandlingStatementOperations( store, mock( LegacyPropertyTrackers.class ),
-                mock( ConstraintIndexCreator.class ), mock(PersistenceManager.class) );
+                mock( ConstraintIndexCreator.class ) );
     }
 
     private void assertNoSuchNode( long node )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -28,17 +28,22 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.kernel.impl.api.KernelStatement;
+
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsIteratorFrom;
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsPrimitiveIntIteratorFrom;
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsPrimitiveLongIteratorFrom;
@@ -278,7 +283,7 @@ public class LabelTransactionStateTest
                 mock( TxState.IdGeneration.class ) );
         state = StatementOperationsTestHelper.mockedState( txState );
         txContext = new StateHandlingStatementOperations( store, mock( LegacyPropertyTrackers.class ),
-                mock( ConstraintIndexCreator.class ), mock(PersistenceManager.class) );
+                mock( ConstraintIndexCreator.class ) );
     }
 
     private static class Labels

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -31,19 +31,25 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
@@ -193,7 +199,6 @@ public class SchemaTransactionStateTest
     private final long nodeId = 20;
 
     private StoreReadLayer store;
-    private PersistenceManager persistenceManager;
     private OldTxStateBridge oldTxState;
     private TxState txState;
     private StateHandlingStatementOperations txContext;
@@ -213,10 +218,8 @@ public class SchemaTransactionStateTest
         when( store.indexesGetForLabel( state, labelId2 ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll( state ) ).then( asAnswer( Collections.<IndexDescriptor>emptyList() ) );
 
-        persistenceManager = mock(PersistenceManager.class);
-
         txContext = new StateHandlingStatementOperations( store, mock( LegacyPropertyTrackers.class ),
-                mock( ConstraintIndexCreator.class ), persistenceManager);
+                mock( ConstraintIndexCreator.class ));
     }
 
     private static <T> Answer<Iterator<T>> asAnswer( final Iterable<T> values )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -27,11 +27,11 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
-import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.state.TxState.IdGeneration;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
@@ -194,7 +194,6 @@ public class StateHandlingStatementOperationsTest
     private StateHandlingStatementOperations newTxStateOps( StoreReadLayer delegate )
     {
         return new StateHandlingStatementOperations( delegate,
-                mock( LegacyPropertyTrackers.class ), mock( ConstraintIndexCreator.class ),
-                mock(PersistenceManager.class) );
+                mock( LegacyPropertyTrackers.class ), mock( ConstraintIndexCreator.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -36,13 +36,13 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
-import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
@@ -288,7 +288,7 @@ public class DiskLayerTest
                 indexingService );
         this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ),
                 resolver.resolveDependency( LabelScanStore.class ), null,
-                null, null, null );
+                null, null, null, null );
     }
 
     @After


### PR DESCRIPTION
o Instead of calling PersistenceManager#currentKernelTransaction() when
  asserting the existence of a transaction, call the (now public)
  #getCurrentTransaction())
o KernelStatement is aware of the NeoStoreTransaction it was created with
  so that PersistenceManager can be avoided.

Going forward PersistenceManager should be deleted and each
NeoStoreTransaction should be tied closer to a kernel transaction. This
will be easier when all operations go through the Kernel API.
