### PR TITLE
Add javadoc comments in the store layer, detailing correct use of the mapped store files

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
@@ -215,6 +215,10 @@ public class NeoStore extends AbstractStore
         }
     }
 
+    /**
+     * This runs as part of verifyFileSizeAndTruncate, which runs before the store file has been
+     * mapped in the page cache. It is therefore okay for it to access the file channel directly.
+     */
     private void insertRecord( int recordPosition, long value ) throws IOException
     {
         try


### PR DESCRIPTION
We still have to do something about the id generator rebuilding. I reckon it's currently buggy, because of how it accesses the StoreChannels directly.
