### PR TITLE
Improve Forsetis try-shared-lock.

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
@@ -290,12 +290,15 @@ public class ForsetiClient implements Locks.Client
                 }
                 else if(existingLock instanceof SharedLock)
                 {
+                    // Note that there is a "safe" race here where someone may be releasing the last reference to a lock
+                    // and thus removing that lock instance (making it unacquirable). In this case, we allow retrying,
+                    // even though this is a try-lock call.
                     if(((SharedLock)existingLock).acquire(this))
                     {
                         // Success!
                         break;
                     }
-                    else
+                    else if( ((SharedLock) existingLock).isUpdateLock() )
                     {
                         return false;
                     }


### PR DESCRIPTION
- There was a case where try-shared would not grab a shared lock if another
  thread had just released the last reference to the lock (thus disposing
  of it). If we come a across a lock like that, we should just retry.
