### PR TITLE
Stop Foldable#exists once it has been found

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/FoldableTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/FoldableTest.scala
@@ -73,7 +73,6 @@ class FoldableTest extends CypherFunSuite {
   }
 
   test("should allow using exist to find patterns deeply nested") {
-
     val ast = Add(Val(1), Add(Val(2), Val(3)))
 
     ast.exists {


### PR DESCRIPTION
Also avoid calling partial function isDefinedAt and apply, by using
a single lifted version ([these are optimised in the common
case](https://github.com/scala/scala/blob/master/src/library/scala/PartialFunction.scala#L103)).
