### PR TITLE
Handle concurrent store copy and logical log pruning

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -685,6 +685,18 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
         return fileListing.listStoreFiles( includeLogicalLogs );
     }
 
+    @Override
+    public ResourceIterator<File> listStoreFiles() throws IOException
+    {
+        return fileListing.listStoreFiles();
+    }
+
+    @Override
+    public ResourceIterator<File> listLogicalLogs() throws IOException
+    {
+        return fileListing.listLogicalLogs();
+    }
+
     public void registerDiagnosticsWith( DiagnosticsManager manager )
     {
         manager.registerAll( Diagnostics.class, this );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -276,6 +276,16 @@ public abstract class XaDataSource implements Lifecycle
         throw new UnsupportedOperationException( getClass().getName() );
     }
 
+    public ResourceIterator<File> listStoreFiles(  ) throws IOException
+    {
+        throw new UnsupportedOperationException( getClass().getName() );
+    }
+
+    public ResourceIterator<File> listLogicalLogs(  ) throws IOException
+    {
+        throw new UnsupportedOperationException( getClass().getName() );
+    }
+
     /**
      * Returns previous value
      */

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreFileListingTest.java
@@ -114,6 +114,51 @@ public class NeoStoreFileListingTest
     }
 
     @Test
+    public void shouldOnlyListLogicalLogs() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        // When
+        ResourceIterator<File> result = fileListing.listLogicalLogs();
+
+        // Then
+        assertThat( asSetOfPaths( result ), equalTo( asSet(
+                "nioneo_logical.log.v0",
+                "nioneo_logical.log.v1",
+                "nioneo_logical.log.v2") ) );
+    }
+
+    @Test
+    public void shouldOnlyListNeoStoreFiles() throws Exception
+    {
+        // Given
+        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
+        NeoStoreFileListing fileListing = newFileListing();
+
+        // When
+        ResourceIterator<File> result = fileListing.listStoreFiles(  );
+
+        // Then
+        assertThat( asSetOfPaths( result ), equalTo( asSet(
+                "neostore.labeltokenstore.db",
+                "neostore.labeltokenstore.db.names",
+                "neostore.nodestore.db",
+                "neostore.nodestore.db.labels",
+                "neostore.propertystore.db",
+                "neostore.propertystore.db.arrays",
+                "neostore.propertystore.db.index",
+                "neostore.propertystore.db.index.keys",
+                "neostore.propertystore.db.strings",
+                "neostore.relationshipstore.db",
+                "neostore.relationshiptypestore.db",
+                "neostore.relationshiptypestore.db.names",
+                "neostore.schemastore.db",
+                "neostore" ) ) );
+    }
+
+    @Test
     public void shouldListNeoStoreFiles() throws Exception
     {
         // Given

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -74,6 +74,7 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.helpers.UTF8;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.PrefetchingResourceIterator;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.TransactionInterceptorProviders;
@@ -922,6 +923,18 @@ public class LuceneDataSource extends LogBackedXaDataSource
                 }
             }
         };
+    }
+
+    @Override
+    public ResourceIterator<File> listStoreFiles() throws IOException
+    {
+        return listStoreFiles( false );
+    }
+
+    @Override
+    public ResourceIterator<File> listLogicalLogs() throws IOException
+    {
+        return IteratorUtil.emptyIterator();
     }
 
     private void makeSureAllIndexesAreInstantiated()

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -24,6 +24,7 @@ import org.neo4j.com.Response;
 import org.neo4j.com.ServerUtil;
 import org.neo4j.com.StoreWriter;
 import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
@@ -54,7 +55,7 @@ class BackupImpl implements TheBackupInterface
     {
         RequestContext context = ServerUtil.rotateLogsAndStreamStoreFiles( spi.getStoreDir(),
                 xaDataSourceManager,
-                kpeg, logger, false, writer );
+                kpeg, logger, false, writer, new DefaultFileSystemAbstraction() );
         writer.done();
         return packResponse( context );
     }

--- a/enterprise/com/pom.xml
+++ b/enterprise/com/pom.xml
@@ -131,6 +131,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerUtilTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerUtilTest.java
@@ -1,0 +1,542 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.regex.Pattern;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.Function;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.impl.nioneo.store.FileLock;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.kernel.impl.transaction.xaframework.XaContainer;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
+import org.neo4j.kernel.impl.transaction.xaframework.XaResourceManager;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServerUtilTest
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.cleanTestDirForTest( getClass() );
+
+    @Test
+    public void shouldIgnoreLogicalLogsWhenCopyingFilesForBackup() throws IOException
+    {
+        // given
+        final FileSystemAbstraction fs = new StubFileSystemAbstraction();
+
+        XaDataSource dataSource = mock( XaDataSource.class );
+
+        FileResourceIterator storeFiles = new FileResourceIterator( fs, testDirectory, "neostore.nodestore.db" );
+        FileResourceIterator logicalLogs = new FileResourceIterator( fs, testDirectory, "nioneo_logical.log.v0" );
+
+        when( dataSource.listStoreFiles() ).thenReturn( storeFiles );
+        when( dataSource.listLogicalLogs() ).thenReturn( logicalLogs );
+        when( dataSource.getBranchId() ).thenReturn( "branch".getBytes() );
+        when( dataSource.getName() ).thenReturn( "branch" );
+
+        XaContainer xaContainer = mock( XaContainer.class );
+        when( dataSource.getXaContainer() ).thenReturn( xaContainer );
+
+        XaLogicalLog xaLogicalLog = mock( XaLogicalLog.class );
+
+        when( xaContainer.getLogicalLog() ).thenReturn( xaLogicalLog );
+
+        XaResourceManager xaResourceManager = mock( XaResourceManager.class );
+        when( xaContainer.getResourceManager() ).thenReturn( xaResourceManager );
+
+        XaDataSourceManager dsManager = new XaDataSourceManager( StringLogger.DEV_NULL );
+        dsManager.registerDataSource( dataSource );
+
+        KernelPanicEventGenerator kernelPanicEventGenerator = mock( KernelPanicEventGenerator.class );
+        StoreWriter storeWriter = mock( StoreWriter.class );
+
+        // when
+        ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
+                StringLogger.DEV_NULL, false, storeWriter, fs );
+
+        // then 
+        verify( storeWriter ).write( eq( "neostore.nodestore.db" ), any( ReadableByteChannel.class ),
+                any( ByteBuffer.class ), any( Boolean.class ) );
+        verify( storeWriter, never() ).write( eq( "nioneo_logical.log.v0" ), any( ReadableByteChannel.class ),
+                any( ByteBuffer.class ), any( Boolean.class ) );
+
+    }
+    
+    @Test
+    public void shouldCopyLogicalLogFile() throws IOException
+    {
+        // given
+        final FileSystemAbstraction fs = new StubFileSystemAbstraction();
+
+        XaDataSource dataSource = mock( XaDataSource.class );
+
+        FileResourceIterator storeFiles = new FileResourceIterator( fs, testDirectory );
+        FileResourceIterator logicalLogs = new FileResourceIterator( fs, testDirectory, "nioneo_logical.log.v0" );
+
+        when( dataSource.listStoreFiles() ).thenReturn( storeFiles );
+        when( dataSource.listLogicalLogs() ).thenReturn( logicalLogs );
+        when( dataSource.getBranchId() ).thenReturn( "branch".getBytes() );
+        when( dataSource.getName() ).thenReturn( "branch" );
+
+        XaContainer xaContainer = mock( XaContainer.class );
+        when( dataSource.getXaContainer() ).thenReturn( xaContainer );
+
+        XaLogicalLog xaLogicalLog = mock( XaLogicalLog.class );
+
+        when( xaContainer.getLogicalLog() ).thenReturn( xaLogicalLog );
+
+        XaResourceManager xaResourceManager = mock( XaResourceManager.class );
+        when( xaContainer.getResourceManager() ).thenReturn( xaResourceManager );
+
+        XaDataSourceManager dsManager = new XaDataSourceManager( StringLogger.DEV_NULL );
+        dsManager.registerDataSource( dataSource );
+
+        KernelPanicEventGenerator kernelPanicEventGenerator = mock( KernelPanicEventGenerator.class );
+        StoreWriter storeWriter = mock( StoreWriter.class );
+
+        // when
+        ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
+                StringLogger.DEV_NULL, true, storeWriter, fs );
+
+        // then
+        verify( storeWriter ).write( eq( "nioneo_logical.log.v0" ), any( ReadableByteChannel.class ),
+                any( ByteBuffer.class ), any( Boolean.class ) );
+    }
+
+    @Test
+    public void shouldNotThrowFileNotFoundExceptionWhenTryingToCopyAMissingLogicalLogFile() throws IOException
+    {
+        // given
+        final FileSystemAbstraction fs = new StubFileSystemAbstraction();
+
+        XaDataSource dataSource = mock( XaDataSource.class );
+
+        FileResourceIterator storeFiles = new FileResourceIterator( fs, testDirectory, "neostore.nodestore.db" );
+
+        FileResourceIterator logicalLogs = new FileResourceIterator( fs, testDirectory, "nioneo_logical.log.v0" );
+        logicalLogs.deleteBeforeCopy( "nioneo_logical.log.v0" );
+
+        when( dataSource.listStoreFiles() ).thenReturn( storeFiles );
+        when( dataSource.listLogicalLogs() ).thenReturn( logicalLogs );
+
+        when( dataSource.getBranchId() ).thenReturn( "branch".getBytes() );
+        when( dataSource.getName() ).thenReturn( "branch" );
+
+        XaContainer xaContainer = mock( XaContainer.class );
+        when( dataSource.getXaContainer() ).thenReturn( xaContainer );
+
+        XaResourceManager xaResourceManager = mock( XaResourceManager.class );
+        when( xaContainer.getResourceManager() ).thenReturn( xaResourceManager );
+
+        XaDataSourceManager dsManager = new XaDataSourceManager( StringLogger.DEV_NULL );
+        dsManager.registerDataSource( dataSource );
+
+        KernelPanicEventGenerator kernelPanicEventGenerator = mock( KernelPanicEventGenerator.class );
+        StoreWriter storeWriter = mock( StoreWriter.class );
+
+        // when
+        ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
+                StringLogger.DEV_NULL, true, storeWriter, fs );
+
+        // then
+        verify( storeWriter ).write( eq( "neostore.nodestore.db" ), any( ReadableByteChannel.class ),
+                any( ByteBuffer.class ), any( Boolean.class ) );
+    }
+
+    @Test
+    public void shouldThrowFileNotFoundExceptionWhenTryingToCopyAStoreFileWhichDoesNotExist() throws IOException
+    {
+        // given
+        final FileSystemAbstraction fs = new StubFileSystemAbstraction();
+
+        XaDataSource dataSource = mock( XaDataSource.class );
+
+        FileResourceIterator storeFiles = new FileResourceIterator( fs, testDirectory, "neostore.nodestore.db" );
+        storeFiles.deleteBeforeCopy( "neostore.nodestore.db" );
+
+        FileResourceIterator logicalLogs = new FileResourceIterator( fs, testDirectory );
+
+        when( dataSource.listStoreFiles() ).thenReturn( storeFiles );
+        when( dataSource.listLogicalLogs() ).thenReturn( logicalLogs );
+
+
+        when( dataSource.getBranchId() ).thenReturn( "branch".getBytes() );
+        when( dataSource.getName() ).thenReturn( "branch" );
+
+        XaContainer xaContainer = mock( XaContainer.class );
+        when( dataSource.getXaContainer() ).thenReturn( xaContainer );
+
+        XaResourceManager xaResourceManager = mock( XaResourceManager.class );
+        when( xaContainer.getResourceManager() ).thenReturn( xaResourceManager );
+
+        XaDataSourceManager dsManager = new XaDataSourceManager( StringLogger.DEV_NULL );
+        dsManager.registerDataSource( dataSource );
+
+        KernelPanicEventGenerator kernelPanicEventGenerator = mock( KernelPanicEventGenerator.class );
+        StoreWriter storeWriter = mock( StoreWriter.class );
+
+        // when
+        try
+        {
+            ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager,
+                    kernelPanicEventGenerator,
+                    StringLogger.DEV_NULL, true, storeWriter, fs );
+            fail( "should have thrown exception" );
+        }
+        catch ( ServerFailureException e )
+        {
+            // then
+            assertEquals( java.io.FileNotFoundException.class, e.getCause().getClass() );
+        }
+    }
+
+    private static class FileResourceIterator implements ResourceIterator<File>
+    {
+        private final FileSystemAbstraction fs;
+        private final TargetDirectory.TestDirectory testDirectory;
+        private Queue<String> files;
+        private String nextFilePath;
+        private List<String> filesToDelete = new ArrayList<>();
+
+        public FileResourceIterator( FileSystemAbstraction fs, TargetDirectory.TestDirectory testDirectory,
+                                     String... files )
+        {
+            this.fs = fs;
+            this.testDirectory = testDirectory;
+            this.files = new ArrayBlockingQueue<>( files.length == 0 ? 1 : files.length, true, Arrays.asList( files ) );
+        }
+
+        @Override
+        public void close()
+        {
+
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            nextFilePath = files.poll();
+            return nextFilePath != null;
+        }
+
+        @Override
+        public File next()
+        {
+            File file = new File( String.format( "%s/%s", testDirectory.directory(), nextFilePath ) );
+            try
+            {
+                fs.create( file );
+            }
+            catch ( IOException e )
+            {
+                e.printStackTrace();
+            }
+
+            if ( filesToDelete.contains( nextFilePath ) )
+            {
+                fs.deleteFile( file );
+            }
+
+            return file;
+        }
+
+        @Override
+        public void remove()
+        {
+
+        }
+
+        public void deleteBeforeCopy( String filePath )
+        {
+            filesToDelete.add( filePath );
+        }
+    }
+
+    private class StubFileSystemAbstraction implements FileSystemAbstraction
+    {
+        private List<File> files = new ArrayList<>();
+
+        @Override
+        public FileChannel open( File fileName, String mode ) throws IOException
+        {
+            if ( files.contains( fileName ) )
+            {
+                FileChannel fileChannel = new FileChannel()
+                {
+                    @Override
+                    public int read( ByteBuffer dst ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public long read( ByteBuffer[] dsts, int offset, int length ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public int write( ByteBuffer src ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public long write( ByteBuffer[] srcs, int offset, int length ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public long position() throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public FileChannel position( long newPosition ) throws IOException
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public long size() throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public FileChannel truncate( long size ) throws IOException
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public void force( boolean metaData ) throws IOException
+                    {
+
+                    }
+
+                    @Override
+                    public long transferTo( long position, long count, WritableByteChannel target ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public long transferFrom( ReadableByteChannel src, long position, long count ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public int read( ByteBuffer dst, long position ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public int write( ByteBuffer src, long position ) throws IOException
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public MappedByteBuffer map( MapMode mode, long position, long size ) throws IOException
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public java.nio.channels.FileLock lock( long position, long size,
+                                                            boolean shared ) throws IOException
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public java.nio.channels.FileLock tryLock( long position, long size,
+                                                               boolean shared ) throws IOException
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    protected void implCloseChannel() throws IOException
+                    {
+
+                    }
+                };
+                return fileChannel;
+            }
+            throw new FileNotFoundException( fileName.getPath() );
+        }
+
+        @Override
+        public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException
+        {
+            return null;
+        }
+
+        @Override
+        public InputStream openAsInputStream( File fileName ) throws IOException
+        {
+            return null;
+        }
+
+        @Override
+        public Reader openAsReader( File fileName, String encoding ) throws IOException
+        {
+            return null;
+        }
+
+        @Override
+        public Writer openAsWriter( File fileName, String encoding, boolean append ) throws IOException
+        {
+            return null;
+        }
+
+        @Override
+        public FileLock tryLock( File fileName, FileChannel channel ) throws IOException
+        {
+            return null;
+        }
+
+        @Override
+        public FileChannel create( File fileName ) throws IOException
+        {
+            files.add( fileName );
+            return null;
+        }
+
+        @Override
+        public boolean fileExists( File fileName )
+        {
+            return files.contains( fileName );
+        }
+
+        @Override
+        public boolean mkdir( File fileName )
+        {
+            return false;
+        }
+
+        @Override
+        public void mkdirs( File fileName ) throws IOException
+        {
+
+        }
+
+        @Override
+        public long getFileSize( File fileName )
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean deleteFile( File fileName )
+        {
+            files.remove( fileName );
+            return false;
+        }
+
+        @Override
+        public void deleteRecursively( File directory ) throws IOException
+        {
+
+        }
+
+        @Override
+        public boolean renameFile( File from, File to ) throws IOException
+        {
+            return false;
+        }
+
+        @Override
+        public File[] listFiles( File directory )
+        {
+            return new File[0];
+        }
+
+        @Override
+        public boolean isDirectory( File file )
+        {
+            return false;
+        }
+
+        @Override
+        public void moveToDirectory( File file, File toDirectory ) throws IOException
+        {
+
+        }
+
+        @Override
+        public void copyFile( File from, File to ) throws IOException
+        {
+
+        }
+
+        @Override
+        public void copyRecursively( File fromDirectory, File toDirectory ) throws IOException
+        {
+
+        }
+
+        @Override
+        public <K extends ThirdPartyFileSystem> K getOrCreateThirdPartyFileSystem( Class<K> clazz, Function<Class<K>,
+                K> creator )
+        {
+            return null;
+        }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Predicate;
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -202,7 +203,8 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
                 kernelPanicEventGenerator,
                 logging.getMessagesLog( MasterImpl.class ),
                 true,
-                writer );
+                writer,
+                new DefaultFileSystemAbstraction());
     }
 
     @Override


### PR DESCRIPTION
o Previously a FileNotFoundException got thrown on a logical
  log file which gets pruned due to log rotation half way
  through a store copy.
o Check logical logs exist before attempting to copy them. If
  they don't exist then it shouldn't matter because they will
  be old ones anyway
o Split up NeoStoreFileListing to return logical logs and
  store files separately. This means there's a double pass of
  the files on FS so will add a benchmark to check this isn't
  detrimental
