### PR TITLE
Improved comprehensibility of database availability logging.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -64,6 +64,11 @@ public class AvailabilityGuard
     private final List<AvailabilityRequirement> blockingComponents = new CopyOnWriteArrayList<>();
     private final Clock clock;
 
+    public AvailabilityGuard( Clock clock )
+    {
+        this(clock, 0);
+    }
+
     public AvailabilityGuard( Clock clock, int conditionCount )
     {
         this.clock = clock;
@@ -209,7 +214,7 @@ public class AvailabilityGuard
         if(blockingComponents.size() > 0 || available.get() > 0)
         {
             String causes = join( ", ", Iterables.map( DESCRIPTION, blockingComponents ) );
-            return "Blocking components ("+available.get()+"): [" + causes + "]";
+            return available.get() + " reasons for blocking: " + causes + ".";
         }
         return "No blocking components";
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -40,6 +40,9 @@ public class DatabaseAvailability
     {
         this.txManager = txManager;
         this.availabilityGuard = availabilityGuard;
+
+        // On initial setup, deny availability
+        availabilityGuard.deny( this );
     }
 
     @Override
@@ -87,6 +90,6 @@ public class DatabaseAvailability
     @Override
     public String description()
     {
-        return getClass().getSimpleName();
+        return "Database is stopped";
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -323,6 +323,7 @@ public abstract class InternalAbstractGraphDatabase
 
         try
         {
+            enableAvailabilityLogging(); // Done after create to avoid a redundant "database is now unavailable"
             registerRecovery();
 
             life.start();
@@ -357,6 +358,24 @@ public abstract class InternalAbstractGraphDatabase
     {
         // This is how we lock the entire database to avoid threads using it during lifecycle events
         life.add( new DatabaseAvailability( txManager, availabilityGuard ) );
+    }
+
+    private void enableAvailabilityLogging()
+    {
+        availabilityGuard.addListener( new AvailabilityGuard.AvailabilityListener()
+        {
+            @Override
+            public void available()
+            {
+                msgLog.info( "Database is now ready" );
+            }
+
+            @Override
+            public void unavailable()
+            {
+                msgLog.info( "Database is now unavailable" );
+            }
+        } );
     }
 
     protected void registerRecovery()
@@ -399,22 +418,7 @@ public abstract class InternalAbstractGraphDatabase
 
     protected void create()
     {
-        availabilityGuard = createAvailabilityGuard();
-
-        availabilityGuard.addListener( new AvailabilityGuard.AvailabilityListener()
-        {
-            @Override
-            public void available()
-            {
-                msgLog.info( "Database is now ready" );
-            }
-
-            @Override
-            public void unavailable()
-            {
-                msgLog.info( "Database is now unavailable" );
-            }
-        } );
+        availabilityGuard = new AvailabilityGuard( Clock.SYSTEM_CLOCK );
 
         fileSystem = createFileSystemAbstraction();
 
@@ -616,11 +620,6 @@ public abstract class InternalAbstractGraphDatabase
                 return getNewGlobalId( DEFAULT_SEED, MASTER_ID_REPRESENTING_NO_MASTER );
             }
         };
-    }
-
-    protected AvailabilityGuard createAvailabilityGuard()
-    {
-        return new AvailabilityGuard( Clock.SYSTEM_CLOCK, 1 );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
@@ -256,6 +256,6 @@ public class AvailabilityGuardTest
         availabilityGuard.deny(REQUIREMENT);
 
         // Then
-        assertThat( availabilityGuard.describeWhoIsBlocking(), equalTo( "Blocking components (2): [Thing, Thing]" ) );
+        assertThat( availabilityGuard.describeWhoIsBlocking(), equalTo( "2 reasons for blocking: Thing, Thing." ) );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaKernelPanicHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaKernelPanicHandler.java
@@ -48,7 +48,6 @@ public class HaKernelPanicHandler implements KernelEventHandler, AvailabilityGua
         this.availabilityGuard = availabilityGuard;
         this.logger = logging.getMessagesLog( getClass() );
         this.masterDelegateInvocationHandler = masterDelegateInvocationHandler;
-        availabilityGuard.grant(this);
     }
 
     @Override
@@ -119,6 +118,6 @@ public class HaKernelPanicHandler implements KernelEventHandler, AvailabilityGua
     @Override
     public String description()
     {
-        return getClass().getSimpleName();
+        return "Database is handling a kernel panic";
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.helpers.collection.Iterables.option;
-import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
-import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
-import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
-import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
-import static org.neo4j.kernel.logging.LogbackWeakDependency.NEW_LOGGER_CONTEXT;
-
 import java.io.File;
 import java.lang.reflect.Proxy;
 import java.net.URI;
@@ -54,10 +47,8 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexManager;
-import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.Factory;
 import org.neo4j.helpers.Predicate;
-import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.IdGeneratorFactory;
@@ -107,6 +98,13 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.helpers.collection.Iterables.option;
+import static org.neo4j.kernel.ha.DelegateInvocationHandler.snapshot;
+import static org.neo4j.kernel.impl.transaction.XidImpl.DEFAULT_SEED;
+import static org.neo4j.kernel.impl.transaction.XidImpl.getNewGlobalId;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
+import static org.neo4j.kernel.logging.LogbackWeakDependency.NEW_LOGGER_CONTEXT;
 
 public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
 {
@@ -171,13 +169,6 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         life.add( new StartupWaiter() );
 
         diagnosticsManager.appendProvider( new HighAvailabilityDiagnostics( memberStateMachine, clusterClient ) );
-    }
-
-    @Override
-    protected AvailabilityGuard createAvailabilityGuard()
-    {
-        // 3 conditions: DatabaseAvailability, HighAvailabilityMemberStateMachine, and HA Kernel Panic
-        return new AvailabilityGuard( Clock.SYSTEM_CLOCK, 3 );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -71,6 +71,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
     public void init() throws Throwable
     {
         events.addClusterMemberListener( eventsListener = new StateMachineClusterEventListener() );
+        // On initial startup, disallow database access
+        availabilityGuard.deny( this );
     }
 
     @Override
@@ -117,7 +119,7 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
     @Override
     public String description()
     {
-        return getClass().getSimpleName() + "[" + getCurrentState() + "]";
+        return "Cluster state is '" + getCurrentState() + "'";
     }
 
     private class StateMachineClusterEventListener extends ClusterMemberListener.Adapter

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -241,7 +241,7 @@ public class HighAvailabilityMemberStateMachineTest
         assertThat( listener.size(), equalTo( 1 ) ); // Sanity check.
         assertThat( toTest.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
-        verify(guard, times(1)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
+        verify(guard, times(2)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
     }
 
     @Test
@@ -300,7 +300,7 @@ public class HighAvailabilityMemberStateMachineTest
         assertThat( listener.size(), equalTo( 1 ) ); // Sanity check.
         assertThat( toTest.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
-        verify(guard, times(1)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
+        verify(guard, times(2)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
     }
 
     @Test
@@ -358,7 +358,7 @@ public class HighAvailabilityMemberStateMachineTest
         assertThat( listener.size(), equalTo( 1 ) ); // Sanity check.
         assertThat( toTest.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
-        verify(guard, times(0)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
+        verify(guard, times(1)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
     }
 
     @Test
@@ -416,7 +416,7 @@ public class HighAvailabilityMemberStateMachineTest
         assertThat( listener.size(), equalTo( 1 ) ); // Sanity check.
         assertThat( toTest.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
-        verify(guard, times(0)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
+        verify(guard, times(1)).deny( any( AvailabilityGuard.AvailabilityRequirement.class) );
     }
 
     @Test


### PR DESCRIPTION
- We no longer use a counter for boot-strap availability, instead components
  mark themselves as blocking during startup, which means they will be included
  in the description of why the database is unavailable during startup.
