### PR TITLE
2.0 shell host fix

### DIFF
--- a/community/shell/src/docs/dev/shell.asciidoc
+++ b/community/shell/src/docs/dev/shell.asciidoc
@@ -38,6 +38,9 @@ Here's some sample configurations:
 # Enable the remote shell feature
 remote_shell_enabled = true
 
+# By default, shell listens only on the loopback interface, but you can specify the IP address of any network interface or use 0.0.0.0 for all interfaces
+remote_shell_host = 127.0.0.1
+
 # The default port is 1337, but you can specify something else if you like
 remote_shell_port = 1337
 

--- a/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
@@ -41,9 +41,9 @@ public class ShellSettings
     @Description("Enable a remote shell server which shell clients can log in to")
     public static final Setting<Boolean> remote_shell_enabled = setting( "remote_shell_enabled", BOOLEAN, FALSE );
 
-    public static final Setting<String> remote_shell_host = setting( "remote_shell_host", STRING, "localhost",
+    public static final Setting<String> remote_shell_host = setting( "remote_shell_host", STRING, "127.0.0.1",
             illegalValueMessage( "must be a valid name", matches( ANY ) ) );
-    
+
     public static final Setting<Integer> remote_shell_port = setting( "remote_shell_port", INTEGER, "1337", port );
 
     public static final Setting<Boolean> remote_shell_read_only = setting( "remote_shell_read_only", BOOLEAN, FALSE );

--- a/community/shell/src/main/java/org/neo4j/shell/impl/HostBoundSocketFactory.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/HostBoundSocketFactory.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.shell.impl;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMIServerSocketFactory;
+
+public class HostBoundSocketFactory implements RMIClientSocketFactory, RMIServerSocketFactory
+{
+    private final InetAddress inetAddress;
+
+    public HostBoundSocketFactory( String host ) throws UnknownHostException
+    {
+        this.inetAddress = InetAddress.getByName( host );
+    }
+
+    @Override
+    public Socket createSocket( String host, int port ) throws IOException
+    {
+        return new Socket( host, port );
+    }
+
+    @Override
+    public ServerSocket createServerSocket( int port ) throws IOException
+    {
+        return new ServerSocket( port, 50, inetAddress );
+    }
+}

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
@@ -20,6 +20,7 @@
 package org.neo4j.shell.impl;
 
 import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.rmi.Naming;
 import java.rmi.NotBoundException;
 import java.rmi.Remote;
@@ -173,12 +174,19 @@ public class RmiLocation
 		try
 		{
 			Naming.list( toShortUrl() );
-			return LocateRegistry.getRegistry( getPort() );
+			return LocateRegistry.getRegistry( getHost(), getPort() );
 		}
 		catch ( RemoteException e )
 		{
-			return LocateRegistry.createRegistry( getPort() );
-		}
+            try
+            {
+                return LocateRegistry.createRegistry( getPort(), null, new HostBoundSocketFactory( host ) );
+            }
+            catch ( UnknownHostException hostException )
+            {
+                throw new RemoteException( "Unable to bind to '"+host+"', unknown hostname.", hostException );
+            }
+        }
 		catch ( java.net.MalformedURLException e )
 		{
 			throw new RemoteException( "Malformed URL", e );

--- a/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/ShellBootstrapTest.java
@@ -20,17 +20,13 @@
 package org.neo4j.shell.impl;
 
 import org.junit.Test;
-
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.shell.ShellSettings;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.valueOf;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class ShellBootstrapTest

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -32,5 +32,7 @@ keep_logical_logs=true
 
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
-# Specify custom shell port (default is 1337).
-#remote_shell_port=1234
+# The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
+#remote_shell_host=127.0.0.1
+# The port the shell will listen on, default is 1337
+#remote_shell_port=1337

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -32,5 +32,7 @@ keep_logical_logs=true
 
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
-# Specify custom shell port (default is 1337).
-#remote_shell_port=1234
+# The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
+#remote_shell_host=127.0.0.1
+# The port the shell will listen on, default is 1337
+#remote_shell_port=1337

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -90,6 +90,7 @@ ha.pull_interval=10
 
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
-# Specify custom shell port (default is 1337).
-#remote_shell_port=1234
-
+# The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
+#remote_shell_host=127.0.0.1
+# The port the shell will listen on, default is 1337
+#remote_shell_port=1337


### PR DESCRIPTION
This does not contain a test. I tried to write a test that verifies that the server is listening to the correct host, but could not find a way to do it that was not platform-specific. I've verified manually that the fix works, but am bit annoyed that I can't cement the behavior. Not sure what to do here, I guess we'll just have to be vigilant if we ever modify this code again to make sure we don't break the behavior.
