### PR TITLE
Make setting a property to the same value a No-Op.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -553,6 +553,10 @@ public class StateHandlingStatementOperations implements
         else
         {
             legacyPropertyTrackers.nodeChangeStoreProperty( nodeId, (DefinedProperty) existingProperty, property );
+            if ( existingProperty.equals( property ) )
+            {
+                return existingProperty; // no change, abort
+            }
             state.neoStoreTransaction.nodeChangeProperty( nodeId, property.propertyKeyId(), property.value() );
         }
         state.txState().nodeDoReplaceProperty( nodeId, existingProperty, property );
@@ -573,6 +577,10 @@ public class StateHandlingStatementOperations implements
         {
             legacyPropertyTrackers.relationshipChangeStoreProperty( relationshipId, (DefinedProperty)
                     existingProperty, property );
+            if ( existingProperty.equals( property ) )
+            {
+                return existingProperty; // no change, abort
+            }
             state.neoStoreTransaction.relChangeProperty( relationshipId, property.propertyKeyId(), property.value() );
         }
         state.txState().relationshipDoReplaceProperty( relationshipId, existingProperty, property );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/PropertiesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/PropertiesTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.kernel.PropertyTracker;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+
+public class PropertiesTest
+{
+    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldNotWriteDataForChangingNodePropertyToSameValue() throws Exception
+    {
+        // given
+        GraphDatabaseService graphdb = db.getGraphDatabaseService();
+        NodeManager nm = db.getGraphDatabaseAPI().getDependencyResolver().resolveDependency( NodeManager.class );
+        NeoStoreXaDataSource datasource = db.getGraphDatabaseAPI().getDependencyResolver()
+                                            .resolveDependency( XaDataSourceManager.class )
+                                            .getNeoStoreDataSource();
+        // create the node
+        Node entity;
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            entity = graphdb.createNode();
+            entity.setProperty( "foo", "bar" );
+            tx.success();
+        }
+        // this should have been the last transaction
+        long txId = datasource.getLastCommittedTxId();
+        // register an auto-index
+        @SuppressWarnings("unchecked")
+        PropertyTracker<Node> propertyTracker = mock( PropertyTracker.class );
+        nm.addNodePropertyTracker( propertyTracker );
+
+        // when
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            entity.setProperty( "foo", "bar" );
+            tx.success();
+        }
+
+        // then
+        assertEquals( "should not commit any transaction", txId, datasource.getLastCommittedTxId() );
+        // we still need the change to be tracked, so that (legacy) auto indexes are updated
+        verify( propertyTracker ).propertyChanged( entity, "foo", "bar", "bar" );
+    }
+
+    @Test
+    public void shouldNotWriteDataForChangingRelationshipPropertyToSameValue() throws Exception
+    {
+        // given
+        GraphDatabaseService graphdb = db.getGraphDatabaseService();
+        NodeManager nm = db.getGraphDatabaseAPI().getDependencyResolver().resolveDependency( NodeManager.class );
+        NeoStoreXaDataSource datasource = db.getGraphDatabaseAPI().getDependencyResolver()
+                                            .resolveDependency( XaDataSourceManager.class )
+                                            .getNeoStoreDataSource();
+        // create the relationship
+        Relationship entity;
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            entity = graphdb.createNode().createRelationshipTo( graphdb.createNode(), withName( "KNOWS" ) );
+            entity.setProperty( "foo", "bar" );
+            tx.success();
+        }
+        // this should have been the last transaction
+        long txId = datasource.getLastCommittedTxId();
+        // register an auto-index
+        @SuppressWarnings("unchecked")
+        PropertyTracker<Relationship> propertyTracker = mock( PropertyTracker.class );
+        nm.addRelationshipPropertyTracker( propertyTracker );
+
+        // when
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            entity.setProperty( "foo", "bar" );
+            tx.success();
+        }
+
+        // then
+        assertEquals( "should not commit any transaction", txId, datasource.getLastCommittedTxId() );
+        // we still need the change to be tracked, so that (legacy) auto indexes are updated
+        verify( propertyTracker ).propertyChanged( entity, "foo", "bar", "bar" );
+    }
+}


### PR DESCRIPTION
When changing a property to the same value as it already has, the
database should not need to commit anything.
Since some users depend on being able to trigger the (legacy)
auto-indexes through setting a property to the same value (for auto-
indexes that were created after the property was first set) we need to
make sure that these events are still triggered, but the property change
itself should not trigger the writing of any data.

2.0 is the earliest version to which this change can be easily applied, 1.9 does not have a single clean cut place to change this behaviour in the same way as 2.x does. Implementing this for 1.9 would be possible, but would look very different.
