### PR TITLE
fix bug in batch-insertion, CalculateDenseNodesStep. 

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
@@ -90,5 +90,6 @@ public class CalculateDenseNodesStep extends ExecutorServiceStep<List<InputRelat
         }
         System.out.println( "# dense nodes: " + numberOfDenseNodes + ", which is " +
                 round( 100D*numberOfDenseNodes/highestSeenNodeId ) + " %" );
+        super.done();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
@@ -129,5 +129,6 @@ public abstract class ExecutorServiceStep<T> extends AbstractStep<T>
     protected void done()
     {
         executor.shutdown();
+        super.done();
     }
 }


### PR DESCRIPTION
No call to super to super.done() to shut down the Executor.
