### PR TITLE
Refactored Cursor API

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LogFileRecoverer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LogFileRecoverer.java
@@ -27,8 +27,6 @@ import org.neo4j.kernel.impl.transaction.xaframework.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.VersionAwareLogEntryReader;
 
-import static org.neo4j.kernel.impl.util.Cursors.exhaust;
-
 public class LogFileRecoverer implements Visitor<ReadableLogChannel, IOException>
 {
     private final VersionAwareLogEntryReader logEntryReader;
@@ -46,7 +44,8 @@ public class LogFileRecoverer implements Visitor<ReadableLogChannel, IOException
     {
         // Intentionally don't close the cursor here since after recovery the channel is still used.
         // I dislike this exception to the rule though.
-        exhaust( new PhysicalTransactionCursor( channel, logEntryReader, visitor ) );
+        PhysicalTransactionCursor physicalTransactionCursor = new PhysicalTransactionCursor( channel, logEntryReader );
+        while (physicalTransactionCursor.next() && visitor.visit( physicalTransactionCursor.get() ) );
         return true;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static org.neo4j.helpers.collection.IteratorUtil.loop;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -121,7 +119,6 @@ import org.neo4j.kernel.impl.transaction.xaframework.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.xaframework.LogFile;
 import org.neo4j.kernel.impl.transaction.xaframework.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPosition;
-import org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPruneStrategy;
 import org.neo4j.kernel.impl.transaction.xaframework.LogRotationControl;
 import org.neo4j.kernel.impl.transaction.xaframework.LogicalTransactionStore;
@@ -135,6 +132,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.TransactionMetadataCache;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.transaction.xaframework.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -145,6 +143,8 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.helpers.collection.IteratorUtil.loop;
 
 public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRotationControl, IndexProviders
 {
@@ -719,13 +719,13 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
     @Override
     public void forceEverything()
     {
-        neoStore.flush();
         indexingService.flushAll();
         labelScanStore.force();
         for ( IndexImplementation index : indexProviders.values() )
         {
             index.force();
         }
+        neoStore.flush();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/LogReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/LogReader.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa.command;
 
-import java.io.IOException;
-
-import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
 import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
-import org.neo4j.kernel.impl.util.Cursor;
 
 public interface LogReader<T extends ReadableLogChannel>
 {
-    public Cursor<IOException> cursor( T channel, Visitor<LogEntry, IOException> visitor );
+    public IOCursor<LogEntry> logEntries( T channel );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/EntryReusingPhysicalTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/EntryReusingPhysicalTransactionCursor.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 
 public class EntryReusingPhysicalTransactionCursor extends PhysicalTransactionCursor
@@ -31,10 +29,9 @@ public class EntryReusingPhysicalTransactionCursor extends PhysicalTransactionCu
     private final List<Command> entries = new ArrayList<>();
 
     public EntryReusingPhysicalTransactionCursor( ReadableLogChannel channel,
-            LogEntryReader<ReadableLogChannel> entryReader,
-            Visitor<CommittedTransactionRepresentation, IOException> visitor )
+            LogEntryReader<ReadableLogChannel> entryReader)
     {
-        super( channel, entryReader, visitor );
+        super( channel, entryReader);
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/IOCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/IOCursor.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
+import java.io.Closeable;
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.util.Cursor;
-
-public interface IOCursor extends Cursor<IOException>
+public interface IOCursor<T> extends Closeable
 {
+    T get();
+
+    boolean next() throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogicalTransactionStore.java
@@ -21,15 +21,13 @@ package org.neo4j.kernel.impl.transaction.xaframework;
 
 import java.io.IOException;
 
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 public interface LogicalTransactionStore extends Lifecycle
 {
     TransactionAppender getAppender();
 
-    IOCursor getCursor( long transactionIdToStartFrom,
-            Visitor<CommittedTransactionRepresentation, IOException> visitor )
+    IOCursor<CommittedTransactionRepresentation> getTransactions( long transactionIdToStartFrom )
             throws NoSuchTransactionException, IOException;
 
     TransactionMetadataCache.TransactionMetadata getMetadataFor( long transactionId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Cursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Cursor.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.kernel.impl.util;
 
-public interface Cursor<E extends Exception> extends AutoCloseable
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
+
+public interface Cursor<T> extends IOCursor<T>
 {
-    boolean next() throws E;
+    boolean next();
 
     @Override
-    void close() throws E;
+    void close();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
@@ -29,17 +29,16 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.TimeZone;
 import java.util.TreeSet;
-
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Args;
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
 import org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogVersionedStoreChannel;
@@ -50,7 +49,6 @@ import org.neo4j.kernel.impl.transaction.xaframework.VersionAwareLogEntryReader;
 import static java.util.TimeZone.getTimeZone;
 
 import static org.neo4j.helpers.Format.DEFAULT_TIME_ZONE;
-import static org.neo4j.kernel.impl.util.Cursors.exhaustAndClose;
 
 public class DumpLogicalLog
 {
@@ -88,13 +86,17 @@ public class DumpLogicalLog
             out.println( "Logical log version: " + logVersion + " with prev committed tx[" +
                 prevLastCommittedTx + "]" );
 
-            LogDeserializer deserializer =
-                    new LogDeserializer( instantiateCommandReaderFactory() );
-            PrintingConsumer consumer = new PrintingConsumer( out, timeZone );
+            LogDeserializer deserializer = new LogDeserializer( instantiateCommandReaderFactory() );
 
             ReadableLogChannel logChannel = new ReadAheadLogChannel(new PhysicalLogVersionedStoreChannel(fileChannel, logVersion), LogVersionBridge.NO_MORE_CHANNELS, 4096);
 
-            exhaustAndClose( deserializer.cursor( logChannel, consumer ) );
+            try (IOCursor<LogEntry> cursor = deserializer.logEntries( logChannel ))
+            {
+                while (cursor.next())
+                {
+                    out.println( cursor.get().toString( timeZone ) );
+                }
+            }
         }
         return logsFound;
     }
@@ -246,25 +248,5 @@ public class DumpLogicalLog
                 return Integer.valueOf( string.substring( index + toFind.length() ) );
             }
         };
-    }
-
-    private class PrintingConsumer implements Visitor<LogEntry, IOException>
-    {
-
-        private final PrintStream out;
-        private final TimeZone timeZone;
-
-        private PrintingConsumer( PrintStream out, TimeZone timeZone )
-        {
-            this.out = out;
-            this.timeZone = timeZone;
-        }
-
-        @Override
-        public boolean visit( LogEntry entry ) throws IOException
-        {
-            out.println( entry.toString( timeZone ) );
-            return true;
-        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -29,9 +29,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.helpers.Function;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.IdGenerator;
 import org.neo4j.kernel.impl.nioneo.store.UnderlyingStorageException;
 import org.neo4j.test.ImpermanentDatabaseRule;
@@ -269,58 +269,6 @@ public class LabelsAcceptanceTest
 
         // Then
         assertThat( myNode, not( inTx( beansAPI, hasLabel( label ) ) ) );
-    }
-
-    @Test
-    public void removingCommittedLabel2() throws Exception
-    {
-        // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
-        Label label = Labels.MY_LABEL;
-
-        Transaction tx = beansAPI.beginTx();
-        Node myNode;
-        try
-        {
-            Node node = beansAPI.createNode( label );
-            tx.success();
-            myNode = node;
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // When
-        tx = beansAPI.beginTx();
-        try
-        {
-            myNode.removeLabel( label );
-            tx.success();
-        }
-        finally
-        {
-            tx.finish();
-        }
-
-        // Then
-        tx = beansAPI.beginTx();
-        try
-        {
-            for ( Node node : beansAPI.findNodesByLabelAndProperty( label, "foo", "bar" ) )
-            {
-                System.out.println(node);
-            }
-
-            for ( Label label1 : myNode.getLabels() )
-            {
-                System.out.println(label1);
-            }
-        }
-        finally
-        {
-            tx.finish();
-        }
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
@@ -47,8 +47,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import static org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory.NO_PRUNING;
 import static org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFile.DEFAULT_NAME;
+import static org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory.NO_PRUNING;
 import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
 
 public class PhysicalLogicalTransactionStoreTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CursorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CursorsTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CursorsTest
+{
+    @Test
+    public void shouldIterateAllCursorItems() throws Exception
+    {
+        List<String> strings = new ArrayList<>(  );
+        strings.add("foo1");
+        strings.add("foo2");
+        strings.add("foo3");
+
+        final Iterator<String> iterator = strings.iterator();
+        Iterable<String> iterable = Cursors.iterable( new IOCursor<String>()
+        {
+            String instance;
+
+            @Override
+            public String get()
+            {
+                return instance;
+            }
+
+            @Override
+            public boolean next() throws IOException
+            {
+                if (iterator.hasNext())
+                {
+                    instance = iterator.next();
+                    return true;
+                } else
+                    return false;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+
+            }
+        } );
+
+        List<String> result = Iterables.addAll( new ArrayList<String>(  ), iterable );
+
+        assertThat(result, equalTo(strings));
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -24,17 +24,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Predicate;
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.transaction.xaframework.CommandWriter;
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntryWriter;
@@ -48,7 +47,6 @@ import org.neo4j.kernel.impl.transaction.xaframework.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.VersionAwareLogEntryReader;
 import org.neo4j.kernel.impl.transaction.xaframework.WritableLogChannel;
-import org.neo4j.kernel.impl.util.Cursor;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -121,43 +119,28 @@ public class LogTestUtils
             VersionAwareLogEntryReader.readLogHeader( buffer, fileChannel, true );
 
             // Read all log entries
-            final List<LogEntry> entries = new ArrayList<>();
             LogDeserializer deserializer = new LogDeserializer( CommandReaderFactory.DEFAULT );
-
-
-            Visitor<LogEntry, IOException> visitor = new Visitor<LogEntry, IOException>()
-            {
-                @Override
-                public boolean visit( LogEntry entry ) throws IOException
-                {
-                    entries.add( entry );
-                    return true;
-                }
-            };
 
             ReadableLogChannel logChannel = new ReadAheadLogChannel(new PhysicalLogVersionedStoreChannel(fileChannel), LogVersionBridge.NO_MORE_CHANNELS, 4096);
 
-            try ( Cursor<IOException> cursor = deserializer.cursor( logChannel, visitor ) )
-            {
-                cursor.next();
-            }
-
             // Assert entries are what we expected
-            for(int entryNo=0;entryNo < expectedEntries.length; entryNo++)
+            try ( IOCursor<LogEntry> cursor = deserializer.logEntries( logChannel) )
             {
-                LogEntry expectedEntry = expectedEntries[entryNo];
-                if(entries.size() <= entryNo)
+                int entryNo=0;
+                while (cursor.next())
                 {
-                    fail("Log ended prematurely. Expected to find '" + expectedEntry.toString() + "' as log entry number "+entryNo+", instead there were no more log entries." );
+                    assertThat( "The log contained more entries than we expected!", entryNo < expectedEntries.length, is( true) );
+
+                    LogEntry expectedEntry = expectedEntries[entryNo];
+                    assertThat( "Unexpected entry at entry number " + entryNo, cursor.get(), is( expectedEntry ) );
+                    entryNo++;
                 }
 
-                LogEntry actualEntry = entries.get( entryNo );
-
-                assertThat( "Unexpected entry at entry number " + entryNo, actualEntry, is( expectedEntry ) );
+                if(entryNo < expectedEntries.length)
+                {
+                    fail("Log ended prematurely. Expected to find '" + expectedEntries[entryNo].toString() + "' as log entry number "+entryNo+", instead there were no more log entries." );
+                }
             }
-
-            // And assert log does not contain more entries
-            assertThat( "The log contained more entries than we expected!", entries.size(), is( expectedEntries.length ) );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
@@ -28,7 +28,6 @@ import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.consistency.checking.full.FullCheck;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
-import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -41,6 +40,7 @@ import org.neo4j.kernel.impl.nioneo.store.StoreAccess;
 import org.neo4j.kernel.impl.nioneo.xa.DataSourceManager;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
 import org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogVersionedStoreChannel;
@@ -57,7 +57,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.DEFAULT;
 import static org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.xaframework.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
-import static org.neo4j.kernel.impl.util.Cursors.exhaustAndClose;
 
 class RebuildFromLogs
 {
@@ -84,18 +83,15 @@ class RebuildFromLogs
         ReadableLogChannel logChannel = new ReadAheadLogChannel(
                 new PhysicalLogVersionedStoreChannel( FS.open( logFile, "R" ), startVersion ),
                 versionBridge, DEFAULT_READ_AHEAD_SIZE );
-        Visitor<CommittedTransactionRepresentation, IOException> visitor = new Visitor<CommittedTransactionRepresentation, IOException>()
+
+        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel,new VersionAwareLogEntryReader( DEFAULT ) ) )
         {
-            @Override
-            public boolean visit( CommittedTransactionRepresentation transaction ) throws IOException
+            while (cursor.next())
             {
-                storeApplier.apply( transaction.getTransactionRepresentation(),
-                        transaction.getCommitEntry().getTxId(), true );
-                return true;
+                storeApplier.apply( cursor.get().getTransactionRepresentation(), cursor.get().getCommitEntry().getTxId(), true );
             }
-        };
-        exhaustAndClose( new PhysicalTransactionCursor( logChannel,
-                new VersionAwareLogEntryReader( DEFAULT ), visitor ) );
+        }
+
         return this;
     }
 
@@ -188,10 +184,17 @@ class RebuildFromLogs
         ReadableLogChannel logChannel = new ReadAheadLogChannel(
                 new PhysicalLogVersionedStoreChannel( FS.open( logFile, "R" ), highestVersion ),
                 NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
-        TransactionIdSeeker transactionIdSeeker = new TransactionIdSeeker();
-        exhaustAndClose( new PhysicalTransactionCursor( logChannel,
-                new VersionAwareLogEntryReader( DEFAULT ), transactionIdSeeker ) );
-        return transactionIdSeeker.highestSeenTransactionId();
+
+        long lastTransactionId = -1;
+
+        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel, new VersionAwareLogEntryReader( DEFAULT )))
+        {
+            while (cursor.next())
+            {
+                lastTransactionId = cursor.get().getCommitEntry().getTxId();
+            }
+        }
+        return lastTransactionId;
     }
 
     private void checkConsistency() throws ConsistencyCheckIncompleteException
@@ -214,22 +217,5 @@ class RebuildFromLogs
         System.err.println( "WHERE:   <source dir>  is the path for where transactions to rebuild from are stored" );
         System.err.println( "         <target dir>  is the path for where to create the new graph database" );
         System.err.println( "         -full     --  to run a full check over the entire store for each transaction" );
-    }
-
-    private static final class TransactionIdSeeker implements Visitor<CommittedTransactionRepresentation, IOException>
-    {
-        private long lastTransactionId = -1;
-
-        @Override
-        public boolean visit( CommittedTransactionRepresentation transaction ) throws IOException
-        {
-            lastTransactionId = transaction.getCommitEntry().getTxId();
-            return true;
-        }
-
-        public long highestSeenTransactionId()
-        {
-            return lastTransactionId;
-        }
     }
 }


### PR DESCRIPTION
Previous version of Cursor API relied on visitor pattern, which turned out to be unnecessary complexity. Removed the visitor pattern, and replaced with getter on the cursor, which is much easier to use, and can be easily combined with visitor pattern by client code.
