### PR TITLE
Touch up of naming

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilder.scala
@@ -54,10 +54,10 @@ class PipeExecutionPlanBuilder(monitors: Monitors) {
           NodeByIdSeekPipe(id, nodeIdExpr.asCommandExpression)
         case RelationshipByIdSeek(IdName(id), relIdExpr) =>
           RelationshipByIdSeekPipe(id, relIdExpr.asCommandExpression)
-        case NodeIndexScan(IdName(id), labelId, propertyKeyId, valueExpr) =>
-          NodeIndexScanPipe(id, Right(labelId), Right(propertyKeyId), valueExpr.asCommandExpression)
         case NodeIndexSeek(IdName(id), labelId, propertyKeyId, valueExpr) =>
           NodeIndexSeekPipe(id, Right(labelId), Right(propertyKeyId), valueExpr.asCommandExpression)
+        case NodeIndexUniqueSeek(IdName(id), labelId, propertyKeyId, valueExpr) =>
+          NodeUniqueIndexSeekPipe(id, Right(labelId), Right(propertyKeyId), valueExpr.asCommandExpression)
       }
     }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/CardinalityEstimator.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/CardinalityEstimator.scala
@@ -30,8 +30,8 @@ trait CardinalityEstimator {
   def estimateNodeByIdSeek(): Int
   def estimateRelationshipByIdSeek(): Int
   def estimateNodeByLabelScan(labelId: Option[LabelId]): Int
-  def estimateAllNodes(): Int
+  def estimateAllNodesScan(): Int
+  def estimateNodeUniqueIndexSeek(labelId: LabelId, propertyKeyId: PropertyKeyId): Int
   def estimateNodeIndexSeek(labelId: LabelId, propertyKeyId: PropertyKeyId): Int
-  def estimateNodeIndexScan(labelId: LabelId, propertyKeyId: PropertyKeyId): Int
   def estimateExpandRelationship(labelIds: Seq[LabelId], relationshipType: Seq[RelTypeId], dir: Direction): Int
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/CostModel.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/CostModel.scala
@@ -34,8 +34,8 @@ trait CostModel {
   def calculateNodeByIdSeek(cardinality: Int): Int
   def calculateRelationshipByIdSeek(cardinality: Int): Int
   def calculateNodeByLabelScan(cardinality: Int): Int
-  def calculateAllNodes(cardinality: Int): Int
+  def calculateAllNodesScan(cardinality: Int): Int
+  def calculateNodeUniqueIndexSeek(cardinality: Int): Int
   def calculateNodeIndexSeek(cardinality: Int): Int
-  def calculateNodeIndexScan(cardinality: Int): Int
   def calculateExpandRelationship(cardinality: Int): Int
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/GuessingEstimator.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/GuessingEstimator.scala
@@ -35,9 +35,9 @@ class GuessingEstimator extends CardinalityEstimator {
     case None => 0
   }
 
-  def estimateNodeIndexScan(labelId: LabelId, propertyKeyId: PropertyKeyId) = 80
+  def estimateNodeIndexSeek(labelId: LabelId, propertyKeyId: PropertyKeyId) = 80
 
-  def estimateNodeIndexSeek(labelId: LabelId, propertyKeyId: PropertyKeyId) = 50
+  def estimateNodeUniqueIndexSeek(labelId: LabelId, propertyKeyId: PropertyKeyId) = 50
 
-  def estimateAllNodes() = 1000
+  def estimateAllNodesScan() = 1000
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/IndexLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/IndexLeafPlanner.scala
@@ -53,11 +53,11 @@ abstract class IndexLeafPlanner extends LeafPlanner {
   protected def findIndexesForLabel(labelId: Int)(implicit context: LogicalPlanContext): Iterator[IndexDescriptor]
 }
 
-case class indexSeekLeafPlanner(predicates: Seq[Expression], labelPredicateMap: Map[IdName, Set[HasLabels]]) extends IndexLeafPlanner {
+case class uniqueIndexSeekLeafPlanner(predicates: Seq[Expression], labelPredicateMap: Map[IdName, Set[HasLabels]]) extends IndexLeafPlanner {
   protected def constructPlan(idName: IdName, labelId: LabelId, propertyKeyId: PropertyKeyId, valueExpr: Expression)(implicit context: LogicalPlanContext): (Seq[Expression]) => PlanTableEntry = {
-    val cardinality = context.estimator.estimateNodeIndexSeek(labelId, propertyKeyId)
-    val cost = context.costs.calculateNodeIndexSeek(cardinality)
-    val plan = NodeIndexSeek(idName, labelId, propertyKeyId, valueExpr)
+    val cardinality = context.estimator.estimateNodeUniqueIndexSeek(labelId, propertyKeyId)
+    val cost = context.costs.calculateNodeUniqueIndexSeek(cardinality)
+    val plan = NodeIndexUniqueSeek(idName, labelId, propertyKeyId, valueExpr)
     (predicates: Seq[Expression]) => PlanTableEntry(plan, predicates, cost, Set(idName), cardinality)
   }
 
@@ -65,11 +65,11 @@ case class indexSeekLeafPlanner(predicates: Seq[Expression], labelPredicateMap: 
     context.planContext.uniqueIndexesGetForLabel(labelId)
 }
 
-case class indexScanLeafPlanner(predicates: Seq[Expression], labelPredicateMap: Map[IdName, Set[HasLabels]]) extends IndexLeafPlanner {
+case class indexSeekLeafPlanner(predicates: Seq[Expression], labelPredicateMap: Map[IdName, Set[HasLabels]]) extends IndexLeafPlanner {
   protected def constructPlan(idName: IdName, labelId: LabelId, propertyKeyId: PropertyKeyId, valueExpr: Expression)(implicit context: LogicalPlanContext): (Seq[Expression]) => PlanTableEntry = {
-    val cardinality = context.estimator.estimateNodeIndexScan(labelId, propertyKeyId)
-    val cost = context.costs.calculateNodeIndexScan(cardinality)
-    val plan = NodeIndexScan(idName, labelId, propertyKeyId, valueExpr)
+    val cardinality = context.estimator.estimateNodeIndexSeek(labelId, propertyKeyId)
+    val cost = context.costs.calculateNodeIndexSeek(cardinality)
+    val plan = NodeIndexSeek(idName, labelId, propertyKeyId, valueExpr)
     (predicates: Seq[Expression]) => PlanTableEntry(plan, predicates, cost, Set(idName), cardinality)
   }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/NodeIndexUniqueSeek.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/NodeIndexUniqueSeek.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 import org.neo4j.cypher.internal.compiler.v2_1.{PropertyKeyId, LabelId}
 import org.neo4j.cypher.internal.compiler.v2_1.ast.Expression
 
-case class NodeIndexScan(idName: IdName, label: LabelId, propertyKeyId: PropertyKeyId, valueExpr: Expression) extends LogicalPlan {
+case class NodeIndexUniqueSeek(idName: IdName, label: LabelId, propertyKeyId: PropertyKeyId, valueExpr: Expression) extends LogicalPlan {
   def rhs: Option[LogicalPlan] = None
   def lhs: Option[LogicalPlan] = None
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleCostModel.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleCostModel.scala
@@ -21,9 +21,9 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 class SimpleCostModel extends CostModel {
   def calculateExpandRelationship(cardinality: Int): Int = cardinality
-  def calculateNodeIndexScan(cardinality: Int): Int = cardinality * 3
   def calculateNodeIndexSeek(cardinality: Int): Int = cardinality * 3
-  def calculateAllNodes(cardinality: Int): Int = cardinality
+  def calculateNodeUniqueIndexSeek(cardinality: Int): Int = cardinality * 3
+  def calculateAllNodesScan(cardinality: Int): Int = cardinality
   def calculateNodeByLabelScan(cardinality: Int): Int = cardinality * 2
   def calculateRelationshipByIdSeek(cardinality: Int): Int = cardinality
   def calculateNodeByIdSeek(cardinality: Int): Int = cardinality

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleLogicalPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleLogicalPlanner.scala
@@ -91,8 +91,8 @@ case class SimpleLogicalPlanner(estimator: CardinalityEstimator, costs: CostMode
 
     val leafPlanners = Seq(
       idSeekLeafPlanner(predicates, semanticTable.isRelationship),
+      uniqueIndexSeekLeafPlanner(predicates, labelPredicateMap),
       indexSeekLeafPlanner(predicates, labelPredicateMap),
-      indexScanLeafPlanner(predicates, labelPredicateMap),
       labelScanLeafPlanner(qg, labelPredicateMap),
       allNodesLeafPlanner(qg)
     )

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/allNodesLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/allNodesLeafPlanner.scala
@@ -25,8 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.SimpleLogicalPlan
 case class allNodesLeafPlanner(qg: QueryGraph) extends LeafPlanner {
   def apply()(implicit context: LogicalPlanContext): CandidateList =
     CandidateList(qg.identifiers.toSeq.map { idName =>
-      val cardinality = context.estimator.estimateAllNodes()
-      val cost = context.costs.calculateAllNodes(cardinality)
+      val cardinality = context.estimator.estimateAllNodesScan()
+      val cost = context.costs.calculateAllNodesScan(cardinality)
       val plan = AllNodesScan(idName)
       PlanTableEntry(plan, Seq.empty, cost, Set(idName), cardinality)
     })

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleLogicalPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/SimpleLogicalPlannerTest.scala
@@ -56,7 +56,7 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
     val qg = QueryGraph(projections, Selections(), Set(IdName("n")))
 
     // when
-    when(estimator.estimateAllNodes()).thenReturn(1000)
+    when(estimator.estimateAllNodesScan()).thenReturn(1000)
     val resultPlan = planner.plan(qg, SemanticTable())(planContext)
 
     // then
@@ -72,7 +72,7 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
     // when
     when(estimator.estimateNodeByLabelScan(None)).thenReturn(1)
     when(estimator.estimateNodeByIdSeek()).thenReturn(2)
-    when(estimator.estimateAllNodes()).thenReturn(1000)
+    when(estimator.estimateAllNodesScan()).thenReturn(1000)
     val resultPlan = planner.plan(qg, SemanticTable())(planContext)
 
     // then
@@ -207,9 +207,9 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
       )(pos),
       Set(IdName("n")) -> HasLabels(identifier, Seq(LabelName("Awesome")(Some(labelId))(pos)))(pos)
     )
-    when(estimator.estimateAllNodes()).thenReturn(1000)
+    when(estimator.estimateAllNodesScan()).thenReturn(1000)
     when(estimator.estimateNodeByLabelScan(Some(labelId))).thenReturn(100)
-    when(estimator.estimateNodeIndexScan(LabelId(12), propertyKeyId)).thenReturn(1)
+    when(estimator.estimateNodeIndexSeek(LabelId(12), propertyKeyId)).thenReturn(1)
     val qg = QueryGraph(projections, Selections(predicates), Set(IdName("n")))
     val semanticQuery = SemanticQueryBuilder().withTyping(identifier -> ExpressionTypeInfo(symbols.CTNode)).result()
 
@@ -217,7 +217,7 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
     val resultPlan = planner.plan(qg, semanticQuery)(planContext)
 
     // then
-    resultPlan should equal(NodeIndexScan(IdName("n"), labelId, propertyKeyId, SignedIntegerLiteral("42")(pos)))
+    resultPlan should equal(NodeIndexSeek(IdName("n"), labelId, propertyKeyId, SignedIntegerLiteral("42")(pos)))
   }
 
   test("index seek when there is an index on the property") {
@@ -238,10 +238,10 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
       )(pos),
       Set(IdName("n")) -> HasLabels(identifier, Seq(LabelName("Awesome")(Some(labelId))(pos)))(pos)
     )
-    when(estimator.estimateAllNodes()).thenReturn(1000)
+    when(estimator.estimateAllNodesScan()).thenReturn(1000)
     when(estimator.estimateNodeByLabelScan(Some(labelId))).thenReturn(100)
     val cost = 99
-    when(estimator.estimateNodeIndexSeek(LabelId(12), propertyKeyId)).thenReturn(cost)
+    when(estimator.estimateNodeUniqueIndexSeek(LabelId(12), propertyKeyId)).thenReturn(cost)
     val qg = QueryGraph(projections, Selections(predicates), Set(IdName("n")))
     val semanticQuery = SemanticQueryBuilder().withTyping(identifier -> ExpressionTypeInfo(symbols.CTNode)).result()
 
@@ -249,6 +249,6 @@ class SimpleLogicalPlannerTest extends CypherFunSuite with MockitoSugar {
     val resultPlan = planner.plan(qg, semanticQuery)(planContext)
 
     // then
-    resultPlan should equal(NodeIndexSeek(IdName("n"), labelId, propertyKeyId, SignedIntegerLiteral("42")(pos)))
+    resultPlan should equal(NodeIndexUniqueSeek(IdName("n"), labelId, propertyKeyId, SignedIntegerLiteral("42")(pos)))
   }
 }


### PR DESCRIPTION
An index scan returns all the nodes in an index. This is an operation we still don't have in Cypher.
We have unique index seek and normal index seek.
