### PR TITLE
Also fix false index collisions for online indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -195,7 +195,6 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations
     @Override
     public PrimitiveLongIterator nodesGetFromIndexLookup( KernelStatement state, IndexDescriptor index, Object value )
             throws IndexNotFoundKernelException
-
     {
         return entityReadOperations.nodesGetFromIndexLookup( state, index, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -27,6 +27,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -34,7 +35,6 @@ import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 
 /**
  * Controls access to {@link IndexPopulator}, {@link IndexAccessor} during different stages

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -29,13 +29,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
-import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 
 public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
@@ -24,15 +24,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.neo4j.kernel.api.index.DuplicateIndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
-import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.impl.util.DiffSets;
-
-import static org.neo4j.helpers.collection.Iterables.single;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 public abstract class UniquePropertyIndexUpdater implements IndexUpdater
 {
@@ -77,27 +72,29 @@ public abstract class UniquePropertyIndexUpdater implements IndexUpdater
     @Override
     public void close() throws IOException, IndexEntryConflictException
     {
-        // verify uniqueness
-        for ( Map.Entry<Object, DiffSets<Long>> entry : referenceCount.entrySet() )
-        {
-            Object value = entry.getKey();
-            int delta = entry.getValue().delta();
-            if ( delta > 1 )
-            {
-                throw new DuplicateIndexEntryConflictException( value, asSet( entry.getValue().getAdded() ) );
-            }
-            if ( delta == 1 )
-            {
-                Long addedNode = single( entry.getValue().getAdded() );
+        // This has been commented out for now. See trello card #1039.
 
-                Long existingNode = lookup.currentlyIndexedNode( value );
-
-                if ( existingNode != null && !addedNode.equals( existingNode ) )
-                {
-                    throw new PreexistingIndexEntryConflictException( value, existingNode, addedNode );
-                }
-            }
-        }
+//        // verify uniqueness
+//        for ( Map.Entry<Object, DiffSets<Long>> entry : referenceCount.entrySet() )
+//        {
+//            Object value = entry.getKey();
+//            int delta = entry.getValue().delta();
+//            if ( delta > 1 )
+//            {
+//                throw new DuplicateIndexEntryConflictException( value, asSet( entry.getValue().getAdded() ) );
+//            }
+//            if ( delta == 1 )
+//            {
+//                Long addedNode = single( entry.getValue().getAdded() );
+//
+//                Long existingNode = lookup.currentlyIndexedNode( value );
+//
+//                if ( existingNode != null && !addedNode.equals( existingNode ) )
+//                {
+//                    throw new PreexistingIndexEntryConflictException( value, existingNode, addedNode );
+//                }
+//            }
+//        }
 
         // flush updates
         flushUpdates( updates );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/MultipleUnderlyingStorageExceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/MultipleUnderlyingStorageExceptions.java
@@ -35,6 +35,11 @@ public class MultipleUnderlyingStorageExceptions extends UnderlyingStorageExcept
     {
         super( buildMessage( exceptions ) );
         this.exceptions = Collections.unmodifiableSet( exceptions );
+
+        for ( Pair<IndexDescriptor, UnderlyingStorageException> exception : exceptions )
+        {
+            this.addSuppressed( exception.other() );
+        }
     }
 
     private static String buildMessage( Set<Pair<IndexDescriptor, UnderlyingStorageException>> exceptions )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
@@ -1119,7 +1119,7 @@ public class NeoStoreTransaction extends XaTransaction
     /**
      * Tries to load the light node with the given id, returns true on success.
      *
-     * @param id The id of the node to load.
+     * @param nodeId The id of the node to load.
      * @return True iff the node record can be found.
      */
     public NodeRecord nodeLoadLight( long nodeId )
@@ -1178,7 +1178,7 @@ public class NeoStoreTransaction extends XaTransaction
      * deleted in this
      * transaction.
      *
-     * @param relId The id of the relationship to delete.
+     * @param id The id of the relationship to delete.
      * @return The properties of the relationship that were removed during the
      *         delete.
      */
@@ -1778,10 +1778,10 @@ public class NeoStoreTransaction extends XaTransaction
      * and of type typeId
      *
      * @param id The id of the relationship to create.
-     * @param typeId The id of the relationship type this relationship will
+     * @param type The id of the relationship type this relationship will
      *            have.
-     * @param startNodeId The id of the start node.
-     * @param endNodeId The id of the end node.
+     * @param firstNodeId The id of the start node.
+     * @param secondNodeId The id of the end node.
      */
     public void relationshipCreate( long id, int type, long firstNodeId, long secondNodeId )
     {
@@ -1845,7 +1845,7 @@ public class NeoStoreTransaction extends XaTransaction
     /**
      * Creates a node for the given id
      *
-     * @param id The id of the node to create.
+     * @param nodeId The id of the node to create.
      */
     public void nodeCreate( long nodeId )
     {
@@ -2216,7 +2216,7 @@ public class NeoStoreTransaction extends XaTransaction
      * map from property index id to property data.
      *
      * @param light If the properties should be loaded light or not.
-     * @param receiver receiver of loaded properties.
+     * @param records receiver of loaded properties.
      */
     public void graphLoadProperties( boolean light, PropertyReceiver records )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/TxIdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/TxIdGenerator.java
@@ -25,7 +25,7 @@ public interface TxIdGenerator
 {
     TxIdGenerator DEFAULT = new TxIdGenerator()
     {
-        public long generate( XaDataSource dataSource, int identifier )
+        public long generate( XaDataSource dataSource, int identifier ) throws XAException
         {
             return dataSource.getLastCommittedTxId() + 1;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -482,7 +482,7 @@ public class XaResourceManager
             }
             else
             {
-                commitWriteTx( xid, onePhase, xaTransaction, isReadOnly, txStatus, txIdGenerator );
+                commitWriteTx( xid, onePhase, xaTransaction, txStatus, txIdGenerator );
             }
         }
 
@@ -521,7 +521,7 @@ public class XaResourceManager
         }
     }
 
-    private void commitWriteTx( Xid xid, boolean onePhase, XaTransaction xaTransaction, boolean readOnly,
+    private void commitWriteTx( Xid xid, boolean onePhase, XaTransaction xaTransaction,
                                 TransactionStatus txStatus, TxIdGenerator txIdGenerator ) throws XAException
     {
         checkStartWritten( txStatus, xaTransaction );
@@ -529,7 +529,7 @@ public class XaResourceManager
         if ( onePhase )
         {
             txStatus.markAsPrepared();
-            if ( !readOnly && !xaTransaction.isRecovered() )
+            if ( !xaTransaction.isRecovered() )
             {
                 xaTransaction.prepare();
 
@@ -540,36 +540,39 @@ public class XaResourceManager
                         xaTransaction.getCommitTxId(), getForceMode() );
             }
         }
+
         if ( !txStatus.prepared() || txStatus.rollback() )
         {
             throw new XAException( "Transaction not prepared or "
                     + "(marked as) rolledbacked" );
         }
-        if ( !readOnly )
+
+        if ( !onePhase && !xaTransaction.isRecovered() )
         {
-            if ( !onePhase && !xaTransaction.isRecovered() )
-            {
-                long txId = txIdGenerator.generate( dataSource,
-                        xaTransaction.getIdentifier() );
-                xaTransaction.setCommitTxId( txId );
-                log.commitTwoPhase( xaTransaction.getIdentifier(),
-                        xaTransaction.getCommitTxId(), getForceMode() );
-            }
-            txStatus.markCommitStarted();
-            if ( xaTransaction.isRecovered() && xaTransaction.getCommitTxId() == -1 )
-            {
-                boolean previousRecoveredValue = dataSource.setRecovered( true );
-                try
-                {
-                    xaTransaction.setCommitTxId( dataSource.getLastCommittedTxId() + 1 );
-                }
-                finally
-                {
-                    dataSource.setRecovered( previousRecoveredValue );
-                }
-            }
-            xaTransaction.commit();
+            long txId = txIdGenerator.generate( dataSource,
+                    xaTransaction.getIdentifier() );
+            xaTransaction.setCommitTxId( txId );
+            log.commitTwoPhase( xaTransaction.getIdentifier(),
+                    xaTransaction.getCommitTxId(), getForceMode() );
         }
+
+        txStatus.markCommitStarted();
+
+        if ( xaTransaction.isRecovered() && xaTransaction.getCommitTxId() == -1 )
+        {
+            boolean previousRecoveredValue = dataSource.setRecovered( true );
+            try
+            {
+                xaTransaction.setCommitTxId( dataSource.getLastCommittedTxId() + 1 );
+            }
+            finally
+            {
+                dataSource.setRecovered( previousRecoveredValue );
+            }
+        }
+
+        xaTransaction.commit();
+
         if ( !xaTransaction.isRecovered() )
         {
             log.done( xaTransaction.getIdentifier() );
@@ -581,7 +584,9 @@ public class XaResourceManager
             recoveredTransactions.put( identifier, new TransactionInfo( identifier, onePhase,
                     xaTransaction.getCommitTxId(), startEntry.getMasterId(), startEntry.getChecksum() ) );
         }
+
         xidMap.remove( xid );
+
         if ( xaTransaction.isRecovered() )
         {
             recoveredTxCount--;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -26,7 +26,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         NonUniqueIndexPopulatorCompatibility.class,
         UniqueIndexPopulatorCompatibility.class,
-        UniqueIndexAccessorCompatibility.class
+        UniqueIndexAccessorCompatibility.class,
+        UniqueConstraintCompatibility.class
 })
 public abstract class IndexProviderCompatibilityTestSuite
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.index;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+@Ignore( "Not a test. This is a compatibility suite that provides test cases for verifying" +
+        " SchemaIndexProvider implementations. Each index provider that is to be tested by this suite" +
+        " must create their own test class extending IndexProviderCompatibilityTestSuite." +
+        " The @Ignore annotation doesn't prevent these tests to run, it rather removes some annoying" +
+        " errors or warnings in some IDEs about test classes needing a public zero-arg constructor." )
+public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTestSuite.Compatibility
+{
+    public UniqueConstraintCompatibility( IndexProviderCompatibilityTestSuite testSuite )
+    {
+        super( testSuite );
+    }
+
+    /*
+     * There are a quite a number of permutations to consider, when it comes to unique
+     * constraints.
+     *
+     * We have two supported providers:
+     *  - InMemoryIndexProvider
+     *  - LuceneSchemaIndexProvider
+     *
+     * An index can be in a number of states, two of which are interesting:
+     *  - ONLINE: the index is in active duty
+     *  - POPULATING: the index is in the process of being created and filled with data
+     *
+     * Further more, indexes that are POPULATING have two ways of injesting data:
+     *  - Through add()'ing existing data
+     *  - Through NodePropertyUpdates sent to a "populating udpater"
+     *
+     * Then, when we add data to an index, two outcomes are possible, depending on the
+     * data:
+     *  - The index does not contain an equivalent value, and the entity id is added to
+     *    the index.
+     *  - The index already contains an equivalent value, and the addition is rejected.
+     *
+     * And when it comes to observing these outcomes, there are a whole bunch of
+     * interesting transaction states that are worth exploring:
+     *  - Adding a label to a node
+     *  - Removing a label from a node
+     *  - Combinations of adding and removing a label, ultimately adding it
+     *  - Combinations of adding and removing a label, ultimately removing it
+     *  - Adding a property
+     *  - Removing a property
+     *  - Changing an existing property
+     *  - Combinations of adding and removing a property, ultimately adding it
+     *  - Combinations of adding and removing a property, ultimately removing it
+     *  - Likewise combinations of adding, removing and changing a property
+     *
+     * To make matters worse, we index a number of different types, some of which may or
+     * may not collide in the index because of coercion. We need to make sure that the
+     * indexes deal with these values correctly. And we also have the ways in which these
+     * operations can be performed in any number of transactions, for instance, if all
+     * the conflicting nodes were added in the same transaction or not.
+     *
+     * All in all, we have many cases to test for!
+     *
+     * Still, it is possible to boild things down a little bit, because there are fewer
+     * outcomes than there are scenarios that lead to those outcomes. With a bit of
+     * luck, we can abstract over the scenarios that lead to those outcomes, and then
+     * only write a test per outcome. These are the outcomes I see:
+     *  - Populating an index succeeds
+     *  - Populating an index fails because of the existing data
+     *  - Populating an index fails because of updates to data
+     *  - Adding to an online index succeeds
+     *  - Adding to an online index fails because of existing data
+     *  - Adding to an online index fails because of data in the same transaction
+     *
+     * There's a lot of work to be done here.
+     */
+
+    // -- Tests:
+
+    @Test
+    public void shouldAcceptDistinctValuesInDifferentTransactionsWhenOnline()
+    {
+        // Given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( label ).assertPropertyIsUnique( property ).create();
+            tx.success();
+        }
+        Node a, b;
+        Object va = "a", vb = "b";
+        try ( Transaction tx = db.beginTx() )
+        {
+            a = db.createNode( label );
+            a.setProperty( property, va );
+            tx.success();
+        }
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            b = db.createNode( label );
+            b.setProperty( property, vb );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, va ) ).getProperty( property ),
+                    is( va ) );
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, vb ) ).getProperty( property ),
+                    is( vb ) );
+            tx.success();
+        }
+    }
+
+    // TODO equiv. of UniqueIAC: shouldConsiderWholeTransactionForValidatingUniqueness
+    // TODO equiv. of UniqueIAC: shouldRejectChangingEntryToAlreadyIndexedValue
+    // TODO equiv. of UniqueIAC: shouldRemoveAndAddEntries
+    // TODO equiv. of UniqueIAC: shouldRejectAddingEntryToValueAlreadyIndexedByPriorChange
+    // TODO equiv. of UniqueIAC: shouldRejectEntryWithAlreadyIndexedValue
+    // TODO equiv. of UniqueIAC: shouldAddUniqueEntries
+    // TODO equiv. of UniqueIAC: shoouldRejectEntriesInSameTransactionWithDuplicateIndexedValue
+    // TODO equiv. of UniqueIAC: shouldUpdateUniqueEntries
+    // TODO equiv. of UniqueIPC: should*EnforceUniqueConstraintsAgainstDataAddedOnline
+    // TODO equiv. of UniqueIPC: should*EnforceUniqueConstraints
+    // TODO equiv. of UniqueIPC: should*EnforceUniqueConstraintsAgainstDataAddedThroughPopulator
+    // TODO equiv. of UniqueIPC: should*EnforceUnqieConstraintsAgainstDataAddedInSameTx
+
+    // TODO equiv. of UniqueLucIAT: shouldRejectChangingEntryToAlreadyIndexedValue
+    // TODO equiv. of UniqueLucIAT: shouldRejectAddingEntryToValueAlreadyIndexedByPriorChange
+    // TODO equiv. of UniqueLucIAT: shouldRejectEntryWithAlreadyIndexedValue
+    // TODO equiv. of UniqueLucIAT: shouldRejectEntriesInSameTransactionWithDuplicatedIndexedValues
+
+    @Test
+    public void shouldAcceptDistinctValuesInSameTransactionsWhenOnline()
+    {
+        // Given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( label ).assertPropertyIsUnique( property ).create();
+            tx.success();
+        }
+        Node a, b;
+        Object va = "a", vb = "b";
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            a = db.createNode( label );
+            a.setProperty( property, va );
+
+            b = db.createNode( label );
+            b.setProperty( property, vb );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, va ) ).getProperty( property ),
+                    is( va ) );
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, vb ) ).getProperty( property ),
+                    is( vb ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldNotFalselyCollideOnFindNodesByLabelAndProperty() throws Exception
+    {
+        // Given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( label ).assertPropertyIsUnique( property ).create();
+            tx.success();
+        }
+        Node a, b;
+        try ( Transaction tx = db.beginTx() )
+        {
+            a = db.createNode( label );
+            a.setProperty( property, 4611686018427387905L );
+            tx.success();
+        }
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            b = db.createNode( label );
+            b.setProperty( property, 4611686018427387907L );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, 4611686018427387905L ) ), is( a ) );
+            assertThat( single( db.findNodesByLabelAndProperty( label, property, 4611686018427387907L ) ), is( b ) );
+            tx.success();
+        }
+    }
+
+
+
+
+    // -- Set Up:
+
+    private Label label = DynamicLabel.label( "Cybermen" );
+    private String property = "name";
+
+    private GraphDatabaseService db;
+
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.cleanTestDirForTest( getClass() );
+
+    @Before
+    public void setUp() {
+        String storeDir = testDirectory.absolutePath();
+        TestGraphDatabaseFactory dbfactory = new TestGraphDatabaseFactory();
+        dbfactory.addKernelExtension( new PredefinedSchemaIndexProviderFactory( indexProvider ) );
+        db = dbfactory.newImpermanentDatabase( storeDir );
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    private static class PredefinedSchemaIndexProviderFactory extends KernelExtensionFactory<PredefinedSchemaIndexProviderFactory.NoDeps>
+    {
+        private final SchemaIndexProvider indexProvider;
+
+        @Override
+        public Lifecycle newKernelExtension( NoDeps noDeps ) throws Throwable
+        {
+            return indexProvider;
+        }
+
+        public static interface NoDeps {
+        }
+
+        public PredefinedSchemaIndexProviderFactory( SchemaIndexProvider indexProvider )
+        {
+            super( indexProvider.getClass().getSimpleName() );
+            this.indexProvider = indexProvider;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
@@ -113,6 +113,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         assertEquals( asList( 1l ), getAllNodes( "value2" ) );
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectChangingEntryToAlreadyIndexedValue() throws Exception
     {
@@ -133,6 +134,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectAddingEntryToValueAlreadyIndexedByPriorChange() throws Exception
     {
@@ -154,6 +156,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectEntryWithAlreadyIndexedValue() throws Exception
     {
@@ -174,6 +177,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectEntriesInSameTransactionWithDuplicatedIndexedValues() throws Exception
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
@@ -83,6 +83,7 @@ public class UniqueIndexPopulatorCompatibility extends IndexProviderCompatibilit
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldProvideAccessorThatEnforcesUniqueConstraintsAgainstDataAddedOnline() throws Exception
     {
@@ -110,6 +111,7 @@ public class UniqueIndexPopulatorCompatibility extends IndexProviderCompatibilit
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldProvideAccessorThatEnforcesUniqueConstraintsAgainstDataAddedThroughPopulator() throws Exception
     {
@@ -136,6 +138,7 @@ public class UniqueIndexPopulatorCompatibility extends IndexProviderCompatibilit
         }
     }
 
+    @Ignore("Needs to be rephrased in UniqueConstraintCompatibility")
     @Test
     public void shouldProvideAccessorThatEnforcesUniqueConstraintsAgainstDataAddedInSameTx() throws Exception
     {

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -80,6 +80,11 @@ the relevant Commercial Agreement.
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.neo4j.kernel.api.index.DuplicateIndexEntryConflictException;
@@ -121,6 +122,7 @@ public class UniqueLuceneIndexAccessorTest
         assertEquals( asList( 1l ), getAllNodes( "value2" ) );
     }
 
+    @Ignore("Rephrase in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectChangingEntryToAlreadyIndexedValue() throws Exception
     {
@@ -144,6 +146,7 @@ public class UniqueLuceneIndexAccessorTest
         }
     }
 
+    @Ignore("Rephrase in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectAddingEntryToValueAlreadyIndexedByPriorChange() throws Exception
     {
@@ -167,6 +170,7 @@ public class UniqueLuceneIndexAccessorTest
         }
     }
 
+    @Ignore("Rephrase in UniqueConstriaintCompatibility")
     @Test
     public void shouldRejectEntryWithAlreadyIndexedValue() throws Exception
     {
@@ -189,6 +193,7 @@ public class UniqueLuceneIndexAccessorTest
         }
     }
 
+    @Ignore("Rephrase in UniqueConstraintCompatibility")
     @Test
     public void shouldRejectEntriesInSameTransactionWithDuplicatedIndexedValues() throws Exception
     {


### PR DESCRIPTION
Note: The point of offering the changes in this state, is to see what our robustness tests thinks of them.

The story so far:
- Indexes store all numbers as doubles, and that means that large long values
  can coerce to the same double values and cause collisions in the index.
  We fixed this for indexes that are populating, by making them read colliding
  values out from the property store to double check if the collision is real
  or not.
- We also added a similar "exact match" filtering to the index lookup
  operations on StateHandlingStatementOperations, to fix index lookups.
- What we didn't fix in the first round, was adding new stuff to indexes that
  are online. This is the bug that Mattias found.
- Specifically, the UniquePropertyIndexUpdater verifies that the constraint is
  still holding in its close method.
- This is super bad, because the close method is called in commit - not in
  prepare, not during the transaction - in commit. Huge no-no.
- Initially you'd think that this puts recovery at risk, but that turns out not
  to be the case, because during recovery, we use a normal index updater
  instead of the unique one.
- So this means that the following scenario was possible: Add two nodes with
  similar but distinct long values to the index. The
  ConstraintEnforcingEntityOperations is fine with this because the values are
  really different. However, the UniquePropertyIndexUpdater trashes the
  transaction in commit. Now suppose the entire database server crashes for
  whatever reason, and we must do recovery. We recover the index using the
  normal updater that just adds the values without checking any constraints.
  And this is actually totally fine, because we filter for exact matches in the
  StateHandlingStatementOperations. And so only then does the index work as
  advertised. We had to crash the database in order to add a valid value to the
  index. Except, there is a window between the crash of the transaction, and
  the crash of the database, where the transaction could have been retried with
  the same exact value and encounter the same exact crash. Now we recover both
  transactions, and boom: we got a duplicate in the unique index!
- The solution I'm going for currently is to just not verify the constraint in
  the UniquePropertyIndexUpdater.close method... just accept the value as
  given, and trust that the ConstraintEnforcingEntityOperations has done it's
  job.
- Implementing this solution is made a bit harder by a number of tests
  operating directly with the IndexUpdaters, instead of checking the publicly
  observable behaviour.
- I intend to rephrase these tests in terms of higher level APIs, but in the
  mean time (because there are a lot of cases to cover) we will have to ignore
  all the now failing tests, and see what the robustness suite says.
