### PR TITLE
Reduce the probability of test flakiness in server

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -55,8 +55,8 @@ public class ServerHelper
 
     public static void cleanTheDatabase( GraphDatabaseAPI db )
     {
-        new Transactor( db, new DeleteAllData( db ) ).execute();
-        new Transactor( db, new DeleteAllSchema( db ) ).execute();
+        new Transactor( db, new DeleteAllData( db ), 5 ).execute();
+        new Transactor( db, new DeleteAllSchema( db ), 5 ).execute();
     }
 
     private static void removeLogs( NeoServer server )


### PR DESCRIPTION
Some transactions have been shown to be prone to transient transaction failures, such
as from DeadLockExceptions. Those transactions will now be retried a limited number of times.
