### PR TITLE
Change executable name within the README

### DIFF
--- a/community/graphviz/README.rst
+++ b/community/graphviz/README.rst
@@ -8,4 +8,4 @@ Also includes a tool for visualizing an entire graph database.
 
 ## Command-line interface
 
-Run `./neoviz --help` for information on use.
+Run `./graphviz --help` for information on use.


### PR DESCRIPTION
The README claims that the shell script is named `neoviz`.
