### PR TITLE
Fixes an issue with phase2Timeout on proposer state

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
@@ -288,7 +288,14 @@ public enum ProposerState
                                 }
 
                                 context.setTimeout( instanceId, message.copyHeadersTo( Message.timeout(
-                                        ProposerMessage.phase1Timeout, message, message.getPayload() ), InstanceId.INSTANCE ) );
+                                        ProposerMessage.phase1Timeout, message, message.getPayload() ),
+                                        InstanceId.INSTANCE ) );
+                            }
+                            else if ( instance.isState( PaxosInstance.State.closed )
+                                    || instance.isState( PaxosInstance.State.delivered ) )
+                            {
+                                outgoing.offer( message.copyHeadersTo( Message.internal( ProposerMessage.propose,
+                                        message.getPayload() ) ) );
                             }
                             break;
                         }


### PR DESCRIPTION
When an instance times out on phase 2, if it is closed or delivered
 it should have its payload retried. This patch adds this functionality.
