### PR TITLE
Refactoring of ExecutionPlanBuilder

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/CypherCompiler.scala
@@ -58,7 +58,7 @@ case class CypherCompiler(parser: CypherParser,
     val (rewrittenStatement, extractedParams) = astRewriter.rewrite(queryText, parsedStatement)
     val table = semanticChecker.check(queryText, parsedStatement)
     val query: AbstractQuery = ReattachAliasedExpressions(rewrittenStatement.asQuery.setQueryText(queryText))
-    val parsedQuery = ParsedQuery(rewrittenStatement, query, table)
+    val parsedQuery = ParsedQuery(rewrittenStatement, query, table, queryText)
 
     val cache = context.getOrCreateFromSchemaState(this, cacheFactory())
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ParsedQuery.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ParsedQuery.scala
@@ -26,5 +26,6 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.SemanticTable
 
 case class ParsedQuery(statement: Statement,
                        abstractQuery: AbstractQuery,
-                       semanticQuery: SemanticTable)
+                       semanticTable: SemanticTable,
+                       queryText: String)
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyPipeBuilder.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyPipeBuilder.scala
@@ -26,8 +26,12 @@ import org.neo4j.cypher.internal.compiler.v2_1.pipes._
 import org.neo4j.cypher.internal.compiler.v2_1.commands.values.{TokenType, KeyToken}
 import org.neo4j.cypher.SyntaxException
 import org.neo4j.cypher.internal.compiler.v2_1.executionplan.builders.prepare.{AggregationPreparationRewriter, KeyTokenResolver}
+import org.neo4j.cypher.internal.compiler.v2_1.ParsedQuery
 
-class PipeBuilder extends PatternGraphBuilder {
+class LegacyPipeBuilder extends PatternGraphBuilder with PipeBuilder {
+
+  def producePlan(inputQuery: ParsedQuery, planContext: PlanContext): PipeInfo =
+    buildPipes(planContext, inputQuery.abstractQuery)
 
   def buildPipes(planContext: PlanContext, in: AbstractQuery): PipeInfo = in match {
     case q: PeriodicCommitQuery => buildPipes(planContext, q.query).copy(periodicCommit = Some(PeriodicCommitInfo(q.batchSize)))

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyVsNewPipeBuilder.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyVsNewPipeBuilder.scala
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_1.executionplan
+
+import org.neo4j.cypher.internal.compiler.v2_1.ParsedQuery
+import org.neo4j.cypher.internal.compiler.v2_1.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v2_1.planner.CantHandleQueryException
+
+class LegacyVsNewPipeBuilder(oldBuilder: PipeBuilder,
+                             newBuilder: PipeBuilder,
+                             monitor: NewQueryPlanSuccessRateMonitor) extends PipeBuilder {
+  def producePlan(inputQuery: ParsedQuery, planContext: PlanContext): PipeInfo = try {
+    val queryText = inputQuery.queryText
+    try {
+      monitor.newQuerySeen(queryText, inputQuery.statement)
+      newBuilder.producePlan(inputQuery, planContext)
+    } catch {
+      case _: CantHandleQueryException =>
+        monitor.unableToHandleQuery(queryText, inputQuery.statement)
+        oldBuilder.producePlan(inputQuery, planContext)
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/Planner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/Planner.scala
@@ -20,15 +20,15 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner
 
 import org.neo4j.cypher.internal.compiler.v2_1.ast.{Statement, Query}
-import org.neo4j.cypher.internal.compiler.v2_1.executionplan.PipeInfo
+import org.neo4j.cypher.internal.compiler.v2_1.executionplan.{PipeBuilder, PipeInfo}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.SimpleLogicalPlanner
 import org.neo4j.graphdb.Direction
 import org.neo4j.cypher.internal.compiler.v2_1.planner.execution.SimpleExecutionPlanBuilder
 import org.neo4j.cypher.internal.compiler.v2_1.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v2_1.{PropertyKeyId, RelTypeId, LabelId}
+import org.neo4j.cypher.internal.compiler.v2_1.{ParsedQuery, PropertyKeyId, RelTypeId, LabelId}
 
 /* This class is responsible for taking a query from an AST object to a runnable object.  */
-case class Planner() {
+case class Planner() extends PipeBuilder {
   val estimator = new CardinalityEstimator {
 
     def estimateExpandRelationship(labelIds: Seq[LabelId], relationshipType: Seq[RelTypeId], dir: Direction) = 20
@@ -53,6 +53,10 @@ case class Planner() {
   val queryGraphBuilder = new SimpleQueryGraphBuilder
   val logicalPlanner = new SimpleLogicalPlanner(estimator)
   val executionPlanBuilder = new SimpleExecutionPlanBuilder
+
+
+  def producePlan(inputQuery: ParsedQuery, planContext: PlanContext): PipeInfo =
+    producePlan(inputQuery.statement, inputQuery.semanticTable)(planContext)
 
   def producePlan(statement: Statement, semanticQuery: SemanticTable)(planContext: PlanContext): PipeInfo = statement match {
     case ast: Query =>

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyPipeBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/LegacyPipeBuilderTest.scala
@@ -29,10 +29,10 @@ import org.neo4j.cypher.internal.compiler.v2_1.ast
 import ast.convert.StatementConverters._
 
 
-class PipeBuilderTest extends MockitoSugar {
+class LegacyPipeBuilderTest extends MockitoSugar {
   val planContext: PlanContext = mock[PlanContext]
   val parser = new CypherParser(mock[ParserMonitor])
-  val planBuilder = new PipeBuilder()
+  val planBuilder = new LegacyPipeBuilder()
 
   @Test def should_use_distinct_pipe_for_distinct() {
     val pipe = buildExecutionPipe("MATCH n RETURN DISTINCT n")


### PR DESCRIPTION
- Introduced the PipeBuilder trait, so EPB does not have to know about their internals
- Introduced a PipeBuilder that knows to switch between new and old PipeBuilding
