### PR TITLE
During recovery, don't activate indexes.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -615,11 +615,11 @@ public class IndexingService extends LifecycleAdapter
     public void activateIndex( long indexId ) throws
             IndexNotFoundKernelException, IndexActivationFailedKernelException, IndexPopulationFailedKernelException
     {
-        IndexProxy index = getProxyForRule( indexId );
         try
         {
             if ( state == State.RUNNING ) // don't do this during recovery.
             {
+                IndexProxy index = getProxyForRule( indexId );
                 index.awaitStoreScanCompleted();
                 index.activate();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -440,6 +440,20 @@ public class IndexingServiceTest
         assertThat( asCollection( files ), equalTo( asCollection( iterator( theFile ) ) ) );
     }
 
+    @Test
+    public void shouldIgnoreActivateCallDuringRecovery() throws Exception
+    {
+        // given
+        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+
+        life.start();
+
+        // when
+        indexingService.activateIndex( 0 );
+
+        // then no exception should be thrown.
+    }
+
     private Answer waitForLatch( final CountDownLatch latch ) {
         return new Answer() {
             @Override


### PR DESCRIPTION
 o Fixes an issue where indexes that have been dropped would
   fail recovery if commands to activate them were run in recovery.
