### PR TITLE
Speed up the internal iteration of PrimitiveLongIntHashMap

### DIFF
--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
@@ -90,11 +90,11 @@ public class PrimitiveLongIntHashMap extends AbstractLongHopScotchCollection<int
         int capacity = table.capacity();
         for ( int i = 0; i < capacity; i++ )
         {
-            long key = table.key( i );
-            if ( key != nullKey )
+            int[] value = table.value( i );
+            if ( value != null )
             {
-                int[] value = table.value( i );
-                if ( value != null )
+                long key = table.key( i );
+                if ( key != nullKey )
                 {
                     visitor.visited( key, value[0] );
                 }


### PR DESCRIPTION
It's still a bit slow, though.

@tinwelint Why do we have the extra null check there? As far as I can see, the other implementations don't do that.

There might be more that can be done to improve the iteration performance. We might also not have measured everything interesting. The benchmark I used is here:

https://github.com/chrisvest/primitive-collections-benchmark
