### PR TITLE
Optimize logging and HTTP filter

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
@@ -25,6 +25,9 @@ import java.net.URL;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
@@ -33,8 +36,6 @@ import org.neo4j.kernel.configuration.RestartOnChange;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-import org.slf4j.Logger;
-import org.slf4j.Marker;
 
 /**
  * Logging service that uses Logback as backend.
@@ -153,10 +154,12 @@ public class LogbackService
             extends StringLogger
     {
         private final Logger logger;
+        private final boolean debugEnabled;
 
         public Slf4jToStringLoggerAdapter( Logger logger )
         {
             this.logger = logger;
+            debugEnabled = logger.isDebugEnabled();
         }
 
         @Override
@@ -182,7 +185,7 @@ public class LogbackService
         @Override
         public void logMessage( String msg, boolean flush )
         {
-            if ( logger.isDebugEnabled() )
+            if ( isDebugEnabled() )
             {
                 logger.debug( msg );
             }
@@ -207,7 +210,10 @@ public class LogbackService
         @Override
         public void debug( String msg )
         {
-            logger.debug( msg );
+            if ( isDebugEnabled() )
+            {
+                logger.debug( msg );
+            }
         }
 
         @Override
@@ -219,7 +225,7 @@ public class LogbackService
         @Override
         public boolean isDebugEnabled()
         {
-            return logger.isDebugEnabled();
+            return debugEnabled;
         }
 
         @Override

--- a/community/server/src/main/java/org/neo4j/server/logging/JettyLoggerAdapter.java
+++ b/community/server/src/main/java/org/neo4j/server/logging/JettyLoggerAdapter.java
@@ -38,6 +38,8 @@ import static java.lang.String.format;
  */
 public class JettyLoggerAdapter implements Logger
 {
+    private boolean debugEnabled;
+
     private final Logging logging;
     private final StringLogger logger;
 
@@ -45,37 +47,45 @@ public class JettyLoggerAdapter implements Logger
     {
         this.logging = logging;
         this.logger = StringLogger.SYSTEM;
+        debugEnabled = logger.isDebugEnabled();
     }
 
     private JettyLoggerAdapter( Logging logging, StringLogger logger )
     {
         this.logging = logging;
         this.logger = logger;
+        debugEnabled = logger.isDebugEnabled();
     }
 
     @Override
     public void debug( String arg0, Throwable arg1 )
     {
-        try
+        if (debugEnabled)
         {
-            logger.debug( wrapNull( arg0 ), arg1 );
-        }
-        catch ( IllegalFormatException e )
-        {
-            logger.debug( safeFormat( arg0, arg1 ) );
+            try
+            {
+                logger.debug( wrapNull( arg0 ), arg1 );
+            }
+            catch ( IllegalFormatException e )
+            {
+                logger.debug( safeFormat( arg0, arg1 ) );
+            }
         }
     }
 
     @Override
     public void debug( String arg0, Object arg1, Object arg2 )
     {
-        try
+        if (debugEnabled)
         {
-            logger.debug( format( wrapNull( arg0 ), arg1, arg2 ) );
-        }
-        catch ( IllegalFormatException e )
-        {
-            logger.debug( safeFormat( arg0, arg1, arg2 ) );
+            try
+            {
+                logger.debug( format( wrapNull( arg0 ), arg1, arg2 ) );
+            }
+            catch ( IllegalFormatException e )
+            {
+                logger.debug( safeFormat( arg0, arg1, arg2 ) );
+            }
         }
     }
 
@@ -112,7 +122,7 @@ public class JettyLoggerAdapter implements Logger
     @Override
     public boolean isDebugEnabled()
     {
-        return true;
+        return debugEnabled;
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/SecurityRulesModule.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 
 import org.apache.commons.configuration.Configuration;
 
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.configuration.Configurator;
@@ -49,14 +50,17 @@ public class SecurityRulesModule implements ServerModule
     public void start()
     {
         Iterable<SecurityRule> securityRules = getSecurityRules();
-        mountedFilter = new SecurityFilter( securityRules );
-
-        webServer.addFilter( mountedFilter, "/*" );
-
-        for ( SecurityRule rule : securityRules )
+        if ( Iterables.count( securityRules ) > 0 )
         {
-            log.log( "Security rule [%s] installed on server",
-                    rule.getClass().getCanonicalName() );
+            mountedFilter = new SecurityFilter( securityRules );
+
+            webServer.addFilter( mountedFilter, "/*" );
+
+            for ( SecurityRule rule : securityRules )
+            {
+                log.log( "Security rule [%s] installed on server",
+                        rule.getClass().getCanonicalName() );
+            }
         }
     }
 

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty6WebServer.java
@@ -33,12 +33,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.servlet.Filter;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import ch.qos.logback.access.jetty.RequestLogImpl;
 import org.mortbay.component.LifeCycle;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Handler;
@@ -65,8 +65,6 @@ import org.neo4j.server.logging.JettyLoggerAdapter;
 import org.neo4j.server.plugins.Injectable;
 import org.neo4j.server.security.KeyStoreInformation;
 import org.neo4j.server.security.SslSocketConnectorFactory;
-
-import ch.qos.logback.access.jetty.RequestLogImpl;
 
 import static java.lang.String.format;
 
@@ -444,8 +442,9 @@ public class Jetty6WebServer implements WebServer
 
         final RequestLogHandler requestLogHandler = new RequestLogHandler();
         requestLogHandler.setRequestLog( requestLog );
-
-        jetty.addHandler( requestLogHandler );
+        requestLogHandler.setServer( jetty );
+        requestLogHandler.setHandler( jetty.getHandler() );
+        jetty.setHandler( requestLogHandler );
 	}
 
 	private String trimTrailingSlashToKeepJettyHappy( String mountPoint )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/GCResistantCache.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/GCResistantCache.java
@@ -372,7 +372,8 @@ public class GCResistantCache<E extends EntityWithSizeObject> implements Cache<E
 
     private void logStatistics( StringLogger log )
     {
-        log.debug( this.toString() );
+        if (log.isDebugEnabled())
+            log.debug( this.toString() );
     }
 
     @Override


### PR DESCRIPTION
Same as #2340, but now for 1.9-maint branch:
This PR primarily fixes so that isDebugEnabled is cached for Jetty and Neo4j calls. During testing with ApacheBench it was found that this gave 200%-1000% performance improvement on REST API calls, due to the excessive number of debug logging calls made by Jetty.

GCResistantCache.put had a debug log call with toString() that did not first check for isDebugEnabled, which caused a pretty heavy string calculation to happen even if debugging was not enabled. This has been fixed.

Also removes the security filter if no rules are configured.
