### PR TITLE
Ties each NeoStoreTransaction to the transaction state object

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.persistence.PersistenceManager.ResourceHolder;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.ArrayMap;
@@ -207,6 +208,17 @@ public class NoTransactionState implements TransactionState
 
     @Override
     public void markAsRemotelyInitialized()
+    {
+    }
+
+    @Override
+    public ResourceHolder getNeoStoreTransaction()
+    {
+        return null;
+    }
+
+    @Override
+    public void setNeoStoreTransaction( ResourceHolder neoStoreTransaction )
     {
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
@@ -24,6 +24,9 @@ import java.util.Set;
 
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransaction;
+import org.neo4j.kernel.impl.persistence.PersistenceManager;
+import org.neo4j.kernel.impl.persistence.PersistenceManager.ResourceHolder;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.util.ArrayMap;
@@ -102,6 +105,16 @@ public interface TransactionState
 
     // Tech debt, this is here waiting for transaction state to move to the TxState class
     Iterable<WritableTransactionState.CowNodeElement> getChangedNodes();
+    
+    /**
+     * Below are two methods for getting and setting a {@link ResourceHolder}, i.e. a carrier of a
+     * {@link NeoStoreTransaction}. This is not a very good strategy. The reason it's here is that it's
+     * less contended to put and reach that instance in each {@link TransactionState} object, instead of
+     * in a shared map or similar in {@link PersistenceManager}.
+     */
+    ResourceHolder getNeoStoreTransaction();
+    
+    void setNeoStoreTransaction( ResourceHolder neoStoreTransaction );
 
     /**
      * A history of slave transactions and their cultural impact on Graph Databases.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/WritableTransactionState.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.persistence.PersistenceManager.ResourceHolder;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockType;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
@@ -61,6 +62,7 @@ public class WritableTransactionState implements TransactionState
     // State
     private List<LockElement> lockElements;
     private PrimitiveElement primitiveElement;
+    private ResourceHolder neoStoreTransaction;
 
     private boolean isRemotelyInitialized = false;
 
@@ -800,5 +802,17 @@ public class WritableTransactionState implements TransactionState
     public void markAsRemotelyInitialized()
     {
         isRemotelyInitialized = true;
+    }
+
+    @Override
+    public ResourceHolder getNeoStoreTransaction()
+    {
+        return neoStoreTransaction;
+    }
+
+    @Override
+    public void setNeoStoreTransaction( ResourceHolder neoStoreTransaction )
+    {
+        this.neoStoreTransaction = neoStoreTransaction;
     }
 }


### PR DESCRIPTION
instead of in a shared (and synchronized) ArrayMap to completely remove
that contention point. It's not an optimal place for those objects, but
it's temporary fix at least.
