### PR TITLE
Try to avoid letting DeadlockIT leave deadlocks in the shared server.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -299,7 +299,12 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Visitor<LineLogger
         {
             commandExecutor.awaitTermination( 10, TimeUnit.SECONDS );
         }
-        catch ( Exception e )
+        catch ( InterruptedException e )
+        {
+            Thread.currentThread().interrupt();
+            // shutdownNow() will interrupt running tasks if necessary
+        }
+        if ( ! commandExecutor.isTerminated() )
         {
             commandExecutor.shutdownNow();
         }


### PR DESCRIPTION
o The test running after DeadlockIT (TransactionErrorIT) very rarely
  fails because there is a deadlock in the cleanup it does before it
  runs.

o These tests (and many other ITs) share a long-running server. My guess
  is that the clean-up at the end of DeadlockIT is not sufficient to get
  rid of the locks -- specifically the executor threads that the test
  use don't get killed off in time.

o This change makes the clean-up of the OtherThreadExecutor more
  rigorous to try to eliminate this corner-case.
