### PR TITLE
Doesn't close IndexReader after verifying deferred constraints

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.rules.ExternalResource;
+
+public class CleanupRule extends ExternalResource
+{
+    private final List<Closeable> toCloseAfterwards = new ArrayList<>();
+    
+    @Override
+    protected void after()
+    {
+        for ( Closeable toClose : toCloseAfterwards )
+        {
+            try
+            {
+                toClose.close();
+            }
+            catch ( Exception e )
+            {
+                System.out.println( "Couldn't clean up " + toClose + " after test finished" );
+            }
+        }
+    }
+    
+    public <T extends Closeable> T add( T toClose )
+    {
+        toCloseAfterwards.add( toClose );
+        return toClose;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -228,10 +228,11 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Visitor<LineLogger
         commandExecutor.shutdown();
         try
         {
-            commandExecutor.awaitTermination( 1000, TimeUnit.SECONDS );
+            commandExecutor.awaitTermination( 10, TimeUnit.SECONDS );
         }
-        catch ( InterruptedException e )
-        {   // OK
+        catch ( Exception e )
+        {
+            commandExecutor.shutdownNow();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/TestLabels.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestLabels.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.neo4j.graphdb.Label;
+
+public enum TestLabels implements Label
+{
+    LABEL_ONE,
+    LABEL_TWO,
+    LABEL_THREE;
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -95,11 +95,11 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
     {
         searcherManager.maybeRefresh();
         IndexSearcher searcher = searcherManager.acquire();
-
-        try ( IndexReader indexReader = searcher.getIndexReader())
+        
+        try
         {
             DuplicateCheckingCollector collector = duplicateCheckingCollector( accessor );
-            TermEnum terms = indexReader.terms();
+            TermEnum terms = searcher.getIndexReader().terms();
             while ( terms.next() )
             {
                 Term term = terms.term();
@@ -122,7 +122,6 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
         }
         finally
         {
-            searcher.close();
             searcherManager.release( searcher );
         }
     }
@@ -166,9 +165,9 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
             {
                 searcherManager.maybeRefresh();
                 IndexSearcher searcher = searcherManager.acquire();
-                DuplicateCheckingCollector collector = duplicateCheckingCollector( accessor );
                 try
                 {
+                    DuplicateCheckingCollector collector = duplicateCheckingCollector( accessor );
                     for ( Object propertyValue : updatedPropertyValues )
                     {
                         collector.reset();
@@ -187,7 +186,6 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
                 }
                 finally
                 {
-                    searcher.close();
                     searcherManager.release( searcher );
                 }
             }


### PR DESCRIPTION
that should be up to the SearcherManager. Closing the IndexReader manually
and then trying to release the searcher holding will fail and consecutive
calls to SearcherManager#acquire will get stuck in busy-loop.

This solves a problem that caused the index population phase to hang after
the node scan was complete, when flipping to ONLINE state and there were
one or more updates to apply before flipping. Having a constraint creation
hang caused the schema write lock be held indefinitely.
