### PR TITLE
HighAvailabilityModeSwitcher refactoring and fixes

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
@@ -22,8 +22,8 @@ package org.neo4j.kernel.ha;
 import java.io.IOException;
 
 import org.neo4j.com.TxChecksumVerifier;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Pair;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
@@ -32,17 +32,17 @@ import org.neo4j.kernel.logging.Logging;
 
 public class BranchDetectingTxVerifier implements TxChecksumVerifier
 {
-    private final GraphDatabaseAPI db;
     private final StringLogger logger;
     private XaDataSource dataSource;
+    private DependencyResolver resolver;
 
-    public BranchDetectingTxVerifier( GraphDatabaseAPI db /* I'd like to get in StringLogger, XaDataSource instead */ )
+    public BranchDetectingTxVerifier( DependencyResolver resolver /* I'd like to get in StringLogger, XaDataSource instead */ )
     {
+        this.resolver = resolver;
         /* We cannot pass in XaResourceManager because it this time we don't have a
          * proper db, merely the HA graph db which is a layer around a not-yet-started db
          * Rickards restructuring will of course fix this */
-        this.db = db;
-        this.logger = db.getDependencyResolver().resolveDependency( Logging.class ).getMessagesLog( getClass() );
+        this.logger = resolver.resolveDependency( Logging.class ).getMessagesLog( getClass() );
     }
     
     @Override
@@ -70,7 +70,7 @@ public class BranchDetectingTxVerifier implements TxChecksumVerifier
     {
         if ( dataSource == null )
         {
-            dataSource = db.getDependencyResolver().resolveDependency( XaDataSourceManager.class )
+            dataSource = resolver.resolveDependency( XaDataSourceManager.class )
                     .getXaDataSource( NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
         }
         return dataSource;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -26,13 +26,13 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
 import javax.transaction.Transaction;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.jboss.netty.logging.InternalLoggerFactory;
 
-import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.com.BindingNotifier;
 import org.neo4j.cluster.logging.NettyLoggerFactory;
@@ -69,6 +69,8 @@ import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.cluster.SimpleHighAvailabilityMemberContext;
+import org.neo4j.kernel.ha.cluster.SwitchToMaster;
+import org.neo4j.kernel.ha.cluster.SwitchToSlave;
 import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
 import org.neo4j.kernel.ha.cluster.member.HighAvailabilitySlaves;
 import org.neo4j.kernel.ha.cluster.zoo.ZooKeeperHighAvailabilityEvents;
@@ -104,8 +106,6 @@ import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.tooling.Clock;
 
-import ch.qos.logback.classic.LoggerContext;
-
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
 import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
@@ -118,7 +118,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     private RequestContextFactory requestContextFactory;
     private Slaves slaves;
     private ClusterMembers members;
-    private DelegateInvocationHandler masterDelegateInvocationHandler;
+    private DelegateInvocationHandler<Master> masterDelegateInvocationHandler;
     private LoggerContext loggerContext;
     private Master master;
     private HighAvailabilityMemberStateMachine memberStateMachine;
@@ -487,10 +487,14 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         idGeneratorFactory = new HaIdGeneratorFactory( masterDelegateInvocationHandler, logging,
                 requestContextFactory );
         highAvailabilityModeSwitcher =
-                new HighAvailabilityModeSwitcher( clusterClient, clusterClient, masterDelegateInvocationHandler,
-                        clusterMemberAvailability, memberStateMachine, this,
-                        (HaIdGeneratorFactory) idGeneratorFactory, config,
-                        logging, requestContextFactory );
+                new HighAvailabilityModeSwitcher( new SwitchToSlave(logging.getConsoleLog( HighAvailabilityModeSwitcher.class ), config, getDependencyResolver(), (HaIdGeneratorFactory) idGeneratorFactory,
+                        logging, masterDelegateInvocationHandler, clusterMemberAvailability, requestContextFactory),
+                        new SwitchToMaster( logging, msgLog, this,
+                        (HaIdGeneratorFactory) idGeneratorFactory, config, getDependencyResolver(), masterDelegateInvocationHandler, clusterMemberAvailability ),
+                        clusterClient, clusterMemberAvailability, logging.getMessagesLog( HighAvailabilityModeSwitcher.class ));
+
+        clusterClient.addBindingListener( highAvailabilityModeSwitcher );
+        memberStateMachine.addHighAvailabilityMemberListener( highAvailabilityModeSwitcher );
 
         /*
          * We always need the mode switcher and we need it to restart on switchover. So:

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -19,110 +19,41 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.transaction.TransactionManager;
 
 import org.neo4j.cluster.BindingListener;
-import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
-import org.neo4j.cluster.com.BindingNotifier;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.cluster.protocol.election.Election;
-import org.neo4j.com.RequestContext;
-import org.neo4j.com.Response;
-import org.neo4j.com.Server;
-import org.neo4j.com.ServerUtil;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Functions;
-import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.Pair;
-import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.InternalAbstractGraphDatabase;
-import org.neo4j.kernel.StoreLockerLifecycleAdapter;
-import org.neo4j.kernel.TransactionInterceptorProviders;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.ha.BranchDetectingTxVerifier;
-import org.neo4j.kernel.ha.BranchedDataException;
-import org.neo4j.kernel.ha.BranchedDataPolicy;
-import org.neo4j.kernel.ha.DelegateInvocationHandler;
-import org.neo4j.kernel.ha.HaSettings;
-import org.neo4j.kernel.ha.HaXaDataSourceManager;
-import org.neo4j.kernel.ha.SlaveStoreWriter;
-import org.neo4j.kernel.ha.StoreOutOfDateException;
-import org.neo4j.kernel.ha.StoreUnableToParticipateInClusterException;
-import org.neo4j.kernel.ha.com.RequestContextFactory;
-import org.neo4j.kernel.ha.com.master.HandshakeResult;
-import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.ha.com.master.MasterImpl;
-import org.neo4j.kernel.ha.com.master.MasterServer;
-import org.neo4j.kernel.ha.com.master.Slave;
-import org.neo4j.kernel.ha.com.slave.MasterClient;
-import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
-import org.neo4j.kernel.ha.com.slave.SlaveImpl;
-import org.neo4j.kernel.ha.com.slave.SlaveServer;
-import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
-import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.index.IndexStore;
-import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.MismatchingStoreIdException;
-import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
-import org.neo4j.kernel.impl.nioneo.store.StoreId;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
-import org.neo4j.kernel.impl.transaction.LockManager;
-import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
-import org.neo4j.kernel.impl.transaction.TxManager;
-import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
-import org.neo4j.kernel.impl.transaction.xaframework.MissingLogDataException;
-import org.neo4j.kernel.impl.transaction.xaframework.NoSuchLogVersionException;
-import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
-import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.kernel.lifecycle.LifecycleStatus;
-import org.neo4j.kernel.logging.ConsoleLogger;
-import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.helpers.Functions.withDefaults;
 import static org.neo4j.helpers.NamedThreadFactory.named;
 import static org.neo4j.helpers.Settings.INTEGER;
 import static org.neo4j.helpers.Uris.parameter;
-import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
 
 /**
  * Performs the internal switches from pending to slave/master, by listening for
  * ClusterMemberChangeEvents. When finished it will invoke {@link org.neo4j.cluster.member.ClusterMemberAvailability#memberIsAvailable(String, URI)} to announce
  * to the cluster it's new status.
  */
-public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListener, Lifecycle
+public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListener, BindingListener, Lifecycle
 {
-    // TODO solve this with lifecycle instance grouping or something
-    @SuppressWarnings( "rawtypes" )
-    private static final Class[] SERVICES_TO_RESTART_FOR_STORE_COPY = new Class[] {
-            StoreLockerLifecycleAdapter.class,
-            XaDataSourceManager.class,
-            TxManager.class,
-            NodeManager.class,
-            IndexStore.class
-    };
-
     public static final String MASTER = "master";
     public static final String SLAVE = "slave";
-    private URI masterHaURI;
     public static final String INADDR_ANY = "0.0.0.0";
-    private URI slaveHaURI;
-    private BindingListener bindingListener;
+
+    private volatile URI masterHaURI;
+    private volatile URI slaveHaURI;
 
     public static int getServerId( URI haUri )
     {
@@ -133,49 +64,37 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
 
     private URI availableMasterId;
 
-    private final HighAvailabilityMemberStateMachine stateHandler;
-    private final BindingNotifier bindingNotifier;
+    private final SwitchToSlave switchToSlave;
+    private final SwitchToMaster switchToMaster;
     private final Election election;
-    private final DelegateInvocationHandler<Master> masterDelegateHandler;
     private final ClusterMemberAvailability clusterMemberAvailability;
-    private final GraphDatabaseAPI graphDb;
-    private final Config config;
-    private LifeSupport haCommunicationLife;
     private final StringLogger msgLog;
-    private final ConsoleLogger console;
 
-    private final HaIdGeneratorFactory idGeneratorFactory;
-    private final Logging logging;
-    private final RequestContextFactory requestContextFactory;
-    private MasterClientResolver masterClientResolver;
+    private LifeSupport haCommunicationLife;
 
     private ScheduledExecutorService modeSwitcherExecutor;
     private volatile URI me;
     private volatile Future<?> modeSwitcherFuture;
     private volatile HighAvailabilityMemberState currentTargetState;
 
-    public HighAvailabilityModeSwitcher( BindingNotifier bindingNotifier,
+    public HighAvailabilityModeSwitcher( SwitchToSlave switchToSlave,
+                                         SwitchToMaster switchToMaster,
                                          Election election,
-                                         DelegateInvocationHandler<Master> delegateHandler,
                                          ClusterMemberAvailability clusterMemberAvailability,
-                                         HighAvailabilityMemberStateMachine stateHandler, GraphDatabaseAPI graphDb,
-                                         HaIdGeneratorFactory idGeneratorFactory, Config config, Logging logging,
-                                         RequestContextFactory requestContextFactory )
+                                         StringLogger msgLog)
     {
-        this.bindingNotifier = bindingNotifier;
+        this.switchToSlave = switchToSlave;
+        this.switchToMaster = switchToMaster;
         this.election = election;
-        this.masterDelegateHandler = delegateHandler;
         this.clusterMemberAvailability = clusterMemberAvailability;
-        this.graphDb = graphDb;
-        this.idGeneratorFactory = idGeneratorFactory;
-        this.config = config;
-        this.logging = logging;
-        this.requestContextFactory = requestContextFactory;
-        this.msgLog = logging.getMessagesLog( getClass() );
+        this.msgLog = msgLog;
         this.haCommunicationLife = new LifeSupport();
-        this.stateHandler = stateHandler;
+    }
 
-        this.console = logging.getConsoleLog( getClass() );
+    @Override
+    public void listeningAt( URI myUri )
+    {
+        me = myUri;
     }
 
     @Override
@@ -183,16 +102,6 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
     {
         modeSwitcherExecutor = Executors.newSingleThreadScheduledExecutor( named( "HA Mode switcher" ) );
 
-        stateHandler.addHighAvailabilityMemberListener( this );
-        bindingListener = new BindingListener()
-        {
-            @Override
-            public void listeningAt( URI myUri )
-            {
-                me = myUri;
-            }
-        };
-        bindingNotifier.addBindingListener( bindingListener );
         haCommunicationLife.init();
     }
 
@@ -211,9 +120,6 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
     @Override
     public synchronized void shutdown() throws Throwable
     {
-        stateHandler.removeHighAvailabilityMemberListener( this );
-        bindingNotifier.removeBindingListener( bindingListener );
-
         modeSwitcherExecutor.shutdown();
 
         modeSwitcherExecutor.awaitTermination( 60, TimeUnit.SECONDS );
@@ -271,8 +177,6 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         switch ( event.getNewState() )
         {
             case TO_MASTER:
-                haCommunicationLife.shutdown();
-                haCommunicationLife = new LifeSupport();
 
                 if ( event.getOldState().equals( HighAvailabilityMemberState.SLAVE ) )
                 {
@@ -282,7 +186,6 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 switchToMaster();
                 break;
             case TO_SLAVE:
-                haCommunicationLife.shutdown();
                 switchToSlave();
                 break;
             case PENDING:
@@ -295,8 +198,25 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                     clusterMemberAvailability.memberIsUnavailable( MASTER );
                 }
 
-                haCommunicationLife.shutdown();
-                haCommunicationLife = new LifeSupport();
+                startModeSwitching( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        haCommunicationLife.shutdown();
+                        haCommunicationLife = new LifeSupport();
+                    }
+                });
+
+                try
+                {
+                    modeSwitcherFuture.get(10, TimeUnit.SECONDS);
+                }
+                catch ( Exception e )
+                {
+                    // Ignore
+                }
+
                 break;
             default:
                 // do nothing
@@ -315,47 +235,12 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                     return;
                 }
 
-                msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) + ", moving to master" );
+                haCommunicationLife.shutdown();
+                haCommunicationLife = new LifeSupport();
+
                 try
                 {
-                    DependencyResolver resolver = graphDb.getDependencyResolver();
-                    HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency( HaXaDataSourceManager.class );
-                    /*
-                     * Synchronizing on the xaDataSourceManager makes sense if you also look at HaKernelPanicHandler. In
-                     * particular, it is possible to get a masterIsElected while recovering the database. That is generally
-                     * going to break things. Synchronizing on the xaDSM as HaKPH does solves this.
-                     */
-                    //noinspection SynchronizationOnLocalVariableOrMethodParameter
-                    synchronized ( xaDataSourceManager )
-                    {
-                        final TransactionManager txManager = graphDb.getDependencyResolver()
-                                .resolveDependency( TransactionManager.class );
-
-                        idGeneratorFactory.switchToMaster();
-
-                        Monitors monitors = graphDb.getDependencyResolver().resolveDependency( Monitors.class );
-
-                        MasterImpl.SPI spi = new DefaultMasterImplSPI( graphDb, logging, txManager, monitors );
-
-                        MasterImpl masterImpl = new MasterImpl( spi, logging, config );
-
-                        MasterServer masterServer = new MasterServer( masterImpl, logging, serverConfig(),
-                                new BranchDetectingTxVerifier( graphDb ),
-                                monitors );
-                        haCommunicationLife.add( masterImpl );
-                        haCommunicationLife.add( masterServer );
-                        assignMaster( masterImpl );
-
-                        haCommunicationLife.start();
-
-                        masterHaURI = URI.create( "ha://" + (ServerUtil.getHostString( masterServer.getSocketAddress() ).contains
-                                ( "0.0.0.0" ) ? me.getHost() : ServerUtil.getHostString( masterServer.getSocketAddress() )) + ":" +
-                                masterServer.getSocketAddress().getPort() + "?serverId=" +
-                                config.get( ClusterSettings.server_id ) );
-                        clusterMemberAvailability.memberIsAvailable( MASTER, masterHaURI );
-                        msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) +
-                                ", successfully moved to master" );
-                    }
+                    masterHaURI = switchToMaster.switchToMaster( haCommunicationLife, me );
                 }
                 catch ( Throwable e )
                 {
@@ -370,93 +255,43 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         } );
     }
 
-    private void assignMaster( Master master )
-    {
-        masterDelegateHandler.setDelegate( master );
-    }
-
-    private URI createHaURI( Server<?,?> server )
-    {
-        String hostString = ServerUtil.getHostString( server.getSocketAddress() );
-        int port = server.getSocketAddress().getPort();
-        Integer serverId = config.get( ClusterSettings.server_id );
-        String host = hostString.contains( INADDR_ANY ) ? me.getHost() : hostString;
-        return URI.create( "ha://" + host + ":" + port + "?serverId=" + serverId );
-    }
-
     private void switchToSlave()
     {
-        this.masterClientResolver = new MasterClientResolver( logging,
-                config.get( HaSettings.read_timeout ).intValue(),
-                config.get( HaSettings.lock_read_timeout ).intValue(),
-                config.get( HaSettings.max_concurrent_channels_per_slave ).intValue(),
-                config.get( HaSettings.com_chunk_size ).intValue()  );
-
         // Do this with a scheduler, so that if it fails, it can retry later with an exponential backoff with max wait time.
+        final URI masterUri = availableMasterId;
         final AtomicLong wait = new AtomicLong();
         startModeSwitching( new Runnable()
         {
             @Override
             public void run()
             {
-                if (haCommunicationLife.getStatus() == LifecycleStatus.STARTED ||
-                        currentTargetState != HighAvailabilityMemberState.TO_SLAVE)
+                if (currentTargetState != HighAvailabilityMemberState.TO_SLAVE)
                 {
                     return; // Already switched - this can happen if a second master becomes available while waiting
                 }
 
                 try
                 {
+                    haCommunicationLife.shutdown();
                     haCommunicationLife = new LifeSupport();
 
-                    URI masterUri = availableMasterId;
-
-                    console.log( "ServerId " + config.get( ClusterSettings.server_id ) + ", moving to slave for master " +
-                            masterUri  );
-
-                    assert masterUri != null; // since we are here it must already have been set from outside
-                    DependencyResolver resolver = graphDb.getDependencyResolver();
-                    HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency(
-                            HaXaDataSourceManager.class );
-                    idGeneratorFactory.switchToSlave();
-                    synchronized ( xaDataSourceManager )
-                    {
-                        if ( !isStorePresent( resolver.resolveDependency( FileSystemAbstraction.class ), config ) )
-                        {
-                            copyStoreFromMaster( masterUri );
-                        }
-
-                        /*
-                         * We get here either with a fresh store from the master copy above so we need to start the ds
-                         * or we already had a store, so we have already started the ds. Either way, make sure it's there.
-                         */
-                        NeoStoreXaDataSource nioneoDataSource = ensureDataSourceStarted( xaDataSourceManager, resolver );
-                        if ( checkDataConsistency( xaDataSourceManager,
-                                resolver.resolveDependency( RequestContextFactory.class ), nioneoDataSource, masterUri ) )
-                        {
-                            if ( startHaCommunication( xaDataSourceManager, nioneoDataSource, masterUri ) )
-                            {
-                                console.log( "ServerId " + config.get( ClusterSettings.server_id ) +
-                                        ", successfully moved to slave for master " + masterUri );
-                                return; // Done
-                            }
-                        }
-                    }
-                }
-                catch ( Throwable t )
+                    slaveHaURI = switchToSlave.switchToSlave(haCommunicationLife, me, masterUri);
+                } catch (MismatchingStoreIdException e)
+                {
+                    // Try again immediately
+                    run();
+                } catch ( Throwable t )
                 {
                     msgLog.logMessage( "Error while trying to switch to slave", t );
+
+                    // Try again later
+                    wait.set( (1 + wait.get()*2) ); // Exponential backoff
+                    wait.set(Math.min(wait.get(), 5*60)); // Wait maximum 5 minutes
+
+                    modeSwitcherFuture = modeSwitcherExecutor.schedule( this, wait.get(), TimeUnit.SECONDS );
+
+                    msgLog.logMessage( "Attempting to switch to slave in "+wait.get()+"s");
                 }
-
-                haCommunicationLife.shutdown();
-
-                // Try again later
-                wait.set( (1 + wait.get()*2) ); // Exponential backoff
-                wait.set(Math.min(wait.get(), 5*60)); // Wait maximum 5 minutes
-
-                modeSwitcherFuture = modeSwitcherExecutor.schedule( this, wait.get(), TimeUnit.SECONDS );
-
-                msgLog.logMessage( "Attempting to switch to slave in "+wait.get()+"s");
             }
         } );
     }
@@ -470,306 +305,5 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         }
 
         modeSwitcherFuture = modeSwitcherExecutor.submit( switcher );
-    }
-
-    private boolean startHaCommunication( HaXaDataSourceManager xaDataSourceManager,
-            NeoStoreXaDataSource nioneoDataSource, URI masterUri )
-    {
-        try
-        {
-            MasterClient master = newMasterClient( masterUri, nioneoDataSource.getStoreId(), haCommunicationLife );
-
-            Slave slaveImpl = new SlaveImpl( nioneoDataSource.getStoreId(), master,
-                    new RequestContextFactory( getServerId( masterUri ), xaDataSourceManager,
-                            graphDb.getDependencyResolver() ), xaDataSourceManager );
-
-            SlaveServer server = new SlaveServer( slaveImpl, serverConfig(), logging,
-                    graphDb.getDependencyResolver().resolveDependency( Monitors.class ) );
-            assignMaster( master );
-            haCommunicationLife.add( slaveImpl );
-            haCommunicationLife.add( server );
-            haCommunicationLife.start();
-
-            slaveHaURI = createHaURI( server );
-            clusterMemberAvailability.memberIsAvailable( SLAVE, slaveHaURI );
-            return true;
-        }
-        catch ( Throwable t )
-        {
-            msgLog.logMessage( "Got exception while starting HA communication", t );
-            haCommunicationLife.shutdown();
-            haCommunicationLife = new LifeSupport();
-        }
-        return false;
-    }
-
-    private Server.Configuration serverConfig()
-    {
-        Server.Configuration serverConfig = new Server.Configuration()
-        {
-            @Override
-            public long getOldChannelThreshold()
-            {
-                return config.get( HaSettings.lock_read_timeout );
-            }
-
-            @Override
-            public int getMaxConcurrentTransactions()
-            {
-                return config.get( HaSettings.max_concurrent_channels_per_slave );
-            }
-
-            @Override
-            public int getChunkSize()
-            {
-                return config.get( HaSettings.com_chunk_size ).intValue();
-            }
-
-            @Override
-            public HostnamePort getServerAddress()
-            {
-                return config.get( HaSettings.ha_server );
-            }
-        };
-        return serverConfig;
-    }
-
-    private boolean checkDataConsistency( HaXaDataSourceManager xaDataSourceManager,
-                                          RequestContextFactory requestContextFactory,
-                                          NeoStoreXaDataSource nioneoDataSource, URI masterUri ) throws Throwable
-    {
-        // Must be called under lock on XaDataSourceManager
-        LifeSupport checkConsistencyLife = new LifeSupport();
-        try
-        {
-            MasterClient checkConsistencyMaster = newMasterClient( masterUri, nioneoDataSource.getStoreId(),
-                    checkConsistencyLife );
-            checkConsistencyLife.start();
-            console.log( "Checking store consistency with master" );
-            checkDataConsistencyWithMaster( checkConsistencyMaster, nioneoDataSource );
-            console.log( "Store is consistent" );
-
-            /*
-             * Pull updates, since the store seems happy and everything. No matter how far back we are, this is just
-             * one thread doing the pulling, while the guard is up. This will prevent a race between all transactions
-             * that may start the moment the database becomes available, where all of them will pull the same txs from
-             * the master but eventually only one will get to apply them.
-             */
-            console.log( "Catching up with master" );
-            RequestContext context = requestContextFactory.newRequestContext( -1 );
-            xaDataSourceManager.applyTransactions( checkConsistencyMaster.pullUpdates( context ) );
-            console.log( "Now consistent with master" );
-            return true;
-        }
-        catch ( StoreUnableToParticipateInClusterException upe )
-        {
-            console.log( "The store is inconsistent. Will treat it as branched and fetch a new one from the master" );
-            msgLog.warn( "Current store is unable to participate in the cluster; fetching new store from master", upe );
-            try
-            {
-                // Unregistering from a running DSManager stops the datasource
-                xaDataSourceManager.unregisterDataSource( Config.DEFAULT_DATA_SOURCE_NAME );
-                stopServicesAndHandleBranchedStore( config.get( HaSettings.branched_data_policy ) );
-            }
-            catch ( IOException e )
-            {
-                msgLog.warn( "Failed while trying to handle branched data", e );
-            }
-        }
-        catch ( MismatchingStoreIdException e )
-        {
-            console.log( "The store does not represent the same database as master. Will remove and fetch a new one from master" );
-            if ( nioneoDataSource.getNeoStore().getLastCommittedTx() == 1 )
-            {
-                msgLog.warn( "Found and deleting empty store with mismatching store id " + e.getMessage() );
-                stopServicesAndHandleBranchedStore( BranchedDataPolicy.keep_none );
-            }
-            else
-            {
-                msgLog.error( "Store cannot participate in cluster due to mismatching store IDs" );
-                throw e;
-            }
-        }
-        catch ( Throwable throwable )
-        {
-            msgLog.warn( "Consistency checker failed", throwable );
-        }
-        finally
-        {
-            checkConsistencyLife.shutdown();
-        }
-        return false;
-    }
-
-    private NeoStoreXaDataSource ensureDataSourceStarted( XaDataSourceManager xaDataSourceManager, DependencyResolver resolver )
-            throws IOException
-    {
-        // Must be called under lock on XaDataSourceManager
-        NeoStoreXaDataSource nioneoDataSource = (NeoStoreXaDataSource) xaDataSourceManager.getXaDataSource( Config.DEFAULT_DATA_SOURCE_NAME );
-        if ( nioneoDataSource == null )
-        {
-            try
-            {
-                nioneoDataSource = new NeoStoreXaDataSource( config,
-                        resolver.resolveDependency( StoreFactory.class ),
-                        resolver.resolveDependency( LockManager.class ),
-                        resolver.resolveDependency( StringLogger.class ),
-                        resolver.resolveDependency( XaFactory.class ),
-                        resolver.resolveDependency( TransactionStateFactory.class ),
-                        resolver.resolveDependency( TransactionInterceptorProviders.class ),
-                        resolver );
-                xaDataSourceManager.registerDataSource( nioneoDataSource );
-                /*
-                 * CAUTION: The next line may cause severe eye irritation, mental instability and potential
-                 * emotional breakdown. On the plus side, it is correct.
-                 * See, it is quite possible to get here without the NodeManager having stopped, because we don't
-                 * properly manage lifecycle in this class (this is the cause of this ugliness). So, after we
-                 * register the datasource with the DsMgr we need to make sure that NodeManager re-reads the reltype
-                 * and propindex information. Normally, we would have shutdown everything before getting here.
-                 */
-                resolver.resolveDependency( NodeManager.class ).start();
-            }
-            catch ( IOException e )
-            {
-                msgLog.logMessage( "Failed while trying to create datasource", e );
-                throw e;
-            }
-        }
-        return nioneoDataSource;
-    }
-
-    private void copyStoreFromMaster( URI masterUri ) throws Throwable
-    {
-        // Must be called under lock on XaDataSourceManager
-        LifeSupport life = new LifeSupport();
-        try
-        {
-            // Remove the current store - neostore file is missing, nothing we can really do
-            stopServicesAndHandleBranchedStore( BranchedDataPolicy.keep_none );
-            MasterClient copyMaster = newMasterClient( masterUri, null, life );
-
-            life.start();
-
-            // This will move the copied db to the graphdb location
-            console.log( "Copying store from master" );
-            new SlaveStoreWriter( config, console ).copyStore( copyMaster );
-
-            startServicesAgain();
-            console.log( "Finished copying store from master" );
-        }
-        finally
-        {
-            life.stop();
-        }
-    }
-
-    private MasterClient newMasterClient( URI masterUri, StoreId storeId, LifeSupport life )
-    {
-        return masterClientResolver.instantiate( masterUri.getHost(), masterUri.getPort(),
-                graphDb.getDependencyResolver().resolveDependency( Monitors.class ), storeId, life );
-    }
-
-    private void startServicesAgain() throws Throwable
-    {
-        @SuppressWarnings( "rawtypes" )
-        List<Class> services = new ArrayList<Class>( Arrays.asList( SERVICES_TO_RESTART_FOR_STORE_COPY ) );
-        for ( Class<?> serviceClass : services )
-        {
-            Lifecycle service = (Lifecycle) graphDb.getDependencyResolver().resolveDependency( serviceClass );
-            service.start();
-        }
-    }
-
-    private void stopServicesAndHandleBranchedStore( BranchedDataPolicy branchPolicy ) throws Throwable
-    {
-        List<Class> services = new ArrayList<Class>( Arrays.asList( SERVICES_TO_RESTART_FOR_STORE_COPY ) );
-        Collections.reverse( services );
-        for ( Class<Lifecycle> serviceClass : services )
-        {
-            graphDb.getDependencyResolver().resolveDependency( serviceClass ).stop();
-        }
-
-        branchPolicy.handle( config.get( InternalAbstractGraphDatabase.Configuration.store_dir ) );
-    }
-
-    private void checkDataConsistencyWithMaster( Master master, NeoStoreXaDataSource nioneoDataSource )
-    {
-        long myLastCommittedTx = nioneoDataSource.getLastCommittedTxId();
-        Pair<Integer, Long> myMaster;
-        try
-        {
-            myMaster = nioneoDataSource.getMasterForCommittedTx( myLastCommittedTx );
-        }
-        catch ( NoSuchLogVersionException e )
-        {
-            msgLog.logMessage(
-                    "Logical log file for txId "
-                            + myLastCommittedTx
-                            + " missing [version="
-                            + e.getVersion()
-                            + "]. If this is startup then it will be recovered later, " +
-                            "otherwise it might be a problem." );
-            return;
-        }
-        catch ( IOException e )
-        {
-            msgLog.logMessage( "Failed to get master ID for txId " + myLastCommittedTx + ".", e );
-            return;
-        }
-        catch ( Exception e )
-        {
-            throw new BranchedDataException( "Exception while getting master ID for txId "
-                    + myLastCommittedTx + ".", e );
-        }
-
-        HandshakeResult handshake;
-        Response<HandshakeResult> response = null;
-        try
-        {
-            response = master.handshake( myLastCommittedTx, nioneoDataSource.getStoreId() );
-            handshake = response.response();
-            requestContextFactory.setEpoch( handshake.epoch() );
-        }
-        catch( BranchedDataException e )
-        {
-            // Rethrow wrapped in a branched data exception on our side, to clarify where the problem originates.
-            throw new BranchedDataException( "Master detected branched data for this machine.", e );
-        }
-        catch ( RuntimeException e )
-        {
-            // Checked exceptions will be wrapped as the cause if this was a serialized
-            // server-side exception
-            if ( e.getCause() instanceof MissingLogDataException )
-            {
-                /*
-                 * This means the master was unable to find a log entry for the txid we just asked. This
-                 * probably means the thing we asked for is too old or too new. Anyway, since it doesn't
-                 * have the tx it is better if we just throw our store away and ask for a new copy. Next
-                 * time around it shouldn't have to even pass from here.
-                 */
-                throw new StoreOutOfDateException( "The master is missing the log required to complete the " +
-                        "consistency check", e.getCause() );
-            }
-            throw e;
-        }
-        finally
-        {
-            if ( response != null )
-            {
-                response.close();
-            }
-        }
-
-        if ( myMaster.first() != XaLogicalLog.MASTER_ID_REPRESENTING_NO_MASTER &&
-                (myMaster.first() != handshake.txAuthor() || myMaster.other() != handshake.txChecksum()) )
-        {
-            String msg = "Branched data, I (machineId:" + config.get( ClusterSettings.server_id ) + ") think machineId for" +
-                    " txId (" +
-                    myLastCommittedTx + ") is " + myMaster + ", but master (machineId:" +
-                    getServerId( availableMasterId ) + ") says that it's " + handshake;
-            throw new BranchedDataException( msg );
-        }
-        msgLog.logMessage( "Master id for last committed tx ok with highestTxId=" +
-                myLastCommittedTx + " with masterId=" + myMaster, true );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import java.net.URI;
+import javax.transaction.TransactionManager;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.member.ClusterMemberAvailability;
+import org.neo4j.com.Server;
+import org.neo4j.com.ServerUtil;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.BranchDetectingTxVerifier;
+import org.neo4j.kernel.ha.DelegateInvocationHandler;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.ha.HaXaDataSourceManager;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.com.master.MasterImpl;
+import org.neo4j.kernel.ha.com.master.MasterServer;
+import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
+
+public class SwitchToMaster
+{
+    private final Logging logging;
+    private final StringLogger msgLog;
+    private final GraphDatabaseAPI graphDb;
+    private final HaIdGeneratorFactory idGeneratorFactory;
+    private final Config config;
+    private final DependencyResolver resolver;
+    private final DelegateInvocationHandler<Master> masterDelegateHandler;
+    private final ClusterMemberAvailability clusterMemberAvailability;
+
+    public SwitchToMaster( Logging logging, StringLogger msgLog, GraphDatabaseAPI graphDb, HaIdGeneratorFactory
+            idGeneratorFactory, Config config, DependencyResolver resolver, DelegateInvocationHandler<Master> masterDelegateHandler, ClusterMemberAvailability clusterMemberAvailability )
+    {
+        this.logging = logging;
+        this.msgLog = msgLog;
+        this.graphDb = graphDb;
+        this.idGeneratorFactory = idGeneratorFactory;
+        this.config = config;
+        this.resolver = resolver;
+        this.masterDelegateHandler = masterDelegateHandler;
+        this.clusterMemberAvailability = clusterMemberAvailability;
+    }
+
+    public URI switchToMaster(LifeSupport haCommunicationLife, URI me)
+    {
+        msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) + ", moving to master" );
+
+        HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency( HaXaDataSourceManager.class );
+        /*
+         * Synchronizing on the xaDataSourceManager makes sense if you also look at HaKernelPanicHandler. In
+         * particular, it is possible to get a masterIsElected while recovering the database. That is generally
+         * going to break things. Synchronizing on the xaDSM as HaKPH does solves this.
+         */
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized ( xaDataSourceManager )
+        {
+            final TransactionManager txManager = resolver.resolveDependency( TransactionManager.class );
+
+            idGeneratorFactory.switchToMaster();
+
+            Monitors monitors = resolver.resolveDependency( Monitors.class );
+
+            MasterImpl.SPI spi = new DefaultMasterImplSPI( graphDb, logging, txManager, monitors );
+
+            MasterImpl masterImpl = new MasterImpl( spi, logging, config );
+
+            MasterServer masterServer = new MasterServer( masterImpl, logging, serverConfig(),
+                    new BranchDetectingTxVerifier( resolver ),
+                    monitors );
+            haCommunicationLife.add( masterImpl );
+            haCommunicationLife.add( masterServer );
+            masterDelegateHandler.setDelegate( masterImpl );
+
+            haCommunicationLife.start();
+
+            URI masterHaURI = URI.create( "ha://" + (ServerUtil.getHostString( masterServer.getSocketAddress
+                    () ).contains
+                    ( "0.0.0.0" ) ? me.getHost() : ServerUtil.getHostString( masterServer
+                    .getSocketAddress() )) + ":" +
+                    masterServer.getSocketAddress().getPort() + "?serverId=" +
+                    config.get( ClusterSettings.server_id ) );
+            clusterMemberAvailability.memberIsAvailable( HighAvailabilityModeSwitcher.MASTER, masterHaURI );
+            msgLog.logMessage( "I am " + config.get( ClusterSettings.server_id ) +
+                    ", successfully moved to master" );
+
+            return masterHaURI;
+        }
+    }
+
+    private Server.Configuration serverConfig()
+    {
+        Server.Configuration serverConfig = new Server.Configuration()
+        {
+            @Override
+            public long getOldChannelThreshold()
+            {
+                return config.get( HaSettings.lock_read_timeout );
+            }
+
+            @Override
+            public int getMaxConcurrentTransactions()
+            {
+                return config.get( HaSettings.max_concurrent_channels_per_slave );
+            }
+
+            @Override
+            public int getChunkSize()
+            {
+                return config.get( HaSettings.com_chunk_size ).intValue();
+            }
+
+            @Override
+            public HostnamePort getServerAddress()
+            {
+                return config.get( HaSettings.ha_server );
+            }
+        };
+        return serverConfig;
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -1,0 +1,463 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.member.ClusterMemberAvailability;
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.Response;
+import org.neo4j.com.Server;
+import org.neo4j.com.ServerUtil;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.Pair;
+import org.neo4j.kernel.InternalAbstractGraphDatabase;
+import org.neo4j.kernel.StoreLockerLifecycleAdapter;
+import org.neo4j.kernel.TransactionInterceptorProviders;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.BranchedDataException;
+import org.neo4j.kernel.ha.BranchedDataPolicy;
+import org.neo4j.kernel.ha.DelegateInvocationHandler;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.ha.HaXaDataSourceManager;
+import org.neo4j.kernel.ha.SlaveStoreWriter;
+import org.neo4j.kernel.ha.StoreOutOfDateException;
+import org.neo4j.kernel.ha.StoreUnableToParticipateInClusterException;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.HandshakeResult;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.com.master.Slave;
+import org.neo4j.kernel.ha.com.slave.MasterClient;
+import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
+import org.neo4j.kernel.ha.com.slave.SlaveImpl;
+import org.neo4j.kernel.ha.com.slave.SlaveServer;
+import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.index.IndexStore;
+import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.impl.nioneo.store.MismatchingStoreIdException;
+import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
+import org.neo4j.kernel.impl.nioneo.store.StoreId;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.transaction.LockManager;
+import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
+import org.neo4j.kernel.impl.transaction.TxManager;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.kernel.impl.transaction.xaframework.MissingLogDataException;
+import org.neo4j.kernel.impl.transaction.xaframework.NoSuchLogVersionException;
+import org.neo4j.kernel.impl.transaction.xaframework.XaFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.logging.ConsoleLogger;
+import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.getServerId;
+import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
+
+public class SwitchToSlave
+{
+    // TODO solve this with lifecycle instance grouping or something
+    @SuppressWarnings( "rawtypes" )
+    private static final Class[] SERVICES_TO_RESTART_FOR_STORE_COPY = new Class[] {
+            StoreLockerLifecycleAdapter.class,
+            XaDataSourceManager.class,
+            TxManager.class,
+            NodeManager.class,
+            IndexStore.class
+    };
+
+    private final Logging logging;
+    private final StringLogger msgLog;
+    private final ConsoleLogger console;
+    private final Config config;
+    private final DependencyResolver resolver;
+    private final HaIdGeneratorFactory idGeneratorFactory;
+    private final DelegateInvocationHandler<Master> masterDelegateHandler;
+    private final ClusterMemberAvailability clusterMemberAvailability;
+    private final RequestContextFactory requestContextFactory;
+
+    private MasterClientResolver masterClientResolver;
+
+    public SwitchToSlave( ConsoleLogger console, Config config, DependencyResolver resolver, HaIdGeneratorFactory
+            idGeneratorFactory, Logging logging, DelegateInvocationHandler<Master> masterDelegateHandler,
+                          ClusterMemberAvailability clusterMemberAvailability, RequestContextFactory
+            requestContextFactory )
+    {
+        this.console = console;
+        this.config = config;
+        this.resolver = resolver;
+        this.idGeneratorFactory = idGeneratorFactory;
+        this.logging = logging;
+        this.clusterMemberAvailability = clusterMemberAvailability;
+        this.requestContextFactory = requestContextFactory;
+        this.msgLog = logging.getMessagesLog( getClass() );
+        this.masterDelegateHandler = masterDelegateHandler;
+    }
+
+    public URI switchToSlave( LifeSupport haCommunicationLife, URI me, URI masterUri ) throws Throwable
+    {
+        console.log( "ServerId " + config.get( ClusterSettings.server_id ) + ", moving to slave for master " +
+                masterUri );
+
+        assert masterUri != null; // since we are here it must already have been set from outside
+
+        this.masterClientResolver = new MasterClientResolver( logging,
+                config.get( HaSettings.read_timeout ).intValue(),
+                config.get( HaSettings.lock_read_timeout ).intValue(),
+                config.get( HaSettings.max_concurrent_channels_per_slave ).intValue(),
+                config.get( HaSettings.com_chunk_size ).intValue()  );
+
+
+        HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency(
+                HaXaDataSourceManager.class );
+        idGeneratorFactory.switchToSlave();
+        synchronized ( xaDataSourceManager )
+        {
+            if ( !isStorePresent( resolver.resolveDependency( FileSystemAbstraction.class ), config ) )
+            {
+                copyStoreFromMaster( masterUri );
+            }
+
+                            /*
+                             * We get here either with a fresh store from the master copy above so we need to
+                             * start the ds
+                             * or we already had a store, so we have already started the ds. Either way,
+                             * make sure it's there.
+                             */
+            NeoStoreXaDataSource nioneoDataSource = ensureDataSourceStarted( xaDataSourceManager, resolver );
+            checkDataConsistency( xaDataSourceManager, resolver.resolveDependency( RequestContextFactory.class ), nioneoDataSource, masterUri );
+
+            URI slaveUri = startHaCommunication( haCommunicationLife, xaDataSourceManager, nioneoDataSource, me, masterUri );
+
+            console.log( "ServerId " + config.get( ClusterSettings.server_id ) +
+                    ", successfully moved to slave for master " + masterUri );
+
+            return slaveUri;
+        }
+    }
+
+    private void checkDataConsistency( HaXaDataSourceManager xaDataSourceManager,
+                                          RequestContextFactory requestContextFactory,
+                                          NeoStoreXaDataSource nioneoDataSource, URI masterUri ) throws Throwable
+    {
+        // Must be called under lock on XaDataSourceManager
+        LifeSupport checkConsistencyLife = new LifeSupport();
+        try
+        {
+            MasterClient checkConsistencyMaster = newMasterClient( masterUri, nioneoDataSource.getStoreId(),
+                    checkConsistencyLife );
+            checkConsistencyLife.start();
+            console.log( "Checking store consistency with master" );
+            checkDataConsistencyWithMaster( masterUri, checkConsistencyMaster, nioneoDataSource );
+            console.log( "Store is consistent" );
+
+            /*
+             * Pull updates, since the store seems happy and everything. No matter how far back we are, this is just
+             * one thread doing the pulling, while the guard is up. This will prevent a race between all transactions
+             * that may start the moment the database becomes available, where all of them will pull the same txs from
+             * the master but eventually only one will get to apply them.
+             */
+            console.log( "Catching up with master" );
+            RequestContext context = requestContextFactory.newRequestContext( -1 );
+            xaDataSourceManager.applyTransactions( checkConsistencyMaster.pullUpdates( context ) );
+            console.log( "Now consistent with master" );
+        }
+        catch ( StoreUnableToParticipateInClusterException upe )
+        {
+            console.log( "The store is inconsistent. Will treat it as branched and fetch a new one from the master" );
+            msgLog.warn( "Current store is unable to participate in the cluster; fetching new store from master", upe );
+            try
+            {
+                // Unregistering from a running DSManager stops the datasource
+                xaDataSourceManager.unregisterDataSource( Config.DEFAULT_DATA_SOURCE_NAME );
+                stopServicesAndHandleBranchedStore( config.get( HaSettings.branched_data_policy ) );
+            }
+            catch ( IOException e )
+            {
+                msgLog.warn( "Failed while trying to handle branched data", e );
+            }
+
+            throw upe;
+        }
+        catch ( MismatchingStoreIdException e )
+        {
+            console.log( "The store does not represent the same database as master. Will remove and fetch a new one from master" );
+            if ( nioneoDataSource.getNeoStore().getLastCommittedTx() == 1 )
+            {
+                msgLog.warn( "Found and deleting empty store with mismatching store id " + e.getMessage() );
+                stopServicesAndHandleBranchedStore( BranchedDataPolicy.keep_none );
+            }
+            else
+            {
+                msgLog.error( "Store cannot participate in cluster due to mismatching store IDs" );
+            }
+            throw e;
+        }
+        finally
+        {
+            checkConsistencyLife.shutdown();
+        }
+    }
+
+    private URI startHaCommunication( LifeSupport haCommunicationLife, HaXaDataSourceManager xaDataSourceManager,
+            NeoStoreXaDataSource nioneoDataSource, URI me, URI masterUri )
+    {
+        MasterClient master = newMasterClient( masterUri, nioneoDataSource.getStoreId(), haCommunicationLife );
+
+        Slave slaveImpl = new SlaveImpl( nioneoDataSource.getStoreId(), master,
+                new RequestContextFactory( getServerId( masterUri ), xaDataSourceManager,
+                        resolver ), xaDataSourceManager );
+
+        SlaveServer server = new SlaveServer( slaveImpl, serverConfig(), logging,
+                resolver.resolveDependency( Monitors.class ) );
+
+        masterDelegateHandler.setDelegate( master );
+
+        haCommunicationLife.add( slaveImpl );
+        haCommunicationLife.add( server );
+        haCommunicationLife.start();
+
+        URI slaveHaURI = createHaURI( me, server );
+        clusterMemberAvailability.memberIsAvailable( HighAvailabilityModeSwitcher.SLAVE, slaveHaURI );
+
+        return slaveHaURI;
+    }
+
+    private Server.Configuration serverConfig()
+    {
+        Server.Configuration serverConfig = new Server.Configuration()
+        {
+            @Override
+            public long getOldChannelThreshold()
+            {
+                return config.get( HaSettings.lock_read_timeout );
+            }
+
+            @Override
+            public int getMaxConcurrentTransactions()
+            {
+                return config.get( HaSettings.max_concurrent_channels_per_slave );
+            }
+
+            @Override
+            public int getChunkSize()
+            {
+                return config.get( HaSettings.com_chunk_size ).intValue();
+            }
+
+            @Override
+            public HostnamePort getServerAddress()
+            {
+                return config.get( HaSettings.ha_server );
+            }
+        };
+        return serverConfig;
+    }
+
+    private URI createHaURI( URI me, Server<?,?> server )
+    {
+        String hostString = ServerUtil.getHostString( server.getSocketAddress() );
+        int port = server.getSocketAddress().getPort();
+        Integer serverId = config.get( ClusterSettings.server_id );
+        String host = hostString.contains( HighAvailabilityModeSwitcher.INADDR_ANY ) ? me.getHost() : hostString;
+        return URI.create( "ha://" + host + ":" + port + "?serverId=" + serverId );
+    }
+
+    private void copyStoreFromMaster( URI masterUri ) throws Throwable
+    {
+        // Must be called under lock on XaDataSourceManager
+        LifeSupport life = new LifeSupport();
+        try
+        {
+            // Remove the current store - neostore file is missing, nothing we can really do
+            stopServicesAndHandleBranchedStore( BranchedDataPolicy.keep_none );
+            MasterClient copyMaster = newMasterClient( masterUri, null, life );
+
+            life.start();
+
+            // This will move the copied db to the graphdb location
+            console.log( "Copying store from master" );
+            new SlaveStoreWriter( config, console ).copyStore( copyMaster );
+
+            startServicesAgain();
+            console.log( "Finished copying store from master" );
+        }
+        finally
+        {
+            life.stop();
+        }
+    }
+
+    private MasterClient newMasterClient( URI masterUri, StoreId storeId, LifeSupport life )
+    {
+        return masterClientResolver.instantiate( masterUri.getHost(), masterUri.getPort(),
+                resolver.resolveDependency( Monitors.class ), storeId, life );
+    }
+
+    private void startServicesAgain() throws Throwable
+    {
+        @SuppressWarnings( "rawtypes" )
+        List<Class> services = new ArrayList<Class>( Arrays.asList( SERVICES_TO_RESTART_FOR_STORE_COPY ) );
+        for ( Class<?> serviceClass : services )
+        {
+            Lifecycle service = (Lifecycle) resolver.resolveDependency( serviceClass );
+            service.start();
+        }
+    }
+
+    private void stopServicesAndHandleBranchedStore( BranchedDataPolicy branchPolicy ) throws Throwable
+    {
+        List<Class> services = new ArrayList<Class>( Arrays.asList( SERVICES_TO_RESTART_FOR_STORE_COPY ) );
+        Collections.reverse( services );
+        for ( Class<Lifecycle> serviceClass : services )
+        {
+            resolver.resolveDependency( serviceClass ).stop();
+        }
+
+        branchPolicy.handle( config.get( InternalAbstractGraphDatabase.Configuration.store_dir ) );
+    }
+
+    private void checkDataConsistencyWithMaster( URI availableMasterId, Master master, NeoStoreXaDataSource nioneoDataSource )
+    {
+        long myLastCommittedTx = nioneoDataSource.getLastCommittedTxId();
+        Pair<Integer, Long> myMaster;
+        try
+        {
+            myMaster = nioneoDataSource.getMasterForCommittedTx( myLastCommittedTx );
+        }
+        catch ( NoSuchLogVersionException e )
+        {
+            msgLog.logMessage(
+                    "Logical log file for txId "
+                            + myLastCommittedTx
+                            + " missing [version="
+                            + e.getVersion()
+                            + "]. If this is startup then it will be recovered later, " +
+                            "otherwise it might be a problem." );
+            return;
+        }
+        catch ( IOException e )
+        {
+            msgLog.logMessage( "Failed to get master ID for txId " + myLastCommittedTx + ".", e );
+            return;
+        }
+        catch ( Exception e )
+        {
+            throw new BranchedDataException( "Exception while getting master ID for txId "
+                    + myLastCommittedTx + ".", e );
+        }
+
+        HandshakeResult handshake;
+        Response<HandshakeResult> response = null;
+        try
+        {
+            response = master.handshake( myLastCommittedTx, nioneoDataSource.getStoreId() );
+            handshake = response.response();
+            requestContextFactory.setEpoch( handshake.epoch() );
+        }
+        catch( BranchedDataException e )
+        {
+            // Rethrow wrapped in a branched data exception on our side, to clarify where the problem originates.
+            throw new BranchedDataException( "Master detected branched data for this machine.", e );
+        }
+        catch ( RuntimeException e )
+        {
+            // Checked exceptions will be wrapped as the cause if this was a serialized
+            // server-side exception
+            if ( e.getCause() instanceof MissingLogDataException )
+            {
+                /*
+                 * This means the master was unable to find a log entry for the txid we just asked. This
+                 * probably means the thing we asked for is too old or too new. Anyway, since it doesn't
+                 * have the tx it is better if we just throw our store away and ask for a new copy. Next
+                 * time around it shouldn't have to even pass from here.
+                 */
+                throw new StoreOutOfDateException( "The master is missing the log required to complete the " +
+                        "consistency check", e.getCause() );
+            }
+            throw e;
+        }
+        finally
+        {
+            if ( response != null )
+            {
+                response.close();
+            }
+        }
+
+        if ( myMaster.first() != XaLogicalLog.MASTER_ID_REPRESENTING_NO_MASTER &&
+                (myMaster.first() != handshake.txAuthor() || myMaster.other() != handshake.txChecksum()) )
+        {
+            String msg = "Branched data, I (machineId:" + config.get( ClusterSettings.server_id ) + ") think machineId for" +
+                    " txId (" +
+                    myLastCommittedTx + ") is " + myMaster + ", but master (machineId:" + getServerId( availableMasterId ) + ") says that it's " + handshake;
+            throw new BranchedDataException( msg );
+        }
+        msgLog.logMessage( "Master id for last committed tx ok with highestTxId=" +
+                myLastCommittedTx + " with masterId=" + myMaster, true );
+    }
+
+    private NeoStoreXaDataSource ensureDataSourceStarted( XaDataSourceManager xaDataSourceManager, DependencyResolver resolver )
+            throws IOException
+    {
+        // Must be called under lock on XaDataSourceManager
+        NeoStoreXaDataSource nioneoDataSource = (NeoStoreXaDataSource) xaDataSourceManager.getXaDataSource( Config.DEFAULT_DATA_SOURCE_NAME );
+        if ( nioneoDataSource == null )
+        {
+            try
+            {
+                nioneoDataSource = new NeoStoreXaDataSource( config,
+                        resolver.resolveDependency( StoreFactory.class ),
+                        resolver.resolveDependency( LockManager.class ),
+                        resolver.resolveDependency( StringLogger.class ),
+                        resolver.resolveDependency( XaFactory.class ),
+                        resolver.resolveDependency( TransactionStateFactory.class ),
+                        resolver.resolveDependency( TransactionInterceptorProviders.class ),
+                        resolver );
+                xaDataSourceManager.registerDataSource( nioneoDataSource );
+                /*
+                 * CAUTION: The next line may cause severe eye irritation, mental instability and potential
+                 * emotional breakdown. On the plus side, it is correct.
+                 * See, it is quite possible to get here without the NodeManager having stopped, because we don't
+                 * properly manage lifecycle in this class (this is the cause of this ugliness). So, after we
+                 * register the datasource with the DsMgr we need to make sure that NodeManager re-reads the reltype
+                 * and propindex information. Normally, we would have shutdown everything before getting here.
+                 */
+                resolver.resolveDependency( NodeManager.class ).start();
+            }
+            catch ( IOException e )
+            {
+                msgLog.logMessage( "Failed while trying to create datasource", e );
+                throw e;
+            }
+        }
+        return nioneoDataSource;
+    }
+}


### PR DESCRIPTION
HAMS has been refactored so that it mainly deals with decision and coordination. The actual switch code is in separate classes.
This PR also fixes that shutdown was not happening on switcher thread, which during testing can cause the situation that an instance is first shutdown, but then switches to slave in the separate thread. All switching now happens on the same thread, so that the outcome is deterministic.
