### PR TITLE
Raise an exception if Server shutdown fails.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -212,4 +212,18 @@ public class Exceptions
     {
         // no instances
     }
+
+    public static <E extends Throwable> E combine( E first, E second )
+    {
+        if ( first == null )
+        {
+            return second;
+        }
+        if (second == null )
+        {
+            return first;
+        }
+        first.addSuppressed( second );
+        return first;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import static org.neo4j.helpers.Exceptions.combine;
+import static org.neo4j.helpers.collection.Iterables.toArray;
+
+public class RunCarefully
+{
+    private final Runnable[] operations;
+
+    public RunCarefully( Runnable... operations )
+    {
+        this.operations = operations;
+    }
+
+    public RunCarefully( Iterable<Runnable> operations )
+    {
+        this( toArray( Runnable.class, operations ) );
+    }
+
+    public void run()
+    {
+        Throwable error = null;
+
+        for ( Runnable o : operations )
+        {
+            try
+            {
+                o.run();
+            }
+            catch ( RuntimeException e)
+            {
+                error = combine( error, e );
+            }
+        }
+
+        if ( error != null )
+        {
+            throw new RuntimeException( error );
+        }
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
@@ -146,7 +146,7 @@ public abstract class Bootstrapper
         }
         catch ( Exception e )
         {
-            log.error( "Failed to cleanly shutdown Neo Server on port [%d], database [%s]. Reason [%s] ",
+            log.error( e, "Failed to cleanly shutdown Neo Server on port [%d], database [%s]. Reason [%s] ",
             		configurator.configuration().getInt(Configurator.WEBSERVER_PORT_PROPERTY_KEY, Configurator.DEFAULT_WEBSERVER_PORT), location, e.getMessage() );
             return 1;
         }

--- a/community/server/src/main/java/org/neo4j/server/logging/Logger.java
+++ b/community/server/src/main/java/org/neo4j/server/logging/Logger.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.logging;
 
+import java.text.MessageFormat;
 import java.util.logging.Level;
 
 public class Logger
@@ -61,6 +62,11 @@ public class Logger
         }
     }
 
+    private void log( Level priority, Throwable e, String message, Object[] parameters )
+    {
+        logger.log( priority, MessageFormat.format( message, parameters ), e );
+    }
+
     public void fatal( String message, Object... parameters )
     {
         log( Level.SEVERE, message, parameters );
@@ -74,6 +80,11 @@ public class Logger
     public void error( Throwable e )
     {
         log( Level.SEVERE, "", e );
+    }
+
+    public void error( Throwable e, String message, Object... parameters)
+    {
+        log( Level.SEVERE, e, message, parameters );
     }
 
     public void warn( Throwable e )

--- a/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
@@ -65,7 +65,10 @@ public class SecurityRulesModule implements ServerModule
     @Override
     public void stop()
     {
-        mountedFilter.destroy();
+        if ( mountedFilter != null )
+        {
+            mountedFilter.destroy();
+        }
     }
 
     private Iterable<SecurityRule> getSecurityRules()

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
@@ -158,15 +158,25 @@ public class Jetty6WebServer implements WebServer
     @Override
     public void stop()
     {
-        try
+        if ( jetty != null )
         {
-            jetty.stop();
-            jetty.join();
+            try
+            {
+                jetty.stop();
+            }
+            catch ( Exception e )
+            {
+                throw new RuntimeException( e );
+            }
+            try
+            {
+                jetty.join();
+            }
+            catch ( InterruptedException e )
+            {
+                log.info( "Interrupted while waiting for Jetty to stop." );
+            }
             jetty = null;
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e );
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/modules/SecurityRulesModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/SecurityRulesModuleTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.modules;
+
+import org.junit.Test;
+
+public class SecurityRulesModuleTest
+{
+    @Test
+    public void shouldStopCleanlyEvenWhenItHasntBeenStarted()
+    {
+        new SecurityRulesModule( null, null ).stop();
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
@@ -107,5 +107,10 @@ public class TestJetty6WebServer {
         assertThat( appender.toString(), containsString( "Remote interface ready and available at" ) );
         testBootstrapper.stop();
     }
-	
+
+    @Test
+    public void shouldStopCleanlyEvenWhenItHasntBeenStarted()
+    {
+        new Jetty6WebServer().stop();
+    }
 }


### PR DESCRIPTION
Rather than just log exceptions that happen during shutdown, we
carefullly catch and record them. Then after shutdown is complete, if
there was an exception during the process we re-raise it.

This change uncovered a couple of problems that were previously being
ignored. They are cases where tests call #stop() even though #start()
did not succeed. Those #stop() methods are now more defensive to cope
with that.
