### PR TITLE
Switches to master/slave role in separate and single thread

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/NamedThreadFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/NamedThreadFactory.java
@@ -53,4 +53,14 @@ public class NamedThreadFactory implements ThreadFactory
         result.setPriority( priority );
         return result;
     }
+
+    public static ThreadFactory named( String threadNamePrefix )
+    {
+        return new NamedThreadFactory( threadNamePrefix );
+    }
+
+    public static ThreadFactory named( String threadNamePrefix, int priority )
+    {
+        return new NamedThreadFactory( threadNamePrefix, priority );
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -26,9 +26,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.transaction.TransactionManager;
 
 import org.neo4j.cluster.BindingListener;
@@ -92,6 +94,7 @@ import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.helpers.Functions.withDefaults;
+import static org.neo4j.helpers.NamedThreadFactory.named;
 import static org.neo4j.helpers.Settings.INTEGER;
 import static org.neo4j.helpers.Uris.parameter;
 import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
@@ -144,8 +147,10 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
     private final RequestContextFactory requestContextFactory;
     private MasterClientResolver masterClientResolver;
 
-    private ScheduledExecutorService scheduledExecutorService;
+    private ScheduledExecutorService modeSwitcherExecutor;
     private volatile URI me;
+    private volatile Future<?> modeSwitcherFuture;
+    private volatile HighAvailabilityMemberState currentTargetState;
 
     public HighAvailabilityModeSwitcher( BindingNotifier bindingNotifier,
                                          DelegateInvocationHandler<Master> delegateHandler,
@@ -172,7 +177,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
     @Override
     public synchronized void init() throws Throwable
     {
-        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(  );
+        modeSwitcherExecutor = Executors.newSingleThreadScheduledExecutor( named( "HA Mode switcher" ) );
 
         stateHandler.addHighAvailabilityMemberListener( this );
         bindingListener = new BindingListener()
@@ -205,9 +210,9 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         stateHandler.removeHighAvailabilityMemberListener( this );
         bindingNotifier.removeBindingListener( bindingListener );
 
-        scheduledExecutorService.shutdown();
+        modeSwitcherExecutor.shutdown();
 
-        scheduledExecutorService.awaitTermination( 60, TimeUnit.SECONDS );
+        modeSwitcherExecutor.awaitTermination( 60, TimeUnit.SECONDS );
 
         haCommunicationLife.shutdown();
     }
@@ -257,6 +262,8 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         {
             return;
         }
+
+        currentTargetState = event.getNewState();
         switch ( event.getNewState() )
         {
             case TO_MASTER:
@@ -294,53 +301,65 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
 
     private void switchToMaster()
     {
-        msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) + ", moving to master" );
-        try
+        startModeSwitching( new Runnable()
         {
-            DependencyResolver resolver = graphDb.getDependencyResolver();
-            HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency( HaXaDataSourceManager.class );
-            /*
-             * Synchronizing on the xaDataSourceManager makes sense if you also look at HaKernelPanicHandler. In
-             * particular, it is possible to get a masterIsElected while recovering the database. That is generally
-             * going to break things. Synchronizing on the xaDSM as HaKPH does solves this.
-             */
-            //noinspection SynchronizationOnLocalVariableOrMethodParameter
-            synchronized ( xaDataSourceManager )
+            @Override
+            public void run()
             {
-                final TransactionManager txManager = graphDb.getDependencyResolver()
-                        .resolveDependency( TransactionManager.class );
+                if ( currentTargetState != HighAvailabilityMemberState.TO_MASTER )
+                {
+                    return;
+                }
 
-                idGeneratorFactory.switchToMaster();
+                msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) + ", moving to master" );
+                try
+                {
+                    DependencyResolver resolver = graphDb.getDependencyResolver();
+                    HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency( HaXaDataSourceManager.class );
+                    /*
+                     * Synchronizing on the xaDataSourceManager makes sense if you also look at HaKernelPanicHandler. In
+                     * particular, it is possible to get a masterIsElected while recovering the database. That is generally
+                     * going to break things. Synchronizing on the xaDSM as HaKPH does solves this.
+                     */
+                    //noinspection SynchronizationOnLocalVariableOrMethodParameter
+                    synchronized ( xaDataSourceManager )
+                    {
+                        final TransactionManager txManager = graphDb.getDependencyResolver()
+                                .resolveDependency( TransactionManager.class );
 
-                Monitors monitors = graphDb.getDependencyResolver().resolveDependency( Monitors.class );
+                        idGeneratorFactory.switchToMaster();
 
-                MasterImpl.SPI spi = new DefaultMasterImplSPI( graphDb, logging, txManager, monitors );
+                        Monitors monitors = graphDb.getDependencyResolver().resolveDependency( Monitors.class );
 
-                MasterImpl masterImpl = new MasterImpl( spi, logging, config );
+                        MasterImpl.SPI spi = new DefaultMasterImplSPI( graphDb, logging, txManager, monitors );
 
-                MasterServer masterServer = new MasterServer( masterImpl, logging, serverConfig(),
-                        new BranchDetectingTxVerifier( graphDb ),
-                        monitors );
-                haCommunicationLife.add( masterImpl );
-                haCommunicationLife.add( masterServer );
-                assignMaster( masterImpl );
+                        MasterImpl masterImpl = new MasterImpl( spi, logging, config );
 
-                haCommunicationLife.start();
+                        MasterServer masterServer = new MasterServer( masterImpl, logging, serverConfig(),
+                                new BranchDetectingTxVerifier( graphDb ),
+                                monitors );
+                        haCommunicationLife.add( masterImpl );
+                        haCommunicationLife.add( masterServer );
+                        assignMaster( masterImpl );
 
-                masterHaURI = URI.create( "ha://" + (ServerUtil.getHostString( masterServer.getSocketAddress() ).contains
-                        ( "0.0.0.0" ) ? me.getHost() : ServerUtil.getHostString( masterServer.getSocketAddress() )) + ":" +
-                        masterServer.getSocketAddress().getPort() + "?serverId=" +
-                        config.get( ClusterSettings.server_id ) );
-                clusterMemberAvailability.memberIsAvailable( MASTER, masterHaURI );
-                msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) +
-                        ", successfully moved to master" );
+                        haCommunicationLife.start();
+
+                        masterHaURI = URI.create( "ha://" + (ServerUtil.getHostString( masterServer.getSocketAddress() ).contains
+                                ( "0.0.0.0" ) ? me.getHost() : ServerUtil.getHostString( masterServer.getSocketAddress() )) + ":" +
+                                masterServer.getSocketAddress().getPort() + "?serverId=" +
+                                config.get( ClusterSettings.server_id ) );
+                        clusterMemberAvailability.memberIsAvailable( MASTER, masterHaURI );
+                        msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) +
+                                ", successfully moved to master" );
+                    }
+                }
+                catch ( Throwable e )
+                {
+                    msgLog.logMessage( "Failed to switch to master", e );
+                    return;
+                }
             }
-        }
-        catch ( Throwable e )
-        {
-            msgLog.logMessage( "Failed to switch to master", e );
-            return;
-        }
+        } );
     }
 
     private void assignMaster( Master master )
@@ -364,15 +383,16 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 config.get( HaSettings.lock_read_timeout ).intValue(),
                 config.get( HaSettings.max_concurrent_channels_per_slave ).intValue(),
                 config.get( HaSettings.com_chunk_size ).intValue()  );
-        
+
         // Do this with a scheduler, so that if it fails, it can retry later with an exponential backoff with max wait time.
         final AtomicLong wait = new AtomicLong();
-        scheduledExecutorService.schedule( new Runnable()
+        startModeSwitching( new Runnable()
         {
             @Override
             public void run()
             {
-                if (haCommunicationLife.getStatus() == LifecycleStatus.STARTED)
+                if (haCommunicationLife.getStatus() == LifecycleStatus.STARTED ||
+                        currentTargetState != HighAvailabilityMemberState.TO_SLAVE)
                 {
                     return; // Already switched - this can happen if a second master becomes available while waiting
                 }
@@ -426,11 +446,22 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 wait.set( (1 + wait.get()*2) ); // Exponential backoff
                 wait.set(Math.min(wait.get(), 5*60)); // Wait maximum 5 minutes
 
-                scheduledExecutorService.schedule( this, wait.get(), TimeUnit.SECONDS );
+                modeSwitcherFuture = modeSwitcherExecutor.schedule( this, wait.get(), TimeUnit.SECONDS );
 
                 msgLog.logMessage( "Attempting to switch to slave in "+wait.get()+"s");
             }
-        }, wait.get(), TimeUnit.SECONDS);
+        } );
+    }
+
+    private void startModeSwitching( Runnable switcher )
+    {
+        if ( modeSwitcherFuture != null )
+        {
+            // Cancel any delayed previous switching
+            modeSwitcherFuture.cancel( false );
+        }
+
+        modeSwitcherFuture = modeSwitcherExecutor.submit( switcher );
     }
 
     private boolean startHaCommunication( HaXaDataSourceManager xaDataSourceManager,
@@ -649,7 +680,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         {
             graphDb.getDependencyResolver().resolveDependency( serviceClass ).stop();
         }
-        
+
         branchPolicy.handle( config.get( InternalAbstractGraphDatabase.Configuration.store_dir ) );
     }
 


### PR DESCRIPTION
Previously switching to master happened in the state machine event thread
which introduced problems if that for some reason took a long time since
no other events could be processed and eventually this instance to become
master would be suspect of suspicions from the other instance. This would
add instabilities during master switches and prolong some switches as
well.

Now the switching happens in a separate, yet single, thread that is shared
by both the slave and master switching and so they cannot happen
concurrently either.
