### PR TITLE
Fix for race between kernel panic and mode switching

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -66,12 +66,15 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
     /**
      * Updates the delegate for this handler, also {@link #harden() hardens} instances
      * {@link #cement(Object) cemented} from the last call to {@link #setDelegate(Object)}.
+     * This call will also dereference the {@link Concrete}, such that future calls to {@link #harden()}
+     * cannot affect any reference received from {@link #cement()} prior to this call.
      * @param delegate the new delegate to set.
      */
     public void setDelegate( T delegate )
     {
         this.delegate = delegate;
         harden();
+        concrete.invalidate();
     }
 
     /**
@@ -80,10 +83,10 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
      * will see the current delegate.
      */
     @SuppressWarnings( "unchecked" )
+
     public void harden()
     {
         ((Concrete<T>)Proxy.getInvocationHandler( concrete.evaluate() )).set( delegate );
-        concrete.invalidate();
     }
     
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -37,6 +37,7 @@ import javax.transaction.Transaction;
 
 import ch.qos.logback.classic.LoggerContext;
 import org.jboss.netty.logging.InternalLoggerFactory;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
@@ -175,7 +176,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         super.create();
 
         kernelEventHandlers.registerKernelEventHandler( new HaKernelPanicHandler( xaDataSourceManager,
-                (TxManager) txManager, availabilityGuard, masterDelegateInvocationHandler ) );
+                (TxManager) txManager, availabilityGuard, logging, masterDelegateInvocationHandler ) );
         life.add( updatePuller = new UpdatePuller( (HaXaDataSourceManager) xaDataSourceManager, master,
                 requestContextFactory, txManager, availabilityGuard, lastUpdateTime, config, msgLog ) );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DelegateInvocationHandlerTest
+{
+    @Test
+    public void shouldNotBeAbleToUseValueBeforeHardened() throws Exception
+    {
+        // GIVEN
+        DelegateInvocationHandler<Value> handler = new DelegateInvocationHandler<Value>( Value.class );
+        Value value = handler.cement();
+        
+        // WHEN
+        try
+        {
+            value.get();
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {   // THEN
+        }
+    }
+    
+    @Test
+    public void shouldBeAbleToUseCementedValueOnceDelegateSet() throws Exception
+    {
+        // GIVEN
+        DelegateInvocationHandler<Value> handler = new DelegateInvocationHandler<Value>( Value.class );
+        Value cementedValue = handler.cement();
+        
+        // WHEN setting the delegate (implies hardening it)
+        handler.setDelegate( value( 10 ) );
+        
+        // THEN
+        assertEquals( 10, cementedValue.get() );
+    }
+    
+    @Test
+    public void shouldBeAbleToUseCementedValueOnceHardened() throws Exception
+    {
+        // GIVEN
+        DelegateInvocationHandler<Value> handler = new DelegateInvocationHandler<Value>( Value.class );
+        Value cementedValue = handler.cement();
+        
+        // WHEN setting the delegate (implies hardening it)
+        handler.setDelegate( value( 10 ) );
+        
+        // THEN
+        assertEquals( 10, cementedValue.get() );
+    }
+    
+    @Test
+    public void setDelegateShouldBeAbleToOverridePreviousHarden() throws Exception
+    {
+        /* This test case stems from a race condition where a thread switching role to slave and
+         * HaKernelPanicHandler thread were competing to harden the master delegate handler.
+         * While all components were switching to their slave versions a kernel panic event came
+         * in and made its switch, ending with hardening the master delegate handler. All components
+         * would take that as a sign about the master delegate being ready to use. When the slave switching
+         * was done, that thread would set the master delegate to the actual one, but all components would
+         * have already gotten a concrete reference to the master such that the latter setDelegate call would
+         * not affect them. */
+        
+        // GIVEN
+        DelegateInvocationHandler<Value> handler = new DelegateInvocationHandler<Value>( Value.class );
+        handler.setDelegate( value( 10 ) );
+        Value cementedValue = handler.cement();
+        handler.harden();
+        
+        // WHEN setting the delegate (implies hardening it)
+        handler.setDelegate( value( 20 ) );
+        
+        // THEN
+        assertEquals( 20, cementedValue.get() );
+    }
+
+    private Value value( final int i )
+    {
+        return new Value()
+        {
+            @Override
+            public int get()
+            {
+                return i;
+            }
+        };
+    }
+
+    private interface Value
+    {
+        int get();
+    }
+}


### PR DESCRIPTION
where a thread switching role to slave and
HaKernelPanicHandler thread were competing to harden the master
delegate handler. While all components were switching to their slave
versions a kernel panic event came in and made its switch, ending with
hardening the master delegate handler. All components would take that
as a sign about the master delegate being ready to use. When the
slave switching was done, that thread would set the master delegate to
the actual one, but all components would have already gotten a concrete
reference to the master such that the latter setDelegate call would
not affect them.

Fix is to only have setDelegate() (not harden()) dereference the Concrete
instance so that a setDelegate() after harden() will override that
delegate, making it visible to the peers of it.
