### PR TITLE
Pulls out "tm ok" state into KernelHealth

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -136,10 +136,20 @@ public class GraphDatabaseFactory
     public void setKernelExtensions( Iterable<KernelExtensionFactory<?>> newKernelExtensions )
     {
         kernelExtensions.clear();
+        addKernelExtensions( newKernelExtensions );
+    }
+
+    public void addKernelExtensions( Iterable<KernelExtensionFactory<?>> newKernelExtensions )
+    {
         for ( KernelExtensionFactory<?> newKernelExtension : newKernelExtensions )
         {
-            kernelExtensions.add( newKernelExtension );
+            addKernelExtension( newKernelExtension );
         }
+    }
+
+    public void addKernelExtension( KernelExtensionFactory<?> newKernelExtension )
+    {
+        kernelExtensions.add( newKernelExtension );
     }
 
     public void setCacheProviders( Iterable<CacheProvider> newCacheProviders )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/KernelHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/KernelHealth.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import org.neo4j.graphdb.event.ErrorState;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.helpers.Exceptions.withCause;
+
+public class KernelHealth
+{
+    private static final String panicMessage = "Kernel has encountered some problem, "
+            + "please perform neccesary action (tx recovery/restart)";
+
+    // Keep that cozy name for legacy purposes
+    private volatile boolean tmOk = true; // TODO rather skip volatile if possible here.
+    private final KernelPanicEventGenerator kpe;
+    private final StringLogger log;
+    private Throwable causeOfPanic;
+
+    public KernelHealth( KernelPanicEventGenerator kpe, Logging logging )
+    {
+        this.kpe = kpe;
+        this.log = logging.getMessagesLog( getClass() );
+    }
+
+    public <EXCEPTION extends Throwable> void assertHealthy( Class<EXCEPTION> panicDisguise )
+            throws EXCEPTION
+    {
+        if ( !tmOk )
+        {
+            EXCEPTION exception = null;
+            try
+            {
+                try
+                {
+                    exception = panicDisguise.getConstructor( String.class, Throwable.class )
+                            .newInstance( panicMessage, causeOfPanic );
+                }
+                catch ( NoSuchMethodException e )
+                {
+                    exception = withCause( panicDisguise.getConstructor( String.class )
+                            .newInstance( panicMessage ), causeOfPanic );
+                }
+            }
+            catch ( Exception e )
+            {
+                throw new Error( panicMessage + ". An exception of type " + panicDisguise.getName() +
+                        " was requested to be thrown but that proved imposslble", e );
+            }
+            throw exception;
+        }
+    }
+
+    public void panic( Throwable cause )
+    {
+        if ( !tmOk )
+        {
+            return;
+        }
+
+        if ( cause == null )
+        {
+            throw new IllegalArgumentException( "Must provide a cause for the kernel panic" );
+        }
+        this.causeOfPanic = cause;
+        this.tmOk = false;
+        // Keeps the "setting TM not OK string for grep:ability
+        log.error( "setting TM not OK. " + panicMessage, cause );
+        kpe.generateEvent( ErrorState.TX_MANAGER_NOT_OK, causeOfPanic );
+    }
+
+    public void healed()
+    {
+        tmOk = true;
+        causeOfPanic = null;
+        log.info( "Kernel health set to OK" );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InterceptingXaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InterceptingXaLogicalLog.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.neo4j.kernel.TransactionInterceptorProviders;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.xa.Command;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -39,10 +40,11 @@ public class InterceptingXaLogicalLog extends XaLogicalLog
             XaCommandFactory cf, XaTransactionFactory xaTf,
             TransactionInterceptorProviders providers,
             FileSystemAbstraction fileSystem, Monitors monitors, Logging logging,
-            LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory, long rotateAtSize )
+            LogPruneStrategy pruneStrategy, TransactionStateFactory stateFactory,
+            KernelHealth kernelHealth, long rotateAtSize )
     {
         super( fileName, xaRm, cf, xaTf, fileSystem, monitors, logging, pruneStrategy,
-                stateFactory, rotateAtSize );
+                stateFactory, kernelHealth, rotateAtSize );
         this.providers = providers;
         this.ds = xaRm.getDataSource();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaFactory.java
@@ -19,17 +19,18 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_log_rotation_threshold;
-
 import java.io.File;
 
 import org.neo4j.kernel.TransactionInterceptorProviders;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_log_rotation_threshold;
 
 /**
 * TODO
@@ -44,10 +45,12 @@ public class XaFactory
     private final Logging logging;
     private final RecoveryVerifier recoveryVerifier;
     private final LogPruneStrategy pruneStrategy;
+    private final KernelHealth kernelHealth;
 
     public XaFactory( Config config, TxIdGenerator txIdGenerator, AbstractTransactionManager txManager,
                       FileSystemAbstraction fileSystemAbstraction,
-                      Monitors monitors, Logging logging, RecoveryVerifier recoveryVerifier, LogPruneStrategy pruneStrategy )
+                      Monitors monitors, Logging logging, RecoveryVerifier recoveryVerifier,
+                      LogPruneStrategy pruneStrategy, KernelHealth kernelHealth )
     {
         this.config = config;
         this.txIdGenerator = txIdGenerator;
@@ -57,6 +60,7 @@ public class XaFactory
         this.logging = logging;
         this.recoveryVerifier = recoveryVerifier;
         this.pruneStrategy = pruneStrategy;
+        this.kernelHealth = kernelHealth;
     }
 
     public XaContainer newXaContainer( XaDataSource xaDataSource, File logicalLog, XaCommandFactory cf,
@@ -78,12 +82,12 @@ public class XaFactory
         if ( providers.shouldInterceptDeserialized() && providers.hasAnyInterceptorConfigured() )
         {
             log = new InterceptingXaLogicalLog( logicalLog, rm, cf, tf, providers, fileSystemAbstraction,
-                    monitors, logging, pruneStrategy, stateFactory, rotateAtSize );
+                    monitors, logging, pruneStrategy, stateFactory, kernelHealth, rotateAtSize );
         }
         else
         {
             log = new XaLogicalLog( logicalLog, rm, cf, tf, fileSystemAbstraction, monitors,
-                    logging, pruneStrategy, stateFactory, rotateAtSize );
+                    logging, pruneStrategy, stateFactory, kernelHealth, rotateAtSize );
         }
 
         // TODO These setters should be removed somehow

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -58,11 +55,11 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.PropertyIndex;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaConnection;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.LockManagerImpl;
 import org.neo4j.kernel.impl.transaction.PlaceboTm;
 import org.neo4j.kernel.impl.transaction.RagManager;
-import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies;
 import org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier;
@@ -77,6 +74,13 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.kernel.impl.transaction.TransactionStateFactory.noStateFactory;
 
 public class TestNeoStore
 {
@@ -148,7 +152,7 @@ public class TestNeoStore
     private void initializeStores() throws IOException
     {
         TransactionManager txManager = new PlaceboTm( null, TxIdGenerator.DEFAULT );
-        
+
         LockManager lockManager = new LockManagerImpl( new RagManager( txManager ) );
 
         final Config config = new Config( MapUtil.stringMap(
@@ -158,11 +162,12 @@ public class TestNeoStore
                 GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( config, new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(),
                 fs.get(), StringLogger.DEV_NULL, null );
+        KernelHealth kernelHealth = mock( KernelHealth.class );
 
         ds = new NeoStoreXaDataSource(config, sf, lockManager, StringLogger.DEV_NULL,
                 new XaFactory(config, TxIdGenerator.DEFAULT, new PlaceboTm( lockManager, TxIdGenerator.DEFAULT ),
                         fs.get(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), TransactionStateFactory.noStateFactory( new DevNullLoggingService() ),
+                        LogPruneStrategies.NO_PRUNING, kernelHealth ), noStateFactory( new DevNullLoggingService() ),
                         new TransactionInterceptorProviders( Collections.<TransactionInterceptorProvider>emptyList(), new DependencyResolver.Adapter()
         {
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/KernelHealthTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/KernelHealthTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.logging.BufferingLogger;
+import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.logging.SingleLoggingService;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.graphdb.event.ErrorState.TX_MANAGER_NOT_OK;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
+
+public class KernelHealthTest
+{
+    @Test
+    public void shouldGenerateKernelPanicEvents() throws Exception
+    {
+        // GIVEN
+        KernelPanicEventGenerator generator = mock( KernelPanicEventGenerator.class );
+        KernelHealth kernelHealth = new KernelHealth( generator, new SingleLoggingService( DEV_NULL ) );
+        kernelHealth.healed();
+
+        // WHEN
+        Exception cause = new Exception( "My own fault" );
+        kernelHealth.panic( cause );
+        kernelHealth.panic( cause );
+
+        // THEN
+        verify( generator, times( 1 ) ).generateEvent( TX_MANAGER_NOT_OK, cause );
+    }
+
+    @Test
+    public void shouldLogKernelPanicEvent() throws Exception
+    {
+        // GIVEN
+        BufferingLogger logger = new BufferingLogger();
+        Logging logging = mock( Logging.class );
+        when( logging.getMessagesLog( any( Class.class ) ) ).thenReturn( logger );
+        KernelHealth kernelHealth = new KernelHealth( mock( KernelPanicEventGenerator.class ), logging );
+        kernelHealth.healed();
+
+        // WHEN
+        String message = "Listen everybody... panic!";
+        kernelHealth.panic( new Exception( message ) );
+
+        // THEN
+        assertThat( logger.toString(), containsString( message ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestXaFramework.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestXaFramework.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
@@ -72,6 +73,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class TestXaFramework extends AbstractNeo4jTestCase
 {
@@ -251,7 +253,7 @@ public class TestXaFramework extends AbstractNeo4jTestCase
                         };
                     }
                 };
-                
+
                 map.put( "store_dir", path().getPath() );
                 xaContainer = xaFactory.newXaContainer( this, resourceFile(),
                         new DummyCommandFactory(),
@@ -396,12 +398,13 @@ public class TestXaFramework extends AbstractNeo4jTestCase
         Map<String, String> config = new HashMap<String, String>();
         config.put( "store_dir", "target/var" );
         FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
+        KernelHealth kernelHealth = mock( KernelHealth.class );
         xaDsMgr.registerDataSource( new DummyXaDataSource(
                 config, UTF8.encode( "DDDDDD" ), "dummy_datasource",
                 new XaFactory( new Config( config, GraphDatabaseSettings.class ),
                         TxIdGenerator.DEFAULT, new PlaceboTm( null, getGraphDbAPI().getTxIdGenerator() ),
                         fileSystem, new Monitors(), new DevNullLoggingService(),
-                        RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING ) ) );
+                        RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING, kernelHealth ) ) );
         XaDataSource xaDs = xaDsMgr.getXaDataSource( "dummy_datasource" );
         DummyXaConnection xaC = null;
         try
@@ -465,10 +468,11 @@ public class TestXaFramework extends AbstractNeo4jTestCase
             Map<String, String> config = new HashMap<String, String>();
             config.put( "store_dir", "target/var" );
             FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
+            KernelHealth kernelHealth = mock( KernelHealth.class );
             xaDsMgr.registerDataSource( new DummyXaDataSource( config, UTF8.encode( "DDDDDD" ), "dummy_datasource1",
                     new XaFactory( new Config( config, GraphDatabaseSettings.class ), TxIdGenerator.DEFAULT,
                             (AbstractTransactionManager)tm, fileSystem, new Monitors(), new DevNullLoggingService(),
-                            RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING ) ) );
+                            RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING, kernelHealth ) ) );
             xaDs1 = (DummyXaDataSource) xaDsMgr
                     .getXaDataSource( "dummy_datasource1" );
             xaC1 = (DummyXaConnection) xaDs1.getXaConnection();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestUpgradeOneDotFourToFiveIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/TestUpgradeOneDotFourToFiveIT.java
@@ -19,18 +19,22 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static org.junit.Assert.fail;
-import static org.neo4j.kernel.CommonFactories.defaultFileSystemAbstraction;
-import static org.neo4j.kernel.impl.util.FileUtils.copyRecursively;
-import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
-
 import java.io.File;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.kernel.CommonFactories.defaultFileSystemAbstraction;
+import static org.neo4j.kernel.impl.util.FileUtils.copyRecursively;
+import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 
 public class TestUpgradeOneDotFourToFiveIT
 {
@@ -46,15 +50,10 @@ public class TestUpgradeOneDotFourToFiveIT
     public void cannotRecoverNoncleanShutdownDbWithOlderLogFormat() throws Exception
     {
         copyRecursively( new File( TestUpgradeOneDotFourToFiveIT.class.getResource( "non-clean-1.4.2-db/neostore" ).getFile() ).getParentFile(), PATH );
-//        Map<Object, Object> config = new HashMap<Object, Object>();
-//        config.put( "store_dir", PATH.getAbsolutePath() );
-//        config.put( StringLogger.class, StringLogger.DEV_NULL );
-//        config.put( FileSystemAbstraction.class, CommonFactories.defaultFileSystemAbstraction() );
-//        config.put( LogBufferFactory.class, CommonFactories.defaultLogBufferFactory() );
-        
+        KernelHealth kernelHealth = mock( KernelHealth.class );
         XaLogicalLog log = new XaLogicalLog( resourceFile(), null, null, null,
                 defaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), LogPruneStrategies.NO_PRUNING,
-                TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), 25 * 1024 * 1024 );
+                TransactionStateFactory.noStateFactory( new DevNullLoggingService() ), kernelHealth, 25 * 1024 * 1024 );
         log.open();
         fail( "Shouldn't be able to start" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+
 import javax.transaction.xa.Xid;
 
 import org.junit.Rule;
@@ -36,6 +37,7 @@ import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.kernel.impl.nioneo.store.StoreFileChannel;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
@@ -112,7 +114,7 @@ public class XaLogicalLogTest
                                                       new SingleLoggingService( StringLogger.wrap( output.writer() ) ),
                                                       LogPruneStrategies.NO_PRUNING,
                                                       mock( TransactionStateFactory.class ),
-                                                      25 * 1024 * 1024 );
+                                                      mock( KernelHealth.class ), 25 * 1024 * 1024 );
         xaLogicalLog.open();
         // -- set the log up with 10 transactions (with no commands, just start and commit)
         for ( int txId = 1; txId <= 10; txId++ )
@@ -129,13 +131,13 @@ public class XaLogicalLogTest
         // then
         assertThat( "should not read excessively from the logical log file channel", reads, lessThan( 10 ) );
     }
-    
+
     @Test
     public void shouldRespectCustomLogRotationThreshold() throws Exception
     {
         // GIVEN
         long maxSize = 1000;
-        XaLogicalLog log = new XaLogicalLog( new File( "log" ), 
+        XaLogicalLog log = new XaLogicalLog( new File( "log" ),
                 mock( XaResourceManager.class ),
                 new FixedSizeXaCommandFactory(),
                 new VersionRespectingXaTransactionFactory(),
@@ -143,10 +145,10 @@ public class XaLogicalLogTest
                 new Monitors(),
                 new DevNullLoggingService(),
                 NO_PRUNING,
-                mock( TransactionStateFactory.class ), maxSize );
+                mock( TransactionStateFactory.class ), mock( KernelHealth.class ), maxSize );
         log.open();
         long initialLogVersion = log.getHighestLogVersion();
-        
+
         // WHEN
         for ( int i = 0; i < 10; i++ )
         {
@@ -156,11 +158,11 @@ public class XaLogicalLogTest
             log.commitOnePhase( identifier, i+1, forced );
             log.done( identifier );
         }
-        
+
         // THEN
         assertEquals( initialLogVersion+1, log.getHighestLogVersion() );
     }
-    
+
     private static class FixedSizeXaCommand extends XaCommand
     {
         private final byte[] data;
@@ -169,7 +171,7 @@ public class XaLogicalLogTest
         {
             this.data = new byte[payloadSize-2/*2 bytes for describing which size will follow*/];
         }
-        
+
         @Override
         public void execute()
         {   // There's nothing to execute
@@ -182,7 +184,7 @@ public class XaLogicalLogTest
             buffer.put( data );
         }
     }
-    
+
     private static class FixedSizeXaCommandFactory extends XaCommandFactory
     {
         @Override
@@ -217,11 +219,11 @@ public class XaLogicalLogTest
             }
         }
     }
-    
+
     private static class VersionRespectingXaTransactionFactory extends XaTransactionFactory
     {
         private long currentVersion = 0;
-        
+
         @Override
         public XaTransaction create( int identifier, TransactionState state )
         {
@@ -257,7 +259,7 @@ public class XaLogicalLogTest
             return 0;
         }
     }
-    
+
     public final @Rule EphemeralFileSystemRule ephemeralFs = new EphemeralFileSystemRule();
     public final Xid xid = new XidImpl( "global".getBytes(), "resource".getBytes() );
 }

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -77,6 +77,11 @@ the relevant Commercial Agreement.
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestLuceneDataSource.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestLuceneDataSource.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.index.impl.lucene;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -34,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexManager;
@@ -42,6 +38,7 @@ import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.index.IndexStore;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.PlaceboTm;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies;
 import org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier;
@@ -50,6 +47,12 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
 import org.neo4j.kernel.impl.util.FileUtils;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class TestLuceneDataSource
 {
@@ -96,7 +99,8 @@ public class TestLuceneDataSource
                 new DefaultFileSystemAbstraction(),
                 new XaFactory( new Config( config(), GraphDatabaseSettings.class ), TxIdGenerator.DEFAULT,
                         new PlaceboTm( null, null ), new DefaultFileSystemAbstraction(),
-                        new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID, LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ),
+                        null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier identifier = identifier( "foo" );
         IndexWriter writer = dataSource.getIndexSearcher( identifier ).getWriter();
@@ -110,7 +114,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         new DefaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier identifier = identifier( "foo" );
         IndexReference searcher = dataSource.getIndexSearcher( identifier );
@@ -129,7 +133,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config1, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config1, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         new DefaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
@@ -152,7 +156,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config1, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config1, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         fileSystem, new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
@@ -177,7 +181,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config1, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config1, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         new DefaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
@@ -205,7 +209,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config1, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config1, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         new DefaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
@@ -226,7 +230,7 @@ public class TestLuceneDataSource
         dataSource = new LuceneDataSource( config, indexStore, new DefaultFileSystemAbstraction(),
                 new XaFactory( config, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         new DefaultFileSystemAbstraction(), new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         dataSource.start();
         IndexIdentifier identifier = new IndexIdentifier( LuceneCommand.NODE, dataSource.nodeEntityType, "foo" );
         IndexReference oldSearcher = dataSource.getIndexSearcher( identifier );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestRecovery.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestRecovery.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.index.impl.lucene;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -41,6 +38,7 @@ import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.index.IndexStore;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.PlaceboTm;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies;
 import org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier;
@@ -49,6 +47,11 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.ProcessStreamHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 /**
  * Don't extend Neo4jTestCase since these tests restarts the db in the tests.
@@ -146,7 +149,7 @@ public class TestRecovery
         LuceneDataSource ds = new LuceneDataSource( config, new IndexStore( getDbPath(), fileSystem ), fileSystem,
                 new XaFactory( config, TxIdGenerator.DEFAULT, new PlaceboTm( null, null ),
                         fileSystemAbstraction, new Monitors(), new DevNullLoggingService(), RecoveryVerifier.ALWAYS_VALID,
-                        LogPruneStrategies.NO_PRUNING ), null, new DevNullLoggingService() );
+                        LogPruneStrategies.NO_PRUNING, mock( KernelHealth.class ) ), null, new DevNullLoggingService() );
         ds.start();
         ds.stop();
     }


### PR DESCRIPTION
which is also now shared with XaLogicalLog so that the same rules about
panicing and respecting a kernel panic event also is in place when
applying external transactions.
