### PR TITLE
Copy overlapping completed transactions during rotation.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DirectLogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DirectLogBuffer.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction.xaframework;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 
@@ -141,6 +142,12 @@ public class DirectLogBuffer implements LogBuffer
     }
 
     public StoreChannel getFileChannel()
+    {
+        return fileChannel;
+    }
+
+    @Override
+    public ReadableByteChannel getReadableChannel()
     {
         return fileChannel;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DirectMappedLogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DirectMappedLogBuffer.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction.xaframework;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
@@ -181,6 +182,12 @@ public class DirectMappedLogBuffer implements LogBuffer
     }
 
     public StoreChannel getFileChannel()
+    {
+        return fileChannel;
+    }
+
+    @Override
+    public ReadableByteChannel getReadableChannel()
     {
         return fileChannel;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogBuffer.java
@@ -143,6 +143,12 @@ public class InMemoryLogBuffer implements LogBuffer, ReadableByteChannel
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public ReadableByteChannel getReadableChannel()
+    {
+        return this;
+    }
+
     public boolean isOpen()
     {
         return true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBuffer.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.transaction.xaframework;
 
 import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
 
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 
@@ -62,4 +63,6 @@ public interface LogBuffer
     long getFileChannelPosition() throws IOException;
 
     StoreChannel getFileChannel();
+
+    ReadableByteChannel getReadableChannel();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogExtractor.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import static java.lang.Math.max;
-import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog.getHighestHistoryLogVersion;
-import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog.readAndAssertLogHeader;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -32,7 +27,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Exceptions;
@@ -47,6 +41,12 @@ import org.neo4j.kernel.impl.util.BufferedFileChannel;
 import org.neo4j.kernel.impl.util.Consumer;
 import org.neo4j.kernel.impl.util.Cursor;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static java.lang.Math.max;
+
+import static org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource.LOGICAL_LOG_DEFAULT_NAME;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog.getHighestHistoryLogVersion;
+import static org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog.readAndAssertLogHeader;
 
 public class LogExtractor
 {
@@ -226,7 +226,7 @@ public class LogExtractor
         {
             extractNext( temp );
             LogDeserializer logDeserializer = new LogDeserializer( localBuffer, commandReaderFactory );
-            cursor = logDeserializer.cursor( temp.getFileChannel() );
+            cursor = logDeserializer.cursor( temp.getReadableChannel() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/NullLogBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/NullLogBuffer.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.transaction.xaframework;
 
 import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
 
 import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 
@@ -48,6 +49,12 @@ public class NullLogBuffer implements LogBuffer
 
     @Override
     public StoreChannel getFileChannel()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadableByteChannel getReadableChannel()
     {
         throw new UnsupportedOperationException();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PartialTransactionCopier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PartialTransactionCopier.java
@@ -24,10 +24,10 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.nioneo.xa.XaCommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.XaCommandWriterFactory;
-import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.Consumer;
 import org.neo4j.kernel.impl.util.Cursor;
@@ -47,7 +47,7 @@ class PartialTransactionCopier
     private final LogExtractor.LogPositionCache positionCache;
     private final LogExtractor.LogLoader logLoader;
     private final ArrayMap<Integer,LogEntry.Start> xidIdentMap;
-    private final DoesSomethingConsumer consumer;
+    private final EntireTransactionCopyingConsumer copyEntireTransactions;
 
     PartialTransactionCopier( ByteBuffer sharedBuffer, XaCommandReaderFactory commandReaderFactory,
                               XaCommandWriterFactory commandWriterFactory, StringLogger log,
@@ -62,21 +62,21 @@ class PartialTransactionCopier
         this.positionCache = positionCache;
         this.logLoader = logLoader;
         this.xidIdentMap = xidIdentMap;
-        consumer = new DoesSomethingConsumer();
+        this.copyEntireTransactions = new EntireTransactionCopyingConsumer();
     }
 
     public void copy( StoreChannel sourceLog, LogBuffer targetLog, long targetLogVersion ) throws IOException
     {
         LogDeserializer deserializer = new LogDeserializer( sharedBuffer, commandReaderFactory );
-        consumer.init( targetLog, targetLogVersion );
+        copyEntireTransactions.init( targetLog, targetLogVersion );
         Cursor<LogEntry, IOException> cursor = deserializer.cursor( sourceLog );
-        while( cursor.next( consumer ) ); // let exceptions propagate, the channel is closed outside
+        while( cursor.next( copyEntireTransactions ) ); // let exceptions propagate, the channel is closed outside
     }
 
-    private class DoesSomethingConsumer implements Consumer<LogEntry, IOException>
+    private class EntireTransactionCopyingConsumer implements Consumer<LogEntry, IOException>
     {
         private final Map<Integer,LogEntry.Start> startEntriesEncountered = new HashMap<>();
-        private final IAmNotReallySureWhatThisDoes consumer = new IAmNotReallySureWhatThisDoes();
+        private final CopyUntilCommitConsumer copyUntilCommitEntry = new CopyUntilCommitConsumer();
         private boolean foundFirstActiveTx;
 
         private LogBuffer targetLog;
@@ -116,8 +116,8 @@ class PartialTransactionCopier
                     LogEntry.Start startEntry = startEntriesEncountered.get( identifier );
                     if ( startEntry == null )
                     {
-                        // Fetch from log extractor instead (all entries except done records, which will be copied from the source).
-                        startEntry = fetchTransactionBulkFromLogExtractor( commitEntry.getTxId() );
+                        // Fetch from log extractor instead (all entries except commit (and done) records, which will be copied from the source).
+                        startEntry = extractTransactionFromEarlierInLog( commitEntry.getTxId() );
                         startEntriesEncountered.put( identifier, startEntry );
                     }
                     else
@@ -132,24 +132,24 @@ class PartialTransactionCopier
                 {
                     logEntryWriter.writeLogEntry( logEntry, targetLog );
                 }
-            };
+            }
             return true;
         }
 
-        private LogEntry.Start fetchTransactionBulkFromLogExtractor( long txId ) throws IOException
+        private LogEntry.Start extractTransactionFromEarlierInLog( long txId ) throws IOException
         {
             LogExtractor extractor = new LogExtractor( positionCache, logLoader, commandReaderFactory,
                     commandWriterFactory, logEntryWriter, txId, txId );
 
-            try (Cursor<LogEntry, IOException> cursor = extractor.cursor( new InMemoryLogBuffer() ) )
+            try ( Cursor<LogEntry, IOException> cursor = extractor.cursor( new InMemoryLogBuffer() ) )
             {
-                while ( cursor.next( consumer ) );
+                while ( cursor.next( copyUntilCommitEntry ) );
             }
 
             return extractor.getLastStartEntry();
         }
 
-        private class IAmNotReallySureWhatThisDoes implements Consumer<LogEntry, IOException>
+        private class CopyUntilCommitConsumer implements Consumer<LogEntry, IOException>
         {
             @Override
             public boolean accept( LogEntry entry ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
@@ -45,13 +46,15 @@ import org.neo4j.kernel.impl.transaction.xaframework.LogBuffer;
 import org.neo4j.kernel.impl.transaction.xaframework.XaCommand;
 
 import static java.util.Arrays.asList;
+
 import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.kernel.impl.nioneo.store.DynamicRecord.dynamicRecord;
 
 /**
  * At any point, a power outage may stop us from writing to the log, which means that, at any point, all our commands
- * need to be able to handl the log ending mid-way through reading it.
+ * need to be able to handle the log ending mid-way through reading it.
  */
 public class LogTruncationTest
 {
@@ -304,6 +307,12 @@ public class LogTruncationTest
         public StoreChannel getFileChannel()
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ReadableByteChannel getReadableChannel()
+        {
+            return this;
         }
 
         @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/BlockLogBuffer.java
@@ -172,6 +172,12 @@ public class BlockLogBuffer implements LogBuffer
         throw new UnsupportedOperationException( "BlockLogBuffer does not have a FileChannel" );
     }
 
+    @Override
+    public ReadableByteChannel getReadableChannel()
+    {
+        return getFileChannel();
+    }
+
     /**
      * Signals the end of use for this buffer over this channel - first byte of
      * the chunk is set to the position of the buffer ( != 0, instead of


### PR DESCRIPTION
During rotation we copy transactions that have not completed to the next
log. We also copy transactions that finished after the start of the
first incomplete transaction. In some cases the transaction that
finished after the start of the first incomplete transaction was started
before the start of the first incomplete transaction, in these cases the
body of that transaction needs to be found and extracted from earlier in
the log. When that code path executes it copies the transaction body
from earlier in the log to an InMemoryLogBuffer then reads the commands
of the transaction from that InMemoryLogBuffer to copy the transaction
into the new log. Reading the transaction from a buffer requires a
cursor to be created over that LogBuffer. This cursor used to be created
by reading from the underlying StoreChannel of the LogBuffer, but an
InMemoryLogBuffer does not have a StoreChannel, something that would
cause failures to rotate the log in these circumstances. Creating a
cursor only requres a ReadableByteChannel, an interface that the
InMemoryLogBuffer supports natively. This changeset solves the issue in
rotating transaction logs by introducing a new method to the LogBuffer
interface for getting only a ReadableByteChannel that
InMemoryLogBuffer can support by returning `this`, and other
implementations can support by returning the StoreChannel as before.

This changeset also updates the naming in the PartialTransactionCopier
to clarify the responsibilites of the various classes, methods, and
fields in there.
