### PR TITLE
Fixes issue with state bookkeeping for reporting instance role

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.ha.cluster.member;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.cluster.InstanceId;
@@ -115,7 +116,17 @@ public class ClusterMember
 
     ClusterMember availableAs( String role, URI roleUri )
     {
-        return new ClusterMember( this.memberId, MapUtil.copyAndPut( roles, role, roleUri ), this.alive );
+        Map<String, URI> copy = new HashMap<String, URI>( roles );
+        if ( role.equals( HighAvailabilityModeSwitcher.MASTER ) )
+        {
+            copy.remove( HighAvailabilityModeSwitcher.SLAVE );
+        }
+        else if ( role.equals( HighAvailabilityModeSwitcher.SLAVE ) )
+        {
+            copy.remove( HighAvailabilityModeSwitcher.MASTER );
+        }
+        copy.put( role, roleUri );
+        return new ClusterMember( this.memberId, copy, this.alive );
     }
 
     ClusterMember unavailableAs( String role )


### PR DESCRIPTION
There are some cases where an instance can switch from MASTER to
 SLAVE without broadcasting the masterIsUnavailable event. In this
 case we cobble the state kept in ClusterMembers and can end up
 reporting the wrong role. This fix introduces knowledge of
 the mutual exclusion of MASTER and SLAVE roles in ClusterMember,
 ensuring that when one is received, the other is properly
 removed.
