### PR TITLE
Fixes race that can cause duplicate writes in XaLogicalLog

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
+import static java.lang.Math.max;
+import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.CLEAN;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG1;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG2;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -50,13 +56,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
-
-import static java.lang.Math.max;
-
-import static org.neo4j.helpers.Exceptions.launderedException;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.CLEAN;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG1;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG2;
 
 /**
  * <CODE>XaLogicalLog</CODE> is a transaction and logical log combined. In
@@ -326,6 +325,7 @@ public class XaLogicalLog implements LogLoader
     // [TX_PREPARE][identifier]
     public synchronized void prepare( int identifier ) throws XAException
     {
+        kernelHealth.assertHealthy( XAException.class );
         LogEntry.Start startEntry = xidIdentMap.get( identifier );
         assert startEntry != null;
         try
@@ -350,6 +350,7 @@ public class XaLogicalLog implements LogLoader
     public synchronized void commitOnePhase( int identifier, long txId, ForceMode forceMode )
             throws XAException
     {
+        kernelHealth.assertHealthy( XAException.class );
         LogEntry.Start startEntry = xidIdentMap.get( identifier );
         assert startEntry != null;
         assert txId != -1;
@@ -407,6 +408,7 @@ public class XaLogicalLog implements LogLoader
     public synchronized void commitTwoPhase( int identifier, long txId, ForceMode forceMode )
             throws XAException
     {
+        kernelHealth.assertHealthy( XAException.class );
         LogEntry.Start startEntry = xidIdentMap.get( identifier );
         assert startEntry != null;
         assert txId != -1;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLogTest.java
@@ -19,49 +19,55 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
+import static org.neo4j.kernel.impl.transaction.xaframework.ForceMode.forced;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies.NO_PRUNING;
+
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
+import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.listeners.InvocationListener;
 import org.mockito.listeners.MethodInvocationReport;
 import org.mockito.stubbing.Answer;
-
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.kernel.impl.nioneo.store.StoreFileChannel;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionStateFactory;
 import org.neo4j.kernel.impl.transaction.XidImpl;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.logging.SingleLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.FailureOutput;
 import org.neo4j.test.TargetDirectory;
-
-import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
-
-import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
-import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
-import static org.neo4j.kernel.impl.transaction.xaframework.ForceMode.forced;
-import static org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategies.NO_PRUNING;
 
 public class XaLogicalLogTest
 {
@@ -163,6 +169,165 @@ public class XaLogicalLogTest
         assertEquals( initialLogVersion+1, log.getHighestLogVersion() );
     }
 
+    @Test
+    public void shouldNotPrepareAfterKernelPanicHasHappened() throws Exception
+    {
+        RandomAccessFile forCheckingSize = null;
+        try
+        {
+            File directory = TargetDirectory.forTest( getClass() ).
+                    directory( "shouldNotPrepareAfterKernelPanicHasHappened", true );
+            Logging mockLogging = mock( Logging.class );
+            when( mockLogging.getMessagesLog( Matchers.<Class>any() ) ).thenReturn( mock( StringLogger.class ) );
+            KernelHealth health = new KernelHealth( mock( KernelPanicEventGenerator.class ), mockLogging );
+            // GIVEN
+            long maxSize = 1000;
+            File logFile = new File( directory, "log" );
+            forCheckingSize = new RandomAccessFile( logFile, "rw" );
+            XaLogicalLog log = new XaLogicalLog( logFile,
+                    mock( XaResourceManager.class ),
+                    new FixedSizeXaCommandFactory(),
+                    new VersionRespectingXaTransactionFactory(),
+                    new DefaultFileSystemAbstraction(),
+                    new Monitors(),
+                    new DevNullLoggingService(),
+                    NO_PRUNING,
+                    mock( TransactionStateFactory.class ), health, maxSize );
+            log.open();
+
+            // When
+            int identifier = log.start( new XidImpl( XidImpl.getNewGlobalId( DEFAULT_SEED, 1 ), NeoStoreXaDataSource.BRANCH_ID ), -1, -1 );
+            log.writeStartEntry( identifier );
+            long sizeBeforePanic = forCheckingSize.getChannel().size();
+            health.panic( new MockException() );
+            try
+            {
+                log.prepare( identifier );
+                fail(); // it should not go through ok
+            }
+            catch( XAException e )
+            {
+                assertEquals( MockException.class, e.getCause().getClass() );
+            }
+
+            // Then
+            assertEquals( sizeBeforePanic, forCheckingSize.getChannel().size() );
+        }
+        finally
+        {
+            if ( forCheckingSize != null )
+            {
+                forCheckingSize.close();
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotCommitOnePhaseAfterKernelPanicHasHappened() throws Exception
+    {
+        RandomAccessFile forCheckingSize = null;
+        try
+        {
+            File directory = TargetDirectory.forTest( getClass() ).
+                    directory( "shouldNotPrepareAfterKernelPanicHasHappened", true );
+            Logging mockLogging = mock( Logging.class );
+            when( mockLogging.getMessagesLog( Matchers.<Class>any() ) ).thenReturn( mock( StringLogger.class ) );
+            KernelHealth health = new KernelHealth( mock( KernelPanicEventGenerator.class ), mockLogging );
+            // GIVEN
+            long maxSize = 1000;
+            File logFile = new File( directory, "log" );
+            forCheckingSize = new RandomAccessFile( logFile, "rw" );
+            XaLogicalLog log = new XaLogicalLog( logFile,
+                    mock( XaResourceManager.class ),
+                    new FixedSizeXaCommandFactory(),
+                    new VersionRespectingXaTransactionFactory(),
+                    new DefaultFileSystemAbstraction(),
+                    new Monitors(),
+                    new DevNullLoggingService(),
+                    NO_PRUNING,
+                    mock( TransactionStateFactory.class ), health, maxSize );
+            log.open();
+
+            // When
+            int identifier = log.start( new XidImpl( XidImpl.getNewGlobalId( DEFAULT_SEED, 1 ), NeoStoreXaDataSource.BRANCH_ID ), -1, -1 );
+            log.writeStartEntry( identifier );
+            long sizeBeforePanic = forCheckingSize.getChannel().size();
+            health.panic( new MockException() );
+            try
+            {
+                log.commitOnePhase( identifier, 2, ForceMode.forced );
+                fail(); // it should not go through ok
+            }
+            catch( XAException e )
+            {
+                assertEquals( MockException.class, e.getCause().getClass() );
+            }
+
+            // Then
+            assertEquals( sizeBeforePanic, forCheckingSize.getChannel().size() );
+        }
+        finally
+        {
+            if ( forCheckingSize != null )
+            {
+                forCheckingSize.close();
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotCommitTwoPhaseAfterKernelPanicHasHappened() throws Exception
+    {
+        RandomAccessFile forCheckingSize = null;
+        try
+        {
+            File directory = TargetDirectory.forTest( getClass() ).
+                    directory( "shouldNotPrepareAfterKernelPanicHasHappened", true );
+            Logging mockLogging = mock( Logging.class );
+            when( mockLogging.getMessagesLog( Matchers.<Class>any() ) ).thenReturn( mock( StringLogger.class ) );
+            KernelHealth health = new KernelHealth( mock( KernelPanicEventGenerator.class ), mockLogging );
+            // GIVEN
+            long maxSize = 1000;
+            File logFile = new File( directory, "log" );
+            forCheckingSize = new RandomAccessFile( logFile, "rw" );
+            XaLogicalLog log = new XaLogicalLog( logFile,
+                    mock( XaResourceManager.class ),
+                    new FixedSizeXaCommandFactory(),
+                    new VersionRespectingXaTransactionFactory(),
+                    new DefaultFileSystemAbstraction(),
+                    new Monitors(),
+                    new DevNullLoggingService(),
+                    NO_PRUNING,
+                    mock( TransactionStateFactory.class ), health, maxSize );
+            log.open();
+
+            // When
+            int identifier = log.start( new XidImpl( XidImpl.getNewGlobalId( DEFAULT_SEED, 1 ), NeoStoreXaDataSource.BRANCH_ID ), -1, -1 );
+            log.writeStartEntry( identifier );
+            long sizeBeforePanic = forCheckingSize.getChannel().size();
+            health.panic( new MockException() );
+            try
+            {
+                log.commitTwoPhase( identifier, 2, ForceMode.forced );
+                fail(); // it should not go through ok
+            }
+            catch( XAException e )
+            {
+                assertEquals( MockException.class, e.getCause().getClass() );
+            }
+
+            // Then
+            assertEquals( sizeBeforePanic, forCheckingSize.getChannel().size() );
+        }
+        finally
+        {
+            if ( forCheckingSize != null )
+            {
+                forCheckingSize.close();
+            }
+        }
+    }
+
     private static class FixedSizeXaCommand extends XaCommand
     {
         private final byte[] data;
@@ -262,4 +427,7 @@ public class XaLogicalLogTest
 
     public final @Rule EphemeralFileSystemRule ephemeralFs = new EphemeralFileSystemRule();
     public final Xid xid = new XidImpl( "global".getBytes(), "resource".getBytes() );
+
+    private static class MockException extends RuntimeException
+    {}
 }


### PR DESCRIPTION
There is a possible window where a transaction may fail to flush
 the log buffer (for example, during a commit) and even though
 it will set the KernelHealth to notOk, another thread can still
 come and try to flush the same contents again (say, by attempting
 a commit of its own tx). This can cause the log to be unrecoverable.
 This commit fixes this issue by introducing checks to KernelHealth
 before any write happens to the log's underlying file.
