### PR TITLE
Prevents transaction push failures to set the transaction manager in bad state

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommitNotificationFailedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommitNotificationFailedException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
+
+/**
+ * Thrown when
+ * {@link TxIdGenerator#committed(org.neo4j.kernel.impl.transaction.xaframework.XaDataSource, int, long, Integer)}
+ * fails. These exceptions will slip through {@link TxManager#commit()} as not being critical and
+ * not set tx manager to "not OK".
+ *
+ * Throwing this still means that the transaction was successfully committed.
+ */
+public class CommitNotificationFailedException extends RuntimeException
+{
+    public CommitNotificationFailedException( Throwable cause )
+    {
+        super( cause );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -373,6 +373,15 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
                 {
                     tx.doCommit();
                 }
+                catch ( CommitNotificationFailedException e )
+                {
+                    // Let this pass through. Catching this exception here will still have the exception
+                    // propagate out to the user (wrapped in a TransactionFailureException), but will not
+                    // set this transaction manager in "not OK" state.
+                    // At the time of adding this, this approach was chosen over throwing an XAException
+                    // with a specific error code since no error code seemed suitable.
+                    log.warn( "Commit notification failed: " + e );
+                }
                 catch ( XAException e )
                 {
                     // Behold, the error handling decision maker of great power.
@@ -431,15 +440,9 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
                 catch ( Throwable e )
                 {
                     setTmNotOk( e );
-                    String commitError;
-                    if ( commitFailureCause != null )
-                    {
-                        commitError = "error in commit: " + commitFailureCause;
-                    }
-                    else
-                    {
-                        commitError = "error code in commit: " + xaErrorCode;
-                    }
+                    String commitError = commitFailureCause != null ?
+                            "error in commit: " + commitFailureCause :
+                            "error code in commit: " + xaErrorCode;
                     String rollbackErrorCode = "Unknown error code";
                     if ( e instanceof XAException )
                     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/KernelHealthTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/KernelHealthTest.java
@@ -22,18 +22,14 @@ package org.neo4j.kernel.impl.transaction;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
-import org.neo4j.kernel.logging.BufferingLogger;
-import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.logging.SingleLoggingService;
+import org.neo4j.test.BufferingLogging;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.event.ErrorState.TX_MANAGER_NOT_OK;
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
@@ -60,9 +56,7 @@ public class KernelHealthTest
     public void shouldLogKernelPanicEvent() throws Exception
     {
         // GIVEN
-        BufferingLogger logger = new BufferingLogger();
-        Logging logging = mock( Logging.class );
-        when( logging.getMessagesLog( any( Class.class ) ) ).thenReturn( logger );
+        BufferingLogging logging = new BufferingLogging();
         KernelHealth kernelHealth = new KernelHealth( mock( KernelPanicEventGenerator.class ), logging );
         kernelHealth.healed();
 
@@ -71,6 +65,6 @@ public class KernelHealthTest
         kernelHealth.panic( new Exception( message ) );
 
         // THEN
-        assertThat( logger.toString(), containsString( message ) );
+        assertThat( logging.toString(), containsString( message ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/OtherDummyXaDataSource.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/OtherDummyXaDataSource.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAResource;
+
+import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+
+/**
+ * Is one-phase commit always performed when only one (or many isSameRM)
+ * resource(s) are present in the transaction?
+ * 
+ * If so it could be tested...
+ */
+// public void test1PhaseCommit()
+// {
+//	
+// }
+public class OtherDummyXaDataSource extends XaDataSource
+{
+    private XAResource xaResource = null;
+
+    public OtherDummyXaDataSource( String name, byte[] branchId, XAResource xaResource )
+    {
+        super( branchId, name );
+        this.xaResource = xaResource;
+    }
+
+    @Override
+    public XaConnection getXaConnection()
+    {
+        return new OtherDummyXaConnection( xaResource );
+    }
+
+    @Override
+    public long getLastCommittedTxId()
+    {
+        return 0;
+    }
+
+    @Override
+    public void init()
+    {
+    }
+
+    @Override
+    public void start()
+    {
+    }
+
+    @Override
+    public void stop()
+    {
+    }
+
+    @Override
+    public void shutdown()
+    {
+    }
+
+    private static class OtherDummyXaConnection implements XaConnection
+    {
+        private XAResource xaResource = null;
+
+        public OtherDummyXaConnection( XAResource xaResource )
+        {
+            this.xaResource = xaResource;
+        }
+
+        @Override
+        public XAResource getXaResource()
+        {
+            return xaResource;
+        }
+
+        @Override
+        public void destroy()
+        {
+        }
+
+        @Override
+        public boolean enlistResource( Transaction javaxTx )
+            throws SystemException, RollbackException
+        {
+            return javaxTx.enlistResource( xaResource );
+        }
+
+        @Override
+        public boolean delistResource( Transaction tx, int tmsuccess )
+            throws IllegalStateException, SystemException
+        {
+            return tx.delistResource( xaResource, tmsuccess );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestInjectMultipleStartEntries.java
@@ -53,8 +53,8 @@ public class TestInjectMultipleStartEntries
         // -- a database with one additional data source and some initial data
         GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
                 .setFileSystem( fs.get() ).newImpermanentDatabase( storeDir );
-        XaDataSourceManager xaDs = db.getXaDataSourceManager();
-        XaDataSource additionalDs = new DummyXaDataSource( "dummy", "dummy".getBytes(), new FakeXAResource( "dummy" ) );
+        XaDataSourceManager xaDs = db.getDependencyResolver().resolveDependency( XaDataSourceManager.class );
+        XaDataSource additionalDs = new OtherDummyXaDataSource( "dummy", "dummy".getBytes(), new FakeXAResource( "dummy" ) );
         xaDs.registerDataSource( additionalDs );
         Node node = createNodeWithOneRelationshipToIt( db );
 
@@ -69,14 +69,14 @@ public class TestInjectMultipleStartEntries
         filterNeostoreLogicalLog( fs.get(), new File( storeDir, LOGICAL_LOG_DEFAULT_NAME + ".v0" ),
                 new VerificationLogHook() );
     }
-    
+
     private final String storeDir = "dir";
     @Rule public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-    
+
     private static class VerificationLogHook extends LogHookAdapter<LogEntry>
     {
         private final Set<Xid> startXids = new HashSet<Xid>();
-        
+
         @Override
         public boolean accept( LogEntry item )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestJtaCompliance.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TestJtaCompliance.java
@@ -55,8 +55,8 @@ public class TestJtaCompliance extends AbstractNeo4jTestCase
         map2.put( "store_dir", "target/var" );
         try
         {
-            xaDsMgr.registerDataSource( new DummyXaDataSource( "fakeRes1", UTF8.encode( "0xDDDDDE" ), new FakeXAResource( "XAResource1" ) ));
-            xaDsMgr.registerDataSource( new DummyXaDataSource( "fakeRes2", UTF8.encode( "0xDDDDDF" ), new FakeXAResource( "XAResource2" ) ));
+            xaDsMgr.registerDataSource( new OtherDummyXaDataSource( "fakeRes1", UTF8.encode( "0xDDDDDE" ), new FakeXAResource( "XAResource1" ) ));
+            xaDsMgr.registerDataSource( new OtherDummyXaDataSource( "fakeRes2", UTF8.encode( "0xDDDDDF" ), new FakeXAResource( "XAResource2" ) ));
         }
         catch ( Exception e )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TxManagerTest.java
@@ -20,41 +20,58 @@
 package org.neo4j.kernel.impl.transaction;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.transaction.SystemException;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.helpers.Factory;
+import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.KernelEventHandlers;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
-import org.neo4j.kernel.logging.SingleLoggingService;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.core.PropertyIndexManager;
+import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
+import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
+import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
+import static org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies.NO_PRUNING;
+import static org.neo4j.kernel.impl.transaction.xaframework.RecoveryVerifier.ALWAYS_VALID;
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 
 public class TxManagerTest
 {
-    @Rule
-    public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-
     @Test
     public void settingTmNotOkShouldAttachCauseToSubsequentErrors() throws Exception
     {
         // Given
         XaDataSourceManager mockXaManager = mock( XaDataSourceManager.class );
         File txLogDir = TargetDirectory.forTest( fs.get(), getClass() ).directory( "log", true );
-        KernelHealth kernelHealth = new KernelHealth( new KernelPanicEventGenerator(
-                new KernelEventHandlers( DEV_NULL) ), new SingleLoggingService( DEV_NULL ) );
+        KernelHealth kernelHealth = new KernelHealth( panicGenerator, logging );
         TxManager txm = new TxManager( txLogDir, mockXaManager, DEV_NULL, fs.get(), null, null,
-                kernelHealth, new Monitors() );
+                kernelHealth, monitors );
         txm.doRecovery(); // Make the txm move to an ok state
 
         String msg = "These kinds of throwables, breaking our transaction managers, are why we can't have nice things.";
@@ -73,5 +90,73 @@ public class TxManagerTest
             assertThat( "TM should forward a cause.", topLevelException.getCause(), is( Throwable.class ) );
             assertThat( "Cause should be the original cause", topLevelException.getCause().getMessage(), is( msg ) );
         }
+    }
+
+    @Test
+    public void shouldNotSetTmNotOKForFailureInCommitted() throws Throwable
+    {
+        /*
+         * I.e. when the commit has been done and the TxIdGenerator#committed method is called and fails,
+         * it should not put the TM in not OK state. However that exception should still be propagated to
+         * the user.
+         */
+
+        // GIVEN
+        File directory = TargetDirectory.forTest( fs.get(), getClass() ).directory( "dir" );
+        TransactionStateFactory stateFactory = new TransactionStateFactory( logging );
+        TxIdGenerator txIdGenerator = mock( TxIdGenerator.class );
+        doThrow( RuntimeException.class ).when( txIdGenerator )
+                .committed( any( XaDataSource.class ), anyInt(), anyLong(), any( Integer.class ) );
+        stateFactory.setDependencies( mock( LockManager.class ), mock( PropertyIndexManager.class ),
+                mock( NodeManager.class ), mock( RemoteTxHook.class ), txIdGenerator );
+        XaDataSourceManager xaDataSourceManager = life.add( new XaDataSourceManager( DEV_NULL ) );
+        KernelHealth kernelHealth = new KernelHealth( panicGenerator, logging );
+        AbstractTransactionManager txManager = life.add( new TxManager( directory, xaDataSourceManager,
+                logging.getMessagesLog( TxManager.class ), fs.get(), stateFactory, xidFactory, kernelHealth, monitors ) );
+        XaFactory xaFactory = new XaFactory( new Config(), txIdGenerator, txManager, fs.get(), monitors,
+                logging, ALWAYS_VALID, NO_PRUNING, kernelHealth );
+        DummyXaDataSource dataSource = new DummyXaDataSource( UTF8.encode( "0xDDDDDE" ), "dummy", xaFactory,
+                stateFactory, new File( directory, "log" ) );
+        xaDataSourceManager.registerDataSource( dataSource );
+        life.start();
+        txManager.doRecovery();
+
+        // WHEN
+        txManager.begin();
+        dataSource.getXaConnection().enlistResource( txManager.getTransaction() );
+        txManager.commit();
+
+        // THEN tx manager should still work here
+        assertThat( logging.toString(), containsString( "Commit notification failed" ) );
+        doNothing().when( txIdGenerator )
+                .committed( any( XaDataSource.class ), anyInt(), anyLong(), any( Integer.class ) );
+        txManager.begin();
+        txManager.rollback();
+        // and of course kernel should be healthy
+        kernelHealth.assertHealthy( AssertionError.class );
+    }
+
+    @Rule
+    public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    private final KernelPanicEventGenerator panicGenerator = new KernelPanicEventGenerator(
+            new KernelEventHandlers(StringLogger.DEV_NULL) );
+    private final Monitors monitors = new Monitors();
+    private final Logging logging = new BufferingLogging();
+    private final Factory<byte[]> xidFactory = new Factory<byte[]>()
+    {
+        private final AtomicInteger id = new AtomicInteger();
+
+        @Override
+        public byte[] newInstance()
+        {
+            return ("test" + id.incrementAndGet()).getBytes();
+        }
+    };
+    private final LifeSupport life = new LifeSupport();
+
+    @After
+    public void after()
+    {
+        life.shutdown();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/BufferingLogging.java
+++ b/community/kernel/src/test/java/org/neo4j/test/BufferingLogging.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.BufferingConsoleLogger;
+import org.neo4j.kernel.logging.BufferingLogger;
+import org.neo4j.kernel.logging.ConsoleLogger;
+import org.neo4j.kernel.logging.Logging;
+
+import static java.lang.String.format;
+
+public class BufferingLogging implements Logging
+{
+    private final BufferingLogger log = new BufferingLogger();
+    private final BufferingConsoleLogger console = new BufferingConsoleLogger();
+
+    @Override
+    public StringLogger getMessagesLog( Class loggingClass )
+    {
+        return log;
+    }
+
+    @Override
+    public ConsoleLogger getConsoleLog( Class loggingClass )
+    {
+        return console;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append( log.toString() ).append( format( "%n" ) ).append( console.toString() );
+        return builder.toString();
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/DatabaseTuningDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/DatabaseTuningDocIT.java
@@ -27,13 +27,12 @@ import org.junit.Test;
 
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.helpers.ServerBuilder;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import static org.neo4j.server.helpers.ServerBuilder.bufferingLogging;
 
 public class DatabaseTuningDocIT extends ExclusiveServerTestBase
 {
@@ -67,7 +66,7 @@ public class DatabaseTuningDocIT extends ExclusiveServerTestBase
     @Test
     public void shouldLogWarningAndContinueIfTuningFilePropertyDoesNotResolve() throws IOException
     {
-        Logging logging = bufferingLogging();
+        Logging logging = new BufferingLogging();
         NeoServer server = ServerBuilder.server( logging )
                 .usingDatabaseDir( folder.getRoot().getAbsolutePath() )
                 .withNonResolvableTuningFile()

--- a/community/server/src/test/java/org/neo4j/server/NeoServerPortConflictDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerPortConflictDocIT.java
@@ -28,13 +28,12 @@ import org.junit.Test;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.helpers.ServerBuilder;
 import org.neo4j.server.web.Jetty6WebServer;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
-import static org.neo4j.server.helpers.ServerBuilder.bufferingLogging;
 
 public class NeoServerPortConflictDocIT extends ExclusiveServerTestBase
 {
@@ -43,7 +42,7 @@ public class NeoServerPortConflictDocIT extends ExclusiveServerTestBase
     {
         int contestedPort = 9999;
         ServerSocket socket = new ServerSocket( contestedPort, 0, InetAddress.getByName(Jetty6WebServer.DEFAULT_ADDRESS) );
-        Logging logging = bufferingLogging();
+        Logging logging = new BufferingLogging();
         CommunityNeoServer server = ServerBuilder.server( logging )
                 .onPort( contestedPort )
                 .onHost( Jetty6WebServer.DEFAULT_ADDRESS )

--- a/community/server/src/test/java/org/neo4j/server/NeoServerShutdownLoggingDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerShutdownLoggingDocIT.java
@@ -27,12 +27,11 @@ import org.junit.Test;
 
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.helpers.ServerHelper;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
-
-import static org.neo4j.server.helpers.ServerBuilder.bufferingLogging;
 
 public class NeoServerShutdownLoggingDocIT extends ExclusiveServerTestBase
 {
@@ -42,7 +41,7 @@ public class NeoServerShutdownLoggingDocIT extends ExclusiveServerTestBase
     @Before
     public void setupServer() throws IOException
     {
-        logging = bufferingLogging();
+        logging = new BufferingLogging();
         server = ServerHelper.createPersistentServer(folder.getRoot(), logging);
         ServerHelper.cleanTheDatabase( server );
     }

--- a/community/server/src/test/java/org/neo4j/server/NeoServerStartupLoggingDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerStartupLoggingDocIT.java
@@ -27,10 +27,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.server.helpers.ServerBuilder;
 import org.neo4j.server.helpers.ServerHelper;
 import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import com.sun.jersey.api.client.Client;
@@ -46,7 +46,7 @@ public class NeoServerStartupLoggingDocIT extends ExclusiveServerTestBase
     @BeforeClass
     public static void setupServer() throws IOException
     {
-        logging = ServerBuilder.bufferingLogging();
+        logging = new BufferingLogging();
         server = ServerHelper.createNonPersistentServer( logging );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/database/TestCommunityDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestCommunityDatabase.java
@@ -37,6 +37,7 @@ import org.neo4j.server.configuration.Configurator;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.ShellLobby;
 import org.neo4j.shell.ShellSettings;
+import org.neo4j.test.BufferingLogging;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -45,7 +46,6 @@ import static org.junit.Assert.assertThat;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.ServerTestUtils.createTempDir;
-import static org.neo4j.server.helpers.ServerBuilder.bufferingLogging;
 
 public class TestCommunityDatabase
 {
@@ -58,7 +58,7 @@ public class TestCommunityDatabase
     public void setup() throws Exception
     {
         databaseDirectory = createTempDir();
-        logging = bufferingLogging();
+        logging = new BufferingLogging();
         theDatabase = new CommunityDatabase( configuratorWithServerProperties( stringMap(
                 Configurator.DATABASE_LOCATION_PROPERTY_KEY, databaseDirectory.getAbsolutePath() ) ), logging );
     }

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerBuilder.java
@@ -31,10 +31,7 @@ import java.util.Properties;
 
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
-import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.BufferingConsoleLogger;
-import org.neo4j.kernel.logging.BufferingLogger;
-import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.CommunityNeoServer;
@@ -52,8 +49,6 @@ import org.neo4j.server.rest.paging.LeaseManager;
 import org.neo4j.server.rest.web.DatabaseActions;
 import org.neo4j.tooling.Clock;
 import org.neo4j.tooling.FakeClock;
-
-import static java.lang.String.format;
 
 import static org.neo4j.server.ServerTestUtils.asOneLine;
 import static org.neo4j.server.ServerTestUtils.createTempPropertyFile;
@@ -484,33 +479,5 @@ public class ServerBuilder
     {
         this.preflightTasks = new PreFlightTasks( DevNullLoggingService.DEV_NULL, tasks );
         return this;
-    }
-
-    public static Logging bufferingLogging()
-    {
-        final BufferingLogger log = new BufferingLogger();
-        final BufferingConsoleLogger console = new BufferingConsoleLogger();
-        return new Logging()
-        {
-            @Override
-            public StringLogger getMessagesLog( Class loggingClass )
-            {
-                return log;
-            }
-
-            @Override
-            public ConsoleLogger getConsoleLog( Class loggingClass )
-            {
-                return console;
-            }
-
-            @Override
-            public String toString()
-            {
-                StringBuilder builder = new StringBuilder();
-                builder.append( log.toString() ).append( format( "%n" ) ).append( console.toString() );
-                return builder.toString();
-            }
-        };
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
+++ b/community/server/src/test/java/org/neo4j/server/preflight/TestPreflightTasks.java
@@ -22,6 +22,7 @@ package org.neo4j.server.preflight;
 import org.junit.Test;
 
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.test.BufferingLogging;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
@@ -30,7 +31,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.kernel.logging.DevNullLoggingService.DEV_NULL;
-import static org.neo4j.server.helpers.ServerBuilder.bufferingLogging;
 
 public class TestPreflightTasks
 {
@@ -58,7 +58,7 @@ public class TestPreflightTasks
     @Test
     public void shouldLogFailedRule()
     {
-        Logging logging = bufferingLogging();
+        Logging logging = new BufferingLogging();
         PreFlightTasks check = new PreFlightTasks( logging, getWithOneFailingRule() );
         check.run();
 

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty6WebServer.java
@@ -39,7 +39,7 @@ import org.neo4j.server.WrappingNeoServer;
 import org.neo4j.server.WrappingNeoServerBootstrapper;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerConfigurator;
-import org.neo4j.server.helpers.ServerBuilder;
+import org.neo4j.test.BufferingLogging;
 import org.neo4j.test.ImpermanentGraphDatabase;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -115,7 +115,7 @@ public class TestJetty6WebServer {
     @Test
     public void shouldBeAbleToSetExecutionLimit() throws Throwable
     {
-        Logging logging = ServerBuilder.bufferingLogging();
+        Logging logging = new BufferingLogging();
         final Guard dummyGuard = new Guard(StringLogger.SYSTEM);
         ImpermanentGraphDatabase db = new ImpermanentGraphDatabase( "path", stringMap(),
                 new DefaultGraphDatabaseDependencies( logging ) )


### PR DESCRIPTION
By introducing a new specific exception class that such code can throw,
and which will be caught and handled specifically in TxManager. Such a
failure will still throw exception out to the user, but will not set the
transaction in not OK state (which would require a restart/recovery to come back).
