### PR TITLE
Allowing for spaces and a typo

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
@@ -63,7 +63,7 @@ goto:eof
   if %command% == "" (
       if not "%1" == "" (
              echo This command is not supported by the Neo4j utility. Please try "Neo4j.bat help" for more info.
-             echo For installing Neo4j as a Windows Service, see Neo4j-Installer.bat
+             echo For installing Neo4j as a Windows Service, see Neo4jInstaller.bat
              goto:eof
       )
       set command=console
@@ -133,7 +133,7 @@ goto:eof
   goto :eof
 
 :console
-  "%javapath%\bin\java.exe" -DworkingDir="%~dps0.." -Djava.util.logging.config.file=conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar %~dps0%wrapperJarFilename%
+  "%javapath%\bin\java.exe" -DworkingDir="%~dps0.." -Djava.util.logging.config.file=conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar "%~dps0%wrapperJarFilename%"
   goto :eof
 
 :help


### PR DESCRIPTION
Allows spaces in directory structure, also fixes a quick typo regarding
the Installer bat file name.

Problem 1:
If you call `neo4j.bat install` the error message you get asks you to use `Neo4j-Installer.bat` but that doesn't exist. 

Problem 2:
If you have the standalone codebase in a folder with spaces (`d:\Neo4j Database`) you receive an error message (`Error: Unable to access jarfile d:\Neo4j`) 
