### PR TITLE
Inline aliased identifiers into node and relationship patterns

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContext.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContext.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_1.ast.rewriters
 import org.neo4j.cypher.internal.compiler.v2_1._
 import org.neo4j.cypher.internal.compiler.v2_1.ast._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.CantHandleQueryException
+import org.neo4j.cypher.internal.compiler.v2_1.bottomUp.BottomUpRewriter
 
 case class InliningContext(projections: Map[Identifier, Expression] = Map.empty, seenIdentifiers: Set[Identifier] = Set.empty) {
 
@@ -37,7 +38,7 @@ case class InliningContext(projections: Map[Identifier, Expression] = Map.empty,
   def spoilIdentifier(identifier: Identifier): InliningContext =
     copy(projections = projections - identifier, seenIdentifiers = seenIdentifiers + identifier)
 
-  def identifierRewriter = bottomUp(Rewriter.lift {
+  def identifierRewriter: BottomUpRewriter = bottomUp(Rewriter.lift {
     case expr: ScopeIntroducingExpression if seen(expr.identifier) =>
       throw new CantHandleQueryException
 
@@ -45,6 +46,24 @@ case class InliningContext(projections: Map[Identifier, Expression] = Map.empty,
       projections.getOrElse(identifier, identifier)
   })
 
-  private def seen(identifier: Identifier) = seenIdentifiers.contains(identifier)
+  def patternRewriter: BottomUpRewriter = bottomUp(Rewriter.lift {
+    case node @ NodePattern(Some(ident), _, _, _) =>
+      alias(ident) match {
+        case alias @ Some(_) => node.copy(identifier = alias)(node.position)
+        case _               => node
+      }
+    case rel @ RelationshipPattern(Some(ident), _, _, _, _, _) =>
+      alias(ident) match {
+        case alias @ Some(_) => rel.copy(identifier = alias)(rel.position)
+        case _               => rel
+      }
+  })
+
+  def seen(identifier: Identifier) = seenIdentifiers.contains(identifier)
+
+  def alias(identifier: Identifier): Option[Identifier] = projections.get(identifier) match {
+    case Some(other: Identifier) => Some(other)
+    case _                       => None
+  }
 }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/inliningContextCreator.scala
@@ -33,10 +33,12 @@ object inliningContextCreator extends (ast.Statement => InliningContext) {
         (context, children) => children(context.enterQueryPart(namedPatternPartPathExpressions(parts)))
 
       case NodePattern(Some(identifier), _, _, _) =>
-        (context, children) => children(context.spoilIdentifier(identifier))
+        (context, children) =>
+          if (context.alias(identifier).isEmpty) children(context.spoilIdentifier(identifier)) else children(context)
 
       case RelationshipPattern(Some(identifier), _, _, _, _, _) =>
-        (context, children) => children(context.spoilIdentifier(identifier))
+        (context, children) =>
+          if (context.alias(identifier).isEmpty) children(context.spoilIdentifier(identifier)) else children(context)
     }
   }
 

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/AstConstructionTestSupport.scala
@@ -26,4 +26,6 @@ trait AstConstructionTestSupport extends CypherTestSupport {
   protected val pos = DummyPosition(0)
 
   implicit def withPos[T](expr: InputPosition => T): T = expr(pos)
+
+  def ident(name: String) = Identifier(name)(pos)
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InlineProjectionsTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InlineProjectionsTest.scala
@@ -63,6 +63,18 @@ class InlineProjectionsTest extends CypherFunSuite with AstRewritingTestSupport 
     result should equal(ast("WITH * WITH * RETURN 1+1 as `m`"))
   }
 
+  test("should inline node patterns: MATCH (a) WITH a as b MATCH (b) RETURN b => MATCH (a) WITH * MATCH (a) RETURN a as `b`") {
+    val result = projectionInlinedAst("MATCH (a) WITH a as b MATCH (b) RETURN b")
+
+    result should equal(ast("MATCH (a) WITH * MATCH (a) RETURN a as `b`"))
+  }
+
+  test("should inline relationship patterns: MATCH ()-[a]->() WITH a as b MATCH ()-[b]->() RETURN b => MATCH ()-[a]->() WITH * MATCH ()-[a]->() RETURN a as `b`") {
+    val result = projectionInlinedAst("MATCH ()-[a]->() WITH a as b MATCH ()-[b]->() RETURN b")
+
+    result should equal(ast("MATCH ()-[a]->() WITH * MATCH ()-[a]->() RETURN a as `b`"))
+  }
+
   // FIXME: 2014-4-30 Davide: No inlining due to missing scope information for the identifiers
   test("should not inline identifiers which are reused multiple times: WITH 1 as n WITH 2 AS n RETURN n") {
     val result = projectionInlinedAst("WITH 1 as n WITH 2 AS n RETURN n")

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContextCreatorTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContextCreatorTest.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_1.ast.rewriters
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_1.planner.AstRewritingTestSupport
+
+class InliningContextCreatorTest extends CypherFunSuite with AstRewritingTestSupport {
+
+  val identA = ident("a")
+  val identB = ident("b")
+
+  test("should not spoil aliased node identifiers") {
+    val ast = parser.parse("match (a) with a as b match (b) return b")
+
+    val context = inliningContextCreator(ast)
+
+    context.projections should equal(Map(identB -> identA))
+    context.alias(identB) should equal(Some(identA))
+  }
+
+  test("should not spoil aliased relationship identifiers") {
+    val ast = parser.parse("match ()-[a]->() with a as b match ()-[b]->() return b")
+
+    val context = inliningContextCreator(ast)
+
+    context.projections should equal(Map(identB -> identA))
+    context.alias(identB) should equal(Some(identA))
+  }
+}

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContextTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/rewriters/InliningContextTest.scala
@@ -21,14 +21,15 @@ package org.neo4j.cypher.internal.compiler.v2_1.ast.rewriters
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.ast._
-import org.neo4j.cypher.internal.compiler.v2_1.ast.Expression.SemanticContext
 import org.neo4j.cypher.internal.compiler.v2_1.planner.CantHandleQueryException
+import org.neo4j.graphdb.Direction
+import org.neo4j.cypher.internal.compiler.v2_1.ast.Expression.SemanticContext
 
 class InliningContextTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  val identN: Identifier = Identifier("n")_
-  val identM: Identifier = Identifier("m")_
-  val identA: Identifier = Identifier("a")_
+  val identN = ident("n")
+  val identM = ident("m")
+  val identA = ident("a")
   val astNull: Null = Null()_
 
   val mapN = Map(identN -> astNull)
@@ -83,5 +84,21 @@ class InliningContextTest extends CypherFunSuite with AstConstructionTestSupport
     }
 
     evaluating { ctx.identifierRewriter(expr) } should produce[CantHandleQueryException]
+  }
+
+  test("should inline aliases into node patterns") {
+    val ctx = InliningContext(mapAtoN)
+
+    val expr: NodePattern = NodePattern(Some(identA), Seq(), None, naked = false)_
+
+    expr.typedRewrite[NodePattern](ctx.patternRewriter).identifier should equal(Some(identN))
+  }
+
+  test("should inline aliases into relationship patterns") {
+    val ctx = InliningContext(mapAtoN)
+
+    val expr: RelationshipPattern = RelationshipPattern(Some(identA), optional = false, Seq(), None, None, Direction.OUTGOING)_
+
+    expr.typedRewrite[RelationshipPattern](ctx.patternRewriter).identifier should equal(Some(identN))
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/AstRewritingTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/AstRewritingTestSupport.scala
@@ -22,12 +22,8 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner
 import org.neo4j.cypher.internal.commons.CypherTestSupport
 import org.neo4j.cypher.internal.compiler.v2_1.{InputPosition, DummyPosition, parser}
 import org.neo4j.cypher.internal.compiler.v2_1.parser.ParserFixture
+import org.neo4j.cypher.internal.compiler.v2_1.ast.AstConstructionTestSupport
 
-trait AstRewritingTestSupport extends CypherTestSupport {
-
+trait AstRewritingTestSupport extends CypherTestSupport with AstConstructionTestSupport {
   val parser = ParserFixture.parser
-
-  val pos = DummyPosition(0)
-
-  implicit def withPos[T](expr: InputPosition => T): T = expr(pos)
 }


### PR DESCRIPTION
This improves on the number of cases where we can actually inline thus allowing us to plan larger query parts all at once
