### PR TITLE
Fix for exhausting the Neo4j Server ThreadPool with too many selectors, so that no acceptors are available

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/security/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/SslSocketConnectorFactory.java
@@ -20,30 +20,33 @@
 package org.neo4j.server.security;
 
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.neo4j.server.web.HttpConnectorFactory;
+
+import java.util.Arrays;
 
 
-public class SslSocketConnectorFactory {
+public class SslSocketConnectorFactory extends HttpConnectorFactory
+{
 
-    public ServerConnector createConnector(Server server, KeyStoreInformation config, String host, int port) {
+    public ServerConnector createConnector( Server server, KeyStoreInformation config, String host, int port, int jettyMaxThreads )
+    {
 
+        SslConnectionFactory sslConnectionFactory = createSslConnectionFactory( config );
+
+        return super.createConnector( server, host, port, jettyMaxThreads, sslConnectionFactory, createHttpConnectionFactory() );
+    }
+
+    private SslConnectionFactory createSslConnectionFactory( KeyStoreInformation config )
+    {
         SslContextFactory sslContextFactory = new SslContextFactory();
 
         sslContextFactory.setKeyStorePath( config.getKeyStorePath() );
         sslContextFactory.setKeyStorePassword( String.valueOf( config.getKeyStorePassword() ) );
         sslContextFactory.setKeyManagerPassword( String.valueOf( config.getKeyPassword() ) );
 
-        ServerConnector connector = new ServerConnector( server, new SslConnectionFactory( sslContextFactory, HttpVersion.HTTP_1_1.asString() ), new HttpConnectionFactory() );
-
-        connector.setPort( port );
-        connector.setHost( host );
-
-        return connector;
-
+        return new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString());
     }
 
 }

--- a/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpConnectorFactory.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.web;
+
+import org.eclipse.jetty.server.*;
+
+import java.util.Arrays;
+
+public class HttpConnectorFactory
+{
+
+    public ConnectionFactory createHttpConnectionFactory()
+    {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setRequestHeaderSize( 20 * 1024 );
+        httpConfig.setResponseHeaderSize( 20 * 1024 );
+        return new HttpConnectionFactory( httpConfig );
+    }
+
+    public ServerConnector createConnector( Server server, String host, int port, int jettyMaxThreads )
+    {
+        ConnectionFactory httpFactory = createHttpConnectionFactory();
+        return createConnector(server, host, port, jettyMaxThreads, httpFactory );
+    }
+
+    public ServerConnector createConnector( Server server, String host, int port, int jettyMaxThreads, ConnectionFactory... httpFactories )
+    {
+        // Note: 1/4 accept, 3/4 select
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int cpusByConfiguredThreads = jettyMaxThreads / 10;
+        int cpusToConsider = Math.max(1, Math.min( availableProcessors, cpusByConfiguredThreads ) );
+        int acceptors = Math.max( 1 ,cpusToConsider / 4 );
+        int selectors = Math.max( 1, cpusToConsider - acceptors );
+
+        ServerConnector connector = new ServerConnector( server , null, null, null, acceptors, selectors, httpFactories );
+
+        connector.setConnectionFactories( Arrays.asList( httpFactories ) );
+
+        // TCP backlog, per socket, 50 is the default, consider adapting if needed
+        connector.setAcceptQueueSize( 50 );
+
+        connector.setHost( host );
+        connector.setPort( port );
+
+        return connector;
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/AcceptorConfigurationIT.java
+++ b/community/server/src/test/java/org/neo4j/server/AcceptorConfigurationIT.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.server.rest.RESTDocsGenerator;
+import org.neo4j.test.TestData;
+import org.neo4j.test.server.ExclusiveServerTestBase;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.server.helpers.CommunityServerBuilder.server;
+import static org.neo4j.test.server.HTTP.GET;
+
+public class AcceptorConfigurationIT extends ExclusiveServerTestBase
+{
+
+    private CommunityNeoServer server;
+
+    @After
+    public void stopTheServer()
+    {
+        server.stop();
+    }
+
+    @Test
+    public void serverShouldNotHangWithThreadPoolSizeSmallerThanCpuCount() throws Exception
+    {
+        server = server().withMaxJettyThreads( 3 )
+                .usingDatabaseDir( folder.getRoot().getAbsolutePath() )
+                .build();
+        server.start();
+
+        assertThat( GET(server.baseUri().toString()).status(), is( 200 ) );
+    }
+}


### PR DESCRIPTION
- extracted HttpConnectorFactory
- SslConnectorFactory inherits from it to use the same approach
- Jetty makes wrong choices for selectors (numcpu instead of numcpu/2), so we have to provide explicit counts for selectors and acceptors
- Determine number of relevant CPUs by taking the size of the thread pool into account
- Add some other performance related configurations from the Jetty docs
