### PR TITLE
Significantly reduce the probability of the StatisticsCollectorTest failing spuriously

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/statistics/StatisticsCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/statistics/StatisticsCollectorTest.java
@@ -94,6 +94,10 @@ public class StatisticsCollectorTest
         // When
         collector.run();
         collector.run();
+        collector.run();
+        collector.run();
+        collector.run();
+        collector.run();
 
         // Then
         assertThat( collector.collectedData().liveNodesRatio(), closeTo( 0.6, 0.1 ) );


### PR DESCRIPTION
With the added data collection runs, the collected statistics seems to become precise enough
that the test doesn't fail after hundreds of thousands of invocations.
