### PR TITLE
Reduce network overhead of locking in HA

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -19,22 +19,14 @@
  */
 package org.neo4j.kernel.ha.lock;
 
-import org.neo4j.com.Response;
 import org.neo4j.kernel.AvailabilityGuard;
-import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.ha.HaXaDataSourceManager;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.impl.locking.AcquireLockTimeoutException;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
-import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-
-import static org.neo4j.kernel.impl.transaction.LockType.READ;
-import static org.neo4j.kernel.impl.transaction.LockType.WRITE;
 
 public class SlaveLockManager extends LifecycleAdapter implements Locks
 {
@@ -79,166 +71,4 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
         local.accept( visitor );
     }
 
-    private static class SlaveLocksClient implements Client
-    {
-        private final Master master;
-        private final Client client;
-        private final Locks localLockManager;
-        private final RequestContextFactory requestContextFactory;
-        private final HaXaDataSourceManager xaDsm;
-        private final AbstractTransactionManager txManager;
-        private final RemoteTxHook txHook;
-        private final AvailabilityGuard availabilityGuard;
-        private final Configuration config;
-
-        public SlaveLocksClient( Master master, Client local, Locks localLockManager, RequestContextFactory requestContextFactory,
-                                 HaXaDataSourceManager xaDsm, AbstractTransactionManager txManager, RemoteTxHook txHook,
-                                 AvailabilityGuard availabilityGuard, Configuration config )
-        {
-            this.master = master;
-            this.client = local;
-            this.localLockManager = localLockManager;
-            this.requestContextFactory = requestContextFactory;
-            this.xaDsm = xaDsm;
-            this.txManager = txManager;
-            this.txHook = txHook;
-            this.availabilityGuard = availabilityGuard;
-            this.config = config;
-        }
-
-        @Override
-        public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
-        {
-            if ( getReadLockOnMaster( resourceType, resourceIds ) )
-            {
-                if ( !client.trySharedLock( resourceType, resourceIds ) )
-                {
-                    throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceIds, READ );
-                }
-            }
-        }
-
-        @Override
-        public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws
-                AcquireLockTimeoutException
-        {
-            if ( acquireExclusiveOnMaster( resourceType, resourceIds ) )
-            {
-                if ( !client.tryExclusiveLock( resourceType, resourceIds ) )
-                {
-                    throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceIds, WRITE );
-                }
-            }
-        }
-
-        @Override
-        public boolean tryExclusiveLock( ResourceType resourceType, long... resourceIds )
-        {
-            throw newUnsupportedDirectTryLockUsageException();
-        }
-
-        @Override
-        public boolean trySharedLock( ResourceType resourceType, long... resourceIds )
-        {
-            throw newUnsupportedDirectTryLockUsageException();
-        }
-
-        @Override
-        public void releaseShared( ResourceType resourceType, long... resourceIds )
-        {
-            client.releaseShared( resourceType, resourceIds );
-        }
-
-        @Override
-        public void releaseExclusive( ResourceType resourceType, long... resourceIds )
-        {
-            client.releaseExclusive( resourceType, resourceIds );
-        }
-
-        @Override
-        public void releaseAllShared()
-        {
-            client.releaseAllShared();
-        }
-
-        @Override
-        public void releaseAllExclusive()
-        {
-            client.releaseAllExclusive();
-        }
-
-        @Override
-        public void releaseAll()
-        {
-            client.releaseAll();
-        }
-
-        @Override
-        public void close()
-        {
-            client.close();
-        }
-
-        private boolean getReadLockOnMaster( ResourceType resourceType, long ... resourceId )
-        {
-            if ( resourceType == ResourceTypes.NODE
-                || resourceType == ResourceTypes.RELATIONSHIP
-                || resourceType == ResourceTypes.GRAPH_PROPS
-                || resourceType == ResourceTypes.LEGACY_INDEX )
-            {
-                makeSureTxHasBeenInitialized();
-                return receiveLockResponse(
-                    master.acquireSharedLock( requestContextFactory.newRequestContext(), resourceType, resourceId ));
-            }
-            else
-            {
-                return true;
-            }
-        }
-
-        private boolean acquireExclusiveOnMaster( ResourceType resourceType, long ... resourceId )
-        {
-            makeSureTxHasBeenInitialized();
-            return receiveLockResponse(
-                    master.acquireExclusiveLock( requestContextFactory.newRequestContext(), resourceType, resourceId ));
-        }
-
-        private boolean receiveLockResponse( Response<LockResult> response )
-        {
-            LockResult result = xaDsm.applyTransactions( response );
-            switch ( result.getStatus() )
-            {
-                case DEAD_LOCKED:
-                    throw new DeadlockDetectedException( result.getDeadlockMessage() );
-                case NOT_LOCKED:
-                    throw new UnsupportedOperationException();
-                case OK_LOCKED:
-                    break;
-                default:
-                    throw new UnsupportedOperationException( result.toString() );
-            }
-
-            return true;
-        }
-
-
-        private void makeSureTxHasBeenInitialized()
-        {
-            if ( !availabilityGuard.isAvailable( config.getAvailabilityTimeout() ) )
-            {
-                // TODO Specific exception instead?
-                throw new RuntimeException( "Timed out waiting for database to allow operations to proceed. "
-                        + availabilityGuard.describeWhoIsBlocking() );
-            }
-
-            txHook.remotelyInitializeTransaction( txManager.getEventIdentifier(), txManager.getTransactionState() );
-        }
-
-        private UnsupportedOperationException newUnsupportedDirectTryLockUsageException()
-        {
-            return new UnsupportedOperationException( "At the time of adding \"try lock\" semantics there was no usage of " +
-                    getClass().getSimpleName() + " calling it directly. It was designed to be called on a local " +
-                    LockManager.class.getSimpleName() + " delegated to from within the waiting version" );
-        }
-    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.lock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.com.Response;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.ha.HaXaDataSourceManager;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.impl.locking.AcquireLockTimeoutException;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.kernel.impl.transaction.LockManager;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
+
+import static org.neo4j.kernel.impl.transaction.LockType.READ;
+import static org.neo4j.kernel.impl.transaction.LockType.WRITE;
+
+class SlaveLocksClient implements Locks.Client
+{
+    private final Master master;
+    private final Locks.Client client;
+    private final Locks localLockManager;
+    private final RequestContextFactory requestContextFactory;
+    private final HaXaDataSourceManager xaDsm;
+    private final AbstractTransactionManager txManager;
+    private final RemoteTxHook txHook;
+    private final AvailabilityGuard availabilityGuard;
+    private final SlaveLockManager.Configuration config;
+
+    private final Map<Locks.ResourceType, Map<Long, AtomicInteger>> sharedLocks;
+    private final Map<Locks.ResourceType, Map<Long, AtomicInteger>> exclusiveLocks;
+
+    public SlaveLocksClient(
+            Master master,
+            Locks.Client local,
+            Locks localLockManager,
+            RequestContextFactory requestContextFactory,
+            HaXaDataSourceManager xaDsm,
+            AbstractTransactionManager txManager,
+            RemoteTxHook txHook,
+            AvailabilityGuard availabilityGuard,
+            SlaveLockManager.Configuration config )
+    {
+        this.master = master;
+        this.client = local;
+        this.localLockManager = localLockManager;
+        this.requestContextFactory = requestContextFactory;
+        this.xaDsm = xaDsm;
+        this.txManager = txManager;
+        this.txHook = txHook;
+        this.availabilityGuard = availabilityGuard;
+        this.config = config;
+        sharedLocks = new HashMap<>();
+        exclusiveLocks = new HashMap<>();
+    }
+
+    private Map<Long, AtomicInteger> getLockMap(
+            Map<Locks.ResourceType, Map<Long, AtomicInteger>> resourceMap,
+            Locks.ResourceType resourceType )
+    {
+        Map<Long, AtomicInteger> lockMap = resourceMap.get( resourceType );
+        if ( lockMap == null )
+        {
+            lockMap = new HashMap<>();
+            resourceMap.put( resourceType, lockMap );
+        }
+        return lockMap;
+    }
+
+    @Override
+    public void acquireShared( Locks.ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    {
+        Map<Long, AtomicInteger> lockMap = getLockMap( sharedLocks, resourceType );
+        long[] untakenIds = incrementAndRemoveAlreadyTakenLocks( lockMap, resourceIds );
+        if ( untakenIds.length > 0 && getReadLockOnMaster( resourceType, untakenIds ) )
+        {
+            if ( client.trySharedLock( resourceType, untakenIds ) )
+            {
+                for ( int i = 0; i < untakenIds.length; i++ )
+                {
+                    lockMap.put( untakenIds[i], new AtomicInteger( 1 ) );
+                }
+            }
+            else
+            {
+                throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceIds, READ );
+
+            }
+        }
+    }
+
+    @Override
+    public void acquireExclusive( Locks.ResourceType resourceType, long... resourceIds ) throws
+            AcquireLockTimeoutException
+    {
+        Map<Long, AtomicInteger> lockMap = getLockMap( exclusiveLocks, resourceType );
+        long[] untakenIds = incrementAndRemoveAlreadyTakenLocks( lockMap, resourceIds );
+        if ( untakenIds.length > 0 && acquireExclusiveOnMaster( resourceType, untakenIds ) )
+        {
+            if ( client.tryExclusiveLock( resourceType, untakenIds ) )
+            {
+                for ( int i = 0; i < untakenIds.length; i++ )
+                {
+                    lockMap.put( untakenIds[i], new AtomicInteger( 1 ) );
+                }
+            }
+            else
+            {
+                throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceIds, WRITE );
+            }
+        }
+    }
+
+    private long[] incrementAndRemoveAlreadyTakenLocks(
+            Map<Long, AtomicInteger> takenLocks,
+            long[] resourceIds )
+    {
+        ArrayList<Long> untakenIds = new ArrayList<>();
+        for ( int i = 0; i < resourceIds.length; i++ )
+        {
+            long id = resourceIds[i];
+            AtomicInteger counter = takenLocks.get( id );
+            if ( counter != null )
+            {
+                counter.incrementAndGet();
+            }
+            else
+            {
+                untakenIds.add( id );
+            }
+        }
+        long[] untaken = new long[untakenIds.size()];
+        for ( int i = 0; i < untaken.length; i++ )
+        {
+            long id = untakenIds.get( i );
+            untaken[i] = id;
+        }
+        return untaken;
+    }
+
+    @Override
+    public boolean tryExclusiveLock( Locks.ResourceType resourceType, long... resourceIds )
+    {
+        throw newUnsupportedDirectTryLockUsageException();
+    }
+
+    @Override
+    public boolean trySharedLock( Locks.ResourceType resourceType, long... resourceIds )
+    {
+        throw newUnsupportedDirectTryLockUsageException();
+    }
+
+    @Override
+    public void releaseShared( Locks.ResourceType resourceType, long... resourceIds )
+    {
+        client.releaseShared( resourceType, resourceIds );
+    }
+
+    @Override
+    public void releaseExclusive( Locks.ResourceType resourceType, long... resourceIds )
+    {
+        client.releaseExclusive( resourceType, resourceIds );
+    }
+
+    @Override
+    public void releaseAllShared()
+    {
+        client.releaseAllShared();
+    }
+
+    @Override
+    public void releaseAllExclusive()
+    {
+        client.releaseAllExclusive();
+    }
+
+    @Override
+    public void releaseAll()
+    {
+        client.releaseAll();
+    }
+
+    @Override
+    public void close()
+    {
+        client.close();
+    }
+
+    private boolean getReadLockOnMaster( Locks.ResourceType resourceType, long ... resourceId )
+    {
+        if ( resourceType == ResourceTypes.NODE
+            || resourceType == ResourceTypes.RELATIONSHIP
+            || resourceType == ResourceTypes.GRAPH_PROPS
+            || resourceType == ResourceTypes.LEGACY_INDEX )
+        {
+            makeSureTxHasBeenInitialized();
+            return receiveLockResponse(
+                master.acquireSharedLock( requestContextFactory.newRequestContext(), resourceType, resourceId ));
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    private boolean acquireExclusiveOnMaster( Locks.ResourceType resourceType, long ... resourceId )
+    {
+        makeSureTxHasBeenInitialized();
+        return receiveLockResponse(
+                master.acquireExclusiveLock( requestContextFactory.newRequestContext(), resourceType, resourceId ));
+    }
+
+    private boolean receiveLockResponse( Response<LockResult> response )
+    {
+        LockResult result = xaDsm.applyTransactions( response );
+        switch ( result.getStatus() )
+        {
+            case DEAD_LOCKED:
+                throw new DeadlockDetectedException( result.getDeadlockMessage() );
+            case NOT_LOCKED:
+                throw new UnsupportedOperationException();
+            case OK_LOCKED:
+                break;
+            default:
+                throw new UnsupportedOperationException( result.toString() );
+        }
+
+        return true;
+    }
+
+
+    private void makeSureTxHasBeenInitialized()
+    {
+        if ( !availabilityGuard.isAvailable( config.getAvailabilityTimeout() ) )
+        {
+            // TODO Specific exception instead?
+            throw new RuntimeException( "Timed out waiting for database to allow operations to proceed. "
+                    + availabilityGuard.describeWhoIsBlocking() );
+        }
+
+        txHook.remotelyInitializeTransaction( txManager.getEventIdentifier(), txManager.getTransactionState() );
+    }
+
+    private UnsupportedOperationException newUnsupportedDirectTryLockUsageException()
+    {
+        return new UnsupportedOperationException( "At the time of adding \"try lock\" semantics there was no usage of " +
+                getClass().getSimpleName() + " calling it directly. It was designed to be called on a local " +
+                LockManager.class.getSimpleName() + " delegated to from within the waiting version" );
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.lock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.ha.HaXaDataSourceManager;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.lock.forseti.ForsetiLockManager;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.kernel.impl.transaction.RemoteTxHook;
+import org.neo4j.kernel.impl.transaction.TxManager;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SlaveLocksClientTest
+{
+    private SlaveLocksClient client;
+    private Master master;
+    private AvailabilityGuard availabilityGuard;
+    private HaXaDataSourceManager xaDsm;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        master = mock( Master.class );
+        Locks localLockManager = new ForsetiLockManager( ResourceTypes.values() );
+        Locks.Client local = localLockManager.newClient();
+        RequestContextFactory requestContextFactory = mock( RequestContextFactory.class );
+        xaDsm = mock( HaXaDataSourceManager.class );
+        when( xaDsm.applyTransactions(
+                (org.neo4j.com.Response<LockResult>) anyObject() )).thenReturn(
+                new LockResult( LockStatus.OK_LOCKED ) );
+        AbstractTransactionManager txManager = mock( TxManager.class );
+        RemoteTxHook txHook = mock( RemoteTxHook.class );
+        AvailabilityGuard availabilityGuard = mock( AvailabilityGuard.class );
+        when( availabilityGuard.isAvailable( anyLong() )).thenReturn( true );
+        SlaveLockManager.Configuration config = mock( SlaveLockManager.Configuration.class );
+        client = new SlaveLocksClient(
+                master, local, localLockManager, requestContextFactory, xaDsm,
+                txManager, txHook, availabilityGuard, config );
+    }
+
+    @Test
+    public void shouldNotTakeSharedLockOnMasterIfWeAreAlreadyHoldingSaidLock()
+    {
+        // When taking a lock twice
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireShared( ResourceTypes.NODE, 1 );
+
+        // Then only a single network roundtrip should be observed
+        verify( master ).acquireSharedLock( null, ResourceTypes.NODE, 1 );
+    }
+
+    @Test
+    public void shouldNotTakeSharedLockOnMasterIfWeAreAlreadyHoldingSaidLock_OverlappingBatch()
+    {
+        // When taking locks twice
+        client.acquireShared( ResourceTypes.NODE, 1, 2 );
+        client.acquireShared( ResourceTypes.NODE, 2, 3 );
+
+        // Then only the relevant network roundtrip should be observed
+        verify( master ).acquireSharedLock( null, ResourceTypes.NODE, 1, 2 );
+        verify( master ).acquireSharedLock( null, ResourceTypes.NODE, 3 );
+    }
+
+    @Test
+    public void shouldNotTakeExclusiveLockOnMasterIfWeAreAlreadyHoldingSaidLock()
+    {
+        // When taking a lock twice
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+
+        // Then only a single network roundtrip should be observed
+        verify( master ).acquireExclusiveLock( null, ResourceTypes.NODE, 1 );
+    }
+
+    @Test
+    public void shouldNotTakeExclusiveLockOnMasterIfWeAreAlreadyHoldingSaidLock_OverlappingBatch()
+    {
+        // When taking locks twice
+        client.acquireExclusive( ResourceTypes.NODE, 1, 2 );
+        client.acquireExclusive( ResourceTypes.NODE, 2, 3 );
+
+        // Then only the relevant network roundtrip should be observed
+        verify( master ).acquireExclusiveLock( null, ResourceTypes.NODE, 1, 2 );
+        verify( master ).acquireExclusiveLock( null, ResourceTypes.NODE, 3 );
+    }
+}


### PR DESCRIPTION
We now keep track of reentrancy locally on each instance, and only do a network round-trip the first time we grab a lock.
