### PR TITLE
Faster upgrade.

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,3 +1,7 @@
+2.1.0-SNAPSHOT
+--------------
+o Performance improvements for upgrade process.
+
 2.1.0-M01
 ------------
 o Introduces utility methods for printing paths into a new class, org.neo4j.graphdb.traveral.Paths

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Abstract64BitRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Abstract64BitRecord.java
@@ -21,23 +21,26 @@ package org.neo4j.kernel.impl.nioneo.store;
 
 public abstract class Abstract64BitRecord extends AbstractBaseRecord
 {
-    private final long id;
+    private long id;
+
+    protected Abstract64BitRecord()
+    {
+
+    }
 
     protected Abstract64BitRecord( long id )
     {
-        super( false );
-        this.id = id;
-    }
-
-    Abstract64BitRecord( long id, boolean inUse )
-    {
-        super( inUse );
         this.id = id;
     }
 
     public long getId()
     {
         return id;
+    }
+
+    public void setId( long id )
+    {
+        this.id = id;
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractBaseRecord.java
@@ -23,14 +23,8 @@ import org.neo4j.helpers.CloneableInPublic;
 
 public abstract class AbstractBaseRecord implements CloneableInPublic
 {
-    private boolean inUse;
+    private boolean inUse = false;
     private boolean created = false;
-
-    AbstractBaseRecord( boolean inUse )
-    {
-        // limit subclasses to this package only
-        this.inUse = inUse;
-    }
     
     public abstract long getLongId();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractRecord.java
@@ -25,13 +25,6 @@ public abstract class AbstractRecord extends AbstractBaseRecord
 
     AbstractRecord( int id )
     {
-        super( false );
-        this.id = id;
-    }
-
-    AbstractRecord( int id, boolean inUse )
-    {
-        super( inUse );
         this.id = id;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PrimitiveRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PrimitiveRecord.java
@@ -22,7 +22,11 @@ package org.neo4j.kernel.impl.nioneo.store;
 public abstract class PrimitiveRecord extends Abstract64BitRecord
 {
     private long nextProp;
-    private final long committedNextProp;
+    private long committedNextProp;
+
+    public PrimitiveRecord()
+    {
+    }
 
     public PrimitiveRecord( long id, long nextProp )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/RelChainBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/RelChainBuilder.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+
+/**
+ * Allows incrementally building up a relationship chain, and allows telling when the chain is complete.
+ */
+public class RelChainBuilder implements Iterable<RelationshipRecord>
+{
+    static class ChainEntry
+    {
+        private final RelationshipRecord record;
+        private final boolean isLast;
+        private ChainEntry next;
+
+        ChainEntry( RelationshipRecord record, boolean isLast, ChainEntry next )
+        {
+            this.record = record;
+            this.isLast = isLast;
+            this.next = next;
+        }
+    }
+
+    private final long nodeId;
+
+    /**
+     * Makes up a singly linked list of relationships, will only contain the parts that are complete starting from
+     * the first rel. */
+    private ChainEntry head = null;
+
+    /** Fast lookup of relationships in the chain by id. */
+    private Map<Long, ChainEntry> chainIndex = new HashMap<>();
+
+    public RelChainBuilder( long nodeId )
+    {
+        this.nodeId = nodeId;
+    }
+
+    public void append( RelationshipRecord record, long prevRel, long nextRel )
+    {
+        boolean isFirst = prevRel == Record.NO_PREV_RELATIONSHIP.intValue();
+        boolean isLast = nextRel == Record.NO_NEXT_RELATIONSHIP.intValue();
+
+        ChainEntry entry = new ChainEntry( record, isLast, chainIndex.get( nextRel ) );
+        chainIndex.put( record.getId(), entry );
+
+        if(isFirst)
+        {
+            head = entry;
+        }
+        else
+        {
+            ChainEntry prevInChain = chainIndex.get( prevRel );
+            if(prevInChain != null)
+            {
+                prevInChain.next = entry;
+
+            }
+        }
+    }
+
+    public boolean isComplete()
+    {
+        for(ChainEntry entry = head; entry != null; entry = entry.next)
+            if(entry.isLast) return true;
+        return false;
+    }
+
+    public int size()
+    {
+        return chainIndex.size();
+    }
+
+    public long nodeId()
+    {
+        return nodeId;
+    }
+
+    @Override
+    public Iterator<RelationshipRecord> iterator()
+    {
+        return new Iterator<RelationshipRecord>()
+        {
+            private ChainEntry next = head;
+
+            @Override
+            public boolean hasNext()
+            {
+                return next != null;
+            }
+
+            @Override
+            public RelationshipRecord next()
+            {
+                ChainEntry current = next;
+                next = current.next;
+                return current.record;
+            }
+
+            @Override
+            public void remove()
+            {
+
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/RelationshipWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/RelationshipWriter.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.NodeStore;
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
+import org.neo4j.kernel.impl.storemigration.legacystore.LegacyNodeStoreReader;
+
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+
+public class RelationshipWriter extends Thread
+{
+    private final ArrayBlockingQueue<RelChainBuilder> chainsToWrite;
+    private final int denseNodeThreshold;
+    private final NodeStore nodeStore;
+    private final RelationshipStore relationshipStore;
+    private final RelationshipGroupStore relGroupStore;
+    private final LegacyNodeStoreReader nodeReader;
+    private final AtomicReference<Throwable> caughtException;
+
+    public RelationshipWriter( ArrayBlockingQueue<RelChainBuilder> chainsToWrite, int denseNodeThreshold, NodeStore
+            nodeStore, RelationshipStore relationshipStore, RelationshipGroupStore relGroupStore,
+            LegacyNodeStoreReader nodeReader, AtomicReference<Throwable> caughtException )
+    {
+        this.chainsToWrite = chainsToWrite;
+        this.denseNodeThreshold = denseNodeThreshold;
+        this.nodeStore = nodeStore;
+        this.relationshipStore = relationshipStore;
+        this.relGroupStore = relGroupStore;
+        this.nodeReader = nodeReader;
+        this.caughtException = caughtException;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            while(true)
+            {
+                RelChainBuilder next = chainsToWrite.take();
+                if(next.nodeId() == -1)
+                {
+                    // Signals that there are no more chains.
+                    return;
+                }
+
+                if ( next.size() >= denseNodeThreshold )
+                {
+                    migrateDenseNode( nodeStore, relationshipStore, relGroupStore, next );
+                }
+                else
+                {
+                    migrateNormalNode( nodeStore, relationshipStore, next );
+                }
+            }
+        }
+        catch ( InterruptedException | IOException e )
+        {
+            caughtException.set( e );
+        }
+    }
+
+    private void migrateNormalNode( NodeStore nodeStore, RelationshipStore relationshipStore,
+                                    RelChainBuilder relationships ) throws IOException
+    {
+        /* Add node record
+         * Add/update all relationship records */
+        nodeStore.forceUpdateRecord( nodeReader.readNodeStore( relationships.nodeId() ) );
+        int i = 0;
+        for ( RelationshipRecord record : relationships )
+        {
+            if ( i == 0 )
+            {
+                setDegree( relationships.nodeId(), record, relationships.size() );
+            }
+            applyChangesToRecord( relationships.nodeId(), record, relationshipStore );
+            relationshipStore.forceUpdateRecord( record );
+            i++;
+        }
+    }
+
+    private void migrateDenseNode( NodeStore nodeStore, RelationshipStore relationshipStore,
+                                   RelationshipGroupStore relGroupStore, RelChainBuilder relChain ) throws IOException
+    {
+        Map<Integer, Relationships> byType = splitUp( relChain.nodeId(), relChain );
+        List<RelationshipGroupRecord> groupRecords = new ArrayList<>();
+        for ( Map.Entry<Integer, Relationships> entry : byType.entrySet() )
+        {
+            Relationships relationships = entry.getValue();
+            applyLinks( relChain.nodeId(), relationships.out, relationshipStore, Direction.OUTGOING );
+            applyLinks( relChain.nodeId(), relationships.in, relationshipStore, Direction.INCOMING );
+            applyLinks( relChain.nodeId(), relationships.loop, relationshipStore, Direction.BOTH );
+            RelationshipGroupRecord groupRecord = new RelationshipGroupRecord( relGroupStore.nextId(), entry.getKey() );
+            groupRecords.add( groupRecord );
+            groupRecord.setInUse( true );
+            if ( !relationships.out.isEmpty() )
+            {
+                groupRecord.setFirstOut( first( relationships.out ).getId() );
+            }
+            if ( !relationships.in.isEmpty() )
+            {
+                groupRecord.setFirstIn( first( relationships.in ).getId() );
+            }
+            if ( !relationships.loop.isEmpty() )
+            {
+                groupRecord.setFirstLoop( first( relationships.loop ).getId() );
+            }
+        }
+
+        RelationshipGroupRecord previousGroup = null;
+        for ( int i = 0; i < groupRecords.size(); i++ )
+        {
+            RelationshipGroupRecord groupRecord = groupRecords.get( i );
+            if ( i+1 < groupRecords.size() )
+            {
+                RelationshipGroupRecord nextRecord = groupRecords.get( i+1 );
+                groupRecord.setNext( nextRecord.getId() );
+            }
+            if ( previousGroup != null )
+            {
+                groupRecord.setPrev( previousGroup.getId() );
+            }
+            previousGroup = groupRecord;
+        }
+        for ( RelationshipGroupRecord groupRecord : groupRecords )
+        {
+            relGroupStore.forceUpdateRecord( groupRecord );
+        }
+
+        NodeRecord node = nodeReader.readNodeStore( relChain.nodeId() );
+        node.setNextRel( groupRecords.get( 0 ).getId() );
+        node.setDense( true );
+        nodeStore.forceUpdateRecord( node );
+    }
+
+    private void applyLinks( long nodeId, List<RelationshipRecord> records, RelationshipStore relationshipStore, Direction dir )
+    {
+        for ( int i = 0; i < records.size(); i++ )
+        {
+            RelationshipRecord record = records.get( i );
+            if ( i > 0 )
+            {   // link previous
+                long previous = records.get( i-1 ).getId();
+                if ( record.getFirstNode() == nodeId )
+                {
+                    record.setFirstPrevRel( previous );
+                }
+                if ( record.getSecondNode() == nodeId )
+                {
+                    record.setSecondPrevRel( previous );
+                }
+            }
+            else
+            {
+                setDegree( nodeId, record, records.size() );
+            }
+
+            if ( i < records.size()-1 )
+            {   // link next
+                long next = records.get( i+1 ).getId();
+                if ( record.getFirstNode() == nodeId )
+                {
+                    record.setFirstNextRel( next );
+                }
+                if ( record.getSecondNode() == nodeId )
+                {
+                    record.setSecondNextRel( next );
+                }
+            }
+            else
+            {   // end of chain
+                if ( record.getFirstNode() == nodeId )
+                {
+                    record.setFirstNextRel( Record.NO_NEXT_RELATIONSHIP.intValue() );
+                }
+                if ( record.getSecondNode() == nodeId )
+                {
+                    record.setSecondNextRel( Record.NO_NEXT_RELATIONSHIP.intValue() );
+                }
+            }
+            applyChangesToRecord( nodeId, record, relationshipStore );
+            relationshipStore.forceUpdateRecord( record );
+        }
+    }
+
+    private void setDegree( long nodeId, RelationshipRecord record, int size )
+    {
+        if ( nodeId == record.getFirstNode() )
+        {
+            record.setFirstInFirstChain( true );
+            record.setFirstPrevRel( size );
+        }
+        if ( nodeId == record.getSecondNode() )
+        {
+            record.setFirstInSecondChain( true );
+            record.setSecondPrevRel( size );
+        }
+    }
+
+    private void applyChangesToRecord( long nodeId, RelationshipRecord record, RelationshipStore relationshipStore )
+    {
+        RelationshipRecord existingRecord = relationshipStore.getLightRel( record.getId() );
+        if(existingRecord == null)
+        {
+            return;
+        }
+
+        // Not necessary for loops since those records will just be copied.
+        if ( nodeId == record.getFirstNode() )
+        {   // Copy end node stuff from the existing record
+            record.setFirstInSecondChain( existingRecord.isFirstInSecondChain() );
+            record.setSecondPrevRel( existingRecord.getSecondPrevRel() );
+            record.setSecondNextRel( existingRecord.getSecondNextRel() );
+        }
+        else
+        {   // Copy start node stuff from the existing record
+            record.setFirstInFirstChain( existingRecord.isFirstInFirstChain() );
+            record.setFirstPrevRel( existingRecord.getFirstPrevRel() );
+            record.setFirstNextRel( existingRecord.getFirstNextRel() );
+        }
+    }
+
+    private Map<Integer, Relationships> splitUp( long nodeId, RelChainBuilder records )
+    {
+        Map<Integer, Relationships> result = new HashMap<>();
+        for ( RelationshipRecord record : records )
+        {
+            Integer type = record.getType();
+            Relationships relationships = result.get( type );
+            if ( relationships == null )
+            {
+                relationships = new Relationships( nodeId );
+                result.put( type, relationships );
+            }
+            relationships.add( record );
+        }
+        return result;
+    }
+
+
+    private static class Relationships
+    {
+        private final long nodeId;
+        final List<RelationshipRecord> out = new ArrayList<>();
+        final List<RelationshipRecord> in = new ArrayList<>();
+        final List<RelationshipRecord> loop = new ArrayList<>();
+
+        Relationships( long nodeId )
+        {
+            this.nodeId = nodeId;
+        }
+
+        void add( RelationshipRecord record )
+        {
+            if ( record.getFirstNode() == nodeId )
+            {
+                if ( record.getSecondNode() == nodeId )
+                {   // Loop
+                    loop.add( record );
+                }
+                else
+                {   // Out
+                    out.add( record );
+                }
+            }
+            else
+            {   // In
+                in.add( record );
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Relationships[" + nodeId + ",out:" + out.size() + ", in:" + in.size() + ", loop:" + loop.size() + "]";
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -20,19 +20,15 @@
 package org.neo4j.kernel.impl.storemigration;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
 
-import org.neo4j.graphdb.Direction;
-import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeStore;
 import org.neo4j.kernel.impl.nioneo.store.Record;
-import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupStore;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
@@ -40,9 +36,6 @@ import org.neo4j.kernel.impl.storemigration.legacystore.LegacyNodeStoreReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyRelationshipStoreReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
-
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.helpers.collection.IteratorUtil.loop;
 
 /**
  * Migrates a neo4j database from one version to the next. Instantiated with a {@link LegacyStore}
@@ -53,6 +46,10 @@ import static org.neo4j.helpers.collection.IteratorUtil.loop;
  */
 public class StoreMigrator
 {
+    // Developers: There is a benchmark, storemigrate-benchmark, that generates large stores and benchmarks
+    // the upgrade process. Please utilize that when writing upgrade code to ensure the code is fast enough to
+    // complete upgrades in a reasonable time period.
+
     private final MigrationProgressMonitor progressMonitor;
 
     public StoreMigrator( MigrationProgressMonitor progressMonitor )
@@ -78,7 +75,7 @@ public class StoreMigrator
         {
             this.legacyStore = legacyStore;
             this.neoStore = neoStore;
-            totalEntities = legacyStore.getNodeStoreReader().getMaxId();
+            totalEntities = legacyStore.getRelStoreReader().getMaxId();
         }
 
         private void migrate() throws IOException
@@ -116,31 +113,93 @@ public class StoreMigrator
              *
              * Keep ids */
 
-            NodeStore nodeStore = neoStore.getNodeStore();
-            RelationshipStore relationshipStore = neoStore.getRelationshipStore();
-            RelationshipGroupStore relGroupStore = neoStore.getRelationshipGroupStore();
-            LegacyNodeStoreReader nodeReader = legacyStore.getNodeStoreReader();
-            LegacyRelationshipStoreReader relReader = legacyStore.getRelStoreReader();
+            final NodeStore nodeStore = neoStore.getNodeStore();
+            final RelationshipStore relationshipStore = neoStore.getRelationshipStore();
+            final RelationshipGroupStore relGroupStore = neoStore.getRelationshipGroupStore();
+            final LegacyNodeStoreReader nodeReader = legacyStore.getNodeStoreReader();
+            final LegacyRelationshipStoreReader relReader = legacyStore.getRelStoreReader();
             nodeStore.setHighId( nodeReader.getMaxId() );
-            int denseNodeThreshold = neoStore.getDenseNodeThreshold();
             relationshipStore.setHighId( relReader.getMaxId() );
+
+            final ArrayBlockingQueue<RelChainBuilder> chainsToWrite = new ArrayBlockingQueue<>( 24 );
+            final AtomicReference<Throwable> writerException = new AtomicReference<>();
+
+            Thread writerThread = new RelationshipWriter( chainsToWrite, neoStore.getDenseNodeThreshold(), nodeStore,
+                    relationshipStore, relGroupStore, nodeReader, writerException );
+            writerThread.start();
+
             try
             {
-                for ( NodeRecord node : loop( nodeReader.readNodeStore() ) )
+
+                final Map<Long, RelChainBuilder> relChains = new HashMap<>();
+                relReader.accept( new LegacyRelationshipStoreReader.Visitor()
                 {
-                    reportProgress( node.getId() );
-                    Collection<RelationshipRecord> relationships = loadRelationships( node, relReader );
-                    if ( relationships.size() >= denseNodeThreshold )
+                    @Override
+                    public void visit( long id, RelationshipRecord record )
                     {
-                        migrateDenseNode( nodeStore, relationshipStore, relGroupStore, node, relationships );
+                        reportProgress( id );
+                        if ( record.inUse() )
+                        {
+                            appendToRelChain( record.getFirstNode(), record.getFirstPrevRel(),
+                                    record.getFirstNextRel(), record );
+                            appendToRelChain( record.getSecondNode(), record.getSecondPrevRel(),
+                                    record.getSecondNextRel(), record );
+                        }
                     }
-                    else
+
+                    private void appendToRelChain( long nodeId, long prevRel, long nextRel, RelationshipRecord record )
                     {
-                        migrateNormalNode( nodeStore, relationshipStore, node, relationships );
+                        RelChainBuilder chain = relChains.get( nodeId );
+                        if ( chain == null )
+                        {
+                            chain = new RelChainBuilder( nodeId );
+                            relChains.put( nodeId, chain );
+                        }
+
+                        chain.append( record, prevRel, nextRel );
+
+                        if ( chain.isComplete() )
+                        {
+                            assertNoWriterException( writerException );
+                            try
+                            {
+                                chainsToWrite.put( relChains.remove( nodeId ) );
+                            }
+                            catch ( InterruptedException e )
+                            {
+                                Thread.interrupted();
+                                throw new RuntimeException( "Interrupted while reading relationships.", e );
+                            }
+                        }
                     }
+                } );
+
+                try
+                {
+                    chainsToWrite.put( new RelChainBuilder( -1 ) );
+                    writerThread.join();
+                    assertNoWriterException( writerException );
                 }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( "Interrupted.", e);
+                }
+
                 legacyStore.copyNodeStoreIdFile( neoStore );
                 legacyStore.copyRelationshipStoreIdFile( neoStore );
+
+                // Migrate nodes with no relationships
+                nodeReader.accept(new LegacyNodeStoreReader.Visitor()
+                {
+                    @Override
+                    public void visit( NodeRecord record )
+                    {
+                        if(record.inUse() && record.getNextRel() == Record.NO_NEXT_RELATIONSHIP.intValue())
+                        {
+                            nodeStore.forceUpdateRecord( record );
+                        }
+                    }
+                });
             }
             finally
             {
@@ -149,197 +208,12 @@ public class StoreMigrator
             }
         }
 
-        private void migrateNormalNode( NodeStore nodeStore, RelationshipStore relationshipStore,
-                NodeRecord node, Collection<RelationshipRecord> relationships )
+        private void assertNoWriterException( AtomicReference<Throwable> writerException )
         {
-            /* Add node record
-             * Add/update all relationship records */
-            nodeStore.forceUpdateRecord( node );
-            int i = 0;
-            for ( RelationshipRecord record : relationships )
+            if(writerException.get() != null)
             {
-                if ( i == 0 )
-                {
-                    setDegree( node.getId(), record, relationships.size() );
-                }
-                applyChangesToRecord( node.getId(), record, relationshipStore );
-                relationshipStore.forceUpdateRecord( record );
-                i++;
+                throw new RuntimeException( writerException.get() );
             }
-        }
-
-        private void migrateDenseNode( NodeStore nodeStore, RelationshipStore relationshipStore,
-                RelationshipGroupStore relGroupStore, NodeRecord node, Collection<RelationshipRecord> records )
-        {
-            Map<Integer, Relationships> byType = splitUp( node.getId(), records );
-            List<RelationshipGroupRecord> groupRecords = new ArrayList<>();
-            for ( Map.Entry<Integer, Relationships> entry : byType.entrySet() )
-            {
-                Relationships relationships = entry.getValue();
-                applyLinks( node.getId(), relationships.out, relationshipStore, Direction.OUTGOING );
-                applyLinks( node.getId(), relationships.in, relationshipStore, Direction.INCOMING );
-                applyLinks( node.getId(), relationships.loop, relationshipStore, Direction.BOTH );
-                RelationshipGroupRecord groupRecord = new RelationshipGroupRecord( relGroupStore.nextId(), entry.getKey() );
-                groupRecords.add( groupRecord );
-                groupRecord.setInUse( true );
-                if ( !relationships.out.isEmpty() )
-                {
-                    groupRecord.setFirstOut( first( relationships.out ).getId() );
-                }
-                if ( !relationships.in.isEmpty() )
-                {
-                    groupRecord.setFirstIn( first( relationships.in ).getId() );
-                }
-                if ( !relationships.loop.isEmpty() )
-                {
-                    groupRecord.setFirstLoop( first( relationships.loop ).getId() );
-                }
-            }
-
-            RelationshipGroupRecord previousGroup = null;
-            for ( int i = 0; i < groupRecords.size(); i++ )
-            {
-                RelationshipGroupRecord groupRecord = groupRecords.get( i );
-                if ( i+1 < groupRecords.size() )
-                {
-                    RelationshipGroupRecord nextRecord = groupRecords.get( i+1 );
-                    groupRecord.setNext( nextRecord.getId() );
-                }
-                if ( previousGroup != null )
-                {
-                    groupRecord.setPrev( previousGroup.getId() );
-                }
-                previousGroup = groupRecord;
-            }
-            for ( RelationshipGroupRecord groupRecord : groupRecords )
-            {
-                relGroupStore.forceUpdateRecord( groupRecord );
-            }
-
-            node.setNextRel( groupRecords.get( 0 ).getId() );
-            node.setDense( true );
-            nodeStore.forceUpdateRecord( node );
-        }
-
-        private void applyLinks( long nodeId, List<RelationshipRecord> records, RelationshipStore relationshipStore, Direction dir )
-        {
-            for ( int i = 0; i < records.size(); i++ )
-            {
-                RelationshipRecord record = records.get( i );
-                if ( i > 0 )
-                {   // link previous
-                    long previous = records.get( i-1 ).getId();
-                    if ( record.getFirstNode() == nodeId )
-                    {
-                        record.setFirstPrevRel( previous );
-                    }
-                    if ( record.getSecondNode() == nodeId )
-                    {
-                        record.setSecondPrevRel( previous );
-                    }
-                }
-                else
-                {
-                    setDegree( nodeId, record, records.size() );
-                }
-
-                if ( i < records.size()-1 )
-                {   // link next
-                    long next = records.get( i+1 ).getId();
-                    if ( record.getFirstNode() == nodeId )
-                    {
-                        record.setFirstNextRel( next );
-                    }
-                    if ( record.getSecondNode() == nodeId )
-                    {
-                        record.setSecondNextRel( next );
-                    }
-                }
-                else
-                {   // end of chain
-                    if ( record.getFirstNode() == nodeId )
-                    {
-                        record.setFirstNextRel( Record.NO_NEXT_RELATIONSHIP.intValue() );
-                    }
-                    if ( record.getSecondNode() == nodeId )
-                    {
-                        record.setSecondNextRel( Record.NO_NEXT_RELATIONSHIP.intValue() );
-                    }
-                }
-                applyChangesToRecord( nodeId, record, relationshipStore );
-                relationshipStore.forceUpdateRecord( record );
-            }
-        }
-
-        private void setDegree( long nodeId, RelationshipRecord record, int size )
-        {
-            if ( nodeId == record.getFirstNode() )
-            {
-                record.setFirstInFirstChain( true );
-                record.setFirstPrevRel( size );
-            }
-            if ( nodeId == record.getSecondNode() )
-            {
-                record.setFirstInSecondChain( true );
-                record.setSecondPrevRel( size );
-            }
-        }
-
-        private void applyChangesToRecord( long nodeId, RelationshipRecord record, RelationshipStore relationshipStore )
-        {
-            try
-            {
-                RelationshipRecord existingRecord = relationshipStore.getRecord( record.getId() );
-                // Not necessary for loops since those records will just be copied.
-                if ( nodeId == record.getFirstNode() )
-                {   // Copy end node stuff from the existing record
-                    record.setFirstInSecondChain( existingRecord.isFirstInSecondChain() );
-                    record.setSecondPrevRel( existingRecord.getSecondPrevRel() );
-                    record.setSecondNextRel( existingRecord.getSecondNextRel() );
-                }
-                else
-                {   // Copy start node stuff from the existing record
-                    record.setFirstInFirstChain( existingRecord.isFirstInFirstChain() );
-                    record.setFirstPrevRel( existingRecord.getFirstPrevRel() );
-                    record.setFirstNextRel( existingRecord.getFirstNextRel() );
-                }
-            }
-            catch ( InvalidRecordException e )
-            {   // No need to apply changes, doesn't exist
-            }
-        }
-
-        private Collection<RelationshipRecord> loadRelationships( NodeRecord nodeRecord,
-                LegacyRelationshipStoreReader relReader )
-        {
-            Collection<RelationshipRecord> records = new ArrayList<>();
-            long rel = nodeRecord.getNextRel();
-            long node = nodeRecord.getId();
-            while ( rel != Record.NO_NEXT_RELATIONSHIP.intValue() )
-            {
-                RelationshipRecord record = relReader.getRecord( rel );
-                records.add( record );
-                rel = record.getFirstNode() == node ?
-                        record.getFirstNextRel() : record.getSecondNextRel();
-            }
-            return records;
-        }
-
-        private Map<Integer, Relationships> splitUp( long nodeId, Collection<RelationshipRecord> records )
-        {
-            Map<Integer, Relationships> result = new HashMap<>();
-            for ( RelationshipRecord record : records )
-            {
-                Integer type = record.getType();
-                Relationships relationships = result.get( type );
-                if ( relationships == null )
-                {
-                    relationships = new Relationships( nodeId );
-                    result.put( type, relationships );
-                }
-                relationships.add( record );
-            }
-            return result;
         }
 
         private void reportProgress( long id )
@@ -350,44 +224,6 @@ public class StoreMigrator
                 percentComplete = newPercent;
                 progressMonitor.percentComplete( percentComplete );
             }
-        }
-    }
-
-    private static class Relationships
-    {
-        private final long nodeId;
-        final List<RelationshipRecord> out = new ArrayList<>();
-        final List<RelationshipRecord> in = new ArrayList<>();
-        final List<RelationshipRecord> loop = new ArrayList<>();
-
-        Relationships( long nodeId )
-        {
-            this.nodeId = nodeId;
-        }
-
-        void add( RelationshipRecord record )
-        {
-            if ( record.getFirstNode() == nodeId )
-            {
-                if ( record.getSecondNode() == nodeId )
-                {   // Loop
-                    loop.add( record );
-                }
-                else
-                {   // Out
-                    out.add( record );
-                }
-            }
-            else
-            {   // In
-                in.add( record );
-            }
-        }
-
-        @Override
-        public String toString()
-        {
-            return "Relationships[" + nodeId + ",out:" + out.size() + ", in:" + in.size() + ", loop:" + loop.size() + "]";
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyNodeStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyNodeStoreReader.java
@@ -25,22 +25,23 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Collections;
-import java.util.Iterator;
 
 import org.neo4j.helpers.UTF8;
-import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 
 import static java.nio.ByteBuffer.allocateDirect;
-
 import static org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore.longFromIntAndMod;
-import static org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore.readIntoBuffer;
 
 public class LegacyNodeStoreReader implements Closeable
 {
+    public interface Visitor
+    {
+        void visit(NodeRecord record);
+    }
+
     public static final String FROM_VERSION = "NodeStore " + LegacyStore.LEGACY_VERSION;
     public static final int RECORD_SIZE = 14;
 
@@ -59,52 +60,98 @@ public class LegacyNodeStoreReader implements Closeable
         return maxId;
     }
 
-    public Iterator<NodeRecord> readNodeStore()
+    public void accept( Visitor visitor ) throws IOException
     {
-        return new PrefetchingIterator<NodeRecord>()
+        ByteBuffer buffer = ByteBuffer.allocateDirect( 4 * 1024 * RECORD_SIZE );
+
+        long position = 0, fileSize = fileChannel.size();
+        while(position < fileSize)
         {
-            long id = 0;
-            ByteBuffer buffer = allocateDirect( RECORD_SIZE );
-
-            @Override
-            protected NodeRecord fetchNextOrNull()
+            int recordOffset = 0;
+            buffer.clear();
+            fileChannel.read( buffer, position );
+            // Visit each record in the page
+            while(recordOffset < buffer.capacity() && (recordOffset + position) < fileSize)
             {
-                NodeRecord nodeRecord = null;
-                while ( nodeRecord == null && id < maxId )
-                {
-                    readIntoBuffer( fileChannel, buffer, RECORD_SIZE );
-                    long inUseByte = buffer.get();
+                buffer.position(recordOffset);
+                long id = (position + recordOffset) / RECORD_SIZE;
 
-                    boolean inUse = (inUseByte & 0x1) == Record.IN_USE.intValue();
-                    if ( inUse )
-                    {
-                        long nextRel = LegacyStore.getUnsignedInt( buffer );
-                        long relModifier = (inUseByte & 0xEL) << 31;
-                        long nextProp = LegacyStore.getUnsignedInt( buffer );
-                        long propModifier = (inUseByte & 0xF0L) << 28;
-                        long lsbLabels = LegacyStore.getUnsignedInt( buffer );
-                        long hsbLabels = buffer.get() & 0xFF; // so that a negative byte won't fill the "extended" bits with ones.
-                        long labels = lsbLabels | (hsbLabels << 32);
-                        nodeRecord = new NodeRecord( id, false, longFromIntAndMod( nextRel, relModifier ),
-                                longFromIntAndMod( nextProp, propModifier ) );
-                        nodeRecord.setLabelField( labels, Collections.<DynamicRecord>emptyList() ); // no need to load 'em heavy
-                    }
-                    else
-                    {
-                        nodeRecord = new NodeRecord( id, false,
-                                Record.NO_NEXT_RELATIONSHIP.intValue(), Record.NO_NEXT_PROPERTY.intValue() );
-                    }
-                    nodeRecord.setInUse( inUse );
-                    id++;
-                }
-                return nodeRecord;
+                visitor.visit( readRecord( buffer, id ) );
+
+                recordOffset += RECORD_SIZE;
             }
-        };
+
+            position += buffer.capacity()   ;
+        }
+    }
+
+    private NodeRecord readRecord( ByteBuffer buffer, long id )
+    {
+        NodeRecord nodeRecord;
+
+        long inUseByte = buffer.get();
+
+        boolean inUse = (inUseByte & 0x1) == Record.IN_USE.intValue();
+        if ( inUse )
+        {
+            long nextRel = LegacyStore.getUnsignedInt( buffer );
+            long relModifier = (inUseByte & 0xEL) << 31;
+            long nextProp = LegacyStore.getUnsignedInt( buffer );
+            long propModifier = (inUseByte & 0xF0L) << 28;
+            long lsbLabels = LegacyStore.getUnsignedInt( buffer );
+            long hsbLabels = buffer.get() & 0xFF; // so that a negative byte won't fill the "extended" bits with ones.
+            long labels = lsbLabels | (hsbLabels << 32);
+            nodeRecord = new NodeRecord( id, false, longFromIntAndMod( nextRel, relModifier ),
+                    longFromIntAndMod( nextProp, propModifier ) );
+            nodeRecord.setLabelField( labels, Collections.<DynamicRecord>emptyList() ); // no need to load 'em heavy
+        }
+        else
+        {
+            nodeRecord = new NodeRecord( id, false,
+                    Record.NO_NEXT_RELATIONSHIP.intValue(), Record.NO_NEXT_PROPERTY.intValue() );
+        }
+        nodeRecord.setInUse( inUse );
+
+        return nodeRecord;
     }
 
     @Override
     public void close() throws IOException
     {
         fileChannel.close();
+    }
+
+    public NodeRecord readNodeStore( long id ) throws IOException
+    {
+        ByteBuffer buffer = allocateDirect( RECORD_SIZE );
+        NodeRecord nodeRecord;
+
+        fileChannel.position( id * RECORD_SIZE );
+        fileChannel.read( buffer );
+        buffer.flip();
+
+        long inUseByte = buffer.get();
+
+        boolean inUse = (inUseByte & 0x1) == Record.IN_USE.intValue();
+        if ( inUse )
+        {
+            long nextRel = LegacyStore.getUnsignedInt( buffer );
+            long relModifier = (inUseByte & 0xEL) << 31;
+            long nextProp = LegacyStore.getUnsignedInt( buffer );
+            long propModifier = (inUseByte & 0xF0L) << 28;
+            long lsbLabels = LegacyStore.getUnsignedInt( buffer );
+            long hsbLabels = buffer.get() & 0xFF; // so that a negative byte won't fill the "extended" bits with ones.
+            long labels = lsbLabels | (hsbLabels << 32);
+            nodeRecord = new NodeRecord( id, false, longFromIntAndMod( nextRel, relModifier ),
+                    longFromIntAndMod( nextProp, propModifier ) );
+            nodeRecord.setLabelField( labels, Collections.<DynamicRecord>emptyList() ); // no need to load 'em heavy
+        }
+        else
+        {
+            nodeRecord = new NodeRecord( id, false,
+                    Record.NO_NEXT_RELATIONSHIP.intValue(), Record.NO_NEXT_PROPERTY.intValue() );
+        }
+        nodeRecord.setInUse( inUse );
+        return nodeRecord;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
@@ -24,26 +24,24 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.Iterator;
 
 import org.neo4j.helpers.UTF8;
-import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 
-import static java.nio.ByteBuffer.allocateDirect;
-
-import static org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore.readIntoBuffer;
-
 public class LegacyRelationshipStoreReader implements Closeable
 {
+    public interface Visitor
+    {
+        void visit( long relId, RelationshipRecord record );
+    }
+
     public static final String FROM_VERSION = "RelationshipStore " + LegacyStore.LEGACY_VERSION;
     public static final int RECORD_SIZE = 33;
 
     private final FileChannel fileChannel;
     private final long maxId;
-    private final ByteBuffer buffer = allocateDirect( RECORD_SIZE );
 
     public LegacyRelationshipStoreReader( FileSystemAbstraction fs, File fileName ) throws IOException
     {
@@ -57,29 +55,35 @@ public class LegacyRelationshipStoreReader implements Closeable
         return maxId;
     }
 
-    public Iterator<RelationshipRecord> readRelationshipStore()
+    public void accept( Visitor visitor ) throws IOException
     {
-        return new PrefetchingIterator<RelationshipRecord>()
-        {
-            long id = 0;
+        ByteBuffer buffer = ByteBuffer.allocateDirect( 4 * 1024 * RECORD_SIZE );
 
-            @Override
-            protected RelationshipRecord fetchNextOrNull()
+        long position = 0, fileSize = fileChannel.size();
+        while(position < fileSize)
+        {
+            int recordOffset = 0;
+            buffer.clear();
+            fileChannel.read( buffer, position );
+            // Visit each record in the page
+            while(recordOffset < buffer.capacity() && (recordOffset + position) < fileSize)
             {
-                RelationshipRecord record = null;
-                while ( record == null && id <= maxId )
-                {
-                    record = getRecord( id++ );
-                }
-                return record;
+                buffer.position(recordOffset);
+                long id = (position + recordOffset) / RECORD_SIZE;
+
+                visitor.visit( id, readRecord( buffer, id ) );
+
+                recordOffset += RECORD_SIZE;
             }
-        };
+
+            position += buffer.capacity()   ;
+        }
     }
-    
-    public RelationshipRecord getRecord( long id )
+
+    private RelationshipRecord readRecord( ByteBuffer buffer, long id )
     {
         RelationshipRecord record;
-        readIntoBuffer( fileChannel, buffer, id*RECORD_SIZE, RECORD_SIZE );
+
         long inUseByte = buffer.get();
 
         boolean inUse = (inUseByte & 0x1) == Record.IN_USE.intValue();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/RelChainBuilderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/RelChainBuilderTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import org.junit.Test;
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class RelChainBuilderTest
+{
+
+    @Test
+    public void shouldDetectCompleteChains() throws Exception
+    {
+        // Given
+        RelChainBuilder chain = new RelChainBuilder( 1l );
+
+        // When
+        chain.append( new RelationshipRecord( 2l ), Record.NO_PREV_RELATIONSHIP.intValue(), 3l );
+        chain.append( new RelationshipRecord( 3l ), 2l, 4l );
+        chain.append( new RelationshipRecord( 4l ), 3l, Record.NO_NEXT_RELATIONSHIP.intValue() );
+
+        // Then
+        assertTrue( chain.isComplete() );
+        assertThat( chain.size(), equalTo(3));
+    }
+
+    @Test
+    public void shouldHandleArbitraryOrdering() throws Exception
+    {
+        // Given
+        RelChainBuilder chain = new RelChainBuilder( 1l );
+
+        // When
+        chain.append( new RelationshipRecord( 4l ), 3l, Record.NO_NEXT_RELATIONSHIP.intValue() );
+        chain.append( new RelationshipRecord( 3l ), 2l, 4l );
+        chain.append( new RelationshipRecord( 2l ), Record.NO_PREV_RELATIONSHIP.intValue(), 3l );
+
+        // Then
+        assertTrue( chain.isComplete() );
+        assertThat( chain.size(), equalTo(3));
+    }
+}


### PR DESCRIPTION
 o Changes strategy from scanning node store to scanning rel store, leading to much less random access.
   Upgrade now requires a single sequential scan through rel store, plus random access into node store,
   one access for each node.
 o Modifies the scanning strategy to use 4K-aligned scan buffer instead of 33b buffer, improves scan speed
   one order of magnitude.
 o Remaining: Memory usage is still very high, need to investigate performance when RAM runs out.
