### PR TITLE
Made legacy indexes wait for availability check.

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -55,7 +55,7 @@ public class HaSettings
     public static final Setting<Long> read_timeout = setting( "ha.read_timeout", DURATION, "20s" );
 
     @Description( "Timeout for waiting for instance to become master or slave." )
-    public static final Setting<Long> state_switch_timeout = setting( "ha.state_switch_timeout", DURATION, "20s" );
+    public static final Setting<Long> state_switch_timeout = setting( "ha.state_switch_timeout", DURATION, "120s" );
 
     @Description( "Timeout for taking remote (write) locks on slaves. Defaults to ha.read_timeout." )
     public static final Setting<Long> lock_read_timeout = setting( "ha.lock_read_timeout", DURATION, read_timeout );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.index;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
-
 import org.junit.After;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
@@ -35,6 +29,12 @@ import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
+import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
 public class AutoIndexConfigIT
 {
@@ -70,20 +70,19 @@ public class AutoIndexConfigIT
         String propertyToIndex = "programmatic-property";
 
         // Given
-        startCluster( 2 );
-        HighlyAvailableGraphDatabase originalMaster = cluster.getMaster();
+        startCluster( 3 );
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
 
-        AutoIndexer<Node> originalAutoIndex = originalMaster.index().getNodeAutoIndexer();
+        AutoIndexer<Node> originalAutoIndex = slave.index().getNodeAutoIndexer();
         originalAutoIndex.setEnabled( true );
         originalAutoIndex.startAutoIndexingProperty( propertyToIndex );
 
         // When
-        ClusterManager.RepairKit originalMasterRepairKit = cluster.shutdown( originalMaster );
+        cluster.shutdown( cluster.getMaster() );
         cluster.await( masterAvailable() );
-        originalMasterRepairKit.repair(); // Bring the original master back as a slave
 
         // Then
-        AutoIndexer<Node> newAutoIndex = originalMaster.index().getNodeAutoIndexer();
+        AutoIndexer<Node> newAutoIndex = slave.index().getNodeAutoIndexer();
 
         assertThat(newAutoIndex.isEnabled(), is(true));
         assertThat( newAutoIndex.getAutoIndexedProperties(), hasItem( propertyToIndex ) );


### PR DESCRIPTION
- Add availability wait in hagdb.index()
- Bump default database availability timeout to 120s, to account
  for time to copy store.
