### PR TITLE
Lazy properties now use a provider for PropertyStore.

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -3,6 +3,9 @@
 o Fixes an issue with tx log reading in severely damaged log files.
 o Fixes a JVM deadlock issue between committing and a reading thread
 o Can now handle more gracefully a larger set of failed index states
+o Fix a cache poisoning issue where large properties would keep a reference to a closed
+  store after a HA role switch. Manifested as NullPointerException when reading very large
+  properties in rare cases.
 
 2.0.1
 -----

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyBlock.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import org.neo4j.kernel.api.properties.DefinedProperty;
 
+import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
+
 public class PropertyBlock implements Cloneable
 {
     private static final long KEY_BITMASK = 0xFFFFFFL;
@@ -224,6 +226,6 @@ public class PropertyBlock implements Cloneable
 
     public DefinedProperty newPropertyData( PropertyStore propertyStore )
     {
-        return getType().readProperty( getKeyIndexId(), this, propertyStore );
+        return getType().readProperty( getKeyIndexId(), this, singletonProvider(propertyStore) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyType.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.nioneo.store;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 
@@ -34,7 +35,7 @@ public enum PropertyType
     BOOL( 1 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.booleanProperty( propertyKeyId, getValue( block.getSingleValueLong() ) );
         }
@@ -53,7 +54,7 @@ public enum PropertyType
     BYTE( 2 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.byteProperty( propertyKeyId, block.getSingleValueByte() );
         }
@@ -67,7 +68,7 @@ public enum PropertyType
     SHORT( 3 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.shortProperty( propertyKeyId, block.getSingleValueShort() );
         }
@@ -81,7 +82,7 @@ public enum PropertyType
     CHAR( 4 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.charProperty( propertyKeyId, (char) block.getSingleValueShort() );
         }
@@ -95,7 +96,7 @@ public enum PropertyType
     INT( 5 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.intProperty( propertyKeyId, block.getSingleValueInt() );
         }
@@ -109,7 +110,7 @@ public enum PropertyType
     LONG( 6 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             long firstBlock = block.getSingleValueBlock();
             long value = valueIsInlined( firstBlock ) ? (block.getSingleValueLong() >>> 1) : block.getValueBlocks()[1];
@@ -144,7 +145,7 @@ public enum PropertyType
     FLOAT( 7 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.floatProperty( propertyKeyId, Float.intBitsToFloat( block.getSingleValueInt() ) );
         }
@@ -163,7 +164,7 @@ public enum PropertyType
     DOUBLE( 8 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.doubleProperty( propertyKeyId, Double.longBitsToDouble( block.getValueBlocks()[1] ) );
         }
@@ -188,14 +189,15 @@ public enum PropertyType
     STRING( 9 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, final PropertyBlock block, final PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, final PropertyBlock block,
+                                             final Provider<PropertyStore> store )
         {
             return Property.lazyStringProperty(propertyKeyId, new Callable<String>()
             {
                 @Override
                 public String call() throws Exception
                 {
-                    return getValue( block, store );
+                    return getValue( block, store.instance() );
                 }
             });
         }
@@ -219,14 +221,14 @@ public enum PropertyType
     ARRAY( 10 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, final PropertyBlock block, final PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, final PropertyBlock block, final Provider<PropertyStore> store )
         {
             return Property.lazyArrayProperty(propertyKeyId, new Callable<Object>()
             {
                 @Override
                 public Object call() throws Exception
                 {
-                    return getValue( block, store );
+                    return getValue( block, store.instance() );
                 }
             });
         }
@@ -264,7 +266,7 @@ public enum PropertyType
     SHORT_STRING( 11 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             return Property.stringProperty( propertyKeyId, LongerShortString.decode( block ) );
         }
@@ -284,7 +286,7 @@ public enum PropertyType
     SHORT_ARRAY( 12 )
     {
         @Override
-        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store )
+        public DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store )
         {
             // TODO: Specialize per type
             return Property.property( propertyKeyId, ShortArray.decode(block) );
@@ -337,7 +339,7 @@ public enum PropertyType
 
     public abstract Object getValue( PropertyBlock block, PropertyStore store );
 
-    public abstract DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, PropertyStore store );
+    public abstract DefinedProperty readProperty( int propertyKeyId, PropertyBlock block, Provider<PropertyStore> store );
 
     public static PropertyType getPropertyType( long propBlock, boolean nullOnIllegal )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.Thunk;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.Visitor;
@@ -85,8 +86,17 @@ import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.LockManager;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
-import org.neo4j.kernel.impl.transaction.xaframework.*;
+import org.neo4j.kernel.impl.transaction.xaframework.LogBackedXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.LogBufferFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptor;
+import org.neo4j.kernel.impl.transaction.xaframework.XaCommand;
+import org.neo4j.kernel.impl.transaction.xaframework.XaCommandFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
+import org.neo4j.kernel.impl.transaction.xaframework.XaContainer;
+import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.XaResource;
+import org.neo4j.kernel.impl.transaction.xaframework.XaTransaction;
+import org.neo4j.kernel.impl.transaction.xaframework.XaTransactionFactory;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -363,8 +373,14 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
 
             kernel = life.add( new Kernel( txManager, propertyKeyTokens, labelTokens, relationshipTypeTokens,
                     persistenceManager, lockManager, updateableSchemaState, schemaWriteGuard,
-                    indexingService, nodeManager, neoStore, persistenceCache, schemaCache, providerMap, labelScanStore,
-                    readOnly ));
+                    indexingService, nodeManager, new Provider<NeoStore>()
+            {
+                @Override
+                public NeoStore instance()
+                {
+                    return getNeoStore();
+                }
+            }, persistenceCache, schemaCache, providerMap, labelScanStore, readOnly ));
 
             life.init();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Providers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Providers.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.neo4j.helpers.Provider;
+
+public class Providers
+{
+    public static <T> Provider<T> singletonProvider( final T value)
+    {
+        return new Provider<T>()
+        {
+            @Override
+            public T instance()
+            {
+                return value;
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -56,11 +55,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.getPropertyKeys;
@@ -70,6 +65,7 @@ import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
 
 public class DiskLayerTest
 {
@@ -284,7 +280,7 @@ public class DiskLayerTest
                 resolver.resolveDependency( LabelTokenHolder.class ),
                 resolver.resolveDependency( RelationshipTypeTokenHolder.class ),
                 new SchemaStorage( neoStore.getSchemaStore() ),
-                neoStore,
+                singletonProvider( neoStore ),
                 indexingService );
         this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ),
                 resolver.resolveDependency( LabelScanStore.class ), null,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+/**
+ * This test ensures that lazy properties
+ */
+public class TestReferenceDangling
+{
+    @Rule
+    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule( );
+
+    @Test
+    public void testPropertyStoreReferencesOnRead() throws Throwable
+    {
+        // Given
+        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+
+        // and Given the cache contains a LazyProperty
+        long nId = ensurePropertyIsCachedLazyProperty( db, "some" );
+
+        // When
+        restartNeoDataSource( db );
+
+        // Then reading the property is still possible
+        try( Transaction tx = db.beginTx() )
+        {
+            db.getNodeById( nId ).getProperty( "some" );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void testPropertyStoreReferencesOnWrite() throws Throwable
+    {
+        // Given
+        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+
+        // and Given the cache contains a LazyProperty
+        long nId = ensurePropertyIsCachedLazyProperty( db, "some" );
+
+        // When
+        restartNeoDataSource( db );
+
+        // Then it should still be possible to manipulate properties on this node
+        try( Transaction tx = db.beginTx() )
+        {
+            db.getNodeById( nId ).setProperty( "some", new long[]{-1,2,2,3,4,5,5} );
+            tx.success();
+        }
+    }
+
+    private long ensurePropertyIsCachedLazyProperty( GraphDatabaseAPI slave, String key )
+    {
+        long nId;
+        try( Transaction tx = slave.beginTx() )
+        {
+            Node n = slave.createNode();
+            nId = n.getId();
+            n.setProperty( key, new long[]{-1,2,2,3,4,5,5} );
+            tx.success();
+        }
+        slave.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+
+        try( Transaction tx = slave.beginTx() )
+        {
+            slave.getNodeById( nId ).hasProperty( key );
+            tx.success();
+        }
+        return nId;
+    }
+
+    private void restartNeoDataSource( GraphDatabaseAPI slave ) throws Throwable
+    {
+        slave.getDependencyResolver().resolveDependency( XaDataSourceManager.class ).getXaDataSource(
+                NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME ).stop();
+        slave.getDependencyResolver().resolveDependency( XaDataSourceManager.class ).getXaDataSource(
+                NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME ).start();
+    }
+}

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyReader.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyReader.java
@@ -29,6 +29,8 @@ import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.store.PropertyStore;
 
+import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
+
 public class PropertyReader
 {
     private final PropertyStore propertyStore;
@@ -51,6 +53,6 @@ public class PropertyReader
 
     public DefinedProperty propertyValue( PropertyBlock block )
     {
-        return block.getType().readProperty( block.getKeyIndexId(), block, propertyStore );
+        return block.getType().readProperty( block.getKeyIndexId(), block, singletonProvider(propertyStore) );
     }
 }


### PR DESCRIPTION
- Fixes a cache issue where LazyProperties would hold old reference to
  property stores after a data source restart.
