### PR TITLE
Get rid of dependencies on native xml+docbook and w3m.

### DIFF
--- a/community/neo4j/src/docs/ops/upgrades.asciidoc
+++ b/community/neo4j/src/docs/ops/upgrades.asciidoc
@@ -3,8 +3,8 @@
 Upgrading
 =========
 
-A database can be upgraded from a minor version to the next, e.g. 1.1 -> 1.2, and 1.2 -> 1.3,
-but you can not jump directly from 1.1 -> 1.3. For version 1.8 in particular, it is possible to
+A database can be upgraded from a minor version to the next, e.g. 1.6 -> 1.7, and 1.7 -> 1.8,
+but you can not jump directly from 1.6 -> 1.8. For version 1.8 in particular, it is possible to
 upgrade directly from version 1.5.3 and later, as an explicit upgrade.
 The upgrade process is a one way step; databases cannot be downgraded. 
 
@@ -14,20 +14,19 @@ automatically when you start up the database using the newer version of Neo4j.
 However, some upgrades require more significant changes to the database store.
 In these cases, Neo4j will refuse to start without explicit configuration to allow the upgrade.
 
-The table below lists recent Neo4j versions, and the type of upgrade required.
+.Upgrade process for recent Neo4j versions
 
-.Upgrade process for Neo4j version
-[format="csv",width="50%",cols="3",options="header"]
-|====
-From Version,To Version,Upgrade Type
-1.3,1.4,Automatic
-1.4,1.5,Explicit
-1.5,1.6,Explicit
-1.6,1.7,Automatic
-1.7,1.8,Automatic
-1.8,1.9,Automatic
-1.9,2.0,Explicit
-|====
+1.6 -> 1.7::
+Automatic
+
+1.7 -> 1.8::
+Automatic
+
+1.8 -> 1.9::
+Automatic
+
+1.9 -> 2.0::
+Explicit
 
 [NOTE]
 Downgrade is supported only between versions which do not have incompatible store layouts.
@@ -177,29 +176,4 @@ In an HA environment these steps need to be performed:
 . remove the databases except the master and start the master database with 1.7
 . start up the other databases so that they get a copy from the master
 
-[[deployment-upgrading-one-six]]
-== Upgrade 1.5 -> 1.6 ==
-
-This upgrade changes lucene version from 3.1 to 3.5. The upgrade itself is done by Lucene by loading an index.
-
-In an HA environment these steps need to be performed:
-
-. shut down all the databases in the cluster
-. shut down the ZooKeeper cluster and clear the 'version-2' directories on all the ZooKeeper instances
-. start the ZooKeeper cluster again
-. start up the other databases so that they get a copy from the master
-
-[[deployment-upgrading-one-five]]
-== Upgrade 1.4 -> 1.5 ==
-
-This upgrade includes a significant change to the layout of property store files, which reduces their size on disk,
-and improves IO performance.  To achieve this layout change, the upgrade process takes some time to process the
-whole of the existing database.  You should budget for several minutes per gigabyte of data as part of your upgrade planning.
-
-[WARNING]
-The upgrade process for this upgrade temporarily requires additional disk space, for the period while the
-upgrade is in progress.  Before starting the upgrade to Neo4j 1.5, you should ensure that the machine performing the
-upgrade has free space equal to the current size of of the database on disk.  You can find the current space occupied
-by the database by inspecting the store file directory ('data/graph.db' is the default location in Neo4j server).
-Once the upgrade is complete, this additional space is no longer required.
 

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -16,5 +16,5 @@ include $(make_dir)/context-manual.make
 
 manpage_list = "neo4j server" "neo4j-installer server" "neo4j-arbiter server" "neo4j-coordinator server" "neo4j-coordinator-shell server" "neo4j-shell shell" "neo4j-backup backup"
 
-webhelp_dist: initialize install-extensions manpages copy-images docbook-html upgrade year-check
+webhelp_dist: initialize install-extensions manpages copy-images docbook-html year-check
 # cleanup

--- a/manual/README.asciidoc
+++ b/manual/README.asciidoc
@@ -7,7 +7,7 @@ The documents use the asciidoc format, see:
 
 == Building the documentation ==
 
-Python is required, as well as graphviz.
+Python is required, as well as graphviz and make.
 
 http://maven.apache.org/[Apache Maven] together with http://www.gnu.org/software/make/[Make] are used to unpack the pieces of the manual and to execute asciidoc on them.
 Note that running parallel jobs with Make (-j option) is not supported.
@@ -29,7 +29,7 @@ Install libraries
 
 === With apt-get on Ubuntu ===
 
-  sudo apt-get install graphviz maven libxml2-utils
+  sudo apt-get install graphviz maven make
 
 
 

--- a/manual/common/css/style.css
+++ b/manual/common/css/style.css
@@ -285,6 +285,10 @@ hr {
   border-top: 0 none;
 }
 
+dl.variablelist > dd {
+  margin-bottom: 0.75em;
+}
+
 span.contentsTab {
   padding-left: 0;
   background: none;

--- a/manual/common/main.js
+++ b/manual/common/main.js
@@ -48,7 +48,7 @@ function addBootstrapStyling()
   var $content = $('#content section');
   $('img', $content).addClass('img-responsive');
   $('div.admonitionblock img', $content).removeClass('img-responsive');
-  $('dl', $content).addClass('dl-horizontal');
+  $('#deployment-requirements dl, #rest-api-traverse dl').addClass('dl-horizontal');
   $('div.table table,div.informaltable table', $content).addClass('table table-condensed table-hover');
   var $admonblocks = $('div.admonitionblock');
   $admonblocks.filter('.Note').find('td.content').addClass('alert alert-info');

--- a/manual/conf/text.xsl
+++ b/manual/conf/text.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+  xmlns:d="http://docbook.org/ns/docbook" exclude-result-prefixes="d">
+
+  <xsl:import href="urn:docbkx:stylesheet" />
+
+  <!-- parameters for optimal text output -->
+  <xsl:param name="callout.graphics" select="0"/>
+  <xsl:param name="callout.unicode" select="0"/>
+  <xsl:param name="section.autolabel" select="1"/>
+  <xsl:param name="section.label.includes.component.label" select="1"/>
+  <xsl:param name="generate.toc">
+  article   toc,title
+  </xsl:param>
+
+  <xsl:template match="d:article/d:articleinfo/d:title" mode="titlepage.mode">
+      <hr />
+        <xsl:apply-imports/>
+      <hr />
+  </xsl:template>
+
+  <xsl:template match="d:article/*/d:title" mode="titlepage.mode">
+      <hr />
+        <xsl:apply-imports/>
+      <hr />
+  </xsl:template>
+
+  <xsl:template match="d:article/d:section/*/d:title" mode="titlepage.mode">
+        <xsl:apply-imports/>
+      <hr width="100" align="left" />
+  </xsl:template>
+  
+  <xsl:template match="d:varlistentry">
+    <dt>
+      <xsl:call-template name="id.attribute"/>
+      <xsl:call-template name="anchor"/>
+      <xsl:apply-templates select="d:term"/>
+    </dt>
+    <dd>
+      <xsl:apply-templates select="d:listitem"/>
+    </dd>
+    <br />
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -24,7 +24,7 @@
     <docs.images>${project.build.outputDirectory}/images</docs.images>
     <docs.tools>${project.build.directory}/tools</docs.tools>
     <neo4j.version>${project.version}</neo4j.version>
-    <doctools.version>16</doctools.version>
+    <doctools.version>18</doctools.version>
     <attach-docs-phase>none</attach-docs-phase>
     <maven.site.skip>true</maven.site.skip>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -358,6 +358,22 @@
               </arguments>
             </configuration>
           </execution>
+          <execution>
+            <id>execute-asciidoc-for-upgrades</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${docs.tools}/bin/asciidoc/asciidoc.py</executable>
+              <arguments>
+                <argument>--backend=docbook</argument>
+                <argument>--attribute=neo4j-version=${project.version}</argument>
+                <argument>--out-file=${project.build.directory}/upgrade/upgrades.xml</argument>
+                <argument>${project.build.directory}/docs/neo4j-docs-jar/ops/upgrades.asciidoc</argument>
+              </arguments>
+            </configuration>
+          </execution>
         </executions>
         <dependencies>
           <dependency>
@@ -368,19 +384,115 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>gmaven-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>create-upgrade-dir</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <upgradeDir>${project.build.directory}/upgrade</upgradeDir>
+              </properties>
+              <source>
+                new File( project.properties.upgradeDir ).mkdirs()
+              </source>
+            </configuration>
+          </execution>
+          <execution>
+            <id>transform-upgrade-html-to-text</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <upgradehtmlLocation>file://${project.build.directory}/docbkx/html/upgrade/upgrades.html</upgradehtmlLocation>
+                <outputFile>${project.build.directory}/upgrade/UPGRADE.txt</outputFile>
+              </properties>
+              <source>
+                import net.htmlparser.jericho.Source
+                import net.htmlparser.jericho.Renderer
+                Source source = new Source( new URL( project.properties.upgradehtmlLocation ) )
+                Renderer renderer = source.getRenderer().setMaxLineLength( 80 ).setConvertNonBreakingSpaces( true )
+                new File( project.properties.outputFile ).write( renderer.toString(), 'UTF-8' )
+              </source>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>it.unimi.di.law</groupId>
+            <artifactId>jericho-html-dev</artifactId>
+            <version>20131217</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>validate-docbook</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>${project.build.directory}</dir>
+              <includes>
+                <include>*.xml</include>
+                <include>upgrade/*.xml</include>
+              </includes>
+            </validationSet>
+          </validationSets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.agilejava.docbkx</groupId>
         <artifactId>docbkx-maven-plugin</artifactId>
         <version>2.0.15</version>
         <executions>
           <execution>
+            <id>generate-manpages</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>generate-manpages</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/manpages</sourceDirectory>
+            <postProcess>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j.1" destfile="${project.build.directory}/manpages/neo4j.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-shell.1" destfile="${project.build.directory}/manpages/neo4j-shell.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-installer.1" destfile="${project.build.directory}/manpages/neo4j-installer.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-backup.1" destfile="${project.build.directory}/manpages/neo4j-backup.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-arbiter.1" destfile="${project.build.directory}/manpages/neo4j-arbiter.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-coordinator.1" destfile="${project.build.directory}/manpages/neo4j-coordinator.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-coordinator-shell.1" destfile="${project.build.directory}/manpages/neo4j-coordinator-shell.1.gz"/>
+            </postProcess>
+            </configuration>
+          </execution>
+          <execution>
             <id>generate-webhelp-html</id>
-            <phase>prepare-package</phase>
+            <phase>process-classes</phase>
             <goals>
               <goal>generate-webhelp</goal>
             </goals>
             <configuration>
               <includes>neo4j-manual-html.xml</includes>
+              <webhelpCustomization>conf/webhelp.xsl</webhelpCustomization>
               <admonGraphicsPath>images/icons/admon/</admonGraphicsPath>
+              <generateLegalnoticeLink>true</generateLegalnoticeLink>
+              <useIdAsFilename>true</useIdAsFilename>
               <generateToc>
                 article toc,title
                 book toc,title
@@ -399,6 +511,13 @@
                 section toc
                 set toc,title
               </generateToc>
+              <preProcess>
+                <move todir="${project.build.directory}" overwrite="true">
+                  <fileset dir="${project.build.directory}/manpages">
+                    <include name="*.xml"/>
+                  </fileset>
+                </move>
+              </preProcess>
               <postProcess>
                 <copy todir="${project.build.directory}/docbkx/webhelp/images" overwrite="true">
                   <fileset dir="${docs.tools}/main/resources/images"/>
@@ -419,6 +538,24 @@
             </configuration>
           </execution>
           <execution>
+            <id>generate-upgrade-html</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>generate-html</goal>
+            </goals>
+            <configuration>
+              <includes>upgrade/upgrades.xml</includes>
+              <calloutGraphics>false</calloutGraphics>
+              <navigGraphics>false</navigGraphics>
+              <admonTextlabel>true</admonTextlabel>
+              <admonGraphics>false</admonGraphics>
+              <htmlCustomization>conf/text.xsl</htmlCustomization>
+              <preProcess>
+                <replace file="${project.build.directory}/upgrade/upgrades.xml" encoding="UTF-8" token="&amp;#8594;" value="--&gt;" />
+              </preProcess>
+            </configuration>
+          </execution>
+          <execution>
             <id>generate-pdf</id>
             <!-- requires the "docbook" goal to be executed in make. -->
             <phase>none</phase>
@@ -427,6 +564,8 @@
             </goals>
             <configuration>
               <includes>neo4j-manual-shortinfo.xml</includes>
+              <foCustomization>conf/fo.xsl</foCustomization>
+              <externalFOPConfiguration>conf/fop.xml</externalFOPConfiguration>
               <generateToc>
                 book toc
                 part toc
@@ -436,9 +575,6 @@
         </executions>
         <configuration>
           <xincludeSupported>true</xincludeSupported>
-          <webhelpCustomization>conf/webhelp.xsl</webhelpCustomization>
-          <foCustomization>conf/fo.xsl</foCustomization>
-          <externalFOPConfiguration>conf/fop.xml</externalFOPConfiguration>
           <glossarySort>true</glossarySort>
           <tocMaxDepth>2</tocMaxDepth>
           <generateSectionTocLevel>1</generateSectionTocLevel>
@@ -446,8 +582,6 @@
           <admonGraphicsExtension>.svg</admonGraphicsExtension>
           <htmlExt>.html</htmlExt>
           <chunkerOutputOmitXmlDeclaration>yes</chunkerOutputOmitXmlDeclaration>
-          <generateLegalnoticeLink>true</generateLegalnoticeLink>
-          <useIdAsFilename>true</useIdAsFilename>
           <chunkSectionDepth>1</chunkSectionDepth>
           <chapterAutolabel>1</chapterAutolabel>
           <sectionAutolabel>1</sectionAutolabel>

--- a/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/neo4j-advanced.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/neo4j-advanced.install
@@ -5,7 +5,6 @@ server/UPGRADE.txt  var/lib/neo4j
 
 server/data/README.txt var/lib/neo4j/data
 
-server/doc          var/lib/neo4j
 server/bin          var/lib/neo4j
 
 server/lib          usr/share/neo4j

--- a/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/neo4j-arbiter.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/neo4j-arbiter.install
@@ -5,8 +5,6 @@ server/UPGRADE.txt      var/lib/neo4j-arbiter
 
 server/data/README.txt  var/lib/neo4j-arbiter/data
 
-server/doc              var/lib/neo4j-arbiter
-
 server/bin/neo4j-arbiter            var/lib/neo4j-arbiter/bin
 server/bin/neo4j-coordinator        var/lib/neo4j-arbiter/bin
 server/bin/neo4j-coordinator-shell  var/lib/neo4j-arbiter/bin

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.install
@@ -5,7 +5,6 @@ server/UPGRADE.txt  var/lib/neo4j
 
 server/data/README.txt var/lib/neo4j/data
 
-server/doc          var/lib/neo4j
 server/bin          var/lib/neo4j
 
 server/lib          usr/share/neo4j

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.install
@@ -5,7 +5,6 @@ server/UPGRADE.txt  var/lib/neo4j
 
 server/data/README.txt var/lib/neo4j/data
 
-server/doc          var/lib/neo4j
 server/bin          var/lib/neo4j
 
 server/lib          usr/share/neo4j

--- a/packaging/installer-linux/installer-rpm/pom.xml
+++ b/packaging/installer-linux/installer-rpm/pom.xml
@@ -83,17 +83,6 @@
                             </mapping>
 
                             <mapping>
-                                <documentation>true</documentation>
-                                <sources>
-                                    <source>
-                                        <location>${project.build.directory}/neo4j-${edition}-${neo4j.version}/doc
-                                        </location>
-                                    </source>
-                                </sources>
-                                <directory>/usr/share/doc/neo4j</directory>
-                            </mapping>
-
-                            <mapping>
                                 <sources>
                                     <source>
                                         <location>${project.build.directory}/neo4j-${edition}-${neo4j.version}/bin

--- a/packaging/installer-linux/installer-rpm/process-resources.build.xml
+++ b/packaging/installer-linux/installer-rpm/process-resources.build.xml
@@ -3,8 +3,6 @@
 
     <untar src="${project.build.directory}/neo4j-${edition}-${neo4j.version}-unix.tar.gz"
            compression="gzip" dest="${project.build.directory}"/>
-    <fixcrlf srcdir="${project.build.directory}/neo4j-${edition}-${neo4j.version}/doc"
-             includes="**/*" tab="asis"/>
 
     <replaceregexp
             file="${project.build.directory}/neo4j-${edition}-${neo4j.version}/conf/neo4j-server.properties"

--- a/packaging/standalone/standalone-advanced/pom.xml
+++ b/packaging/standalone/standalone-advanced/pom.xml
@@ -109,25 +109,6 @@ terms of the relevant Commercial Agreement.
             <id>get-javadoc-sources</id>
             <phase>none</phase>
           </execution>
-          <execution>
-            <id>unpack-manpages</id>
-            <phase>generate-resources</phase>
-            <goals><goal>unpack</goal></goals>
-             <configuration>
-               <artifactItems>
-                 <artifactItem>
-                  <groupId>org.neo4j.doc</groupId>
-                  <artifactId>neo4j-manual</artifactId>
-                  <version>${neo4j.version}</version>
-                  <classifier>manpages</classifier>
-                  <type>jar</type>
-                  <outputDirectory>${project.build.directory}/manpages</outputDirectory>
-                  <includes>*.txt,**/*.txt</includes>
-                  <excludes>META-INF/**</excludes>
-                 </artifactItem>
-               </artifactItems>
-             </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -95,15 +95,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
@@ -67,16 +67,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <lineEnding>dos</lineEnding>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
   
 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/README.txt
@@ -16,7 +16,6 @@ Here in the installation directory, you'll find:
 * bin - scripts and other executables
 * conf - server configuration
 * data - database, log, and other variable files
-* doc - command line reference
 * lib - core libraries
 * plugins - user extensions
 * system - super-secret server stuff

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -109,25 +109,6 @@ terms of the relevant Commercial Agreement.
             <id>get-javadoc-sources</id>
             <phase>none</phase>
           </execution>
-          <execution>
-            <id>unpack-manpages</id>
-            <phase>generate-resources</phase>
-            <goals><goal>unpack</goal></goals>
-             <configuration>
-               <artifactItems>
-                 <artifactItem>
-                  <groupId>org.neo4j.doc</groupId>
-                  <artifactId>neo4j-manual</artifactId>
-                  <version>${neo4j.version}</version>
-                  <classifier>manpages</classifier>
-                  <type>jar</type>
-                  <outputDirectory>${project.build.directory}/manpages</outputDirectory>
-                  <includes>*.txt,**/*.txt</includes>
-                  <excludes>META-INF/**</excludes>
-                 </artifactItem>
-               </artifactItems>
-             </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -82,15 +82,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -67,16 +67,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <lineEnding>dos</lineEnding>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
@@ -16,7 +16,6 @@ Here in the installation directory, you'll find:
 * bin - scripts and other executables
 * conf - server configuration
 * data - database, log, and other variable files
-* doc - command line reference
 * lib - core libraries
 * plugins - user extensions
 * system - super-secret server stuff

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -109,25 +109,6 @@ terms of the relevant Commercial Agreement.
             <id>get-javadoc-sources</id>
             <phase>none</phase>
           </execution>
-          <execution>
-            <id>unpack-manpages</id>
-            <phase>generate-resources</phase>
-            <goals><goal>unpack</goal></goals>
-             <configuration>
-               <artifactItems>
-                 <artifactItem>
-                  <groupId>org.neo4j.doc</groupId>
-                  <artifactId>neo4j-manual</artifactId>
-                  <version>${neo4j.version}</version>
-                  <classifier>manpagesenterprise</classifier>
-                  <type>jar</type>
-                  <outputDirectory>${project.build.directory}/manpages</outputDirectory>
-                  <includes>*.txt,**/*.txt</includes>
-                  <excludes>META-INF/**</excludes>
-                 </artifactItem>
-               </artifactItems>
-             </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -94,15 +94,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -62,16 +62,6 @@
         <include>UPGRADE.txt</include>
       </includes>
     </fileSet>
-    <!-- die manpages -->
-    <fileSet>
-      <directory>target/manpages</directory>
-      <outputDirectory>/doc</outputDirectory>
-      <fileMode>0644</fileMode>
-      <lineEnding>dos</lineEnding>
-      <includes>
-        <include>*.txt</include>
-      </includes>
-    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/README.txt
@@ -17,7 +17,6 @@ Here in the installation directory, you'll find:
 * bin - scripts and other executables
 * conf - server configuration
 * data - database, log, and other variable files
-* doc - command line reference
 * lib - core libraries
 * plugins - user extensions
 * system - super-secret server stuff


### PR DESCRIPTION
- Validate docbook xml using mvn.
- Build manpages using mvn.
- Remove manpages in text format.
- Use jericho instead of  w3m.
- Fix bug with missing content in UPGRADE.txt.
- Make the text in UPGRADE.txt more readable.
