### PR TITLE
Fixes bug in transaction state wrt indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -342,9 +342,10 @@ public class StateHandlingStatementOperations implements
         }
         DiffSets<IndexDescriptor> ruleDiffSet = state.txState().indexDiffSetsByLabel( labelId );
 
-        Iterator<IndexDescriptor> rules =
-                state.hasTxStateWithChanges() ? ruleDiffSet.apply( committedRules.iterator() ) : committedRules
-                        .iterator();
+        boolean hasTxStateWithChanges = state.hasTxStateWithChanges();
+        Iterator<IndexDescriptor> rules = hasTxStateWithChanges ?
+                filterByPropertyKeyId( ruleDiffSet.apply( committedRules.iterator() ), propertyKey ) :
+                committedRules.iterator();
         IndexDescriptor single = singleOrNull( rules );
         if ( single == null )
         {
@@ -352,6 +353,21 @@ public class StateHandlingStatementOperations implements
                     propertyKey + " not found" );
         }
         return single;
+    }
+
+    private Iterator<IndexDescriptor> filterByPropertyKeyId(
+            Iterator<IndexDescriptor> descriptorIterator,
+            final int propertyKey )
+    {
+        Predicate<IndexDescriptor> predicate = new Predicate<IndexDescriptor>()
+        {
+            @Override
+            public boolean accept( IndexDescriptor item )
+            {
+                return item.getPropertyKeyId() == propertyKey;
+            }
+        };
+        return filter( predicate, descriptorIterator );
     }
 
     @Override
@@ -788,11 +804,6 @@ public class StateHandlingStatementOperations implements
         Set<Long> removedNodesWithLabel = txState.nodesWithLabelChanged( index.getLabelId() ).getRemoved();
         diff.removeAll( filter( hasPropertyFilter, removedNodesWithLabel.iterator() ) );
         return diff;
-    }
-
-    private long nodeIfNotDeleted( long nodeId, TxState txState )
-    {
-        return txState.nodeIsDeletedInThisTx( nodeId ) ? NO_SUCH_NODE : nodeId;
     }
 
     private class HasPropertyFilter implements Predicate<Long>

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -142,6 +142,48 @@ public class SchemaTransactionStateTest
     }
 
     @Test
+    public void shouldReturnNonExistentRuleAddedInTransactionFromLookup() throws Exception
+    {
+        // GIVEN
+        // -- the store already have an index on the label and a different property
+        IndexDescriptor existingRule1 = new IndexDescriptor( labelId1, key1 );
+        when( store.indexesGetForLabelAndPropertyKey( state, labelId1, key1 ) ).thenReturn( existingRule1 );
+        // -- the store already have an index on a different label with the same property
+        IndexDescriptor existingRule2 = new IndexDescriptor( labelId2, key2 );
+        when( store.indexesGetForLabelAndPropertyKey( state, labelId2, key2 ) ).thenReturn( existingRule2 );
+        // -- a non-existent rule has been added in the transaction
+        txContext.indexCreate( state, labelId1, key2 );
+
+        // WHEN
+        IndexDescriptor rule = txContext.indexesGetForLabelAndPropertyKey( state, labelId1, key2 );
+
+        // THEN
+        assertEquals( new IndexDescriptor( labelId1, key2 ), rule );
+    }
+
+    @Test
+    public void shouldNotReturnRulesAddedInTransactionWithDifferentLabelOrPropertyFromLookup() throws Exception
+    {
+        // GIVEN
+        // -- the store already have an index on the label and a different property
+        IndexDescriptor existingRule1 = new IndexDescriptor( labelId1, key1 );
+        when( store.indexesGetForLabelAndPropertyKey( state, labelId1, key1 ) ).thenReturn( existingRule1 );
+        // -- the store already have an index on a different label with the same property
+        IndexDescriptor existingRule2 = new IndexDescriptor( labelId2, key2 );
+        when( store.indexesGetForLabelAndPropertyKey( state, labelId2, key2 ) ).thenReturn( existingRule2 );
+        // -- a non-existent rule has been added in the transaction
+        txContext.indexCreate( state, labelId1, key2 );
+
+        // WHEN
+        IndexDescriptor lookupRule1 = txContext.indexesGetForLabelAndPropertyKey( state, labelId1, key1 );
+        IndexDescriptor lookupRule2 = txContext.indexesGetForLabelAndPropertyKey( state, labelId2, key2 );
+
+        // THEN
+        assertEquals( existingRule1, lookupRule1 );
+        assertEquals( existingRule2, lookupRule2 );
+    }
+
+    @Test
     public void shouldNotReturnExistentRuleDroppedInTransaction() throws Exception
     {
         // GIVEN


### PR DESCRIPTION
When an index had been added to a transaction, for a particular label and property,
and the store already had a committed index for that particular label but a
different property, and you tried to look up that index, e.g. to examine its state,
then we did not properly filter out the uncommitted index when we applied the
state of the transaction to the lookup results.

This fixes #2279
