### PR TITLE
Fixed issue where relationship loading could stop mid-way

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
@@ -28,6 +28,8 @@ import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 
+import static java.lang.String.format;
+
 import static org.neo4j.helpers.collection.IteratorUtil.toPrimitiveArray;
 
 public class DenseNodeChainPosition implements RelationshipLoadingPosition
@@ -36,7 +38,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     private final Map<Integer, RelationshipGroupRecord> groups;
     private final int[] types;
     private RelationshipLoadingPosition currentPosition;
-    
+
     public DenseNodeChainPosition( Map<Integer, RelationshipGroupRecord> groups )
     {
         this.types = toPrimitiveArray( groups.keySet() );
@@ -65,7 +67,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     {
         // TODO here we need relationship groups for any new
     }
-    
+
     @Override
     public long position( DirectionWrapper direction, int[] types )
     {
@@ -107,7 +109,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         }
         return position( direction, types );
     }
-    
+
     @Override
     public boolean hasMore( DirectionWrapper direction, int[] types )
     {
@@ -125,7 +127,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         }
         return false;
     }
-    
+
     @Override
     public void compareAndAdvance( long relIdDeleted, long nextRelId )
     {
@@ -140,13 +142,22 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     {
         return new DenseNodeChainPosition( this );
     }
-    
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder( getClass().getSimpleName() + ":" );
+        builder.append( format( "%n  groups: %s", groups ) );
+        builder.append( format( "%n  positions: %s", positions ) );
+        return builder.toString();
+    }
+
     private static class TypePosition implements RelationshipLoadingPosition
     {
         private final EnumMap<DirectionWrapper, RelationshipLoadingPosition> directions =
                 new EnumMap<>( DirectionWrapper.class );
         private RelationshipLoadingPosition currentPosition;
-        
+
         TypePosition( RelationshipGroupRecord record )
         {
             for ( DirectionWrapper dir : DirectionWrapper.values() )
@@ -154,7 +165,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
                 directions.put( dir, new SingleChainPosition( dir.getNextRel( record ) ) );
             }
         }
-        
+
         private TypePosition( TypePosition copyFrom )
         {
             for ( Entry<DirectionWrapper,RelationshipLoadingPosition> entry : copyFrom.directions.entrySet() )
@@ -167,13 +178,13 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
                 }
             }
         }
-        
+
         @Override
         public void updateFirst( long first )
         {
             throw new UnsupportedOperationException();
         }
-        
+
         @Override
         public long position( DirectionWrapper direction, int[] types )
         {
@@ -213,7 +224,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
             }
             return position( direction, types );
         }
-        
+
         @Override
         public boolean hasMore( DirectionWrapper direction, int[] types )
         {
@@ -243,6 +254,12 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         public RelationshipLoadingPosition clone()
         {
             return new TypePosition( this );
+        }
+
+        @Override
+        public String toString()
+        {
+            return directions.toString();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.util.RelIdIterator;
 
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.binarySearch;
+
 import static org.neo4j.helpers.collection.IteratorUtil.emptyPrimitiveLongIterator;
 import static org.neo4j.kernel.impl.cache.SizeOfs.REFERENCE_SIZE;
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
@@ -263,7 +264,7 @@ public class NodeImpl extends ArrayBasedPrimitive
     {
         ensureRelationshipMapNotNull( nm, DirectionWrapper.BOTH, NO_RELATIONSHIP_TYPES );
     }
-    
+
     private void loadInitialRelationships( NodeManager nodeManager, DirectionWrapper direction,
             int[] types )
     {
@@ -386,7 +387,7 @@ public class NodeImpl extends ArrayBasedPrimitive
     {
         return relChainPosition != null && relChainPosition.hasMore( DirectionWrapper.BOTH, NO_RELATIONSHIP_TYPES );
     }
-    
+
     boolean hasMoreRelationshipsToLoad( DirectionWrapper direction, int[] types )
     {
         return relChainPosition != null && relChainPosition.hasMore( direction, types );
@@ -565,7 +566,7 @@ public class NodeImpl extends ArrayBasedPrimitive
     {
         return this.relChainPosition;
     }
-    
+
     // Mostly for testing
     void setRelChainPosition( RelationshipLoadingPosition position )
     {
@@ -581,7 +582,7 @@ public class NodeImpl extends ArrayBasedPrimitive
             // Done loading - Shrink arrays
             for ( int i = 0; i < array.length; i++ )
             {
-                array[i] = array[i].shrink();
+                array[i].shrink();
             }
             relChainPosition = RelationshipLoadingPosition.EMPTY;
         }
@@ -640,7 +641,7 @@ public class NodeImpl extends ArrayBasedPrimitive
     {
         return Property.noNodeProperty( getId(), key );
     }
-    
+
     private void ensureAllRelationshipsAreLoaded( NodeManager nm )
     {
         ensureRelationshipMapNotNull( nm );
@@ -668,7 +669,7 @@ public class NodeImpl extends ArrayBasedPrimitive
         }
         return getDegreeByDirection( nm, wrap( direction ) );
     }
-    
+
     private int getDegreeByDirection( NodeManager nm, DirectionWrapper direction )
     {
         ensureAllRelationshipsAreLoaded( nm );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipIterator.java
@@ -36,7 +36,7 @@ class RelationshipIterator implements PrimitiveLongIterator
     private final NodeImpl fromNode;
     private final DirectionWrapper direction;
     private final NodeManager nodeManager;
-    
+
     private boolean lastTimeILookedThereWasMoreToLoad;
     private final boolean allTypes;
     private final int[] types;
@@ -98,7 +98,7 @@ class RelationshipIterator implements PrimitiveLongIterator
                 hasNext = true;
                 return;
             }
-            
+
             LoadStatus status;
             while ( !currentTypeIterator.hasNext() )
             {
@@ -132,7 +132,7 @@ class RelationshipIterator implements PrimitiveLongIterator
                         }
                         newRels.put( type, itr );
                     }
-                    
+
                     // If we wanted relationships of any type check if there are
                     // any new relationship types loaded for this node and if so
                     // initiate iterators for them
@@ -154,7 +154,7 @@ class RelationshipIterator implements PrimitiveLongIterator
                             }
                         }
                     }
-                    
+
                     initializeRels( newRels.values().toArray( new RelIdIterator[newRels.size()] ) );
                     currentTypeIterator = rels[currentTypeIndex];
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
@@ -25,19 +25,19 @@ import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 public class SingleChainPosition implements RelationshipLoadingPosition
 {
     private long position;
-    
+
     public SingleChainPosition( long firstPosition )
     {
         this.position = firstPosition;
     }
-    
+
     @Override
     public void updateFirst( long first )
     {
         // TODO assert that it's the first position in the chain
         this.position = first;
     }
-    
+
     @Override
     public long position( DirectionWrapper direction, int[] types )
     {
@@ -50,7 +50,7 @@ public class SingleChainPosition implements RelationshipLoadingPosition
         this.position = nextRel;
         return nextRel;
     }
-    
+
     @Override
     public boolean hasMore( DirectionWrapper direction, int[] types )
     {
@@ -70,5 +70,11 @@ public class SingleChainPosition implements RelationshipLoadingPosition
     public RelationshipLoadingPosition clone()
     {
         return new SingleChainPosition( position );
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "[" + position + "]";
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static java.util.Arrays.binarySearch;
-import static java.util.Arrays.copyOf;
-import static org.neo4j.helpers.collection.IteratorUtil.asPrimitiveIterator;
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.kernel.impl.nioneo.store.PropertyStore.encodeString;
-import static org.neo4j.kernel.impl.nioneo.store.labels.NodeLabelsField.parseLabelsField;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.CREATE;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.DELETE;
-import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.UPDATE;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -97,6 +87,17 @@ import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
+
+import static java.util.Arrays.binarySearch;
+import static java.util.Arrays.copyOf;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asPrimitiveIterator;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.nioneo.store.PropertyStore.encodeString;
+import static org.neo4j.kernel.impl.nioneo.store.labels.NodeLabelsField.parseLabelsField;
+import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.CREATE;
+import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.DELETE;
+import static org.neo4j.kernel.impl.nioneo.xa.Command.Mode.UPDATE;
 
 /**
  * Transaction containing {@link Command commands} reflecting the operations

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArrayWithLoops.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelIdArrayWithLoops.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.util;
 
 public class RelIdArrayWithLoops extends RelIdArray
 {
-    private IdBlock lastLoopBlock;
+    private IdBlock loopBlock;
 
     public RelIdArrayWithLoops( int type )
     {
@@ -31,31 +31,31 @@ public class RelIdArrayWithLoops extends RelIdArray
     @Override
     public int sizeOfObjectInBytesIncludingOverhead()
     {
-        return super.sizeOfObjectInBytesIncludingOverhead() + sizeOfBlockWithReference( lastLoopBlock );
+        return super.sizeOfObjectInBytesIncludingOverhead() + sizeOfBlockWithReference( loopBlock );
     }
 
     protected RelIdArrayWithLoops( RelIdArray from )
     {
         super( from );
-        lastLoopBlock = from.getLastLoopBlock();
+        loopBlock = from.getLastLoopBlock();
     }
 
     protected RelIdArrayWithLoops( int type, IdBlock out, IdBlock in, IdBlock loop )
     {
         super( type, out, in );
-        this.lastLoopBlock = loop;
+        this.loopBlock = loop;
     }
 
     @Override
     protected IdBlock getLastLoopBlock()
     {
-        return this.lastLoopBlock;
+        return this.loopBlock;
     }
 
     @Override
     protected void setLastLoopBlock( IdBlock block )
     {
-        this.lastLoopBlock = block;
+        this.loopBlock = block;
     }
 
     @Override
@@ -67,7 +67,7 @@ public class RelIdArrayWithLoops extends RelIdArray
     @Override
     public RelIdArray downgradeIfPossible()
     {
-        return lastLoopBlock == null ? new RelIdArray( this ) : this;
+        return loopBlock == null ? new RelIdArray( this ) : this;
     }
 
     @Override
@@ -80,23 +80,5 @@ public class RelIdArrayWithLoops extends RelIdArray
     protected boolean accepts( RelIdArray source )
     {
         return true;
-    }
-
-    @Override
-    public boolean couldBeNeedingUpdate()
-    {
-        return true;
-    }
-
-    @Override
-    public RelIdArray shrink()
-    {
-        IdBlock lastOutBlock = DirectionWrapper.OUTGOING.getBlock( this );
-        IdBlock lastInBlock = DirectionWrapper.INCOMING.getBlock( this );
-        IdBlock shrunkOut = lastOutBlock != null ? lastOutBlock.shrink() : null;
-        IdBlock shrunkIn = lastInBlock != null ? lastInBlock.shrink() : null;
-        IdBlock shrunkLoop = lastLoopBlock != null ? lastLoopBlock.shrink() : null;
-        return shrunkOut == lastOutBlock && shrunkIn == lastInBlock && shrunkLoop == lastLoopBlock ? this :
-                new RelIdArrayWithLoops( getType(), shrunkOut, shrunkIn, shrunkLoop );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIteratorIssuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipIteratorIssuesTest.java
@@ -29,16 +29,19 @@ import java.util.Queue;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.neo4j.kernel.impl.core.NodeImpl.LoadStatus;
 import org.neo4j.kernel.impl.util.RelIdArray;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.RelIdIterator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.OUTGOING;
 
 /**
@@ -53,19 +56,19 @@ public class RelationshipIteratorIssuesTest
         // -- a node manager capable of serving light-weight RelationshipProxy capable of answering getId()
         NodeManager nodeManager = mock( NodeManager.class );
         when( nodeManager.newRelationshipProxyById( anyLong() ) ).thenAnswer( relationshipProxyWithId() );
-        
+
         // -- a node that says it cannot load any more relationships
         NodeImpl node = mock( NodeImpl.class );
         when( node.getMoreRelationships( eq( nodeManager ), any( DirectionWrapper.class ),
                 any( int[].class )) ).thenReturn( LoadStatus.NOTHING );
-        
+
         // -- a type iterator that at this point contains one relationship (0)
         ControlledRelIdIterator typeIterator = new ControlledRelIdIterator( 0L );
         RelationshipIterator iterator = new RelationshipIterator( new RelIdIterator[] { typeIterator },
                 node, OUTGOING, new int[0], nodeManager, false, false );
         // -- go forth one step in the iterator
         iterator.next();
-        
+
         // WHEN
         // -- one relationship has been returned, and we're in the middle of the next call to next()
         //    typeIterator will get one more relationship in it. To mimic this we control the outcome of
@@ -73,15 +76,15 @@ public class RelationshipIteratorIssuesTest
         typeIterator.queueHasNextAnswers( false, false, true );
         long otherRelationship = 1, thirdRelationship = 2;
         typeIterator.add( otherRelationship, thirdRelationship );
-        
+
         // -- go one more step, getting us into the state where the type index in RelationshipIterator
         //    was incremented by mistake. Although this particular call to next() succeeds
         iterator.next();
-        
+
         // -- call next() again, where the first thing happening is to get the RelIdIterator with the
         //    now invalid type index, causing ArrayIndexOutOfBoundsException
         long returnedThirdRelationship = iterator.next();
-        
+
         // THEN
         assertEquals( thirdRelationship, returnedThirdRelationship );
     }
@@ -99,7 +102,7 @@ public class RelationshipIteratorIssuesTest
             }
         };
     }
-    
+
     private static class ControlledRelIdIterator implements RelIdIterator
     {
         private final List<Long> ids;
@@ -110,7 +113,7 @@ public class RelationshipIteratorIssuesTest
         {
             this.ids = new ArrayList<>( Arrays.asList( ids ) );
         }
-        
+
         void add( long... ids )
         {
             for ( long id : ids )
@@ -118,7 +121,7 @@ public class RelationshipIteratorIssuesTest
                 this.ids.add( id );
             }
         }
-        
+
         void queueHasNextAnswers( boolean... answers )
         {
             for ( boolean answer : answers )
@@ -126,7 +129,7 @@ public class RelationshipIteratorIssuesTest
                 controlledHasNextResults.add( answer );
             }
         }
-        
+
         @Override
         public int getType()
         {
@@ -141,7 +144,7 @@ public class RelationshipIteratorIssuesTest
             {
                 return controlledAnswer.booleanValue();
             }
-            
+
             return index < ids.size();
         }
 
@@ -160,7 +163,7 @@ public class RelationshipIteratorIssuesTest
         {
             throw new UnsupportedOperationException();
         }
-        
+
         @Override
         public void doAnotherRound()
         {

--- a/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
@@ -31,13 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 
-import org.neo4j.test.server.HTTP;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
-
 public class ServerTestUtils
 {
     public static File createTempDir() throws IOException
@@ -67,7 +60,7 @@ public class ServerTestUtils
     {
         writePropertyToFile( outerPropertyName, asOneLine( properties ), propertyFile );
     }
-    
+
     public static void writePropertiesToFile( Map<String, String> properties, File propertyFile )
     {
         Properties props = loadProperties( propertyFile );


### PR DESCRIPTION
A relationship iterator iterating lazily loading relationships as it
progressed could come to the conclusion that there were no more
relationships to iterate over, even if there had just been a fresh batch
loaded.
