### PR TITLE
Reinstates a batching page cache for batch import

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
@@ -27,6 +27,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -48,8 +49,16 @@ public class TargetDirectory
 
         public File directory()
         {
-            if ( subdir == null ) throw new IllegalStateException( "Not initialized" );
+            if ( subdir == null )
+            {
+                throw new IllegalStateException( "Not initialized" );
+            }
             return subdir;
+        }
+
+        public File file( String name )
+        {
+            return new File( directory(), name );
         }
 
         @Override
@@ -216,7 +225,9 @@ public class TargetDirectory
     private File ensureBase()
     {
         if ( fileSystem.fileExists( base ) && !fileSystem.isDirectory( base ) )
+        {
             throw new IllegalStateException( base + " exists and is not a directory!" );
+        }
 
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static java.lang.Math.min;
+
+/**
+* {@link PageCache} that is optimized for single threaded batched access.
+* There's only one cursor that moves with the supposedly sequential access when page boundaries are
+* crossed. As part of moving the window the data in the page (residing in a {@link ByteBuffer}) is written
+* to the channel.
+*/
+public class BatchingPageCache implements PageCache
+{
+    public interface WriterFactory
+    {
+        Writer create( File file, StoreChannel channel, Monitor monitor );
+    }
+
+    /**
+     * Receives requests to write data to the underlying channel.
+     */
+    public interface Writer
+    {
+        void write( ByteBuffer byteBuffer, long position ) throws IOException;
+    }
+
+    public static final WriterFactory SYNCHRONOUS = new WriterFactory()
+    {
+        @Override
+        public Writer create( File file, final StoreChannel channel, final Monitor monitor )
+        {
+            return new Writer()
+            {
+                @Override
+                public void write( ByteBuffer data, long position ) throws IOException
+                {
+                    channel.position( position );
+                    int written = channel.write( data );
+                    monitor.dataWritten( written );
+                }
+            };
+        }
+    };
+
+    public static enum Mode
+    {
+        APPEND_ONLY
+        {
+            @Override
+            boolean canReadFrom( long windowIndex )
+            {
+                return windowIndex == 0;
+            }
+        },
+        UPDATE
+        {
+            @Override
+            boolean canReadFrom( long windowIndex )
+            {
+                return true;
+            }
+        };
+
+        abstract boolean canReadFrom( long windowIndex );
+    }
+
+    private final int pageSize;
+    private final FileSystemAbstraction fs;
+    private final Map<File, BatchingPagedFile> pagedFiles = new HashMap<>();
+    private final WriterFactory writerFactory;
+    private final Monitor monitor;
+    private final Mode mode;
+
+    public BatchingPageCache( FileSystemAbstraction fs, int pageSize, WriterFactory writerFactory,
+            Monitor monitor, Mode mode )
+    {
+        this.fs = fs;
+        this.pageSize = pageSize;
+        this.writerFactory = writerFactory;
+        this.monitor = monitor;
+        this.mode = mode;
+    }
+
+    @Override
+    public PagedFile map( File file, int pageSize ) throws IOException
+    {
+        StoreChannel channel = fs.open( file, "rw" );
+        BatchingPagedFile pageFile = new BatchingPagedFile( channel, file,
+                writerFactory.create( file, channel, monitor ), pageSize, mode );
+        pagedFiles.put( file, pageFile );
+        return pageFile;
+    }
+
+    @Override
+    public void unmap( File file ) throws IOException
+    {
+        BatchingPagedFile pageFile = pagedFiles.remove( file );
+        if ( pageFile == null )
+        {
+            throw new IllegalArgumentException( file.toString() );
+        }
+        pageFile.close();
+    }
+
+    @Override
+    public void flush() throws IOException
+    {   // no need to do anything here
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        for ( BatchingPagedFile pagedFile : pagedFiles.values() )
+        {
+            pagedFile.close();
+        }
+        pagedFiles.clear();
+    }
+
+    @Override
+    public int pageSize()
+    {
+        return pageSize;
+    }
+
+    @Override
+    public int maxCachedPages()
+    {
+        return 1;
+    }
+
+    static class BatchingPagedFile implements PagedFile
+    {
+        private final BatchingPageCursor singleCursor;
+        private final StoreChannel channel;
+        private final int pageSize;
+
+        public BatchingPagedFile( StoreChannel channel, File file, Writer writer, int pageSize, Mode mode )
+        {
+            this.channel = channel;
+            this.pageSize = pageSize;
+            this.singleCursor = new BatchingPageCursor( channel, file, writer, pageSize, mode );
+        }
+
+        @Override
+        public PageCursor io( long pageId, int pf_flags ) throws IOException
+        {
+            singleCursor.ensurePagePlacedOver( pageId );
+            // Do this so that the first call to next() will have the cursor "placed" there
+            // and consecutive calls move the cursor forwards.
+            singleCursor.pinned = false;
+            return singleCursor;
+        }
+
+        @Override
+        public int pageSize()
+        {
+            return pageSize;
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            flush();
+            singleCursor.close();
+            channel.close();
+        }
+
+        @Override
+        public int numberOfCachedPages()
+        {
+            return 1;
+        }
+
+        @Override
+        public void flush() throws IOException
+        {
+            singleCursor.flush();
+            force();
+        }
+
+        @Override
+        public void force() throws IOException
+        {
+            channel.force( true );
+        }
+    }
+
+    static class BatchingPageCursor implements PageCursor
+    {
+        private final ByteBuffer singleBuffer;
+        private final StoreChannel channel;
+        private final File file;
+        private final Writer writer;
+        private long currentPageId = -1;
+        private final Mode mode;
+        private final int pageSize;
+        private boolean pinned;
+
+        BatchingPageCursor( StoreChannel channel, File file, Writer writer, int pageSize, Mode mode )
+        {
+            this.channel = channel;
+            this.file = file;
+            this.writer = writer;
+            this.pageSize = pageSize;
+            this.mode = mode;
+            this.singleBuffer = ByteBuffer.allocateDirect( pageSize );
+        }
+
+        private void unpin()
+        {
+            pinned = false;
+        }
+
+        @Override
+        public byte getByte()
+        {
+            return singleBuffer.get();
+        }
+
+        @Override
+        public void putByte( byte value )
+        {
+            singleBuffer.put( value );
+        }
+
+        @Override
+        public long getLong()
+        {
+            return singleBuffer.getLong();
+        }
+
+        @Override
+        public void putLong( long value )
+        {
+            singleBuffer.putLong( value );
+        }
+
+        @Override
+        public int getInt()
+        {
+            return singleBuffer.getInt();
+        }
+
+        @Override
+        public void putInt( int value )
+        {
+            singleBuffer.putInt( value );
+        }
+
+        @Override
+        public long getUnsignedInt()
+        {
+            return getInt() & 0xFFFFFFFFL;
+        }
+
+        @Override
+        public void getBytes( byte[] data )
+        {
+            singleBuffer.get( data );
+        }
+
+        @Override
+        public void putBytes( byte[] data )
+        {
+            singleBuffer.put( data );
+        }
+
+        @Override
+        public short getShort()
+        {
+            return singleBuffer.getShort();
+        }
+
+        @Override
+        public void putShort( short value )
+        {
+            singleBuffer.putShort( value );
+        }
+
+        @Override
+        public void setOffset( int offset )
+        {
+            singleBuffer.position( offset );
+        }
+
+        @Override
+        public int getOffset()
+        {
+            return singleBuffer.position();
+        }
+
+        @Override
+        public long getCurrentPageId()
+        {
+            return currentPageId;
+        }
+
+        @Override
+        public void rewind() throws IOException
+        {
+            throw new UnsupportedOperationException(
+                    "Unsupported in this batching page cache, since it's all about strictly sequential access" );
+        }
+
+        @Override
+        public boolean next() throws IOException
+        {
+            return next( currentPageId+1 );
+        }
+
+        @Override
+        public boolean next( long pageId ) throws IOException
+        {
+            if ( !pinned )
+            {
+                pinned = true;
+                return true;
+            }
+
+            ensurePagePlacedOver( pageId );
+            return true;
+        }
+
+        @Override
+        public void close()
+        {   // no-op
+        }
+
+        @Override
+        public boolean retry()
+        {
+            return false;
+        }
+
+        private void ensurePagePlacedOver( long pageId ) throws IOException
+        {
+            if ( pageId == currentPageId )
+            {
+                return;
+            }
+
+            if ( currentPageId != -1 )
+            {
+                flush();
+            }
+
+            // If we're not in append-only mode, i.e. if we're in update mode
+            // OR if this is the first window index we read the contents.
+            // The reason for reading the first windows is that in order to play nicely with
+            // NeoStore and loading the store sometimes header information needs to be read,
+            // even if we're in append-only mode
+            if ( mode.canReadFrom( pageId ) )
+            {
+                readFromChannelIntoBuffer( pageId );
+            }
+            else
+            {
+                zeroBuffer( singleBuffer );
+            }
+            // buffer position after we placed the window is irrelevant since every future access
+            // will set offset explicitly before use.
+            currentPageId = pageId;
+            prepared( singleBuffer );
+        }
+
+        private void readFromChannelIntoBuffer( long pageId ) throws IOException
+        {
+            channel.position( pageId*pageSize );
+            channel.read( prepared( singleBuffer ) );
+        }
+
+        private void flush() throws IOException
+        {
+            if ( currentPageId == -1 )
+            {
+                return;
+            }
+
+            writer.write( prepared( singleBuffer ), currentPageId*pageSize );
+            singleBuffer.clear();
+        }
+
+        private ByteBuffer prepared( ByteBuffer buffer )
+        {
+            buffer.flip();
+            buffer.limit( pageSize ); // always write the full page
+            return buffer;
+        }
+    }
+
+    private static final ByteBuffer ZEROS = ByteBuffer.allocateDirect( 1024*4 );
+
+    private static void zeroBuffer( ByteBuffer buffer )
+    {
+        // Duplicate for thread safety
+        ByteBuffer zeros = ZEROS.duplicate();
+        buffer.clear();
+        while ( buffer.hasRemaining() )
+        {
+            int chunkSize = min( buffer.remaining(), zeros.capacity() );
+            zeros.clear();
+            zeros.limit( chunkSize );
+            buffer.put( zeros );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/ChannelReusingFileSystemAbstraction.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/ChannelReusingFileSystemAbstraction.java
@@ -188,7 +188,7 @@ public class ChannelReusingFileSystemAbstraction extends LifecycleAdapter implem
             Function<Class<K>, K> creator )
     {
         return delegate.getOrCreateThirdPartyFileSystem( clazz, creator );
-    };
+    }
 
     public static class KeepAliveStoreChannel implements StoreChannel
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/TailoredPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/TailoredPageCache.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+
+/**
+ * A {@link PageCache} that can assign specific {@link PageCache page caches} tailored
+ * for each individual store.
+ */
+public class TailoredPageCache implements PageCache
+{
+    private final PageCache defaultPageCache;
+    private final Map<String,PageCache> overrides = new HashMap<>();
+    private final Map<File,PageCache> mappedPageFiles = new HashMap<>();
+
+    public TailoredPageCache( PageCache defaultPageCache )
+    {
+        this.defaultPageCache = defaultPageCache;
+    }
+
+    public void override( String storeNamePart, PageCache override )
+    {
+        overrides.put( NeoStore.DEFAULT_NAME + storeNamePart, override );
+    }
+
+    @Override
+    public PagedFile map( File file, int pageSize ) throws IOException
+    {
+        PageCache override = overrides.get( file.getName() );
+        PageCache factory = override != null ? override : defaultPageCache;
+        mappedPageFiles.put( file, factory );
+        return factory.map( file, pageSize );
+    }
+
+    private Iterable<PageCache> allPageCaches()
+    {
+        Set<PageCache> pageCaches = new HashSet<>( overrides.values() );
+        pageCaches.add( defaultPageCache );
+        return pageCaches;
+    }
+
+    @Override
+    public void unmap( File file ) throws IOException
+    {
+        PageCache pageCache = mappedPageFiles.remove( file );
+        if ( pageCache == null )
+        {
+            throw new IllegalArgumentException( file + " not mapped" );
+        }
+        pageCache.unmap( file );
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        for ( PageCache pageCache : allPageCaches() )
+        {
+            pageCache.flush();
+        }
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        for ( PageCache pageCache : allPageCaches() )
+        {
+            pageCache.close();
+        }
+    }
+
+    @Override
+    public int pageSize()
+    {
+        return defaultPageCache.pageSize();
+    }
+
+    @Override
+    public int maxCachedPages()
+    {
+        return defaultPageCache.maxCachedPages();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallellBatchImporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallellBatchImporterTest.java
@@ -41,7 +41,6 @@ import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.staging.DetailedExecutionMonitor;
 
-//@Ignore
 public class ParallellBatchImporterTest
 {
     private static final long seed = 12345L;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCacheTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingPageCache.Mode;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.unsafe.impl.batchimport.store.BatchingPageCache.SYNCHRONOUS;
+import static org.neo4j.unsafe.impl.batchimport.store.Monitor.NO_MONITOR;
+
+public class BatchingPageCacheTest
+{
+    @Test
+    public void shouldAppendThroughMultiplePages() throws Exception
+    {
+        // GIVEN
+        int numberOfRecords = 100;
+        PageCache pageCache = new BatchingPageCache( FS, numberOfRecords, SYNCHRONOUS, NO_MONITOR, Mode.APPEND_ONLY );
+        File file = directory.file( "store" );
+        PagedFile pagedFile = pageCache.map( file, recordSize*recordsPerPage /* =90 */ );
+
+        // WHEN
+        try ( PageCursor cursor = pagedFile.io( 0, 0 ) )
+        {
+            cursor.next();
+            for ( int i = 0; i < numberOfRecords; i++ )
+            {
+                if ( i > 0 && i%recordsPerPage == 0 )
+                {
+                    cursor.next(); // no need for looping here in the batching thingie
+                }
+                writeRecord( cursor, i );
+            }
+        }
+        pageCache.close();
+
+        // THEN
+        assertRecordsAreCorrect( file, numberOfRecords );
+    }
+
+    @Test
+    public void shouldReadAndUpdateExistingContentsInUpdateMode() throws Exception
+    {
+        // GIVEN
+        int pageSize = 100;
+        File file = directory.file( "store" );
+        fillFileWithByteContents( file );
+        PageCache pageCache = new BatchingPageCache( FS, pageSize, SYNCHRONOUS, NO_MONITOR, Mode.UPDATE );
+        PagedFile pagedFile = pageCache.map( file, pageSize );
+
+        // WHEN
+        for ( int p = 0; p <= 1; p++ )
+        {
+            try ( PageCursor cursor = pagedFile.io( p, 0 ) )
+            {
+                cursor.next();
+                for ( int i = 0; i < pageSize; i++ )
+                {
+                    int offset = cursor.getOffset();
+                    byte value = cursor.getByte();
+                    if ( i%3 == 0 )
+                    {
+                        cursor.setOffset( offset );
+                        value++;
+                        cursor.putByte( value );
+                    }
+                }
+            }
+        }
+        pageCache.close();
+
+        // THEN
+        assertByteContentsAreCorrect( file );
+    }
+
+    private void assertByteContentsAreCorrect( File file ) throws IOException
+    {
+        try ( StoreChannel channel = FS.open( file, "r" ) )
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( 255 );
+            int read = channel.read( buffer );
+            System.out.println( read );
+            buffer.flip();
+            int counter = 0;
+            for ( int i = 0; i <= 1; i++ )
+            {
+                for ( int j = 0; j < 100; j++ )
+                {
+                    byte value = buffer.get();
+                    byte expectedValue = (byte) counter++;
+                    if ( j%3 == 0 )
+                    {
+                        expectedValue++;
+                    }
+                    assertEquals( expectedValue, value );
+                }
+            }
+        }
+    }
+
+    private void fillFileWithByteContents( File file ) throws IOException
+    {
+        try ( StoreChannel channel = FS.open( file, "rw" ) )
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( 256 );
+            for ( int i = 0; i < buffer.capacity(); i++ )
+            {
+                buffer.put( (byte) i );
+            }
+            buffer.flip();
+            channel.write( buffer );
+        }
+    }
+
+    private void assertRecordsAreCorrect( File file, int numberOfRecords ) throws IOException
+    {
+        try ( StoreChannel channel = FS.open( file, "r" ) )
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( recordSize );
+            for ( int i = 0; i < numberOfRecords; i++ )
+            {
+                buffer.clear();
+                channel.read( buffer );
+                buffer.flip();
+                assertRecord( i, buffer );
+            }
+        }
+    }
+
+    private void assertRecord( int i, ByteBuffer buffer )
+    {
+        assertEquals( i, buffer.getLong() );
+        int length = recordSize-8;
+        byte[] readBytes = new byte[length];
+        buffer.get( readBytes );
+        assertArrayEquals( bytesStartingAt( length, i ), readBytes );
+    }
+
+    private void writeRecord( PageCursor cursor, int index )
+    {
+        cursor.putLong( index );
+        cursor.putBytes( bytesStartingAt( recordSize-8, index ) );
+        // = 15
+    }
+
+    private byte[] bytesStartingAt( int length, int start )
+    {
+        byte[] bytes = new byte[length];
+        for ( int i = 0; i < length; i++ )
+        {
+            bytes[i] = (byte) (start+i);
+        }
+        return bytes;
+    }
+
+    public final @Rule TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    private final FileSystemAbstraction FS = new DefaultFileSystemAbstraction();
+    private final int recordSize = 15;
+    private final int recordsPerPage = 6;
+}


### PR DESCRIPTION
Basically it's the "page cache" version of
https://github.com/neo4j/neo4j/blob/2.1.2/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchFriendlyWindowPoolFactory.java

such that there's only one page per store in memory all the time and it
moves along with the batch importer "cursor", no other store file memory required.
