### PR TITLE
Calls doAfterCompletion in TxManager#commit/rollback

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -1430,6 +1430,10 @@ public abstract class InternalAbstractGraphDatabase
             {
                 return (T) DependencyResolverImpl.this;
             }
+            else if ( KernelHealth.class.isAssignableFrom( type ) )
+            {
+                return (T) kernelHealth;
+            }
             return null;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionImpl.java
@@ -99,17 +99,17 @@ class TransactionImpl implements Transaction
     {
         return globalId;
     }
-    
+
     boolean hasChanges()
     {
         return hasChanges;
     }
-    
+
     public TransactionState getState()
     {
         return state;
     }
-    
+
     private String getStatusAsString()
     {
         return txManager.getTxStatusAsString( status ) + (active ? "" : " (suspended)");
@@ -420,19 +420,22 @@ class TransactionImpl implements Transaction
 
 	synchronized void doAfterCompletion()
     {
-        for ( Synchronization s : syncHooks )
-        {
-            try
+	    if ( syncHooks != null )
+	    {
+            for ( Synchronization s : syncHooks )
             {
-                s.afterCompletion( status );
+                try
+                {
+                    s.afterCompletion( status );
+                }
+                catch ( Throwable t )
+                {
+                    logger.warn( "Caught exception from tx syncronization[" + s
+                            + "] afterCompletion()", t );
+                }
             }
-            catch ( Throwable t )
-            {
-                logger.warn( "Caught exception from tx syncronization[" + s
-                        + "] afterCompletion()", t );
-            }
-        }
-        syncHooks = null; // help gc
+            syncHooks = null; // help gc
+	    }
     }
 
     @Override
@@ -687,7 +690,7 @@ class TransactionImpl implements Transaction
         }
         active = false;
     }
-    
+
     public ForceMode getForceMode()
     {
         return forceMode;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -340,6 +340,8 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         }
         finally
         {
+            // Call after completion as a safety net
+            tx.doAfterCompletion();
             txThreadMap.remove();
             tx.finish( successful );
         }
@@ -598,6 +600,8 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         }
         finally
         {
+            // Call after completion as a safety net
+            tx.doAfterCompletion();
             txThreadMap.remove();
             tx.finish( false );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/FakeXAResource.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/FakeXAResource.java
@@ -142,4 +142,25 @@ public class FakeXAResource implements XAResource
             new Integer( flags ) }, new String[] { "javax.transaction.xa.Xid",
             "java.lang.Integer" } ) );
     }
+
+    public static class FailingFakeXAResource extends FakeXAResource
+    {
+        private boolean failInCommit;
+
+        public FailingFakeXAResource( String name, boolean failInCommit )
+        {
+            super( name );
+            this.failInCommit = failInCommit;
+        }
+
+        @Override
+        public void commit( Xid xid, boolean onePhase )
+        {
+            if ( failInCommit )
+            {
+                throw new RuntimeException( "I was told to fail" );
+            }
+            super.commit( xid, onePhase );
+        }
+    }
 }


### PR DESCRIPTION
since vital functions happen there, for example lock releasing. Previously
there were a scenario where a transaction started and ran into a "tm not OK"
exception on commit, where the after completions wouldn't be called.
This might happen if the tm not OK came from a kernel panic and a handler
brought the db back on its feet again.
