### PR TITLE
Makes sure only locked records are changed

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -255,7 +255,7 @@ public abstract class GraphDatabaseSettings
 
     @Description("Relationship count threshold for considering a node dense")
     public static final Setting<Integer> dense_node_threshold = setting( "dense_node_threshold", INTEGER, "50", min(1) );
-    
+
     private static String[] availableCaches()
     {
         List<String> available = new ArrayList<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -64,11 +64,13 @@ import org.neo4j.kernel.impl.util.PrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 
 import static java.lang.String.format;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.Iterables.asResourceIterable;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.IteratorUtil.asList;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_RELATIONSHIP_TYPE;
+import static org.neo4j.kernel.impl.core.TokenHolder.NO_ID;
 
 public class NodeProxy implements Node
 {
@@ -623,7 +625,12 @@ public class NodeProxy implements Node
         try ( Statement statement = statementContextProvider.instance() )
         {
             ReadOperations ops = statement.readOperations();
-            return ops.nodeGetDegree( nodeId, Direction.BOTH, ops.relationshipTypeGetForName( type.name() ) );
+            int typeId = ops.relationshipTypeGetForName( type.name() );
+            if ( typeId == NO_ID )
+            {   // This type doesn't even exist. Return 0
+                return 0;
+            }
+            return ops.nodeGetDegree( nodeId, Direction.BOTH, typeId );
         }
         catch ( EntityNotFoundException e )
         {
@@ -651,7 +658,12 @@ public class NodeProxy implements Node
         try ( Statement statement = statementContextProvider.instance() )
         {
             ReadOperations ops = statement.readOperations();
-            return ops.nodeGetDegree( nodeId, direction, ops.relationshipTypeGetForName( type.name() ) );
+            int typeId = ops.relationshipTypeGetForName( type.name() );
+            if ( typeId == NO_ID )
+            {   // This type doesn't even exist. Return 0
+                return 0;
+            }
+            return ops.nodeGetDegree( nodeId, direction, typeId );
         }
         catch ( EntityNotFoundException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
@@ -69,7 +69,7 @@ public class NeoStoreTransactionContext
         propertyTraverser = new PropertyTraverser();
         propertyCreator = new PropertyCreator( neoStore.getPropertyStore(), propertyTraverser );
         propertyDeleter = new PropertyDeleter( neoStore.getPropertyStore(), propertyTraverser );
-        relationshipCreator = new RelationshipCreator( locker, relationshipGroupGetter, neoStore );
+        relationshipCreator = new RelationshipCreator( locker, relationshipGroupGetter, neoStore.getDenseNodeThreshold() );
         relationshipDeleter = new RelationshipDeleter( locker, relationshipGroupGetter, propertyDeleter);
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipStore;
+
+public class BatchRelationshipIterable implements Iterable<RelationshipRecord>
+{
+    private final NeoStore neoStore;
+    private final RelationshipStore relStore;
+    private final RelationshipGroupStore groupStore;
+    private final long nodeId;
+
+    public BatchRelationshipIterable( NeoStore neoStore, long nodeId )
+    {
+        this.neoStore = neoStore;
+        this.relStore = neoStore.getRelationshipStore();
+        this.groupStore = neoStore.getRelationshipGroupStore();
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public Iterator<RelationshipRecord> iterator()
+    {
+        NodeRecord nodeRecord = neoStore.getNodeStore().getRecord( nodeId );
+        if ( nodeRecord.isDense() )
+        {
+            return new DenseIterator( nodeRecord );
+        }
+        return new SparseIterator( nodeRecord );
+    }
+
+    public long nextRelationship( long relId, NodeRecord nodeRecord )
+    {
+        RelationshipRecord relRecord = relStore.getRecord( relId );
+        long firstNode = relRecord.getFirstNode();
+        long secondNode = relRecord.getSecondNode();
+        long nextRel;
+        if ( firstNode == nodeId )
+        {
+            nextRel = relRecord.getFirstNextRel();
+        }
+        else if ( secondNode == nodeId )
+        {
+            nextRel = relRecord.getSecondNextRel();
+        }
+        else
+        {
+            throw new InvalidRecordException( "Node[" + nodeId +
+                    "] not part of firstNode[" + firstNode +
+                    "] or secondNode[" + secondNode + "]" );
+        }
+        return nextRel;
+    }
+
+    public class SparseIterator extends PrefetchingIterator<RelationshipRecord>
+    {
+        private final NodeRecord nodeRecord;
+        private long nextRelId;
+
+        public SparseIterator( NodeRecord nodeRecord )
+        {
+            this.nodeRecord = nodeRecord;
+            this.nextRelId = nodeRecord.getNextRel();
+        }
+
+        @Override
+        protected RelationshipRecord fetchNextOrNull()
+        {
+            if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
+            {
+                return null;
+            }
+
+            try
+            {
+                return relStore.getRecord( nextRelId );
+            }
+            finally
+            {
+                nextRelId = nextRelationship( nextRelId, nodeRecord );
+            }
+        }
+    }
+
+    public class DenseIterator extends PrefetchingIterator<RelationshipRecord>
+    {
+        private final NodeRecord nodeRecord;
+        private RelationshipGroupRecord groupRecord;
+        private int groupChainIndex;
+        private long nextRelId;
+
+        public DenseIterator( NodeRecord nodeRecord )
+        {
+            this.nodeRecord = nodeRecord;
+            this.groupRecord = groupStore.getRecord( nodeRecord.getNextRel() );
+            this.nextRelId = nextChainStart();
+        }
+
+        private long nextChainStart()
+        {
+            while ( groupRecord != null )
+            {
+                // Go to the next chain within the group
+                while ( groupChainIndex < GroupChain.values().length )
+                {
+                    long chainStart = GroupChain.values()[groupChainIndex++].chainStart( groupRecord );
+                    if ( chainStart != Record.NO_NEXT_RELATIONSHIP.intValue() )
+                    {
+                        return chainStart;
+                    }
+                }
+
+                // Go to the next group
+                groupRecord = groupRecord.getNext() != Record.NO_NEXT_RELATIONSHIP.intValue() ?
+                        groupStore.getRecord( groupRecord.getNext() ) : null;
+                groupChainIndex = 0;
+            }
+            return Record.NO_NEXT_RELATIONSHIP.intValue();
+        }
+
+        @Override
+        protected RelationshipRecord fetchNextOrNull()
+        {
+            if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
+            {
+                return null;
+            }
+
+            try
+            {
+                return relStore.getRecord( nextRelId );
+            }
+            finally
+            {
+                nextRelId = nextRelationship( nextRelId, nodeRecord );
+                if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
+                {   // End of chain, try the next chain
+                    nextRelId = nextChainStart();
+                    // Potentially end of all chains here, and that's fine
+                }
+            }
+        }
+    }
+
+    private static enum GroupChain
+    {
+        OUT
+        {
+            @Override
+            long chainStart( RelationshipGroupRecord groupRecord )
+            {
+                return groupRecord.getFirstOut();
+            }
+        },
+        IN
+        {
+            @Override
+            long chainStart( RelationshipGroupRecord groupRecord )
+            {
+                return groupRecord.getFirstIn();
+            }
+        },
+        LOOP
+        {
+            @Override
+            long chainStart( RelationshipGroupRecord groupRecord )
+            {
+                return groupRecord.getFirstLoop();
+            }
+        };
+
+        abstract long chainStart( RelationshipGroupRecord groupRecord );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreatorTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.PrimitiveRecord;
+import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.unsafe.batchinsert.DirectRecordAccessSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RelationshipCreatorTest
+{
+    @Test
+    public void shouldOnlyChangeLockedRecordsWhenUpgradingToDenseNode() throws Exception
+    {
+        // GIVEN
+        long nodeId = createNodeWithRelationships( DENSE_NODE_THRESHOLD );
+        NeoStore neoStore = flipToNeoStore();
+
+        Tracker tracker = new Tracker( neoStore );
+        RelationshipGroupGetter groupGetter = new RelationshipGroupGetter( neoStore.getRelationshipGroupStore() );
+        RelationshipCreator relationshipCreator = new RelationshipCreator( tracker, groupGetter, 5 );
+
+        // WHEN
+        relationshipCreator.relationshipCreate( idGeneratorFactory.get( IdType.RELATIONSHIP ).nextId(), 0,
+                nodeId, nodeId, tracker );
+
+        // THEN
+        assertEquals( tracker.relationshipLocksAcquired.size(), tracker.changedRelationships.size() );
+        assertFalse( tracker.relationshipLocksAcquired.isEmpty() );
+    }
+
+    private NeoStore flipToNeoStore()
+    {
+        return dbRule.getGraphDatabaseAPI().getDependencyResolver().resolveDependency(
+                NeoStoreProvider.class ).evaluate();
+    }
+
+    private long createNodeWithRelationships( int count )
+    {
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            for ( int i = 0; i < count; i++ )
+            {
+                node.createRelationshipTo( db.createNode(), MyRelTypes.TEST );
+            }
+            tx.success();
+            return node.getId();
+        }
+    }
+
+    static class Tracker implements RelationshipLocker, RecordAccessSet
+    {
+        private final RecordAccessSet delegate;
+        private final TrackingRecordAccess<RelationshipRecord, Void> relRecords;
+        private final Set<Long> relationshipLocksAcquired = new HashSet<>();
+        private final Set<Long> changedRelationships = new HashSet<>();
+
+        public Tracker( NeoStore neoStore )
+        {
+            this.delegate = new DirectRecordAccessSet( neoStore );
+            this.relRecords = new TrackingRecordAccess<>( delegate.getRelRecords(), this );
+        }
+
+        @Override
+        public void getWriteLock( long relId )
+        {
+            relationshipLocksAcquired.add( relId );
+        }
+
+        protected void changingRelationship( long relId )
+        {   // Called by tracking record proxies
+            assertTrue( "Tried to change relationship " + relId + " without this transaction having it locked",
+                    relationshipLocksAcquired.contains( relId ) );
+            changedRelationships.add( relId );
+        }
+
+        @Override
+        public RecordAccess<Long, NodeRecord, Void> getNodeRecords()
+        {
+            return delegate.getNodeRecords();
+        }
+
+        @Override
+        public RecordAccess<Long, PropertyRecord, PrimitiveRecord> getPropertyRecords()
+        {
+            return delegate.getPropertyRecords();
+        }
+
+        @Override
+        public RecordAccess<Long, RelationshipRecord, Void> getRelRecords()
+        {
+            return relRecords;
+        }
+
+        @Override
+        public RecordAccess<Long, RelationshipGroupRecord, Integer> getRelGroupRecords()
+        {
+            return delegate.getRelGroupRecords();
+        }
+
+        @Override
+        public RecordAccess<Long, Collection<DynamicRecord>, SchemaRule> getSchemaRuleChanges()
+        {
+            return delegate.getSchemaRuleChanges();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+    }
+
+    private static final int DENSE_NODE_THRESHOLD = 5;
+    public final @Rule DatabaseRule dbRule = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( GraphDatabaseSettings.dense_node_threshold, String.valueOf( DENSE_NODE_THRESHOLD ) );
+        }
+    };
+    private IdGeneratorFactory idGeneratorFactory;
+
+    @Before
+    public void before()
+    {
+        idGeneratorFactory = dbRule.getGraphDatabaseAPI().getDependencyResolver().resolveDependency(
+                IdGeneratorFactory.class );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TrackingRecordAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TrackingRecordAccess.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import org.neo4j.kernel.impl.nioneo.xa.RelationshipCreatorTest.Tracker;
+
+public class TrackingRecordAccess<RECORD, ADDITIONAL> implements RecordAccess<Long, RECORD, ADDITIONAL>
+{
+    private final RecordAccess<Long, RECORD, ADDITIONAL> delegate;
+    private final Tracker tracker;
+
+    public TrackingRecordAccess( RecordAccess<Long, RECORD, ADDITIONAL> delegate, Tracker tracker )
+    {
+        this.delegate = delegate;
+        this.tracker = tracker;
+    }
+
+    @Override
+    public RecordProxy<Long, RECORD, ADDITIONAL> getOrLoad( Long key, ADDITIONAL additionalData )
+    {
+        return new TrackingRecordProxy<>( delegate.getOrLoad( key, additionalData ), false, tracker );
+    }
+
+    @Override
+    public RecordProxy<Long, RECORD, ADDITIONAL> create( Long key, ADDITIONAL additionalData )
+    {
+        return new TrackingRecordProxy<>( delegate.create( key, additionalData ), true, tracker );
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TrackingRecordProxy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/TrackingRecordProxy.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import org.neo4j.kernel.impl.nioneo.xa.RecordAccess.RecordProxy;
+import org.neo4j.kernel.impl.nioneo.xa.RelationshipCreatorTest.Tracker;
+
+public class TrackingRecordProxy<RECORD, ADDITIONAL> implements RecordProxy<Long, RECORD, ADDITIONAL>
+{
+    private final RecordProxy<Long, RECORD, ADDITIONAL> delegate;
+    private final Tracker tracker;
+    private final boolean created;
+
+    public TrackingRecordProxy( RecordProxy<Long, RECORD, ADDITIONAL> delegate, boolean created, Tracker tracker )
+    {
+        this.delegate = delegate;
+        this.created = created;
+        this.tracker = tracker;
+    }
+
+    @Override
+    public Long getKey()
+    {
+        return delegate.getKey();
+    }
+
+    @Override
+    public RECORD forChangingLinkage()
+    {
+        trackChange();
+        return delegate.forChangingLinkage();
+    }
+
+    private void trackChange()
+    {
+        if ( !created )
+        {
+            tracker.changingRelationship( getKey() );
+        }
+    }
+
+    @Override
+    public RECORD forChangingData()
+    {
+        trackChange();
+        return delegate.forChangingData();
+    }
+
+    @Override
+    public RECORD forReadingLinkage()
+    {
+        return delegate.forReadingLinkage();
+    }
+
+    @Override
+    public RECORD forReadingData()
+    {
+        return delegate.forReadingData();
+    }
+
+    @Override
+    public ADDITIONAL getAdditionalData()
+    {
+        return delegate.getAdditionalData();
+    }
+
+    @Override
+    public RECORD getBefore()
+    {
+        return delegate.getBefore();
+    }
+}


### PR DESCRIPTION
There were an issue in RelationshipCreator where, during upgrading a node
to dense representation, some relationships might be read and marked for
changing before they were locked. This could lead to changes being applied
to stale record data.

This commit also fixes other unrelated issues:
 o Getting node degree for a relationship type that didn't exist would be
   mistakedly interpreted as getting the degree for all relationships for
   that node.
 o BatchInserter#getRelationshipIds/getRelationships didn't regard dense
   node representations and so invalid relationships where returned for
   dense nodes.
