### PR TITLE
Ensure index recovery happens after neostore fully recovered

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
@@ -46,8 +46,8 @@ public class GraphDatabaseBuilder
         GraphDatabaseService newDatabase( Map<String, String> config );
     }
 
-    DatabaseCreator creator;
-    Map<String, String> config = new HashMap<String, String>();
+    protected DatabaseCreator creator;
+    protected Map<String, String> config = new HashMap<String, String>();
 
     public GraphDatabaseBuilder( DatabaseCreator creator )
     {
@@ -119,6 +119,7 @@ public class GraphDatabaseBuilder
      * @return the builder
      * @deprecated Use setConfig with explicit {@link Setting} instead
      */
+    @Deprecated
     @SuppressWarnings("deprecation")
     public GraphDatabaseBuilder setConfig( Map<String, String> config )
     {
@@ -197,7 +198,7 @@ public class GraphDatabaseBuilder
     {
         return creator.newDatabase( config );
     }
-    
+
     public static class Delegator extends GraphDatabaseBuilder
     {
         private final GraphDatabaseBuilder actual;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -172,6 +172,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
     private SchemaCache schemaCache;
 
     private LabelScanStore labelScanStore;
+    private final IndexingService.Monitor indexingServiceMonitor;
 
     private enum Diagnostics implements DiagnosticsExtractor<NeoStoreXaDataSource>
     {
@@ -267,7 +268,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
                                  PropertyKeyTokenHolder propertyKeyTokens, LabelTokenHolder labelTokens,
                                  RelationshipTypeTokenHolder relationshipTypeTokens,
                                  PersistenceManager persistenceManager, LockManager lockManager,
-                                 SchemaWriteGuard schemaWriteGuard )
+                                 SchemaWriteGuard schemaWriteGuard, IndexingService.Monitor indexingServiceMonitor )
     {
         super( BRANCH_ID, DEFAULT_DATA_SOURCE_NAME );
         this.config = config;
@@ -284,6 +285,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
         this.persistenceManager = persistenceManager;
         this.lockManager = lockManager;
         this.schemaWriteGuard = schemaWriteGuard;
+        this.indexingServiceMonitor = indexingServiceMonitor;
 
         readOnly = config.get( Configuration.read_only );
         msgLog = stringLogger;
@@ -352,7 +354,7 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
                             providerMap,
                             new NeoStoreIndexStoreView( locks, neoStore ),
                             tokenNameLookup, updateableSchemaState,
-                            logging ) );
+                            logging, indexingServiceMonitor ) );
 
             integrityValidator = new IntegrityValidator( neoStore, indexingService );
 
@@ -406,6 +408,10 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
                     neoStore.getPropertyStore().getPropertyKeyTokenStore() );
             setLogicalLogAtCreationTime( xaContainer.getLogicalLog() );
 
+            // TODO Problem here is that we don't know if recovery has been performed at this point
+            // if it hasn't then no index recovery will be performed since the node store is still in
+            // "not ok" state and forceGetRecord will always return place holder node records that are not in use.
+            // This issue will certainly introduce index inconsistencies.
             life.start();
         }
         catch ( Throwable e )
@@ -716,5 +722,11 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
     public NeoStore evaluate()
     {
         return neoStore;
+    }
+
+    @Override
+    public void recoveryCompleted() throws IOException
+    {
+        indexingService.startIndexes();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxLog.java
@@ -84,7 +84,7 @@ public class TxLog
         {
             this.bytes = bytes;
         }
-        
+
         @Override
         public int hashCode()
         {
@@ -102,14 +102,12 @@ public class TxLog
      * Initializes a transaction log using <CODE>filename</CODE>. If the file
      * isn't empty the position will be set to size of file so new records will
      * be appended.
-     * 
+     *
      * @param fileName
      *            Filename of file to use
-<<<<<<< HEAD
      * @param fileSystem
      *            The concrete FileSystemAbstraction to use.
-=======
->>>>>>> 1.9-maint
+     * @param monitors {@link Monitors}.
      * @throws IOException
      *             If unable to open file
      */
@@ -192,7 +190,7 @@ public class TxLog
 
     /**
      * Writes a <CODE>TX_START</CODE> record to the file.
-     * 
+     *
      * @param globalId
      *            The global id of the new transaction
      * @throws IOException
@@ -221,7 +219,7 @@ public class TxLog
 
     /**
      * Writes a <CODE>BRANCH_ADD</CODE> record to the file.
-     * 
+     *
      * @param globalId
      *            The global id of the transaction
      * @param branchId
@@ -253,7 +251,7 @@ public class TxLog
     /**
      * Writes a <CODE>MARK_COMMIT</CODE> record to the file and forces the
      * file to disk.
-     * 
+     *
      * @param globalId
      *            The global id of the transaction
      * @throws IOException
@@ -274,7 +272,7 @@ public class TxLog
 
     /**
      * Writes a <CODE>TX_DONE</CODE> record to the file.
-     * 
+     *
      * @param globalId
      *            The global id of the transaction completed
      * @throws IOException
@@ -338,6 +336,7 @@ public class TxLog
             return seqNr;
         }
 
+        @Override
         public String toString()
         {
             XidImpl xid = new XidImpl( globalId, branchId == null ? new byte[0] : branchId );
@@ -582,7 +581,7 @@ public class TxLog
     /**
      * Switches log file. Copies the dangling records in current log file to the
      * <CODE>newFile</CODE> and then makes the switch closing the old log file.
-     * 
+     *
      * @param newFile
      *            The filename of the new file to switch to
      * @throws IOException
@@ -606,6 +605,7 @@ public class TxLog
         }
         Collections.sort( records, new Comparator<Record>()
         {
+            @Override
             public int compare( Record r1, Record r2 )
             {
                 return r1.getSequenceNumber() - r2.getSequenceNumber();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -724,7 +724,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         {
             throw new ThreadAssociatedWithOtherTransactionException( Thread.currentThread(), associatedTx, tx );
         }
-        
+
         TransactionImpl txImpl = (TransactionImpl) tx;
         if ( txImpl.getStatus() != Status.STATUS_NO_TRANSACTION )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogEntry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogEntry.java
@@ -52,7 +52,7 @@ public abstract class LogEntry
     {
         return identifier;
     }
-    
+
     public String toString( TimeZone timeZone )
     {
         return toString();
@@ -84,7 +84,7 @@ public abstract class LogEntry
         {
             return xid;
         }
-        
+
         public int getMasterId()
         {
             return masterId;
@@ -104,7 +104,7 @@ public abstract class LogEntry
         {
             this.startPosition = position;
         }
-        
+
         public long getTimeWritten()
         {
             return timeWritten;
@@ -114,7 +114,7 @@ public abstract class LogEntry
         {
             return lastCommittedTxWhenTransactionStarted;
         }
-        
+
         /**
          * @return combines necessary state to get a unique checksum to identify this transaction uniquely.
          */
@@ -131,7 +131,7 @@ public abstract class LogEntry
         {
             return toString( Format.DEFAULT_TIME_ZONE );
         }
-        
+
         @Override
         public String toString( TimeZone timeZone )
         {
@@ -140,8 +140,8 @@ public abstract class LogEntry
                     lastCommittedTxWhenTransactionStarted+"]";
         }
     }
-    
-    static class Prepare extends LogEntry
+
+    public static class Prepare extends LogEntry
     {
         private final long timeWritten;
 
@@ -150,7 +150,7 @@ public abstract class LogEntry
             super( identifier );
             this.timeWritten = timeWritten;
         }
-        
+
         public long getTimeWritten()
         {
             return timeWritten;
@@ -161,7 +161,7 @@ public abstract class LogEntry
         {
             return toString( Format.DEFAULT_TIME_ZONE );
         }
-        
+
         @Override
         public String toString( TimeZone timeZone )
         {
@@ -187,18 +187,18 @@ public abstract class LogEntry
         {
             return txId;
         }
-        
+
         public long getTimeWritten()
         {
             return timeWritten;
         }
-        
+
         @Override
         public String toString()
         {
             return toString( Format.DEFAULT_TIME_ZONE );
         }
-        
+
         @Override
         public String toString( TimeZone timeZone )
         {
@@ -235,7 +235,7 @@ public abstract class LogEntry
             return "Done[" + getIdentifier() + "]";
         }
     }
-    
+
     public static class Command extends LogEntry
     {
         private final XaCommand command;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -255,7 +255,7 @@ public abstract class XaDataSource implements Lifecycle
     {
         throw new UnsupportedOperationException( getClass().getName() );
     }
-    
+
     public void setLastCommittedTxId( long txId )
     {
         throw new UnsupportedOperationException( getClass().getName() );
@@ -276,7 +276,7 @@ public abstract class XaDataSource implements Lifecycle
         throw new UnsupportedOperationException( getClass().getName() );
     }
 
-    public ResourceIterator<File> listStoreFiles(  ) throws IOException
+    public ResourceIterator<File> listStoreFiles() throws IOException
     {
         throw new UnsupportedOperationException( getClass().getName() );
     }
@@ -297,5 +297,9 @@ public abstract class XaDataSource implements Lifecycle
     public LogExtractor getLogExtractor( long startTxId, long endTxIdHint ) throws IOException
     {
         throw new UnsupportedOperationException( getClass().getName() );
+    }
+
+    public void recoveryCompleted() throws IOException
+    {
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -369,8 +369,7 @@ public class XaResourceManager
             xidMap.remove( xid );
             if ( xaTransaction.isRecovered() )
             {
-                recoveredTxCount--;
-                checkIfRecoveryComplete();
+                oneMoreTransactionRecovered();
             }
             return XAResource.XA_RDONLY;
         }
@@ -381,6 +380,12 @@ public class XaResourceManager
             txStatus.markAsPrepared();
             return XAResource.XA_OK;
         }
+    }
+
+    private void oneMoreTransactionRecovered()
+    {
+        recoveredTxCount--;
+        checkIfRecoveryComplete();
     }
 
     // called from XaResource internal recovery
@@ -399,8 +404,7 @@ public class XaResourceManager
             xidMap.remove( xid );
             if ( xaTransaction.isRecovered() )
             {
-                recoveredTxCount--;
-                checkIfRecoveryComplete();
+                oneMoreTransactionRecovered();
             }
             return true;
         }
@@ -521,8 +525,7 @@ public class XaResourceManager
         xidMap.remove( xid );
         if ( xaTransaction.isRecovered() )
         {
-            recoveredTxCount--;
-            checkIfRecoveryComplete();
+            oneMoreTransactionRecovered();
         }
     }
 
@@ -594,8 +597,7 @@ public class XaResourceManager
 
         if ( xaTransaction.isRecovered() )
         {
-            recoveredTxCount--;
-            checkIfRecoveryComplete();
+            oneMoreTransactionRecovered();
         }
         transactionMonitor.transactionCommitted( xid, xaTransaction.isRecovered() );
     }
@@ -628,8 +630,7 @@ public class XaResourceManager
         xidMap.remove( xid );
         if ( xaTransaction.isRecovered() )
         {
-            recoveredTxCount--;
-            checkIfRecoveryComplete();
+            oneMoreTransactionRecovered();
         }
 
         return txStatus.getTransaction();
@@ -655,8 +656,7 @@ public class XaResourceManager
         xidMap.remove( xid );
         if ( xaTransaction.isRecovered() )
         {
-            recoveredTxCount--;
-            checkIfRecoveryComplete();
+            oneMoreTransactionRecovered();
         }
         return xaTransaction;
     }
@@ -686,8 +686,7 @@ public class XaResourceManager
         if ( xaTransaction.isRecovered() )
         {
             recoveredTransactions.remove( xaTransaction.getIdentifier() );
-            recoveredTxCount--;
-            checkIfRecoveryComplete();
+            oneMoreTransactionRecovered();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.DependencyResolver.Adapter;
 import org.neo4j.graphdb.Node;
@@ -66,6 +60,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
+import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.AutoLoadingCache;
@@ -100,6 +95,14 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class TestNeoStore
 {
@@ -197,7 +200,7 @@ public class TestNeoStore
                 dependencyResolverForNoIndexProvider( nodeManager ), mock( AbstractTransactionManager.class),
                 mock( PropertyKeyTokenHolder.class ), mock(LabelTokenHolder.class),
                 mock( RelationshipTypeTokenHolder.class), mock(PersistenceManager.class), mock(LockManager.class),
-                mock( SchemaWriteGuard.class));
+                mock( SchemaWriteGuard.class), IndexingService.NO_MONITOR );
         ds.init();
         ds.start();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestXa.java
@@ -19,15 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
-import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -48,6 +39,7 @@ import javax.transaction.xa.Xid;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.DependencyResolver.Adapter;
 import org.neo4j.graphdb.Node;
@@ -65,6 +57,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
+import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.cache.AutoLoadingCache;
@@ -93,6 +86,16 @@ import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.SingleLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class TestXa
 {
@@ -386,7 +389,7 @@ public class TestXa
                 dependencyResolverForNoIndexProvider( nodeManager ), txManager,
                 mock( PropertyKeyTokenHolder.class ), mock(LabelTokenHolder.class),
                 mock( RelationshipTypeTokenHolder.class), mock(PersistenceManager.class), mock(LockManager.class),
-                mock( SchemaWriteGuard.class));
+                mock( SchemaWriteGuard.class), IndexingService.NO_MONITOR);
         neoStoreXaDataSource.init();
         neoStoreXaDataSource.start();
         return neoStoreXaDataSource;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -19,34 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.neo4j.helpers.collection.Iterables.count;
-import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
-import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
-import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
-import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
-import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.nioneo.store.IndexRule.indexRule;
-import static org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule.uniquenessConstraintRule;
-import static org.neo4j.kernel.impl.transaction.xaframework.InjectedTransactionValidator.ALLOW_ALL;
-import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,6 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
@@ -104,6 +77,35 @@ import org.neo4j.kernel.logging.SingleLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
+import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
+import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
+import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
+import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
+import static org.neo4j.kernel.impl.nioneo.store.IndexRule.indexRule;
+import static org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule.uniquenessConstraintRule;
+import static org.neo4j.kernel.impl.transaction.xaframework.InjectedTransactionValidator.ALLOW_ALL;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class WriteTransactionTest
 {
@@ -907,12 +909,12 @@ public class WriteTransactionTest
 
         public CapturingIndexingService()
         {
-            super(  null,
+            super( null,
                     new DefaultSchemaIndexProviderMap( NO_INDEX_PROVIDER ),
                     new NeoStoreIndexStoreView( locks, neoStore ),
                     null,
                     new KernelSchemaStateStore(),
-                    new SingleLoggingService( DEV_NULL )
+                    new SingleLoggingService( DEV_NULL ), IndexingService.NO_MONITOR
                 );
         }
 

--- a/community/neo4j/src/test/java/recovery/TestIndexingServiceRecovery.java
+++ b/community/neo4j/src/test/java/recovery/TestIndexingServiceRecovery.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package recovery;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
+import org.neo4j.helpers.Pair;
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.EmbeddedGraphDatabase;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.impl.api.NonTransactionalTokenNameLookup;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
+import org.neo4j.test.LogTestUtils;
+import org.neo4j.test.LogTestUtils.LogHook;
+import org.neo4j.test.LogTestUtils.LogHookAdapter;
+
+import static java.lang.Long.parseLong;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+import static org.neo4j.test.LogTestUtils.filterNeostoreLogicalLog;
+import static org.neo4j.test.LogTestUtils.oneOrTwo;
+import static org.neo4j.test.ProcessUtil.executeSubProcess;
+import static org.neo4j.test.TargetDirectory.forTest;
+
+/**
+ * There was an issue with recovery where IndexingService#start was called too early, before
+ * {@link NeoStore} had been recovered. This would effectively disable recovery of schema related
+ * indexes and constraints. The startup order in a faulty scenario was like this:
+ *
+ * <pre>
+ * XaDsMgr#start
+ * NodeStore#setStoreNotOk
+ * NodeStore#setStoreNotOk
+ * IndexingService#initIndexes
+ * ... nioneo_logical.log.1/2 is read and store recovered as much as possible ...
+ * IndexingService#start
+ * TxManager#start
+ * TxManager#doRecovery
+ * NodeStore#makeStoreOk <-- happens here since there are one or more 2PC transactions the data source
+ *                           didn't know what to do with above
+ * </pre>
+ *
+ * Where it's essential that TxManager#doRecovery and NodeStore#makeStoreOk must have been called
+ * before IndexingService#start (where deferred index recovery is performed).
+ * IndexingService recovery uses NodeStore#forceGetRecord which just returns a "not in use" node record
+ * for any requested id if not yet recovered, so this faulty startup order was hidden by that.
+ * Here, we'll try to expose it.
+ */
+public class TestIndexingServiceRecovery
+{
+    @Test
+    public void shouldRecoverSchemaIndexesAfterNeoStoreFullyRecovered() throws Exception
+    {
+        // GIVEN a db with schema and some data in it
+        File storeDir = forTest( getClass() ).graphDbDir( true );
+        Long[] nodeIds = createSchemaData( storeDir );
+        // crashed store that has at least one 2PC transaction
+        executeSubProcess( getClass(), 30, SECONDS, args( storeDir.getAbsolutePath(), nodeIds ) );
+        // and that 2PC transaction is missing the 2PC commit record in the neostore data source,
+        // which simulates a 2PC transaction where not all data sources have committed fully.
+        makeItLookLikeNeoStoreDataSourceDidntCommitLastTransaction( storeDir );
+
+        // WHEN recovering that store
+        Pair<Collection<Long>, Collection<NodePropertyUpdate>> updatesSeenDuringRecovery = recoverStore( storeDir );
+
+        // THEN the index should be recovered with the expected data from neostore
+        int labelId = 0, propertyKey = 0; // TODO bad assuming id 0
+        assertEquals( "Test contains invalid assumptions. Recovery process should have seen updates around these nodes",
+                asSet( nodeIds ), updatesSeenDuringRecovery.first() );
+        assertEquals( asSet( add( nodeIds[0], propertyKey, value, new long[] {labelId} ) ),
+                updatesSeenDuringRecovery.other() );
+    }
+
+    // The process that will crash the db uses this main method
+    public static void main( String[] args )
+    {
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( args[0] );
+
+        // Set the property that we'll want to recover
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.getNodeById( parseLong( args[1] ) );
+            node.setProperty( key, value );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            // Create an arbitrary 2PC transaction with which we'll use to break shit later on
+            Node otherNode = db.getNodeById( parseLong( args[2] ) );
+            otherNode.setProperty( "some key", "some value" );
+            db.index().forNodes( "nodes" ).add( otherNode, key, value );
+            tx.success();
+        }
+        // Crash on purpose
+        System.exit( 0 );
+    }
+
+    private Pair<Collection<Long>,Collection<NodePropertyUpdate>> recoverStore( File storeDir )
+    {
+        final Collection<Long> affectedNodeIds = new HashSet<>();
+        final Collection<NodePropertyUpdate> allUpdates = new HashSet<>();
+        final IndexingService.Monitor recoveryMonitor = new IndexingService.MonitorAdapter()
+        {
+            @Override
+            public void applyingRecoveredData( Collection<Long> nodeIds )
+            {
+                affectedNodeIds.addAll( nodeIds );
+            }
+
+            @Override
+            public void appliedRecoveredData( Iterable<NodePropertyUpdate> updates )
+            {
+                for ( NodePropertyUpdate update : updates )
+                {
+                    allUpdates.add( update );
+                }
+            }
+        };
+
+        GraphDatabaseService db = new GraphDatabaseFactory()
+        {
+            @SuppressWarnings( "deprecation" )
+            @Override
+            public GraphDatabaseService newEmbeddedDatabase( String path )
+            {
+                GraphDatabaseFactoryState state = getStateCopy();
+                return new EmbeddedGraphDatabase( path, new HashMap<String,String>(),
+                        state.getKernelExtension(),
+                        state.getCacheProviders(),
+                        state.getTransactionInterceptorProviders() )
+                {
+                    @Override
+                    protected void createNeoDataSource()
+                    {
+                        // Register our little special recovery listener
+                        neoDataSource = new NeoStoreXaDataSource( config,
+                                storeFactory, logging.getMessagesLog( NeoStoreXaDataSource.class ),
+                                xaFactory, stateFactory, transactionInterceptorProviders, jobScheduler, logging,
+                                updateableSchemaState, new NonTransactionalTokenNameLookup( labelTokenHolder, propertyKeyTokenHolder ),
+                                dependencyResolver, txManager, propertyKeyTokenHolder, labelTokenHolder, relationshipTypeTokenHolder,
+                                persistenceManager, lockManager, this, recoveryMonitor );
+                        xaDataSourceManager.registerDataSource( neoDataSource );
+                    }
+                };
+            }
+        }.newEmbeddedDatabase( storeDir.getAbsolutePath() );
+        db.shutdown();
+        return Pair.of( affectedNodeIds, allUpdates );
+    }
+
+    private Long[] createSchemaData( File storeDir )
+    {
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( storeDir.getAbsolutePath() );
+        try
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().indexFor( label ).on( key ).create();
+                tx.success();
+            }
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().awaitIndexesOnline( 10, SECONDS );
+                tx.success();
+            }
+
+            long nodeId;
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = db.createNode( label );
+                nodeId = node.getId();
+                tx.success();
+            }
+
+            long otherNodeId;
+            try ( Transaction tx = db.beginTx() )
+            {
+                otherNodeId = db.createNode().getId();
+                tx.success();
+            }
+            return new Long[] {nodeId, otherNodeId};
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private void makeItLookLikeNeoStoreDataSourceDidntCommitLastTransaction( File storeDir ) throws IOException
+    {
+        // Capture the identifier of the last transaction
+        File logFile = single( iterator( oneOrTwo( fs, new File( storeDir, LOGICAL_LOG_DEFAULT_NAME ) ) ) );
+        final AtomicInteger lastIdentifier = new AtomicInteger();
+        filterNeostoreLogicalLog( fs, logFile, LogTestUtils.findLastTransactionIdentifier( lastIdentifier ) );
+
+        // Filter any commit/prepare/done entries from that transaction
+        LogHook<LogEntry> prune = new LogHookAdapter<LogEntry>()
+        {
+            @Override
+            public boolean accept( LogEntry item )
+            {
+                // Let through everything exception COMMIT/DONE for the last tx
+                boolean shouldPruneEntry = item.getIdentifier() == lastIdentifier.get() &&
+                        (item instanceof LogEntry.Commit || item instanceof LogEntry.Done);
+                return !shouldPruneEntry;
+            }
+        };
+        File tempFile = filterNeostoreLogicalLog( fs, logFile, prune );
+        fs.deleteFile( logFile );
+        fs.renameFile( tempFile, logFile );
+    }
+
+    private String[] args( String absolutePath, Long[] nodeIds )
+    {
+        List<String> result = new ArrayList<>();
+        result.add( absolutePath );
+        for ( Long id : nodeIds )
+        {
+            result.add( String.valueOf( id ) );
+        }
+        return result.toArray( new String[result.size()] );
+    }
+
+    @SuppressWarnings( "deprecation" )
+    private final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+    private static final Label label = label( "Label" );
+    private static final String key = "key", value = "Value";
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.transaction.TransactionManager;
 
 import org.neo4j.cluster.BindingListener;
@@ -72,6 +73,7 @@ import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.impl.api.NonTransactionalTokenNameLookup;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
+import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
@@ -379,7 +381,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 config.get( HaSettings.lock_read_timeout ).intValue(),
                 config.get( HaSettings.max_concurrent_channels_per_slave ).intValue(),
                 config.get( HaSettings.com_chunk_size ).intValue()  );
-        
+
         // Do this with a scheduler, so that if it fails, it can retry later with an exponential backoff with max wait time.
         final AtomicLong wait = new AtomicLong();
         scheduledExecutorService.schedule( new Runnable()
@@ -602,7 +604,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                     resolver.resolveDependency( RelationshipTypeTokenHolder.class ),
                     resolver.resolveDependency( PersistenceManager.class ),
                     resolver.resolveDependency( LockManager.class ),
-                    (SchemaWriteGuard)graphDb);
+                    (SchemaWriteGuard)graphDb, monitors.newMonitor( IndexingService.Monitor.class ));
             xaDataSourceManager.registerDataSource( nioneoDataSource );
                 /*
                  * CAUTION: The next line may cause severe eye irritation, mental instability and potential
@@ -668,7 +670,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
             Lifecycle service = (Lifecycle) graphDb.getDependencyResolver().resolveDependency( serviceClass );
             service.stop();
         }
-        
+
         branchPolicy.handle( config.get( InternalAbstractGraphDatabase.Configuration.store_dir ) );
     }
 


### PR DESCRIPTION
Before this commit the deferred recovery of schema related indexes (done
in IndexingService#start) was done in NeoStoreXaDataSource#start. That
worked fine if the neostore data source could resolve all recovered
transactions by itself, i.e. there were only 1PC transactions or the
encountered 2PC transactions all had their 2PC log entries present.
If not then there were an additional pass where the tx log was consulted
and finally each individual data source was notified about what to do with
the pending transactions. If one or more transactions needed to involve the
tx log then making the neostore "OK" was delayed until after
TxManager#doRecovery had been called.

Now deferred schema index recovery takes place as part of the
TxManager#doRecovery pass and so will always see all recovered
transactions and get the deferred index updates from a fully recovered
store.
