### PR TITLE
Solves issue with skipped relationships on dense nodes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -19,6 +19,14 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.binarySearch;
+import static org.neo4j.kernel.impl.cache.SizeOfs.REFERENCE_SIZE;
+import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
+import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverheadIncludingReferences;
+import static org.neo4j.kernel.impl.util.RelIdArray.empty;
+import static org.neo4j.kernel.impl.util.RelIdArray.wrap;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -45,15 +53,6 @@ import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.RelIdIterator;
-
-import static java.lang.System.arraycopy;
-import static java.util.Arrays.binarySearch;
-
-import static org.neo4j.kernel.impl.cache.SizeOfs.REFERENCE_SIZE;
-import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
-import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverheadIncludingReferences;
-import static org.neo4j.kernel.impl.util.RelIdArray.empty;
-import static org.neo4j.kernel.impl.util.RelIdArray.wrap;
 
 /**
  * This class currently has multiple responsibilities, and a very complex set of interrelationships with the world
@@ -255,7 +254,7 @@ public class NodeImpl extends ArrayBasedPrimitive
     private void ensureRelationshipMapNotNull( NodeManager nodeManager, DirectionWrapper direction,
             int[] types )
     {
-        if ( relationships == null )
+        if ( relationships == null || (relationships.length == 0 && relChainPosition.hasMore( direction, types ) ) )
         {
             loadInitialRelationships( nodeManager, direction, types );
         }
@@ -272,7 +271,7 @@ public class NodeImpl extends ArrayBasedPrimitive
         Triplet<ArrayMap<Integer, RelIdArray>, List<RelationshipImpl>, RelationshipLoadingPosition> rels = null;
         synchronized ( this )
         {
-            if ( relationships == null )
+            if ( relationships == null || (relationships.length == 0 && relChainPosition.hasMore( direction, types ) ) )
             {
                 try
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestDenseNodeRelChainPositionIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestDenseNodeRelChainPositionIT.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.test.TargetDirectory;
+
+public class TestDenseNodeRelChainPositionIT
+{
+    /*
+     * Tests for a particular bug with dense nodes. It used to be that if a dense node had relationships
+     * for only one direction, if a request for relationships of the other direction was made, no relationships
+     * would be returned, ever.
+     */
+    @Test
+    public void givenDenseNodeWhenAskForWrongDirectionThenIncorrectNrOfRelsReturned() throws Exception
+    {
+        final int denseNodeThreshold =
+                Integer.parseInt( GraphDatabaseSettings.dense_node_threshold.getDefaultValue() )
+                + 1 // We must be over the dense node threshold for the bug to manifest
+                ;
+
+        File dbPath = TargetDirectory.forTest( getClass() )
+                .cleanDirectory( "givenDenseNodeWhenAskForWrongDirectionThenIncorrectNrOfRelsReturned" );
+        // Given
+        GraphDatabaseAPI db = (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( dbPath.getAbsolutePath() )
+                .newGraphDatabase();
+
+        Node node1;
+        try (Transaction tx = db.beginTx())
+        {
+            node1 = db.createNode();
+            Node node2 = db.createNode();
+
+            for ( int i = 0; i < denseNodeThreshold; i++ )
+            {
+                node1.createRelationshipTo( node2, DynamicRelationshipType.withName( "FOO" ) );
+            }
+            tx.success();
+        }
+
+        db.getDependencyResolver().resolveDependency( NodeManager.class ).clearCache();
+
+        // When/Then
+        try ( Transaction ignored = db.beginTx() )
+        {
+            Node node1b = db.getNodeById( node1.getId() );
+
+            Iterable<Relationship> rels = node1b.getRelationships( Direction.INCOMING );
+            assertEquals( 0, Iterables.count( rels ) );
+
+            Iterable<Relationship> rels2 = node1b.getRelationships( Direction.OUTGOING);
+            assertEquals(denseNodeThreshold, Iterables.count( rels2 ) );
+        }
+    }
+}


### PR DESCRIPTION
Assume a dense node had relationships only in one direction, say
 OUTGOING. Before this fix, if the node was not in cache and as
 the first operation on it all INCOMING relationships were retrieved,
 (which would return an empty iterator), then subsequent calls for
 OUGOING relationships would also return empty.
 This was caused by improperly assuming that an initialized but empty
 relationship array meant no relationships were present. This may be
 true for non dense nodes, but dense nodes need to be initialized
 essentially by type and direction.
This commit fixes the above issue and provides a test for it.
