### PR TITLE
Reimplement IdGenerator rebuilding

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -61,4 +61,6 @@ public interface PagedFile
 
     /** Force all changes to this file handle down to disk. Does not flush dirty pages. */
     void force() throws IOException;
+
+    long getLastPageId() throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/StandardPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/StandardPagedFile.java
@@ -216,6 +216,7 @@ public class StandardPagedFile implements PagedFile
         swapper.force();
     }
 
+    @Override
     public long getLastPageId() throws IOException
     {
         return lastPageId.get();

--- a/community/kernel/src/main/java/org/neo4j/kernel/DefaultIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DefaultIdGeneratorFactory.java
@@ -34,12 +34,14 @@ import org.neo4j.kernel.impl.nioneo.store.IdGeneratorImpl;
 public class DefaultIdGeneratorFactory
     implements IdGeneratorFactory
 {
-    private final Map<IdType, IdGenerator> generators = new HashMap<IdType, IdGenerator>();
+    private final Map<IdType, IdGenerator> generators = new HashMap<>();
 
     public IdGenerator open( FileSystemAbstraction fs, File fileName, int grabSize, IdType idType, long highId )
     {
-        IdGenerator generator = new IdGeneratorImpl( fs, fileName, grabSize, idType.getMaxValue(),
-                idType.allowAggressiveReuse(), highId );
+        long maxValue = idType.getMaxValue();
+        boolean aggressiveReuse = idType.allowAggressiveReuse();
+        IdGenerator generator = new IdGeneratorImpl( fs, fileName, grabSize, maxValue,
+                aggressiveReuse, highId );
         generators.put( idType, generator );
         return generator;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractStore.java
@@ -21,19 +21,15 @@ package org.neo4j.kernel.impl.nioneo.store;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.LinkedList;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.ReadOnlyDbException;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -121,111 +117,21 @@ public abstract class AbstractStore extends CommonAbstractStore
         }
     }
 
-    private long findHighIdBackwards() throws IOException
-    {
-        // Duplicated method
-        StoreChannel fileChannel = getFileChannel();
-        int recordSize = getRecordSize();
-        long fileSize = fileChannel.size();
-        long highId = fileSize / recordSize;
-        ByteBuffer byteBuffer = ByteBuffer.allocate( getRecordSize() );
-        for ( long i = highId; i > 0; i-- )
-        {
-            fileChannel.position( i * recordSize );
-            if ( fileChannel.read( byteBuffer ) > 0 )
-            {
-                byteBuffer.flip();
-                boolean isInUse = isRecordInUse( byteBuffer );
-                byteBuffer.clear();
-                if ( isInUse )
-                {
-                    return i;
-                }
-            }
-        }
-        return 0;
-    }
-
-    protected boolean isRecordInUse( ByteBuffer buffer )
-    {
-        byte inUse = buffer.get();
-        return (inUse & 0x1) == Record.IN_USE.byteValue();
-    }
-
-    /**
-     * Rebuilds the {@link IdGenerator} by looping through all records and
-     * checking if record in use or not.
-     */
     @Override
-    protected void rebuildIdGenerator()
+    protected boolean isInUse( byte inUseByte )
     {
-        if ( isReadOnly() && !isBackupSlave() )
-        {
-            throw new ReadOnlyDbException();
-        }
+        return (inUseByte & 0x1) == Record.IN_USE.intValue();
+    }
 
-        stringLogger.debug( "Rebuilding id generator for[" + getStorageFileName() + "] ..." );
-        closeIdGenerator();
-        File idFile = new File( getStorageFileName().getPath() + ".id" );
-        if ( fileSystemAbstraction.fileExists( idFile ) )
-        {
-            boolean success = fileSystemAbstraction.deleteFile( idFile );
-            assert success : "Couldn't delete " + idFile.getPath() + ", still open?";
-        }
-        createIdGenerator( idFile );
-        openIdGenerator();
-        StoreChannel fileChannel = getFileChannel();
-        long highId = 1;
-        long defraggedCount = 0;
-        try
-        {
-            long fileSize = fileChannel.size();
-            int recordSize = getRecordSize();
-            boolean fullRebuild = true;
-            if ( conf.get( Configuration.rebuild_idgenerators_fast ) )
-            {
-                fullRebuild = false;
-                highId = findHighIdBackwards();
-            }
-            ByteBuffer byteBuffer = ByteBuffer.allocate( recordSize );
-            // Duplicated code block
-            LinkedList<Long> freeIdList = new LinkedList<Long>();
-            if ( fullRebuild )
-            {
-                for ( long i = 0; i * recordSize < fileSize && recordSize > 0; i++ )
-                {
-                    fileChannel.position( i * recordSize );
-                    byteBuffer.clear();
-                    fileChannel.read( byteBuffer );
-                    byteBuffer.flip();
-                    if ( !isRecordInUse( byteBuffer ) )
-                    {
-                        freeIdList.add( i );
-                    }
-                    else
-                    {
-                        highId = i;
-                        setHighId( highId + 1 );
-                        while ( !freeIdList.isEmpty() )
-                        {
-                            freeId( freeIdList.removeFirst() );
-                            defraggedCount++;
-                        }
-                    }
-                }
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException(
-                    "Unable to rebuild id generator " + getStorageFileName(), e );
-        }
-        setHighId( highId + 1 );
-        stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
-                                 " defragged count=" + defraggedCount, true );
-        stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId()
-                            + " (defragged=" + defraggedCount + ")" );
-        closeIdGenerator();
-        openIdGenerator();
+    @Override
+    protected boolean useFastIdGeneratorRebuilding()
+    {
+        return conf.get( Configuration.rebuild_idgenerators_fast );
+    }
+
+    @Override
+    protected boolean firstRecordIsHeader()
+    {
+        return false;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static java.nio.ByteBuffer.wrap;
-import static org.neo4j.helpers.Exceptions.launderedException;
-import static org.neo4j.helpers.UTF8.encode;
-import static org.neo4j.io.fs.FileUtils.windowsSafeIOOperation;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -37,6 +32,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils.FileOperation;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -45,6 +41,14 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ReadOnlyDbException;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static java.nio.ByteBuffer.wrap;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.UTF8.encode;
+import static org.neo4j.io.fs.FileUtils.windowsSafeIOOperation;
+import static org.neo4j.io.pagecache.PagedFile.PF_READ_AHEAD;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 
 /**
  * Contains common implementation for {@link AbstractStore} and
@@ -259,7 +263,7 @@ public abstract class CommonAbstractStore implements IdSequence
         return (int) (id * getEffectiveRecordSize() % storeFile.pageSize());
     }
 
-    protected long recordsPerPage()
+    protected int recordsPerPage()
     {
         return storeFile.pageSize() / getEffectiveRecordSize();
     }
@@ -346,6 +350,12 @@ public abstract class CommonAbstractStore implements IdSequence
         }
     }
 
+    protected abstract boolean isInUse( byte inUseByte );
+
+    protected abstract boolean useFastIdGeneratorRebuilding();
+
+    protected abstract boolean firstRecordIsHeader();
+
     /**
      * Should rebuild the id generator from scratch.
      * <p>
@@ -354,7 +364,138 @@ public abstract class CommonAbstractStore implements IdSequence
      * map their own temporary PagedFile for the store file, and do their file IO through that,
      * if they need to access the data in the store file.
      */
-    protected abstract void rebuildIdGenerator();
+    protected void rebuildIdGenerator()
+    {
+        int blockSize = getEffectiveRecordSize();
+        if ( blockSize <= 0 )
+        {
+            throw new InvalidRecordException( "Illegal blockSize: " + blockSize );
+        }
+        stringLogger.debug( "Rebuilding id generator for[" + getStorageFileName() + "] ..." );
+        closeIdGenerator();
+        File idFile = new File( getStorageFileName().getPath() + ".id" );
+        if ( fileSystemAbstraction.fileExists( idFile ) )
+        {
+            boolean success = fileSystemAbstraction.deleteFile( idFile );
+            assert success : "Couldn't delete " + idFile.getPath() + ", still open?";
+        }
+        createIdGenerator( idFile );
+        openIdGenerator();
+        if ( firstRecordIsHeader() )
+        {
+            setHighId( 1 ); // reserved first block containing blockSize
+        }
+
+        int filePageSize = storeFile.pageSize();
+        int recordsPerPage = recordsPerPage();
+        long defraggedCount;
+
+        try
+        {
+            PagedFile pagedFile = pageCache.map( storageFileName, filePageSize );
+            try
+            {
+                if ( useFastIdGeneratorRebuilding() )
+                {
+                    try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_LOCK ) )
+                    {
+                        defraggedCount = rebuildIdGeneratorFast( cursor, recordsPerPage, blockSize, pagedFile.getLastPageId() );
+                    }
+                }
+                else
+                {
+                    try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_LOCK | PF_READ_AHEAD ) )
+                    {
+                        defraggedCount = rebuildIdGeneratorSlow( cursor, recordsPerPage, blockSize );
+                    }
+                }
+            }
+            finally
+            {
+                pageCache.unmap( storageFileName );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException(
+                    "Unable to rebuild id generator " + getStorageFileName(), e );
+        }
+
+        stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId()
+                + " (defragged=" + defraggedCount + ")" );
+        stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
+                " defragged count=" + defraggedCount, true );
+        closeIdGenerator();
+        openIdGenerator();
+    }
+
+    private long rebuildIdGeneratorFast( PageCursor cursor, int recordsPerPage, int blockSize, long lastPageId ) throws IOException
+    {
+        long nextPageId = lastPageId;
+
+        while ( nextPageId >= 0 && cursor.next( nextPageId ) )
+        {
+            nextPageId--;
+            do {
+                int currentRecord = recordsPerPage;
+                while ( currentRecord --> 0 )
+                {
+                    cursor.setOffset( currentRecord * blockSize );
+                    byte inUseByte = cursor.getByte();
+
+                    if ( isInUse( inUseByte ) )
+                    {
+                        // We've found the highest id that is in use
+                        setHighId( (cursor.getCurrentPageId() * recordsPerPage) + currentRecord );
+                        // Return the number of records that we skipped over to find it
+                        return ((lastPageId - nextPageId) * recordsPerPage) - currentRecord;
+                    }
+                }
+            } while ( cursor.retry() );
+        }
+
+        return 0;
+    }
+
+    private long rebuildIdGeneratorSlow( PageCursor cursor, int recordsPerPage, int blockSize ) throws IOException
+    {
+        long defragCount = 0;
+        long[] freedBatch = new long[recordsPerPage]; // we process in batches of one page worth of records
+        int startingId = firstRecordIsHeader()? 1 : 0;
+        int defragged;
+
+        while ( cursor.next() )
+        {
+            long idPageOffset = (cursor.getCurrentPageId() * recordsPerPage);
+
+            do {
+                defragged = 0;
+                for ( int i = startingId; i < recordsPerPage; i++ )
+                {
+                    cursor.setOffset( i * blockSize );
+                    byte inUseByte = cursor.getByte();
+
+                    long recordId = idPageOffset + i;
+                    if ( !isInUse( inUseByte ) )
+                    {
+                        freedBatch[defragged] = recordId;
+                        defragged++;
+                    }
+                }
+            } while ( cursor.retry() );
+
+            setHighId( idPageOffset + recordsPerPage );
+            for ( int i = 0; i < defragged; i++ )
+            {
+                long freedId = freedBatch[i];
+                freeId( freedId );
+            }
+            defragCount += defragged;
+            startingId = 0;
+        }
+
+        return defragCount;
+    }
 
     /**
      * This method should close/release all resources that the implementation of
@@ -409,7 +550,8 @@ public abstract class CommonAbstractStore implements IdSequence
      *
      * @return The next free id
      */
-    @Override public long nextId()
+    @Override
+    public long nextId()
     {
         return idGenerator.nextId();
     }
@@ -537,7 +679,6 @@ public abstract class CommonAbstractStore implements IdSequence
     protected void openIdGenerator()
     {
         idGenerator = openIdGenerator( new File( storageFileName.getPath() + ".id" ), idType.getGrabSize() );
-
         /* MP: 2011-11-23
          * There may have been some migration done in the startup process, so if there have been some
          * high id registered during, then update id generators. updateHighId does nothing if
@@ -556,8 +697,9 @@ public abstract class CommonAbstractStore implements IdSequence
      */
     protected IdGenerator openIdGenerator( File fileName, int grabSize )
     {
-        return idGeneratorFactory
-                .open( fileSystemAbstraction, fileName, grabSize, getIdType(), figureOutHighestIdInUse() );
+        IdType type = getIdType();
+        long highestIdInUse = figureOutHighestIdInUse();
+        return idGeneratorFactory.open( fileSystemAbstraction, fileName, grabSize, type, highestIdInUse );
     }
 
     /**
@@ -739,10 +881,7 @@ public abstract class CommonAbstractStore implements IdSequence
 
     protected void registerIdFromUpdateRecord( long id )
     {
-//        if ( isInRecoveryMode() )
-        {
-            highestUpdateRecordId = Math.max( highestUpdateRecordId, id + 1 );
-        }
+        highestUpdateRecordId = Math.max( highestUpdateRecordId, id + 1 );
     }
 
     protected void updateHighId()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorImpl.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static java.lang.Math.max;
-import static org.neo4j.io.fs.FileUtils.truncateFile;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,6 +27,10 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
+
+import static java.lang.Math.max;
+
+import static org.neo4j.io.fs.FileUtils.truncateFile;
 
 /**
  * This class generates unique ids for a resource type. For example, nodes in a
@@ -88,7 +89,7 @@ public class IdGeneratorImpl implements IdGenerator
     private StoreChannel fileChannel = null;
     // defragged ids read from file (freed in a previous session).
     private final LinkedList<Long> idsReadFromFile = new LinkedList<>();
-    // ids freed in this session that havn't been flushed to disk yet
+    // ids freed in this session that haven't been flushed to disk yet
     private final LinkedList<Long> releasedIdList = new LinkedList<>();
 
     private final long max;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
@@ -195,8 +195,8 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
                     // [    ,   x] in use bit
                     // [    ,xxx ] higher bits for rel id
                     // [xxxx,    ] higher bits for prop id
-                    long inUseByte = cursor.getByte();
-                    isInUse = recordIsInUse( inUseByte );
+                    byte inUseByte = cursor.getByte();
+                    isInUse = isInUse( inUseByte );
                     if ( isInUse )
                     {
                         if ( record == null )
@@ -315,7 +315,7 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
                 do
                 {
                     cursor.setOffset( offset );
-                    recordIsInUse = recordIsInUse( cursor.getByte() );
+                    recordIsInUse = isInUse( cursor.getByte() );
                 } while ( cursor.retry() );
             }
             return recordIsInUse;
@@ -326,12 +326,7 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
         }
     }
 
-    private boolean recordIsInUse( long inUseByte )
-    {
-        return (inUseByte & 0x1) == Record.IN_USE.intValue();
-    }
-
-    private void readIntoRecord( PageCursor cursor, NodeRecord record, long inUseByte, boolean inUse )
+    private void readIntoRecord( PageCursor cursor, NodeRecord record, byte inUseByte, boolean inUse )
     {
         long nextRel = cursor.getUnsignedInt();
         long nextProp = cursor.getUnsignedInt();
@@ -444,16 +439,5 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
     {
         dynamicLabelStore.updateHighId();
         super.updateHighId();
-    }
-
-    public void flushAll()
-    {
-        try
-        {
-            storeFile.flush();
-        } catch(IOException e)
-        {
-            throw new UnderlyingStorageException( e );
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.nioneo.store;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -33,9 +32,6 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.impl.common.ByteBufferPage;
-import org.neo4j.io.pagecache.impl.common.OffsetTrackingCursor;
-import org.neo4j.io.pagecache.impl.standard.StandardPageCursor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -169,16 +165,6 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     public int getRecordHeaderSize()
     {
         return RECORD_SIZE - DEFAULT_PAYLOAD_SIZE;
-    }
-
-    public void freeStringBlockId( long blockId )
-    {
-        stringPropertyStore.freeId( blockId );
-    }
-
-    public void freeArrayBlockId( long blockId )
-    {
-        arrayPropertyStore.freeId( blockId );
     }
 
     public PropertyKeyTokenStore getPropertyKeyTokenStore()
@@ -657,15 +643,6 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     public int getArrayBlockSize()
     {
         return arrayPropertyStore.getBlockSize();
-    }
-
-    // TODO this is only for rebuilding id generators... remove when those are rewritten
-    @Override
-    protected boolean isRecordInUse( ByteBuffer buffer )
-    {
-        // TODO: The next line is an ugly hack, but works.
-        OffsetTrackingCursor cursor = new StandardPageCursor( null ).reset(new ByteBufferPage( buffer ));
-        return buffer.limit() >= RECORD_SIZE && getRecordFromBuffer( 0, cursor ).inUse();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipTypeTokenStore.java
@@ -20,11 +20,8 @@
 package org.neo4j.kernel.impl.nioneo.store;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -66,63 +63,6 @@ public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeToken
     public <FAILURE extends Exception> void accept( Processor<FAILURE> processor, RelationshipTypeTokenRecord record ) throws FAILURE
     {
         processor.processRelationshipTypeToken( this, record );
-    }
-
-    @Override
-    // TODO: Remove this method?
-    protected void rebuildIdGenerator()
-    {
-        stringLogger.debug( "Rebuilding id generator for[" + getStorageFileName()
-            + "] ..." );
-        closeIdGenerator();
-        if ( fileSystemAbstraction.fileExists( new File( getStorageFileName().getPath() + ".id" )) )
-        {
-            boolean success = fileSystemAbstraction.deleteFile( new File( getStorageFileName().getPath() + ".id" ));
-            assert success;
-        }
-        createIdGenerator( new File( getStorageFileName().getPath() + ".id" ));
-        openIdGenerator();
-        StoreChannel fileChannel = getFileChannel();
-        long highId = -1;
-        int recordSize = getRecordSize();
-        try
-        {
-            long fileSize = fileChannel.size();
-            ByteBuffer byteBuffer = ByteBuffer.wrap( new byte[recordSize] );
-            for ( int i = 0; i * recordSize < fileSize; i++ )
-            {
-                fileChannel.read( byteBuffer, i * recordSize );
-                byteBuffer.flip();
-                byte inUse = byteBuffer.get();
-                byteBuffer.flip();
-                if ( inUse != Record.IN_USE.byteValue() )
-                {
-                    // hole found, marking as reserved
-                    byteBuffer.clear();
-                    byteBuffer.put( Record.IN_USE.byteValue() ).putInt(
-                        Record.RESERVED.intValue() );
-                    byteBuffer.flip();
-                    fileChannel.write( byteBuffer, i * recordSize );
-                    byteBuffer.clear();
-                }
-                else
-                {
-                    highId = i;
-                }
-                // nextId();
-            }
-            highId++;
-            fileChannel.truncate( highId * recordSize );
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException(
-                "Unable to rebuild id generator " + getStorageFileName(), e );
-        }
-        setHighId( highId );
-        stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId() );
-        closeIdGenerator();
-        openIdGenerator();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -38,6 +36,8 @@ import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
 * Factory for Store implementations. Can also be used to create empty stores.
@@ -155,7 +155,7 @@ public class StoreFactory
                 idGeneratorFactory, pageCache, fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
     }
 
-    private DynamicStringStore newDynamicStringStore( File fileName, IdType nameIdType )
+    public DynamicStringStore newDynamicStringStore( File fileName, IdType nameIdType )
     {
         return new DynamicStringStore( fileName, config, nameIdType, idGeneratorFactory, pageCache,
                 fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
@@ -353,7 +353,7 @@ public class StoreFactory
         store.close();
     }
 
-    private void createDynamicStringStore( File fileName, int blockSize, IdType idType )
+    public void createDynamicStringStore( File fileName, int blockSize, IdType idType )
     {
         createEmptyDynamicStore( fileName, blockSize, DynamicStringStore.VERSION, idType );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Settings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
@@ -49,7 +50,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.PageCacheRule;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.test.subprocess.BreakPoint;
 import org.neo4j.test.subprocess.BreakpointHandler;
 import org.neo4j.test.subprocess.BreakpointTrigger;
@@ -103,15 +103,10 @@ public class IdGeneratorRebuildFailureEmulationTest
         @BreakpointHandler("setHighId")
         public static void on_setHighId( DebugInterface di, BreakPoint setHighId )
         {
-            if ( setHighId.invocationCount() > 1
-                    || RelationshipTypeTokenStore.class.getName().equals( di.thread().getStackTrace()
-                    [2].getClassName() ) )
-            {
-                setHighId.disable();
-                // emulate a failure in recovery by changing the id parameter to setHighId(id) to an invalid value,
-                // causing an exception to be thrown.
-                di.setLocalVariable( "id", -1 );
-            }
+            setHighId.disable();
+            // emulate a failure in recovery by changing the id parameter to setHighId(id) to an invalid value,
+            // causing an exception to be thrown.
+            di.setLocalVariable( "id", -1 );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGenerator.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -38,14 +39,15 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.core.Caches;
 import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
@@ -59,7 +61,10 @@ import static org.neo4j.io.fs.FileUtils.deleteRecursively;
 
 public class TestIdGenerator
 {
-    @Rule public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    @ClassRule
+    public static PageCacheRule pageCacheRule = new PageCacheRule();
+    @Rule
+    public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     private EphemeralFileSystemAbstraction fs;
 
     @Before
@@ -446,7 +451,6 @@ public class TestIdGenerator
     @Test
     public void testRandomTest()
     {
-        int numberOfCloses = 0;
         java.util.Random random = new java.util.Random( System.currentTimeMillis() );
         int capacity = random.nextInt( 1024 ) + 1024;
         int grabSize = random.nextInt( 128 ) + 128;
@@ -476,7 +480,6 @@ public class TestIdGenerator
                     closeIdGenerator( idGenerator );
                     grabSize = random.nextInt( 128 ) + 128;
                     idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, 0 );
-                    numberOfCloses++;
                 }
             }
             closeIdGenerator( idGenerator );
@@ -489,7 +492,6 @@ public class TestIdGenerator
                 assertTrue( file.delete() );
             }
         }
-
     }
 
     @Test
@@ -572,7 +574,7 @@ public class TestIdGenerator
     }
 
     @Test
-    public void makeSureMagicMinusOneIsntReturnedFromNodeIdGenerator() throws Exception
+    public void makeSureMagicMinusOneIsNotReturnedFromNodeIdGenerator() throws Exception
     {
         makeSureMagicMinusOneIsSkipped( IdType.NODE );
         makeSureMagicMinusOneIsSkipped( IdType.RELATIONSHIP );
@@ -700,7 +702,7 @@ public class TestIdGenerator
     }
 
     @Test
-    public void testChurnIdBatchAtGrabsize()
+    public void testChurnIdBatchAtGrabSize()
     {
         IdGenerator idGenerator = null;
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGeneratorRebuilding.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGeneratorRebuilding.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.PageCacheRule;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TestIdGeneratorRebuilding
+{
+    @ClassRule
+    public static PageCacheRule pageCacheRule = new PageCacheRule();
+    @Rule
+    public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private EphemeralFileSystemAbstraction fs;
+
+    @Before
+    public void doBefore()
+    {
+        fs = fsRule.get();
+    }
+
+    private File path()
+    {
+        String path = AbstractNeo4jTestCase.getStorePath( "xatest" );
+        File file = new File( path );
+        fs.mkdirs( file );
+        return file;
+    }
+
+    private File file( String name )
+    {
+        return new File( path(), name );
+    }
+
+    @Test
+    public void verifyFixedSizeStoresCanRebuildIdGeneratorSlowly() throws IOException
+    {
+        // Given we have a store ...
+        Config config = new Config( MapUtil.stringMap(
+                GraphDatabaseSettings.rebuild_idgenerators_fast.name(), "false" ) );
+        File storeFile = file( "nodes" );
+        fs.create( storeFile );
+        IdGeneratorImpl.createGenerator( fs, file( "nodes.id" ) );
+
+        NodeStore store = new NodeStore(
+                storeFile,
+                config,
+                new DefaultIdGeneratorFactory(),
+                pageCacheRule.getPageCache( fs, config ),
+                fs,
+                StringLogger.DEV_NULL,
+                null,
+                null,
+                new Monitors() );
+
+        // ... that contain a number of records ...
+        NodeRecord record = new NodeRecord( 0 );
+        record.setInUse( true );
+        for ( int i = 0; i < 50; i++ )
+        {
+            assertThat( store.nextId(), is( (long) i ) );
+            record.setId( i );
+            store.updateRecord( record );
+        }
+        store.updateHighId(); // This is usually done in the commit path.
+
+        // ... and some have been deleted
+        Long[] idsToFree = {2L, 3L, 5L, 7L};
+        record.setInUse( false );
+        for ( long toDelete : idsToFree )
+        {
+            record.setId( toDelete );
+            store.updateRecord( record );
+        }
+
+        // Then when we rebuild the id generator
+        store.rebuildIdGenerator();
+        store.closeIdGenerator();
+        store.openIdGenerator(); // simulate a restart to allow id reuse
+
+        // We should observe that the ids above got freed
+        List<Long> nextIds = new ArrayList<>();
+        nextIds.add( store.nextId() ); // 2
+        nextIds.add( store.nextId() ); // 3
+        nextIds.add( store.nextId() ); // 5
+        nextIds.add( store.nextId() ); // 7
+        nextIds.add( store.nextId() ); // 51
+        assertThat( nextIds, contains( 2L, 3L, 5L, 7L, 50L ) );
+    }
+
+    @Test
+    public void verifyDynamicSizedStoresCanRebuildIdGeneratorSlowly() throws Exception
+    {
+        // Given we have a store ...
+        Config config = new Config( MapUtil.stringMap(
+                GraphDatabaseSettings.rebuild_idgenerators_fast.name(), "false" ) );
+        config = StoreFactory.configForStoreDir( config, path() );
+        File storeFile = file( "strings" );
+
+        StoreFactory storeFactory = new StoreFactory(
+                config,
+                new DefaultIdGeneratorFactory(),
+                pageCacheRule.getPageCache( fs, config ),
+                fs,
+                StringLogger.DEV_NULL,
+                new Monitors() );
+        storeFactory.createDynamicStringStore( storeFile, 30, IdType.STRING_BLOCK );
+        DynamicStringStore store = storeFactory.newDynamicStringStore(
+                storeFile, IdType.STRING_BLOCK );
+
+        // ... that contain a number of records ...
+        DynamicRecord record = new DynamicRecord( 1 );
+        record.setInUse( true, PropertyType.STRING.intValue() );
+        for ( int i = 1; i <= 50; i++ ) // id '0' is the dynamic store header
+        {
+            assertThat( store.nextId(), is( (long) i ) );
+            record.setId( i );
+            StringBuilder sb = new StringBuilder( i );
+            for ( int j = 0; j < i; j++ )
+            {
+                sb.append( 'a' );
+            }
+            record.setData( sb.toString().getBytes( "UTF-16" ) );
+            store.updateRecord( record );
+        }
+        store.updateHighId();
+
+        // ... and some have been deleted
+        Long[] idsToFree = {2L, 3L, 5L, 7L};
+        record.setInUse( false );
+        for ( long toDelete : idsToFree )
+        {
+            record.setId( toDelete );
+            store.updateRecord( record );
+        }
+
+        // Then when we rebuild the id generator
+        store.rebuildIdGenerator();
+
+        // We should observe that the ids above got freed
+        List<Long> nextIds = new ArrayList<>();
+        nextIds.add( store.nextId() ); // 2
+        nextIds.add( store.nextId() ); // 3
+        nextIds.add( store.nextId() ); // 5
+        nextIds.add( store.nextId() ); // 7
+        nextIds.add( store.nextId() ); // 51
+        assertThat( nextIds, contains( 2L, 3L, 5L, 7L, 51L ) );
+    }
+
+    @Test
+    public void rebuildingIdGeneratorMustNotMissOutOnFreeRecordsAtEndOfFilePage() throws IOException
+    {
+        // Given we have a store ...
+        Config config = new Config( MapUtil.stringMap(
+                GraphDatabaseSettings.rebuild_idgenerators_fast.name(), "false" ) );
+        File storeFile = file( "nodes" );
+        fs.create( storeFile );
+        IdGeneratorImpl.createGenerator( fs, file( "nodes.id" ) );
+
+        NodeStore store = new NodeStore(
+                storeFile,
+                config,
+                new DefaultIdGeneratorFactory(),
+                pageCacheRule.getPageCache( fs, config ),
+                fs,
+                StringLogger.DEV_NULL,
+                null,
+                null,
+                new Monitors() );
+
+        // ... that contain enough records to fill several file pages ...
+        int recordsPerPage = store.recordsPerPage();
+        NodeRecord record = new NodeRecord( 0 );
+        record.setInUse( true );
+        for ( int i = 0; i < recordsPerPage * 3; i++ ) // 3 pages worth of records
+        {
+            assertThat( store.nextId(), is( (long) i ) );
+            record.setId( i );
+            store.updateRecord( record );
+        }
+        store.updateHighId(); // This is usually done in the commit path.
+
+        // ... and some records at the end of a page have been deleted
+        Long[] idsToFree = {recordsPerPage - 2L, recordsPerPage - 1L}; // id's are zero based, hence -2 and -1
+        record.setInUse( false );
+        for ( long toDelete : idsToFree )
+        {
+            record.setId( toDelete );
+            store.updateRecord( record );
+        }
+
+        // Then when we rebuild the id generator
+        store.rebuildIdGenerator();
+        store.closeIdGenerator();
+        store.openIdGenerator(); // simulate a restart to allow id reuse
+
+        // We should observe that the ids above got freed
+        List<Long> nextIds = new ArrayList<>();
+        nextIds.add( store.nextId() ); // recordsPerPage - 2
+        nextIds.add( store.nextId() ); // recordsPerPage - 1
+        nextIds.add( store.nextId() ); // recordsPerPage * 3 (we didn't use this id in the create-look above)
+        assertThat( nextIds, contains( recordsPerPage - 2L, recordsPerPage - 1L, recordsPerPage * 3L ) );
+    }
+}


### PR DESCRIPTION
The procedure for rebuilding the IdGenerators has been reimplemented to use the new PageCache API for accessing
the store files, instead of accessing the StoreChannels directly. We had to make this change, because the page
cache may contain changes that are not reflected in the store channel.
This commit also introduces some refactoring, where the procedure has been generalised for all stores, and
pulled up into the CommonAbstractStore class. This removes 3 other implementations in various stores.
Tests have been added to make sure that the behaviour did not otherwise change. One thing that has changed, is
how we count the number of ids that have been defragmented and salvaged. This is because we now operate in
whole-page increments, and so we now also count the last empty records of the last page in the file.
