### PR TITLE
 Refactor: separating input from context in planning

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/Planner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/Planner.scala
@@ -65,8 +65,8 @@ case class Planner(monitors: Monitors,
 
     val metrics = metricsFactory.newMetrics(planContext.statistics, semanticTable)
 
-    val context = LogicalPlanningContext(planContext, metrics, semanticTable, plannerQuery, queryGraphSolver, subQueriesLookupTable)
-    val plan = strategy.plan(context)
+    val context = LogicalPlanningContext(planContext, metrics, semanticTable, queryGraphSolver)
+    val plan = strategy.plan(plannerQuery)(context, subQueriesLookupTable)
     plan
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/SimplePlannerQueryBuilder.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/SimplePlannerQueryBuilder.scala
@@ -153,15 +153,14 @@ class SimplePlannerQueryBuilder extends PlannerQueryBuilder {
                                            subQueryLookupTable: Map[PatternExpression, QueryGraph],
                                            clauses: Seq[Clause]): (PlannerQuery, Map[PatternExpression, QueryGraph]) =
     clauses match {
-      case Return(false, ListedReturnItems(expressions), optOrderBy, skip, limit) :: tl =>
-
-        // Can't handle pattern expressions as projections yet
-        expressions.foreach(_.expression.exists {
+      case Return(false, ListedReturnItems(items), optOrderBy, skip, limit) :: tl =>
+        // Can't handle pattern items as projections yet
+        items.foreach(_.expression.exists {
           case _:PatternExpression => throw new CantHandleQueryException
         })
 
         val sortItems = produceSortItems(optOrderBy)
-        val projection = produceProjectionsMaps(expressions)
+        val projection = produceProjectionsMaps(items)
           .withSortItems(sortItems)
           .withLimit(limit.map(_.expression))
           .withSkip(skip.map(_.expression))
@@ -269,9 +268,9 @@ class SimplePlannerQueryBuilder extends PlannerQueryBuilder {
   private def produceSortItems(optOrderBy: Option[OrderBy]) =
     optOrderBy.fold(Seq.empty[SortItem])(_.sortItems)
 
-  private def produceProjectionsMaps(expressions: Seq[ReturnItem]): QueryProjection = {
+  private def produceProjectionsMaps(items: Seq[ReturnItem]): QueryProjection = {
     val (aggregatingItems: Seq[ReturnItem], nonAggrItems: Seq[ReturnItem]) =
-      expressions.partition(item => IsAggregate(item.expression))
+      items.partition(item => IsAggregate(item.expression))
 
     def turnIntoMap(x: Seq[ReturnItem]) = x.map(e => e.name -> e.expression).toMap
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilder.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.execution
 
 import org.neo4j.cypher.internal.compiler.v2_1.ast.convert.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v2_1.pipes._
-import org.neo4j.cypher.internal.compiler.v2_1.ast.Expression
+import org.neo4j.cypher.internal.compiler.v2_1.ast.{PatternExpression, Expression}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_1.Monitors
 import org.neo4j.cypher.internal.compiler.v2_1.executionplan.PipeInfo
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.v2_1.ast.convert.OtherConverters._
 import org.neo4j.cypher.internal.compiler.v2_1.symbols._
 import org.neo4j.cypher.internal.compiler.v2_1.commands.expressions.AggregationExpression
 
+case class PipeExecutionBuilderContext(patternExpressionPlanLookup: Map[PatternExpression, LogicalPlan])
 
 class PipeExecutionPlanBuilder(monitors: Monitors) {
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/GreedyQueryGraphSolver.scala
@@ -22,17 +22,19 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
 import org.neo4j.cypher.internal.helpers.Converge.iterateUntilConverged
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.cartesianProduct
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 class GreedyQueryGraphSolver(config: PlanningStrategyConfiguration = PlanningStrategyConfiguration.default)
   extends QueryGraphSolver {
 
-  def plan(implicit context: QueryGraphSolvingContext, leafPlan: Option[QueryPlan] = None): QueryPlan = {
+  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph], leafPlan: Option[QueryPlan] = None) = {
     val select = config.applySelections.asFunctionInContext
     val pickBest = config.pickBestCandidate.asFunctionInContext
 
     def generateLeafPlanTable() = {
-      val leafPlanCandidateLists = config.leafPlanners.candidateLists(context.queryGraph)
-      val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(select))
+      val leafPlanCandidateLists = config.leafPlanners.candidateLists(queryGraph)
+      val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(select(_, queryGraph)))
       val bestLeafPlans: Iterable[QueryPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
       val startTable: PlanTable = leafPlan.foldLeft(PlanTable.empty)(_ + _)
       bestLeafPlans.foldLeft(startTable)(_ + _)
@@ -40,8 +42,8 @@ class GreedyQueryGraphSolver(config: PlanningStrategyConfiguration = PlanningStr
 
     def findBestPlan(planGenerator: CandidateGenerator[PlanTable]) = {
       (planTable: PlanTable) =>
-        val generated = planGenerator(planTable).plans.toList
-        val selected = generated.map(select)
+        val generated = planGenerator(planTable, queryGraph).plans.toList
+        val selected = generated.map(select(_, queryGraph))
         val best = pickBest(CandidateList(selected))
         best.fold(planTable)(planTable + _)
     }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/LeafPlannerList.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/LeafPlannerList.scala
@@ -20,9 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 case class LeafPlannerList(leafPlanners: LeafPlanner*) {
-  def candidateLists(qg: QueryGraph)(implicit context: QueryGraphSolvingContext): Iterable[CandidateList] = {
+  def candidateLists(qg: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): Iterable[CandidateList] = {
     val queryPlans = leafPlanners.flatMap(_(qg).plans)
     queryPlans.groupBy(_.availableSymbols).values.map(CandidateList)
   }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/LogicalPlanningFunction.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/LogicalPlanningFunction.scala
@@ -20,18 +20,25 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
-import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_1.planner.{PlannerQuery, QueryGraph}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
-trait LogicalPlanningFunction[-A, +B] {
-  def apply(input: A)(implicit context: QueryGraphSolvingContext): B
+trait LogicalPlanningFunction1[-A, +B] {
+  def apply(input: A)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): B
 
-  def asFunctionInContext(implicit context: QueryGraphSolvingContext): A => B = apply
+  def asFunctionInContext(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): A => B = apply
 }
 
-trait CandidateGenerator[-T] extends LogicalPlanningFunction[T, CandidateList]
+trait LogicalPlanningFunction2[-A1, -A2, +B] {
+  def apply(input1: A1, input2: A2)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): B
 
-trait CandidateSelector extends LogicalPlanningFunction[CandidateList, Option[QueryPlan]]
+  def asFunctionInContext(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): (A1, A2) => B = apply
+}
 
-trait PlanTransformer extends LogicalPlanningFunction[QueryPlan, QueryPlan]
+trait CandidateGenerator[-T] extends LogicalPlanningFunction2[T, QueryGraph, CandidateList]
 
-trait LeafPlanner extends CandidateGenerator[QueryGraph]
+trait PlanTransformer[-T] extends LogicalPlanningFunction2[QueryPlan, T, QueryPlan]
+
+trait CandidateSelector extends LogicalPlanningFunction1[CandidateList, Option[QueryPlan]]
+
+trait LeafPlanner  extends LogicalPlanningFunction1[QueryGraph, CandidateList]

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanningStrategy.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanningStrategy.scala
@@ -20,11 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
+import org.neo4j.cypher.internal.compiler.v2_1.planner.{QueryGraph, PlannerQuery}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 trait PlanningStrategy {
-  def plan(implicit context: LogicalPlanningContext, leafPlan: Option[QueryPlan] = None): QueryPlan
+  def plan(plannerQuery: PlannerQuery)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph], leafPlan: Option[QueryPlan] = None): QueryPlan
 }
 
 trait QueryGraphSolver {
-  def plan(implicit context: QueryGraphSolvingContext, leafPlan: Option[QueryPlan] = None): QueryPlan
+  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph], leafPlan: Option[QueryPlan] = None): QueryPlan
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanningStrategyConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanningStrategyConfiguration.scala
@@ -20,10 +20,11 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps._
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 case class PlanningStrategyConfiguration(
   leafPlanners: LeafPlannerList,
-  applySelections: PlanTransformer,
+  applySelections: PlanTransformer[QueryGraph],
   pickBestCandidate: CandidateSelector
 )
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/QueryGraphSolvingContext.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/QueryGraphSolvingContext.scala
@@ -24,42 +24,26 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.{PlannerQuery, QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_1.ast.{PatternExpression, Identifier}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.IdName
 
-case class QueryGraphSolvingContext(planContext: PlanContext,
-                                    metrics: Metrics,
-                                    semanticTable: SemanticTable,
-                                    queryGraph: QueryGraph,
-                                    subQueriesLookupTable: Map[PatternExpression, QueryGraph],
-                                    strategy: QueryGraphSolver) {
-
-  def statistics = planContext.statistics
-  def cost = metrics.cost
-  def cardinality = metrics.cardinality
-}
 
 case class LogicalPlanningContext(planContext: PlanContext,
                                   metrics: Metrics,
                                   semanticTable: SemanticTable,
-                                  query: PlannerQuery,
-                                  strategy: QueryGraphSolver,
-                                  subQueriesLookupTable: Map[PatternExpression, QueryGraph]) {
+                                  strategy: QueryGraphSolver) {
 
   def statistics = planContext.statistics
   def cost = metrics.cost
   def cardinality = metrics.cardinality
-
-  def asQueryGraphSolvingContext(graph: QueryGraph) =
-    QueryGraphSolvingContext(planContext, metrics, semanticTable, graph, subQueriesLookupTable, strategy)
 }
 
 object NodeIdName {
-  def unapply(v: Any)(implicit context: QueryGraphSolvingContext): Option[IdName] = v match {
+  def unapply(v: Any)(implicit context: LogicalPlanningContext): Option[IdName] = v match {
     case identifier @ Identifier(name) if context.semanticTable.isNode(identifier) => Some(IdName(identifier.name))
     case _                                                                         => None
   }
 }
 
 object RelationshipIdName {
-  def unapply(v: Any)(implicit context: QueryGraphSolvingContext): Option[IdName] = v match {
+  def unapply(v: Any)(implicit context: LogicalPlanningContext): Option[IdName] = v match {
     case identifier @ Identifier(name) if context.semanticTable.isRelationship(identifier) => Some(IdName(identifier.name))
     case _                                                                                 => None
   }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/QueryPlanningStrategy.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/QueryPlanningStrategy.scala
@@ -22,50 +22,47 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps._
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 class QueryPlanningStrategy(config: PlanningStrategyConfiguration = PlanningStrategyConfiguration.default) extends PlanningStrategy {
 
   import QueryPlanProducer._
 
-  def plan(implicit context: LogicalPlanningContext, leafPlan: Option[QueryPlan] = None): QueryPlan = {
-    val query = context.query
+  def plan(query: PlannerQuery)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph], leafPlan: Option[QueryPlan] = None): QueryPlan = {
     val firstPart = planPart(query, leafPlan)
-    val projectedFirstPart = planEventHorizon(query.projection, firstPart)
-    val finalPlan = plan(projectedFirstPart, query.tail, context)
-    verifyBestPlan(finalPlan)
+    val projectedFirstPart = planEventHorizon(query, firstPart)
+    val finalPlan = plan(projectedFirstPart, query.tail)
+    verifyBestPlan(finalPlan, query)
   }
 
-  private def plan(pred: QueryPlan, remaining: Option[PlannerQuery], context: LogicalPlanningContext): QueryPlan = remaining match {
+  private def plan(pred: QueryPlan, remaining: Option[PlannerQuery])(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = remaining match {
     case Some(query) =>
-      val innerContext = context.copy(query = query)
       val lhs = pred
-      val rhs = planPart(query, Some(planQueryArgumentRow(query.graph)))(innerContext)
+      val rhs = planPart(query, Some(planQueryArgumentRow(query.graph)))
       val applyPlan = planTailApply(lhs, rhs)
-      val projectedPlan = planEventHorizon(query.projection, applyPlan)(innerContext)
-      plan( projectedPlan, query.tail, innerContext )
+      val projectedPlan = planEventHorizon(query, applyPlan)(context, subQueryLookupTable)
+      plan(projectedPlan, query.tail)
     case None =>
       pred
   }
 
-  private def planPart(query: PlannerQuery, leafPlan: Option[QueryPlan] = None)(implicit context: LogicalPlanningContext): QueryPlan = {
-    val graphSolvingContext = context.asQueryGraphSolvingContext(query.graph)
-    val afterSolvingPattern = context.strategy.plan(graphSolvingContext, leafPlan)
-
-    afterSolvingPattern
+  private def planPart(query: PlannerQuery, leafPlan: Option[QueryPlan] = None)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = {
+    context.strategy.plan(query.graph)(context, subQueryLookupTable, leafPlan)
   }
 
-  private def planEventHorizon(queryProjection: QueryProjection, plan: QueryPlan)(implicit context: LogicalPlanningContext) = {
-    val graph = context.query.graph
-    val selectedPlan = config.applySelections(plan)(context.asQueryGraphSolvingContext(graph))
+  private def planEventHorizon(query: PlannerQuery, plan: QueryPlan)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph]) = {
+    val selectedPlan = config.applySelections(plan, query.graph)
+    val queryProjection = query.projection
     val projectedPlan = queryProjection match {
-      case aggr:AggregationProjection =>
+      case aggr: AggregationProjection =>
         val aggregationPlan = aggregation(selectedPlan, aggr)
-        sortSkipAndLimit(aggregationPlan)
+        sortSkipAndLimit(aggregationPlan, query)
 
       case _ =>
-        val sortedAndLimited = sortSkipAndLimit(selectedPlan)
+        val sortedAndLimited = sortSkipAndLimit(selectedPlan, query)
         projection(sortedAndLimited, queryProjection.projections)
     }
+
     projectedPlan
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/expandsOrJoins.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/expandsOrJoins.scala
@@ -20,11 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.{join, expand}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 object expandsOrJoins extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
-    val expansions = expand(planTable)
-    val joins = join(planTable)
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
+    val expansions = expand(planTable, queryGraph)
+    val joins = join(planTable, queryGraph)
     expansions ++ joins
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/optionalMatches.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/optionalMatches.scala
@@ -20,13 +20,15 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.{optionalExpand, outerJoin, optional, applyOptional}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 object optionalMatches extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
-    val optionalApplies = applyOptional(planTable)
-    val optionals = optional(planTable)
-    val outerJoins = outerJoin(planTable)
-    val optionalExpands = optionalExpand(planTable)
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
+    val optionalApplies = applyOptional(planTable, queryGraph)
+    val optionals = optional(planTable, queryGraph)
+    val outerJoins = outerJoin(planTable, queryGraph)
+    val optionalExpands = optionalExpand(planTable, queryGraph)
     optionalApplies ++ optionals ++ outerJoins ++ optionalExpands
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/QueryPlan.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/QueryPlan.scala
@@ -21,6 +21,9 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.PlannerQuery
 import org.neo4j.cypher.internal.compiler.v2_1.perty.pformat
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+
+case class PlanningResult(queryPlan: QueryPlan, subPlansLookupTable: Map[PatternExpression, QueryPlan])
 
 case class QueryPlan(plan: LogicalPlan, solved: PlannerQuery) {
 
@@ -29,10 +32,4 @@ case class QueryPlan(plan: LogicalPlan, solved: PlannerQuery) {
   override def toString = pformat(this)
 
   def updateSolved(f: PlannerQuery => PlannerQuery) = copy(solved = f(solved))
-
-
 }
-
-
-
-

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/IndexLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/IndexLeafPlanner.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v2_1.commands.{SingleQueryExpression, 
 
 
 abstract class IndexLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit context: QueryGraphSolvingContext) = {
+  def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]) = {
     implicit val semanticTable = context.semanticTable
     val predicates: Seq[Expression] = qg.selections.flatPredicates
     val labelPredicateMap: Map[IdName, Set[HasLabels]] = qg.selections.labelPredicates
@@ -63,11 +63,13 @@ abstract class IndexLeafPlanner extends LeafPlanner {
                               label: LabelToken,
                               propertyKey: PropertyKeyToken,
                               valueExpr: QueryExpression[Expression],
-                              hint: Option[UsingIndexHint])(implicit context: QueryGraphSolvingContext): (Seq[Expression]) => QueryPlan
+                              hint: Option[UsingIndexHint])
+                             (implicit context: LogicalPlanningContext,
+                              subQueriesLookupTable: Map[PatternExpression, QueryGraph]): (Seq[Expression]) => QueryPlan
 
 
 
-  protected def findIndexesFor(label: String, property: String)(implicit context: QueryGraphSolvingContext): Option[IndexDescriptor]
+  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor]
 }
 
 object uniqueIndexSeekLeafPlanner extends IndexLeafPlanner {
@@ -76,12 +78,13 @@ object uniqueIndexSeekLeafPlanner extends IndexLeafPlanner {
                               propertyKey: PropertyKeyToken,
                               valueExpr: QueryExpression[Expression],
                               hint: Option[UsingIndexHint])
-                              (implicit context: QueryGraphSolvingContext): (Seq[Expression]) => QueryPlan =
+                             (implicit context: LogicalPlanningContext,
+                              subQueriesLookupTable: Map[PatternExpression, QueryGraph]): (Seq[Expression]) => QueryPlan =
     (predicates: Seq[Expression]) =>
       planNodeIndexUniqueSeek(idName, label, propertyKey, valueExpr, predicates, hint)
 
 
-  protected def findIndexesFor(label: String, property: String)(implicit context: QueryGraphSolvingContext): Option[IndexDescriptor] =
+  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] =
     context.planContext.getUniqueIndexRule(label, property)
 }
 
@@ -91,11 +94,12 @@ object indexSeekLeafPlanner extends IndexLeafPlanner {
                               propertyKey: PropertyKeyToken,
                               valueExpr: QueryExpression[Expression],
                               hint: Option[UsingIndexHint])
-                             (implicit context: QueryGraphSolvingContext): (Seq[Expression]) => QueryPlan =
+                             (implicit context: LogicalPlanningContext,
+                              subQueriesLookupTable: Map[PatternExpression, QueryGraph]): (Seq[Expression]) => QueryPlan =
     (predicates: Seq[Expression]) =>
       planNodeIndexSeek(idName, label, propertyKey, valueExpr, predicates, hint)
 
-  protected def findIndexesFor(label: String, property: String)(implicit context: QueryGraphSolvingContext): Option[IndexDescriptor] =
+  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] =
     context.planContext.getIndexRule(label, property)
 
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/allNodesLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/allNodesLeafPlanner.scala
@@ -19,16 +19,15 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.LeafPlanner
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, LeafPlanner, CandidateList}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.CandidateList
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.QueryGraphSolvingContext
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 
 object allNodesLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit context: QueryGraphSolvingContext) =
+  def apply(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]) =
     CandidateList(
-      context.queryGraph.patternNodes.map(planAllNodesScan).toSeq
+      queryGraph.patternNodes.map(planAllNodesScan).toSeq
     )
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/applyOptional.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/applyOptional.scala
@@ -23,14 +23,15 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 object applyOptional extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
     val applyCandidates =
-      for (optionalQG <- context.queryGraph.optionalMatches;
+      for (optionalQG <- queryGraph.optionalMatches;
            lhs <- planTable.plans if applicable(lhs, optionalQG))
       yield {
-        val rhs = context.strategy.plan(context.copy(queryGraph = optionalQG))
+        val rhs = context.strategy.plan(optionalQG)
         planApply(lhs, planOptional(rhs))
       }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/argumentLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/argumentLeafPlanner.scala
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{Candidates, LeafPlanner, QueryGraphSolvingContext}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, Candidates, LeafPlanner}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 object argumentLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit ignored: QueryGraphSolvingContext) = {
+  def apply(qg: QueryGraph)(implicit ignored: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]) = {
     val givenNodeIds = qg.argumentIds intersect qg.patternNodes
     if (givenNodeIds.isEmpty)
       Candidates()

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/cartesianProduct.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/cartesianProduct.scala
@@ -22,9 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.CandidateList
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 object cartesianProduct extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(planTable: PlanTable, ignored: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
     if (planTable.size > 1) {
       val plans = planTable.plans
       val cartesianProducts =

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/idSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/idSeekLeafPlanner.scala
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.compiler.v2_1.InputPosition.NONE
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
 
 object idSeekLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit context: QueryGraphSolvingContext) = {
-    val predicates: Seq[Expression] = qg.selections.flatPredicates
+  def apply(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]) = {
+    val predicates: Seq[Expression] = queryGraph.selections.flatPredicates
 
     val candidatePlans = predicates.collect {
       // MATCH (a)-[r]->b WHERE id(r) IN value
@@ -41,7 +41,7 @@ object idSeekLeafPlanner extends LeafPlanner {
         (predicate, idExpr, idValueExprs)
     }.collect {
       case (predicate, Identifier(idName), idValues) =>
-        context.queryGraph.patternRelationships.find(_.name.name == idName) match {
+        queryGraph.patternRelationships.find(_.name.name == idName) match {
           case Some(relationship) =>
             createRelationshipByIdSeek(relationship, idValues, predicate)
           case None =>

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/join.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/join.scala
@@ -22,9 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 object join extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
     val joinPlans: Seq[QueryPlan] = (for {
       left <- planTable.plans
       right <- planTable.plans if left != right

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/labelScanLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/labelScanLeafPlanner.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{CandidateList, QueryGraphSolvingContext, LeafPlanner}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, CandidateList, LeafPlanner}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
-import org.neo4j.cypher.internal.compiler.v2_1.ast.{UsingScanHint, Identifier, UsingIndexHint}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.{PatternExpression, UsingScanHint, Identifier}
 
 object labelScanLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit context: QueryGraphSolvingContext) = {
+  def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]) = {
     implicit val semanticTable = context.semanticTable
     val labelPredicateMap = qg.selections.labelPredicates
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/optional.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/optional.scala
@@ -19,15 +19,18 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{CandidateGenerator, CandidateList, QueryGraphSolvingContext, PlanTable}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.CandidateList
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 
 object optional extends CandidateGenerator[PlanTable] {
-  def apply(ignored: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(ignored: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
     val optionalCandidates =
-      for (optionalQG <- context.queryGraph.optionalMatches if optionalQG.argumentIds.isEmpty)
+      for (optionalQG <- queryGraph.optionalMatches if optionalQG.argumentIds.isEmpty)
       yield {
-        val rhs = context.strategy.plan(context.copy(queryGraph = optionalQG))
+        val rhs = context.strategy.plan(optionalQG)
 
         planOptional(rhs)
       }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/optionalExpand.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/optionalExpand.scala
@@ -23,13 +23,14 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.{Selections, QueryGraph}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 object optionalExpand extends CandidateGenerator[PlanTable] {
 
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
 
     val outerJoinPlans: Seq[QueryPlan] = for {
-      optionalQG <- context.queryGraph.optionalMatches
+      optionalQG <- queryGraph.optionalMatches
       lhs <- planTable.plans
       patternRel <- findSinglePatternRelationship(lhs, optionalQG)
       argumentId = optionalQG.argumentIds.head

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/outerJoin.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/outerJoin.scala
@@ -23,16 +23,16 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
 import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 object outerJoin extends CandidateGenerator[PlanTable] {
-  def apply(planTable: PlanTable)(implicit context: QueryGraphSolvingContext): CandidateList = {
+  def apply(planTable: PlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): CandidateList = {
 
     val outerJoinPlans = for {
-      optionalQG <- context.queryGraph.optionalMatches
+      optionalQG <- queryGraph.optionalMatches
       lhs <- planTable.plans if applicable(lhs, optionalQG)
     } yield {
-      val innerLogicalPlanContext = context.copy(queryGraph = optionalQG.withoutArguments())
-      val rhs = context.strategy.plan(innerLogicalPlanContext)
+      val rhs = context.strategy.plan(optionalQG.withoutArguments())
       planOuterHashJoin(optionalQG.argumentIds.head, lhs, rhs)
     }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/pickBestPlan.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/pickBestPlan.scala
@@ -20,9 +20,11 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{CandidateList, QueryGraphSolvingContext, CandidateSelector}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, CandidateList, CandidateSelector}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 object pickBestPlan extends CandidateSelector {
-  def apply(candidateList: CandidateList)(implicit context: QueryGraphSolvingContext): Option[QueryPlan] =
+  def apply(candidateList: CandidateList)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): Option[QueryPlan] =
     candidateList.bestPlan(context.cost)
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/selectCovered.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/selectCovered.scala
@@ -39,12 +39,14 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{PlanTransformer, QueryGraphSolvingContext}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, PlanTransformer}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
-object selectCovered extends PlanTransformer {
-  def apply(plan: QueryPlan)(implicit context: QueryGraphSolvingContext): QueryPlan = {
-    val unsolvedPredicates = context.queryGraph.selections
+object selectCovered extends PlanTransformer[QueryGraph] {
+  def apply(plan: QueryPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = {
+    val unsolvedPredicates = queryGraph.selections
       .scalarPredicatesGiven(plan.availableSymbols)
       .filterNot(predicate => plan.solved.exists(_.graph.selections.contains(predicate)))
     if (unsolvedPredicates.isEmpty)

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/sortSkipAndLimit.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/sortSkipAndLimit.scala
@@ -24,14 +24,14 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_1.ast
 import org.neo4j.cypher.internal.compiler.v2_1.helpers.FreshIdNameGenerator
 import org.neo4j.cypher.internal.compiler.v2_1.pipes.{Descending, Ascending, SortDescription}
-import org.neo4j.cypher.internal.compiler.v2_1.planner.PlannerQuery
+import org.neo4j.cypher.internal.compiler.v2_1.planner.{QueryGraph, PlannerQuery}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
-object sortSkipAndLimit {
+object sortSkipAndLimit extends PlanTransformer[PlannerQuery] {
 
   import QueryPlanProducer._
 
-  def apply(plan: QueryPlan)(implicit context: LogicalPlanningContext): QueryPlan = {
-    val query = context.query
+  def apply(plan: QueryPlan, query: PlannerQuery)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = {
     val projection = query.projection
 
     val producedPlan = (projection.sortItems.toList, projection.skip, projection.limit) match {

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/verifyBestPlan.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/verifyBestPlan.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_1.planner.{PlannerQuery, CantHandleQueryException}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.{QueryGraph, PlannerQuery, CantHandleQueryException}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.QueryPlan
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{PlanTransformer, LogicalPlanningContext}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
-object verifyBestPlan {
-  def apply(plan: QueryPlan)(implicit context: LogicalPlanningContext): QueryPlan = {
-    val expected = context.query
+object verifyBestPlan extends PlanTransformer[PlannerQuery] {
+  def apply(plan: QueryPlan, expected: PlannerQuery)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = {
     val constructed = plan.solved
     if (expected != constructed)
       throw new CantHandleQueryException()

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/execution/PipeExecutionPlanBuilderTest.scala
@@ -33,7 +33,7 @@ class PipeExecutionPlanBuilderTest extends CypherFunSuite with LogicalPlanningTe
 
   implicit val planContext = newMockedPlanContext
   implicit val pipeMonitor = monitors.newMonitor[PipeMonitor]()
-  implicit val context = newMockedQueryGraphSolvingContext(planContext)
+  implicit val context = newMockedLogicalPlanningContext(planContext)
   val patternRel = PatternRelationship("r", ("a", "b"), Direction.OUTGOING, Seq.empty, SimplePatternLength)
 
   val planBuilder = new PipeExecutionPlanBuilder(monitors)

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanTableTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/PlanTableTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.LogicalPlanningTestSuppor
 
 class PlanTableTest extends CypherFunSuite with LogicalPlanningTestSupport {
   implicit val planContext = newMockedPlanContext
-  implicit val context = newMockedQueryGraphSolvingContext(planContext)
+  implicit val context = newMockedLogicalPlanningContext(planContext)
 
   val x = newMockedQueryPlan("x")
   val x2 = newMockedQueryPlan("x")

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/AllNodesLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/AllNodesLeafPlannerTest.scala
@@ -24,19 +24,19 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.{QueryGraph, LogicalPlann
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.allNodesLeafPlanner
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.Candidates
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
-class AllNodesLeafPlannerTest
-  extends CypherFunSuite
-  with LogicalPlanningTestSupport {
+class AllNodesLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
+
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
 
   test("simple all nodes scan") {
     // given
     val queryGraph = QueryGraph(patternNodes = Set(IdName("n")))
 
     implicit val planContext = newMockedPlanContext
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = planContext,
-      query = queryGraph,
       metrics = newMockedMetricsFactory.newMetrics(hardcodedStatistics, newMockedSemanticTable))
 
     // when

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/ArgumentLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/ArgumentLeafPlannerTest.scala
@@ -24,11 +24,14 @@ import org.neo4j.cypher.internal.compiler.v2_1.planner.{QueryGraph, LogicalPlann
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.argumentLeafPlanner
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{Candidates, CandidateList}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 class ArgumentLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
+
   test("should return an empty candidate list argument ids is empty") {
-    implicit val context = newMockedQueryGraphSolvingContext(newMockedPlanContext)
+    implicit val context = newMockedLogicalPlanningContext(newMockedPlanContext)
 
     val qg = QueryGraph(
       argumentIds = Set(),
@@ -39,7 +42,7 @@ class ArgumentLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("should return an empty candidate list pattern nodes is empty") {
-    implicit val context = newMockedQueryGraphSolvingContext(newMockedPlanContext)
+    implicit val context = newMockedLogicalPlanningContext(newMockedPlanContext)
 
     val qg = QueryGraph(
       argumentIds = Set("a", "b"),
@@ -50,7 +53,7 @@ class ArgumentLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("should return a plan containing all the id in argument ids and in pattern nodes") {
-    implicit val context = newMockedQueryGraphSolvingContext(newMockedPlanContext)
+    implicit val context = newMockedLogicalPlanningContext(newMockedPlanContext)
 
     val qg = QueryGraph(
       argumentIds = Set("a", "b", "c"),

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/IdSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/IdSeekLeafPlannerTest.scala
@@ -35,6 +35,7 @@ import scala.collection.mutable
 class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupport {
 
   private val statistics = hardcodedStatistics
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
 
   // NOTE: the ronja rewriters make sure that all EQUALS will be rewritten to IN so here only the latter should be tested
 
@@ -57,9 +58,8 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
       case _: NodeByIdSeek => Cardinality(1)
       case _               => Cardinality(Double.MaxValue)
     })
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, newMockedSemanticTable)
     )
     when(context.semanticTable.isNode(identifier)).thenReturn(true)
@@ -98,9 +98,8 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
       case _: DirectedRelationshipByIdSeek => Cardinality(1)
       case _                               => Cardinality(Double.MaxValue)
     })
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, newMockedSemanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
@@ -136,9 +135,8 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
       case _: UndirectedRelationshipByIdSeek => Cardinality(2)
       case _                                 => Cardinality(Double.MaxValue)
     })
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, newMockedSemanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
@@ -180,9 +178,8 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
       case _: UndirectedRelationshipByIdSeek => Cardinality(2)
       case _                                 => Cardinality(Double.MaxValue)
     })
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, semanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
@@ -228,9 +225,8 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
       case _: UndirectedRelationshipByIdSeek => Cardinality(2)
       case _                                 => Cardinality(Double.MaxValue)
     })
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, semanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/IndexLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/IndexLeafPlannerTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.ast._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.{uniqueIndexSeekLeafPlanner, indexSeekLeafPlanner}
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.QueryGraphSolvingContext
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.v2_1.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v2_1.commands.ManyQueryExpression
 
@@ -41,9 +41,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
     new given {
       qg = queryGraph(inCollectionValue, hasLabels)
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx: LogicalPlanningContext, table: Map[PatternExpression, QueryGraph]) =>
         // when
-        val resultPlans = indexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = indexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans shouldBe empty
@@ -54,9 +54,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
     new given {
       qg = queryGraph(inCollectionValue, hasLabels)
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans shouldBe empty
@@ -70,9 +70,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
       indexOn("Awesome", "prop")
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = indexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = indexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans.map(_.plan) should beLike {
@@ -88,9 +88,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
       indexOn("Awesome", "prop")
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = indexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = indexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans.map(_.plan) should beLike {
@@ -106,9 +106,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
       uniqueIndexOn("Awesome", "prop")
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans.map(_.plan) should beLike {
@@ -126,9 +126,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
       indexOn("Awesome", "prop")
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = indexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = indexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans.map(_.plan) should beLike {
@@ -150,9 +150,9 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
       uniqueIndexOn("Awesome", "prop")
 
-      withQueryGraphSolvingContext { (ctx: QueryGraphSolvingContext) =>
+      withLogicalPlanningContext { (ctx, table) =>
         // when
-        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx)
+        val resultPlans = uniqueIndexSeekLeafPlanner(qg)(ctx, table)
 
         // then
         resultPlans.plans.map(_.plan) should beLike {

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/LabelScanLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/plans/LabelScanLeafPlannerTest.scala
@@ -34,6 +34,8 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
 
   val statistics = hardcodedStatistics
 
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
+
   test("simple label scan without compile-time label id") {
     // given
     val idName = IdName("n")
@@ -51,10 +53,9 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     val semanticTable = newMockedSemanticTable
     when(semanticTable.resolvedLabelIds).thenReturn(mutable.Map.empty[String, LabelId])
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       semanticTable = semanticTable,
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, newMockedSemanticTable)
     )
 
@@ -83,10 +84,9 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     val semanticTable = newMockedSemanticTable
     when(semanticTable.resolvedLabelIds).thenReturn(mutable.Map("Awesome" -> labelId))
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       semanticTable = semanticTable,
       planContext = newMockedPlanContext,
-      query = qg,
       metrics = factory.newMetrics(statistics, semanticTable)
     )
 

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/AggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/AggregationTest.scala
@@ -38,8 +38,8 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
       skip = None
     )
 
+    val query = PlannerQuery(projection = projection)
     val context = newMockedLogicalPlanningContext(
-      query = PlannerQuery(projection = projection),
       planContext = newMockedPlanContext
     )
 
@@ -61,8 +61,8 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
       skip = None
     )
 
+    val query = PlannerQuery(projection = projection)
     val context = newMockedLogicalPlanningContext(
-      query = PlannerQuery(projection = projection),
       planContext = newMockedPlanContext
     )
 

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/ExtractBestPlanTest.scala
@@ -24,8 +24,11 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.PlanTable
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
 
 class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport {
+
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
 
   test("should throw when finding plan that does not solve all selections") {
     val query = PlannerQuery(
@@ -35,13 +38,12 @@ class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport
       )
     )
     implicit val logicalPlanContext = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      query = query)
+      planContext = newMockedPlanContext)
     val plan = newMockedQueryPlan("b")
     val planTable = PlanTable(Map(Set(IdName("a")) -> plan))
 
     evaluating {
-      verifyBestPlan(planTable.uniquePlan)
+      verifyBestPlan(planTable.uniquePlan, query)
     } should produce[CantHandleQueryException]
   }
 
@@ -54,14 +56,13 @@ class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport
       )
     )
     implicit val logicalPlanContext = newMockedLogicalPlanningContext(
-      planContext= newMockedPlanContext,
-      query = query
+      planContext= newMockedPlanContext
     )
     val plan = newMockedQueryPlan("b")
     val planTable = PlanTable(Map(Set(IdName("a")) -> plan))
 
     evaluating {
-      verifyBestPlan(planTable.uniquePlan)
+      verifyBestPlan(planTable.uniquePlan, query)
     } should produce[CantHandleQueryException]
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/OptionalTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/OptionalTest.scala
@@ -23,13 +23,16 @@ import org.neo4j.graphdb.Direction
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical._
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_1.ast.PatternExpression
+import scala.collection.mutable
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{Cardinality, QueryGraphSolver, QueryGraphSolvingContext, PlanTable}
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
-import scala.collection.mutable
 
 class OptionalTest extends CypherFunSuite with LogicalPlanningTestSupport {
+
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
 
   test("should introduce apply for unsolved exclusive optional match") {
     // OPTIONAL MATCH (a)-[r]->(b)
@@ -49,16 +52,15 @@ class OptionalTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     val fakePlan = newMockedQueryPlan(Set(IdName("a"), IdName("b")))
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       strategy = newMockedStrategy(fakePlan),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
     val planTable = PlanTable(Map())
 
-    optional(planTable).plans should equal(Seq(planOptional(fakePlan)))
+    optional(planTable, qg).plans should equal(Seq(planOptional(fakePlan)))
   }
 
   test("should solve multiple optional matches") {
@@ -87,20 +89,19 @@ class OptionalTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val fakePlan1 = newMockedQueryPlan(Set(IdName("a"), IdName("b")))
     val fakePlan2 = newMockedQueryPlan(Set(IdName("a"), IdName("c")))
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
       strategy = FakePlanningStrategy(fakePlan1, fakePlan2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
     val planTable = PlanTable(Map())
 
-    optional(planTable).plans should equal(Seq(planOptional(fakePlan1)))
+    optional(planTable, qg).plans should equal(Seq(planOptional(fakePlan1)))
   }
 }
 
 case class FakePlanningStrategy(plans: QueryPlan*) extends QueryGraphSolver {
   val queue = mutable.Queue[QueryPlan](plans:_*)
-  override def plan(implicit context: QueryGraphSolvingContext, leafPlan: Option[QueryPlan]): QueryPlan = queue.dequeue()
+  override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueryLookupTable: Map[PatternExpression, QueryGraph], leafPlan: Option[QueryPlan] = None) = queue.dequeue()
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/ProjectionTest.scala
@@ -65,17 +65,17 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
                              limit: Option[ast.Expression] = None,
                              sortItems: Seq[ast.SortItem] = Seq.empty,
                              projectionsMap: Map[String, ast.Expression] = Map("n" -> ast.Identifier("n")(pos))): (LogicalPlanningContext, QueryPlan) = {
-    val projections = QueryProjection(
-      limit = limit,
-      skip = skip,
-      sortItems = sortItems,
-      projections = projectionsMap)
-
-    val qg = QueryGraph(patternNodes = Set(IdName("n")))
+//    val projections = QueryProjection(
+//      limit = limit,
+//      skip = skip,
+//      sortItems = sortItems,
+//      projections = projectionsMap)
+//
+//    val qg = QueryGraph(patternNodes = Set(IdName("n")))
+//    val query = PlannerQuery(qg, projections)
 
     val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      query = PlannerQuery(qg, projections)
+      planContext = newMockedPlanContext
     )
 
     val plan = QueryPlan(

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SelectCoveredTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SelectCoveredTest.scala
@@ -20,25 +20,26 @@
 package org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_1.ast.{SignedIntegerLiteral, Expression}
+import org.neo4j.cypher.internal.compiler.v2_1.ast.{PatternExpression, SignedIntegerLiteral, Expression}
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans.{QueryPlan, IdName}
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
 
 class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
-  implicit val planContext = newMockedPlanContext
-
+  private implicit val planContext = newMockedPlanContext
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
+  private implicit val context = newMockedLogicalPlanningContext(planContext)
 
   test("when a predicate that isn't already solved is solvable it should be applied") {
     // Given
     val predicate = mock[Expression]
     val queryPlan = newMockedQueryPlan("x")
     val selections = Selections(Set(Predicate(queryPlan.availableSymbols, predicate)))
-    implicit val context = newMockedQueryGraphSolvingContext(planContext,
-      query = QueryGraph(selections = selections))
+
+    val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(queryPlan)
+    val result = selectCovered(queryPlan, qg)
 
     // Then
     result should equal(planSelection(Seq(predicate), queryPlan))
@@ -48,13 +49,12 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     // Given
     val predicate = mock[Expression]
     val selections = Selections(Set(Predicate(Set(IdName("x")), predicate)))
-    implicit val context = newMockedQueryGraphSolvingContext(planContext,
-      query = QueryGraph(selections = selections))
     val queryPlan = newMockedQueryPlanWithProjections("x")
 
+    val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(queryPlan)
+    val result = selectCovered(queryPlan, qg)
 
     // Then
     result should equal(planSelection(Seq(predicate), queryPlan))
@@ -67,12 +67,12 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val selections = Selections(Set(
       Predicate(Set(IdName("x")), predicate1),
       Predicate(Set(IdName("x")), predicate2)))
-    implicit val context = newMockedQueryGraphSolvingContext(planContext,
-      query = QueryGraph(selections = selections))
     val queryPlan: QueryPlan = newMockedQueryPlanWithProjections("x")
 
+    val qg = QueryGraph(selections = selections)
+
     // When
-    val result = selectCovered(queryPlan)
+    val result = selectCovered(queryPlan, qg)
 
     // Then
     result should equal(planSelection(Seq(predicate1, predicate2), queryPlan))
@@ -80,15 +80,12 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("when a predicate is already solved, it should not be applied again") {
     // Given
-    implicit val context = newMockedQueryGraphSolvingContext(planContext)
-
     val coveredIds = Set(IdName("x"))
-    val selectionsQG = QueryGraph(selections = Selections(Set(Predicate(coveredIds, SignedIntegerLiteral("1")_))))
-
-    val queryPlan = newMockedQueryPlanWithProjections("x").copy(solved = PlannerQuery(selectionsQG))
+    val qg = QueryGraph(selections = Selections(Set(Predicate(coveredIds, SignedIntegerLiteral("1")_))))
+    val queryPlan = newMockedQueryPlanWithProjections("x").copy(solved = PlannerQuery(qg))
 
     // When
-    val result = selectCovered(queryPlan)(context.copy(queryGraph = selectionsQG))
+    val result = selectCovered(queryPlan, qg)
 
     // Then
     result should equal(queryPlan)
@@ -98,11 +95,11 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     // Given
     val predicate = mock[Expression]
     val selections = Selections(Set(Predicate(Set(IdName("x"), IdName("y")), predicate)))
-    implicit val context = newMockedQueryGraphSolvingContext(planContext, query = QueryGraph(selections = selections))
     val queryPlan = newMockedQueryPlanWithProjections("x")
+    val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(queryPlan)
+    val result = selectCovered(queryPlan, qg)
 
     // Then
     result should equal(queryPlan)

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -24,10 +24,10 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_1.ast._
 import org.neo4j.cypher.internal.compiler.v2_1.planner._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{Cardinality, QueryGraphSolvingContext, PlanTransformer}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.{LogicalPlanningContext, Cardinality, PlanTransformer}
+import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.steps.QueryPlanProducer._
 
 class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport {
   val dir = Direction.OUTGOING
@@ -48,8 +48,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     case _ => Cardinality(1000)
   })
 
-  val passThrough = new PlanTransformer {
-    def apply(input: QueryPlan)(implicit context: QueryGraphSolvingContext) = input
+  val passThrough = new PlanTransformer[QueryGraph] {
+    def apply(input: QueryPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, subQueriesLookupTable: Map[PatternExpression, QueryGraph]): QueryPlan = input
   }
 
   test("should introduce semi apply for unsolved exclusive pattern predicate") {
@@ -67,10 +67,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -78,7 +78,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName(nodeName), IdName(relName), SimplePatternLength, patternRel)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(planSemiApply(aPlan, inner, patternExp))
@@ -100,10 +100,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -111,7 +111,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName(nodeName), IdName(relName), SimplePatternLength, patternRel)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(planAntiSemiApply(aPlan, inner, patternExp, notExpr))
@@ -133,16 +133,16 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
     val bPlan = newMockedQueryPlan("b")
     // When
-    val result = selectPatternPredicates(passThrough)(bPlan)
+    val result = selectPatternPredicates(passThrough)(bPlan, qg)
 
     // Then
     result should equal(bPlan)
@@ -168,10 +168,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -180,7 +180,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = planExpand(singleRow, IdName("a"), dir, types, IdName(nodeName), IdName(relName), SimplePatternLength, patternRel)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrSemiApply(aPlan, inner, equals), orsExp))
@@ -206,10 +206,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -217,7 +217,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName(nodeName), IdName(relName), SimplePatternLength, patternRel)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrAntiSemiApply(aPlan, inner, equals), orsExp))
@@ -253,10 +253,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -265,7 +265,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName("  UNNAMED4"), IdName("  UNNAMED3"), SimplePatternLength, patternRel2)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrSemiApply(planLetSemiApply(aPlan, inner, IdName("  FRESHID0")), inner2, ident("  FRESHID0")), orsExp))
@@ -300,10 +300,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -312,7 +312,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName("  UNNAMED4"), IdName("  UNNAMED3"), SimplePatternLength, patternRel2)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrAntiSemiApply(planLetSemiApply(aPlan, inner, IdName("  FRESHID0")), inner2, ident("  FRESHID0")), orsExp))
@@ -347,10 +347,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -359,7 +359,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName("  UNNAMED4"), IdName("  UNNAMED3"), SimplePatternLength, patternRel2)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrSemiApply(planLetAntiSemiApply(aPlan, inner, IdName("  FRESHID0")), inner2, ident("  FRESHID0")), orsExp))
@@ -399,10 +399,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -411,7 +411,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName("  UNNAMED4"), IdName("  UNNAMED3"), SimplePatternLength, patternRel2)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrAntiSemiApply(planLetSelectOrSemiApply(aPlan, inner, IdName("  FRESHID0"), equals), inner2, ident("  FRESHID0")), orsExp))
@@ -451,10 +451,10 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
       selections = selections
     )
 
-    implicit val context = newMockedQueryGraphSolvingContext(
+    implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
+
+    implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      query = qg,
-      subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2),
       metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
     )
 
@@ -463,7 +463,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = planExpand(planArgumentRow(Set(IdName("a"))), IdName("a"), dir, types, IdName("  UNNAMED4"), IdName("  UNNAMED3"), SimplePatternLength, patternRel2)
 
     // When
-    val result = selectPatternPredicates(passThrough)(aPlan)
+    val result = selectPatternPredicates(passThrough)(aPlan, qg)
 
     // Then
     result should equal(solvePredicate(planSelectOrSemiApply(planLetSelectOrAntiSemiApply(aPlan, inner, IdName("  FRESHID0"), equals), inner2, ident("  FRESHID0")), orsExp))

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SortSkipAndLimitTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/planner/logical/steps/SortSkipAndLimitTest.scala
@@ -25,9 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_1.ast
 import org.neo4j.cypher.internal.compiler.v2_1.pipes.SortDescription
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_1.planner.logical.LogicalPlanningContext
-import org.neo4j.cypher.internal.compiler.v2_1.ast.UnsignedIntegerLiteral
+import org.neo4j.cypher.internal.compiler.v2_1.ast.{PatternExpression, UnsignedIntegerLiteral, AscSortItem}
 import org.neo4j.cypher.internal.compiler.v2_1.pipes.Ascending
-import org.neo4j.cypher.internal.compiler.v2_1.ast.AscSortItem
 
 class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -38,14 +37,16 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
   val identifierSortItem: AscSortItem = ast.AscSortItem(ast.Identifier("n") _) _
   val sortDescription: SortDescription = Ascending("n")
 
+  private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
+
   test("should add skip if query graph contains skip") {
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       skip = Some(x)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.plan should equal(Skip(startPlan.plan, x))
@@ -54,12 +55,12 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
   test("should add limit if query graph contains limit") {
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       limit = Some(x)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.plan should equal(Limit(startPlan.plan, x))
@@ -68,13 +69,13 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
   test("should add skip first and then limit if the query graph contains both") {
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       limit = Some(x),
       skip = Some(y)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.plan should equal(Limit(Skip(startPlan.plan, y), x))
@@ -84,12 +85,12 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
   test("should add sort if query graph contains sort items") {
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       sortItems = Seq(identifierSortItem)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.plan should equal(Sort(startPlan.plan, Seq(sortDescription)))
@@ -101,12 +102,12 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
     val exp: ast.Expression = ast.Add(UnsignedIntegerLiteral("10") _, UnsignedIntegerLiteral("10") _) _
     val expressionSortItem: AscSortItem = ast.AscSortItem(exp) _
 
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       sortItems = Seq(expressionSortItem)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.solved.projection.sortItems should equal(Seq(expressionSortItem))
@@ -127,12 +128,12 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
     val exp: ast.Expression = ast.Add(UnsignedIntegerLiteral("10") _, UnsignedIntegerLiteral("10") _) _
     val expressionSortItem: AscSortItem = ast.AscSortItem(exp) _
 
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       sortItems = Seq(expressionSortItem, identifierSortItem)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result.solved.projection.sortItems should equal(Seq(expressionSortItem, identifierSortItem))
@@ -151,13 +152,13 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
   test("should add SortedLimit when query uses both ORDER BY and LIMIT") {
     val sortItems: Seq[AscSortItem] = Seq(identifierSortItem)
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       sortItems = sortItems,
       limit = Some(x)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result should equal(
@@ -170,14 +171,14 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
 
   test("should add SortedLimit when query uses both ORDER BY and LIMIT, and add the SKIP value to the SortedLimit") {
     // given
-    implicit val (context, startPlan) = queryGraphWith(
+    implicit val (query, context, startPlan) = queryGraphWith(
       sortItems = Seq(identifierSortItem),
       limit = Some(x),
       skip = Some(y)
     )
 
     // when
-    val result = sortSkipAndLimit(startPlan)
+    val result = sortSkipAndLimit(startPlan, query)
 
     // then
     result should equal(
@@ -197,7 +198,7 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
   private def queryGraphWith(skip: Option[ast.Expression] = None,
                              limit: Option[ast.Expression] = None,
                              sortItems: Seq[ast.SortItem] = Seq.empty,
-                             projectionsMap: Map[String, ast.Expression] = Map("n" -> ast.Identifier("n")(pos))): (LogicalPlanningContext, QueryPlan) = {
+                             projectionsMap: Map[String, ast.Expression] = Map("n" -> ast.Identifier("n")(pos))): (PlannerQuery, LogicalPlanningContext, QueryPlan) = {
     val projections = QueryProjection(
       limit = limit,
       skip = skip,
@@ -205,10 +206,10 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
       projections = projectionsMap)
 
     val qg = QueryGraph(patternNodes = Set(IdName("n")))
+    val query = PlannerQuery(qg, projections)
 
     val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      query = PlannerQuery(qg, projections)
+      planContext = newMockedPlanContext
     )
 
     val plan = QueryPlan(
@@ -216,6 +217,6 @@ class SortSkipAndLimitTest extends CypherFunSuite with LogicalPlanningTestSuppor
       PlannerQuery(QueryGraph.empty.addPatternNodes(IdName("n")))
     )
 
-    (context, plan)
+    (query, context, plan)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher
 import org.scalatest.Matchers
 import org.neo4j.graphdb.Node
 
-class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matchers with NewPlannerTestSupport{
+class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matchers with NewPlannerTestSupport {
 
   test("should filter relationships with properties") {
     // given


### PR DESCRIPTION
- using an unique context when planning
- sub query lookup table is not in the context anymore
