### PR TITLE
Removed single:// and ha:// prefixes in backup.

### DIFF
--- a/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
+++ b/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
@@ -40,12 +40,9 @@ SOURCE URI
 
 Backup sources are given in the following format:
 
-*<running mode>://<host>[:<port>][,<host>[:<port>]]...*
+*<host>[:<port>][,<host>[:<port>]]...*
 
 Note that multiple hosts can be defined.
-
-*running mode*::
-  \'single' or \'ha'. \'ha' is for instances in High Availability mode, \'single' is for standalone databases.
 
 *host*::
   In single mode, the host of a source database; in ha mode, the cluster address of a cluster member. Note that multiple hosts can be given when using High Availability mode.
@@ -75,19 +72,19 @@ EXAMPLES
 ----
 # Performing a backup the first time: create a blank directory and run the backup tool
 mkdir /mnt/backup/neo4j-backup
-neo4j-backup -from single://192.168.1.34 -to /mnt/backup/neo4j-backup
+neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Subsequent backups using the same _target_-directory will be incremental and therefore quick
-neo4j-backup -from single://freja -to /mnt/backup/neo4j-backup
+neo4j-backup -from freja -to /mnt/backup/neo4j-backup
 
 # Performing a backup where the service is registered on a custom port
-neo4j-backup -from single://freja:9999 -to /mnt/backup/neo4j-backup
+neo4j-backup -from freja:9999 -to /mnt/backup/neo4j-backup
 
 # Performing a backup from HA cluster, specifying only one cluster member
-./neo4j-backup -from ha://oden:5002 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from oden:5002 -to /mnt/backup/neo4j-backup
 
 # Performing a backup from HA cluster, specifying two cluster members
-./neo4j-backup -from ha://oden:5001,loke:5002 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from oden:5001,loke:5002 -to /mnt/backup/neo4j-backup
 ----
 
 [[neo4j-backup-manpage-restore]]

--- a/enterprise/backup/src/docs/ops/backup.asciidoc
+++ b/enterprise/backup/src/docs/ops/backup.asciidoc
@@ -21,9 +21,9 @@ Regardless of the mode a backup is created with, the resulting files represent a
 
 The database to be backed up is specified using a URI with syntax
 
-<running mode>://<host>[:port]{,<host>[:port]*}
+<host>[:port]{,<host>[:port]*}
 
-Running mode must be defined and is either _single_ for non-HA or _ha_ for HA clusters. The <host>[:port] part
+The <host>[:port] part
 points to a host running the database, on port _port_ if not the default. The additional _host:port_ arguments
 are useful for passing multiple cluster members.
 
@@ -40,13 +40,13 @@ To perform a backup from a running embedded or server database run:
 ----
 # Performing a full backup: create a blank directory and run the backup tool
 mkdir /mnt/backup/neo4j-backup
-./neo4j-backup -from single://192.168.1.34 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Performing an incremental backup: just specify the location of your previous backup
-./neo4j-backup -from single://192.168.1.34 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Performing an incremental backup where the service is registered on a custom port
-./neo4j-backup -from single://192.168.1.34:9999 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from 192.168.1.34:9999 -to /mnt/backup/neo4j-backup
 ----
 
 [[backup-java]]
@@ -76,10 +76,10 @@ That is, use the value of the +ha.cluster_server+ setting in the configuration.
 [source,shell]
 ----
 # Performing a backup from HA cluster, specifying only one cluster member
-./neo4j-backup -from ha://192.168.1.15:5001 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from 192.168.1.15:5001 -to /mnt/backup/neo4j-backup
 
 # Performing a backup from HA cluster, specifying two possible cluster members
-./neo4j-backup -from ha://192.168.1.15:5001,192.168.1.16:5002 -to /mnt/backup/neo4j-backup
+./neo4j-backup -from 192.168.1.15:5001,192.168.1.16:5002 -to /mnt/backup/neo4j-backup
 ----
 
 [[backup-restoring]]

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import ch.qos.logback.classic.LoggerContext;
+
 import org.neo4j.com.ComException;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.TransactionFailureException;
@@ -47,8 +48,9 @@ import org.neo4j.kernel.logging.LogbackService;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.logging.SystemOutLogging;
 
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.slf4j.impl.StaticLoggerBinder.getSingleton;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class BackupTool
 {
@@ -95,6 +97,10 @@ public class BackupTool
         String to = arguments.get( TO, null );
         boolean verify = arguments.getBoolean( VERIFY, true, true );
         Config tuningConfiguration = readTuningConfiguration( TO, arguments );
+
+        if (!from.contains( ":" ))
+            from = "single://"+from;
+
         URI backupURI = null;
         try
         {
@@ -155,7 +161,10 @@ public class BackupTool
 
         try
         {
-            systemOut.println("Performing backup from '" + backupURI.toASCIIString() + "'");
+            String str = backupURI.toASCIIString();
+            if (str.contains( "://" ))
+                str = str.split( "://" )[1];
+            systemOut.println("Performing backup from '" + str + "'");
             doBackup( backupURI, to, verify, tuningConfiguration );
         }
         catch ( TransactionFailureException e )
@@ -190,10 +199,9 @@ public class BackupTool
         if ( arguments.get( FROM, null ) == null )
         {
             throw new ToolFailureException( "Please specify " + dash( FROM ) + ", examples:\n" +
-                    "  " + dash( FROM ) + " single://192.168.1.34\n" +
-                    "  " + dash( FROM ) + " single://192.168.1.34:1234\n" +
-                    "  " + dash( FROM ) + " ha://192.168.1.15:2181\n" +
-                    "  " + dash( FROM ) + " ha://192.168.1.15:2181,192.168.1.16:2181" );
+                    "  " + dash( FROM ) + " 192.168.1.34\n" +
+                    "  " + dash( FROM ) + " 192.168.1.34:1234\n" +
+                    "  " + dash( FROM ) + " 192.168.1.15:2181,192.168.1.16:2181" );
         }
 
         if ( arguments.get( TO, null ) == null )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
@@ -49,7 +49,7 @@ public class BackupToolTest
     @Test
     public void shouldUseIncrementalOrFallbackToFull() throws Exception
     {
-        String[] args = new String[]{"-from", "single://localhost", "-to", "my_backup"};
+        String[] args = new String[]{"-from", "localhost", "-to", "my_backup"};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
 
@@ -59,14 +59,14 @@ public class BackupToolTest
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ),
                 eq( BackupServer.DEFAULT_PORT ), eq( "my_backup" ), eq( true ), any( Config.class ) );
-        verify( systemOut ).println( "Performing backup from 'single://localhost'" );
+        verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
 
     @Test
     public void shouldIgnoreIncrementalFlag() throws Exception
     {
-        String[] args = new String[]{"-incremental", "-from", "single://localhost", "-to", "my_backup"};
+        String[] args = new String[]{"-incremental", "-from", "localhost", "-to", "my_backup"};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
 
@@ -76,14 +76,14 @@ public class BackupToolTest
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ), eq( BackupServer.DEFAULT_PORT ),
                 eq( "my_backup" ), eq( true ), any( Config.class ) );
-        verify( systemOut ).println( "Performing backup from 'single://localhost'" );
+        verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
 
     @Test
     public void shouldIgnoreFullFlag() throws Exception
     {
-        String[] args = new String[]{"-full", "-from", "single://localhost", "-to", "my_backup"};
+        String[] args = new String[]{"-full", "-from", "localhost", "-to", "my_backup"};
         BackupService service = mock( BackupService.class );
         when(service.directoryContainsDb( anyString() )).thenReturn( true );
         PrintStream systemOut = mock( PrintStream.class );
@@ -94,7 +94,7 @@ public class BackupToolTest
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ), eq( BackupServer.DEFAULT_PORT ),
                 eq( "my_backup" ), eq( true ), any(Config.class) );
-        verify( systemOut ).println( "Performing backup from 'single://localhost'" );
+        verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
 
@@ -102,7 +102,7 @@ public class BackupToolTest
     public void appliesDefaultTuningConfigurationForConsistencyChecker() throws Exception
     {
         // given
-        String[] args = new String[]{"-from", "single://localhost",
+        String[] args = new String[]{"-from", "localhost",
                 "-to", "my_backup"};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
@@ -133,7 +133,7 @@ public class BackupToolTest
         properties.setProperty( ConsistencyCheckSettings.consistency_check_property_owners.name(), "true" );
         properties.store( new FileWriter( propertyFile ), null );
 
-        String[] args = new String[]{"-from", "single://localhost",
+        String[] args = new String[]{"-from", "localhost",
                 "-to", "my_backup", "-config", propertyFile.getPath()};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
@@ -153,7 +153,7 @@ public class BackupToolTest
     {
         // given
         File propertyFile = TargetDirectory.forTest( getClass() ).file( "nonexistent_file" );
-        String[] args = new String[]{"-from", "single://localhost",
+        String[] args = new String[]{"-from", "localhost",
                 "-to", "my_backup", "-config", propertyFile.getPath()};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
@@ -194,10 +194,9 @@ public class BackupToolTest
         {
             // then
             assertEquals( "Please specify -from, examples:\n" +
-                    "  -from single://192.168.1.34\n" +
-                    "  -from single://192.168.1.34:1234\n" +
-                    "  -from ha://192.168.1.15:2181\n" +
-                    "  -from ha://192.168.1.15:2181,192.168.1.16:2181",
+                    "  -from 192.168.1.34\n" +
+                    "  -from 192.168.1.34:1234\n" +
+                    "  -from 192.168.1.15:2181,192.168.1.16:2181",
                     e.getMessage() );
         }
 
@@ -234,7 +233,7 @@ public class BackupToolTest
     public void exitWithFailureIfNoDestinationSpecified() throws Exception
     {
         // given
-        String[] args = new String[]{"-from", "single://localhost"};
+        String[] args = new String[]{"-from", "localhost"};
         BackupService service = mock( BackupService.class );
         PrintStream systemOut = mock( PrintStream.class );
         BackupTool backupTool = new BackupTool( service, systemOut );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.ha;
 
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.backup.BackupEmbeddedIT.BACKUP_PATH;
-import static org.neo4j.backup.BackupEmbeddedIT.PATH;
-import static org.neo4j.backup.BackupEmbeddedIT.createSomeData;
-import static org.neo4j.backup.BackupEmbeddedIT.runBackupToolFromOtherJvmToGetExitCode;
-import static org.neo4j.test.ha.ClusterManager.fromXml;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
@@ -42,6 +36,14 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.backup.BackupEmbeddedIT.BACKUP_PATH;
+import static org.neo4j.backup.BackupEmbeddedIT.PATH;
+import static org.neo4j.backup.BackupEmbeddedIT.createSomeData;
+import static org.neo4j.backup.BackupEmbeddedIT.runBackupToolFromOtherJvmToGetExitCode;
+import static org.neo4j.test.ha.ClusterManager.fromXml;
 
 @Ignore("Breaks occasionally, needs investigation")
 public class BackupHaIT
@@ -90,18 +92,18 @@ public class BackupHaIT
     public void makeSureBackupCanBePerformedFromWronglyNamedCluster() throws Throwable
     {
         assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode(
-                backupArguments( "ha://localhost:5001", BACKUP_PATH.getPath(), "non.existent" ) ) );
+                backupArguments( "localhost:5001", BACKUP_PATH.getPath(), "non.existent" ) ) );
     }
 
     private void testBackupFromCluster( String askForCluster ) throws Throwable
     {
         assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode(
-                backupArguments( "ha://localhost:5001", BACKUP_PATH.getPath(), askForCluster ) ) );
+                backupArguments( "localhost:5001", BACKUP_PATH.getPath(), askForCluster ) ) );
         assertEquals( representation, DbRepresentation.of( BACKUP_PATH ) );
         ManagedCluster cluster = clusterManager.getCluster( askForCluster == null ? "neo4j.ha" : askForCluster );
         DbRepresentation newRepresentation = createSomeData( cluster.getAnySlave() );
         assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode(
-                backupArguments( "ha://localhost:5001", BACKUP_PATH.getPath(), askForCluster ) ) );
+                backupArguments( "localhost:5001", BACKUP_PATH.getPath(), askForCluster ) ) );
         assertEquals( newRepresentation, DbRepresentation.of( BACKUP_PATH ) );
     }
 


### PR DESCRIPTION
single:// and ha:// prefixes to backup tool have been deprecated. They still work, but are not needed when calling the tool, and all mention of these prefixes have been removed from docs.
