### PR TITLE
Fix rare race condition in Forseti lock manager

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
@@ -406,23 +406,41 @@ public class ForsetiClient implements Locks.Client
     @Override
     public void releaseAll()
     {
-        releaseAll( exclusiveLockCounts );
-        releaseAll( sharedLockCounts );
-    }
-
-    private void releaseAll( Map<Long, Integer>[] lockCounts )
-    {
-        for ( int i = 0; i < lockCounts.length; i++ )
+        // Force the release of all locks held.
+        for ( int i = 0; i < exclusiveLockCounts.length; i++ )
         {
-            Map<Long, Integer> localLocks = lockCounts[i];
-            if(localLocks != null)
+            Map<Long, Integer> exclusiveLocks = exclusiveLockCounts[i];
+            Map<Long, Integer> sharedLocks = sharedLockCounts[i];
+
+            // Begin releasing exclusive locks, as we may hold both exclusive and shared locks on the same resource,
+            // and so releasing shared locks means we can "throw away" our shared lock (which would normally have been
+            // re-instated after releasing the exclusive lock).
+            if(exclusiveLocks != null)
             {
                 ConcurrentMap<Long, ForsetiLockManager.Lock> lockMap = lockMaps[i];
-                for ( Long resourceId : localLocks.keySet() )
+                for ( Long resourceId : exclusiveLocks.keySet() )
+                {
+                    releaseGlobalLock( lockMap, resourceId );
+
+                    // If we hold this as a shared lock, we can throw that shared lock away directly, since we haven't
+                    // followed the down-grade protocol.
+                    if(sharedLocks != null)
+                    {
+                        sharedLocks.remove( resourceId );
+                    }
+                }
+                exclusiveLocks.clear();
+            }
+
+            // Then release all remaining shared locks
+            if(sharedLocks != null)
+            {
+                ConcurrentMap<Long, ForsetiLockManager.Lock> lockMap = lockMaps[i];
+                for ( Long resourceId : sharedLocks.keySet() )
                 {
                     releaseGlobalLock( lockMap, resourceId );
                 }
-                localLocks.clear();
+                sharedLocks.clear();
             }
         }
     }


### PR DESCRIPTION
When doing a release-all on a forseti lock client which held one or more
upgraded exclusive locks (eg it originally held a shared lock and then
upgraded it), if another thread acquired a shared lock right when the client
was releasing its exclusive lock, the client could end up in a bad state.

This resolves this race by discarding references to local shared locks if they
have been upgrade when we do a release-all on every lock the client holds.
