### PR TITLE
Add some comments to the Forseti implementation after review.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FastRandom.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/FastRandom.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 
 import static java.lang.Math.abs;
 
+// TODO This is only used in "tests" so it should be moved to the test source tree.
 public class FastRandom
 {
     private long currentSeed;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
@@ -28,6 +28,12 @@ public enum LockWaitStrategies implements WaitStrategy<AcquireLockTimeoutExcepti
         @Override
         public void apply( long iteration ) throws AcquireLockTimeoutException
         {
+            // TODO We can experiment with introducing branch mispredictions here, to create
+            // TODO bubbles in the pipeline that'll allow hyper-threaded threads on the
+            // TODO same core to make progress. We can do that by generating a random number,
+            // TODO e.g. with XorShift, and based on that, randomly branch to do a volatile
+            // TODO write to one of two fields. The volatile fields would be there to give
+            // TODO side-effect to the operation, preventing dead-code elimination.
         }
     },
     YIELD
@@ -48,6 +54,7 @@ public enum LockWaitStrategies implements WaitStrategy<AcquireLockTimeoutExcepti
         {
             if(iteration < spinIterations)
             {
+                SPIN.apply( iteration );
                 return;
             }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -30,7 +30,7 @@ import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
 
 /**
  * Tests simple acquiring and releasing of single locks.
- * For testing "stacking" locks on the same client, see {@link LockStackingCompatibility}. */
+ * For testing "stacking" locks on the same client, see {@link LockReentrancyCompatibility}. */
 @Ignore("Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite.")
 public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTestSuite.Compatibility
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -43,7 +43,7 @@ import static org.neo4j.test.OtherThreadRule.isWaiting;
 @Suite.SuiteClasses({
         AcquireAndReleaseLocksCompatibility.class,
         DeadlockCompatibility.class,
-        LockStackingCompatibility.class,
+        LockReentrancyCompatibility.class,
         RWLockCompatibility.class
 })
 public abstract class LockingCompatibilityTestSuite

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/performance/PerformanceTestLegacyLocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/performance/PerformanceTestLegacyLocks.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.util.FastRandom;
  * Performance numbers show total number of locks per second, the number of locks listed in the stats denote how many
  * locks are taken per "transaction".
  */
+// TODO We should move our benchmarks, like this one, to a dedicated repository or maven module.
 public class PerformanceTestLegacyLocks
 {
     // Contention: 8 random locks
@@ -166,7 +167,7 @@ public class PerformanceTestLegacyLocks
         @Override
         public void setRollbackOnly() throws IllegalStateException, SystemException
         {
+        }
     }
-}
 
 }


### PR DESCRIPTION
Convert the Forseti client pool from an anonymous class to a static inner, and clarify the initialization order of the fields in ForsetiLockManager.
ConcurrentLinkedQueue is faster than ConcurrentLinkedDeque, according to their internal documentation. Taking it at face value.
Describe my conclusion that the batched lock-grabbing API should be dropped completely in favor of always taking the locks one at a time.
Rename LockStackingCompatibility to LockReentrancyCompatibility, to keep with the nomenclature.
Note on using SimpleBitSet for reusing client ids.
Lots of other general notes all over the place.
