### PR TITLE
Export float/double values in decimal notation. Fixes #1781.

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
@@ -253,6 +253,10 @@ public class SubGraphExporter
         {
             return "\"" + value + "\"";
         }
+        if ( value instanceof Float || value instanceof Double )
+        {
+            return String.format( "%f", value );
+        }
         if ( value instanceof Iterator )
         {
             return toString( ((Iterator) value) );

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
@@ -81,6 +81,24 @@ public class ExportTest
         assertEquals( "create (_0 {`name`:\"Andres\"})" + NL, doExportGraph( gdb ) );
     }
 
+    @Test
+    public void testNodeWithFloatProperty() throws Exception
+    {
+        final float floatValue = 10.1f;
+        final String expected = "10.100000";
+        gdb.createNode().setProperty( "float", floatValue );
+        assertEquals( "create (_0 {`float`:" + expected + "})" + NL, doExportGraph( gdb ) );
+    }
+
+    @Test
+    public void testNodeWithDoubleProperty() throws Exception
+    {
+        final double doubleValue = 123456.123456;
+        final String expected = "123456.123456";
+        gdb.createNode().setProperty( "double", doubleValue );
+        assertEquals( "create (_0 {`double`:" + expected + "})" + NL, doExportGraph( gdb ) );
+    }
+
     private String doExportGraph( GraphDatabaseService db )
     {
         SubGraph graph = DatabaseSubGraph.from( db );


### PR DESCRIPTION
This aligns the representation of double values with the format used
in the browser, as well as producing a notation that can be feed back
to Cypher.

Note that the shell still prints double values in scientific notation, so there's some inconsistency left, assuming decimal notation is the way to go (currently the only form accepted by Cypher). From what I gathered, the shell uses _org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/StringFunctions.scala:69_ to format a double value, which calls _Object.toString()_ which uses the scientific notation. However, if that is to be changed I'd like someone else to take over as I'm just getting into Scala and I can't really judge the ramifications such a change in the heart of the Cypher compiler would have.
