### PR TITLE
Replace CTDouble with CTFloat

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ArithmeticFunctions.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ArithmeticFunctions.scala
@@ -39,7 +39,7 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
     // "a" + 1.1 => "a1.1"
     val stringTypes =
       if (lhsTypes containsAny CTString.covariant)
-        CTString.covariant | CTInteger.covariant | CTDouble.covariant
+        CTString.covariant | CTInteger.covariant | CTFloat.covariant
       else
         TypeSpec.none
 
@@ -50,8 +50,8 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
     // 1.1 + 1 => 2.1
     // 1.1 + 1.1 => 2.2
     val numberTypes =
-      if (lhsTypes containsAny (CTInteger.covariant | CTDouble.covariant))
-        CTString.covariant | CTInteger.covariant | CTDouble.covariant
+      if (lhsTypes containsAny (CTInteger.covariant | CTFloat.covariant))
+        CTString.covariant | CTInteger.covariant | CTFloat.covariant
       else
         TypeSpec.none
 
@@ -81,7 +81,7 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
     // 1 + "b" => "1b"
     // 1.1 + "b" => "1.1b"
     val stringTypes: TypeSpec =
-      when(CTString.covariant, CTInteger.covariant | CTDouble.covariant | CTString.covariant)(CTString)
+      when(CTString.covariant, CTInteger.covariant | CTFloat.covariant | CTString.covariant)(CTString)
 
     // 1 + 1 => 2
     // 1 + 1.1 => 2.1
@@ -89,7 +89,7 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
     // 1.1 + 1.1 => 2.2
     val numberTypes: TypeSpec =
       when(CTInteger.covariant, CTInteger.covariant)(CTInteger) |
-        when(CTDouble.covariant, CTDouble.covariant | CTInteger.covariant)(CTDouble)
+        when(CTFloat.covariant, CTFloat.covariant | CTInteger.covariant)(CTFloat)
 
     // [a] + [b] => [a, b]
     // [a] + b => [a, b]
@@ -112,22 +112,22 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
 case class UnaryAdd(rhs: Expression)(val position: InputPosition) extends Expression with PrefixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 }
 
 case class Subtract(lhs: Expression, rhs: Expression)(val position: InputPosition) extends Expression with InfixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTInteger, CTDouble), outputType = CTDouble),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 }
 
 case class UnarySubtract(rhs: Expression)(val position: InputPosition) extends Expression with PrefixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 }
 
@@ -138,8 +138,8 @@ case class Multiply(lhs: Expression, rhs: Expression)(val position: InputPositio
   // 1.1 * 1.1 => 1.21
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTInteger, CTDouble), outputType = CTDouble),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 }
 
@@ -150,8 +150,8 @@ case class Divide(lhs: Expression, rhs: Expression)(val position: InputPosition)
   // 1.1 / 1.1 => 1.0
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTInteger, CTDouble), outputType = CTDouble),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 }
 
@@ -162,8 +162,8 @@ case class Modulo(lhs: Expression, rhs: Expression)(val position: InputPosition)
   // 1.1 % 1.1 => 0.0
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTInteger, CTDouble), outputType = CTDouble),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTFloat),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 }
 
@@ -173,6 +173,6 @@ case class Pow(lhs: Expression, rhs: Expression)(val position: InputPosition) ex
   // 1.1 ^ 1 => 1.1
   // 1.1 ^ 1.1 => 1.1105
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Literal.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Literal.scala
@@ -49,7 +49,7 @@ case class UnsignedIntegerLiteral(stringVal: String)(val position: InputPosition
 case class DoubleLiteral(stringVal: String)(val position: InputPosition) extends Literal with SimpleTyping {
   val value = stringVal.toDouble
 
-  protected def possibleTypes = CTDouble
+  protected def possibleTypes = CTFloat
 
   override def semanticCheck(ctx: SemanticContext): SemanticCheck =
     when(value.isInfinite) {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/PredicateExpressions.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/PredicateExpressions.scala
@@ -95,7 +95,7 @@ case class IsNotNull(lhs: Expression)(val position: InputPosition) extends Expre
 case class LessThan(lhs: Expression, rhs: Expression)(val position: InputPosition) extends Expression with InfixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTBoolean),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTBoolean),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     Signature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean)
   )
 }
@@ -103,7 +103,7 @@ case class LessThan(lhs: Expression, rhs: Expression)(val position: InputPositio
 case class LessThanOrEqual(lhs: Expression, rhs: Expression)(val position: InputPosition) extends Expression with InfixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTBoolean),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTBoolean),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     Signature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean)
   )
 }
@@ -111,7 +111,7 @@ case class LessThanOrEqual(lhs: Expression, rhs: Expression)(val position: Input
 case class GreaterThan(lhs: Expression, rhs: Expression)(val position: InputPosition) extends Expression with InfixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTBoolean),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTBoolean),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     Signature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean)
   )
 }
@@ -119,7 +119,7 @@ case class GreaterThan(lhs: Expression, rhs: Expression)(val position: InputPosi
 case class GreaterThanOrEqual(lhs: Expression, rhs: Expression)(val position: InputPosition) extends Expression with InfixFunctionTyping {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger, CTInteger), outputType = CTBoolean),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTBoolean),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTBoolean),
     Signature(argumentTypes = Vector(CTString, CTString), outputType = CTBoolean)
   )
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/MathFunction.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/MathFunction.scala
@@ -57,7 +57,7 @@ case class AcosFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(AcosFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class AsinFunction(argument: Expression) extends MathFunction(argument) {
@@ -65,7 +65,7 @@ case class AsinFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(AsinFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class AtanFunction(argument: Expression) extends MathFunction(argument) {
@@ -73,7 +73,7 @@ case class AtanFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(AtanFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class Atan2Function(y: Expression, x: Expression) extends Expression with NumericHelper {
@@ -83,7 +83,7 @@ case class Atan2Function(y: Expression, x: Expression) extends Expression with N
 
   def rewrite(f: (Expression) => Expression) = f(Atan2Function(y.rewrite(f), x.rewrite(f)))
 
-  def calculateType(symbols: SymbolTable): CypherType = CTDouble
+  def calculateType(symbols: SymbolTable): CypherType = CTFloat
 
   def symbolTableDependencies = x.symbolTableDependencies ++ y.symbolTableDependencies
 }
@@ -99,7 +99,7 @@ case class CosFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(CosFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class CotFunction(argument: Expression) extends MathFunction(argument) {
@@ -107,7 +107,7 @@ case class CotFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(CotFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class DegreesFunction(argument: Expression) extends MathFunction(argument) {
@@ -115,7 +115,7 @@ case class DegreesFunction(argument: Expression) extends MathFunction(argument) 
 
   def rewrite(f: (Expression) => Expression) = f(DegreesFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class EFunction() extends Expression() {
@@ -127,7 +127,7 @@ case class EFunction() extends Expression() {
 
   def rewrite(f: (Expression) => Expression) = f(EFunction())
 
-  def calculateType(symbols: SymbolTable) = CTDouble
+  def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class ExpFunction(argument: Expression) extends MathFunction(argument) {
@@ -135,7 +135,7 @@ case class ExpFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(ExpFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class FloorFunction(argument: Expression) extends MathFunction(argument) {
@@ -149,7 +149,7 @@ case class LogFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(LogFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class Log10Function(argument: Expression) extends MathFunction(argument) {
@@ -157,7 +157,7 @@ case class Log10Function(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(Log10Function(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class PiFunction() extends Expression {
@@ -169,7 +169,7 @@ case class PiFunction() extends Expression {
 
   def rewrite(f: (Expression) => Expression) = f(PiFunction())
 
-  def calculateType(symbols: SymbolTable) = CTDouble
+  def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class RadiansFunction(argument: Expression) extends MathFunction(argument) {
@@ -177,7 +177,7 @@ case class RadiansFunction(argument: Expression) extends MathFunction(argument) 
 
   def rewrite(f: (Expression) => Expression) = f(RadiansFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class SinFunction(argument: Expression) extends MathFunction(argument) {
@@ -185,7 +185,7 @@ case class SinFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(SinFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class HaversinFunction(argument: Expression) extends MathFunction(argument) {
@@ -194,7 +194,7 @@ case class HaversinFunction(argument: Expression) extends MathFunction(argument)
 
   def rewrite(f: (Expression) => Expression) = f(HaversinFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class TanFunction(argument: Expression) extends MathFunction(argument) {
@@ -202,7 +202,7 @@ case class TanFunction(argument: Expression) extends MathFunction(argument) {
 
   def rewrite(f: (Expression) => Expression) = f(TanFunction(argument.rewrite(f)))
 
-  override def calculateType(symbols: SymbolTable) = CTDouble
+  override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class RandFunction() extends Expression {
@@ -214,7 +214,7 @@ case class RandFunction() extends Expression {
 
   def rewrite(f: (Expression) => Expression) = f(RandFunction())
 
-  def calculateType(symbols: SymbolTable) = CTDouble
+  def calculateType(symbols: SymbolTable) = CTFloat
 }
 
 case class RangeFunction(start: Expression, end: Expression, step: Expression) extends Expression with NumericHelper {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/Stdev.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/Stdev.scala
@@ -29,7 +29,7 @@ case class Stdev(anInner: Expression) extends AggregationWithInnerExpression(anI
 
   def rewrite(f: (Expression) => Expression) = f(Stdev(anInner.rewrite(f)))
 
-  def calculateType(symbols: SymbolTable): CypherType = CTDouble
+  def calculateType(symbols: SymbolTable): CypherType = CTFloat
 }
 
 case class StdevP(anInner: Expression) extends AggregationWithInnerExpression(anInner) {
@@ -39,6 +39,6 @@ case class StdevP(anInner: Expression) extends AggregationWithInnerExpression(an
 
   def rewrite(f: (Expression) => Expression) = f(StdevP(anInner.rewrite(f)))
 
-  def calculateType(symbols: SymbolTable): CypherType = CTDouble
+  def calculateType(symbols: SymbolTable): CypherType = CTFloat
 }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Abs.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Abs.scala
@@ -29,7 +29,7 @@ case object Abs extends Function with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Acos.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Acos.scala
@@ -28,7 +28,7 @@ case object Acos extends Function with SimpleTypedFunction {
   def name = "acos"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Asin.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Asin.scala
@@ -28,7 +28,7 @@ case object Asin extends Function with SimpleTypedFunction {
   def name = "asin"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Atan.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Atan.scala
@@ -28,7 +28,7 @@ case object Atan extends Function with SimpleTypedFunction {
   def name = "atan"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Atan2.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Atan2.scala
@@ -28,7 +28,7 @@ case object Atan2 extends Function with SimpleTypedFunction {
   def name = "atan2"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Avg.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Avg.scala
@@ -30,7 +30,7 @@ case object Avg extends AggregatingFunction with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Ceil.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Ceil.scala
@@ -28,7 +28,7 @@ case object Ceil extends Function with SimpleTypedFunction {
   def name = "ceil"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Cos.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Cos.scala
@@ -28,7 +28,7 @@ case object Cos extends Function with SimpleTypedFunction {
   def name = "cos"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Cot.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Cot.scala
@@ -28,7 +28,7 @@ case object Cot extends Function with SimpleTypedFunction {
   def name = "cot"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Degrees.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Degrees.scala
@@ -28,7 +28,7 @@ case object Degrees extends Function with SimpleTypedFunction {
   def name = "degrees"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/E.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/E.scala
@@ -27,7 +27,7 @@ case object E extends Function with SimpleTypedFunction {
   def name = "e"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(), outputType = CTDouble)
+    Signature(argumentTypes = Vector(), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Exp.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Exp.scala
@@ -28,7 +28,7 @@ case object Exp extends Function with SimpleTypedFunction {
   def name = "exp"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Floor.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Floor.scala
@@ -28,7 +28,7 @@ case object Floor extends Function with SimpleTypedFunction {
   def name = "floor"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Haversin.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Haversin.scala
@@ -28,7 +28,7 @@ case object Haversin extends Function with SimpleTypedFunction {
   def name = "haversin"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Log.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Log.scala
@@ -28,7 +28,7 @@ case object Log extends Function with SimpleTypedFunction {
   def name = "log"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Log10.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Log10.scala
@@ -28,7 +28,7 @@ case object Log10 extends Function with SimpleTypedFunction {
   def name = "log10"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Max.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Max.scala
@@ -30,7 +30,7 @@ case object Max extends AggregatingFunction with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Min.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Min.scala
@@ -30,7 +30,7 @@ case object Min extends AggregatingFunction with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileCont.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileCont.scala
@@ -29,7 +29,7 @@ case object PercentileCont extends AggregatingFunction with SimpleTypedFunction 
   def name = "percentileCont"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileDisc.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileDisc.scala
@@ -29,8 +29,8 @@ case object PercentileDisc extends AggregatingFunction with SimpleTypedFunction 
   def name = "percentileDisc"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTInteger, CTDouble), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble, CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTInteger),
+    Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Pi.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Pi.scala
@@ -27,7 +27,7 @@ case object Pi extends Function with SimpleTypedFunction {
   def name = "pi"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(), outputType = CTDouble)
+    Signature(argumentTypes = Vector(), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = commandexpressions.PiFunction()

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Radians.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Radians.scala
@@ -28,7 +28,7 @@ case object Radians extends Function with SimpleTypedFunction {
   def name = "radians"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Rand.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Rand.scala
@@ -27,7 +27,7 @@ case object Rand extends Function with SimpleTypedFunction {
   def name = "rand"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(), outputType = CTDouble)
+    Signature(argumentTypes = Vector(), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Round.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Round.scala
@@ -28,7 +28,7 @@ case object Round extends Function with SimpleTypedFunction {
   def name = "round"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sign.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sign.scala
@@ -29,7 +29,7 @@ case object Sign extends Function with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTInteger)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTInteger)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sin.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sin.scala
@@ -28,7 +28,7 @@ case object Sin extends Function with SimpleTypedFunction {
   def name = "sin"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sqrt.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sqrt.scala
@@ -28,7 +28,7 @@ case object Sqrt extends Function with SimpleTypedFunction {
   def name = "sqrt"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/StdDev.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/StdDev.scala
@@ -29,7 +29,7 @@ case object StdDev extends AggregatingFunction with SimpleTypedFunction {
   def name = "stdev"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/StdDevP.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/StdDevP.scala
@@ -29,7 +29,7 @@ case object StdDevP extends AggregatingFunction with SimpleTypedFunction {
   def name = "stdevp"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sum.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Sum.scala
@@ -30,7 +30,7 @@ case object Sum extends AggregatingFunction with SimpleTypedFunction {
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) = {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Tan.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/Tan.scala
@@ -28,7 +28,7 @@ case object Tan extends Function with SimpleTypedFunction {
   def name = "tan"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTDouble), outputType = CTDouble)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/FloatType.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/FloatType.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_0.symbols
 
-object DoubleType {
-  val instance = new DoubleType() {
+object FloatType {
+  val instance = new FloatType() {
     val parentType = CTNumber
     override lazy val coercibleTo: Set[CypherType] = Set(CTBoolean)
-    override val toString = "Double"
+    override val toString = "Float"
   }
 }
 
-sealed abstract class DoubleType extends CypherType
+sealed abstract class FloatType extends CypherType

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/IntegerType.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/IntegerType.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_0.symbols
 object IntegerType {
   val instance = new IntegerType() {
     val parentType = CTNumber
-    override lazy val coercibleTo: Set[CypherType] = Set(CTBoolean, CTDouble)
+    override lazy val coercibleTo: Set[CypherType] = Set(CTBoolean, CTFloat)
     override val toString = "Integer"
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpec.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpec.scala
@@ -28,7 +28,7 @@ object TypeSpec {
   private val simpleTypes = Vector(
     CTAny,
     CTBoolean,
-    CTDouble,
+    CTFloat,
     CTInteger,
     CTMap,
     CTNode,

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/package.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/package.scala
@@ -24,7 +24,7 @@ package object symbols {
   val CTBoolean = BooleanType.instance
   val CTString = StringType.instance
   val CTNumber = NumberType.instance
-  val CTDouble = DoubleType.instance
+  val CTFloat = FloatType.instance
   val CTInteger = IntegerType.instance
   val CTMap = MapType.instance
   val CTNode = NodeType.instance

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/type_system.txt
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/type_system.txt
@@ -8,14 +8,14 @@ To do this, it has a hierarchy of types, with Any as the root of it all.
         /           /               \         \        \            \
        /         Number             Map        \        \            \
       /        /       \          /     \       \        \            \
- CTString  CTInteger CTDouble  CTNode  CTRel  CTPath   CTBoolean  CTCollection<T>
+ CTString  CTInteger CTFloat   CTNode  CTRel  CTPath   CTBoolean  CTCollection<T>
 
 All expressions have a type. Some expressions type depend on other expressions types -
 e.g. LAST(x) will have type T, given that x has type Collection<T>.
 
 An expression can also have an expectation about inner expressions type, LENGTH(X)
 expects that X is an Collection<T>. These expectations are met by any subtype of the
-expected type - e.g. if the expectation is a Number, Double and Integer are fine, but
+expected type - e.g. if the expectation is a Number, Float and Integer are fine, but
 not a String.
 
 An expression has dependencies on what identifiers exists in the symbol table,

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/AddTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/AddTest.scala
@@ -43,41 +43,41 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
   def shouldHandleAllSpecializations() {
     testValidTypes(CTString, CTString)(CTString)
     testValidTypes(CTString, CTInteger)(CTString)
-    testValidTypes(CTString, CTDouble)(CTString)
+    testValidTypes(CTString, CTFloat)(CTString)
     testValidTypes(CTInteger, CTString)(CTString)
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTString)(CTString)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTString)(CTString)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
 
     testValidTypes(CTCollection(CTNode), CTCollection(CTNode))(CTCollection(CTNode))
-    testValidTypes(CTCollection(CTDouble), CTCollection(CTDouble))(CTCollection(CTDouble))
+    testValidTypes(CTCollection(CTFloat), CTCollection(CTFloat))(CTCollection(CTFloat))
 
     testValidTypes(CTCollection(CTNode), CTNode)(CTCollection(CTNode))
-    testValidTypes(CTCollection(CTDouble), CTDouble)(CTCollection(CTDouble))
+    testValidTypes(CTCollection(CTFloat), CTFloat)(CTCollection(CTFloat))
 
     testValidTypes(CTNode, CTCollection(CTNode))(CTCollection(CTNode))
-    testValidTypes(CTDouble, CTCollection(CTDouble))(CTCollection(CTDouble))
+    testValidTypes(CTFloat, CTCollection(CTFloat))(CTCollection(CTFloat))
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTString, CTInteger)(CTDouble | CTString)
-    testValidTypes(CTDouble | CTCollection(CTDouble), CTDouble)(CTDouble | CTCollection(CTDouble))
-    testValidTypes(CTDouble, CTDouble | CTCollection(CTDouble))(CTDouble | CTCollection(CTDouble))
+    testValidTypes(CTFloat | CTString, CTInteger)(CTFloat | CTString)
+    testValidTypes(CTFloat | CTCollection(CTFloat), CTFloat)(CTFloat | CTCollection(CTFloat))
+    testValidTypes(CTFloat, CTFloat | CTCollection(CTFloat))(CTFloat | CTCollection(CTFloat))
   }
 
   @Test
   def shouldHandleCoercions() {
-    testValidTypes(CTCollection(CTDouble), CTInteger)(CTCollection(CTDouble))
-    testValidTypes(CTDouble | CTCollection(CTDouble), CTInteger)(CTDouble | CTCollection(CTDouble))
+    testValidTypes(CTCollection(CTFloat), CTInteger)(CTCollection(CTFloat))
+    testValidTypes(CTFloat | CTCollection(CTFloat), CTInteger)(CTFloat | CTCollection(CTFloat))
   }
 
   @Test
   def shouldFailTypeCheckForIncompatibleArguments() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double, Integer, String or Collection<Integer> but was Boolean"
+      "Type mismatch: expected Float, Integer, String or Collection<Integer> but was Boolean"
     )
     testInvalidApplication(CTCollection(CTInteger), CTString)(
       "Type mismatch: expected Integer, Collection<Integer> or Collection<Collection<Integer>> but was String"

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpressionTest.scala
@@ -34,13 +34,13 @@ class CaseExpressionTest extends Assertions {
       alternatives = Seq(
         (
           DummyExpression(CTString),
-          DummyExpression(CTDouble)
+          DummyExpression(CTFloat)
         ), (
           DummyExpression(CTString),
           DummyExpression(CTInteger)
         )
       ),
-      default = Some(DummyExpression(CTDouble))
+      default = Some(DummyExpression(CTFloat))
     )(DummyPosition(2))
 
     val result = caseExpression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
@@ -55,13 +55,13 @@ class CaseExpressionTest extends Assertions {
       Seq(
         (
           DummyExpression(CTBoolean),
-          DummyExpression(CTDouble | CTString)
+          DummyExpression(CTFloat | CTString)
         ), (
           DummyExpression(CTBoolean),
           DummyExpression(CTInteger)
         )
       ),
-      Some(DummyExpression(CTDouble | CTNode))
+      Some(DummyExpression(CTFloat | CTNode))
     )(DummyPosition(2))
 
     val result = caseExpression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
@@ -76,13 +76,13 @@ class CaseExpressionTest extends Assertions {
       Seq(
         (
           DummyExpression(CTBoolean),
-          DummyExpression(CTDouble)
+          DummyExpression(CTFloat)
         ), (
           DummyExpression(CTString, DummyPosition(12)),
           DummyExpression(CTInteger)
         )
       ),
-      Some(DummyExpression(CTDouble))
+      Some(DummyExpression(CTFloat))
     )(DummyPosition(2))
 
     val result = caseExpression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CollectionIndexTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CollectionIndexTest.scala
@@ -47,6 +47,6 @@ class CollectionIndexTest extends Assertions {
     )(DummyPosition(4))
 
     val result = index.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
-    assertEquals(Seq(SemanticError("Type mismatch: expected Integer but was Double", index.idx.position)), result.errors)
+    assertEquals(Seq(SemanticError("Type mismatch: expected Integer but was Float", index.idx.position)), result.errors)
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CollectionSliceTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CollectionSliceTest.scala
@@ -62,6 +62,6 @@ class CollectionSliceTest extends Assertions {
     )(DummyPosition(4))
 
     val result = slice.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
-    assertEquals(Seq(SemanticError("Type mismatch: expected Integer but was Double", to.position)), result.errors)
+    assertEquals(Seq(SemanticError("Type mismatch: expected Integer but was Float", to.position)), result.errors)
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/DivideTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/DivideTest.scala
@@ -35,23 +35,23 @@ class DivideTest extends InfixExpressionTestBase(Divide(_, _)(DummyPosition(0)))
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble | CTInteger)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/GreaterThanOrEqualTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/GreaterThanOrEqualTest.scala
@@ -32,7 +32,7 @@ class GreaterThanOrEqualTest extends InfixExpressionTestBase(GreaterThanOrEqual(
 
   @Test
   def shouldSupportComparingDoubles() {
-    testValidTypes(CTDouble, CTDouble)(CTBoolean)
+    testValidTypes(CTFloat, CTFloat)(CTBoolean)
   }
 
   @Test
@@ -42,7 +42,7 @@ class GreaterThanOrEqualTest extends InfixExpressionTestBase(GreaterThanOrEqual(
 
   @Test
   def shouldReturnErrorIfInvalidArgumentTypes() {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Double, Integer or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer or String but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Integer but was Node")
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/GreaterThanTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/GreaterThanTest.scala
@@ -32,7 +32,7 @@ class GreaterThanTest extends InfixExpressionTestBase(GreaterThan(_, _)(DummyPos
 
   @Test
   def shouldSupportComparingDoubles() {
-    testValidTypes(CTDouble, CTDouble)(CTBoolean)
+    testValidTypes(CTFloat, CTFloat)(CTBoolean)
   }
 
   @Test
@@ -42,7 +42,7 @@ class GreaterThanTest extends InfixExpressionTestBase(GreaterThan(_, _)(DummyPos
 
   @Test
   def shouldReturnErrorIfInvalidArgumentTypes() {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Double, Integer or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer or String but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Integer but was Node")
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/LessThanOrEqualTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/LessThanOrEqualTest.scala
@@ -32,7 +32,7 @@ class LessThanOrEqualTest extends InfixExpressionTestBase(LessThanOrEqual(_, _)(
 
   @Test
   def shouldSupportComparingDoubles() {
-    testValidTypes(CTDouble, CTDouble)(CTBoolean)
+    testValidTypes(CTFloat, CTFloat)(CTBoolean)
   }
 
   @Test
@@ -42,7 +42,7 @@ class LessThanOrEqualTest extends InfixExpressionTestBase(LessThanOrEqual(_, _)(
 
   @Test
   def shouldReturnErrorIfInvalidArgumentTypes() {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Double, Integer or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer or String but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Integer but was Node")
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/LessThanTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/LessThanTest.scala
@@ -32,7 +32,7 @@ class LessThanTest extends InfixExpressionTestBase(LessThan(_, _)(DummyPosition(
 
   @Test
   def shouldSupportComparingDoubles() {
-    testValidTypes(CTDouble, CTDouble)(CTBoolean)
+    testValidTypes(CTFloat, CTFloat)(CTBoolean)
   }
 
   @Test
@@ -42,7 +42,7 @@ class LessThanTest extends InfixExpressionTestBase(LessThan(_, _)(DummyPosition(
 
   @Test
   def shouldReturnErrorIfInvalidArgumentTypes() {
-    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Double, Integer or String but was Node")
+    testInvalidApplication(CTNode, CTInteger)("Type mismatch: expected Float, Integer or String but was Node")
     testInvalidApplication(CTInteger, CTNode)("Type mismatch: expected Integer but was Node")
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ModuloTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ModuloTest.scala
@@ -35,23 +35,23 @@ class ModuloTest extends InfixExpressionTestBase(Modulo(_, _)(DummyPosition(0)))
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble | CTInteger)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/MultiplyTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/MultiplyTest.scala
@@ -34,23 +34,23 @@ class MultiplyTest extends InfixExpressionTestBase(Multiply(_, _)(DummyPosition(
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble | CTInteger)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/PowTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/PowTest.scala
@@ -34,24 +34,24 @@ class PowTest extends InfixExpressionTestBase(Pow(_, _)(DummyPosition(0))) {
 
   @Test
   def shouldHandleAllSpecializations() {
-    testValidTypes(CTInteger, CTInteger)(CTDouble)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTInteger)(CTFloat)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat)
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double but was Boolean"
+      "Type mismatch: expected Float but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double but was Boolean"
+      "Type mismatch: expected Float but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReduceExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReduceExpressionTest.scala
@@ -55,14 +55,14 @@ class ReduceExpressionTest extends Assertions {
 
   @Test
   def shouldReturnMinimalTypeOfAccumulatorAndReduceFunction() {
-    val initType = CTString.covariant | CTDouble.covariant
+    val initType = CTString.covariant | CTFloat.covariant
     val collectionType = CTCollection(CTInteger)
 
     val reduceExpression = new DummyExpression(CTAny, DummyPosition(10)) {
       override def semanticCheck(ctx: SemanticContext) = s => {
-        assert(s.symbolTypes("x") === (CTString | CTDouble))
+        assert(s.symbolTypes("x") === (CTString | CTFloat))
         assert(s.symbolTypes("y") === collectionType.innerType.invariant)
-        (this.specifyType(CTDouble) then SemanticCheckResult.success)(s)
+        (this.specifyType(CTFloat) then SemanticCheckResult.success)(s)
       }
     }
 
@@ -76,7 +76,7 @@ class ReduceExpressionTest extends Assertions {
 
     val result = filter.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
     assert(result.errors === Seq())
-    assert(filter.types(result.state) === (CTAny | CTDouble))
+    assert(filter.types(result.state) === (CTAny | CTFloat))
   }
 
   @Test

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/SubtractTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/SubtractTest.scala
@@ -34,23 +34,23 @@ class SubtractTest extends InfixExpressionTestBase(Subtract(_, _)(DummyPosition(
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble | CTInteger)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
   @Test
   def shouldFailTypeCheckForIncompatibleArguments() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/ExtractBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/ExtractBuilderTest.scala
@@ -105,7 +105,7 @@ class ExtractBuilderTest extends BuilderTest {
 
     val returnItems = result.query.returns.toSet
     assertEquals( Set(
-      Solved(ReturnItem(CachedExpression("bar", CTDouble), "bar")),
+      Solved(ReturnItem(CachedExpression("bar", CTFloat), "bar")),
       Solved(ReturnItem(CachedExpression("foo", CTNumber), "foo"))
     ), returnItems )
   }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/AbsTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/AbsTest.scala
@@ -28,22 +28,22 @@ class AbsTest extends FunctionTestBase("abs") {
   @Test
   def shouldFailIfWrongArguments() {
     testInvalidApplication()("Insufficient parameters for function 'abs'")
-    testInvalidApplication(CTDouble, CTDouble)("Too many parameters for function 'abs'")
+    testInvalidApplication(CTFloat, CTFloat)("Too many parameters for function 'abs'")
   }
 
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger)(CTInteger)
-    testValidTypes(CTDouble)(CTDouble)
+    testValidTypes(CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger)(CTDouble | CTInteger)
+    testValidTypes(CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
   @Test
   def shouldReturnErrorIfInvalidArgumentTypes() {
-    testInvalidApplication(CTNode)("Type mismatch: expected Double or Integer but was Node")
+    testInvalidApplication(CTNode)("Type mismatch: expected Float or Integer but was Node")
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileContTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileContTest.scala
@@ -30,30 +30,30 @@ class PercentileContTest extends FunctionTestBase("percentileCont") {
 
   @Test
   def shouldHandleAllSpecializations() {
-    testValidTypes(CTInteger, CTInteger)(CTDouble)
-    testValidTypes(CTInteger, CTDouble)(CTDouble)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTInteger)(CTFloat)
+    testValidTypes(CTInteger, CTFloat)(CTFloat)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTDouble)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat)
   }
 
   @Test
   def shouldFailIfWrongArguments() {
-    testInvalidApplication(CTDouble)("Insufficient parameters for function 'percentileCont'")
-    testInvalidApplication(CTDouble, CTDouble, CTDouble)("Too many parameters for function 'percentileCont'")
+    testInvalidApplication(CTFloat)("Insufficient parameters for function 'percentileCont'")
+    testInvalidApplication(CTFloat, CTFloat, CTFloat)("Too many parameters for function 'percentileCont'")
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double but was Boolean"
+      "Type mismatch: expected Float but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double but was Boolean"
+      "Type mismatch: expected Float but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileDiscTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/PercentileDiscTest.scala
@@ -31,29 +31,29 @@ class PercentileDiscTest extends FunctionTestBase("percentileDisc") {
   @Test
   def shouldHandleAllSpecializations() {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
-    testValidTypes(CTInteger, CTDouble)(CTInteger)
-    testValidTypes(CTDouble, CTInteger)(CTDouble)
-    testValidTypes(CTDouble, CTDouble)(CTDouble)
+    testValidTypes(CTInteger, CTFloat)(CTInteger)
+    testValidTypes(CTFloat, CTInteger)(CTFloat)
+    testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
   @Test
   def shouldHandleCombinedSpecializations() {
-    testValidTypes(CTDouble | CTInteger, CTDouble | CTInteger)(CTInteger | CTDouble)
+    testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTInteger | CTFloat)
   }
 
   @Test
   def shouldFailIfWrongArguments() {
-    testInvalidApplication(CTDouble)("Insufficient parameters for function 'percentileDisc'")
-    testInvalidApplication(CTDouble, CTDouble, CTDouble)("Too many parameters for function 'percentileDisc'")
+    testInvalidApplication(CTFloat)("Insufficient parameters for function 'percentileDisc'")
+    testInvalidApplication(CTFloat, CTFloat, CTFloat)("Too many parameters for function 'percentileDisc'")
   }
 
   @Test
   def shouldFailTypeCheckWhenAddingIncompatible() {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Double but was Boolean"
+      "Type mismatch: expected Float but was Boolean"
     )
     testInvalidApplication(CTBoolean, CTInteger)(
-      "Type mismatch: expected Double or Integer but was Boolean"
+      "Type mismatch: expected Float or Integer but was Boolean"
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/CypherTypeTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/CypherTypeTest.scala
@@ -47,8 +47,8 @@ class CypherTypeTest extends Assertions {
     assertCorrectTypeMergeUp(CTNumber, CTAny, CTAny)
     assertCorrectTypeMergeUp(CTNumber, CTString, CTAny)
     assertCorrectTypeMergeUp(CTNumber, CTCollection(CTAny), CTAny)
-    assertCorrectTypeMergeUp(CTInteger, CTDouble, CTNumber)
-    assertCorrectTypeMergeUp(CTMap, CTDouble, CTAny)
+    assertCorrectTypeMergeUp(CTInteger, CTFloat, CTNumber)
+    assertCorrectTypeMergeUp(CTMap, CTFloat, CTAny)
   }
 
   @Test
@@ -58,8 +58,8 @@ class CypherTypeTest extends Assertions {
     assertCorrectTypeMergeDown(CTCollection(CTNumber), CTCollection(CTInteger), Some(CTCollection(CTInteger)))
     assertCorrectTypeMergeDown(CTNumber, CTString, None)
     assertCorrectTypeMergeDown(CTNumber, CTCollection(CTAny), None)
-    assertCorrectTypeMergeDown(CTInteger, CTDouble, None)
-    assertCorrectTypeMergeDown(CTMap, CTDouble, None)
+    assertCorrectTypeMergeDown(CTInteger, CTFloat, None)
+    assertCorrectTypeMergeDown(CTMap, CTFloat, None)
     assertCorrectTypeMergeDown(CTBoolean, CTCollection(CTAny), None)
   }
 

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeRangeTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeRangeTest.scala
@@ -29,14 +29,14 @@ class TypeRangeTest extends Assertions {
     val rangeOfInteger = TypeRange(CTInteger, CTInteger)
     assertTrue(rangeOfInteger.contains(CTInteger))
     assertFalse(rangeOfInteger.contains(CTNumber))
-    assertFalse(rangeOfInteger.contains(CTDouble))
+    assertFalse(rangeOfInteger.contains(CTFloat))
     assertFalse(rangeOfInteger.contains(CTString))
     assertFalse(rangeOfInteger.contains(CTAny))
 
     val rangeOfNumber = TypeRange(CTNumber, CTNumber)
     assertFalse(rangeOfNumber.contains(CTInteger))
     assertTrue(rangeOfNumber.contains(CTNumber))
-    assertFalse(rangeOfNumber.contains(CTDouble))
+    assertFalse(rangeOfNumber.contains(CTFloat))
     assertFalse(rangeOfNumber.contains(CTString))
     assertFalse(rangeOfNumber.contains(CTAny))
 
@@ -57,11 +57,11 @@ class TypeRangeTest extends Assertions {
     assertTrue(rangeRootedAtAny.contains(CTString))
     assertTrue(rangeRootedAtAny.contains(CTNumber))
     assertTrue(rangeRootedAtAny.contains(CTInteger))
-    assertTrue(rangeRootedAtAny.contains(CTDouble))
+    assertTrue(rangeRootedAtAny.contains(CTFloat))
     assertTrue(rangeRootedAtAny.contains(CTNode))
     assertTrue(rangeRootedAtAny.contains(CTCollection(CTAny)))
-    assertTrue(rangeRootedAtAny.contains(CTCollection(CTDouble)))
-    assertTrue(rangeRootedAtAny.contains(CTCollection(CTCollection(CTDouble))))
+    assertTrue(rangeRootedAtAny.contains(CTCollection(CTFloat)))
+    assertTrue(rangeRootedAtAny.contains(CTCollection(CTCollection(CTFloat))))
   }
 
   @Test
@@ -69,12 +69,12 @@ class TypeRangeTest extends Assertions {
     val rangeRootedAtInteger = TypeRange(CTInteger, None)
     assertTrue(rangeRootedAtInteger.contains(CTInteger))
     assertFalse(rangeRootedAtInteger.contains(CTNumber))
-    assertFalse(rangeRootedAtInteger.contains(CTDouble))
+    assertFalse(rangeRootedAtInteger.contains(CTFloat))
     assertFalse(rangeRootedAtInteger.contains(CTAny))
 
     val rangeRootedAtCollectionOfNumber = TypeRange(CTCollection(CTNumber), None)
     assertTrue(rangeRootedAtCollectionOfNumber.contains(CTCollection(CTInteger)))
-    assertTrue(rangeRootedAtCollectionOfNumber.contains(CTCollection(CTDouble)))
+    assertTrue(rangeRootedAtCollectionOfNumber.contains(CTCollection(CTFloat)))
     assertTrue(rangeRootedAtCollectionOfNumber.contains(CTCollection(CTNumber)))
     assertFalse(rangeRootedAtCollectionOfNumber.contains(CTCollection(CTString)))
     assertFalse(rangeRootedAtCollectionOfNumber.contains(CTAny))
@@ -84,7 +84,7 @@ class TypeRangeTest extends Assertions {
   def unboundedTypeRangeRootedAtBranchTypeShouldContainAllMoreSpecificTypes() {
     val rangeRootedAtInteger = TypeRange(CTNumber, None)
     assertTrue(rangeRootedAtInteger.contains(CTInteger))
-    assertTrue(rangeRootedAtInteger.contains(CTDouble))
+    assertTrue(rangeRootedAtInteger.contains(CTFloat))
     assertTrue(rangeRootedAtInteger.contains(CTNumber))
     assertFalse(rangeRootedAtInteger.contains(CTString))
     assertFalse(rangeRootedAtInteger.contains(CTAny))
@@ -104,18 +104,18 @@ class TypeRangeTest extends Assertions {
     val rangeRootedAtInteger = TypeRange(CTInteger, None)
     assertTrue(rangeRootedAtNumber.contains(rangeRootedAtInteger))
 
-    val rangeOfNumberToDouble = TypeRange(CTNumber, CTDouble)
+    val rangeOfNumberToDouble = TypeRange(CTNumber, CTFloat)
     assertFalse(rangeOfNumberToDouble.contains(rangeRootedAtInteger))
     assertFalse(rangeOfNumberToDouble.contains(rangeRootedAtNumber))
 
-    val rangeOfDouble = TypeRange(CTDouble, CTDouble)
+    val rangeOfDouble = TypeRange(CTFloat, CTFloat)
     val rangeOfNumber = TypeRange(CTNumber, CTNumber)
     val rangeOfInteger = TypeRange(CTInteger, CTInteger)
     assertTrue(rangeOfNumberToDouble.contains(rangeOfDouble))
     assertTrue(rangeOfNumberToDouble.contains(rangeOfNumber))
     assertFalse(rangeOfNumberToDouble.contains(rangeOfInteger))
 
-    val rangeRootedAtDouble = TypeRange(CTDouble, None)
+    val rangeRootedAtDouble = TypeRange(CTFloat, None)
     assertFalse(rangeOfNumberToDouble.contains(rangeRootedAtDouble))
     assertTrue(rangeRootedAtDouble.contains(rangeOfDouble))
 

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpecTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpecTest.scala
@@ -31,11 +31,11 @@ class TypeSpecTest extends Assertions {
     assertTrue(TypeSpec.all contains CTString)
     assertTrue(TypeSpec.all contains CTNumber)
     assertTrue(TypeSpec.all contains CTInteger)
-    assertTrue(TypeSpec.all contains CTDouble)
+    assertTrue(TypeSpec.all contains CTFloat)
     assertTrue(TypeSpec.all contains CTNode)
     assertTrue(TypeSpec.all contains CTCollection(CTAny))
-    assertTrue(TypeSpec.all contains CTCollection(CTDouble))
-    assertTrue(TypeSpec.all contains CTCollection(CTCollection(CTDouble)))
+    assertTrue(TypeSpec.all contains CTCollection(CTFloat))
+    assertTrue(TypeSpec.all contains CTCollection(CTCollection(CTFloat)))
   }
 
   @Test
@@ -70,15 +70,15 @@ class TypeSpecTest extends Assertions {
 
   @Test
   def shouldUnion() {
-    assertEquals(CTNumber | CTDouble | CTInteger | CTString,
+    assertEquals(CTNumber | CTFloat | CTInteger | CTString,
       CTNumber.covariant | CTString.covariant)
-    assertEquals(CTNumber | CTDouble | CTInteger | CTBoolean,
+    assertEquals(CTNumber | CTFloat | CTInteger | CTBoolean,
       CTNumber.covariant | CTBoolean)
 
-    assertEquals(CTNumber | CTDouble | CTInteger | CTCollection(CTString),
+    assertEquals(CTNumber | CTFloat | CTInteger | CTCollection(CTString),
       CTNumber.covariant union CTCollection(CTString).covariant)
     assertEquals(CTCollection(CTNumber) | CTCollection(CTString),
-      CTCollection(CTNumber) union (CTCollection(CTString).covariant))
+      CTCollection(CTNumber) union CTCollection(CTString).covariant)
   }
 
   @Test
@@ -89,7 +89,7 @@ class TypeSpecTest extends Assertions {
 
     assertEquals(CTNumber.invariant, (CTNumber | CTInteger) & (CTAny | CTNumber))
     assertEquals(CTNumber.invariant, CTNumber.contravariant & CTNumber.covariant)
-    assertEquals(CTNumber.invariant, (CTNumber | CTInteger) & (CTNumber | CTDouble))
+    assertEquals(CTNumber.invariant, (CTNumber | CTInteger) & (CTNumber | CTFloat))
 
     assertEquals(CTCollection(CTAny) | CTCollection(CTCollection(CTAny)),
       CTCollection(CTCollection(CTAny)).contravariant intersect CTCollection(CTAny).covariant)
@@ -101,7 +101,7 @@ class TypeSpecTest extends Assertions {
   @Test
   def shouldConstrain() {
     assertEquals(CTInteger.invariant, CTInteger.covariant)
-    assertEquals(CTNumber | CTDouble | CTInteger, CTNumber.covariant)
+    assertEquals(CTNumber | CTFloat | CTInteger, CTNumber.covariant)
 
     assertEquals(CTInteger.invariant, CTInteger constrain CTNumber)
     assertEquals(CTInteger.invariant, CTNumber.covariant constrain CTInteger)
@@ -120,7 +120,7 @@ class TypeSpecTest extends Assertions {
   @Test
   def constrainToBranchTypeWithinCollectionContains() {
     assertEquals(
-      CTCollection(CTNumber) | CTCollection(CTInteger) | CTCollection(CTDouble),
+      CTCollection(CTNumber) | CTCollection(CTInteger) | CTCollection(CTFloat),
       TypeSpec.all constrain CTCollection(CTNumber))
   }
 
@@ -140,7 +140,7 @@ class TypeSpecTest extends Assertions {
 
   @Test
   def unionTwoBranches() {
-    assertEquals(CTNumber | CTInteger | CTDouble | CTString,
+    assertEquals(CTNumber | CTInteger | CTFloat | CTString,
       CTNumber.covariant | CTString.covariant)
   }
 
@@ -165,7 +165,7 @@ class TypeSpecTest extends Assertions {
   @Test
   def constrainToSubTypeOfSome() {
     val constrainedToNumberOrCollectionT = CTNumber.covariant | CTCollection(CTAny).covariant
-    assertEquals(CTCollection(CTNumber) | CTCollection(CTDouble) | CTCollection(CTInteger),
+    assertEquals(CTCollection(CTNumber) | CTCollection(CTFloat) | CTCollection(CTInteger),
       constrainedToNumberOrCollectionT constrain CTCollection(CTNumber))
   }
 
@@ -306,7 +306,7 @@ class TypeSpecTest extends Assertions {
 
   @Test
   def mergeUpWithEquivalent() {
-    assertEquals(CTNumber.covariant, CTNumber.covariant mergeUp (CTNumber | CTInteger | CTDouble))
+    assertEquals(CTNumber.covariant, CTNumber.covariant mergeUp (CTNumber | CTInteger | CTFloat))
   }
 
   @Test
@@ -319,20 +319,20 @@ class TypeSpecTest extends Assertions {
 
   @Test
   def shouldIdentifyCoercions() {
-    assertEquals(CTBoolean.invariant, CTDouble.covariant.coercions)
-    assertEquals(CTBoolean | CTDouble, CTInteger.covariant.coercions)
-    assertEquals(CTBoolean | CTDouble, (CTDouble | CTInteger).coercions)
+    assertEquals(CTBoolean.invariant, CTFloat.covariant.coercions)
+    assertEquals(CTBoolean | CTFloat, CTInteger.covariant.coercions)
+    assertEquals(CTBoolean | CTFloat, (CTFloat | CTInteger).coercions)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant.coercions)
     assertEquals(CTBoolean.invariant, TypeSpec.exact(CTCollection(CTPath)).coercions)
-    assertEquals(CTBoolean | CTDouble, TypeSpec.all.coercions)
+    assertEquals(CTBoolean | CTFloat, TypeSpec.all.coercions)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant.coercions)
   }
 
   @Test
   def shouldIntersectWithCoercions() {
     assertEquals(CTInteger.invariant, TypeSpec.all intersectOrCoerce CTInteger)
-    assertEquals(CTDouble.invariant, CTInteger intersectOrCoerce CTDouble)
-    assertEquals(TypeSpec.none, CTNumber intersectOrCoerce CTDouble)
+    assertEquals(CTFloat.invariant, CTInteger intersectOrCoerce CTFloat)
+    assertEquals(TypeSpec.none, CTNumber intersectOrCoerce CTFloat)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant intersectOrCoerce CTBoolean)
     assertEquals(CTBoolean.invariant, CTNumber.covariant intersectOrCoerce CTBoolean)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant intersectOrCoerce CTBoolean)
@@ -342,8 +342,8 @@ class TypeSpecTest extends Assertions {
   @Test
   def shouldConstrainWithCoercions() {
     assertEquals(CTInteger.invariant, TypeSpec.all constrainOrCoerce CTInteger)
-    assertEquals(CTDouble.invariant, CTInteger constrainOrCoerce CTDouble)
-    assertEquals(TypeSpec.none, CTNumber constrainOrCoerce CTDouble)
+    assertEquals(CTFloat.invariant, CTInteger constrainOrCoerce CTFloat)
+    assertEquals(TypeSpec.none, CTNumber constrainOrCoerce CTFloat)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant constrainOrCoerce CTBoolean)
     assertEquals(CTBoolean.invariant, CTNumber.covariant constrainOrCoerce CTBoolean)
     assertEquals(CTBoolean.invariant, CTCollection(CTAny).covariant constrainOrCoerce CTBoolean)
@@ -357,9 +357,9 @@ class TypeSpecTest extends Assertions {
     assertEquals(CTString.covariant, CTString.invariant)
     assertEquals(CTString.invariant, CTString.covariant)
 
-    assertEquals(CTNumber | CTInteger | CTDouble, CTDouble | CTInteger | CTNumber)
-    assertEquals(CTNumber | CTInteger | CTDouble, CTNumber.covariant)
-    assertEquals(CTNumber.covariant, CTNumber | CTInteger | CTDouble)
+    assertEquals(CTNumber | CTInteger | CTFloat, CTFloat | CTInteger | CTNumber)
+    assertEquals(CTNumber | CTInteger | CTFloat, CTNumber.covariant)
+    assertEquals(CTNumber.covariant, CTNumber | CTInteger | CTFloat)
 
     assertEquals(CTNumber.covariant, CTNumber.covariant | CTInteger.covariant)
     assertNotEquals(CTNumber.covariant, CTNumber.covariant | CTString.covariant)
@@ -438,15 +438,15 @@ class TypeSpecTest extends Assertions {
     assertEquals("Collection<T>", CTCollection(CTAny).covariant.mkString(", "))
     assertEquals("Boolean, Collection<T>", (CTCollection(CTAny).covariant | CTBoolean).mkString(", "))
     assertEquals("Boolean, Collection<String>, Collection<Collection<T>>",
-      ((CTCollection(CTCollection(CTAny)).covariant) | CTBoolean | CTCollection(CTString)).mkString(", "))
+      (CTCollection(CTCollection(CTAny)).covariant | CTBoolean | CTCollection(CTString)).mkString(", "))
   }
 
   @Test
   def shouldFormatToStringForDefiniteSizedSet() {
     assertEquals("Any", CTAny.invariant.mkString(", "))
     assertEquals("String", CTString.invariant.mkString(", "))
-    assertEquals("Double, Integer, Number", CTNumber.covariant.mkString(", "))
-    assertEquals("Boolean, Double, Integer, Number",
+    assertEquals("Float, Integer, Number", CTNumber.covariant.mkString(", "))
+    assertEquals("Boolean, Float, Integer, Number",
       (CTNumber.covariant | CTBoolean.covariant).mkString(", "))
     assertEquals("Any, Number", CTNumber.contravariant.mkString(", "))
     assertEquals("Boolean, String, Collection<Boolean>, Collection<String>",
@@ -460,9 +460,9 @@ class TypeSpecTest extends Assertions {
   def shouldIterateOverDefiniteSizedSet() {
     assertEquals(Seq(CTString),
       CTString.invariant.iterator.toSeq)
-    assertEquals(Seq(CTDouble, CTInteger, CTNumber),
+    assertEquals(Seq(CTFloat, CTInteger, CTNumber),
       CTNumber.covariant.iterator.toSeq)
-    assertEquals(Seq(CTBoolean, CTDouble, CTInteger, CTNumber),
+    assertEquals(Seq(CTBoolean, CTFloat, CTInteger, CTNumber),
       (CTNumber.covariant | CTBoolean.covariant).iterator.toSeq)
     assertEquals(Seq(CTAny, CTNumber),
       CTNumber.contravariant.iterator.toSeq)


### PR DESCRIPTION
And replace use of "Double" with "Float" in error messaging and tests
