### PR TITLE
Fixes to the graphalgo facilities for 2.1 maint

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ParallellCentralityCalculation.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ParallellCentralityCalculation.java
@@ -46,7 +46,7 @@ public class ParallellCentralityCalculation<ShortestPathCostType>
 {
     protected SingleSourceShortestPath<ShortestPathCostType> singleSourceShortestPath;
     protected Set<Node> nodeSet;
-    List<ShortestPathBasedCentrality<?,ShortestPathCostType>> calculations = new LinkedList<ShortestPathBasedCentrality<?,ShortestPathCostType>>();
+    protected List<ShortestPathBasedCentrality<?,ShortestPathCostType>> calculations = new LinkedList<ShortestPathBasedCentrality<?,ShortestPathCostType>>();
     protected boolean doneCalculation = false;
 
     /**
@@ -80,7 +80,7 @@ public class ParallellCentralityCalculation<ShortestPathCostType>
                 "Trying to add a centrality calculation to a parallell computation that has already been done." );
         }
         calculations.add( shortestPathBasedCentrality );
-        shortestPathBasedCentrality.doneCalculation = true;
+        shortestPathBasedCentrality.skipCalculation();
     }
 
     /**

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ShortestPathBasedCentrality.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/ShortestPathBasedCentrality.java
@@ -161,6 +161,23 @@ public abstract class ShortestPathBasedCentrality<CentralityType,ShortestPathCos
             processShortestPaths( startNode, singleSourceShortestPath );
         }
     }
+    
+    /**
+     * This method allows to skip the calculation of the centrality via
+     * the calculate method. This is to allow user defined calculation of
+     * the centralities via the processShortestPaths method.
+     */
+    public void skipCalculation(){
+    	doneCalculation = true;
+    }
+    
+	/**
+     * Checks if the calculation is already done
+     * @return	status of the calculation
+     */
+    public boolean isCalculated(){
+    	return doneCalculation;
+    }
 
     /**
      * This is the abstract method all centrality algorithms based on this class


### PR DESCRIPTION
The ParallelCentralityCalculation has (most likely accidentally) set the list of centralities to private instead of protected. This made it impossible to extend the class and override the calculate method, as the user could not gain access to the centralities.

Upon adding a centrality it also used the package visibility to set the doneCalculation flag in the ShortestPathBasedCentrality. While the user should not be able to mess around with that it also prohibits the user from recreating functionality like the ParallelCentralityCalculation via the processShortestPaths.
The proposed fixes to ShortestPathBasedCentrality aim to remedy this.
