### PR TITLE
Fix: merge must fail when trying to create 2 nodes with same id but different labels

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/ExecuteUpdateCommandsPipe.scala
@@ -82,12 +82,16 @@ trait NoLushEntityCreation {
   assertNothingIsCreatedWhenItShouldNot()
 
   private def extractEntities(action: UpdateAction): Seq[NamedExpectation] = action match {
-    case CreateNode(key, props, labels)              => Seq(NamedExpectation(key, props, labels))
-    case CreateRelationship(key, from, to, _, props) => Seq(NamedExpectation(key, props, Seq.empty)) ++
-      extractIfEntity(from) ++
-      extractIfEntity(to)
-    case CreateUniqueAction(links@_*)                => links.flatMap(l => Seq(l.start, l.end, l.rel))
-    case _                                           => Seq()
+    case CreateNode(key, props, labels) =>
+      Seq(NamedExpectation(key, props, labels))
+    case CreateRelationship(key, from, to, _, props) =>
+      Seq(NamedExpectation(key, props, Seq.empty)) ++ extractIfEntity(from) ++ extractIfEntity(to)
+    case CreateUniqueAction(links@_*) =>
+      links.flatMap(l => Seq(l.start, l.end, l.rel))
+    case MergePatternAction(_, _, _, Some(updates), _) =>
+      updates.flatMap(extractEntities(_))
+    case _ =>
+      Seq()
   }
 
   private def extractIfEntity(from: RelationshipEndpoint): Option[NamedExpectation] =

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,5 +1,9 @@
-2.0.2-SNAPSHOT
+2.0.3-SNAPSHOT
 --------------
+o MERGE must fail when trying to create 2 nodes with same id but different labels (e.g., MERGE (a: Foo)-[r:KNOWS]->(a: Bar))
+
+2.0.2
+-----
 o Fixes #1897 - goes into never ending loop for some aggregate queries
 o Add the functions toInt(...) and toFloat(...)
 o Renames the Cypher type Double to Float

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeRelationshipAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeRelationshipAcceptanceTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher
 
-import org.scalatest.Assertions
 import org.junit.Test
 import org.neo4j.graphdb.{Path, Relationship}
 
@@ -484,4 +483,9 @@ class MergeRelationshipAcceptanceTest
     assert(Set(r1, r2) === result)
   }
 
+  @Test def should_reject_merging_nodes_having_the_same_id_but_different_labels() {
+    intercept[SyntaxException]{
+      execute("merge (a: Foo)-[r:KNOWS]->(a: Bar)")
+    }
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ErrorMessagesTest.scala
@@ -191,6 +191,13 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with StringHelper {
     )
   }
 
+  test("merge 2 nodes with same identifier but different labels") {
+    expectError(
+      "MERGE (a: Foo)-[r:KNOWS]->(a: Bar)",
+      "Can't create `a` with properties or labels here. It already exists in this context"
+    )
+  }
+
   test("type of identifier is wrong") {
     expectError(
       "start n=node(0) with [n] as users MATCH users-->messages RETURN messages",


### PR DESCRIPTION
e.g., MERGE (a: Foo)-[r:KNOWS]->(a: Bar)
