### PR TITLE
Hide Ronja behind a new keyword

### DIFF
--- a/community/cypher/cypher-commons/src/main/scala/org/neo4j/cypher/CypherVersion.scala
+++ b/community/cypher/cypher-commons/src/main/scala/org/neo4j/cypher/CypherVersion.scala
@@ -32,6 +32,7 @@ object CypherVersion {
   case object v1_9 extends CypherVersion("1.9")
   case object v2_0 extends CypherVersion("2.0")
   case object v2_1 extends CypherVersion("2.1")
+  case object experimental extends CypherVersion("experimental")
 
   def apply(versionName: String) = findVersionByExactName(CypherVersionName.asCanonicalName(versionName)).getOrElse {
     throw new SyntaxException(s"Supported versions are: ${allVersions.map(_.name).mkString(", ")}")
@@ -40,5 +41,5 @@ object CypherVersion {
   def findVersionByExactName(versionName: String) = allVersions.find( _.name == versionName )
 
   val vDefault = v2_1
-  val allVersions = Seq(v1_9,  v2_0, v2_1)
+  val allVersions = Seq(v1_9,  v2_0, v2_1, experimental)
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -55,7 +55,8 @@ class CypherCompiler(graph: GraphDatabaseService,
   private val queryCache2_0 = new LRUCache[String, Object](queryCacheSize)
   private val queryCache1_9 = new LRUCache[String, Object](queryCacheSize)
 
-  val compiler2_1 = CypherCompilerFactory2_1.newInstance(graph, queryCacheSize, kernelMonitors)
+  val ronjaCompiler2_1 = CypherCompilerFactory2_1.ronjaCompiler(graph, queryCacheSize, kernelMonitors)
+  val legacyCompiler2_1 = CypherCompilerFactory2_1.legacyCompiler(graph, queryCacheSize, kernelMonitors)
   val compiler2_0 = new CypherCompiler2_0(graph, (q, f) => queryCache2_0.getOrElseUpdate(q, f))
   val compiler1_9 = new CypherCompiler1_9(graph, (q, f) => queryCache1_9.getOrElseUpdate(q, f))
 
@@ -64,8 +65,12 @@ class CypherCompiler(graph: GraphDatabaseService,
     val (version, remainingQuery) = versionedQuery(query)
 
     version match {
+      case CypherVersion.experimental =>
+        val (plan, extractedParameters) = ronjaCompiler2_1.prepare(remainingQuery, new PlanContext_v2_1(statement, kernelAPI, context))
+        (new ExecutionPlanWrapperForV2_1(plan), extractedParameters)
+
       case CypherVersion.v2_1 =>
-        val (plan, extractedParameters) = compiler2_1.prepare(remainingQuery, new PlanContext_v2_1(statement, kernelAPI, context))
+        val (plan, extractedParameters) = legacyCompiler2_1.prepare(remainingQuery, new PlanContext_v2_1(statement, kernelAPI, context))
         (new ExecutionPlanWrapperForV2_1(plan), extractedParameters)
 
       case CypherVersion.v2_0 =>
@@ -83,7 +88,7 @@ class CypherCompiler(graph: GraphDatabaseService,
     val (version, remainingQuery) = versionedQuery(query)
 
     version match  {
-      case CypherVersion.v2_1 => compiler2_1.isPeriodicCommit(remainingQuery)
+      case CypherVersion.v2_1 => ronjaCompiler2_1.isPeriodicCommit(remainingQuery)
       case _                  => false
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -32,7 +32,6 @@ import org.neo4j.cypher.internal.spi.v2_1.TransactionBoundPlanContext
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.cypher.internal.commons.{CypherTestSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.CypherCompiler
-import org.neo4j.kernel.impl.api.Kernel
 
 trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   self: CypherTestSuite  =>
@@ -40,9 +39,11 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   var graph: GraphDatabaseAPI with Snitch = null
   var nodes: List[Node] = null
 
+  def databaseConfig(): Map[String,String] = Map.empty
+
   override protected def initTest() {
     super.initTest()
-    graph = new ImpermanentGraphDatabase() with Snitch
+    graph = new ImpermanentGraphDatabase(databaseConfig().asJava) with Snitch
   }
 
   override protected def stopTest() {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -62,6 +62,8 @@ class NewPlannerMonitor extends NewQueryPlanSuccessRateMonitor {
 trait NewPlannerTestSupport extends CypherTestSupport {
   self: ExecutionEngineFunSuite =>
 
+  override def databaseConfig(): Map[String,String] = Map("cypher_parser_version" -> CypherVersion.experimental.name)
+
   val newPlannerMonitor = new NewPlannerMonitor
 
   override protected def initTest() {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -113,7 +113,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
   test("allows optional match to start a query") {
     //GIVEN
-    val result: ExecutionResult = engine.profile("optional match (n) return n")
+    val result: ExecutionResult = engine.profile("cypher experimental optional match (n) return n")
 
     //WHEN THEN
     assertRows(1)(result)("Optional")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/CypherCompilerAstCacheAcceptanceTest.scala
@@ -43,7 +43,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should monitor cache misses") {
-    val compiler = newCurrentCompiler.compiler2_1
+    val compiler = newCurrentCompiler.ronjaCompiler2_1
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
@@ -53,7 +53,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should monitor cache hits") {
-    val compiler = newCurrentCompiler.compiler2_1
+    val compiler = newCurrentCompiler.ronjaCompiler2_1
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
@@ -64,7 +64,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   }
 
   test("should monitor cache flushes") {
-    val compiler = newCurrentCompiler.compiler2_1
+    val compiler = newCurrentCompiler.ronjaCompiler2_1
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -92,7 +92,7 @@ public abstract class GraphDatabaseSettings
     @Description("Enable this to specify a parser other than the default one.")
     public static final Setting<String> cypher_parser_version = setting(
             "cypher_parser_version",
-            options( "1.9", "2.0", "2.1" ), NO_DEFAULT );
+            options( "1.9", "2.0", "2.1", "experimental" ), NO_DEFAULT );
 
     @Description("Used to set the number of Cypher query execution plans that are cached.")
     public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "100", min( 0 ) );


### PR DESCRIPTION
This commit makes the old planner the default
planner to use. Ronja can still be used, but
has to be explicitly selected.
