### PR TITLE
Add Monitors to Cypher

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/Query.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/Query.scala
@@ -140,7 +140,7 @@ case class Query(returns: Return,
       includeIfNotEmpty((if(optional) "optional " else "") + "match  : ", matching) +
       includeIfNotEmpty("paths  : ", namedPaths) +
       includeIfNotEmpty("hints  : ", hints) +
-      (if (where == True()) "" else where.toString) +
+      (if (where == True()) "" else "where  : " + where.toString + "\n") +
       includeIfNotEmpty("aggreg : ", aggregation) +
       includeIfNotEmpty("return : ", returns.returnItems) +
       includeIfNotEmpty("order  : ", sort) +

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/PipeBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/PipeBuilderTest.scala
@@ -21,14 +21,17 @@ package org.neo4j.cypher.internal.compiler.v2_1.executionplan
 
 import org.junit.Test
 import org.neo4j.cypher.internal.compiler.v2_1.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v2_1.parser.CypherParser
+import org.neo4j.cypher.internal.compiler.v2_1.parser.{ParserMonitor, CypherParser}
 import org.neo4j.cypher.internal.compiler.v2_1.pipes.{Pipe, TraversalMatchPipe, DistinctPipe}
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
+import org.neo4j.cypher.internal.compiler.v2_1.ast
+import ast.convert.StatementConverters._
+
 
 class PipeBuilderTest extends MockitoSugar {
   val planContext: PlanContext = mock[PlanContext]
-  val parser = CypherParser()
+  val parser = CypherParser(mock[ParserMonitor])
   val planBuilder = new PipeBuilder()
 
   @Test def should_use_distinct_pipe_for_distinct() {
@@ -47,7 +50,7 @@ class PipeBuilderTest extends MockitoSugar {
   }
 
   private def buildExecutionPipe(q: String): Pipe = {
-    val (abstractQuery, _) = parser.parseToQuery(q)
+    val abstractQuery = parser.parse(q).asQuery
     planBuilder.buildPipes(planContext, abstractQuery).pipe
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ParserFixture.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ParserFixture.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.parser
 
-object ParserFixture {
-  val parser = CypherParser()
+import org.scalatest.mock.MockitoSugar
+
+object ParserFixture extends MockitoSugar {
+  val parser = CypherParser(mock[ParserMonitor])
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/SimpleQueryGraphBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/SimpleQueryGraphBuilderTest.scala
@@ -21,13 +21,14 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.{Selections, SimpleQueryG
 import org.neo4j.cypher.internal.compiler.v2_1.{InputPosition, DummyPosition}
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.ast._
-import org.neo4j.cypher.internal.compiler.v2_1.parser.CypherParser
+import org.neo4j.cypher.internal.compiler.v2_1.parser.{ParserMonitor, CypherParser}
 import org.neo4j.cypher.internal.compiler.v2_1.DummyPosition
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.Id
 
 class SimpleQueryGraphBuilderTest extends CypherFunSuite {
 
-  val parser = new CypherParser()
+  // TODO: we may want to have normalized queries instead that simply parsed queries
+  val parser = new CypherParser(mock[ParserMonitor])
   val pos = DummyPosition(0)
 
   test("projection only query") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/CypherCompilerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/CypherCompilerTest.scala
@@ -19,15 +19,26 @@
  */
 package org.neo4j.cypher.internal
 
-import org.scalatest.{Matchers, FunSuite}
 import org.neo4j.graphdb.GraphDatabaseService
-import org.scalatest.mock.MockitoSugar
 import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.kernel.monitoring.Monitors
+import org.mockito.Mockito._
+import org.neo4j.cypher.internal.compiler.v2_1.executionplan.NewQueryPlanSuccessRateMonitor
+import org.neo4j.cypher.internal.compiler.v2_1.{AstRewritingMonitor, SemanticCheckMonitor}
+import org.neo4j.cypher.internal.compiler.v2_1.parser.ParserMonitor
 
 class CypherCompilerTest extends CypherFunSuite {
+
   test("isPeriodicCommit handles versioned queries") {
     val gds = mock[GraphDatabaseService]
-    val compiler = new CypherCompiler(gds)
-    compiler.isPeriodicCommit("CYPHER 2.1 USING PERIODIC COMMIT CREATE n RETURN n") should be(true)
+
+    val monitors: Monitors = mock[Monitors]
+    when(monitors.newMonitor(classOf[NewQueryPlanSuccessRateMonitor], "compiler2.1")).thenReturn(mock[NewQueryPlanSuccessRateMonitor])
+    when(monitors.newMonitor(classOf[SemanticCheckMonitor])).thenReturn(mock[SemanticCheckMonitor])
+    when(monitors.newMonitor(classOf[AstRewritingMonitor])).thenReturn(mock[AstRewritingMonitor])
+    when(monitors.newMonitor(classOf[ParserMonitor], "compiler2.1")).thenReturn(mock[ParserMonitor])
+
+    val compiler = new CypherCompiler(gds, monitors)
+    compiler.isPeriodicCommit("CYPHER 2.1 USING PERIODIC COMMIT CREATE n RETURN n") should equal(true)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ExecutionPlanBuilderTest.scala
@@ -53,7 +53,7 @@ class ExecutionPlanBuilderTest extends CypherFunSuite with GraphDatabaseTestSupp
     val planContext = mock[PlanContext]
 
     val exception = intercept[ExecutionException](timeoutAfter(5) {
-      val epi = new ExecutionPlanBuilder(graph, new FakePipeBuilder(Seq(new BadBuilder)))
+      val epi = new ExecutionPlanBuilder(graph, mock[NewQueryPlanSuccessRateMonitor], new FakePipeBuilder(Seq(new BadBuilder)))
       epi.build(planContext, q, ast)
     })
 
@@ -66,7 +66,7 @@ class ExecutionPlanBuilderTest extends CypherFunSuite with GraphDatabaseTestSupp
     val tx = graph.beginTx()
     val q = Query.start(NodeById("x", 0)).returns(ReturnItem(Identifier("x"), "x"))
 
-    val execPlanBuilder = new ExecutionPlanBuilder(graph, new FakePipeBuilder(Seq(new ExplodingPipeBuilder)))
+    val execPlanBuilder = new ExecutionPlanBuilder(graph, mock[NewQueryPlanSuccessRateMonitor], new FakePipeBuilder(Seq(new ExplodingPipeBuilder)))
     val queryContext = new TransactionBoundQueryContext(graph, tx, isTopLevelTx = true, statement)
 
     // when

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/TraversalMatcherBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/TraversalMatcherBuilderTest.scala
@@ -23,15 +23,15 @@ import commands._
 import commands.expressions._
 import pipes.NullPipe
 import executionplan.{ExecutionPlanInProgress, PartiallySolvedQuery}
-import parser.CypherParser
+import org.neo4j.cypher.internal.compiler.v2_1.parser.{ParserMonitor, CypherParser}
 import org.neo4j.cypher.internal.compiler.v2_1.spi.PlanContext
 import org.neo4j.graphdb.Transaction
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions
 import org.junit.Assert._
 import org.neo4j.cypher.internal.compiler.v2_1.executionplan.builders.{Solved, Unsolved, TraversalMatcherBuilder, BuilderTest}
 import org.neo4j.cypher.internal.spi.v2_1.TransactionBoundPlanContext
 import org.neo4j.cypher.GraphDatabaseJUnitSuite
+import ast.convert.StatementConverters._
 
 class TraversalMatcherBuilderTest extends GraphDatabaseJUnitSuite with BuilderTest {
   var builder: TraversalMatcherBuilder = null
@@ -109,11 +109,11 @@ class TraversalMatcherBuilderTest extends GraphDatabaseJUnitSuite with BuilderTe
   def assertQueryHasNotSolvedPathExpressions(newPlan: ExecutionPlanInProgress) {
     newPlan.query.where.foreach {
       case Solved(pred) if pred.exists(_.isInstanceOf[PathExpression]) => fail("Didn't expect the predicate to be solved")
-      case _                                                             =>
+      case _                                                           =>
     }
   }
 
-  val parser = CypherParser()
+  val parser = CypherParser(mock[ParserMonitor])
 
-  private def query(text: String): PartiallySolvedQuery = PartiallySolvedQuery(parser.parseToQuery(text)._1.asInstanceOf[Query])
+  private def query(text: String): PartiallySolvedQuery = PartiallySolvedQuery(parser.parse(text).asQuery.asInstanceOf[Query])
 }


### PR DESCRIPTION
Add Monitors to parsing, semantic checking, AST rewriting and compiling with the new planner
- Moved out semantic checking from the parser to the compiler
- Same for AST rewriting: Parser -> Compiler
