### PR TITLE
Ensures rolling upgrades from 1.9.5 to 1.9.6

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/snapshot/SnapshotState.java
@@ -101,8 +101,18 @@ public enum SnapshotState
                         {
                             SnapshotMessage.SnapshotState state = message.getPayload();
 
-                            // If we have already delivered everything that is rolled into this snapshot, ignore it
-                            state.setState( context.getSnapshotProvider(), context.getClusterContext().getObjectInputStreamFactory() );
+                            /*
+                             * This is here just for compatibility with 1.9.5. 1.9.6 onwards does not depend on
+                             * snapshots for setting the state on cluster join. But we cannot have rolling upgrades
+                             * from 1.9.5 to 1.9.6 without this snapshot thing because before 1.9.6 not every
+                             * masterIsElected was acknowledged with a masterIsAvailable.
+                             * On the other hand, we cannot have snapshots going around after 1.9.6. So for the
+                             * time being we'll simply have 1.9.6 master instances respond with a null state message.
+                             */
+                            if ( state != null )
+                            {
+                                state.setState( context.getSnapshotProvider(), context.getClusterContext().getObjectInputStreamFactory() );
+                            }
 
                             return ready;
                         }
@@ -153,11 +163,15 @@ public enum SnapshotState
 
                         case sendSnapshot:
                         {
-                            outgoing.offer( Message.respond( SnapshotMessage.snapshot, message,
-                                    new SnapshotMessage.SnapshotState( context.getLearnerContext()
-                                            .getLastDeliveredInstanceId(), context.getSnapshotProvider(),
-                                            context.getClusterContext().getObjectInputStreamFactory(),
-                                            context.getClusterContext().getObjectOutputStreamFactory()) ) );
+                            /*
+                             * This is here just for compatibility with 1.9.5. 1.9.6 onwards does not depend on
+                             * snapshots for setting the state on cluster join. But we cannot have rolling upgrades
+                             * from 1.9.5 to 1.9.6 without this snapshot thing because before 1.9.6 not every
+                             * masterIsElected was acknowledged with a masterIsAvailable.
+                             * On the other hand, we cannot have snapshots going around after 1.9.6. So for the
+                             * time being we'll simply have 1.9.6 master instances respond with a null state message.
+                             */
+                            outgoing.offer( Message.respond( SnapshotMessage.snapshot, message, null ) );
                             break;
                         }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.kernel.ha;
 
+import static org.neo4j.helpers.collection.Iterables.option;
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.NEW_LOGGER_CONTEXT;
+
 import java.io.File;
 import java.lang.reflect.Proxy;
 import java.net.URI;
@@ -28,8 +35,8 @@ import java.util.Map;
 
 import javax.transaction.Transaction;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.jboss.netty.logging.InternalLoggerFactory;
-
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
@@ -101,15 +108,6 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.tooling.Clock;
-
-import ch.qos.logback.classic.LoggerContext;
-
-import static org.neo4j.helpers.collection.Iterables.option;
-import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
-import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
-import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
-import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
-import static org.neo4j.kernel.logging.LogbackWeakDependency.NEW_LOGGER_CONTEXT;
 
 public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
 {
@@ -336,13 +334,14 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         // and when that election is finished refresh the snapshot
         clusterClient.addClusterListener( new ClusterListener.Adapter()
         {
-            boolean hasRequestedElection = true; // This ensures that the election result is (at least) from our
+            boolean hasRequestedElection = false; // This ensures that the election result is (at least) from our
             // request or thereafter
 
             @Override
             public void enteredCluster( ClusterConfiguration clusterConfiguration )
             {
                 clusterClient.performRoleElections();
+                hasRequestedElection = true;
             }
 
             @Override
@@ -350,7 +349,17 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
             {
                 if ( hasRequestedElection && role.equals( ClusterConfiguration.COORDINATOR ) )
                 {
+
+                    /*
+                     * This is here just for compatibility with 1.9.5. 1.9.6 onwards does not depend on
+                     * snapshots for setting the state on cluster join. But we cannot have rolling upgrades
+                     * from 1.9.5 to 1.9.6 without this snapshot thing because before 1.9.6 not every
+                     * masterIsElected was acknowledged with a masterIsAvailable.
+                     * See also SnapshotState.ready
+                     */
+                    clusterClient.refreshSnapshot();
                     clusterClient.removeClusterListener( this );
+
                 }
             }
         } );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
@@ -115,7 +115,6 @@ public final class HaBackupProvider extends BackupExtensionService
             @Override
             public void enteredCluster( ClusterConfiguration clusterConfiguration )
             {
-                clusterClient.refreshSnapshot();
                 clusterClient.removeClusterListener( this );
             }
         });


### PR DESCRIPTION
Reintroduces snapshot requests from joining instances. The reason is that
 1.9.5 instances do not provide any means of discovering the state of the
 cluster other than snapshots. So if we want 1.9.6 instances to properly
 join they have to ask and receive snapshots. But, we do not want 1.9.6
 instances to actually serve snapshots, so now the coordinator returns
 a null snapshot state which is detected and discarded. This should
 allow the 1.9.6 instances to work problem free while being able
 to replace a 1.9.5 cluster.
