### PR TITLE
[2.0] Ensure UniquenessConstraint created by BatchInserter are consistent.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -458,7 +458,7 @@ public class BatchInserterImpl implements BatchInserter
                 this.schemaIndexProviders.getDefaultProvider().getProviderDescriptor(),
                 constraintRuleId );
         UniquenessConstraintRule constraintRule = UniquenessConstraintRule.uniquenessConstraintRule(
-                schemaStore.nextId(), constraint.label(), constraint.propertyKeyId(), indexRuleId );
+                constraintRuleId, constraint.label(), constraint.propertyKeyId(), indexRuleId );
 
         for ( DynamicRecord record : schemaStore.allocateFrom( constraintRule ) )
         {


### PR DESCRIPTION
This is a PR against 2.0-maint, it will need to be forward ported/merged to 2.1-maint and 2.2 (master) as well.

A UniquenessConstraint consists of two records in the Schema store, one representing the constraint, and one representing the backing index. The backing index should reference the constraint as its owning constraint, and the constraint should reference that it owns the index. The BatchInserter failed to set up this relationship properly since it generated the id for the constraint record twice.
This commit fixes that issue.
