### PR TITLE
Ensure `toString(...)` only does type conversion

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/Function.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/Function.scala
@@ -88,7 +88,7 @@ object Function {
     functions.ToFloat,
     functions.ToInt,
     functions.ToLower,
-    functions.ToStr,
+    functions.ToString,
     functions.ToUpper,
     functions.Trim,
     functions.Type,

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ToStringFunction.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ToStringFunction.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.commands.expressions
+
+import org.neo4j.cypher.internal.compiler.v2_0.{symbols, ExecutionContext}
+import org.neo4j.cypher.internal.compiler.v2_0.pipes.QueryState
+import symbols._
+import org.neo4j.cypher.ParameterWrongTypeException
+import java.lang.NumberFormatException
+
+case class ToStringFunction(a: Expression) extends NullInNullOutExpression(a) with StringHelper {
+  def symbolTableDependencies: Set[String] = a.symbolTableDependencies
+
+  protected def calculateType(symbols: SymbolTable): CypherType = CTString
+
+  def arguments: Seq[Expression] = Seq(a)
+
+  def rewrite(f: (Expression) => Expression): Expression = f(ToStringFunction(a.rewrite(f)))
+
+  def compute(value: Any, m: ExecutionContext)(implicit state: QueryState): Any = a(m) match {
+    case v: Number => v.toString
+    case v: String => v
+    case v =>
+      throw new ParameterWrongTypeException("Expected a String or Number, got: " + v.toString)
+  }
+}

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/ToString.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/ToString.scala
@@ -24,13 +24,15 @@ import ast.convert.ExpressionConverters._
 import commands.{expressions => commandexpressions}
 import symbols._
 
-case object ToStr extends Function with SimpleTypedFunction {
+case object ToString extends Function with SimpleTypedFunction {
   def name = "toString"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTAny), outputType = CTString)
+    Signature(argumentTypes = Vector(CTFloat), outputType = CTString),
+    Signature(argumentTypes = Vector(CTInteger), outputType = CTString),
+    Signature(argumentTypes = Vector(CTString), outputType = CTString)
   )
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =
-    commandexpressions.StrFunction(invocation.arguments(0).asCommandExpression)
+    commandexpressions.ToStringFunction(invocation.arguments(0).asCommandExpression)
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ToStringFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ToStringFunctionTest.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.commands.expressions
+
+import org.neo4j.cypher.internal.compiler.v2_0.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_0.pipes.QueryStateHelper
+import org.neo4j.cypher.ParameterWrongTypeException
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+
+class ToStringFunctionTest extends CypherFunSuite {
+
+  test("should return null if argument is null") {
+    assert(toStringFunction(null) === null)
+  }
+
+  test("should not change a string") {
+    toStringFunction("10.599") should be("10.599")
+  }
+
+  test("should convert an integer to a string") {
+    toStringFunction(21) should be("21")
+  }
+
+  test("should convert an float to a string") {
+    toStringFunction(23.34) should be("23.34")
+  }
+
+  test("should convert a negative float to a string") {
+    toStringFunction(-12.66) should be("-12.66")
+  }
+
+  test("should convert a negative integer to a string") {
+    toStringFunction(-12) should be("-12")
+  }
+
+  test("should throw an exception if the argument is an object which cannot be converted to a float") {
+    evaluating { toStringFunction(new Object) } should produce[ParameterWrongTypeException]
+  }
+
+  private def toStringFunction(orig: Any) = {
+    ToStringFunction(Literal(orig))(ExecutionContext.empty)(QueryStateHelper.empty)
+  }
+}

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/ToStringTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/functions/ToStringTest.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.functions
+
+import org.junit.Test
+import org.neo4j.cypher.internal.compiler.v2_0.symbols._
+
+class ToStringTest extends FunctionTestBase("toString")  {
+
+  @Test
+  def shouldAcceptCorrectTypes() {
+    testValidTypes(CTString)(CTString)
+    testValidTypes(CTFloat)(CTString)
+    testValidTypes(CTInteger)(CTString)
+  }
+
+  @Test
+  def shouldFailTypeCheckForIncompatibleArguments() {
+    testInvalidApplication(CTCollection(CTAny))(
+      "Type mismatch: expected Float, Integer or String but was Collection<Any>"
+    )
+
+    testInvalidApplication(CTNode)(
+      "Type mismatch: expected Float, Integer or String but was Node"
+    )
+  }
+
+  @Test
+  def shouldFailIfWrongNumberOfArguments() {
+    testInvalidApplication()(
+      "Insufficient parameters for function 'toString'"
+    )
+    testInvalidApplication(CTString, CTString)(
+      "Too many parameters for function 'toString'"
+    )
+  }
+}

--- a/community/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/community/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -64,6 +64,8 @@ include::toint.asciidoc[]
 
 include::tofloat.asciidoc[]
 
+include::tostring.asciidoc[]
+
 :leveloffset: 1
 
 [[query-functions-collection]]

--- a/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -765,6 +765,18 @@ In case all arguments are +NULL+, +NULL+ will be returned.""",
     )
   }
 
+  @Test def toStringFunc() {
+    testThis(
+      title = "TOSTRING",
+      syntax = "TOSTRING( expression )",
+      arguments = List("expression" -> "An expression that returns anything"),
+      text = "`TOSTRING` converts the argument to a string. It converts integers and floating point numbers to strings, and if called with a string will leave it unchanged.",
+      queryText = "return toString(11.5), toString(\"already a string\")",
+      returns = "",
+      assertions = (p) => assert(List(Map("toString(11.5)" -> "11.5", "toString(\"already a string\")" -> "already a string")) === p.toList)
+    )
+  }
+
   @Test def now() {
     testThis(
       title = "TIMESTAMP",

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -2,6 +2,7 @@
 -----
 o Adds support for Octal literals (using a preceding 0, e.g. 03517)
 o Add `exists(...)` predicate function for checking patterns and properties
+o Ensure `toString(...)` only does type conversion
 
 2.0.4
 -----

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/FunctionsAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/FunctionsAcceptanceTest.scala
@@ -68,4 +68,18 @@ class FunctionsAcceptanceTest extends ExecutionEngineJUnitSuite {
     assert(result === 4.0)
   }
 
+  @Test
+  def toString_should_work_as_expected() {
+    // When
+    val result = executeScalar[String](
+      "CREATE (m:Movie { rating: 4 })" +
+        "WITH * " +
+        "MATCH (n) " +
+        "RETURN toString(n.rating)"
+    )
+
+    // Then
+    assert(result === "4")
+  }
+
 }


### PR DESCRIPTION
As opposed to `str(...)`, it should not return the literal form of a
string argument. i.e. `str("foo")` should return `"foo"`, but
`toString("foo")` should not change the input and return only `foo`.
