### PR TITLE
RelationshipGroupRecords are sorted in their linked chain

### DIFF
--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -19,17 +19,16 @@
  */
 package org.neo4j.graphalgo.path;
 
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphalgo.PathFinder;
 import org.neo4j.graphalgo.impl.path.ExactDepthPathFinder;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpanders;
-import org.neo4j.kernel.Traversal;
 
 import common.Neo4jAlgoTestCase;
+import static org.junit.Assert.assertNotNull;
 
 public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
 {
@@ -53,19 +52,19 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
         graph.makeEdgeChain( "SUPER,7,8" );
         graph.makeEdgeChain( "SOURCE,z,9,0,TARGET" );
     }
-    
+
     private PathFinder<Path> newFinder()
     {
         return new ExactDepthPathFinder( PathExpanders.allTypesAndDirections(), 4, 4 );
     }
-    
+
     @Test
     public void testSingle()
     {
         PathFinder<Path> finder = newFinder();
         Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) );
         assertNotNull( path );
-        assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" ); 
+        assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" );
     }
 
     @Test

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Loaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Loaders.java
@@ -23,21 +23,24 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
-import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeStore;
 import org.neo4j.kernel.impl.nioneo.store.PrimitiveRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupStore;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
 import org.neo4j.kernel.impl.nioneo.xa.RecordAccess.Loader;
 
 public class Loaders
 {
-    public static Loader<Long,NodeRecord,Void> nodeLoader( final NeoStore neoStore )
+    public static Loader<Long,NodeRecord,Void> nodeLoader( final NodeStore store )
     {
         return new Loader<Long,NodeRecord,Void>()
         {
@@ -51,13 +54,13 @@ public class Loaders
             @Override
             public NodeRecord load( Long key, Void additionalData )
             {
-                return neoStore.getNodeStore().getRecord( key );
+                return store.getRecord( key );
             }
 
             @Override
             public void ensureHeavy( NodeRecord record )
             {
-                neoStore.getNodeStore().ensureHeavy( record );
+                store.ensureHeavy( record );
             }
 
             @Override
@@ -68,7 +71,7 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader( final NeoStore neoStore )
+    public static Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader( final PropertyStore store )
     {
         return new RecordChanges.Loader<Long,PropertyRecord,PrimitiveRecord>()
         {
@@ -91,7 +94,7 @@ public class Loaders
             @Override
             public PropertyRecord load( Long key, PrimitiveRecord additionalData )
             {
-                PropertyRecord record = neoStore.getPropertyStore().getRecord( key.longValue() );
+                PropertyRecord record = store.getRecord( key.longValue() );
                 setOwner( record, additionalData );
                 return record;
             }
@@ -101,7 +104,7 @@ public class Loaders
             {
                 for ( PropertyBlock block : record.getPropertyBlocks() )
                 {
-                    neoStore.getPropertyStore().ensureHeavy( block );
+                    store.ensureHeavy( block );
                 }
             }
 
@@ -113,7 +116,7 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,RelationshipRecord,Void> relationshipLoader( final NeoStore neoStore )
+    public static Loader<Long,RelationshipRecord,Void> relationshipLoader( final RelationshipStore store )
     {
         return new RecordChanges.Loader<Long, RelationshipRecord, Void>()
         {
@@ -126,7 +129,7 @@ public class Loaders
             @Override
             public RelationshipRecord load( Long key, Void additionalData )
             {
-                return neoStore.getRelationshipStore().getRecord( key );
+                return store.getRecord( key );
             }
 
             @Override
@@ -142,7 +145,8 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader( final NeoStore neoStore )
+    public static Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader(
+            final RelationshipGroupStore store )
     {
         return new RecordChanges.Loader<Long, RelationshipGroupRecord, Integer>()
         {
@@ -155,7 +159,7 @@ public class Loaders
             @Override
             public RelationshipGroupRecord load( Long key, Integer type )
             {
-                return neoStore.getRelationshipGroupStore().getRecord( key );
+                return store.getRecord( key );
             }
 
             @Override
@@ -171,29 +175,28 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,Collection<DynamicRecord>,SchemaRule> schemaRuleLoader( final NeoStore neoStore )
+    public static Loader<Long,Collection<DynamicRecord>,SchemaRule> schemaRuleLoader( final SchemaStore store )
     {
         return new RecordChanges.Loader<Long, Collection<DynamicRecord>, SchemaRule>()
         {
             @Override
             public Collection<DynamicRecord> newUnused(Long key, SchemaRule additionalData)
             {
-                return neoStore.getSchemaStore().allocateFrom(additionalData);
+                return store.allocateFrom(additionalData);
             }
 
             @Override
             public Collection<DynamicRecord> load(Long key, SchemaRule additionalData)
             {
-                return neoStore.getSchemaStore().getRecords( key );
+                return store.getRecords( key );
             }
 
             @Override
             public void ensureHeavy(Collection<DynamicRecord> dynamicRecords)
             {
-                SchemaStore schemaStore = neoStore.getSchemaStore();
                 for ( DynamicRecord record : dynamicRecords)
                 {
-                    schemaStore.ensureHeavy(record);
+                    store.ensureHeavy(record);
                 }
             }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
@@ -65,7 +65,7 @@ public class NeoStoreTransactionContext
         commandSet = new CommandSet( neoStore );
 
         locker = new TransactionalRelationshipLocker();
-        relationshipGroupGetter = new RelationshipGroupGetter( recordChangeSet.getRelGroupRecords() );
+        relationshipGroupGetter = new RelationshipGroupGetter( neoStore.getRelationshipGroupStore() );
         propertyTraverser = new PropertyTraverser();
         propertyCreator = new PropertyCreator( neoStore.getPropertyStore(), propertyTraverser );
         propertyDeleter = new PropertyDeleter( neoStore.getPropertyStore(), propertyTraverser );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChangeSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChangeSet.java
@@ -40,11 +40,11 @@ public class RecordChangeSet implements RecordAccessSet
 
     public RecordChangeSet( NeoStore neoStore )
     {
-        this.nodeRecords = new RecordChanges<>( Loaders.nodeLoader( neoStore ), true );
-        this.propertyRecords = new RecordChanges<>( Loaders.propertyLoader( neoStore ), true );
-        this.relRecords = new RecordChanges<>( Loaders.relationshipLoader( neoStore ), false );
-        this.relGroupRecords = new RecordChanges<>( Loaders.relationshipGroupLoader( neoStore ), false );
-        this.schemaRuleChanges = new RecordChanges<>( Loaders.schemaRuleLoader( neoStore ), true );
+        this.nodeRecords = new RecordChanges<>( Loaders.nodeLoader( neoStore.getNodeStore() ), true );
+        this.propertyRecords = new RecordChanges<>( Loaders.propertyLoader( neoStore.getPropertyStore() ), true );
+        this.relRecords = new RecordChanges<>( Loaders.relationshipLoader( neoStore.getRelationshipStore() ), false );
+        this.relGroupRecords = new RecordChanges<>( Loaders.relationshipGroupLoader( neoStore.getRelationshipGroupStore() ), false );
+        this.schemaRuleChanges = new RecordChanges<>( Loaders.schemaRuleLoader( neoStore.getSchemaStore() ), true );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipDeleter.java
@@ -131,7 +131,8 @@ public class RelationshipDeleter
         else
         {
             RecordProxy<Long, RelationshipGroupRecord, Integer> groupChange =
-                    relGroupGetter.getRelationshipGroup( startNode, rel.getType() );
+                    relGroupGetter.getRelationshipGroup( startNode, rel.getType(),
+                            recordChanges.getRelGroupRecords() ).group();
             assert groupChange != null : "Relationship group " + rel.getType() + " should have existed here";
             RelationshipGroupRecord group = groupChange.forReadingData();
             RelIdArray.DirectionWrapper dir = DirectionIdentifier.wrapDirection( rel, startNode );
@@ -164,7 +165,8 @@ public class RelationshipDeleter
         else
         {
             RecordProxy<Long, RelationshipGroupRecord, Integer> groupChange =
-                    relGroupGetter.getRelationshipGroup( endNode, rel.getType() );
+                    relGroupGetter.getRelationshipGroup( endNode, rel.getType(),
+                            recordChanges.getRelGroupRecords() ).group();
             RelIdArray.DirectionWrapper dir = DirectionIdentifier.wrapDirection( rel, endNode );
             assert groupChange != null || loop : "Group has been deleted";
             if ( groupChange != null )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -250,7 +250,7 @@ public class BatchInserterImpl implements BatchInserter
         // Record access
         recordAccess = new DirectRecordAccessSet( neoStore );
         relationshipCreator = new RelationshipCreator( RelationshipLocker.NO_LOCKING,
-                new RelationshipGroupGetter( recordAccess.getRelGroupRecords() ), neoStore );
+                new RelationshipGroupGetter( neoStore.getRelationshipGroupStore() ), neoStore );
         propertyTraverser = new PropertyTraverser();
         propertyCreator = new PropertyCreator( getPropertyStore(), propertyTraverser );
         propertyDeletor = new PropertyDeleter( getPropertyStore(), propertyTraverser );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
@@ -43,10 +43,10 @@ public class DirectRecordAccessSet implements RecordAccessSet
 
     public DirectRecordAccessSet( NeoStore neoStore )
     {
-        nodeRecords = new DirectRecordAccess<>( neoStore.getNodeStore(), Loaders.nodeLoader( neoStore ) );
-        propertyRecords = new DirectRecordAccess<>( neoStore.getPropertyStore(), Loaders.propertyLoader( neoStore ) );
-        relationshipRecords = new DirectRecordAccess<>( neoStore.getRelationshipStore(), Loaders.relationshipLoader( neoStore ) );
-        relationshipGroupRecords = new DirectRecordAccess<>( neoStore.getRelationshipGroupStore(), Loaders.relationshipGroupLoader( neoStore ) );
+        nodeRecords = new DirectRecordAccess<>( neoStore.getNodeStore(), Loaders.nodeLoader( neoStore.getNodeStore() ) );
+        propertyRecords = new DirectRecordAccess<>( neoStore.getPropertyStore(), Loaders.propertyLoader( neoStore.getPropertyStore() ) );
+        relationshipRecords = new DirectRecordAccess<>( neoStore.getRelationshipStore(), Loaders.relationshipLoader( neoStore.getRelationshipStore() ) );
+        relationshipGroupRecords = new DirectRecordAccess<>( neoStore.getRelationshipGroupStore(), Loaders.relationshipGroupLoader( neoStore.getRelationshipGroupStore() ) );
 //        schemaRecords = new DirectRecordAccess<>( neoStore.getSchemaStore(), Loaders.schemaRuleLoader( neoStore ) ); // TODO
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipGroupGetterTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.nioneo.xa.RelationshipGroupGetter.RelationshipGroupPosition;
+import org.neo4j.unsafe.batchinsert.DirectRecordAccess;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RelationshipGroupGetterTest
+{
+    @Test
+    public void shouldAbortLoadingGroupChainIfComeTooFar() throws Exception
+    {
+        // GIVEN a node with relationship group chain 2-->4-->10-->23
+        RelationshipGroupStore store = mock( RelationshipGroupStore.class );
+        RelationshipGroupGetter groupGetter = new RelationshipGroupGetter( store );
+        RelationshipGroupRecord group_2 = new RelationshipGroupRecord( 0, 2 );
+        RelationshipGroupRecord group_4 = new RelationshipGroupRecord( 1, 4 );
+        RelationshipGroupRecord group_10 = new RelationshipGroupRecord( 2, 10 );
+        RelationshipGroupRecord group_23 = new RelationshipGroupRecord( 3, 23 );
+        linkAndMock( store, group_2, group_4, group_10, group_23 );
+        NodeRecord node = new NodeRecord( 0, true, group_2.getId(), -1 );
+
+        // WHEN trying to find relationship group 7
+        RecordAccess<Long, RelationshipGroupRecord, Integer> access =
+                new DirectRecordAccess<>( store, Loaders.relationshipGroupLoader( store ) );
+        RelationshipGroupPosition result = groupGetter.getRelationshipGroup( node, 7, access );
+
+        // THEN only groups 2, 4 and 10 should have been loaded
+        InOrder verification = inOrder( store );
+        verification.verify( store ).getRecord( group_2.getId() );
+        verification.verify( store ).getRecord( group_4.getId() );
+        verification.verify( store ).getRecord( group_10.getId() );
+        verification.verifyNoMoreInteractions();
+
+        // it should also be reported as not found
+        assertNull( result.group() );
+        // with group 4 as closes previous one
+        assertEquals( group_4, result.closestPrevious().forReadingData() );
+    }
+
+    private void linkAndMock( RelationshipGroupStore store, RelationshipGroupRecord... groups )
+    {
+        for ( int i = 0; i < groups.length; i++ )
+        {
+            when( store.getRecord( groups[i].getId() ) ).thenReturn( groups[i] );
+            if ( i > 0 )
+            {
+                groups[i].setPrev( groups[i-1].getId() );
+            }
+            if ( i < groups.length-1 )
+            {
+                groups[i].setNext( groups[i+1].getId() );
+            }
+        }
+    }
+}

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.Traversal;
 
 @Description( "Here you can describe your plugin. It will show up in the description of the methods." )
 public class FunctionalTestPlugin extends ServerPlugin

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/Plugin.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/Plugin.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.collection.FilteringIterable;
-import org.neo4j.kernel.Traversal;
 
 @Description( "Here you can describe your plugin. It will show up in the description of the methods." )
 public class Plugin extends ServerPlugin


### PR DESCRIPTION
this to always create a predictable outcome when new groups are added
and to be able to earlier abort scanning the chain if a particular group
is not found.
