### PR TITLE
Refactor master -> slave pushing to its own class.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.logging.Logging;
 
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexPopulation;
 
 
 public class PopulatingIndexProxy implements IndexProxy
@@ -70,7 +71,7 @@ public class PopulatingIndexProxy implements IndexProxy
     @Override
     public void start()
     {
-        scheduler.schedule( job );
+        scheduler.schedule( indexPopulation, job );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cleanup/ReferenceQueueBasedCleanupService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cleanup/ReferenceQueueBasedCleanupService.java
@@ -29,6 +29,8 @@ import org.neo4j.helpers.collection.ResourceClosingIterator;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.logging.Logging;
 
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.unusedResourceCleanup;
+
 class ReferenceQueueBasedCleanupService extends CleanupService implements Runnable
 {
     private volatile boolean running;
@@ -72,7 +74,7 @@ class ReferenceQueueBasedCleanupService extends CleanupService implements Runnab
     public void start()
     {
         running = true;
-        scheduler.scheduleRecurring( this, 1, TimeUnit.SECONDS );
+        scheduler.scheduleRecurring( unusedResourceCleanup, this, 1, TimeUnit.SECONDS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -28,7 +28,22 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  */
 public interface JobScheduler extends Lifecycle
 {
-    void schedule( Runnable job );
+    /**
+     * This is an exhaustive list of job types that run in the database. It should be expanded as needed for new groups
+     * of jobs.
+     *
+     * For now, this does naming only, but it will allow us to define per-group configuration, such as how to handle
+     * failures, shared threads and (later on) affinity strategies.
+     */
+    enum Group
+    {
+        indexPopulation,
+        masterTransactionPushing,
+        serverTransactionTimeout,
+        unusedResourceCleanup,
+    }
 
-    void scheduleRecurring( Runnable runnable, long period, TimeUnit timeUnit );
+    void schedule( Group group, Runnable job );
+
+    void scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
@@ -57,13 +57,13 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     }
 
     @Override
-    public void schedule( Runnable job )
+    public void schedule( Group group, Runnable job )
     {
         this.executor.submit( job );
     }
 
     @Override
-    public void scheduleRecurring( final Runnable runnable, long period, TimeUnit timeUnit )
+    public void scheduleRecurring( Group group, final Runnable runnable, long period, TimeUnit timeUnit )
     {
         timer.schedule( new TimerTask()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cleanup/CleanupServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cleanup/CleanupServiceTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
-
 import org.neo4j.graphdb.Resource;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.Thunk;
@@ -35,16 +34,10 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-
+import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.Thunks.TRUE;
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
@@ -63,7 +56,7 @@ public class CleanupServiceTest
         service.start();
 
         // THEN
-        verify( scheduler ).scheduleRecurring( Matchers.<Runnable> any(), anyLong(), any( TimeUnit.class ) );
+        verify( scheduler ).scheduleRecurring(  Matchers.<JobScheduler.Group> any(), Matchers.<Runnable> any(), anyLong(), any( TimeUnit.class ) );
     }
 
     @Test
@@ -239,7 +232,7 @@ public class CleanupServiceTest
     private Runnable acquireCleanupTask()
     {
         ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass( Runnable.class );
-        verify( scheduler ).scheduleRecurring( taskCaptor.capture(), anyLong(), any( TimeUnit.class ) );
+        verify( scheduler ).scheduleRecurring( any( JobScheduler.Group.class ), taskCaptor.capture(), anyLong(), any( TimeUnit.class ) );
         Runnable task = taskCaptor.getValue();
         return task;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
@@ -29,6 +29,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexPopulation;
 
 public class Neo4jJobSchedulerTest
 {
@@ -49,7 +50,7 @@ public class Neo4jJobSchedulerTest
 
         // When
         scheduler.start();
-        scheduler.scheduleRecurring( new Runnable()
+        scheduler.scheduleRecurring( indexPopulation, new Runnable()
         {
             public void run()
             {

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -83,6 +83,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 import static org.neo4j.helpers.collection.Iterables.option;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.serverTransactionTimeout;
 import static org.neo4j.server.configuration.Configurator.DEFAULT_SCRIPT_SANDBOXING_ENABLED;
 import static org.neo4j.server.configuration.Configurator.DEFAULT_TRANSACTION_TIMEOUT;
 import static org.neo4j.server.configuration.Configurator.SCRIPT_SANDBOXING_ENABLED_KEY;
@@ -237,7 +238,7 @@ public abstract class AbstractNeoServer implements NeoServer
         // ensure that this is > 0
         long runEvery = round( timeoutMillis / 2.0 );
 
-        resolveDependency( JobScheduler.class ).scheduleRecurring( new Runnable()
+        resolveDependency( JobScheduler.class ).scheduleRecurring( serverTransactionTimeout, new Runnable()
         {
             @Override
             public void run()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import javax.transaction.Transaction;
 
 import org.jboss.netty.logging.InternalLoggerFactory;
-
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
@@ -389,7 +388,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
 
         new TxIdGeneratorModeSwitcher( memberStateMachine, txIdGeneratorDelegate,
                 (HaXaDataSourceManager) xaDataSourceManager, masterDelegateInvocationHandler, requestContextFactory,
-                msgLog, config, slaves, txManager );
+                msgLog, config, slaves, txManager, jobScheduler );
         return txIdGenerator;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -75,7 +75,6 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.Logging;
 
 import static java.lang.String.format;
-
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
 /**

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
@@ -19,11 +19,13 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
+import java.io.PrintStream;
+
 import org.neo4j.com.Response;
 import org.neo4j.com.ServerUtil;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 
@@ -43,11 +45,14 @@ public class SlaveImpl implements Slave
         this.xaDsm = xaDsm;
     }
 
+    private static PrintStream out = System.out;
     @Override
     public Response<Void> pullUpdates( String resource, long upToAndIncludingTxId )
     {
-        // Pull updates from the master
+        long start = System.currentTimeMillis(), delta;
         xaDsm.applyTransactions( master.pullUpdates( requestContextFactory.newRequestContext( 0 ) ), ServerUtil.NO_ACTION );
+        if( (delta=System.currentTimeMillis() - start) > 100)
+            out.println("  WARN: master.pullUpdates() " + delta + "ms." );
         return ServerUtil.packResponseWithoutTransactionStream( storeId, null );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.transaction;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+import org.neo4j.com.Response;
+import org.neo4j.kernel.ha.com.master.Slave;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.masterTransactionPushing;
+
+public class CommitPusher extends LifecycleAdapter
+{
+    private static class PullUpdateFuture
+            extends FutureTask<Object>
+    {
+        private Slave slave;
+        private long txId;
+
+        public PullUpdateFuture( Slave slave, long txId )
+        {
+            super( new Callable<Object>()
+            {
+                @Override
+                public Object call() throws Exception
+                {
+                    return null;
+                }
+            });
+            this.slave = slave;
+            this.txId = txId;
+        }
+
+        @Override
+        public void done()
+        {
+            super.set( null );
+            super.done();
+        }
+
+        @Override
+        public void setException( Throwable t )
+        {
+            super.setException( t );
+        }
+
+        public Slave getSlave()
+        {
+            return slave;
+        }
+
+        private long getTxId()
+        {
+            return txId;
+        }
+    }
+
+    private final Map<Integer, BlockingQueue<PullUpdateFuture>> pullUpdateQueues = new HashMap<>(  );
+    private final JobScheduler scheduler;
+
+    public CommitPusher( JobScheduler scheduler )
+    {
+        this.scheduler = scheduler;
+    }
+
+    public void queuePush( final XaDataSource dataSource, Slave slave, final long txId )
+    {
+        PullUpdateFuture pullRequest = new PullUpdateFuture(slave, txId);
+
+        BlockingQueue<PullUpdateFuture> queue = pullUpdateQueues.get( slave.getServerId() );
+
+        // Create a new queue if needed
+        queue = queue == null ? createNewQueue( dataSource, slave ) : queue;
+
+        // Add our request to the queue
+        while( !queue.offer( pullRequest ) )
+        {
+            Thread.yield();
+        }
+
+        try
+        {
+            // Wait for request to finish
+            pullRequest.get();
+        }
+        catch ( InterruptedException e )
+        {
+            Thread.interrupted(); // Clear interrupt flag
+            throw new RuntimeException( e );
+        }
+        catch ( ExecutionException e )
+        {
+            if (e.getCause() instanceof RuntimeException)
+                throw ((RuntimeException)e.getCause());
+            else
+                throw new RuntimeException( e.getCause() );
+        }
+    }
+
+    private synchronized BlockingQueue<PullUpdateFuture> createNewQueue( final XaDataSource dataSource, Slave slave )
+    {
+        BlockingQueue<PullUpdateFuture> queue = pullUpdateQueues.get( slave.getServerId() );
+        if (queue == null)
+        {
+            // Create queue and worker
+            queue = new ArrayBlockingQueue<>( 100 );
+            pullUpdateQueues.put( slave.getServerId(), queue );
+
+            final BlockingQueue<PullUpdateFuture> finalQueue = queue;
+            scheduler.schedule( masterTransactionPushing, new Runnable()
+            {
+                List<PullUpdateFuture> currentPulls = new ArrayList<>();
+
+                @Override
+                public void run()
+                {
+                    try
+                    {
+                        while (true)
+                        {
+                            // Poll queue and call pullUpdate
+                            currentPulls.clear();
+                            currentPulls.add( finalQueue.take() );
+
+                            finalQueue.drainTo( currentPulls );
+
+                            try
+                            {
+                                PullUpdateFuture pullUpdateFuture = currentPulls.get( 0 );
+                                Response<Void> response = pullUpdateFuture.getSlave().pullUpdates( dataSource.getName(), pullUpdateFuture.getTxId() );
+                                response.close();
+
+                                // Notify the futures
+                                for ( PullUpdateFuture currentPull : currentPulls )
+                                {
+                                    currentPull.done();
+                                }
+                            }
+                            catch ( Exception e )
+                            {
+                                // Notify the futures
+                                for ( PullUpdateFuture currentPull : currentPulls )
+                                {
+                                    currentPull.setException( e );
+                                }
+                            }
+                        }
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        // Quit
+                    }
+                }
+            } );
+        }
+        return queue;
+    }
+
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -40,8 +39,7 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
@@ -71,7 +69,8 @@ public class TxPushStrategyConfigIT
         startCluster( 5, 2, "round_robin" );
 
         createTransactionOnMaster();
-        assertLastTransactions( lastTx( FIRST_SLAVE, 2 ), lastTx( SECOND_SLAVE, 2 ), lastTx( THIRD_SLAVE, 1 ), lastTx( FOURTH_SLAVE, 1 ) );
+        assertLastTransactions( lastTx( FIRST_SLAVE, 2 ), lastTx( SECOND_SLAVE, 2 ), lastTx( THIRD_SLAVE, 1 ),
+                lastTx( FOURTH_SLAVE, 1 ) );
 
         createTransactionOnMaster();
         assertLastTransactions( lastTx( FIRST_SLAVE, 2 ), lastTx( SECOND_SLAVE, 3 ), lastTx( THIRD_SLAVE, 3 ), lastTx( FOURTH_SLAVE, 1 ) );


### PR DESCRIPTION
 o Moves half the master -> slave push logic to its own class
 o Background slave pusher now uses the Neo Scheduler for its threads
 o Fixes a bug where the previous implementation didn't take into account
   that the queue of pushes sometimes does not accept another item,
   leading to the committing thread waiting for a callback that never
   gets called.

 o Remaining: There are still two pools of threads used for the pushing,
              it should all be consolidated into one service.
 o Remaining: The current implementation still leaks threads in a long
              running cluster. It maps threads to slaves, but does not
              do any cleanup if a slave disconnects. It would probably
              be better to consolidate all pushing into a single background
              thread.
 o Remaining: The push protocol is still master-[notify]->slave-[pull]->master
              it should be master-[push]->slave
