### PR TITLE
 Layout fixes for the manual.

### DIFF
--- a/manual/common/css/positioning.css
+++ b/manual/common/css/positioning.css
@@ -17,7 +17,7 @@ body.console-is-expanded #header {
 }
 
 #header h1 {
-  margin: 8px 200px 0 8px;
+  margin: 8px 20% 0 8px;
   position: fixed;
   top: 0;
   left: 0;
@@ -27,13 +27,13 @@ body.console-is-expanded #header {
   position: fixed;
   right: 0;
   top: 0;
-  padding: 6px 0 5px 10px;
+  padding: 6px 10px 5px 10px;
+  max-width: 20%;
 }
 
 #logo img {
   width: 130px;
-  height: 60px;
-  margin-right: 10px;
+  max-width: 100%;
 }
 
 #sidebar-wrapper {
@@ -380,5 +380,15 @@ div.note *,div.caution *,div.important *,div.tip *,div.warning * {
   }
   footer p a {
     padding-right: 1em;
+  }
+}
+
+@media screen and (max-width: 740px) {
+  #additional-versions, body #header h1 #book-title {
+    display: none;
+  }
+  
+  body #header h1 span {
+    font-size: 18px;
   }
 }

--- a/manual/common/css/style.css
+++ b/manual/common/css/style.css
@@ -173,6 +173,11 @@ span.searchTab {
   font-size: 24px;
 }
 
+#header h1 #book-title {
+  display: block;
+  font-size: 18px;
+}
+
 a#showHideButton,a.navLinkPrevious,a.navLinkNext {
   background: none;
 }

--- a/manual/common/images/logo-neo4j.svg
+++ b/manual/common/images/logo-neo4j.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="792px" height="367.481px" viewBox="0 125.584 792 367.481" enable-background="new 0 125.584 792 367.481"
+	 width="129.313px" height="60px" viewBox="0 125.584 792 367.481" enable-background="new 0 125.584 792 367.481"
 	 xml:space="preserve">
 <g id="Layer_2" display="none">
 	<polyline display="inline" fill="#11659E" stroke="#82B85A" stroke-miterlimit="10" points="792,612 0,612 0,0 792,0 	"/>

--- a/manual/common/main.js
+++ b/manual/common/main.js
@@ -20,7 +20,8 @@ $( document ).ready( function()
     {
       $.cookie( SIDEBAR_COOKIE_NAME, value, { expires: 3, path: '/' } );
     }
-    if ( $.cookie( SIDEBAR_COOKIE_NAME ) === 'no' )
+    var sidebarCookieValue = $.cookie( SIDEBAR_COOKIE_NAME );
+    if ( sidebarCookieValue === 'no' || ( typeof sidebarCookieValue === 'undefined' && $( window ).width() < 769 ) )
     {
       $body.addClass( 'toc-is-hidden' );
     }

--- a/manual/conf/webhelp.xsl
+++ b/manual/conf/webhelp.xsl
@@ -125,7 +125,9 @@
       <xsl:call-template name="webhelpheader.logo" />
       <!-- Display the page title and the main heading(parent) of it -->
       <h1>
-        <xsl:apply-templates select="/*[1]" mode="title.markup" />
+        <span id="book-title">
+          <xsl:apply-templates select="/*[1]" mode="title.markup" />
+        </span>
         <xsl:choose>
           <xsl:when test="not(generate-id(.) = generate-id(/*))">
             <span>

--- a/manual/js/versionswitcher.js
+++ b/manual/js/versionswitcher.js
@@ -35,48 +35,26 @@ function versionSwitcher( $ )
   loadVersions();
 
   /**
-  * Load an array of version into a div element and check if the current page actually exists in these versions.
-  * Non-existing entries will be unlinked.
-  * Current version will be marked as such.
-  */
+   * Load an array of version into a div element and check if the current page actually exists in these versions.
+   * Non-existing entries will be unlinked. Current version will be marked as such.
+   */
   function loadVersions()
   {
     var $navHeader = $( '#navheader' );
-    var $versionSelector = $( '<div id="versions"/>' );
-    var $links = $( '<ul class="list-inline"/>' ).appendTo( $versionSelector );
-    var extraVersions = [];
-    var stableCount = 0;
+    var $additionalVersions = $( '<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1"/>' );
     $.each( availableDocVersions, function( index, version )
     {
       if ( version === currentVersion )
       {
         return;
       }
-      var firstChar = version.charAt( 0 );
-      if ( firstChar < '0' || firstChar > '9' )
+      else
       {
-        extraVersions.push( version );
-        return;
+        addVersion( version, $additionalVersions );
       }
-      if ( version.indexOf( 'M' ) === -1 )
-      {
-        stableCount++;
-        if ( stableCount > MAX_STABLE_COUNT )
-        {
-          extraVersions.push( version );
-          return;
-        }
-      }
-      addVersion( version, $links );
     } );
-    $navHeader.append( $versionSelector );
 
-    var $dropdown = $( '<div id="additional-versions"><div class="dropdown"><a class="dropdown-toggle"id="dropdownMenu1" data-toggle="dropdown"><i class="fa fa-caret-down"></i></a></div></div>' );
-    var $additionalVersions = $( '<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1"/>' );
-    $.each( extraVersions, function( index, version )
-    {
-      addVersion( version, $additionalVersions );
-    } );
+    var $dropdown = $( '<div id="additional-versions"><div class="dropdown"><a class="dropdown-toggle"id="dropdownMenu1" data-toggle="dropdown">Other versions <i class="fa fa-caret-down"></i></a></div></div>' );
     $dropdown.children().first().append( $additionalVersions );
     $navHeader.append( $dropdown );
   }


### PR DESCRIPTION
- Resize the logo to fix rendering in Firefox.
- Wrap the book title in a separate element for styling.
- Make the version switcher less confusing.
- Default to hide the TOC on smaller screens.
