### PR TITLE
Fixes issue where high id would take a leap after crash

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.neo4j.helpers.Exceptions.launderedException;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -40,6 +38,8 @@ import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPool;
 import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+import static org.neo4j.helpers.Exceptions.launderedException;
+
 /**
  * Contains common implementation for {@link AbstractStore} and
  * {@link AbstractDynamicStore}.
@@ -50,7 +50,7 @@ public abstract class CommonAbstractStore
     {
         public static final Setting<File> store_dir = InternalAbstractGraphDatabase.Configuration.store_dir;
         public static final Setting<File> neo_store = InternalAbstractGraphDatabase.Configuration.neo_store;
-        
+
         public static final GraphDatabaseSetting.BooleanSetting read_only = GraphDatabaseSettings.read_only;
         public static final GraphDatabaseSetting.BooleanSetting backup_slave = GraphDatabaseSettings.backup_slave;
         public static final GraphDatabaseSetting.BooleanSetting use_memory_mapped_buffers = GraphDatabaseSettings.use_memory_mapped_buffers;
@@ -477,6 +477,20 @@ public abstract class CommonAbstractStore
         isRecovered = false;
     }
 
+    public boolean setRecoveredStatus( boolean status )
+    {
+        boolean previous = isRecovered;
+        if ( status )
+        {
+            setRecovered();
+        }
+        else
+        {
+            unsetRecovered();
+        }
+        return previous;
+    }
+
     /**
      * Returns the name of this store.
      *
@@ -504,7 +518,7 @@ public abstract class CommonAbstractStore
 
     protected IdGenerator openIdGenerator( File fileName, int grabSize, boolean firstTime )
     {
-        return idGeneratorFactory.open( fileSystemAbstraction, fileName, grabSize, getIdType(), figureOutHighestIdInUse() );
+        return idGeneratorFactory.open( fileSystemAbstraction, fileName, grabSize, getIdType(), 0 );
     }
 
     protected abstract long figureOutHighestIdInUse();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
@@ -173,10 +173,18 @@ public class NeoStore extends AbstractStore
          * A little silent upgrade for the "next prop" record. It adds one record last to the neostore file.
          * It's backwards compatible, that's why it can be a silent and automatic upgrade.
          */
-        if ( getFileChannel().size() == RECORD_SIZE*5 )
+        boolean previous = setRecoveredStatus( true );
+        try
         {
-            insertRecord( 5, -1 );
-            registerIdFromUpdateRecord( 5 );
+            if ( getFileChannel().size() == RECORD_SIZE * 5 )
+            {
+                insertRecord( 5, -1 );
+                registerIdFromUpdateRecord( 5 );
+            }
+        }
+        finally
+        {
+            setRecoveredStatus( previous );
         }
     }
 
@@ -392,18 +400,6 @@ public class NeoStore extends AbstractStore
     public void setRandomNumber( long nr )
     {
         setRecord( 1, nr );
-    }
-
-    public void setRecoveredStatus( boolean status )
-    {
-        if ( status )
-        {
-            setRecovered();
-        }
-        else
-        {
-            unsetRecovered();
-        }
     }
 
     public long getVersion()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdJumping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdJumping.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.ProcessStreamHandler;
+import org.neo4j.test.TargetDirectory;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestIdJumping
+{
+    @Test
+    public void shouldNotAllowHighIdsToJumpAfterCrash() throws Exception
+    {
+        // GIVEN an almost empty db that crashed
+        executeSubProcess( storeDir );
+
+        // WHEN
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        try
+        {
+            long newNodeId, newRelationshipId;
+            Transaction tx = db.beginTx();
+            try
+            {
+                Node node = db.createNode();
+                newNodeId = node.getId();
+                newRelationshipId = node.createRelationshipTo( node, MyRelTypes.TEST2 ).getId();
+                tx.success();
+            }
+            finally
+            {
+                tx.finish();
+            }
+
+            // THEN
+            assertEquals( 3, newNodeId );
+            assertEquals( 1, newRelationshipId );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private void executeSubProcess( String... mainArguments ) throws Exception
+    {
+        List<String> args = new ArrayList<String>();
+        args.addAll( asList( "java", "-cp", System.getProperty( "java.class.path" ), TestIdJumping.class.getName() ) );
+        args.addAll( asList( mainArguments ) );
+        Process process = Runtime.getRuntime().exec( args.toArray( new String[args.size()] ) );
+        ProcessStreamHandler processOutput = new ProcessStreamHandler( process, false );
+        processOutput.launch();
+        if ( process.waitFor() != 0 )
+        {
+            throw new RuntimeException( "Failed executing sub process, exit value:" + process.exitValue() );
+        }
+    }
+
+    public static void main( String[] args )
+    {
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( args[0] );
+        Transaction tx = db.beginTx();
+        try
+        {
+            Node node1 = db.createNode();
+            Node node2 = db.createNode();
+            node1.setProperty( "name", "Long long long long name that expands into a dynamic record !#¤%&/" );
+            node1.createRelationshipTo( node2, MyRelTypes.TEST );
+            tx.success();
+        }
+        finally
+        {
+            tx.finish();
+        }
+        // Crash the database
+        System.exit( 0 );
+    }
+
+    private final String storeDir = TargetDirectory.forTest( getClass() ).graphDbDir( true ).getAbsolutePath();
+}


### PR DESCRIPTION
Problem was that the id generator was openened with the highest seen id
passed in as the highId argument when constructing the id generator. It
should have been 0 since at that point whatever is persisted takes
presedence.

Also fixed an issue with silent upgrades of neostore, where those are done
inside a "recovery" block. That problem somehow surfaced after the above
change.
