### PR TITLE
More consistency checking for relationship group records

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/AnnotationProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/annotations/AnnotationProcessor.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.annotations;
 
-import static org.neo4j.kernel.impl.util.Charsets.UTF_8;
-import static org.neo4j.kernel.impl.util.FileUtils.newFilePrintWriter;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -43,6 +40,9 @@ import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
+import static org.neo4j.kernel.impl.util.Charsets.UTF_8;
+import static org.neo4j.kernel.impl.util.FileUtils.newFilePrintWriter;
+
 public abstract class AnnotationProcessor extends AbstractProcessor
 {
     private CompilationManipulator manipulator = null;
@@ -53,8 +53,10 @@ public abstract class AnnotationProcessor extends AbstractProcessor
         super.init( processingEnv );
         manipulator = CompilationManipulator.load( this, processingEnv );
         if ( manipulator == null )
+        {
             processingEnv.getMessager().printMessage( Kind.NOTE,
                     "Cannot write values to this compiler: " + processingEnv.getClass().getName() );
+        }
     }
 
     @Override
@@ -161,7 +163,10 @@ public abstract class AnnotationProcessor extends AbstractProcessor
         {
             for ( String previous : nl.split( fo.getCharContent( true ), 0 ) )
             {
-                if ( line.equals( previous ) ) return;
+                if ( line.equals( previous ) )
+                {
+                    return;
+                }
             }
         }
         else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -100,6 +100,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     }
 
     @Override
+    public int getNumberOfReservedLowIds()
+    {
+        return 1;
+    }
+
+    @Override
     protected void verifyFileSizeAndTruncate() throws IOException
     {
         int expectedVersionLength = UTF8.encode( buildTypeDescriptorAndVersion( getTypeDescriptor() ) ).length;
@@ -214,7 +220,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     {
         updateRecord( record );
     }
-    
+
     // [next][type][data]
 
     protected Collection<DynamicRecord> allocateRecordsFromBytes( byte src[] )
@@ -476,12 +482,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         {
             totalLength += record.getLength();
         }
-        
+
         if ( target.length < totalLength )
         {
             target = new byte[totalLength];
         }
-        
+
         ByteBuffer buffer = ByteBuffer.wrap( target, 0, totalLength );
         for ( DynamicRecord record : records )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractRecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractRecordStore.java
@@ -50,4 +50,10 @@ public abstract class AbstractRecordStore<R extends AbstractBaseRecord> extends 
     {
         return null;
     }
+
+    @Override
+    public int getNumberOfReservedLowIds()
+    {
+        return 0;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DelegatingRecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DelegatingRecordStore.java
@@ -30,6 +30,7 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
     {
         this.delegate = delegate;
     }
+    @Override
     public String toString()
     {
         return delegate.toString();
@@ -71,6 +72,7 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
         return delegate.getRecord( id );
     }
 
+    @Override
     public Long getNextRecordReference( R record )
     {
         return delegate.getNextRecordReference( record );
@@ -82,6 +84,7 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
         return delegate.getRecords( id );
     }
 
+    @Override
     public void updateRecord( R record )
     {
         delegate.updateRecord( record );
@@ -93,6 +96,7 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
         return delegate.forceGetRecord( id );
     }
 
+    @Override
     public R forceGetRaw( R record )
     {
         return delegate.forceGetRaw( record );
@@ -104,11 +108,13 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
         return delegate.forceGetRaw( id );
     }
 
+    @Override
     public void forceUpdateRecord( R record )
     {
         delegate.forceUpdateRecord( record );
     }
 
+    @Override
     public <FAILURE extends Exception> void accept( Processor<FAILURE> processor, R record ) throws FAILURE
     {
         delegate.accept( processor, record );
@@ -130,5 +136,11 @@ public class DelegatingRecordStore<R extends AbstractBaseRecord> implements Reco
     public void close()
     {
         delegate.close();
+    }
+
+    @Override
+    public int getNumberOfReservedLowIds()
+    {
+        return delegate.getNumberOfReservedLowIds();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipGroupRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipGroupRecord.java
@@ -26,61 +26,61 @@ public class RelationshipGroupRecord extends Abstract64BitRecord
     private long firstOut = Record.NO_NEXT_RELATIONSHIP.intValue();
     private long firstIn = Record.NO_NEXT_RELATIONSHIP.intValue();
     private long firstLoop = Record.NO_NEXT_RELATIONSHIP.intValue();
-    
+
     // Not stored, just kept in memory temporarily when loading the group chain
     private long prev = Record.NO_NEXT_RELATIONSHIP.intValue();
-    
+
     public RelationshipGroupRecord( long id, int type )
     {
         super( id );
         this.type = type;
     }
-    
+
     public int getType()
     {
         return type;
     }
-    
+
     public long getFirstOut()
     {
         return firstOut;
     }
-    
+
     public void setFirstOut( long firstOut )
     {
         this.firstOut = firstOut;
     }
-    
+
     public long getFirstIn()
     {
         return firstIn;
     }
-    
+
     public void setFirstIn( long firstIn )
     {
         this.firstIn = firstIn;
     }
-    
+
     public long getFirstLoop()
     {
         return firstLoop;
     }
-    
+
     public void setFirstLoop( long firstLoop )
     {
         this.firstLoop = firstLoop;
     }
-    
+
     public long getNext()
     {
         return next;
     }
-    
+
     public void setNext( long next )
     {
         this.next = next;
     }
-    
+
     /**
      * The previous pointer, i.e. previous group in this chain of groups isn't
      * persisted in the store, but only set during reading of the group
@@ -91,7 +91,7 @@ public class RelationshipGroupRecord extends Abstract64BitRecord
     {
         this.prev = prev;
     }
-    
+
     /**
      * The previous pointer, i.e. previous group in this chain of groups isn't
      * persisted in the store, but only set during reading of the group
@@ -102,7 +102,7 @@ public class RelationshipGroupRecord extends Abstract64BitRecord
     {
         return prev;
     }
-    
+
     @Override
     public String toString()
     {
@@ -113,7 +113,7 @@ public class RelationshipGroupRecord extends Abstract64BitRecord
                 .append( ",loop=" + firstLoop )
                 .append( ",prev=" + prev )
                 .append( ",next=" + next )
-                .append( ",inUse=" + inUse() )
+                .append( ",used=" + inUse() )
                 .append( "]" ).toString();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreIdIterator.java
@@ -33,6 +33,7 @@ public class StoreIdIterator implements PrimitiveLongIterator
     public StoreIdIterator( RecordStore<?> store )
     {
         this.store = store;
+        this.id = store.getNumberOfReservedLowIds();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
@@ -189,11 +189,13 @@ public class NeoStoreTransaction extends XaTransaction
                    context.getRelCommands().isEmpty() && context.getSchemaRuleCommands().isEmpty() &&
                     context.getRelationshipTypeTokenCommands().isEmpty() &&
                    context.getLabelTokenCommands().isEmpty() &&
+                   context.getRelGroupCommands().isEmpty() &&
                     context.getPropertyKeyTokenCommands().isEmpty() && kernelTransaction.isReadOnly();
         }
         return context.getNodeRecords().changeSize() == 0 && context.getRelRecords().changeSize() == 0 &&
                 context.getSchemaRuleChanges().changeSize() == 0 &&
                context.getPropertyRecords().changeSize() == 0 && relationshipTypeTokenRecords == null &&
+               context.getRelGroupRecords().changeSize() == 0 &&
                labelTokenRecords == null && propertyKeyTokenRecords == null && kernelTransaction.isReadOnly();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionWriter.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.TokenRecord;
@@ -150,6 +151,36 @@ public class TransactionWriter
         update( relationship );
     }
 
+    public void update( RelationshipRecord relationship ) throws IOException
+    {
+        relationship.setInUse( true );
+        add( relationship );
+    }
+
+    public void delete( RelationshipRecord relationship ) throws IOException
+    {
+        relationship.setInUse( false );
+        add( relationship );
+    }
+
+    public void create( RelationshipGroupRecord group ) throws IOException
+    {
+        group.setCreated();
+        update( group );
+    }
+
+    public void update( RelationshipGroupRecord group ) throws IOException
+    {
+        group.setInUse( true );
+        add( group );
+    }
+
+    public void delete( RelationshipGroupRecord group ) throws IOException
+    {
+        group.setInUse( false );
+        add( group );
+    }
+
     public void createSchema( Collection<DynamicRecord> beforeRecord, Collection<DynamicRecord> afterRecord ) throws IOException
     {
         for ( DynamicRecord record : afterRecord )
@@ -166,18 +197,6 @@ public class TransactionWriter
             record.setInUse( true );
         }
         addSchema( beforeRecords, afterRecords );
-    }
-
-    public void update( RelationshipRecord relationship ) throws IOException
-    {
-        relationship.setInUse( true );
-        add( relationship );
-    }
-
-    public void delete( RelationshipRecord relationship ) throws IOException
-    {
-        relationship.setInUse( false );
-        add( relationship );
     }
 
     public void create( PropertyRecord property ) throws IOException
@@ -222,6 +241,11 @@ public class TransactionWriter
     public void add( RelationshipRecord relationship ) throws IOException
     {
         write( new Command.RelationshipCommand( null, relationship ) );
+    }
+
+    public void add( RelationshipGroupRecord group ) throws IOException
+    {
+        write( new Command.RelationshipGroupCommand( null, group ) );
     }
 
     public void add( PropertyRecord before, PropertyRecord property ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.core;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -29,9 +30,12 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+
 import static junit.framework.Assert.assertNotNull;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.helpers.collection.IteratorUtil.primitiveLongIterator;
 
 public class NodeProxySingleRelationshipTest

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestJavaTestDocsGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestJavaTestDocsGenerator.java
@@ -104,12 +104,12 @@ public class TestJavaTestDocsGenerator implements GraphHolder
 
     /**
      * Title2.
-     * 
+     *
      * @@snippet1
-     * 
+     *
      *            more stuff
-     * 
-     * 
+     *
+     *
      * @@snippet2
      */
     @Documented
@@ -159,13 +159,16 @@ public class TestJavaTestDocsGenerator implements GraphHolder
     {
         graphdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
     }
-    
+
     @AfterClass
     public static void shutdown()
     {
         try
         {
-            if ( graphdb != null ) graphdb.shutdown();
+            if ( graphdb != null )
+            {
+                graphdb.shutdown();
+            }
         }
         finally
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.cypher.javacompat.ExecutionResult;
@@ -30,12 +36,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.transactional.error.InternalBeginTransactionError;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
 import org.neo4j.server.rest.web.TransactionUriScheme;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Encapsulates executing statements in a transaction, committing the transaction, or rolling it back.
@@ -311,7 +311,7 @@ public class TransactionHandle
     }
 
 
-    private void executePeriodicCommitStatement( 
+    private void executePeriodicCommitStatement(
            StatementDeserializer statements, ExecutionResultSerializer output, List<Neo4jError> errors )
     {
         try

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -37,7 +38,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.server.rest.domain.JsonHelper.jsonNode;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoErrors;
@@ -223,7 +226,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         assertThat( response.status(), equalTo(200) );
         assertThat( response, hasErrors(Status.Statement.InvalidSemantics) );
     }
-    
+
     @Test
     public void begin_and_execute_invalid_query_and_commit() throws Exception
     {
@@ -323,7 +326,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
          * This issue was reported from the community. It resulted in a refactoring of the interaction
          * between TxManager and TransactionContexts.
          */
-        
+
         // GIVEN
         long nodesInDatabaseBeforeTransaction = countNodes();
         Response response = http.POST( "/db/data/transaction/commit",
@@ -332,7 +335,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         JsonNode everything = jsonNode( response.rawContent() );
         JsonNode result = everything.get( "results" ).get( 0 );
         long id = result.get( "data" ).get( 0 ).get( "row" ).get( 0 ).getLongValue();
-        
+
         // WHEN
         http.POST( "/db/data/cypher", rawPayload( "{\"query\":\"start n = node(" + id + ") delete n\"}" ) );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
@@ -124,6 +124,7 @@ public class TestBackup
             server = startServer( serverPath );
             OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
             backup.full( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             shutdownServer( server );
             server = null;
 
@@ -137,6 +138,7 @@ public class TestBackup
             addMoreData( serverPath );
             server = startServer( serverPath );
             backup.incremental( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             shutdownServer( server );
             server = null;
 
@@ -170,12 +172,14 @@ public class TestBackup
             server = startServer( serverPath );
             OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
             backup.full( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             shutdownServer( server );
             server = null;
 
             addMoreData( serverPath );
             server = startServer( serverPath );
             backup.incremental( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             shutdownServer( server );
             server = null;
 
@@ -186,6 +190,7 @@ public class TestBackup
             addMoreData( serverPath );
             server = startServer( serverPath );
             backup.incremental( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             shutdownServer( server );
             server = null;
 
@@ -231,6 +236,7 @@ public class TestBackup
         // START SNIPPET: onlineBackup
         OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
         backup.full( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         // END SNIPPET: onlineBackup
         assertEquals( initialDataSetRepresentation, DbRepresentation.of( backupPath ) );
         shutdownServer( server );
@@ -240,6 +246,7 @@ public class TestBackup
         // START SNIPPET: onlineBackup
         backup.incremental( backupPath.getPath() );
         // END SNIPPET: onlineBackup
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( furtherRepresentation, DbRepresentation.of( backupPath ) );
         shutdownServer( server );
     }
@@ -253,15 +260,18 @@ public class TestBackup
 
         // First check full
         backup.full( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertFalse( checkLogFileExistence( backupPath.getPath() ) );
         // Then check empty incremental
         backup.incremental( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertFalse( checkLogFileExistence( backupPath.getPath() ) );
         // Then check real incremental
         shutdownServer( server );
         addMoreData( serverPath );
         server = startServer( serverPath );
         backup.incremental( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertFalse( checkLogFileExistence( backupPath.getPath() ) );
         shutdownServer( server );
     }
@@ -276,6 +286,7 @@ public class TestBackup
         // Grab initial backup from server A
         OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
         backup.full( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( initialDataSetRepresentation, DbRepresentation.of( backupPath ) );
         shutdownServer( server );
 
@@ -300,6 +311,7 @@ public class TestBackup
         DbRepresentation furtherRepresentation = addMoreData( serverPath );
         server = startServer( serverPath );
         backup.incremental( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( furtherRepresentation, DbRepresentation.of( backupPath ) );
         shutdownServer( server );
     }
@@ -393,6 +405,7 @@ public class TestBackup
 
             OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
             backup.full( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
             long lastCommittedTxForLucene = getLastCommittedTx( backupPath.getPath() );
 
             for ( int i = 0; i < 5; i++ )
@@ -440,6 +453,8 @@ public class TestBackup
 
             OnlineBackup backup = OnlineBackup.from( "127.0.0.1" );
             backup.full( backupPath.getPath() );
+            assertTrue( "Should be consistent", backup.isConsistent() );
+            assertTrue( backup.isConsistent() );
         }
         finally
         {
@@ -488,10 +503,12 @@ public class TestBackup
         {
             tx.finish();
         }
-        OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
+        OnlineBackup backup = OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( DbRepresentation.of( db ), DbRepresentation.of( backupPath ) );
         FileUtils.deleteDirectory( new File( backupPath.getPath() ) );
-        OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
+        backup = OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
+        assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( DbRepresentation.of( db ), DbRepresentation.of( backupPath ) );
 
         tx = db.beginTx();
@@ -505,7 +522,7 @@ public class TestBackup
             tx.finish();
         }
         FileUtils.deleteDirectory( new File( backupPath.getPath() ) );
-        OnlineBackup backup = OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
+        backup = OnlineBackup.from( "127.0.0.1" ).full( backupPath.getPath() );
         assertTrue( "Should be consistent", backup.isConsistent() );
         assertEquals( DbRepresentation.of( db ), DbRepresentation.of( backupPath ) );
         db.shutdown();

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/RecordType.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/RecordType.java
@@ -34,6 +34,8 @@ public enum RecordType
     RELATIONSHIP_TYPE,
     RELATIONSHIP_TYPE_NAME,
 
+    RELATIONSHIP_GROUP,
+
     LABEL,
     LABEL_NAME,
 

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/AbstractStoreProcessor.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/AbstractStoreProcessor.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 
@@ -47,6 +48,7 @@ public abstract class AbstractStoreProcessor extends RecordStore.Processor<Runti
     private final RecordCheck<PropertyKeyTokenRecord, ConsistencyReport.PropertyKeyTokenConsistencyReport> propertyKeyTokenChecker;
     private final RecordCheck<RelationshipTypeTokenRecord, ConsistencyReport.RelationshipTypeConsistencyReport> relationshipTypeTokenChecker;
     private final RecordCheck<LabelTokenRecord, ConsistencyReport.LabelTokenConsistencyReport> labelTokenChecker;
+    private final RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> relationshipGroupChecker;
 
     public AbstractStoreProcessor()
     {
@@ -63,6 +65,7 @@ public abstract class AbstractStoreProcessor extends RecordStore.Processor<Runti
         this.relationshipTypeTokenChecker = decorator.decorateRelationshipTypeTokenChecker( new
                 RelationshipTypeTokenRecordCheck() );
         this.labelTokenChecker = decorator.decorateLabelTokenChecker( new LabelTokenRecordCheck() );
+        this.relationshipGroupChecker = decorator.decorateRelationshipGroupChecker( new RelationshipGroupRecordCheck() );
     }
 
     protected abstract void checkNode(
@@ -99,6 +102,10 @@ public abstract class AbstractStoreProcessor extends RecordStore.Processor<Runti
     protected abstract void checkDynamicLabel(
             RecordType type, RecordStore<DynamicRecord> store, DynamicRecord string,
             RecordCheck<DynamicRecord, ConsistencyReport.DynamicLabelConsistencyReport> checker );
+
+    protected abstract void checkRelationshipGroup(
+            RecordStore<RelationshipGroupRecord> store, RelationshipGroupRecord record,
+            RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> checker );
 
     @Override
     public void processSchema( RecordStore<DynamicRecord> store, DynamicRecord schema )
@@ -192,5 +199,12 @@ public abstract class AbstractStoreProcessor extends RecordStore.Processor<Runti
     public void processLabelToken( RecordStore<LabelTokenRecord> store, LabelTokenRecord record )
     {
         checkLabelToken( store, record, labelTokenChecker );
+    }
+
+    @Override
+    public void processRelationshipGroup( RecordStore<RelationshipGroupRecord> store, RelationshipGroupRecord record )
+            throws RuntimeException
+    {
+        checkRelationshipGroup( store, record, relationshipGroupChecker );
     }
 }

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/CheckDecorator.java
@@ -20,11 +20,13 @@
 package org.neo4j.consistency.checking;
 
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.NeoStoreRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 
@@ -54,6 +56,8 @@ public interface CheckDecorator
     RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> decorateLabelMatchChecker(
             RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> checker );
 
+    RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> decorateRelationshipGroupChecker(
+            RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> checker );
 
     static CheckDecorator NONE = new CheckDecorator()
     {
@@ -109,6 +113,13 @@ public interface CheckDecorator
         @Override
         public RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> decorateLabelMatchChecker(
                 RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> checker )
+        {
+            return checker;
+        }
+
+        @Override
+        public RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> decorateRelationshipGroupChecker(
+                RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
         {
             return checker;
         }

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipGroupRecordCheck.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipGroupRecordCheck.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.checking;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
+import org.neo4j.consistency.store.DiffRecordAccess;
+import org.neo4j.consistency.store.RecordAccess;
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
+
+import static java.util.Arrays.asList;
+
+public class RelationshipGroupRecordCheck implements
+        RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>
+{
+    private final static List<RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>> fields;
+    static
+    {
+        List<RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>> list = new ArrayList<>();
+        list.add( RelationshipTypeField.RELATIONSHIP_TYPE );
+        list.add( GroupField.NEXT );
+        list.addAll( asList( RelationshipField.values() ) );
+        fields = Collections.unmodifiableList( list );
+    }
+
+    private enum RelationshipTypeField implements
+            RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>,
+            ComparativeRecordChecker<RelationshipGroupRecord, RelationshipTypeTokenRecord, ConsistencyReport.RelationshipGroupConsistencyReport>
+    {
+        RELATIONSHIP_TYPE;
+        @Override
+        public void checkConsistency( RelationshipGroupRecord record,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            if ( record.getType() < 0 )
+            {
+                engine.report().illegalRelationshipType();
+            }
+            else
+            {
+                engine.comparativeCheck( records.relationshipType( record.getType() ), this );
+            }
+        }
+
+        @Override
+        public long valueFrom( RelationshipGroupRecord record )
+        {
+            return record.getType();
+        }
+
+        @Override
+        public void checkChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                DiffRecordAccess records )
+        {   // nothing to check
+        }
+
+        @Override
+        public void checkReference( RelationshipGroupRecord record, RelationshipTypeTokenRecord referred,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            if ( !referred.inUse() )
+            {
+                engine.report().relationshipTypeNotInUse( referred );
+            }
+        }
+    }
+
+    private enum GroupField implements
+            RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>,
+            ComparativeRecordChecker<RelationshipGroupRecord, RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>
+    {
+        NEXT;
+
+        @Override
+        public void checkConsistency( RelationshipGroupRecord record,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            if ( record.getNext() != Record.NO_NEXT_RELATIONSHIP.intValue() )
+            {
+                engine.comparativeCheck( records.relationshipGroup( record.getNext() ), this );
+            }
+        }
+
+        @Override
+        public long valueFrom( RelationshipGroupRecord record )
+        {
+            return record.getNext();
+        }
+
+        @Override
+        public void checkChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                DiffRecordAccess records )
+        {
+            // Can't easily verify since we have no prev pointers on relationship groups
+        }
+
+        @Override
+        public void checkReference( RelationshipGroupRecord record, RelationshipGroupRecord referred,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            if ( !referred.inUse() )
+            {
+                engine.report().nextGroupNotInUse();
+            }
+            else if ( record.getType() >= referred.getType() )
+            {
+                engine.report().invalidTypeSortOrder();
+            }
+        }
+    }
+
+    private enum RelationshipField implements
+            RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport>,
+            ComparativeRecordChecker<RelationshipGroupRecord, RelationshipRecord, ConsistencyReport.RelationshipGroupConsistencyReport>
+    {
+        OUT
+        {
+            @Override
+            public long valueFrom( RelationshipGroupRecord record )
+            {
+                return record.getFirstOut();
+            }
+
+            @Override
+            protected void relationshipNotInUse( RelationshipGroupConsistencyReport report )
+            {
+                report.firstOutgoingRelationshipNotInUse();
+            }
+
+            @Override
+            protected void relationshipNotFirstInChain( RelationshipGroupConsistencyReport report )
+            {
+                report.firstOutgoingRelationshipNotFirstInChain();
+            }
+
+            @Override
+            protected boolean isFirstInChain( RelationshipRecord relationship )
+            {
+                return relationship.isFirstInFirstChain();
+            }
+
+            @Override
+            protected void relationshipOfOtherType( RelationshipGroupConsistencyReport report )
+            {
+                report.firstOutgoingRelationshipOfOfOtherType();
+            }
+        },
+        IN
+        {
+            @Override
+            public long valueFrom( RelationshipGroupRecord record )
+            {
+                return record.getFirstIn();
+            }
+
+            @Override
+            protected void relationshipNotInUse( RelationshipGroupConsistencyReport report )
+            {
+                report.firstIncomingRelationshipNotInUse();
+            }
+
+            @Override
+            protected void relationshipNotFirstInChain( RelationshipGroupConsistencyReport report )
+            {
+                report.firstIncomingRelationshipNotFirstInChain();
+            }
+
+            @Override
+            protected boolean isFirstInChain( RelationshipRecord relationship )
+            {
+                return relationship.isFirstInSecondChain();
+            }
+
+            @Override
+            protected void relationshipOfOtherType( RelationshipGroupConsistencyReport report )
+            {
+                report.firstIncomingRelationshipOfOfOtherType();
+            }
+        },
+        LOOP
+        {
+            @Override
+            public long valueFrom( RelationshipGroupRecord record )
+            {
+                return record.getFirstLoop();
+            }
+
+            @Override
+            protected void relationshipNotInUse( RelationshipGroupConsistencyReport report )
+            {
+                report.firstLoopRelationshipNotInUse();
+            }
+
+            @Override
+            protected void relationshipNotFirstInChain( RelationshipGroupConsistencyReport report )
+            {
+                report.firstLoopRelationshipNotFirstInChain();
+            }
+
+            @Override
+            protected boolean isFirstInChain( RelationshipRecord relationship )
+            {
+                return relationship.isFirstInSecondChain() && relationship.isFirstInSecondChain();
+            }
+
+            @Override
+            protected void relationshipOfOtherType( RelationshipGroupConsistencyReport report )
+            {
+                report.firstLoopRelationshipOfOfOtherType();
+            }
+        };
+
+        @Override
+        public void checkConsistency( RelationshipGroupRecord record,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            long relId = valueFrom( record );
+            if ( relId != Record.NO_NEXT_RELATIONSHIP.intValue() )
+            {
+                engine.comparativeCheck( records.relationship( relId ), this );
+            }
+        }
+
+        @Override
+        public void checkChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                DiffRecordAccess records )
+        {
+            // Check anything here?
+        }
+
+        @Override
+        public void checkReference( RelationshipGroupRecord record, RelationshipRecord referred,
+                CheckerEngine<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> engine,
+                RecordAccess records )
+        {
+            if ( !referred.inUse() )
+            {
+                relationshipNotInUse( engine.report() );
+            }
+            else
+            {
+                if ( !isFirstInChain( referred ) )
+                {
+                    relationshipNotFirstInChain( engine.report() );
+                }
+                if ( referred.getType() != record.getType() )
+                {
+                    relationshipOfOtherType( engine.report() );
+                }
+            }
+        }
+
+        protected abstract void relationshipOfOtherType( RelationshipGroupConsistencyReport report );
+
+        protected abstract void relationshipNotFirstInChain( RelationshipGroupConsistencyReport report );
+
+        protected abstract boolean isFirstInChain( RelationshipRecord referred );
+
+        protected abstract void relationshipNotInUse( RelationshipGroupConsistencyReport report );
+    }
+
+    @Override
+    public void check( RelationshipGroupRecord record,
+            CheckerEngine<RelationshipGroupRecord, RelationshipGroupConsistencyReport> engine, RecordAccess records )
+    {
+        if ( !record.inUse() )
+        {
+            return;
+        }
+        for ( RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> field : fields )
+        {
+            field.checkConsistency( record, engine, records );
+        }
+    }
+
+    @Override
+    public void checkChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+            CheckerEngine<RelationshipGroupRecord, RelationshipGroupConsistencyReport> engine, DiffRecordAccess records )
+    {
+        check( newRecord, engine, records );
+        if ( oldRecord.inUse() )
+        {
+            for ( RecordField<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> field : fields )
+            {
+                field.checkChange( oldRecord, newRecord, engine, records );
+            }
+        }
+    }
+}

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
@@ -287,10 +287,10 @@ class RelationshipRecordCheck
                                  DiffRecordAccess records )
         {
             if ( !newRecord.inUse() || valueFrom( oldRecord ) != valueFrom( newRecord ) )
-            {
+            {   // if we're deleting or creating this relationship record
                 if ( !endOfChain( oldRecord )
                      && records.changedRelationship( valueFrom( oldRecord ) ) == null )
-                {
+                {   // and we didn't update an expected pointer --> report
                     notUpdated( engine.report() );
                 }
             }

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -80,6 +80,8 @@ public class ConsistencyCheckTasks
 
         tasks.add( create( nativeStores.getArrayStore(), multiPass.processors( ARRAYS ) ) );
 
+        tasks.add( create( nativeStores.getRelationshipGroupStore(), multiPass.processors( RELATIONSHIPS ) ) );
+
         // The schema store is verified in multiple passes that share state since it fits into memory
         // and we care about the consistency of back references (cf. SemanticCheck)
 

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
@@ -34,6 +34,7 @@ import org.neo4j.consistency.checking.DynamicStore;
 import org.neo4j.consistency.checking.PrimitiveRecordCheck;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.consistency.store.DiffRecordAccess;
 import org.neo4j.consistency.store.RecordAccess;
 import org.neo4j.helpers.progress.ProgressListener;
@@ -48,6 +49,7 @@ import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyType;
 import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.TokenRecord;
@@ -138,6 +140,7 @@ class OwnerCheck implements CheckDecorator
         }
         return new PrimitiveCheckerDecorator<NeoStoreRecord, ConsistencyReport.NeoStoreConsistencyReport>( checker )
         {
+            @Override
             PropertyOwner owner( NeoStoreRecord record )
             {
                 return PropertyOwner.OWNING_GRAPH;
@@ -155,6 +158,7 @@ class OwnerCheck implements CheckDecorator
         }
         return new PrimitiveCheckerDecorator<NodeRecord, ConsistencyReport.NodeConsistencyReport>( checker )
         {
+            @Override
             PropertyOwner owner( NodeRecord record )
             {
                 return new PropertyOwner.OwningNode( record );
@@ -173,6 +177,7 @@ class OwnerCheck implements CheckDecorator
         return new PrimitiveCheckerDecorator<RelationshipRecord, ConsistencyReport.RelationshipConsistencyReport>(
                 checker )
         {
+            @Override
             PropertyOwner owner( RelationshipRecord record )
             {
                 return new PropertyOwner.OwningRelationship( record );
@@ -368,6 +373,14 @@ class OwnerCheck implements CheckDecorator
                 checker.checkChange( oldRecord, newRecord, engine, records );
             }
         };
+    }
+
+    @Override
+    public RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> decorateRelationshipGroupChecker(
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+        // TODO implement owner checking for relationship groups?
+        return checker;
     }
 
     private ConcurrentMap<Long, DynamicOwner> dynamicOwners( RecordType type )

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
@@ -25,16 +25,17 @@ import org.neo4j.consistency.checking.CheckDecorator;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.checking.SchemaRecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.DynamicLabelConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
-
-import static org.neo4j.consistency.report.ConsistencyReport.DynamicLabelConsistencyReport;
 
 /**
  * Full check works by spawning StoreProcessorTasks that call StoreProcessor. StoreProcessor.applyFiltered()
@@ -117,6 +118,13 @@ class StoreProcessor extends AbstractStoreProcessor
                                       RecordCheck<DynamicRecord, DynamicLabelConsistencyReport> checker )
     {
         report.forDynamicLabelBlock( type, string, checker );
+    }
+
+    @Override
+    protected void checkRelationshipGroup( RecordStore<RelationshipGroupRecord> store, RelationshipGroupRecord record,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+        report.forRelationshipGroup( record, checker );
     }
 
     void setSchemaRecordCheck( SchemaRecordCheck schemaRecordCheck )

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/incremental/StoreProcessor.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/incremental/StoreProcessor.java
@@ -23,16 +23,17 @@ import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.AbstractStoreProcessor;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.DynamicLabelConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
-
-import static org.neo4j.consistency.report.ConsistencyReport.DynamicLabelConsistencyReport;
 
 class StoreProcessor extends AbstractStoreProcessor
 {
@@ -102,5 +103,12 @@ class StoreProcessor extends AbstractStoreProcessor
                                       RecordCheck<DynamicRecord, DynamicLabelConsistencyReport> checker )
     {
         report.forDynamicLabelBlockChange( type, store.forceGetRaw( string ), string, checker );
+    }
+
+    @Override
+    protected void checkRelationshipGroup( RecordStore<RelationshipGroupRecord> store, RelationshipGroupRecord record,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+        report.forRelationshipGroupChange( store.forceGetRaw( record ), record, checker );
     }
 }

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -120,6 +120,12 @@ public interface ConsistencyReport
                             RecordCheck<IndexEntry, ConsistencyReport.IndexConsistencyReport> checker );
 
         void forNodeLabelMatch( NodeRecord nodeRecord, RecordCheck<NodeRecord, LabelsMatchReport> nodeLabelCheck );
+
+        void forRelationshipGroup( RelationshipGroupRecord record,
+                RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> checker );
+
+        void forRelationshipGroupChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+                RecordCheck<RelationshipGroupRecord, ConsistencyReport.RelationshipGroupConsistencyReport> checker );
     }
 
     interface PrimitiveConsistencyReport extends ConsistencyReport
@@ -510,6 +516,66 @@ public interface ConsistencyReport
         /** The string record referred from this key is also referred from a another key. */
         @Documented
         void nameMultipleOwners( PropertyKeyTokenRecord otherOwner );
+    }
+
+    interface RelationshipGroupConsistencyReport extends ConsistencyReport
+    {
+        /** The relationship type field has an illegal value. */
+        @Documented
+        void illegalRelationshipType();
+
+        /** The relationship type record is not in use. */
+        @Documented
+        void relationshipTypeNotInUse( RelationshipTypeTokenRecord referred );
+
+        /** The next relationship group reference has changed, but the previously referenced record has not been updated. */
+        @Documented
+        @IncrementalOnly
+        void nextNotUpdated();
+
+        /** The next relationship group is not in use. */
+        @Documented
+        void nextGroupNotInUse();
+
+        /** The location of group in the chain is invalid, should be sorted by type ascending. */
+        @Documented
+        void invalidTypeSortOrder();
+
+        /** The first outgoing relationship is not in use. */
+        @Documented
+        void firstOutgoingRelationshipNotInUse();
+
+        /** The first incoming relationship is not in use. */
+        @Documented
+        void firstIncomingRelationshipNotInUse();
+
+        /** The first loop relationship is not in use. */
+        @Documented
+        void firstLoopRelationshipNotInUse();
+
+        /** The first outgoing relationship is not the first in its chain. */
+        @Documented
+        void firstOutgoingRelationshipNotFirstInChain();
+
+        /** The first incoming relationship is not the first in its chain. */
+        @Documented
+        void firstIncomingRelationshipNotFirstInChain();
+
+        /** The first loop relationship is not the first in its chain. */
+        @Documented
+        void firstLoopRelationshipNotFirstInChain();
+
+        /** The first outgoing relationship is of a different type than its group. */
+        @Documented
+        void firstOutgoingRelationshipOfOfOtherType();
+
+        /** The first incoming relationship is of a different type than its group. */
+        @Documented
+        void firstIncomingRelationshipOfOfOtherType();
+
+        /** The first loop relationship is of a different type than its group. */
+        @Documented
+        void firstLoopRelationshipOfOfOtherType();
     }
 
     interface DynamicConsistencyReport extends ConsistencyReport

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -30,6 +30,7 @@ import org.neo4j.consistency.checking.CheckerEngine;
 import org.neo4j.consistency.checking.ComparativeRecordChecker;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport.DynamicLabelConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.consistency.store.DiffRecordAccess;
 import org.neo4j.consistency.store.RecordAccess;
 import org.neo4j.consistency.store.RecordReference;
@@ -42,6 +43,7 @@ import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 
@@ -76,6 +78,8 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
             ProxyFactory.create( ConsistencyReport.LabelScanConsistencyReport.class );
     private static final ProxyFactory<ConsistencyReport.IndexConsistencyReport> INDEX =
             ProxyFactory.create( ConsistencyReport.IndexConsistencyReport.class );
+    private static final ProxyFactory<ConsistencyReport.RelationshipGroupConsistencyReport> RELATIONSHIP_GROUP_REPORT =
+            ProxyFactory.create( ConsistencyReport.RelationshipGroupConsistencyReport.class );
 
     private final DiffRecordAccess records;
     private final InconsistencyReport report;
@@ -501,6 +505,20 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
                                             RecordCheck<DynamicRecord, DynamicLabelConsistencyReport> checker )
     {
         dispatchChange( type, DYNAMIC_LABEL_REPORT, oldRecord, newRecord, checker );
+    }
+
+    @Override
+    public void forRelationshipGroup( RelationshipGroupRecord record,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+        dispatch( RecordType.RELATIONSHIP_GROUP, RELATIONSHIP_GROUP_REPORT, record, checker );
+    }
+
+    @Override
+    public void forRelationshipGroupChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+        dispatchChange( RecordType.RELATIONSHIP_GROUP, RELATIONSHIP_GROUP_REPORT, oldRecord, newRecord, checker );
     }
 
     static class ProxyFactory<T>

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencySummaryStatistics.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencySummaryStatistics.java
@@ -77,8 +77,8 @@ public class ConsistencySummaryStatistics
     {
         if ( errors > 0 )
         {
-            inconsistentRecordCount.get( recordType ).incrementAndGet();
-            totalInconsistencyCount.incrementAndGet();
+            inconsistentRecordCount.get( recordType ).addAndGet( errors );
+            totalInconsistencyCount.addAndGet( errors );
             errorCount.addAndGet( errors );
         }
         if ( warnings > 0 )

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
@@ -62,9 +62,13 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
 
     public void markDirty( long id )
     {
-        if ( !diff.containsKey( id ) ) diff.put( id, null );
+        if ( !diff.containsKey( id ) )
+        {
+            diff.put( id, null );
+        }
     }
 
+    @Override
     public R forceGetRaw( R record )
     {
         if ( diff.containsKey( record.getLongId() ) )
@@ -140,8 +144,14 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
     private R getRecord( long id, boolean force )
     {
         R record = diff.get( id );
-        if ( record == null ) return force ? actual.forceGetRecord( id ) : actual.getRecord( id );
-        if ( !force && !record.inUse() ) throw new InvalidRecordException( record.getClass().getSimpleName() + "[" + id + "] not in use" );
+        if ( record == null )
+        {
+            return force ? actual.forceGetRecord( id ) : actual.getRecord( id );
+        }
+        if ( !force && !record.inUse() )
+        {
+            throw new InvalidRecordException( record.getClass().getSimpleName() + "[" + id + "] not in use" );
+        }
         return record;
     }
 
@@ -166,7 +176,10 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
     @Override
     public void updateRecord( R record )
     {
-        if ( record.getLongId() > highId ) highId = record.getLongId();
+        if ( record.getLongId() > highId )
+        {
+            highId = record.getLongId();
+        }
         diff.put( record.getLongId(), record );
     }
 
@@ -203,6 +216,12 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
     public boolean hasChanges()
     {
         return !diff.isEmpty();
+    }
+
+    @Override
+    public int getNumberOfReservedLowIds()
+    {
+        return actual.getNumberOfReservedLowIds();
     }
 
     @SuppressWarnings( "unchecked" )

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.NeoStoreRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.StoreAccess;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
@@ -151,6 +152,11 @@ public abstract class GraphStoreFixture implements TestRule
         public long relationship()
         {
             return relId++;
+        }
+
+        public long relationshipGroup()
+        {
+            return relGroupId++;
         }
 
         public long property()
@@ -320,6 +326,42 @@ public abstract class GraphStoreFixture implements TestRule
             }
         }
 
+        public void create( RelationshipGroupRecord group )
+        {
+            try
+            {
+                writer.create( group );
+            }
+            catch ( IOException e )
+            {
+                throw ioError( e );
+            }
+        }
+
+        public void update(  RelationshipGroupRecord group )
+        {
+            try
+            {
+                writer.update( group );
+            }
+            catch ( IOException e )
+            {
+                throw ioError( e );
+            }
+        }
+
+        public void delete(  RelationshipGroupRecord group )
+        {
+            try
+            {
+                writer.delete( group );
+            }
+            catch ( IOException e )
+            {
+                throw ioError( e );
+            }
+        }
+
         public void create( PropertyRecord property )
         {
             try
@@ -422,6 +464,7 @@ public abstract class GraphStoreFixture implements TestRule
     private int labelId;
     private long nodeLabelsId;
     private long relId;
+    private long relGroupId;
     private int propId;
     private long stringPropId;
     private long arrayPropId;
@@ -440,6 +483,7 @@ public abstract class GraphStoreFixture implements TestRule
             labelId = (int) stores.getLabelTokenStore().getHighId();
             nodeLabelsId = stores.getNodeDynamicLabelStore().getHighId();
             relId = stores.getRelationshipStore().getHighId();
+            relGroupId = stores.getRelationshipGroupStore().getHighId();
             propId = (int) stores.getPropertyStore().getHighId();
             stringPropId = stores.getStringStore().getHighId();
             arrayPropId = stores.getArrayStore().getHighId();

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
@@ -37,6 +37,7 @@ import org.neo4j.consistency.checking.GraphStoreFixture;
 import org.neo4j.consistency.checking.PrimitiveRecordCheck;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.consistency.report.ConsistencySummaryStatistics;
 import org.neo4j.consistency.report.InconsistencyLogger;
 import org.neo4j.consistency.report.InconsistencyReport;
@@ -288,6 +289,13 @@ public class ExecutionOrderIntegrationTest
         @Override
         public RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> decorateLabelMatchChecker(
                 RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> checker )
+        {
+            return logging( checker );
+        }
+
+        @Override
+        public RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> decorateRelationshipGroupChecker(
+                RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
         {
             return logging( checker );
         }

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NullReporter.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NullReporter.java
@@ -22,6 +22,7 @@ package org.neo4j.consistency.checking.full;
 import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.consistency.report.ConsistencyReport.RelationshipGroupConsistencyReport;
 import org.neo4j.consistency.store.synthetic.IndexEntry;
 import org.neo4j.consistency.store.synthetic.LabelScanDocument;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
@@ -29,6 +30,7 @@ import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 
@@ -149,6 +151,18 @@ public class NullReporter implements ConsistencyReport.Reporter
 
     @Override
     public void forNodeLabelMatch( NodeRecord nodeRecord, RecordCheck<NodeRecord, ConsistencyReport.LabelsMatchReport> nodeLabelCheck )
+    {
+    }
+
+    @Override
+    public void forRelationshipGroup( RelationshipGroupRecord record,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
+    {
+    }
+
+    @Override
+    public void forRelationshipGroupChange( RelationshipGroupRecord oldRecord, RelationshipGroupRecord newRecord,
+            RecordCheck<RelationshipGroupRecord, RelationshipGroupConsistencyReport> checker )
     {
     }
 }

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/incremental/IncrementalCheckIntegrationTest.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/incremental/IncrementalCheckIntegrationTest.java
@@ -203,7 +203,7 @@ public class IncrementalCheckIntegrationTest
     @Test
     public void shouldReportRelationshipInconsistency() throws Exception
     {
-        verifyInconsistencyReported( RecordType.RELATIONSHIP, 1, new GraphStoreFixture.Transaction()
+        verifyInconsistencyReported( RecordType.RELATIONSHIP, 2, new GraphStoreFixture.Transaction()
         {
             @Override
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
@@ -218,7 +218,7 @@ public class IncrementalCheckIntegrationTest
     @Test
     public void shouldReportPropertyInconsistency() throws Exception
     {
-        verifyInconsistencyReported( RecordType.PROPERTY, 1, new GraphStoreFixture.Transaction()
+        verifyInconsistencyReported( RecordType.PROPERTY, 2, new GraphStoreFixture.Transaction()
         {
             @Override
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
@@ -300,6 +300,8 @@ public class IncrementalCheckIntegrationTest
             }
         } );
     }
+
+    // Remember to add relationship group inconsistency checks if we add prev pointer to relationship groups
 
     private static String LONG_STRING, LONG_SHORT_STRING;
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -496,7 +496,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 new ClusterDatabaseInfoProvider( members, new OnDiskLastTxIdGetter( new File( getStoreDir() ) ),
                         lastUpdateTime ) );
     }
-    
+
     @Override
     protected Factory<byte[]> createXidGlobalIdFactory()
     {


### PR DESCRIPTION
Added the following checks:
o RelationshipGroupRecord has invalid rel type id
o RelationshipGroupRecord has invalid next pointer
o RelationshipGroupRecord chain is unsorted
o RelationshipGroupRecord refers to relationship that is not in use
o RelationshipGroupRecord refers to relationship that is not first in its
  chain
o RelationshipGroupRecord refers to relationship that is of a different
  relationship type than its group
