### PR TITLE
Fixed property loading tx state leakage

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
@@ -1407,7 +1407,7 @@ public class NeoStoreTransaction extends XaTransaction
             }
         }
 
-        RelationshipRecord relRecord = relRecords.getOrLoad( relId, null ).forReadingLinkage();
+        RelationshipRecord relRecord = getRelationshipStore().getRecord( relId );
         if ( !relRecord.inUse() )
         {
             throw new InvalidRecordException( "Relationship[" + relId + "] not in use" );
@@ -1438,7 +1438,7 @@ public class NeoStoreTransaction extends XaTransaction
             }
         }
 
-        NodeRecord nodeRecord = nodeRecords.getOrLoad( nodeId, null ).forReadingLinkage();
+        NodeRecord nodeRecord = getNodeStore().getRecord( nodeId );
         if ( !nodeRecord.inUse() )
         {
             throw new IllegalStateException( "Node[" + nodeId + "] has been deleted in this tx" );
@@ -2220,8 +2220,7 @@ public class NeoStoreTransaction extends XaTransaction
      */
     public void graphLoadProperties( boolean light, PropertyReceiver records )
     {
-        loadProperties( getPropertyStore(),
-                getOrLoadNeoStoreRecord().forReadingLinkage().getNextProp(), records );
+        loadProperties( getPropertyStore(), neoStore.asRecord().getNextProp(), records );
     }
 
     public void createSchemaRule( SchemaRule schemaRule )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -24,17 +24,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
-import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -45,85 +51,82 @@ import static org.junit.Assert.fail;
 
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cache_type;
 
-public class TestTransactionEvents extends AbstractNeo4jTestCase
+public class TestTransactionEvents
 {
     @Test
     public void testRegisterUnregisterHandlers()
     {
-        commit();
         Object value1 = 10;
         Object value2 = 3.5D;
-        DummyTransactionEventHandler<Integer> handler1 = new DummyTransactionEventHandler<Integer>(
-                (Integer) value1 );
-        DummyTransactionEventHandler<Double> handler2 = new DummyTransactionEventHandler<Double>(
-                (Double) value2 );
+        DummyTransactionEventHandler<Integer> handler1 = new DummyTransactionEventHandler<>( (Integer) value1 );
+        DummyTransactionEventHandler<Double> handler2 = new DummyTransactionEventHandler<>( (Double) value2 );
 
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
         try
         {
-            getGraphDb().unregisterTransactionEventHandler( handler1 );
-            fail( "Shouldn't be able to do unregister on a "
-                  + "unregistered handler" );
+            db.unregisterTransactionEventHandler( handler1 );
+            fail( "Shouldn't be able to do unregister on a unregistered handler" );
         }
         catch ( IllegalStateException e )
         { /* Good */
         }
 
-        assertTrue( handler1 == getGraphDb().registerTransactionEventHandler(
-                handler1 ) );
-        assertTrue( handler1 == getGraphDb().registerTransactionEventHandler(
-                handler1 ) );
-        assertTrue( handler1 == getGraphDb().unregisterTransactionEventHandler(
-                handler1 ) );
+        assertTrue( handler1 == db.registerTransactionEventHandler( handler1 ) );
+        assertTrue( handler1 == db.registerTransactionEventHandler( handler1 ) );
+        assertTrue( handler1 == db.unregisterTransactionEventHandler( handler1 ) );
 
         try
         {
-            getGraphDb().unregisterTransactionEventHandler( handler1 );
-            fail( "Shouldn't be able to do unregister on a "
-                  + "unregistered handler" );
+            db.unregisterTransactionEventHandler( handler1 );
+            fail( "Shouldn't be able to do unregister on a unregistered handler" );
         }
         catch ( IllegalStateException e )
         { /* Good */
         }
 
-        assertTrue( handler1 == getGraphDb().registerTransactionEventHandler(
+        assertTrue( handler1 == db.registerTransactionEventHandler(
                 handler1 ) );
-        assertTrue( handler2 == getGraphDb().registerTransactionEventHandler(
+        assertTrue( handler2 == db.registerTransactionEventHandler(
                 handler2 ) );
-        assertTrue( handler1 == getGraphDb().unregisterTransactionEventHandler(
+        assertTrue( handler1 == db.unregisterTransactionEventHandler(
                 handler1 ) );
-        assertTrue( handler2 == getGraphDb().unregisterTransactionEventHandler(
+        assertTrue( handler2 == db.unregisterTransactionEventHandler(
                 handler2 ) );
 
-        getGraphDb().registerTransactionEventHandler( handler1 );
-        newTransaction();
-        getGraphDb().createNode().delete();
-        commit();
+        db.registerTransactionEventHandler( handler1 );
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode().delete();
+            tx.success();
+        }
+        
         assertNotNull( handler1.beforeCommit );
         assertNotNull( handler1.afterCommit );
         assertNull( handler1.afterRollback );
         assertEquals( value1, handler1.receivedState );
         assertNotNull( handler1.receivedTransactionData );
-        getGraphDb().unregisterTransactionEventHandler( handler1 );
+        db.unregisterTransactionEventHandler( handler1 );
     }
 
     @Test
     public void makeSureHandlersCantBeRegisteredTwice()
     {
-        commit();
-        DummyTransactionEventHandler<Object> handler =
-                new DummyTransactionEventHandler<Object>( null );
-        getGraphDb().registerTransactionEventHandler( handler );
-        getGraphDb().registerTransactionEventHandler( handler );
-        newTransaction();
-        getGraphDb().createNode().delete();
-        commit();
-
+        DummyTransactionEventHandler<Object> handler = new DummyTransactionEventHandler<>( null );
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        db.registerTransactionEventHandler( handler );
+        db.registerTransactionEventHandler( handler );
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode().delete();
+            tx.success();
+        }
         assertEquals( Integer.valueOf( 0 ), handler.beforeCommit );
         assertEquals( Integer.valueOf( 1 ), handler.afterCommit );
         assertNull( handler.afterRollback );
 
-        getGraphDb().unregisterTransactionEventHandler( handler );
+        db.unregisterTransactionEventHandler( handler );
     }
 
     @Test
@@ -131,48 +134,50 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
     {
         // Create new data, nothing modified, just added/created
         ExpectedTransactionData expectedData = new ExpectedTransactionData();
-        VerifyingTransactionEventHandler handler = new VerifyingTransactionEventHandler(
-                expectedData );
-        getGraphDb().registerTransactionEventHandler( handler );
-        newTransaction();
+        VerifyingTransactionEventHandler handler = new VerifyingTransactionEventHandler( expectedData );
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        db.registerTransactionEventHandler( handler );
         Node node1 = null, node2, node3 = null;
         Relationship rel1 = null, rel2 = null;
         try
         {
-            node1 = getGraphDb().createNode();
-            expectedData.expectedCreatedNodes.add( node1 );
+            try ( Transaction tx = db.beginTx() )
+            {
+                node1 = db.createNode();
+                expectedData.expectedCreatedNodes.add( node1 );
+    
+                node2 = db.createNode();
+                expectedData.expectedCreatedNodes.add( node2 );
+    
+                rel1 = node1.createRelationshipTo( node2, RelTypes.TXEVENT );
+                expectedData.expectedCreatedRelationships.add( rel1 );
+    
+                node1.setProperty( "name", "Mattias" );
+                expectedData.assignedProperty( node1, "name", "Mattias", null );
+    
+                node1.setProperty( "last name", "Persson" );
+                expectedData.assignedProperty( node1, "last name", "Persson", null );
+    
+                node1.setProperty( "counter", 10 );
+                expectedData.assignedProperty( node1, "counter", 10, null );
+    
+                rel1.setProperty( "description", "A description" );
+                expectedData.assignedProperty( rel1, "description",
+                        "A description", null );
+    
+                rel1.setProperty( "number", 4.5D );
+                expectedData.assignedProperty( rel1, "number", 4.5D, null );
+    
+                node3 = db.createNode();
+                expectedData.expectedCreatedNodes.add( node3 );
+                rel2 = node3.createRelationshipTo( node2, RelTypes.TXEVENT );
+                expectedData.expectedCreatedRelationships.add( rel2 );
+    
+                node3.setProperty( "name", "Node 3" );
+                expectedData.assignedProperty( node3, "name", "Node 3", null );
+                tx.success();
+            }
 
-            node2 = getGraphDb().createNode();
-            expectedData.expectedCreatedNodes.add( node2 );
-
-            rel1 = node1.createRelationshipTo( node2, RelTypes.TXEVENT );
-            expectedData.expectedCreatedRelationships.add( rel1 );
-
-            node1.setProperty( "name", "Mattias" );
-            expectedData.assignedProperty( node1, "name", "Mattias", null );
-
-            node1.setProperty( "last name", "Persson" );
-            expectedData.assignedProperty( node1, "last name", "Persson", null );
-
-            node1.setProperty( "counter", 10 );
-            expectedData.assignedProperty( node1, "counter", 10, null );
-
-            rel1.setProperty( "description", "A description" );
-            expectedData.assignedProperty( rel1, "description",
-                    "A description", null );
-
-            rel1.setProperty( "number", 4.5D );
-            expectedData.assignedProperty( rel1, "number", 4.5D, null );
-
-            node3 = getGraphDb().createNode();
-            expectedData.expectedCreatedNodes.add( node3 );
-            rel2 = node3.createRelationshipTo( node2, RelTypes.TXEVENT );
-            expectedData.expectedCreatedRelationships.add( rel2 );
-
-            node3.setProperty( "name", "Node 3" );
-            expectedData.assignedProperty( node3, "name", "Node 3", null );
-
-            newTransaction();
             assertTrue( "Should have been invoked", handler.hasBeenCalled() );
             if ( handler.failure() != null )
             {
@@ -181,60 +186,62 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
         }
         finally
         {
-            getGraphDb().unregisterTransactionEventHandler( handler );
+            db.unregisterTransactionEventHandler( handler );
         }
 
         // Use the above data and modify it, change properties, delete stuff
         expectedData = new ExpectedTransactionData();
         handler = new VerifyingTransactionEventHandler( expectedData );
-        getGraphDb().registerTransactionEventHandler( handler );
-        newTransaction();
+        db.registerTransactionEventHandler( handler );
         try
         {
-            Node newNode = getGraphDb().createNode();
-            expectedData.expectedCreatedNodes.add( newNode );
-            
-            Node tempNode = getGraphDb().createNode();
-            Relationship tempRel = tempNode.createRelationshipTo( node1,
-                    RelTypes.TXEVENT );
-            tempNode.setProperty( "something", "Some value" );
-            tempRel.setProperty( "someproperty", 101010 );
-            tempNode.removeProperty( "nothing" );
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node newNode = db.createNode();
+                expectedData.expectedCreatedNodes.add( newNode );
+                
+                Node tempNode = db.createNode();
+                Relationship tempRel = tempNode.createRelationshipTo( node1,
+                        RelTypes.TXEVENT );
+                tempNode.setProperty( "something", "Some value" );
+                tempRel.setProperty( "someproperty", 101010 );
+                tempNode.removeProperty( "nothing" );
+    
+                node3.setProperty( "test", "hello" );
+                node3.setProperty( "name", "No name" );
+                node3.delete();
+                expectedData.expectedDeletedNodes.add( node3 );
+                expectedData.removedProperty( node3, "name", null, "Node 3" );
+    
+                node1.setProperty( "new name", "A name" );
+                node1.setProperty( "new name", "A better name" );
+                expectedData.assignedProperty( node1, "new name", "A better name",
+                        null );
+                node1.setProperty( "name", "Nothing" );
+                node1.setProperty( "name", "Mattias Persson" );
+                expectedData.assignedProperty( node1, "name", "Mattias Persson",
+                        "Mattias" );
+                node1.removeProperty( "counter" );
+                expectedData.removedProperty( node1, "counter", null, 10 );
+                node1.removeProperty( "last name" );
+                node1.setProperty( "last name", "Hi" );
+                expectedData.assignedProperty( node1, "last name", "Hi", "Persson" );
+    
+                rel2.delete();
+                expectedData.expectedDeletedRelationships.add( rel2 );
+    
+                rel1.removeProperty( "number" );
+                expectedData.removedProperty( rel1, "number", null, 4.5D );
+                rel1.setProperty( "description", "Ignored" );
+                rel1.setProperty( "description", "New" );
+                expectedData.assignedProperty( rel1, "description", "New",
+                        "A description" );
+    
+                tempRel.delete();
+                tempNode.delete();
+                tx.success();
+            }
 
-            node3.setProperty( "test", "hello" );
-            node3.setProperty( "name", "No name" );
-            node3.delete();
-            expectedData.expectedDeletedNodes.add( node3 );
-            expectedData.removedProperty( node3, "name", null, "Node 3" );
-
-            node1.setProperty( "new name", "A name" );
-            node1.setProperty( "new name", "A better name" );
-            expectedData.assignedProperty( node1, "new name", "A better name",
-                    null );
-            node1.setProperty( "name", "Nothing" );
-            node1.setProperty( "name", "Mattias Persson" );
-            expectedData.assignedProperty( node1, "name", "Mattias Persson",
-                    "Mattias" );
-            node1.removeProperty( "counter" );
-            expectedData.removedProperty( node1, "counter", null, 10 );
-            node1.removeProperty( "last name" );
-            node1.setProperty( "last name", "Hi" );
-            expectedData.assignedProperty( node1, "last name", "Hi", "Persson" );
-
-            rel2.delete();
-            expectedData.expectedDeletedRelationships.add( rel2 );
-
-            rel1.removeProperty( "number" );
-            expectedData.removedProperty( rel1, "number", null, 4.5D );
-            rel1.setProperty( "description", "Ignored" );
-            rel1.setProperty( "description", "New" );
-            expectedData.assignedProperty( rel1, "description", "New",
-                    "A description" );
-
-            tempRel.delete();
-            tempNode.delete();
-
-            newTransaction();
             assertTrue( "Should have been invoked", handler.hasBeenCalled() );
             if ( handler.failure() != null )
             {
@@ -243,55 +250,56 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
         }
         finally
         {
-            getGraphDb().unregisterTransactionEventHandler( handler );
+            db.unregisterTransactionEventHandler( handler );
         }
     }
 
     @Test
     public void makeSureBeforeAfterAreCalledCorrectly()
     {
-        commit();
-
         List<TransactionEventHandler<Object>> handlers = new ArrayList<>();
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), false ) );
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), false ) );
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), true ) );
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), false ) );
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
         for ( TransactionEventHandler<Object> handler : handlers )
         {
-            getGraphDb().registerTransactionEventHandler( handler );
+            db.registerTransactionEventHandler( handler );
         }
 
         try
         {
-            newTransaction();
-            getGraphDb().createNode().delete();
+            Transaction tx = db.beginTx();
             try
             {
-                commit();
+                db.createNode().delete();
+                tx.success();
+                tx.close();
                 fail( "Should fail commit" );
             }
             catch ( TransactionFailureException e )
-            {
-                // OK
+            {   // OK
             }
             verifyHandlerCalls( handlers, false );
 
-            getGraphDb().unregisterTransactionEventHandler( handlers.remove( 2 ) );
+            db.unregisterTransactionEventHandler( handlers.remove( 2 ) );
             for ( TransactionEventHandler<Object> handler : handlers )
             {
                 ((DummyTransactionEventHandler<Object>) ((FailingEventHandler<Object>)handler).source).reset();
             }
-            newTransaction();
-            getGraphDb().createNode().delete();
-            commit();
+            try ( Transaction transaction = db.beginTx() )
+            {
+                db.createNode().delete();
+                transaction.success();
+            }
             verifyHandlerCalls( handlers, true );
         }
         finally
         {
             for ( TransactionEventHandler<Object> handler : handlers )
             {
-                getGraphDb().unregisterTransactionEventHandler( handler );
+                db.unregisterTransactionEventHandler( handler );
             }
         }
     }
@@ -299,23 +307,23 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
     @Test
     public void shouldBeAbleToAccessExceptionThrownInEventHook()
     {
-        commit();
-
         class MyFancyException extends Exception 
         {
         	
         }
 
         ExceptionThrowingEventHandler handler = new ExceptionThrowingEventHandler( new MyFancyException(), null, null );
-        getGraphDb().registerTransactionEventHandler( handler );
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        db.registerTransactionEventHandler( handler );
 
         try
         {
-            newTransaction();
-            getGraphDb().createNode().delete();
+            Transaction tx = db.beginTx();
             try
             {
-                commit();
+                db.createNode().delete();
+                tx.success();
+                tx.close();
                 fail( "Should fail commit" );
             }
             catch ( TransactionFailureException e )
@@ -328,37 +336,48 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
                     {
                         return;
                     }
-                } while ( currentEx.getCause() != null );
+                }
+                while ( currentEx.getCause() != null );
                 fail("Expected to find the exception thrown in the event hook as the cause of transaction failure.");
             }
         }
         finally
         {
-            getGraphDb().unregisterTransactionEventHandler( handler );
+            db.unregisterTransactionEventHandler( handler );
         }
     }
     
     @Test
     public void deleteNodeRelTriggerPropertyRemoveEvents()
     {
-        Node node1 = getGraphDb().createNode();
-        Node node2 = getGraphDb().createNode();
-        Relationship rel = node1.createRelationshipTo( node2, RelTypes.TXEVENT );
-        node1.setProperty( "test1", "stringvalue" );
-        node1.setProperty( "test2", 1l );
-        rel.setProperty( "test1", "stringvalue" );
-        rel.setProperty( "test2", 1l );
-        rel.setProperty( "test3", new int[] { 1,2,3 } );
-        commit();
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        Node node1;
+        Node node2;
+        Relationship rel;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node1 = db.createNode();
+            node2 = db.createNode();
+            rel = node1.createRelationshipTo( node2, RelTypes.TXEVENT );
+            node1.setProperty( "test1", "stringvalue" );
+            node1.setProperty( "test2", 1l );
+            rel.setProperty( "test1", "stringvalue" );
+            rel.setProperty( "test2", 1l );
+            rel.setProperty( "test3", new int[] { 1, 2, 3 } );
+            tx.success();
+        }
         MyTxEventHandler handler = new MyTxEventHandler(); 
-        getGraphDb().registerTransactionEventHandler( handler );
-        newTransaction();
-        getGraphDbAPI().getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
-        rel.delete();
-        node1.delete();
-        node2.delete();
-        getGraphDbAPI().getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
-        commit();
+        db.registerTransactionEventHandler( handler );
+        try ( Transaction tx = db.beginTx() )
+        {
+            GraphDatabaseAPI dbApi = dbRule.getGraphDatabaseAPI();
+            dbApi.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+            rel.delete();
+            node1.delete();
+            node2.delete();
+            dbApi.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+            tx.success();
+        }
         assertEquals( "stringvalue", handler.nodeProps.get( "test1" ) );
         assertEquals( "stringvalue", handler.relProps.get( "test1" ) );
         assertEquals( 1l , handler.nodeProps.get( "test2" ) );
@@ -569,22 +588,23 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
     @Test
     public void makeSureHandlerIsntCalledWhenTxRolledBack()
     {
-        commit();
         DummyTransactionEventHandler<Integer> handler =
             new DummyTransactionEventHandler<Integer>( 10 );
-        getGraphDb().registerTransactionEventHandler( handler );
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        db.registerTransactionEventHandler( handler );
         try
         {
-            newTransaction();
-            getGraphDb().createNode().delete();
-            rollback();
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.createNode().delete();
+            }
             assertNull( handler.beforeCommit );
             assertNull( handler.afterCommit );
             assertNull( handler.afterRollback );
         }
         finally
         {
-            getGraphDb().unregisterTransactionEventHandler( handler );
+            db.unregisterTransactionEventHandler( handler );
         }
     }
     
@@ -593,12 +613,17 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
     {
         // Given
         // -- create node and set property on it in one transaction
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
         final String key = "key";
         final Object value1 = "the old value";
         final Object value2 = "the new value";
-        final Node node = getGraphDb().createNode();
-        node.setProperty( key, "initial value" );
-        commit();
+        final Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( key, "initial value" );
+            tx.success();
+        }
         // -- register a tx handler which will override a property
         TransactionEventHandler<Void> handler = new TransactionEventHandler.Adapter<Void>()
         {
@@ -611,15 +636,25 @@ public class TestTransactionEvents extends AbstractNeo4jTestCase
                 return null;
             }
         };
-        getGraphDb().registerTransactionEventHandler( handler );
+        db.registerTransactionEventHandler( handler );
         
-        // When
-        newTransaction();
-        node.setProperty( key, value1 );
-        commit();
-        
+        try ( Transaction tx = db.beginTx() )
+        {
+            // When
+            node.setProperty( key, value1 );
+            tx.success();
+        }
         // Then
-        assertThat(node, inTx(getGraphDb(), hasProperty(key).withValue(value2)));
-        getGraphDb().unregisterTransactionEventHandler( handler );
-    } 
+        assertThat(node, inTx(db, hasProperty(key).withValue(value2)));
+        db.unregisterTransactionEventHandler( handler );
+    }
+    
+    public static final @ClassRule DatabaseRule dbRule = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( cache_type, "none" );
+        }
+    };
 }


### PR DESCRIPTION
when loading properties from a node or relationship the transaction state
was considered. This is not allowed since the result of such loading goes
into the cache. Fixed by disregarding transaction state there.
