### PR TITLE
Merged commit 9079426036c5cf9f9953c1349717aeea8d21fed3

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
@@ -211,10 +211,7 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
         tle.readCount--;
         if ( tle.isFree() )
         {
-            if ( !this.isMarked() )
-            {
-                txLockElementMap.remove( tx );
-            }
+            txLockElementMap.remove( tx );
             ragManager.lockReleased( this, tx );
         }
         if ( waitingThreadList.size() > 0 )
@@ -377,10 +374,7 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
         tle.writeCount--;
         if ( tle.isFree() )
         {
-            if ( !this.isMarked() )
-            {
-                txLockElementMap.remove( tx );
-            }
+            txLockElementMap.remove( tx );
             ragManager.lockReleased( this, tx );
         }
 
@@ -572,5 +566,10 @@ class RWLock implements Visitor<LineLogger, RuntimeException>
             txLockElementMap.put( tx, tle = new TxLockElement( tx ) );
         }
         return tle;
+    }
+
+    synchronized Object getTxLockElementCount()
+    {
+        return txLockElementMap.size();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockLeakTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockLeakTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking.community;
+
+import static org.mockito.Mockito.mock;
+
+import javax.transaction.Transaction;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class RWLockLeakTest
+{
+    @Test
+    public void assertWriteLockDoesNotLeakMemory() throws InterruptedException
+    {
+        final RagManager ragManager = new RagManager();
+        final Object resource = new Object();
+        final RWLock lock = new RWLock( resource, ragManager );
+        final Transaction tx1 = mock( Transaction.class );
+        
+        lock.mark();
+        lock.acquireWriteLock( tx1 );
+        lock.mark();
+        
+        assertEquals( 1, lock.getTxLockElementCount() );
+        lock.releaseWriteLock( tx1 );
+        assertEquals( 0, lock.getTxLockElementCount() );
+    }
+
+    @Test
+    public void assertReadLockDoesNotLeakMemory() throws InterruptedException
+    {
+        final RagManager ragManager = new RagManager();
+        final Object resource = new Object();
+        final RWLock lock = new RWLock( resource, ragManager );
+        final Transaction tx1 = mock( Transaction.class );
+        
+        lock.mark();
+        lock.acquireReadLock( tx1 );
+        lock.mark();
+        
+        assertEquals( 1, lock.getTxLockElementCount() );
+        lock.releaseReadLock( tx1 );
+        assertEquals( 0, lock.getTxLockElementCount() );
+    }
+}


### PR DESCRIPTION
Fixed bug that caused RWLock not to free up entries in txLockElementMap.

The mark flag is used to guard against creating multiple RWLocks for the same resource and has nothing to do with TxLockElement entries.

TxLockElement creation and removal is still safe since it is synchronized on the RWLock.

Conflicts:
    community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/RWLock.java
