### PR TITLE
Do recovery on HA master/slave switch

### DIFF
--- a/community/neo4j/src/test/java/recovery/TestIndexingServiceRecovery.java
+++ b/community/neo4j/src/test/java/recovery/TestIndexingServiceRecovery.java
@@ -39,12 +39,11 @@ import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
-import org.neo4j.kernel.impl.api.NonTransactionalTokenNameLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.LogTestUtils;
 import org.neo4j.test.LogTestUtils.LogHook;
 import org.neo4j.test.LogTestUtils.LogHookAdapter;
@@ -173,16 +172,11 @@ public class TestIndexingServiceRecovery
                         state.databaseDependencies() )
                 {
                     @Override
-                    protected void createNeoDataSource()
+                    protected Monitors createMonitors()
                     {
-                        // Register our little special recovery listener
-                        neoDataSource = new NeoStoreXaDataSource( config,
-                                storeFactory, logging.getMessagesLog( NeoStoreXaDataSource.class ),
-                                xaFactory, stateFactory, transactionInterceptorProviders, jobScheduler, logging,
-                                updateableSchemaState, new NonTransactionalTokenNameLookup( labelTokenHolder, propertyKeyTokenHolder ),
-                                dependencyResolver, txManager, propertyKeyTokenHolder, labelTokenHolder, relationshipTypeTokenHolder,
-                                persistenceManager, lockManager, this, recoveryMonitor );
-                        xaDataSourceManager.registerDataSource( neoDataSource );
+                        Monitors monitors = super.createMonitors();
+                        monitors.addMonitorListener( recoveryMonitor );
+                        return monitors;
                     }
                 };
             }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -134,7 +134,7 @@ public class MultiPaxosServerFactory
                     Executor stateMachineExecutor, final MultiPaxosContext context,
                     StateMachine[] machines )
     {
-        StateMachines stateMachines = new StateMachines( input, output, timeouts, executor, stateMachineExecutor, me );
+        StateMachines stateMachines = new StateMachines( logging.getMessagesLog( StateMachines.class ), input, output, timeouts, executor, stateMachineExecutor, me );
 
         for ( StateMachine machine : machines )
         {

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/StateMachines.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/StateMachines.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.cluster;
 
-import static org.neo4j.cluster.com.message.Message.CONVERSATION_ID;
-import static org.neo4j.cluster.com.message.Message.CREATED_BY;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -41,8 +38,10 @@ import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.statemachine.StateMachine;
 import org.neo4j.cluster.statemachine.StateTransitionListener;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.neo4j.cluster.com.message.Message.CONVERSATION_ID;
+import static org.neo4j.cluster.com.message.Message.CREATED_BY;
 
 
 /**
@@ -54,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public class StateMachines
         implements MessageProcessor, MessageSource
 {
-    private final Logger logger = LoggerFactory.getLogger( StateMachines.class );
+    private final StringLogger logger;
 
     private final MessageSender sender;
     private DelayedDirectExecutor executor;
@@ -69,11 +68,12 @@ public class StateMachines
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock( true );
     private final String instanceIdHeaderValue;
 
-    public StateMachines( MessageSource source,
+    public StateMachines( StringLogger logger, MessageSource source,
                           final MessageSender sender,
                           Timeouts timeouts,
                           DelayedDirectExecutor executor, Executor stateMachineExecutor, InstanceId instanceId )
     {
+        this.logger = logger;
         this.sender = sender;
         this.executor = executor;
         this.stateMachineExecutor = stateMachineExecutor;

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.cluster;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.neo4j.cluster.com.message.Message.internal;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -40,6 +30,7 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageSender;
@@ -48,7 +39,19 @@ import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.statemachine.State;
 import org.neo4j.cluster.statemachine.StateMachine;
 import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.cluster.com.message.Message.internal;
 
 public class StateMachinesTest
 {
@@ -56,7 +59,7 @@ public class StateMachinesTest
     public void whenMessageHandlingCausesNewMessagesThenEnsureCorrectOrder() throws Exception
     {
         // Given
-        StateMachines stateMachines = new StateMachines( Mockito.mock(MessageSource.class),
+        StateMachines stateMachines = new StateMachines( mock(StringLogger.class), Mockito.mock(MessageSource.class),
                 Mockito.mock( MessageSender.class), Mockito.mock( Timeouts.class),
                 Mockito.mock(DelayedDirectExecutor.class), new Executor()
         {
@@ -105,15 +108,16 @@ public class StateMachinesTest
             }
         } ).when( sender ).process( Matchers.<List<Message<? extends MessageType>>>any() );
 
-        StateMachines stateMachines = new StateMachines( mock( MessageSource.class ), sender,
-        mock( Timeouts.class ), mock( DelayedDirectExecutor.class ), new Executor()
-        {
-            @Override
-            public void execute( Runnable command )
-            {
-                command.run();
-            }
-        }, me );
+        StateMachines stateMachines = new StateMachines( mock( StringLogger.class), mock( MessageSource.class ), sender,
+                mock( Timeouts.class ), mock( DelayedDirectExecutor.class ), new Executor()
+                {
+                    @Override
+                    public void execute( Runnable command )
+                    {
+                        command.run();
+                    }
+                }, me
+        );
 
         // The state machine, which has a TestMessage message type and simply adds a TO header to the messages it
         // is handed to handle.

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRecovery.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRecovery.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+public class HaRecovery implements AvailabilityGuard.AvailabilityRequirement
+{
+    private final XaDataSourceManager dataSourceManager;
+    private final StringLogger logger;
+    private final AvailabilityGuard availabilityGuard;
+    private final AbstractTransactionManager txManager;
+    private final DelegateInvocationHandler<Master> masterDelegateInvocationHandler;
+
+    private final AtomicInteger epoch = new AtomicInteger();
+
+    public HaRecovery( XaDataSourceManager dataSourceManager, StringLogger logger, AvailabilityGuard availabilityGuard,
+                       AbstractTransactionManager txManager, DelegateInvocationHandler<Master> masterDelegateInvocationHandler )
+    {
+        this.dataSourceManager = dataSourceManager;
+        this.logger = logger;
+        this.availabilityGuard = availabilityGuard;
+        this.txManager = txManager;
+        this.masterDelegateInvocationHandler = masterDelegateInvocationHandler;
+
+        availabilityGuard.grant(this);
+    }
+
+    public void recover()
+    {
+        try
+        {
+            int myEpoch = epoch.get();
+            synchronized ( dataSourceManager )
+            {
+                if ( myEpoch != epoch.get() )
+                {
+                    return;
+                }
+
+                logger.info( "Recovering from HA kernel panic" );
+                epoch.incrementAndGet();
+                availabilityGuard.deny( this );
+                try
+                {
+                    txManager.stop();
+                    dataSourceManager.stop();
+                    dataSourceManager.start();
+                    txManager.start();
+                    txManager.doRecovery();
+                    masterDelegateInvocationHandler.harden();
+                }
+                finally
+                {
+                    availabilityGuard.grant( this );
+                    logger.info( "Done recovering from HA kernel panic" );
+                }
+            }
+        }
+        catch ( Throwable t )
+        {
+            String msg = "Error while handling HA kernel panic";
+            logger.warn( msg, t );
+            throw new RuntimeException( msg, t );
+        }
+    }
+
+    @Override
+    public String description()
+    {
+        return getClass().getSimpleName();
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.neo4j.com.RequestContext;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
@@ -36,12 +36,11 @@ public class RequestContextFactory
     private long epoch;
     private final int serverId;
     private final XaDataSourceManager xaDsm;
-    private final DependencyResolver resolver;
-    private AbstractTransactionManager txManager;
+    private Provider<AbstractTransactionManager> txManager;
 
-    public RequestContextFactory( int serverId, XaDataSourceManager xaDsm, DependencyResolver resolver )
+    public RequestContextFactory( int serverId, XaDataSourceManager xaDsm, Provider<AbstractTransactionManager> txManager )
     {
-        this.resolver = resolver;
+        this.txManager = txManager;
         this.epoch = -1;
         this.serverId = serverId;
         this.xaDsm = xaDsm;
@@ -50,7 +49,6 @@ public class RequestContextFactory
     public void setEpoch( long epoch )
     {
         this.epoch = epoch;
-        this.txManager = resolver.resolveDependency( AbstractTransactionManager.class );
     }
 
     public RequestContext newRequestContext( int eventIdentifier )
@@ -124,11 +122,11 @@ public class RequestContextFactory
 
     public RequestContext newRequestContext( XaDataSource dataSource )
     {
-        return newRequestContext( dataSource, epoch, serverId, txManager.getEventIdentifier() );
+        return newRequestContext( dataSource, epoch, serverId, txManager.instance().getEventIdentifier() );
     }
 
     public RequestContext newRequestContext()
     {
-        return newRequestContext( epoch, serverId, txManager.getEventIdentifier() );
+        return newRequestContext( epoch, serverId, txManager.instance().getEventIdentifier() );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaLoggingIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaLoggingIT.java
@@ -19,18 +19,19 @@
  */
 package org.neo4j.kernel.ha;
 
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.AbstractClusterTest;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
 import static org.neo4j.kernel.impl.util.StringLogger.DEFAULT_NAME;
 import static org.neo4j.test.ha.ClusterManager.clusterWithAdditionalClients;
 import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 import static org.neo4j.test.ha.ClusterManager.masterSeesMembers;
-
-import java.io.File;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.test.AbstractClusterTest;
 
 public class HaLoggingIT extends AbstractClusterTest
 {
@@ -39,7 +40,6 @@ public class HaLoggingIT extends AbstractClusterTest
     {
         // GIVEN
         // -- look at the slave and see notices of startup diagnostics
-        cluster.await( masterSeesMembers( 3 ) );
         String logMessage = "Just a test for that logging continues as expected";
         HighlyAvailableGraphDatabase db = cluster.getAnySlave();
         StringLogger logger = db.getDependencyResolver().resolveDependency( StringLogger.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestUniqueKeys.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestUniqueKeys.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
@@ -40,7 +41,6 @@ import org.neo4j.test.AbstractClusterTest;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
 public class TestUniqueKeys extends AbstractClusterTest
 {
@@ -193,7 +193,6 @@ public class TestUniqueKeys extends AbstractClusterTest
     public void getCluster() throws Exception
     {
         cluster = clusterManager.getDefaultCluster();
-        cluster.await( masterAvailable() );
     }
 
     private <KEY extends Token> int highestIdOf( TokenHolder<KEY> holder, int high ) throws TokenNotFoundException

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
@@ -19,17 +19,12 @@
  */
 package org.neo4j.kernel.index;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
@@ -43,6 +38,11 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.ha.ClusterManager;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class IndexOperationsIT extends AbstractClusterTest
 {
     @Test
@@ -50,7 +50,6 @@ public class IndexOperationsIT extends AbstractClusterTest
     {
         // GIVEN
         // -- a slave
-        cluster.await( allSeesAllAsAvailable() );
         String key = "name";
         String value = "Mattias";
         HighlyAvailableGraphDatabase author = cluster.getAnySlave();
@@ -73,7 +72,6 @@ public class IndexOperationsIT extends AbstractClusterTest
     {
         // GIVEN
         // -- an existing index
-        cluster.await( allSeesAllAsAvailable() );
         String key = "key", value = "value";
         HighlyAvailableGraphDatabase master = cluster.getMaster();
         long nodeId = createNode( master, key, value, true );
@@ -144,7 +142,6 @@ public class IndexOperationsIT extends AbstractClusterTest
     {
         // GIVEN
         // -- two instances, each begin a transaction
-        cluster.await( allSeesAllAsAvailable() );
         String key = "key", value = "value";
         HighlyAvailableGraphDatabase db1 = cluster.getMaster(), db2 = cluster.getAnySlave();
         long node = createNode( db1, key, value, false );

--- a/enterprise/ha/src/test/java/org/neo4j/test/AbstractClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/AbstractClusterTest.java
@@ -19,17 +19,13 @@
  */
 package org.neo4j.test;
 
-import static org.neo4j.cluster.ClusterSettings.default_timeout;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
-
 import java.io.File;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
@@ -37,6 +33,10 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.ha.ClusterManager.Provider;
+
+import static org.neo4j.cluster.ClusterSettings.default_timeout;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
 
 public abstract class AbstractClusterTest
 {
@@ -79,7 +79,7 @@ public abstract class AbstractClusterTest
         } );
         life.start();
         cluster = clusterManager.getDefaultCluster();
-        cluster.await( masterAvailable() );
+        cluster.await( ClusterManager.allSeesAllAsAvailable() );
     }
 
     protected void configureClusterMember( GraphDatabaseBuilder builder, String clusterName, InstanceId serverId )
@@ -93,6 +93,7 @@ public abstract class AbstractClusterTest
     @After
     public void after() throws Exception
     {
+        cluster.debug( "Shutting down cluster" );
         life.shutdown();
     }
 }

--- a/enterprise/ha/src/test/resources/custom-logback.xml
+++ b/enterprise/ha/src/test/resources/custom-logback.xml
@@ -41,6 +41,12 @@
   <logger name="org.neo4j.kernel.ha" level="debug">
   </logger>
 
+  <!--
+  <logger name="org.neo4j.test" level="debug">
+    <appender-ref ref="FILE"/>
+  </logger>
+-->
+
   <root level="debug">
 <!--
     <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
This PR ensures that HA master/slave switches do recovery during the process, rather than waiting for a live transaction to fail and cause a recovery.

Also includes refactorings to make it easier to test HA.
