### PR TITLE
Moves status codes into kernel.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/EntityNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/EntityNotFoundException.java
@@ -25,11 +25,11 @@ public class EntityNotFoundException extends KernelException
 {
     public EntityNotFoundException( EntityType entityType, long entityId, Throwable cause )
     {
-        super( cause, "Unable to load %s with id %s.", entityType.name(), entityId );
+        super( Status.Statement.EntityNotFound, cause, "Unable to load %s with id %s.", entityType.name(), entityId );
     }
 
     public EntityNotFoundException( EntityType entityType, long entityId )
     {
-        super( "Unable to load %s with id %s.", entityType.name(), entityId );
+        super( Status.Statement.EntityNotFound, "Unable to load %s with id %s.", entityType.name(), entityId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/InvalidTransactionTypeKernelException.java
@@ -23,6 +23,6 @@ public class InvalidTransactionTypeKernelException extends KernelException
 {
     public InvalidTransactionTypeKernelException(String message)
     {
-        super( (Throwable) null, message );
+        super( Status.Transaction.InvalidType, (Throwable) null, message );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/KernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/KernelException.java
@@ -24,33 +24,25 @@ import org.neo4j.kernel.api.TokenNameLookup;
 /** A super class of checked exceptions coming from the {@link org.neo4j.kernel.api.KernelAPI Kernel API}. */
 public abstract class KernelException extends Exception
 {
-    protected KernelException( Throwable cause, String message, Object... parameters )
+    private final Status statusCode;
+
+    protected KernelException( Status statusCode, Throwable cause, String message, Object... parameters )
     {
-        this( message, parameters );
+        super( String.format( message, parameters ) );;
+        this.statusCode = statusCode;
         initCause( cause );
     }
-    
-    protected KernelException( String message, Object... parameters )
+
+    protected KernelException( Status statusCode, String message, Object... parameters )
     {
-        super( String.format( message, parameters ) );
+        super( String.format( message, parameters ) );;
+        this.statusCode = statusCode;
     }
 
-    @Deprecated
-    public KernelException( String message, Throwable cause )
+    /** The Neo4j status code associated with this exception type. */
+    public Status status()
     {
-        super( message, cause );
-    }
-
-    @Deprecated
-    public KernelException( String message )
-    {
-        super( message );
-    }
-
-    @Deprecated
-    public KernelException( Throwable cause )
-    {
-        super( cause );
+        return statusCode;
     }
 
     public String getUserMessage( TokenNameLookup tokenNameLookup )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/LabelNotFoundKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/LabelNotFoundKernelException.java
@@ -23,6 +23,6 @@ public class LabelNotFoundKernelException extends KernelException
 {
     public LabelNotFoundKernelException( String message, Exception cause )
     {
-        super( message, cause );
+        super( Status.Schema.NoSuchLabel, cause, message);
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyIdNotFoundKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyIdNotFoundKernelException.java
@@ -23,6 +23,6 @@ public class PropertyKeyIdNotFoundKernelException extends KernelException
 {
     public PropertyKeyIdNotFoundKernelException( int propertyKeyId, Exception cause )
     {
-        super( cause, "Property key id '%s' not found", propertyKeyId );
+        super( Status.Schema.NoSuchPropertyKey, cause, "Property key id '%s' not found", propertyKeyId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyKeyNotFoundException.java
@@ -21,13 +21,8 @@ package org.neo4j.kernel.api.exceptions;
 
 public class PropertyKeyNotFoundException extends KernelException
 {
-    public PropertyKeyNotFoundException( String propertyKey )
-    {
-        super( "Property key '" + propertyKey + "' not found" );
-    }
-    
     public PropertyKeyNotFoundException( String propertyKey, Exception cause )
     {
-        super( "Property key '" + propertyKey + "' not found", cause );
+        super( Status.Schema.NoSuchPropertyKey, cause, "Property key '" + propertyKey + "' not found" );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/PropertyNotFoundException.java
@@ -37,7 +37,7 @@ public class PropertyNotFoundException extends KernelException
 
     private PropertyNotFoundException( String entity, int propertyKeyId )
     {
-        super( "%s has no property with propertyKeyId=%s.", entity, propertyKeyId );
+        super( Status.Statement.NoSuchProperty, "%s has no property with propertyKeyId=%s.", entity, propertyKeyId );
         this.entity = entity;
         this.propertyKeyId = propertyKeyId;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReadOnlyDatabaseKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReadOnlyDatabaseKernelException.java
@@ -19,12 +19,10 @@
  */
 package org.neo4j.kernel.api.exceptions;
 
-import org.neo4j.kernel.api.exceptions.KernelException;
-
 public class ReadOnlyDatabaseKernelException extends KernelException
 {
     public ReadOnlyDatabaseKernelException()
     {
-        super( (Throwable) null, "Cannot modify a read-only database" );
+        super( Status.General.ReadOnly, (Throwable) null, "Cannot modify a read-only database" );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeIdNotFoundKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/RelationshipTypeIdNotFoundKernelException.java
@@ -23,6 +23,6 @@ public class RelationshipTypeIdNotFoundKernelException extends KernelException
 {
     public RelationshipTypeIdNotFoundKernelException( long relationshipTypeId, Exception cause )
     {
-        super( cause, "Relationship type id '%s' not found", relationshipTypeId );
+        super( Status.Schema.NoSuchRelationshipType, cause, "Relationship type id '%s' not found", relationshipTypeId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReleaseLocksFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ReleaseLocksFailedKernelException.java
@@ -23,6 +23,6 @@ public class ReleaseLocksFailedKernelException extends KernelException
 {
     public ReleaseLocksFailedKernelException( String msg, Exception releaseException )
     {
-        super(releaseException, msg);
+        super(Status.Transaction.ReleaseLocksFailed, releaseException, msg);
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/FlipFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/FlipFailedKernelException.java
@@ -20,16 +20,17 @@
 package org.neo4j.kernel.api.exceptions.index;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public abstract class FlipFailedKernelException extends KernelException
 {
     public FlipFailedKernelException( Throwable cause, String message, Object... parameters )
     {
-        super( cause, message, parameters );
+        super( Status.Schema.IndexCreationFailure, cause, message, parameters );
     }
 
     public FlipFailedKernelException( String message, Object... parameters )
     {
-        super( message, parameters );
+        super( Status.Schema.IndexCreationFailure, message, parameters );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexActivationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexActivationFailedKernelException.java
@@ -20,11 +20,12 @@
 package org.neo4j.kernel.api.exceptions.index;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class IndexActivationFailedKernelException extends KernelException
 {
     public IndexActivationFailedKernelException( Throwable cause, String message )
     {
-        super( cause, message );
+        super( Status.Schema.IndexCreationFailure, cause, message );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotFoundKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexNotFoundKernelException.java
@@ -20,16 +20,17 @@
 package org.neo4j.kernel.api.exceptions.index;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class IndexNotFoundKernelException extends KernelException
 {
     public IndexNotFoundKernelException( String message, Throwable cause )
     {
-        super( cause, message );
+        super( Status.Schema.NoSuchIndex, cause, message );
     }
 
     public IndexNotFoundKernelException( String msg )
     {
-        super( msg );
+        super( Status.Schema.NoSuchIndex, msg );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.index;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 public class IndexPopulationFailedKernelException extends KernelException
@@ -29,13 +30,14 @@ public class IndexPopulationFailedKernelException extends KernelException
     public IndexPopulationFailedKernelException( IndexDescriptor descriptor, String indexUserDescription,
                                                  Throwable cause )
     {
-        super( cause, FORMAT_MESSAGE, indexUserDescription, descriptor.getLabelId(), descriptor.getPropertyKeyId() );
+        super( Status.Schema.IndexCreationFailure, cause, FORMAT_MESSAGE, indexUserDescription,
+                descriptor.getLabelId(), descriptor.getPropertyKeyId() );
     }
 
     public IndexPopulationFailedKernelException( IndexDescriptor descriptor, String indexUserDescription,
                                                  String message )
     {
-        super( FORMAT_MESSAGE + ", due to " + message,
+        super( Status.Schema.IndexCreationFailure, FORMAT_MESSAGE + ", due to " + message,
                indexUserDescription, descriptor.getLabelId(), descriptor.getPropertyKeyId() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AddIndexFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AddIndexFailureException.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 import static java.lang.String.format;
@@ -34,7 +35,7 @@ public class AddIndexFailureException extends SchemaKernelException
 
     public AddIndexFailureException( int labelId, int propertyKey, KernelException cause )
     {
-        super( format( MESSAGE, new IndexDescriptor( labelId, propertyKey ), cause.getMessage() ), cause );
+        super( Status.Schema.IndexCreationFailure, format( MESSAGE, new IndexDescriptor( labelId, propertyKey ), cause.getMessage() ), cause );
         this.labelId = labelId;
         this.propertyKey = propertyKey;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.Status;
 
 import static java.lang.String.format;
 
@@ -31,7 +32,7 @@ public class AlreadyConstrainedException extends SchemaKernelException
 
     public AlreadyConstrainedException( UniquenessConstraint constraint )
     {
-        super( format( message, constraint ) );
+        super( Status.Schema.ConstraintAlreadyExists, format( message, constraint ) );
         this.constraint = constraint;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 public class AlreadyIndexedException extends SchemaKernelException
@@ -30,7 +31,7 @@ public class AlreadyIndexedException extends SchemaKernelException
 
     public AlreadyIndexedException( IndexDescriptor descriptor )
     {
-        super( String.format( MESSAGE, descriptor ) );
+        super( Status.Schema.IndexAlreadyExists, String.format( MESSAGE, descriptor ) );
         this.descriptor = descriptor;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ConstraintValidationKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ConstraintValidationKernelException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 /**
  * Constraint validation is the process of finding applicable constraints and verifying that
@@ -34,11 +35,11 @@ public abstract class ConstraintValidationKernelException extends KernelExceptio
 {
     protected ConstraintValidationKernelException( String message, Object... parameters )
     {
-        super( message, parameters );
+        super( Status.Schema.ConstraintViolation, message, parameters );
     }
 
     protected ConstraintValidationKernelException( Throwable cause, String message, Object... parameters )
     {
-        super( cause, message, parameters );
+        super( Status.Schema.ConstraintViolation, cause, message, parameters );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ConstraintVerificationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ConstraintVerificationFailedKernelException.java
@@ -22,10 +22,11 @@ package org.neo4j.kernel.api.exceptions.schema;
 import java.util.Collections;
 import java.util.Set;
 
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
-import org.neo4j.kernel.api.TokenNameLookup;
 
 /**
  * Constraint verification happens when a new constraint is created, and the database verifies that existing
@@ -72,14 +73,15 @@ public class ConstraintVerificationFailedKernelException extends KernelException
 
     public ConstraintVerificationFailedKernelException( UniquenessConstraint constraint, Set<Evidence> evidence )
     {
-        super( "Existing data does not satisfy %s.", constraint );
+        super( Status.Schema.ConstraintVerificationFailure, "Existing data does not satisfy %s.", constraint );
         this.constraint = constraint;
         this.evidence = evidence;
     }
 
     public ConstraintVerificationFailedKernelException( UniquenessConstraint constraint, Throwable failure )
     {
-        super( failure, "Failed to verify constraint %s: %s", constraint, failure.getMessage() );
+        super( Status.Schema.ConstraintVerificationFailure, failure, "Failed to verify constraint %s: %s", constraint,
+                failure.getMessage() );
         this.constraint = constraint;
         this.evidence = null;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/CreateConstraintFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/CreateConstraintFailureException.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.exceptions.schema;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class CreateConstraintFailureException extends SchemaKernelException
 {
@@ -29,7 +30,8 @@ public class CreateConstraintFailureException extends SchemaKernelException
 
     public CreateConstraintFailureException( UniquenessConstraint constraint, Throwable cause )
     {
-        super( cause, "Unable to create constraint %s: %s", constraint, cause.getMessage() );
+        super( Status.Schema.ConstraintCreationFailure, cause, "Unable to create constraint %s: %s", constraint,
+                cause.getMessage() );
         this.constraint = constraint;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropConstraintFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropConstraintFailureException.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class DropConstraintFailureException extends SchemaKernelException
 {
@@ -29,7 +30,7 @@ public class DropConstraintFailureException extends SchemaKernelException
 
     public DropConstraintFailureException( UniquenessConstraint constraint, Throwable cause )
     {
-        super( cause, "Unable to drop constraint %s: %s", constraint, cause.getMessage() );
+        super( Status.Schema.ConstraintDropFailure, cause, "Unable to drop constraint %s: %s", constraint, cause.getMessage() );
         this.constraint = constraint;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 import static java.lang.String.format;
@@ -32,7 +33,7 @@ public class DropIndexFailureException extends SchemaKernelException
 
     public DropIndexFailureException( IndexDescriptor indexDescriptor, SchemaKernelException cause )
     {
-        super( format( message, indexDescriptor, cause.getMessage() ), cause );
+        super( Status.Schema.IndexDropFailure, format( message, indexDescriptor, cause.getMessage() ), cause );
         this.indexDescriptor = indexDescriptor;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IllegalTokenNameException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IllegalTokenNameException.java
@@ -19,11 +19,14 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 public class IllegalTokenNameException extends SchemaKernelException
 {
     public IllegalTokenNameException( String tokenName )
     {
-        super( String.format( "%s is not a valid token name. Only non-null, non-empty strings are allowed.",
+        super( Status.Schema.IllegalTokenName,
+                String.format( "%s is not a valid token name. Only non-null, non-empty strings are allowed.",
                 tokenName != null ? "'" + tokenName + "'" : "Null" ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 import static java.lang.String.format;
@@ -31,7 +32,7 @@ public class IndexBelongsToConstraintException extends SchemaKernelException
 
     public IndexBelongsToConstraintException( IndexDescriptor index )
     {
-        super( format( "Index belongs to constraint: %s", index ) );
+        super( Status.Schema.IndexBelongsToConstraint, format( "Index belongs to constraint: %s", index ) );
         this.index = index;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBrokenKernelException.java
@@ -20,11 +20,12 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class IndexBrokenKernelException extends KernelException
 {
     public IndexBrokenKernelException( String indexFailureCause )
     {
-        super( "The index is in a failed state: '%s'.", indexFailureCause );
+        super( Status.General.FailedIndex, "The index is in a failed state: '%s'.", indexFailureCause );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/MalformedSchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/MalformedSchemaRuleException.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 /**
  * Signals that a schema rule in the schema store was malformed, i.e. contained corrupted data and could not
  * be parsed.
@@ -27,16 +29,16 @@ public class MalformedSchemaRuleException extends SchemaKernelException
 {
     public MalformedSchemaRuleException( Throwable cause, String message, Object... parameters )
     {
-        super( cause, message, parameters );
+        super( Status.General.CorruptSchemaRule, cause, message, parameters );
     }
 
     public MalformedSchemaRuleException( String message, Throwable cause )
     {
-        super( message, cause );
+        super( Status.General.CorruptSchemaRule, message, cause );
     }
 
     public MalformedSchemaRuleException( String message )
     {
-        super( message );
+        super( Status.General.CorruptSchemaRule, message );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchConstraintException.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.Status;
 
 import static java.lang.String.format;
 
@@ -31,7 +32,7 @@ public class NoSuchConstraintException extends SchemaKernelException
 
     public NoSuchConstraintException( UniquenessConstraint constraint )
     {
-        super( format( message, constraint ) );
+        super( Status.Schema.NoSuchConstraint, format( message, constraint ) );
         this.constraint = constraint;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 import static java.lang.String.format;
@@ -31,7 +32,7 @@ public class NoSuchIndexException extends SchemaKernelException
 
     public NoSuchIndexException( IndexDescriptor descriptor )
     {
-        super( format( message, descriptor ) );
+        super( Status.Schema.NoSuchIndex, format( message, descriptor ) );
         this.descriptor = descriptor;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 /**
  * Signals that some constraint has been violated in a {@link org.neo4j.kernel.api.KernelAPI kernel interaction},
@@ -27,19 +28,19 @@ import org.neo4j.kernel.api.exceptions.KernelException;
  */
 public abstract class SchemaKernelException extends KernelException
 {
-    protected SchemaKernelException( Throwable cause, String message, Object... parameters )
+    protected SchemaKernelException( Status statusCode, Throwable cause, String message, Object... parameters )
     {
-        super( cause, message, parameters );
+        super( statusCode, cause, message, parameters );
     }
 
-    public SchemaKernelException( String message, Throwable cause )
+    public SchemaKernelException( Status statusCode, String message, Throwable cause )
     {
-        super( message, cause );
+        super( statusCode, cause, message );
     }
 
-    public SchemaKernelException( String message )
+    public SchemaKernelException( Status statusCode, String message )
     {
-        super( message );
+        super( statusCode, message );
     }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleNotFoundException.java
@@ -19,18 +19,20 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 import static java.lang.String.format;
 
 public class SchemaRuleNotFoundException extends SchemaKernelException
 {
     public SchemaRuleNotFoundException( String message )
     {
-        super( message );
+        super( Status.Schema.NoSuchSchemaRule, message );
     }
 
     public SchemaRuleNotFoundException( String message, Throwable cause )
     {
-        super( message, cause );
+        super( Status.Schema.NoSuchSchemaRule, message, cause );
     }
 
     public SchemaRuleNotFoundException( long labelId, long propertyKeyId, String message )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/TooManyLabelsException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/TooManyLabelsException.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 public class TooManyLabelsException extends SchemaKernelException
 {
     public TooManyLabelsException( Throwable cause )
     {
-        super( "The maximum number of labels available has been reached. Cannot create more labels.", cause );
+        super( Status.Schema.LabelLimitReached, "The maximum number of labels available has been reached. Cannot create more labels.", cause );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exception/StatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exception/StatusTest.java
@@ -17,15 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.server.rest.transactional.error;
+package org.neo4j.kernel.api.exception;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
+import org.neo4j.kernel.api.exceptions.Status;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class StatusTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactorTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.core.Transactor;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -236,7 +237,7 @@ public class TransactorTest
     {
         protected SpecificKernelException()
         {
-            super( "very specific" );
+            super( Status.General.UnknownFailure, "very specific" );
         }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/CypherExceptionMapping.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/CypherExceptionMapping.java
@@ -40,7 +40,8 @@ import org.neo4j.cypher.ProfilerStatisticsNotReadyException;
 import org.neo4j.cypher.SyntaxException;
 import org.neo4j.cypher.UniquePathNotUniqueException;
 import org.neo4j.helpers.Function;
-import org.neo4j.server.rest.transactional.error.Status;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class CypherExceptionMapping implements Function<CypherException, Status>
 {
@@ -61,8 +62,9 @@ public class CypherExceptionMapping implements Function<CypherException, Status>
         }
         if ( CypherExecutionException.class.isInstance( e ) )
         {
-            // TODO: map the causing KernelException further...
-            return Status.Statement.ExecutionFailure;
+            // These are always caused by KernelException's, so just map to the status code from the kernel exception.
+            CypherExecutionException c = (CypherExecutionException)e;
+            return c.getCause() == null ? Status.Statement.ExecutionFailure : ((KernelException)c.getCause()).status();
         }
         if ( UniquePathNotUniqueException.class.isInstance( e ) )
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
@@ -32,20 +32,17 @@ import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.map.JsonMappingException;
-
 import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
-import org.neo4j.server.rest.transactional.error.Status;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
-
 import static org.codehaus.jackson.JsonToken.END_ARRAY;
 import static org.codehaus.jackson.JsonToken.END_OBJECT;
 import static org.codehaus.jackson.JsonToken.FIELD_NAME;
 import static org.codehaus.jackson.JsonToken.START_ARRAY;
 import static org.codehaus.jackson.JsonToken.START_OBJECT;
-
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 import static org.neo4j.helpers.collection.MapUtil.map;
 

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -29,10 +29,10 @@ import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.transactional.error.InternalBeginTransactionError;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.server.rest.web.TransactionUriScheme;
 
 /**
@@ -169,7 +169,7 @@ public class TransactionHandle
     {
         executeStatements( statements, output, errors );
 
-        if ( Status.Code.shouldRollBackOn( errors ) )
+        if ( Neo4jError.shouldRollBackOn( errors ) )
         {
             rollback( errors );
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/ErrorDocumentationGenerator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/ErrorDocumentationGenerator.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 /**
  * Generates Asciidoc for {@link Status}.
  *

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InternalBeginTransactionError.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InternalBeginTransactionError.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.transactional.error;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 public class InternalBeginTransactionError extends TransactionLifecycleException
 {
     public InternalBeginTransactionError( RuntimeException cause )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidConcurrentTransactionAccess.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidConcurrentTransactionAccess.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.transactional.error;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 public class InvalidConcurrentTransactionAccess extends TransactionLifecycleException
 {
     public InvalidConcurrentTransactionAccess()

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidTransactionId.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/InvalidTransactionId.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.transactional.error;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 public class InvalidTransactionId extends TransactionLifecycleException
 {
     public InvalidTransactionId()

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/TransactionLifecycleException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/TransactionLifecycleException.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.transactional.error;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 /**
  * TransactionLifecycleExceptions are internal exceptions that may be thrown
  * due to server transaction lifecycle transitions that map directly on a

--- a/community/server/src/test/java/org/neo4j/server/TransactionTimeoutDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/TransactionTimeoutDocIT.java
@@ -24,19 +24,16 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Test;
-
 import org.neo4j.test.server.ExclusiveServerTestBase;
 import org.neo4j.test.server.HTTP;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.exceptions.Status.Transaction.UnknownId;
 import static org.neo4j.server.configuration.Configurator.TRANSACTION_TIMEOUT;
 import static org.neo4j.server.helpers.CommunityServerBuilder.server;
-import static org.neo4j.server.rest.transactional.error.Status.Transaction.UnknownId;
 
 public class TransactionTimeoutDocIT extends ExclusiveServerTestBase
 {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/CypherExceptionMappingTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/CypherExceptionMappingTest.java
@@ -20,18 +20,19 @@
 package org.neo4j.server.rest.transactional;
 
 import org.junit.Test;
-
 import org.neo4j.cypher.CypherException;
+import org.neo4j.cypher.CypherExecutionException;
 import org.neo4j.cypher.InternalException;
 import org.neo4j.cypher.ParameterNotFoundException;
 import org.neo4j.cypher.SyntaxException;
-import org.neo4j.server.rest.transactional.error.Status;
+import org.neo4j.kernel.api.exceptions.schema.UniqueConstraintViolationKernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 
-import static org.junit.Assert.assertEquals;
-
-import static org.neo4j.server.rest.transactional.error.Status.Statement.ExecutionFailure;
-import static org.neo4j.server.rest.transactional.error.Status.Statement.InvalidSyntax;
-import static org.neo4j.server.rest.transactional.error.Status.Statement.ParameterMissing;
+import static org.junit.Assert.*;
+import static org.neo4j.kernel.api.exceptions.Status.Schema.ConstraintViolation;
+import static org.neo4j.kernel.api.exceptions.Status.Statement.ExecutionFailure;
+import static org.neo4j.kernel.api.exceptions.Status.Statement.InvalidSyntax;
+import static org.neo4j.kernel.api.exceptions.Status.Statement.ParameterMissing;
 
 public class CypherExceptionMappingTest
 {
@@ -58,6 +59,13 @@ public class CypherExceptionMappingTest
     {
         assertEquals( ExecutionFailure, map( new CypherException( "message", null ) {} ));
     }
+
+    @Test
+    public void shouldMap_CypherExecutionException_caused_by_ConstraintViolation_to_CONSTRAINT_VIOLATION() throws Exception
+    {
+        assertEquals( ConstraintViolation, map( new CypherExecutionException( "message", new UniqueConstraintViolationKernelException(1, 2, "value", 12))));
+    }
+
 
     private Status map( CypherException cypherException )
     {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -33,27 +33,21 @@ import java.util.Set;
 import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
-
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.impl.util.TestLogger;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.test.mocking.GraphMock;
 import org.neo4j.test.mocking.Link;
 
 import static java.util.Arrays.asList;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.util.TestLogger.LogCall.error;
 import static org.neo4j.server.rest.domain.JsonHelper.jsonNode;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/StatementDeserializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/StatementDeserializerTest.java
@@ -24,17 +24,13 @@ import java.io.UnsupportedEncodingException;
 import java.util.Iterator;
 
 import org.junit.Test;
-
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
-import org.neo4j.server.rest.transactional.error.Status;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.server.rest.domain.JsonHelper.createJsonFrom;
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
@@ -26,21 +26,17 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-
 import org.neo4j.kernel.impl.annotations.Documented;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
 import org.neo4j.server.rest.repr.util.RFC1123;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 import static org.neo4j.server.rest.RESTDocsGenerator.ResponseEntity;
 import static org.neo4j.server.rest.domain.JsonHelper.jsonToMap;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -30,30 +30,16 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
 import org.neo4j.cypher.SyntaxException;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.cypher.javacompat.ExecutionResult;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.server.rest.web.TransactionUriScheme;
 
 import static java.util.Arrays.asList;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-
+import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.server.rest.transactional.StubStatementDeserializer.statements;
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
@@ -20,16 +20,14 @@
 package org.neo4j.server.rest.transactional.integration;
 
 import org.junit.Test;
-
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
 import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.neo4j.server.rest.transactional.error.Status.Request.InvalidFormat;
-import static org.neo4j.server.rest.transactional.error.Status.Statement.InvalidSyntax;
+import static org.neo4j.kernel.api.exceptions.Status.Request.InvalidFormat;
+import static org.neo4j.kernel.api.exceptions.Status.Statement.InvalidSyntax;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoStackTraces;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.hasErrors;
 import static org.neo4j.test.server.HTTP.POST;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -25,11 +25,10 @@ import java.util.Set;
 
 import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
-
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.test.server.HTTP;
 import org.neo4j.test.server.HTTP.Response;
 import org.neo4j.tooling.GlobalGraphOperations;
@@ -38,9 +37,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.server.rest.domain.JsonHelper.jsonNode;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoErrors;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
@@ -29,21 +29,18 @@ import org.codehaus.jackson.JsonNode;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.util.RFC1123;
-import org.neo4j.server.rest.transactional.error.Status;
 import org.neo4j.test.server.HTTP;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 
 /**


### PR DESCRIPTION
 o Each kernel exception now has an associated status code.
 o The transactional endpoint attempts to unwrap kernel exceptions and
   return their status codes. This resolves an outstanding issue with
   constraint violation error messages.
 o Remaining: Cypher exceptions should map to status codes as well,
   obviating the need to the complex exception mapper in transactional
   endpoint.
