### PR TITLE
rewrite: extract parameters from literals

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Literal.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Literal.scala
@@ -28,7 +28,9 @@ sealed trait Literal extends Expression {
   def value: Any
 }
 
-sealed abstract class IntegerLiteral(stringVal: String) extends Literal with SimpleTyping {
+sealed trait NumberLiteral extends Literal
+
+sealed abstract class IntegerLiteral(stringVal: String) extends NumberLiteral with SimpleTyping {
   lazy val value = stringVal.toLong
 
   protected def possibleTypes = CTInteger
@@ -46,7 +48,7 @@ sealed abstract class IntegerLiteral(stringVal: String) extends Literal with Sim
 case class SignedIntegerLiteral(stringVal: String)(val position: InputPosition) extends IntegerLiteral(stringVal)
 case class UnsignedIntegerLiteral(stringVal: String)(val position: InputPosition) extends IntegerLiteral(stringVal)
 
-case class DoubleLiteral(stringVal: String)(val position: InputPosition) extends Literal with SimpleTyping {
+case class DoubleLiteral(stringVal: String)(val position: InputPosition) extends NumberLiteral with SimpleTyping {
   val value = stringVal.toDouble
 
   protected def possibleTypes = CTFloat
@@ -77,12 +79,14 @@ case class Null()(val position: InputPosition) extends Literal with SimpleTyping
   protected def possibleTypes = CTAny.covariant
 }
 
-case class True()(val position: InputPosition) extends Literal with SimpleTyping {
+sealed trait BooleanLiteral extends Literal
+
+case class True()(val position: InputPosition) extends BooleanLiteral with SimpleTyping {
   val value = true
   protected def possibleTypes = CTBoolean
 }
 
-case class False()(val position: InputPosition) extends Literal with SimpleTyping {
+case class False()(val position: InputPosition) extends BooleanLiteral with SimpleTyping {
   val value = false
   protected def possibleTypes = CTBoolean
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/bottomUpExpressions.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/bottomUpExpressions.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v2_0._
+
+case class bottomUpExpressions(rewriters: Rewriter*) extends Rewriter {
+  import Rewritable._
+
+  def apply(term: AnyRef): Some[AnyRef] = Some(term match {
+    case _: ast.Match | _: ast.Create | _: ast.CreateUnique | _: ast.Merge | _: ast.SetClause | _: ast.Return | _: ast.With =>
+      term.dup(t => this.apply(t).get)
+
+    case _: ast.Clause =>
+      term
+
+    case n: ast.NodePattern =>
+      val rewrittenProperties = n.properties.map(t => this.apply(t).get).asInstanceOf[Option[ast.Expression]]
+      if (rewrittenProperties == n.properties)
+        n
+      else
+        n.copy(properties = rewrittenProperties)(n.position)
+
+    case n: ast.RelationshipPattern =>
+      val rewrittenProperties = n.properties.map(t => this.apply(t).get).asInstanceOf[Option[ast.Expression]]
+      if (rewrittenProperties == n.properties)
+        n
+      else
+        n.copy(properties = rewrittenProperties)(n.position)
+
+    case _: ast.Expression =>
+      rewriters.foldLeft(term.dup(t => this.apply(t).get)) {
+        (t, r) => t.rewrite(r)
+      }
+
+    case _ =>
+      term.dup(t => this.apply(t).get)
+  })
+}

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/literalReplacement.scala
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v2_0._
+import ast._
+
+object literalReplacement {
+  case class ExtractParameterRewriter(replaceableLiterals: Map[(Any, InputPosition), Parameter]) extends Rewriter {
+    def apply(that: AnyRef): Option[AnyRef] = rewriter.apply(that)
+
+    private val rewriter: Rewriter = Rewriter.lift {
+      case l: Literal =>
+        replaceableLiterals.get((l.value, l.position)).getOrElse(l)
+    }
+  }
+
+  private val literalMatcher: PartialFunction[Any, Map[(Any, InputPosition), ast.Parameter] => Map[(Any, InputPosition), ast.Parameter]] = {
+    case l: ast.StringLiteral => m => m + ((l.value, l.position) -> ast.Parameter(s"  AUTOSTRING${m.size}")(l.position))
+    case l: ast.IntegerLiteral => m => m + ((l.value, l.position) -> ast.Parameter(s"  AUTOINT${m.size}")(l.position))
+    case l: ast.DoubleLiteral => m => m + ((l.value, l.position) -> ast.Parameter(s"  AUTODOUBLE${m.size}")(l.position))
+    case l: ast.BooleanLiteral => m => m + ((l.value, l.position) -> ast.Parameter(s"  AUTOBOOL${m.size}")(l.position))
+  }
+
+  def apply(term: ASTNode): (Rewriter, Map[String, Any]) = {
+    val replaceableLiterals = term.foldt(Map.empty[(Any,InputPosition), ast.Parameter]) {
+      case u: ast.SetClause =>
+        (acc, _) => u.fold(acc)(literalMatcher)
+      case r: ast.Return =>
+        (acc, _) => r.fold(acc)(literalMatcher)
+      case w: ast.With =>
+        (acc, _) => w.fold(acc)(literalMatcher)
+      case _: ast.Match | _: ast.Create | _: ast.CreateUnique | _: ast.Merge =>
+        (acc, children) => children(acc)
+      case _: ast.Clause =>
+        (acc, _) => acc
+      case n: ast.NodePattern =>
+        (acc, _) => n.properties.fold(acc)(_.fold(acc)(literalMatcher))
+      case r: ast.RelationshipPattern =>
+        (acc, _) => r.properties.fold(acc)(_.fold(acc)(literalMatcher))
+      case w: ast.Where =>
+        (acc, _) => w.fold(acc)(literalMatcher)
+    }
+
+    (ExtractParameterRewriter(replaceableLiterals), replaceableLiterals.map {
+      case (l, p) => (p.name, l._1)
+    })
+  }
+}

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/LiteralReplacementTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/rewriters/LiteralReplacementTest.scala
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v2_0._
+import org.neo4j.cypher.internal.commons.CypherTestSuite
+
+class LiteralReplacementTest extends CypherTestSuite {
+  import parser.ParserFixture._
+
+  test("should extract literals in return clause") {
+    assertRewrite(s"RETURN 1 as result", s"RETURN {`  AUTOINT0`} as result", Map("  AUTOINT0" -> 1))
+    assertRewrite(s"RETURN 1.1 as result", s"RETURN {`  AUTODOUBLE0`} as result", Map("  AUTODOUBLE0" -> 1.1))
+    assertRewrite(s"RETURN true as result", s"RETURN {`  AUTOBOOL0`} as result", Map("  AUTOBOOL0" -> true))
+    assertRewrite(s"RETURN false as result", s"RETURN {`  AUTOBOOL0`} as result", Map("  AUTOBOOL0" -> false))
+    assertRewrite("RETURN 'apa' as result", "RETURN {`  AUTOSTRING0`} as result", Map("  AUTOSTRING0" -> "apa"))
+    assertRewrite("RETURN \"apa\" as result", "RETURN {`  AUTOSTRING0`} as result", Map("  AUTOSTRING0" -> "apa"))
+  }
+
+  test("should extract literals in match clause") {
+    assertRewrite(s"MATCH ({a:1})", s"MATCH ({a:{`  AUTOINT0`}})", Map("  AUTOINT0" -> 1))
+    assertRewrite(s"MATCH ({a:1.1})", s"MATCH ({a:{`  AUTODOUBLE0`}})", Map("  AUTODOUBLE0" -> 1.1))
+    assertRewrite(s"MATCH ({a:true})", s"MATCH ({a:{`  AUTOBOOL0`}})", Map("  AUTOBOOL0" -> true))
+    assertRewrite(s"MATCH ({a:false})", s"MATCH ({a:{`  AUTOBOOL0`}})", Map("  AUTOBOOL0" -> false))
+    assertRewrite("MATCH ({a:'apa'})", "MATCH ({a:{`  AUTOSTRING0`}})", Map("  AUTOSTRING0" -> "apa"))
+    assertRewrite("MATCH ({a:\"apa\"})", "MATCH ({a:{`  AUTOSTRING0`}})", Map("  AUTOSTRING0" -> "apa"))
+  }
+
+  test("should extract literals in skip limit clause") {
+    assertRewrite(
+      s"RETURN 0 as x SKIP 1 limit 2",
+      s"RETURN {`  AUTOINT0`} as x SKIP {`  AUTOINT1`} LIMIT {`  AUTOINT2`}",
+      Map("  AUTOINT0" -> 0, "  AUTOINT1" -> 1, "  AUTOINT2" -> 2)
+    )
+  }
+
+  test("should extract literals in create statement clause") {
+    assertRewrite(
+      "create (a {a:0, b:'name 0', c:10000000, d:'a very long string 0'})",
+      "create (a {a:{`  AUTOINT0`}, b:{`  AUTOSTRING1`}, c:{`  AUTOINT2`}, d:{`  AUTOSTRING3`}})",
+      Map("  AUTOINT0"->0,"  AUTOSTRING1"->"name 0","  AUTOINT2"->10000000,"  AUTOSTRING3"->"a very long string 0")
+    )
+  }
+
+  test("should extract literals in merge clause") {
+    assertRewrite(
+      s"MERGE (n {a:'apa'}) ON CREATE SET n.foo = 'apa' ON MATCH SET n.foo = 'apa'",
+      s"MERGE (n {a:{`  AUTOSTRING0`}}) ON CREATE SET n.foo = {`  AUTOSTRING1`} ON MATCH SET n.foo = {`  AUTOSTRING2`}",
+      Map("  AUTOSTRING0" -> "apa", "  AUTOSTRING1" -> "apa", "  AUTOSTRING2" -> "apa")
+    )
+  }
+
+  test("should extract literals in multiple patterns") {
+    assertRewrite(
+      s"create (a {a:0, b:'name 0', c:10000000, d:'a very long string 0'}) create (b {a:0, b:'name 0', c:10000000, d:'a very long string 0'}) create (a)-[:KNOWS {since: 0}]->(b)",
+      s"create (a {a:{`  AUTOINT0`}, b:{`  AUTOSTRING1`}, c:{`  AUTOINT2`}, d:{`  AUTOSTRING3`}}) create (b {a:{`  AUTOINT4`}, b:{`  AUTOSTRING5`}, c:{`  AUTOINT6`}, d:{`  AUTOSTRING7`}}) create (a)-[:KNOWS {since: {`  AUTOINT8`}}]->(b)",
+      Map(
+        "  AUTOINT0" -> 0, "  AUTOSTRING1" -> "name 0", "  AUTOINT2" -> 10000000, "  AUTOSTRING3" -> "a very long string 0",
+        "  AUTOINT4" -> 0, "  AUTOSTRING5" -> "name 0", "  AUTOINT6" -> 10000000, "  AUTOSTRING7" -> "a very long string 0",
+        "  AUTOINT8" -> 0
+      )
+    )
+  }
+
+  private def assertRewrite(originalQuery: String, expectedQuery: String, replacements: Map[String, Any]) {
+    val original = parser.parse(originalQuery)
+    val expected = parser.parse(expectedQuery)
+
+    val (rewriter, replacedLiterals) = literalReplacement(original)
+
+    val result = original.rewrite(bottomUpExpressions(rewriter))
+    assert(result === expected)
+    assert(replacements === replacedLiterals)
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -44,11 +44,11 @@ object CypherCompiler {
 
   case class VersionProxy(graph: GraphDatabaseService, defaultVersion: CypherVersion) {
     private val queryCache = new LRUCache[(CypherVersion, Object), Object](getQueryCacheSize)
-    private val compiler2_0 = new CypherCompiler2_0(graph, (q, f) => queryCache.getOrElseUpdate((v2_0, q), f))
+    private val compiler2_0 = new CypherCompiler2_0(graph, (q, f) =>  queryCache.getOrElseUpdate((v2_0, q), f))
     private val compiler1_9 = new CypherCompiler1_9(graph, (q, f) => queryCache.getOrElseUpdate((v1_9, q), f))
 
     @throws(classOf[SyntaxException])
-    def prepare(query: String, context: GraphDatabaseService, statement: Statement): ExecutionPlan = {
+    def prepare(query: String, context: GraphDatabaseService, statement: Statement): (ExecutionPlan, Map[String,Any]) = {
       val (version, remainingQuery) = query match {
         case hasVersionDefined(versionName, remainingQuery) => (CypherVersion(versionName), remainingQuery)
         case _                                              => (defaultVersion, query)
@@ -57,11 +57,11 @@ object CypherCompiler {
       version match {
         case CypherVersion.v1_9 =>
           val plan = compiler1_9.prepare(remainingQuery)
-          new ExecutionPlanWrapperForV1_9(plan)
+          (new ExecutionPlanWrapperForV1_9(plan), Map.empty)
 
         case CypherVersion.v2_0 => 
-          val plan = compiler2_0.prepare(remainingQuery, new TransactionBoundPlanContext(statement, context))
-          new ExecutionPlanWrapperForV2_0(plan)
+          val (plan, extractedParameters) = compiler2_0.prepare(remainingQuery, new TransactionBoundPlanContext(statement, context))
+          (new ExecutionPlanWrapperForV2_0(plan), extractedParameters)
       }
     }
 


### PR DESCRIPTION
This Pull Request adds functionality to cypher to automatically replace literals in statements with parameters. This enables reuse of already built query plans of the same structure that used other literal values in the same places.

After the rewriting the AST is equal to previously rewritten ASTs so the compiled query plan can be found in the plan-cache.

It uses the rewriting mechanisms in the compiler.

This mechanism saves up to 30% of execution time. Esp. in high load scenarios that currently use literals instead of parameters. Common use-cases are
1. Unoptimized applications with high numbers of the same literal cypher statements executed on behalf of web-application users
2. Massive import from different import sources that doesn't use parameters but generates cypher statements to create and update nodes and relationships.
