### PR TITLE
Fixes a cache poisoning issue.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.core;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -291,7 +292,7 @@ public class NodeImpl extends ArrayBasedPrimitive
                 updateSize( nodeManager );
             }
         }
-        if ( rels != null )
+        if ( rels != null && rels.second().size() > 0 )
         {
             nodeManager.putAllInRelCache( rels.second() );
         }
@@ -351,15 +352,16 @@ public class NodeImpl extends ArrayBasedPrimitive
     {
         if ( !hasMoreRelationshipsToLoad( direction, types ) )
         {
-            return null;
+            return Triplet.of( null, Collections.<RelationshipImpl>emptyList(), relChainPosition );
         }
+
         Triplet<ArrayMap<Integer, RelIdArray>, List<RelationshipImpl>,RelationshipLoadingPosition> rels =
                 loadMoreRelationshipsFromNodeManager( nodeManager, direction, types );
 
         ArrayMap<Integer, RelIdArray> addMap = rels.first();
         if ( addMap.size() == 0 )
         {
-            return null;
+            return rels;
         }
         for ( Integer type : addMap.keySet() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -98,7 +98,7 @@ public abstract class KernelIntegrationTest
     public void setup()
     {
         fs = new EphemeralFileSystemAbstraction();
-        startDb();
+        startDb("soft");
     }
 
     @After
@@ -108,15 +108,21 @@ public abstract class KernelIntegrationTest
         fs.shutdown();
     }
 
-    protected void startDb()
+    protected void startDb(String cacheType)
     {
         TestGraphDatabaseBuilder graphDatabaseFactory = (TestGraphDatabaseBuilder) new TestGraphDatabaseFactory().setFileSystem(fs).newImpermanentDatabaseBuilder();
 
         //noinspection deprecation
-        db = (GraphDatabaseAPI) graphDatabaseFactory.setConfig(GraphDatabaseSettings.cache_type,"none").newGraphDatabase();
+        db = (GraphDatabaseAPI) graphDatabaseFactory.setConfig(GraphDatabaseSettings.cache_type,cacheType).newGraphDatabase();
         statementContextProvider = db.getDependencyResolver().resolveDependency(
                 ThreadToStatementContextBridge.class );
         kernel = db.getDependencyResolver().resolveDependency( KernelAPI.class );
+    }
+
+    protected void dbWithNoCache()
+    {
+        stopDb();
+        startDb("none");
     }
 
     protected void stopDb()
@@ -131,7 +137,7 @@ public abstract class KernelIntegrationTest
     protected void restartDb()
     {
         stopDb();
-        startDb();
+        startDb("soft");
     }
 
     protected NeoStore neoStore()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -277,6 +277,8 @@ public class PropertyIT extends KernelIntegrationTest
     public void nodeHasStringPropertyIfSetAndLazyPropertyIfRead() throws Exception
     {
         // GIVEN
+        dbWithNoCache();
+
         int propertyKeyId;
         long nodeId;
         String value = "Bozo the Clown is a clown character very popular in the United States, peaking in the 1960s";
@@ -310,6 +312,8 @@ public class PropertyIT extends KernelIntegrationTest
     public void nodeHasArrayPropertyIfSetAndLazyPropertyIfRead() throws Exception
     {
         // GIVEN
+        dbWithNoCache();
+
         int propertyKeyId;
         long nodeId;
         int[] value = new int[] {-1,0,1,2,3,4,5,6,7,8,9,10};
@@ -343,6 +347,8 @@ public class PropertyIT extends KernelIntegrationTest
     public void shouldListAllPropertyKeys() throws Exception
     {
         // given
+        dbWithNoCache();
+
         long prop1;
         long prop2;
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -28,24 +28,26 @@ import java.util.concurrent.TimeoutException;
 import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadRule;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.Direction.BOTH;
 import static org.neo4j.graphdb.Direction.INCOMING;
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.helpers.collection.IteratorUtil.asList;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.helpers.collection.IteratorUtil.toJavaIterator;
 
 public class RelationshipIT extends KernelIntegrationTest
 {
@@ -196,6 +198,96 @@ public class RelationshipIT extends KernelIntegrationTest
             assertRels( statement.nodeGetRelationships( refNode, Direction.OUTGOING, relType2, relType1 ), theRel );
 
             commit();
+        }
+    }
+
+    @Test
+    public void askingForNonExistantReltypeOnDenseNodeShouldNotCorruptState() throws Exception
+    {
+        // Given a dense node with one type of rels
+        long[] rels = new long[200];
+        long refNode;
+        int relTypeTheNodeDoesUse, relTypeTheNodeDoesNotUse;
+        {
+            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+
+            relTypeTheNodeDoesUse = statement.relationshipTypeGetOrCreateForName( "Type1" );
+            relTypeTheNodeDoesNotUse = statement.relationshipTypeGetOrCreateForName( "Type2" );
+
+            refNode = statement.nodeCreate();
+            long otherNode = statement.nodeCreate();
+
+            for ( int i = 0; i < rels.length; i++ )
+            {
+                rels[i] = statement.relationshipCreate( relTypeTheNodeDoesUse, refNode, otherNode );
+            }
+            commit();
+        }
+
+        // Given the cache is empty
+        this.db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+
+        {
+            ReadOperations stmt = readOperationsInNewTransaction();
+
+            // When I've asked for rels that the node does not have
+            assertRels( stmt.nodeGetRelationships(refNode, Direction.INCOMING, relTypeTheNodeDoesNotUse) );
+
+            // Then the node should still load the real rels
+            assertRels( stmt.nodeGetRelationships(refNode, Direction.BOTH, relTypeTheNodeDoesUse), rels );
+        }
+    }
+
+    @Test
+    public void shouldHandleInterleavedSmallAndLargeRelGroupLoading() throws Exception
+    {
+        int grabSize = Integer.parseInt(GraphDatabaseSettings.relationship_grab_size.getDefaultValue());
+
+        // Given a dense node with one type of rels
+        long[] largeRelGroup = new long[grabSize + 1];
+        long[] smallRelGroup = new long[1];
+
+        long refNode;
+        int largeGroupType, smallGroupType;
+        {
+            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+
+            largeGroupType = statement.relationshipTypeGetOrCreateForName( "Type1" );
+            smallGroupType = statement.relationshipTypeGetOrCreateForName( "Type2" );
+
+            refNode = statement.nodeCreate();
+            long otherNode = statement.nodeCreate();
+
+            for ( int i = 0; i < largeRelGroup.length; i++ )
+            {
+                largeRelGroup[i] = statement.relationshipCreate( largeGroupType, refNode, otherNode );
+            }
+            for ( int i = 0; i < smallRelGroup.length; i++ )
+            {
+                smallRelGroup[i] = statement.relationshipCreate( smallGroupType, refNode, otherNode );
+            }
+
+            commit();
+        }
+
+        // Given the cache is empty
+        this.db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+
+        {
+            ReadOperations stmt = readOperationsInNewTransaction();
+
+            // When I exhaust up to the grab size
+            PrimitiveLongIterator iter = stmt.nodeGetRelationships( refNode, Direction.BOTH, largeGroupType );
+            for ( int i = 0; i < grabSize - 1; i++ )
+            {
+                assertTrue(iter.hasNext());
+                iter.next();
+            }
+
+            // Then both the small rel group, the remaining rels in the iterator should work
+            assertRels( stmt.nodeGetRelationships( refNode, Direction.BOTH, smallGroupType ) );
+            assertThat( count( toJavaIterator( iter ) ), equalTo(2) );
+            assertRels( stmt.nodeGetRelationships( refNode, Direction.BOTH, largeGroupType ), largeRelGroup );
         }
     }
 


### PR DESCRIPTION
- The new dense nodes relationship loading had a bug in it where
  if you asked it to load relationships of a type it did not have it
  would incorrectly mark the node as having no relationships at all.
  This corrects that.
