### PR TITLE
Reintroduce deletion of test directories for passing tests.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -150,7 +150,7 @@ public class Exceptions
         }
         return root;
     }
-    
+
     public static String stringify( Throwable cause )
     {
         try

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.helpers;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
 
 public class TestExceptions
 {
@@ -82,7 +83,7 @@ public class TestExceptions
         assertTrue( Exceptions.contains( cause, "words", NullPointerException.class ) );
         assertFalse( Exceptions.contains( cause, "not", NullPointerException.class ) );
     }
-    
+
     private static class LevelOneException extends Exception
     {
         public LevelOneException( String message )


### PR DESCRIPTION
This now includes a workaround for the problem that we see when deleting
test directories on Windows for tests that memory-map files.

Conflicts:
    community/kernel/src/main/java/org/neo4j/kernel/impl/util/FileUtils.java
