### PR TITLE
Fix memory leak in XaResourceManager.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
@@ -71,7 +71,7 @@ public class LogMatchers
         }
     }
 
-    public static Iterable<LogEntry> logEntries( FileSystemAbstraction fileSystem, File file ) throws IOException
+    public static List<LogEntry> logEntries( FileSystemAbstraction fileSystem, File file ) throws IOException
     {
         return logEntries( fileSystem, file.getPath() );
     }


### PR DESCRIPTION
The txOrderMap was initially only meant for and used by recovery. However, HA started
injecting transactions using the same recovery code as well. This meant that the
txOrderMap was steadily accumulating data, but never got cleared, because the clearing
only happened at the end of recovery.

This memory leak has been fixed by removing the txOrderMap completely, and instead let
the TransactionStatus objects know how to order themselves.
