### PR TITLE
Fixes #1735

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/NodeFetchStrategy.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/NodeFetchStrategy.scala
@@ -130,7 +130,7 @@ object IndexSeekStrategy extends NodeStrategy {
       val schemaIndex = SchemaIndex(node, labelPredicate.solution, propertyPredicate.solution, AnyIndex, None)
       val optConstraint = ctx.getUniquenessConstraint(labelPredicate.solution, propertyPredicate.solution)
       val rating = if (optConstraint.isDefined) Single else IndexEquality
-      val predicates = Seq(labelPredicate.predicate, propertyPredicate.predicate)
+      val predicates = Seq.empty // These are still not solved.
       RatedStartItem(schemaIndex, rating, predicates)
     }
   }

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -3,6 +3,7 @@
 o Fixes bug around MERGE inside a FOREACH inside a FOREACH
 o Makes it possible to write MERGE queries with no already known parts
 o Fixes problem with compiling queries with NOT expressions in them
+o Fixes #1735 - Indexes and AND predicates produce wrong results
 
 2.0.0-RC1
 ---------

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.junit.Test
+
+class IndexUsageAcceptanceTest extends ExecutionEngineHelper {
+  @Test
+  def should_not_forget_predicates() {
+    // Given
+    execute("CREATE (_0:Matrix { name:'The Architect' }),(_1:Matrix { name:'Agent Smith' }),(_2:Matrix:Crew { name:'Cypher' }),(_3:Crew { name:'Trinity' }),(_4:Crew { name:'Morpheus' }),(_5:Crew { name:'Neo' }), _1-[:CODED_BY]->_0, _2-[:KNOWS]->_1, _4-[:KNOWS]->_3, _4-[:KNOWS]->_2, _5-[:KNOWS]->_4, _5-[:LOVES]->_3")
+    execute("CREATE INDEX ON :Crew(name)")
+
+    // When
+    val result = execute("MATCH (n:Crew) WHERE n.name = 'Neo' AND n.name= 'Morpheus' RETURN n")
+
+    // Then
+    assert(result.isEmpty, "Should not find anything here")
+  }
+}


### PR DESCRIPTION
The fetch strategy does not mark predicates as solved until at the last point. This
way, we know we are not marking predicates as solved prematurely.
