### PR TITLE
Fix state bug from upgrading a shared lock using tryExclusive()

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -198,4 +198,17 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
         // And other clients are denied it
         assertFalse( clientB.trySharedLock( NODE, 1l ) );
     }
+
+    @Test
+    public void shouldUpgradeExclusiveOnTry() throws Exception
+    {
+        // Given I've grabbed a shared lock
+        clientA.acquireShared( NODE, 1l );
+
+        // When
+        assertTrue( clientA.tryExclusiveLock( NODE, 1l ) );
+
+        // Then I should be able to release it
+        clientA.releaseExclusive( NODE, 1l );
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
@@ -223,7 +223,8 @@ public class ForsetiClient implements Locks.Client
                         if(sharedLock.numberOfHolders() == 1)
                         {
                             lockMap.put( resourceId, myExclusiveLock );
-                            return true;
+                            heldLocks.put( resourceId, 1 );
+                            continue;
                         }
                         else
                         {


### PR DESCRIPTION
If a shared lock is held when tryExclusive was called, the local lock
state in the client would not be updated properly, instead the call would
return early from this code path. It should have continued the loop to acquire
locks, and it should have updated the local lock map state.

Now it does, this appears to have been a copy-paste error.
