### PR TITLE
2.0 file descriptor leak

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -59,12 +59,14 @@ import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.util.DiffSets;
 import org.neo4j.kernel.impl.util.PrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
+import org.neo4j.kernel.impl.util.PrimitiveLongResourceIterator;
 
 import static java.util.Collections.emptyList;
 
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.helpers.collection.IteratorUtil.filter;
+import static org.neo4j.helpers.collection.IteratorUtil.resourceIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
 import static org.neo4j.helpers.collection.IteratorUtil.singleOrNull;
 import static org.neo4j.helpers.collection.IteratorUtil.toPrimitiveIntIterator;
@@ -446,9 +448,10 @@ public class StateHandlingStatementOperations implements
             Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
-        PrimitiveLongIterator committed = storeLayer.nodeGetUniqueFromIndexLookup( state, index, value );
+        PrimitiveLongResourceIterator committed = storeLayer.nodeGetUniqueFromIndexLookup( state, index, value );
         PrimitiveLongIterator exactMatches = filterExactIndexMatches( state, index, value, committed );
-        PrimitiveLongIterator changeFilteredMatches = filterIndexStateChanges( state, index, value, exactMatches );
+        PrimitiveLongIterator exactMatchesResource = resourceIterator( exactMatches, committed );
+        PrimitiveLongIterator changeFilteredMatches = filterIndexStateChanges( state, index, value, exactMatchesResource );
         return single( changeFilteredMatches, NO_SUCH_NODE );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -66,6 +66,7 @@ import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.util.PrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.PrimitiveIntIteratorForArray;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
+import org.neo4j.kernel.impl.util.PrimitiveLongResourceIterator;
 
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.map;
@@ -304,7 +305,7 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetUniqueFromIndexLookup(
+    public PrimitiveLongResourceIterator nodeGetUniqueFromIndexLookup(
             KernelStatement state,
             IndexDescriptor index,
             Object value )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.util.PrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
+import org.neo4j.kernel.impl.util.PrimitiveLongResourceIterator;
 
 /**
  * Abstraction for reading committed data.
@@ -94,7 +95,7 @@ public interface StoreReadLayer
 
     Iterator<UniquenessConstraint> constraintsGetAll( KernelStatement state );
 
-    PrimitiveLongIterator nodeGetUniqueFromIndexLookup( KernelStatement state, IndexDescriptor index,
+    PrimitiveLongResourceIterator nodeGetUniqueFromIndexLookup( KernelStatement state, IndexDescriptor index,
                                                         Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveIntIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveIntIterator.java
@@ -22,10 +22,14 @@ package org.neo4j.kernel.impl.util;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.neo4j.graphdb.Resource;
+
 /**
  * Please dedup with {@link DiffApplyingPrimitiveLongIterator}
+ * Applies a diffset to the given source PrimitiveIntIterator.
+ * If the given source is a Resource, then so is this DiffApplyingPrimitiveIntIterator.
  */
-public final class DiffApplyingPrimitiveIntIterator extends AbstractPrimitiveIntIterator
+public final class DiffApplyingPrimitiveIntIterator extends AbstractPrimitiveIntIterator implements Resource
 {
     private enum Phase
     {
@@ -114,6 +118,15 @@ public final class DiffApplyingPrimitiveIntIterator extends AbstractPrimitiveInt
         else
         {
             endReached();
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if ( source instanceof Resource )
+        {
+            ((Resource) source).close();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
@@ -22,7 +22,13 @@ package org.neo4j.kernel.impl.util;
 import java.util.Iterator;
 import java.util.Set;
 
-public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLongIterator
+import org.neo4j.graphdb.Resource;
+
+/**
+ * Applies a diffset to the given source PrimitiveLongIterator.
+ * If the given source is a Resource, then so is this DiffApplyingPrimitiveLongIterator.
+ */
+public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLongIterator implements Resource
 {
     private enum Phase
     {
@@ -111,6 +117,15 @@ public final class DiffApplyingPrimitiveLongIterator extends AbstractPrimitiveLo
         else
         {
             endReached();
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if ( source instanceof Resource )
+        {
+            ((Resource) source).close();
         }
     }
 }

--- a/community/neo4j/pom.xml
+++ b/community/neo4j/pom.xml
@@ -80,6 +80,16 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <licenses>

--- a/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
+++ b/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package files;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.TargetDirectory;
+
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class TestNoFileDescriptorLeaks
+{
+    private static final AtomicInteger counter = new AtomicInteger();
+
+    private static int nextId()
+    {
+        return counter.incrementAndGet();
+    }
+
+    @Rule
+    public TargetDirectory.TestDirectory directory =
+            TargetDirectory.testDirForTest( TestNoFileDescriptorLeaks.class );
+
+    private GraphDatabaseService db;
+    private MBeanServer jmx;
+    private ObjectName osMBean;
+    private ExecutionEngine cypher;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        db = new GraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
+        cypher = new ExecutionEngine(db);
+        osMBean = ObjectName.getInstance("java.lang:type=OperatingSystem");
+        jmx = getPlatformMBeanServer();
+    }
+
+    @After
+    public void stopNeo()
+    {
+        db.shutdown();
+    }
+
+    private long getOpenFileDescriptorCount() throws Exception
+    {
+        return (long) jmx.getAttribute( osMBean, "OpenFileDescriptorCount" );
+    }
+
+    @Test
+    public void mustNotLeakFileDescriptorsFromMerge() throws Exception
+    {
+        // GIVEN
+        try ( Transaction tx = db.beginTx() )
+        {
+            cypher.execute("create constraint on (n:Node) assert n.id is unique");
+            tx.success();
+        }
+        cycleMerge( 1 );
+
+        long initialFDs = getOpenFileDescriptorCount();
+
+        // WHEN
+        cycleMerge( 300 );
+
+        // THEN
+        long finalFDs = getOpenFileDescriptorCount();
+        long upperBoundFDs = initialFDs + 50; // allow some slack
+        assertThat( finalFDs, lessThan( upperBoundFDs ) );
+    }
+
+    private void cycleMerge( int iterations )
+    {
+        for ( int i = 0; i < iterations; i++ )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                cypher.execute(
+                        "MERGE (a:Node {id: {a}}) " +
+                        "MERGE (b:Node {id: {b}}) " +
+                        "MERGE (c:Node {id: {c}}) " +
+                        "MERGE (d:Node {id: {d}}) " +
+                        "MERGE (e:Node {id: {e}}) " +
+                        "MERGE (f:Node {id: {f}}) ",
+                        map("a", nextId() % 100,
+                                "b", nextId() % 100,
+                                "c", nextId() % 100,
+                                "d", nextId(),
+                                "e", nextId(),
+                                "f", nextId())
+                );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() % 100) );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() % 100) );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() % 100) );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() ) );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() ) );
+                cypher.execute( "MERGE (n:Node {id: {a}}) ", map("a", nextId() ) );
+                tx.success();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Turns out we did not properly close our IndexReaders when the transaction contained relevant changes
and wrapped the lookup iterators (that are resources) in diff-applying iterators (that are not).

This fixes #1799
