### PR TITLE
Produces NodePropertyUpdates given all changed property records for node

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+import static org.neo4j.kernel.impl.nioneo.store.AbstractDynamicStore.readFullByteArrayFromHeavyRecords;
 import static org.neo4j.kernel.impl.nioneo.store.labels.NodeLabelsField.parseLabelsField;
 
 /**
@@ -341,6 +342,12 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
         return LabelIdArray.stripNodeId( storedLongs );
     }
 
+    public static long[] getDynamicLabelsArrayFromHeavyRecords( Iterable<DynamicRecord> records )
+    {
+        long[] storedLongs = (long[])
+            DynamicArrayStore.getRightArray( readFullByteArrayFromHeavyRecords( records, PropertyType.ARRAY ) );
+        return LabelIdArray.stripNodeId( storedLongs );
+    }
 
     public Pair<Long, long[]> getDynamicLabelsArrayAndOwner( Iterable<DynamicRecord> records )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.nioneo.store.windowpool.WindowPoolFactory;
+import org.neo4j.kernel.impl.nioneo.xa.PropertyRecordChange;
 import org.neo4j.kernel.impl.util.StringLogger;
 
 import static org.neo4j.helpers.collection.IteratorUtil.first;
@@ -48,7 +49,7 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     public static abstract class Configuration extends AbstractStore.Configuration
     {
     }
-    
+
     public static final int DEFAULT_DATA_BLOCK_SIZE = 120;
     public static final int DEFAULT_PAYLOAD_SIZE = 32;
 
@@ -305,7 +306,9 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
                 }
             }
             for ( DynamicRecord stringRecord : block.getValueRecords() )
+            {
                 stringPropertyStore.ensureHeavy( stringRecord );
+            }
         }
         else if ( block.getType() == PropertyType.ARRAY )
         {
@@ -319,7 +322,9 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
                 }
             }
             for ( DynamicRecord arrayRecord : block.getValueRecords() )
+            {
                 arrayPropertyStore.ensureHeavy( arrayRecord );
+            }
         }
     }
 
@@ -615,7 +620,7 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     {
         return UTF8.decode( byteArray );
     }
-    
+
     public String getStringFor( PropertyBlock propertyBlock )
     {
         ensureHeavy( propertyBlock );
@@ -700,7 +705,7 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     {
         return super.toString() + "[blocksPerRecord:" + PropertyType.getPayloadSizeLongs() + "]";
     }
-    
+
     public Collection<PropertyRecord> getPropertyRecordChain( long firstRecordId )
     {
         long nextProp = firstRecordId;
@@ -713,11 +718,10 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         }
         return toReturn;
     }
-    
-    public Iterable<NodePropertyUpdate> toLogicalUpdates(
-            PropertyRecord before, long[] nodeLabelsBefore,
-            PropertyRecord after, long[] nodeLabelsAfter )
+
+    public void toLogicalUpdates( Collection<NodePropertyUpdate> target,
+            Iterable<PropertyRecordChange> changes, long[] nodeLabelsBefore, long[] nodeLabelsAfter )
     {
-        return physicalToLogicalConverter.apply( before, nodeLabelsBefore, after, nodeLabelsAfter );
+        physicalToLogicalConverter.apply( target, changes, nodeLabelsBefore, nodeLabelsAfter );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.nioneo.store.labels;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -180,6 +181,11 @@ public class DynamicNodeLabels implements NodeLabels
     @Override
     public String toString()
     {
-        return format( "Dynamic(id:%d)", getFirstDynamicRecordId() );
+        if ( node.isLight() )
+        {
+            return format( "Dynamic(id:%d)", getFirstDynamicRecordId() );
+        }
+        return format( "Dynamic(id:%d,[%s])", getFirstDynamicRecordId(),
+                Arrays.toString( NodeStore.getDynamicLabelsArrayFromHeavyRecords( node.getDynamicLabelRecords() ) ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/Command.java
@@ -823,7 +823,7 @@ public abstract class Command extends XaCommand
         }
     };
 
-    static class PropertyCommand extends Command
+    static class PropertyCommand extends Command implements PropertyRecordChange
     {
         private final PropertyStore store;
         private final PropertyRecord before;
@@ -866,11 +866,13 @@ public abstract class Command extends XaCommand
             }
         }
 
+        @Override
         public PropertyRecord getBefore()
         {
             return before;
         }
 
+        @Override
         public PropertyRecord getAfter()
         {
             return after;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LazyIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LazyIndexUpdates.java
@@ -23,14 +23,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.impl.api.index.UpdateMode;
 import org.neo4j.kernel.impl.api.index.IndexUpdates;
+import org.neo4j.kernel.impl.api.index.UpdateMode;
 import org.neo4j.kernel.impl.core.IteratingPropertyReceiver;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeStore;
@@ -49,12 +51,12 @@ class LazyIndexUpdates implements IndexUpdates
 {
     private final NodeStore nodeStore;
     private final PropertyStore propertyStore;
-    private final Collection<PropertyCommand> propCommands;
+    private final Collection<List<PropertyCommand>> propCommands;
     private final Map<Long, NodeCommand> nodeCommands;
     private Collection<NodePropertyUpdate> updates;
 
     public LazyIndexUpdates( NodeStore nodeStore, PropertyStore propertyStore,
-                             Collection<PropertyCommand> propCommands, Map<Long, NodeCommand> nodeCommands )
+                             Collection<List<PropertyCommand>> propCommands, Map<Long, NodeCommand> nodeCommands )
     {
         this.nodeStore = nodeStore;
         this.propertyStore = propertyStore;
@@ -76,9 +78,9 @@ class LazyIndexUpdates implements IndexUpdates
     public Set<Long> changedNodeIds()
     {
         Set<Long> nodeIds = new HashSet<>( nodeCommands.keySet() );
-        for ( PropertyCommand propCmd : propCommands )
+        for ( List<PropertyCommand> propCmd : propCommands )
         {
-            PropertyRecord record = propCmd.getAfter();
+            PropertyRecord record = propCmd.get( 0 ).getAfter();
             if ( record.isNodeSet() )
             {
                 nodeIds.add( record.getNodeId() );
@@ -99,16 +101,18 @@ class LazyIndexUpdates implements IndexUpdates
     private void gatherUpdatesFromPropertyCommands( Collection<NodePropertyUpdate> updates,
                                                     Map<Pair<Long, Integer>, NodePropertyUpdate> propertyLookup )
     {
-        for ( PropertyCommand propertyCommand : propCommands )
+        for ( List<PropertyCommand> propertyCommands : propCommands )
         {
-            PropertyRecord after = propertyCommand.getAfter();
-            if ( !after.isNodeSet() )
-            {
+            // Let after state of first command here be representative of the whole group
+            PropertyRecord representative = propertyCommands.get( 0 ).getAfter();
+            if ( !representative.isNodeSet() )
+            {   // These changes wasn't for a node, skip them
                 continue;
             }
 
+            long nodeId = representative.getNodeId();
             long[] nodeLabelsBefore, nodeLabelsAfter;
-            NodeCommand nodeChanges = nodeCommands.get( after.getNodeId() );
+            NodeCommand nodeChanges = nodeCommands.get( nodeId );
             if ( nodeChanges != null )
             {
                 nodeLabelsBefore = parseLabelsField( nodeChanges.getBefore() ).get( nodeStore );
@@ -131,19 +135,20 @@ class LazyIndexUpdates implements IndexUpdates
                  * if this happens and we're in recovery mode that the node in question will be deleted
                  * in an upcoming transaction, so just skip this update.
                  */
-                NodeRecord nodeRecord = nodeStore.getRecord( after.getNodeId() );
+                NodeRecord nodeRecord = nodeStore.getRecord( nodeId );
                 nodeLabelsBefore = nodeLabelsAfter = parseLabelsField( nodeRecord ).get( nodeStore );
             }
 
-            for ( NodePropertyUpdate update :
-                    propertyStore.toLogicalUpdates( propertyCommand.getBefore(), nodeLabelsBefore, after,
-                                                    nodeLabelsAfter ) )
+            propertyStore.toLogicalUpdates( updates,
+                    Iterables.<PropertyRecordChange,PropertyCommand>cast( propertyCommands ),
+                    nodeLabelsBefore, nodeLabelsAfter );
+        }
+
+        for ( NodePropertyUpdate update : updates )
+        {
+            if ( update.getUpdateMode() == UpdateMode.CHANGED )
             {
-                updates.add( update );
-                if ( update.getUpdateMode() == UpdateMode.CHANGED )
-                {
-                    propertyLookup.put( Pair.of( update.getNodeId(), update.getPropertyKeyId() ), update );
-                }
+                propertyLookup.put( Pair.of( update.getNodeId(), update.getPropertyKeyId() ), update );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/PropertyRecordChange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/PropertyRecordChange.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
+
+public interface PropertyRecordChange
+{
+    PropertyRecord getBefore();
+
+    PropertyRecord getAfter();
+}


### PR DESCRIPTION
instead of doing so per changed property record. This needs to be like
this since properties (PropertyBlock) can move from one record to another
and should be interpreted as a change. The issue that caused this change
was that such a move produced one ADD and one REMOVE update and if they
got executed in the order of ADD then REMOVE the index would end up not
having that entry in it.
