### PR TITLE
Fix a race in PersistenceWindowPool related code.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -299,7 +299,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         {
             Buffer buf = window.getBuffer();
             // NOTE: skip of header in offset
-            int offset = (int) (blockId-buf.position()) * getBlockSize() + BLOCK_HEADER_SIZE;
+            int offset = (int) (blockId-window.position()) * getBlockSize() + BLOCK_HEADER_SIZE;
             buf.setOffset( offset );
             byte bytes[] = new byte[record.getLength()];
             buf.get( bytes );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractPersistenceWindow.java
@@ -60,7 +60,7 @@ abstract class AbstractPersistenceWindow extends LockableWindow
     @Override
     public Buffer getOffsettedBuffer( long id )
     {
-        int offset = (int) (id - buffer.position()) * recordSize;
+        int offset = (int) (id - position) * recordSize;
         buffer.setOffset( offset );
         return buffer;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Buffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/Buffer.java
@@ -33,8 +33,6 @@ import java.nio.ByteBuffer;
  */
 public class Buffer
 {
-//    private static Logger logger = Logger.getLogger( Buffer.class.getName() );
-
     private final ByteBuffer buf;
     private final PersistenceWindow persistenceWindow;
 
@@ -46,21 +44,6 @@ public class Buffer
             throw new IllegalArgumentException( "null buf" );
         }
         this.buf = buf;
-    }
-
-//    void setByteBuffer( ByteBuffer byteBuffer )
-//    {
-//        this.buf = byteBuffer;
-//    }
-
-    /**
-     * Returns the position of the persistence window tied to this buffer.
-     *
-     * @return The persistence window's position
-     */
-    public long position()
-    {
-        return persistenceWindow.position();
     }
 
     /**
@@ -94,10 +77,8 @@ public class Buffer
         }
         catch ( java.lang.IllegalArgumentException e )
         {
-//            logger.severe( "Illegal buffer position: Pos=" + position()
-//                + " off=" + offset + " capacity=" + buf.capacity() );
             throw new IllegalArgumentException( "Illegal offset " + offset +
-                    " for window position:" + position() + ", buffer:" + buf, e );
+                    " for buffer:" + buf, e );
         }
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/LockableWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/LockableWindow.java
@@ -46,11 +46,6 @@ public abstract class LockableWindow implements PersistenceWindow
         this.fileChannel = fileChannel;
     }
 
-    boolean encapsulates( long position )
-    {
-        return position() <= position && position < position() + size();
-    }
-
     StoreChannel getFileChannel()
     {
         return fileChannel;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/MappedPersistenceWindow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/MappedPersistenceWindow.java
@@ -52,8 +52,6 @@ class MappedPersistenceWindow extends LockableWindow
         {
             buffer = new Buffer( this, channel.map( mapMode,
                     position * recordSize, totalSize ) );
-//            buffer.setByteBuffer( channel.map( mapMode,
-//                position * recordSize, totalSize ) );
         }
         catch ( IOException e )
         {
@@ -133,15 +131,16 @@ class MappedPersistenceWindow extends LockableWindow
     @Override
     public Buffer getOffsettedBuffer( long id )
     {
-        int offset = (int) (id - buffer.position()) * recordSize;
+        int offset = (int) (id - position) * recordSize;
         try
         {
             buffer.setOffset( offset );
             return buffer;
         } catch(IllegalArgumentException e)
         {
-            throw new IllegalArgumentException( "Unable to set offset. id:" + id + ", position:" + buffer.position()
-                    + ", recordSize:" + recordSize, e );
+            throw new IllegalArgumentException(
+                    "Unable to set offset. id: " + id +
+                            ", position: " + position + ", recordSize: " + recordSize, e );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceRow.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceRow.java
@@ -87,10 +87,10 @@ public class PersistenceRow extends LockableWindow
     @Override
     public Buffer getOffsettedBuffer( long id )
     {
-        if ( id != buffer.position() )
+        if ( id != position )
         {
             throw new InvalidRecordException( "Id[" + id + 
-                "] not equal to buffer position[" + buffer.position() + "]" );
+                "] not equal to buffer position[" + position + "]" );
         }
         return buffer;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPool.java
@@ -183,7 +183,7 @@ public class PersistenceWindowPool implements WindowPool
                     // Someone else put it there before us. Close this row
                     // which was unnecessarily opened. The next go in this loop
                     // will get that one instead.
-                    dpw.close();;
+                    dpw.close();
                     if(theBrick != null)
                     {
                         // theBrick may be null here if brick size is 0.
@@ -552,7 +552,7 @@ public class PersistenceWindowPool implements WindowPool
             }
 
             LockableWindow window = mappedBrick.getWindow();
-            if (window.writeOutAndCloseIfFree( readOnly ) )
+            if ( window.writeOutAndCloseIfFree( readOnly ) )
             {
                 mappedBrick.setWindow( null );
                 memUsed -= brickSize;

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/SetCacheProvidersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/SetCacheProvidersTest.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.graphdb.factory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.cache.SoftCacheProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SetCacheProvidersTest
 {
@@ -44,7 +45,6 @@ public class SetCacheProvidersTest
         }
         catch ( IllegalArgumentException iae )
         {
-            iae.printStackTrace();
             assertTrue( iae.getMessage().contains( "No provider for cache type" ) );
             assertTrue( iae.getMessage().contains( "register" ) );
             assertTrue( iae.getMessage().contains( "missing" ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPoolRaceTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/PersistenceWindowPoolRaceTestIT.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.TargetDirectory;
+
+public class PersistenceWindowPoolRaceTestIT
+{
+    private static final Throwable STOP_SIGNAL = new Throwable( "Test stop signal" );
+
+    @Rule
+    public TargetDirectory.TestDirectory testDir =
+            TargetDirectory.testDirForTest( PersistenceWindowPoolRaceTestIT.class );
+
+    @Test
+    public void raceOnClaimReleaseForAtMost30Seconds() throws Throwable
+    {
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+
+        File file = new File( testDir.directory(), "test.file.db" );
+        file.deleteOnExit();
+
+        int blockSize = 512;
+        int maxId = 10000;
+        RandomAccessFile raf = new RandomAccessFile( file, "rw" );
+        FileChannel fileChannel = raf.getChannel();
+        setSize( fileChannel, blockSize * maxId);
+        long mappedMem = blockSize + (blockSize * (maxId / 10)) + (blockSize / 2);
+        boolean useMemoryMappedBuffers = true;
+        boolean readOnly = false;
+        ConcurrentMap<Long, PersistenceRow> activeRowWindows = new ConcurrentHashMap<Long, PersistenceRow>();
+        BrickElementFactory brickFactory = BrickElementFactory.DEFAULT;
+        StringLogger log = StringLogger.SYSTEM;
+
+        PersistenceWindowPool pwp = new PersistenceWindowPool(
+                file,
+                blockSize,
+                new StoreFileChannel( fileChannel ),
+                mappedMem,
+                useMemoryMappedBuffers,
+                readOnly,
+                activeRowWindows,
+                brickFactory,
+                log );
+
+        for ( int i = 0; i <= 9; i++ )
+        {
+            PersistenceWindow window = pwp.acquire( i * 10, OperationType.WRITE );
+            pwp.release( window );
+        }
+
+        AtomicReference<Throwable> mailbox = new AtomicReference<Throwable>();
+
+        AcquireReleaseJob[] jobs = new AcquireReleaseJob[] {
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox ),
+                new AcquireReleaseJob( pwp, maxId, mailbox )};
+
+        for ( AcquireReleaseJob job : jobs )
+        {
+            executor.submit( job );
+        }
+
+        // The test will run for at most ~30 seconds.
+        long deadline = System.currentTimeMillis() + 30000;
+        Throwable observedFailure;
+        do
+        {
+            Thread.sleep( 100 );
+            observedFailure = mailbox.get();
+        } while ( observedFailure == null && System.currentTimeMillis() < deadline );
+        executor.shutdown();
+        mailbox.compareAndSet( null, STOP_SIGNAL );
+
+        if ( observedFailure != null )
+        {
+            throw observedFailure;
+        }
+    }
+
+    private void setSize( FileChannel fileChannel, long sizeInBytes ) throws IOException
+    {
+        fileChannel.write( ByteBuffer.wrap( new byte[] { 0 }), sizeInBytes - 1 );
+    }
+
+    private static class AcquireReleaseJob implements Runnable
+    {
+        private final PersistenceWindowPool pwp;
+        private final AtomicReference<Throwable> mailbox;
+        private final long maxId;
+
+        public AcquireReleaseJob( PersistenceWindowPool pwp, int maxId, AtomicReference<Throwable> mailbox )
+        {
+            this.pwp = pwp;
+            this.mailbox = mailbox;
+            this.maxId = maxId - 1;
+        }
+
+        @Override
+        public void run()
+        {
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+
+            try
+            {
+                while ( mailbox.get() == null )
+                {
+                    long id = random.nextLong( 0, maxId );
+                    PersistenceWindow window = pwp.acquire( id, OperationType.WRITE );
+                    window.getOffsettedBuffer( id ).put( (byte) (0xFF & random.nextInt()) );
+                    pwp.release( window );
+                }
+            }
+            catch ( Throwable e )
+            {
+                mailbox.set( e );
+            }
+        }
+    }
+}

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/windowpool/MappedWindow.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/store/windowpool/MappedWindow.java
@@ -49,7 +49,7 @@ class MappedWindow implements PersistenceWindow
     @Override
     public Buffer getOffsettedBuffer( long id )
     {
-        int offset = (int) (id - buffer.position()) * recordSize;
+        int offset = (int) (id - startRecordId) * recordSize;
         buffer.setOffset( offset );
         return buffer;
     }


### PR DESCRIPTION
This closes a race window where a thread could mistakenly acquire a closed window from the PersistenceWindowPool.
When this happened, the bug would manifest itself as an "illegal position" exception from the getOffsettedBuffer call.
