### PR TITLE
Fix problem that could lead to missing index constraints in HA

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -169,6 +169,12 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     @Override
     public void start()
     {
+        loadSchemaCache();
+    }
+
+    public void loadSchemaCache()
+    {
+        schemaCache.clear();
         for ( SchemaRule schemaRule : loop( neoStore.getSchemaStore().loadAllSchemaRules() ) )
         {
             schemaCache.addSchemaRule( schemaRule );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -151,7 +151,15 @@ public class SchemaCache
                     indexRule.getPropertyKey(), indexRule.getId() ) );
         }
     }
-    
+
+    public void clear()
+    {
+        rulesByLabelMap.clear();
+        ruleByIdMap.clear();
+        constraints.clear();
+        indexDescriptors.clear();
+    }
+
     // We could have had this class extend IndexDescriptor instead. That way we could have gotten the id
     // from an IndexDescriptor instance directly. The problem is that it would only work for index descriptors
     // instantiated by a SchemaCache. Perhaps that is always the case. Anyways, doing it like that resulted

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -750,4 +750,12 @@ public class NeoStoreXaDataSource extends LogBackedXaDataSource implements NeoSt
             }
         } );
     }
+
+    /**
+     * This must only be called when the database is otherwise inaccessible.
+     */
+    public void reloadSchemaCache()
+    {
+        ((Kernel) kernel).loadSchemaCache();
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.MasterImpl;
 import org.neo4j.kernel.ha.com.master.MasterServer;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
@@ -86,6 +87,9 @@ public class SwitchToMaster
             final TransactionManager txManager = resolver.resolveDependency( TransactionManager.class );
 
             idGeneratorFactory.switchToMaster();
+            NeoStoreXaDataSource neoStoreXaDataSource = (NeoStoreXaDataSource) xaDataSourceManager.getXaDataSource(
+                    NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
+            neoStoreXaDataSource.reloadSchemaCache();
 
             Monitors monitors = resolver.resolveDependency( Monitors.class );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.ha;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
-import static org.neo4j.test.ha.ClusterManager.masterAvailable;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
@@ -37,8 +26,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.cluster.InstanceId;
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
@@ -46,6 +38,8 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
@@ -56,17 +50,37 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.ha.ClusterManager;
 
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.test.ha.ClusterManager.masterAvailable;
+
 public class TransactionConstraintsIT extends AbstractClusterTest
 {
+
+    private static final String PROPERTY_KEY = "name";
+    private static final String PROPERTY_VALUE = "yo";
+    private static final String LABEL = "Person";
+
     @Before
     public void stableCluster()
     {
         // Ensure a stable cluster before starting tests
-        cluster.await( ClusterManager.allSeesAllAsAvailable() );
+        cluster.await( allSeesAllAsAvailable() );
     }
 
     @Test
-    public void start_tx_as_slave_and_finish_it_after_having_switched_to_master_should_not_succeed() throws Exception
+    public void startTxAsSlaveAndFinishItAfterHavingSwitchedToMasterShouldNotSucceed() throws Exception
     {
         // GIVEN
         GraphDatabaseService db = cluster.getAnySlave();
@@ -95,7 +109,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
 
     @Test
-    public void start_tx_as_slave_and_finish_it_after_another_master_being_available_should_not_succeed() throws Exception
+    public void startTxAsSlaveAndFinishItAfterAnotherMasterBeingAvailableShouldNotSucceed() throws Exception
     {
         // GIVEN
         HighlyAvailableGraphDatabase db = cluster.getAnySlave();
@@ -127,7 +141,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
     
     @Test
-    public void slave_should_not_be_able_to_produce_an_invalid_transaction() throws Exception
+    public void slaveShouldNotBeAbleToProduceAnInvalidTransaction() throws Exception
     {
         // GIVEN
         HighlyAvailableGraphDatabase aSlave = cluster.getAnySlave();
@@ -149,7 +163,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
 
     @Test
-    public void master_should_not_be_able_to_produce_an_invalid_transaction() throws Exception
+    public void masterShouldNotBeAbleToProduceAnInvalidTransaction() throws Exception
     {
         // GIVEN
         HighlyAvailableGraphDatabase master = cluster.getMaster();
@@ -171,7 +185,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
     
     @Test
-    public void write_operation_on_slave_has_to_be_performed_within_a_transaction() throws Exception
+    public void writeOperationOnSlaveHasToBePerformedWithinTransaction() throws Exception
     {
         // GIVEN
         HighlyAvailableGraphDatabase aSlave = cluster.getAnySlave();
@@ -189,7 +203,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
     
     @Test
-    public void write_operation_on_master_has_to_be_performed_within_a_transaction() throws Exception
+    public void writeOperationOnMasterHasToBePerformedWithinTransaction() throws Exception
     {
         // GIVEN
         HighlyAvailableGraphDatabase master = cluster.getMaster();
@@ -207,7 +221,7 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
     
     @Test
-    public void slave_should_not_be_able_to_modify_node_deleted_on_master() throws Exception
+    public void slaveShouldNotBeAbleToModifyNodeDeletedOnMaster() throws Exception
     {
         // GIVEN
         // -- node created on slave
@@ -235,14 +249,14 @@ public class TransactionConstraintsIT extends AbstractClusterTest
     }
 
     @Test
-    public void deadlock_detection_involving_two_slaves() throws Exception
+    public void deadlockDetectionInvolvingTwoSlaves() throws Exception
     {
         HighlyAvailableGraphDatabase slave1 = cluster.getAnySlave();
         deadlockDetectionBetween( slave1, cluster.getAnySlave( slave1 ) );
     }
     
     @Test
-    public void deadlock_detection_involving_slave_and_master() throws Exception
+    public void deadlockDetectionInvolvingSlaveAndMaster() throws Exception
     {
         deadlockDetectionBetween( cluster.getAnySlave(), cluster.getMaster() );
     }
@@ -299,9 +313,57 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         thread2.close();
     }
 
+    @Test
+    public void createdSchemaConstraintsMustBeRetainedAcrossModeSwitches() throws Throwable
+    {
+        // GIVEN
+        // -- a node with a label and a property, and a constraint on those
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        createConstraint( master, LABEL, PROPERTY_KEY );
+        createNode( master, LABEL ).getId();
+
+        // WHEN
+        cluster.sync();
+        ClusterManager.RepairKit repairKit = cluster.fail( master );
+        cluster.await( masterAvailable( master ) );
+        takeTheLeadInAnEventualMasterSwitch( cluster.getMaster() );
+        cluster.sync();
+
+        // TODO There is a bug, where the master does not notice that its followers have vanished.
+        // We have to do this sleep here to make sure that it times them out properly.
+        // See https://trello.com/c/hcTvl0bv
+        Thread.sleep( 30000 );
+
+        repairKit.repair();
+        cluster.await( allSeesAllAsAvailable() );
+        cluster.sync();
+        cluster.stop();
+
+        // THEN
+        // -- these fiddlings with the stores must not throw
+        for ( HighlyAvailableGraphDatabase instance : cluster.getAllMembers() )
+        {
+            GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( instance.getStoreDir() );
+            Label label = DynamicLabel.label( LABEL );
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = db.createNode( label );
+                node.setProperty( PROPERTY_KEY, PROPERTY_VALUE + "1" );
+                tx.success();
+            }
+            try ( Transaction tx = db.beginTx() )
+            {
+                ConstraintDefinition constraint = single( db.schema().getConstraints( label ) );
+                constraint.drop();
+                tx.success();
+            }
+            db.shutdown();
+        }
+    }
+
     @Ignore( "Known issue where locks acquired from Transaction#acquireXXXLock() methods doesn't get properly released when calling Lock#release() method" )
     @Test
-    public void manually_acquire_and_release_transaction_lock() throws Exception
+    public void manuallyAcquireAndReleaseTransactionLock() throws Exception
     {
         // GIVEN
         // -- a slave acquiring a lock on an ubiquitous node
@@ -343,26 +405,33 @@ public class TransactionConstraintsIT extends AbstractClusterTest
         createNode( db );
     }
 
-    private Node createNode( GraphDatabaseService db )
+    private Node createNode( GraphDatabaseService db, String... labels )
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             Node node = db.createNode();
-            node.setProperty( "name", "yo" );
+            for ( String label : labels )
+            {
+                node.addLabel( DynamicLabel.label( label ) );
+            }
+            node.setProperty( PROPERTY_KEY, PROPERTY_VALUE );
             tx.success();
             return node;
         }
-        finally
+    }
+
+    private void createConstraint( HighlyAvailableGraphDatabase db, String label, String propertyName )
+    {
+        try ( Transaction tx = db.beginTx() )
         {
-            tx.finish();
+            db.schema().constraintFor( DynamicLabel.label( label ) ).assertPropertyIsUnique( propertyName ).create();
+            tx.success();
         }
     }
     
     private Node createMiniTree( GraphDatabaseService db )
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             Node root = db.createNode();
             root.createRelationshipTo( db.createNode(), MyRelTypes.TEST );
@@ -370,23 +439,14 @@ public class TransactionConstraintsIT extends AbstractClusterTest
             tx.success();
             return root;
         }
-        finally
-        {
-            tx.finish();
-        }
     }
     
     private void deleteNode( HighlyAvailableGraphDatabase db, long id )
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             db.getNodeById( id ).delete();
             tx.success();
-        }
-        finally
-        {
-            tx.finish();
         }
     }
     
@@ -472,14 +532,9 @@ public class TransactionConstraintsIT extends AbstractClusterTest
 
     private void doABogusTransaction( GraphDatabaseService db ) throws Exception
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction ignore = db.beginTx() )
         {
             db.createNode();
-        }
-        finally
-        {
-            tx.finish();
         }
     }
 }


### PR DESCRIPTION
Here's the thing: When we insert a new record into a store, we do the write immediately to grab
the id associated with that particular location in the file. When we update a record, we keep
the change around in memory until the stores are flushed, which only happens on log rotation.

When we create a new constraint, we first create the associated constraint index, and start off
the index population job. At this point, the owner field for this constraint index is empty.
When the population completes and our transaction commits, we then create the related
constraint rule, and update the index constraint record such that its owner fields references
this newly created constraint rule. This is of course all written to the transaction log, and
applied to the store files with as little actual IO as possible. Like I said above, we only
flush the store files when we rotate the log.

Because we want really fast access to the small bits of information that is our schema store,
we load up and cache the entire schema store when the database starts up. This schema cache is
then kept in sync with the schema store, when schema-mutating transactions are committed and
applied.

When we start up, we do recovery (if needed) and then we do our post-recovery. In our post-
recovery, we seek out all constraint indexes that have no owning constraint, and then we drop
them. We do this because we might have crashed in between creating the index, and creating
and committing the associated constraint. If that happens, then the constraint ended up never
being committed, and so we don't need the index that was created for it.

When we do a mode switch, from leader to follower or follower to leader, we _partially_ restart
the database. This means that we don't do any recovery, and we don't attempt to rotate the log.
We do still do our post-recovery, however, and this is look through all our constraint rules,
and drop indexes that don't have any owning constraints.

Now, it somehow happened, that we occasionally had schema-mutations applied to our schema store,
but not to the schema cache. Specifically, the schema cache would containt constraint indexes
that had an empty owner field, while the store had been correctly updated. The new leader
instance of the cluster would then inject a transaction that dropped all the constraint indexes,
and push that transaction out to the followers.

The constraint would then be rendered broken. So broken, in fact, that it couldn't even be
dropped, since dropping a constraint also implies dropping its index, but the index can no
longer be read from the schema store because it has been deleted.

This commit fixes this problem, by reloading the schema cache when we have a
follower-to-leader mode switch.
