### PR TITLE
Fixes issue where high id would take a leap after crash

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesImpl.java
@@ -238,7 +238,7 @@ public class GraphPropertiesImpl extends Primitive implements GraphProperties
     @Override
     public String toString()
     {
-        return getClass().getSimpleName();
+        return "GraphProperties";
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -490,7 +490,7 @@ public abstract class CommonAbstractStore implements IdSequence
     protected IdGenerator openIdGenerator( File fileName, int grabSize )
     {
         return idGeneratorFactory
-                .open( fileSystemAbstraction, fileName, grabSize, getIdType(), figureOutHighestIdInUse() );
+                .open( fileSystemAbstraction, fileName, grabSize, getIdType(), 0 );
     }
 
     protected abstract long figureOutHighestIdInUse();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdJumping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdJumping.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.CleanupRule;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.test.ProcessUtil.executeSubProcess;
+import static org.neo4j.test.TestLabels.LABEL_ONE;
+
+public class TestIdJumping
+{
+    @Test
+    public void shouldNotAllowHighIdsToJumpAfterCrash() throws Exception
+    {
+        // GIVEN an almost empty db that crashed
+        executeSubProcess( getClass(), 10, SECONDS, dir.absolutePath() );
+
+        // WHEN
+        GraphDatabaseService db = cleanup.add( new GraphDatabaseFactory().newEmbeddedDatabase( dir.absolutePath() ) );
+        long nodeId;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            nodeId = node.getId();
+        }
+
+        // THEN
+        assertEquals( 1, nodeId );
+    }
+
+    public final @Rule CleanupRule cleanup = new CleanupRule();
+
+    public static void main( String[] args )
+    {
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( args[0] );
+        try ( Transaction tx = db.beginTx() )
+        {
+            // TODO create something in every store
+            db.createNode( LABEL_ONE ).setProperty( "name", "something" );
+            tx.success();
+        }
+        // Crash the database
+        System.exit( 0 );
+    }
+
+    public final @Rule TestDirectory dir = TargetDirectory.cleanTestDirForTest( getClass() );
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.DependencyResolver.Adapter;
 import org.neo4j.graphdb.Node;
@@ -100,6 +94,14 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class TestNeoStore
 {

--- a/community/kernel/src/test/java/org/neo4j/test/TargetDirectory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TargetDirectory.java
@@ -30,7 +30,6 @@ import org.junit.runners.model.Statement;
 
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
-import org.neo4j.kernel.impl.util.FileUtils;
 
 import static java.lang.String.format;
 
@@ -53,7 +52,10 @@ public class TargetDirectory
 
         public File directory()
         {
-            if ( subdir == null ) throw new IllegalStateException( "Not initialized" );
+            if ( subdir == null )
+            {
+                throw new IllegalStateException( "Not initialized" );
+            }
             return subdir;
         }
 
@@ -89,7 +91,10 @@ public class TargetDirectory
 
         private void complete( boolean success )
         {
-            if ( success && subdir != null ) recursiveDelete( subdir );
+            if ( success && subdir != null )
+            {
+                recursiveDelete( subdir );
+            }
             subdir = null;
         }
     }
@@ -121,22 +126,9 @@ public class TargetDirectory
 
     public File directoryForDescription( Description description, boolean clean )
     {
-        String testName = description.getMethodName();
-        String dirName = DigestUtils.md5Hex( testName );
-        return TargetDirectory.this.registeredDirectory( dirName, testName, clean );
-    }
-
-    private File registeredDirectory( String dirName, String testName, boolean clean )
-    {
-        try
-        {
-            FileUtils.writeToFile( new File( base(), ".register" ), format("%s=%s\n", dirName, testName), true );
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
-        return directory( dirName, clean );
+        String methodName = description.getMethodName();
+        String dirName = DigestUtils.md5Hex( methodName );
+        return directory( methodName + "_" + dirName, clean );
     }
 
     public File file( String name )
@@ -211,7 +203,9 @@ public class TargetDirectory
     private File base()
     {
         if ( fileSystem.fileExists( base ) && !fileSystem.isDirectory( base ) )
+        {
             throw new IllegalStateException( base + " exists and is not a directory!" );
+        }
 
         try
         {


### PR DESCRIPTION
Problem was that the id generator was openened with the highest seen id
passed in as the highId argument when constructing the id generator. It
should have been 0 since at that point whatever is persisted takes
presedence.

Also fixed an issue with silent upgrades of neostore, where those are done
inside a "recovery" block. That problem somehow surfaced after the above
change.
