### PR TITLE
Resolves a 2.1.1 recovery issue.

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,3 +1,8 @@
+2.1.2
+-----
+o Resolves a dangerous recovery issue, where multiple crashes in a row without clean shutdown or log rotation
+  in between could cause data loss.
+
 2.1.0
 -----
 o Fixes potential leak of transaction state in entity locks that could

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogBuffer.java
@@ -154,7 +154,7 @@ public class InMemoryLogBuffer implements LogBuffer, ReadableByteChannel
 
     public ByteBuffer asByteBuffer()
     {
-        return ByteBuffer.wrap( bytes );
+        return ByteBuffer.wrap( bytes, readIndex, writeIndex );
     }
 
     public int read( ByteBuffer dst ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static java.lang.Math.max;
-import static org.neo4j.helpers.Exceptions.launderedException;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.CLEAN;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG1;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG2;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -70,6 +64,12 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static java.lang.Math.max;
+import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.CLEAN;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG1;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLogTokens.LOG2;
 
 /**
  * <CODE>XaLogicalLog</CODE> is a transaction and logical log combined. In

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.recovery;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.commandEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.containsExactly;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.doneEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.logEntries;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.onePhaseCommitEntry;
+import static org.neo4j.kernel.impl.transaction.xaframework.LogMatchers.startEntry;
+
+public class KernelRecoveryTest
+{
+
+    @Rule public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldHandleWritesProperlyAfterRecovery() throws Exception
+    {
+        // Given
+        EphemeralFileSystemAbstraction fs = fsRule.get();
+        GraphDatabaseService db = newDB( fs );
+
+        try( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+
+        // And given the power goes out
+        EphemeralFileSystemAbstraction crashedFs = fs.snapshot();
+        db.shutdown();
+        db = newDB( crashedFs );
+
+        // When
+        try( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        db.shutdown();
+
+        // Then the logical log should be in sync
+        assertThat(
+                logEntries( crashedFs, new File( "target/test-data/impermanent-db/nioneo_logical.log.v0" ) ),
+                containsExactly(
+                    // Tx before recovery
+                    startEntry( 3, -1, -1 ),
+                    commandEntry( 3 ),
+                    onePhaseCommitEntry( 3, 2 ),
+                    doneEntry( 3 ),
+
+                    // Tx after recovery
+                    startEntry( 6, -1, -1 ),
+                    commandEntry( 6 ),
+                    onePhaseCommitEntry( 6, 3 ),
+                    doneEntry( 6 )
+                )
+        );
+
+    }
+
+    private GraphDatabaseService newDB( EphemeralFileSystemAbstraction fs )
+    {
+        return new TestGraphDatabaseFactory()
+                    .setFileSystem( fs )
+                    .newImpermanentDatabase();
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
@@ -175,7 +175,6 @@ public class LogMatchers
             public void describeTo( Description description )
             {
                 description.appendText( String.format( "1PC[%d, txId=%d, <Any Date>],", identifier, txId ) );
-
             }
         };
     }
@@ -195,6 +194,25 @@ public class LogMatchers
             public void describeTo( Description description )
             {
                 description.appendText( String.format( "Done[%d]", identifier ) );
+            }
+        };
+    }
+
+    public static Matcher<? extends LogEntry> commandEntry( final int identifier )
+    {
+        return new TypeSafeMatcher<LogEntry.Command>()
+        {
+
+            @Override
+            public boolean matchesSafely( LogEntry.Command cmd )
+            {
+                return cmd != null && cmd.getIdentifier() == identifier;
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( String.format( "Command[%d]", identifier ) );
             }
         };
     }


### PR DESCRIPTION
- Due to a buffer offset error, after recovery the database would end up in
  a dangerous state where it would potentially fail to recover from a
  second crash if there had not been a log rotation or a safe shutdown.
