### PR TITLE
Fix a memory leak in RerferenceCache

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.cache;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,19 +32,23 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import static org.neo4j.kernel.impl.cache.ReferenceCache.MAX_NUM_PUT_BEFORE_POLL;
 
 @RunWith(Parameterized.class)
 public class ReferenceCacheTest
 {
-    static class SpyCreatingWeakValueFactory implements ReferenceWithKey.Factory
+    static class SpyCreatingValueFactory implements ReferenceWithKey.Factory
     {
-        ArrayList<ReferenceWithKey> weakValues = new ArrayList<>();
+        ArrayList<ReferenceWithKey> values = new ArrayList<>();
         private final ArrayList<Object> hardReferencesToStopGC = new ArrayList<>();
         private final ReferenceWithKey.Factory refFactory;
 
-        SpyCreatingWeakValueFactory( ReferenceWithKey.Factory referenceFactory )
+        SpyCreatingValueFactory( ReferenceWithKey.Factory referenceFactory )
         {
             refFactory = referenceFactory;
         }
@@ -53,20 +58,20 @@ public class ReferenceCacheTest
         {
             ReferenceWithKey<FK, FV> ref = Mockito.spy( refFactory.newReference( key, value, queue ) );
             hardReferencesToStopGC.add( value );
-            weakValues.add( ref );
+            values.add( ref );
             return ref;
         }
 
         public void clearAndQueueReferenceNo( int index )
         {
-            ReferenceWithKey val = weakValues.get( index );
+            ReferenceWithKey val = values.get( index );
             val.clear();
             val.enqueue();
         }
 
         public void reset()
         {
-            weakValues.clear();
+            values.clear();
             hardReferencesToStopGC.clear();
         }
     }
@@ -75,14 +80,14 @@ public class ReferenceCacheTest
     public static Collection<Object[]> parameters()
     {
         return asList( new Object[][]{
-            {new SpyCreatingWeakValueFactory( WeakValue.WEAK_VALUE_FACTORY )},
-            {new SpyCreatingWeakValueFactory( SoftValue.SOFT_VALUE_FACTORY )}
+                {new SpyCreatingValueFactory( WeakValue.WEAK_VALUE_FACTORY )},
+                {new SpyCreatingValueFactory( SoftValue.SOFT_VALUE_FACTORY )}
         });
     }
 
-    private SpyCreatingWeakValueFactory spyFactory;
+    private SpyCreatingValueFactory spyFactory;
 
-    public ReferenceCacheTest( SpyCreatingWeakValueFactory factory )
+    public ReferenceCacheTest( SpyCreatingValueFactory factory )
     {
         this.spyFactory = factory;
         spyFactory.reset(); // Instance is shared across tests
@@ -105,8 +110,51 @@ public class ReferenceCacheTest
         TestCacheTypes.Entity returnedEntity = cache.put( newEntity );
 
         // Then
-        assertEquals(newEntity, returnedEntity);
-        assertEquals(newEntity, cache.get(0));
+        assertEquals( newEntity, returnedEntity );
+        assertEquals( newEntity, cache.get( 0 ) );
+    }
+
+    @Test
+    public void shouldForceACacheCleanupAfterManyPutsWithoutReading() throws Exception
+    {
+        // Given
+        ReferenceCache<TestCacheTypes.Entity> cache = new ReferenceCache<>( "MyCache!", spyFactory );
+
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL; i++ )
+        {
+            cache.put( new TestCacheTypes.Entity( i ) );
+        }
+
+        // Clear the weak reference that the cache will have created (emulating GC doing this)
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL / 2; i++ )
+        {
+            spyFactory.clearAndQueueReferenceNo( i );
+        }
+
+        // this should trigger a poll and remove the collected values from the cache
+        cache.put( new TestCacheTypes.Entity( MAX_NUM_PUT_BEFORE_POLL ) );
+
+        assertEquals( (MAX_NUM_PUT_BEFORE_POLL / 2) + 1, cache.size() );
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL / 2; i++ )
+        {
+            assertNull( cache.get( i ) );
+        }
+    }
+
+    @Test
+    public void shouldReturnTheValueIfNotGCed() throws Exception
+    {
+        // Given
+        ReferenceCache<TestCacheTypes.Entity> cache = new ReferenceCache<>( "MyCache!", spyFactory );
+
+        TestCacheTypes.Entity entity = new TestCacheTypes.Entity( 0 );
+        cache.put( entity );
+
+        // When
+        TestCacheTypes.Entity returnedEntity = cache.get( 0 );
+
+        // Then
+        assertEquals( entity, returnedEntity );
     }
 
     @Test
@@ -115,37 +163,79 @@ public class ReferenceCacheTest
         // Given
         ReferenceCache<TestCacheTypes.Entity> cache = new ReferenceCache<>( "MyCache!", spyFactory );
 
-        final TestCacheTypes.Entity originalEntity = new TestCacheTypes.Entity( 0 );
-        cache.put( originalEntity );
+        cache.put( new TestCacheTypes.Entity( 0 ) );
+        cache.put( new TestCacheTypes.Entity( 1 ) );
+        cache.put( new TestCacheTypes.Entity( 2 ) );
 
         // Clear the weak reference that the cache will have created (emulating GC doing this)
-        when( spyFactory.weakValues.get( 0 ).get() ).thenAnswer( entityFirstTimeNullAfterThat( originalEntity ) );
+        spyFactory.clearAndQueueReferenceNo( 0 );
+        spyFactory.clearAndQueueReferenceNo( 1 );
 
         // When
-        TestCacheTypes.Entity returnedEntity = cache.get( 0 );
+        TestCacheTypes.Entity returnedEntity = cache.get( 1 );
 
         // Then
-        assertEquals(originalEntity, returnedEntity);
+        assertNull( returnedEntity );
+        assertEquals( 1, cache.size() );
     }
 
-    private Answer<Object> entityFirstTimeNullAfterThat( final TestCacheTypes.Entity originalEntity )
+    @Test
+    public void shouldPollAfterAPutAllInvocation()
     {
-        return new Answer<Object>()
-        {
-            int invocations = 0;
+        // Given
+        ReferenceCache<TestCacheTypes.Entity> cache = new ReferenceCache<>( "MyCache!", spyFactory );
 
-            @Override
-            public Object answer( InvocationOnMock invocationOnMock ) throws Throwable
-            {
-                if(invocations++ == 0)
-                {
-                    return originalEntity;
-                } else
-                {
-                    return null;
-                }
-            }
-        };
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL / 2; i++ )
+        {
+            cache.put( new TestCacheTypes.Entity( i ) );
+        }
+
+        // Clear the weak reference that the cache will have created (emulating GC doing this)
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL / 3; i++ )
+        {
+            spyFactory.clearAndQueueReferenceNo( i );
+        }
+
+
+        List<TestCacheTypes.Entity> entities = new ArrayList<>();
+        for ( int i = MAX_NUM_PUT_BEFORE_POLL / 2; i < MAX_NUM_PUT_BEFORE_POLL + 1; i++ )
+        {
+            entities.add( new TestCacheTypes.Entity( i ) );
+        }
+
+        // this should trigger a poll and remove the collected values from the cache
+        cache.putAll( entities );
+
+        assertEquals( MAX_NUM_PUT_BEFORE_POLL - (MAX_NUM_PUT_BEFORE_POLL / 3) + 1, cache.size() );
+        for ( int i = 0; i < MAX_NUM_PUT_BEFORE_POLL / 3; i++ )
+        {
+            assertNull( cache.get( i ) );
+        }
     }
 
+    @Test
+    public void shouldHandleReferenceGarbageCollectedDuringRemove() throws Exception
+    {
+        // Given
+        ReferenceCache<TestCacheTypes.Entity> cache = new ReferenceCache<>( "MyCache!", spyFactory );
+
+        cache.put( new TestCacheTypes.Entity( 0 ) );
+        cache.put( new TestCacheTypes.Entity( 1 ) );
+        cache.put( new TestCacheTypes.Entity( 2 ) );
+        cache.put( new TestCacheTypes.Entity( 3 ) );
+
+        spyFactory.clearAndQueueReferenceNo( 0 );
+        spyFactory.clearAndQueueReferenceNo( 1 );
+
+        // When
+        TestCacheTypes.Entity returnedEntity = cache.remove( 1 );
+
+        // Then
+        assertNull( returnedEntity );
+        assertEquals( 2, cache.size() );
+        assertNull( cache.get( 0 ) );
+        assertNull( cache.get( 1 ) );
+        assertNotNull( cache.get( 2 ) );
+        assertNotNull( cache.get( 3 ) );
+    }
 }

--- a/community/neo4j/src/test/java/files/ReferenceCacheIT.java
+++ b/community/neo4j/src/test/java/files/ReferenceCacheIT.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package files;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.cache.SoftCacheProvider;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+@Ignore("This is not a real test but something useful to reproduce a memory leak in ReferenceCache")
+public class ReferenceCacheIT
+{
+    @Rule
+    public TargetDirectory.TestDirectory directory =
+            TargetDirectory.testDirForTest( ReferenceCacheIT.class );
+    private GraphDatabaseAPI db;
+    private ExecutionEngine engine;
+
+    @Before
+    public void setUp()
+    {
+        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( directory.absolutePath() )
+                .setConfig( GraphDatabaseSettings.cache_type.name(), SoftCacheProvider.NAME )
+                .newGraphDatabase();
+        engine = new ExecutionEngine( db );
+    }
+
+    @Test
+    public void test()
+    {
+        // Given indexes
+        int nrPeople = 1000;
+        int nrAddresses = 100000;
+        int nrPhones = 50000;
+
+        Map<String, String>[] people = new HashMap[nrPeople];
+        Map<String, String>[] addresses = new HashMap[nrAddresses];
+        String[] phones = new String[nrAddresses];
+
+        for ( int i = 0; i < nrAddresses; i++ )
+        {
+            addresses[i] = new HashMap<>();
+            addresses[i].put( "street", "STREET" + i );
+            addresses[i].put( "city", "CITY" + i );
+            addresses[i].put( "zipcode", "ZIPCODE" + i );
+            addresses[i].put( "state", "STATE" + i );
+            addresses[i].put( "uuid", "AUUID" + i );
+        }
+
+        for ( int i = 0; i < nrPhones; i++ )
+        {
+            phones[i] = "" + i;
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            engine.execute( "CREATE INDEX ON :Person(first_name)" );
+            engine.execute( "CREATE INDEX ON :Person(last_name)" );
+            engine.execute( "CREATE INDEX ON :Person(uuid)" );
+            engine.execute( "CREATE INDEX ON :Address(uuid)" );
+            engine.execute( "CREATE INDEX ON :Phone(number)" );
+            tx.success();
+        }
+
+        Random random = new Random( System.currentTimeMillis() );
+
+        for ( int i = 0; i < Integer.MAX_VALUE; i++ )
+        {
+            System.out.println( "====== Start " + i + " ======" );
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                updatePeople( i, people, nrPeople );
+                for ( int j = 0; j < nrPeople; j++ )
+                {
+                    Map<String, String> address1 = addresses[random.nextInt( nrAddresses )];
+                    Map<String, String> address2 = addresses[random.nextInt( nrAddresses )];
+                    String phone = phones[random.nextInt( nrPhones )];
+
+                    engine.execute( "CREATE (n:Person {props})",
+                            Collections.<String, Object>singletonMap( "props", people[j] ) );
+                    engine.execute( "MERGE (n: Address {uuid: {props}.uuid}) ON CREATE SET n = {props}",
+                            Collections.<String, Object>singletonMap( "props", address1 ) );
+                    engine.execute( "MERGE (n: Address {uuid: {props}.uuid}) ON CREATE SET n = {props}",
+                            Collections.<String, Object>singletonMap( "props", address2 ) );
+                    engine.execute( "MERGE (n: Phone {number: {number}}) ",
+                            Collections.<String, Object>singletonMap( "number", phone ) );
+
+                    Map<String, Object> params = new HashMap<>();
+                    params.put( "person_uuid", people[j].get( "uuid" ) );
+                    params.put( "addr1_uuid", address1.get( "uuid" ) );
+                    params.put( "addr2_uuid", address2.get( "uuid" ) );
+                    params.put( "phone_number", phone );
+
+                    engine.execute(
+                            "MATCH (person: Person {uuid: {person_uuid}})," +
+                                    "      (addr1: Address {uuid: {addr1_uuid}})," +
+                                    "      (addr2: Address {uuid: {addr2_uuid}})," +
+                                    "      (phone: Phone {number: {phone_number}})" +
+                                    "CREATE (person)-[: ADDRESS]->(addr1)," +
+                                    "       (person)-[: ADDRESS]->(addr2)," +
+                                    "       (person)-[: PHONE]->(phone) ",
+                            params
+                    );
+                }
+                tx.success();
+            }
+            System.out.println( "====== End " + i + " ======" );
+        }
+
+        db.shutdown();
+    }
+
+    private static void updatePeople( int it, Map<String, String>[] people, int nrPeople )
+    {
+        for ( int i = 0; i < nrPeople; i++ )
+        {
+            people[i] = new HashMap<>();
+            people[i].put( "first_name", "NAME" + i + it );
+            people[i].put( "last_name", "SURNAME" + i + it );
+            people[i].put( "email", "EMAIL$i$it" + i + it );
+            people[i].put( "text", "TEST" + i + it );
+            people[i].put( "uuid", "PUUID" + i + it );
+        }
+    }
+}


### PR DESCRIPTION
The leak was caused by the fact that when inserting new data in the cache
noone is cleaning up the old GCed values still present in the cache.
Indeed the cleanup was triggered only by updating existing node which have
been GCed or at some extend by getting GCed values.

This PR also tries to improve the polling when during get/remove by looking
to the whole queue instead of just removing the single element.
