### PR TITLE
Adds INSTANCE_ID header in all outgoing messages. HIAAProcessor uses that

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -90,7 +90,8 @@ public class MultiPaxosServerFactory
         DelayedDirectExecutor executor = new DelayedDirectExecutor();
 
         // Create state machines
-        StateMachines stateMachines = new StateMachines( input, output, timeoutStrategy, executor, stateMachineExecutor );
+        StateMachines stateMachines = new StateMachines( input, output, timeoutStrategy, executor, stateMachineExecutor,
+                me );
         Timeouts timeouts = stateMachines.getTimeouts();
 
         final MultiPaxosContext context = new MultiPaxosContext( me,

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
@@ -80,6 +80,7 @@ public class Message<MESSAGETYPE extends MessageType>
     public static final String CREATED_BY = "created-by";
     public static final String FROM = "from";
     public static final String TO = "to";
+    public static final String INSTANCE_ID = "instance-id";
 
     final private MESSAGETYPE messageType;
     final private Object payload;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.cluster.protocol.cluster;
 
+import static org.neo4j.cluster.com.message.Message.internal;
+import static org.neo4j.cluster.com.message.Message.respond;
+import static org.neo4j.cluster.com.message.Message.timeout;
+import static org.neo4j.cluster.com.message.Message.to;
+import static org.neo4j.helpers.collection.Iterables.count;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,12 +39,6 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMess
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.statemachine.State;
 import org.neo4j.helpers.collection.Iterables;
-
-import static org.neo4j.cluster.com.message.Message.internal;
-import static org.neo4j.cluster.com.message.Message.respond;
-import static org.neo4j.cluster.com.message.Message.timeout;
-import static org.neo4j.cluster.com.message.Message.to;
-import static org.neo4j.helpers.collection.Iterables.count;
 
 /**
  * State machine for the Cluster API
@@ -429,9 +429,12 @@ public enum ClusterState
                             boolean messageComesFromSameHost = request.getJoiningId().equals( context.getMyId() );
                             boolean otherInstanceJoiningWithSameId = context.isInstanceJoiningFromDifferentUri(
                                     joiningId, joiningUri );
+                            boolean isFromSameURIAsTheOneWeAlreadyKnow = context.getUriForId( joiningId ) != null &&
+                                    context.getUriForId( joiningId ).equals( joiningUri );
 
                             boolean somethingIsWrong =
-                                    (isInCluster && !messageComesFromSameHost && isCurrentlyAlive) || otherInstanceJoiningWithSameId ;
+                                    ( isInCluster && !messageComesFromSameHost && isCurrentlyAlive && !isFromSameURIAsTheOneWeAlreadyKnow )
+                                            || otherInstanceJoiningWithSameId ;
 
                             if ( somethingIsWrong )
                             {

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
@@ -19,13 +19,26 @@
  */
 package org.neo4j.cluster;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.cluster.com.message.Message.internal;
+
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
-import org.mockito.Mockito;
-
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageSender;
@@ -36,37 +49,104 @@ import org.neo4j.cluster.statemachine.StateMachine;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.kernel.logging.Logging;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-
-import static org.neo4j.cluster.com.message.Message.internal;
-
 public class StateMachinesTest
 {
     @Test
     public void whenMessageHandlingCausesNewMessagesThenEnsureCorrectOrder() throws Exception
     {
         // Given
-        StateMachines stateMachines = new StateMachines( Mockito.mock(MessageSource.class), Mockito.mock( MessageSender.class), Mockito.mock( TimeoutStrategy.class), Mockito.mock(DelayedDirectExecutor.class), new Executor()
+        StateMachines stateMachines = new StateMachines( mock( MessageSource.class ), mock( MessageSender.class ),
+                mock( TimeoutStrategy.class ), mock( DelayedDirectExecutor.class ), new Executor()
         {
             @Override
             public void execute( Runnable command )
             {
                 command.run();
             }
-        } );
+        }, mock( InstanceId.class ) );
 
         ArrayList<TestMessage> handleOrder = new ArrayList<TestMessage>(  );
-        StateMachine stateMachine = new StateMachine( handleOrder, TestMessage.class, TestState.test, Mockito.mock(Logging.class) );
+        StateMachine stateMachine = new StateMachine( handleOrder, TestMessage.class, TestState.test,
+                mock( Logging.class ) );
 
         stateMachines.addStateMachine( stateMachine );
-
 
         // When
         stateMachines.process( internal( TestMessage.message1 ) );
 
         // Then
         assertThat( handleOrder.toString(), equalTo( "[message1, message2, message4, message5, message3]" ) );
+    }
+
+    @Test
+    public void shouldAlwaysAddItsInstanceIdToOutgoingMessages() throws Exception
+    {
+        InstanceId me = new InstanceId( 42 );
+        final List<Message> sentOut = new LinkedList<Message>();
+
+        /*
+         * Lots of setup required. Must have a sender that keeps messages so we can see what the machine sent out.
+         * We must have the StateMachines actually delegate the incoming message and retrieve the generated outgoing.
+         * That means we need an actual StateMachine with a registered MessageType. And most of those are void
+         * methods, which means lots of Answer objects.
+         */
+        // Given
+        MessageSender sender = mock( MessageSender.class );
+        // The sender, which adds messages outgoing to the list above.
+        doAnswer( new Answer()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                sentOut.addAll( (Collection<? extends Message>) invocation.getArguments()[0] );
+                return null;
+            }
+        } ).when( sender ).process( Matchers.<List<Message<? extends MessageType>>>any() );
+
+        StateMachines stateMachines = new StateMachines( mock( MessageSource.class ), sender,
+        mock( TimeoutStrategy.class ), mock( DelayedDirectExecutor.class ), new Executor()
+        {
+            @Override
+            public void execute( Runnable command )
+            {
+                command.run();
+            }
+        }, me );
+
+        // The state machine, which has a TestMessage message type and simply adds a TO header to the messages it
+        // is handed to handle.
+        StateMachine machine = mock( StateMachine.class );
+        when( machine.getMessageType() ).then(  new Answer<Object>()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                return TestMessage.class;
+            }
+        });
+        doAnswer( new Answer<Object>()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                Message message = (Message) invocation.getArguments()[0];
+                MessageHolder holder = (MessageHolder) invocation.getArguments()[1];
+                message.setHeader( Message.TO, "to://neverland" );
+                holder.offer( message );
+                return null;
+            }
+        } ).when( machine ).handle( any( Message.class ), any( MessageHolder.class ) );
+        stateMachines.addStateMachine( machine );
+
+        // When
+        stateMachines.process( Message.internal( TestMessage.message1 ) );
+
+        // Then
+        assertEquals( "StateMachines should not make up messages from thin air", 1, sentOut.size() );
+        Message sent = sentOut.get( 0 );
+        assertTrue( "StateMachines should add the instance-id header", sent.hasHeader( Message.INSTANCE_ID ) );
+        assertEquals( "StateMachines should add instance-id header that has the correct value",
+                me.toString(), sent.getHeader( Message.INSTANCE_ID ) );
     }
 
     public enum TestMessage

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.heartbeat;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.com.message.Message;
+import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
+import org.neo4j.cluster.protocol.cluster.ClusterContext;
+
+public class HeartbeatIAmAliveProcessorTest
+{
+    @Test
+    public void shouldNotCreateHeartbeatsForNonExistingInstances() throws Exception
+    {
+        // GIVEN
+        MessageHolder outgoing = mock( MessageHolder.class );
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+            {{
+                put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+            }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( outgoing, mockContext );
+
+        Message incoming = Message.to( mock( MessageType.class ), URI.create( "ha://someAwesomeInstanceInJapan") )
+                .setHeader( Message.FROM, "some://value" ).setHeader( Message.INSTANCE_ID, "5" );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        verifyZeroInteractions( outgoing );
+    }
+
+    @Test
+    public void shouldNotProcessMessagesWithEqualFromAndToHeaders() throws Exception
+    {
+        URI to = URI.create( "ha://someAwesomeInstanceInJapan" );
+
+        // GIVEN
+        MessageHolder outgoing = mock( MessageHolder.class );
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+                {{
+                        put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                        put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+                    }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( outgoing, mockContext );
+        Message incoming = Message.to( mock( MessageType.class ), to ).setHeader( Message.FROM, to.toASCIIString() )
+                .setHeader( Message.INSTANCE_ID, "1" );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        verifyZeroInteractions( outgoing );
+    }
+
+    @Test
+    public void shouldCorrectlySetTheInstanceIdHeaderInTheGeneratedHeartbeat() throws Exception
+    {
+        final List<Message> sentOut = new LinkedList<Message>();
+
+        // Given
+        MessageHolder holder = mock( MessageHolder.class );
+        // The sender, which adds messages outgoing to the list above.
+        doAnswer( new Answer()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                sentOut.add( (Message) invocation.getArguments()[0] );
+                return null;
+            }
+        } ).when( holder ).offer( Matchers.<Message<MessageType>>any() );
+
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+                {{
+                        put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                        put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+                    }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( holder, mockContext );
+
+        Message incoming = Message.to( mock( MessageType.class ), URI.create( "ha://someAwesomeInstanceInJapan") )
+                .setHeader( Message.INSTANCE_ID, "2" ).setHeader( Message.FROM, "ha://2" );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        assertEquals( 1, sentOut.size() );
+        assertEquals( HeartbeatMessage.i_am_alive, sentOut.get( 0 ).getMessageType() );
+        assertEquals( new InstanceId( 2 ), ((HeartbeatMessage.IAmAliveState) sentOut.get( 0 ).getPayload() ).getServer() );
+    }
+
+    /*
+     * This test is required to ensure compatibility with the previous version. If we fail on non existing INSTANCE_ID
+     * header then heartbeats may pause during rolling upgrades and cause timeouts, which we don't want.
+     */
+    @Test
+    public void shouldRevertToInverseUriLookupIfNoInstanceIdHeader() throws Exception
+    {
+        final List<Message> sentOut = new LinkedList<Message>();
+        String instance2UriString = "ha://2";
+
+        // Given
+        MessageHolder holder = mock( MessageHolder.class );
+        // The sender, which adds messages outgoing to the list above.
+        doAnswer( new Answer()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                sentOut.add( (Message) invocation.getArguments()[0] );
+                return null;
+            }
+        } ).when( holder ).offer( Matchers.<Message<MessageType>>any() );
+
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getIdForUri( URI.create( instance2UriString ) ) ).thenReturn( new InstanceId( 2 ) );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+                {{
+                        put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                        put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+                    }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( holder, mockContext );
+
+        Message incoming = Message.to( mock( MessageType.class ), URI.create( "ha://someAwesomeInstanceInJapan") )
+                .setHeader( Message.FROM, instance2UriString );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        assertEquals( 1, sentOut.size() );
+        assertEquals( HeartbeatMessage.i_am_alive, sentOut.get( 0 ).getMessageType() );
+        assertEquals( new InstanceId( 2 ), ((HeartbeatMessage.IAmAliveState) sentOut.get( 0 ).getPayload() ).getServer() );
+    }
+}


### PR DESCRIPTION
HeartbeatIAmAliveProcessor relies on incoming message's URI to determine the
 originating InstanceId. That is error prone and unnatural, since every
 layer but the network should not care about URIs. This commit ensures
 that all outgoing messages have an INSTANCE_ID header with the sending
 instance's ID.
This commit also ensures that HIAAProcessor reverts to looking at
 FROM if the INSTANCE_ID header is not present, since we need to
 make sure that during rolling upgrades from 1.9.6 forward we don't
 loose contact with older version instances
