### PR TITLE
HostnamePort matches also when URI getHost() returns hostname instead of IP Address

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
@@ -193,8 +193,8 @@ public class HostnamePort
             return false;
         }
 
-        // URI always contains IP, so make sure we convert ours too
+        // URI may contain IP, so make sure we check it too by converting ours, if necessary
 
-        return result && getHost(null).equalsIgnoreCase( toMatch.getHost() );
+        return result && ( host.equalsIgnoreCase( toMatch.getHost() ) || getHost(null).equalsIgnoreCase( toMatch.getHost() ) );
     }
 }


### PR DESCRIPTION
Hi, during a full building I got a test failure on method matches(URI) of class org.neo4j.helpers.HostnamePort. Specifically it was an assertion failure on line 101 of its testing class HostnamePortTest.
After some analysis it turned out that URI.getHost() method does not always returns IP address, as it is assumed in HostnamePort.matches(URI), but this seems to be true only when the IP is passed to static method URI.create().
Also, the java SE7 reference http://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getHost() states that the host component of a URI returned by getHost() can be a "dotted-quad IPv4 address", so I thought of changing the return statement of HostnamePort.matches(URI) method to test first the equality of hostname "as is" and then using IP address of its field "host" only if that test fails, so that it would return true in both cases.
I also added two test methods that replicate exactly what the other testing methods do when using HostnamePort.matches(URI) but creating URI by passing an IP address.
This way I was able to pass the test and build the module.
Hope this can help.
