### PR TITLE
Updated changelogs in preperation for 2.1.3

### DIFF
--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,6 +1,7 @@
 2.1.3
 -----
 o Adds support for Octal literals (using a preceding 0, e.g. 03517)
+o Adds support for Hexadecimal literals (using a preceding 0x, e.g. 0xF0071E55)
 o Add `exists(...)` predicate function for checking patterns and properties
 o Ensure `toString(...)` only does type conversion
 

--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,3 +1,14 @@
+2.1.3
+-----
+o Fixed a bug where the BatchInserter would generate inconsistent uniqueness
+  constraints.
+o Fixed a bug where relationships sometimes were not loaded up for nodes that
+  has many relationships in one direction, and none in the other direction.
+o Fixes a memory leak in the object cache when the database was only creating
+  new entities, i.e. when not reading or updating existing entities.
+o Adds support for upgrading directly from 1.9 stores, in addition to the
+  existing ability to upgrade from 2.0 stores.
+
 2.1.2
 -----
 o Resolves a recovery issue, where multiple crashes in a row without clean shutdown or log rotation
@@ -439,7 +450,7 @@ o Fixed performance bug when loading relationship chains that caused the arrays 
 o Added the ability to auto index properties for database primitives
 o Locks on database primitives acquired by neostore XAResources are now released during afterCompletion()
   of the global transaction. This allows for nodes and relationships to be used as monitors in distributed
-  settings. 
+  settings.
 
 1.4.M03 (2011-05-26)
 --------------------
@@ -456,7 +467,7 @@ o Changed the default implementation of the logical log to a DirectMappedLogBuff
 o Changed the TxLog to use a DirectMappedLogBuffer instead of its ad hoc implementation.
 o Added a configuration parameter (Config.USE_MEMORY_MAPPED_LOG) for controlling the log implementation (mmapped vs buffered)
   separately from the store files with a default value of 'false'.
-  
+
 1.3.M05 (2011-03-24)
 --------------------
 o Added support for HA and backup on Windows.
@@ -585,11 +596,11 @@ o Read only operations can now execute without a transaction.
 
 -API
 o Added a method to get the GraphDatabaseService on Node and Relationship.
-o Moved the commons component utilities into kernel component, 
+o Moved the commons component utilities into kernel component,
   see helpers package.
 
 -Bug fixes
-o Fixed issues with logical log and active log that could cause recovery 
+o Fixed issues with logical log and active log that could cause recovery
   to throw an exception.
 o Fixed buffer overflow for large string/array properties.
 o Fixed bug that could cause leak of NodeImpl.
@@ -598,25 +609,25 @@ o Fixed bug that could cause leak of NodeImpl.
 1.0 (2010-02-16)
 ----------------
 
--API 
+-API
 o Updated javadoc.
 
 -Bug fixes
 o Fixed leak of non committed property changes to other transactions.
 o Fixed cache duplication bug of relationships.
-o Fixed problem that could cause other exception to be thrown than 
+o Fixed problem that could cause other exception to be thrown than
   NotFoundException on getNodeById/RelationshipById.
-o Fixed problem with recovery when LuceneFulltextIndex entries existed 
+o Fixed problem with recovery when LuceneFulltextIndex entries existed
   in global transaction log.
 o BatchInserter now throws exception when trying to create a relationship
   with same start and end node.
-o Fixed problem with broken entries in logical log that could cause recovery 
+o Fixed problem with broken entries in logical log that could cause recovery
   to throw an exception.
 
 1.0-rc (2010-01-10)
 ------------------
 
-o API: moved API to org.neo4j.grapdb and implementation to 
+o API: moved API to org.neo4j.grapdb and implementation to
   org.neo4j.kernel.impl
 
 1.0-b11 (2009-12-27)
@@ -635,22 +646,22 @@ o Fixed some bugs in batch inserter.
 --------------------
 
 -Enhancements, new features and major changes
-o Core: Read-only mode. It is now possible to start multiple read only 
+o Core: Read-only mode. It is now possible to start multiple read only
   NeoServices to the same store (using EmbeddedReadOnlyNeo).
-o Core:  Improved depth first traversal speed on nodes with many 
+o Core:  Improved depth first traversal speed on nodes with many
   relationships by loading relationships on demand. This will also
   reduce the stress on GC when traversing over a node with many
   relationships since much fewer objects will be created.
 
 -Minor enhancements, changes and tweaks
 o Core: Faster rebuild of id generators after a crash
-o Core: Exception cleanup removing bad code either catching Throwable or 
+o Core: Exception cleanup removing bad code either catching Throwable or
   throwing RuntimeException.
-o Core: Fixed so a read only NeoService can apply a logical log from a 
+o Core: Fixed so a read only NeoService can apply a logical log from a
   backup.
 
 -Bug Fixes
-o Fixed a bug when using plain buffers instead of memory mapped ones that 
+o Fixed a bug when using plain buffers instead of memory mapped ones that
   could case recovery to fail due to buffers not being flushed properly.
 
 
@@ -700,7 +711,7 @@ o Core: Removed event manager dependency since it needs a rewrite (event
 o Core: Transaction events have been removed, need proper specification.
 o Core: Removed read lock on loading of non-cached node/relationship,
   replaced with reentrant lock stripe.
-o Core: Persistence row windows in nioneo now only load data if acquired for 
+o Core: Persistence row windows in nioneo now only load data if acquired for
   read operation.
 o Core: Upgraded to JTA 1.1
 o Core: Improved some error messages.
@@ -711,16 +722,16 @@ o Core: Increased default block size for string and array stores to better
 
 -Bug fixes
 o Core: Fixed missing close on TM's active log file.
-o Core: A bug with copy on write "diff" maps that could cause wrong cached value 
+o Core: A bug with copy on write "diff" maps that could cause wrong cached value
   to be read (for both properties and relationships) has been fixed.
 o Core: Fixed an issue with non committed properties/relationships
-  modifications leaking to other transactions (in cache layer during cache 
+  modifications leaking to other transactions (in cache layer during cache
   resize).
 o Core: Fixed bug in property index manager that could cause created index
   not to be published at the right time.
 o Core: Fixed bug that allowed for relationship/property loads on deleted
   node (in same tx).
-o Core: Fixed some bugs caused by use of JTA tx synchronization hooks (we can't 
+o Core: Fixed some bugs caused by use of JTA tx synchronization hooks (we can't
   use them when ordering is required).
 o Core: Fixed bug with relationship type store not handling "holes" correctly.
 o Core: Fixed problem with multiple calls to close() on XaDataSources
@@ -749,14 +760,14 @@ o API: NotFound and NotInTransaction runtime exceptions have been moved from
 o API: getRelationshipById is now exposed in NeoService.
 o API: A common base interface for Node and Relationship has been added that
   contains the set/get/remove property operations.
-o Core: Made it easy to embed Neo4j in a Spring application. Spring can also be 
+o Core: Made it easy to embed Neo4j in a Spring application. Spring can also be
   configured to use Neo4j's transaction manager.
 o Core: All known bugs have been fixed.
 o Core: Removed singletons and made everything IoC.
 o Core: Lots of minor optimization and improvements above native store
   layer (nioneo).
 o Core: Cleanup of code (removed non used code) and improved exception handling.
-o Core: Improved read performance and parallelism by implementing MVCC-like 
+o Core: Improved read performance and parallelism by implementing MVCC-like
   features. No locks are now taken during read-only operations, instead
   concurrent operations are working against snapshot versions. Rather than full
   versioning, for higher performance diffs are kept and applied to the right

--- a/enterprise/ha/CHANGES.txt
+++ b/enterprise/ha/CHANGES.txt
@@ -1,3 +1,16 @@
+2.1.3
+-----
+o Fixes a bug where instances could not join a cluster if their transaction log
+  files were not sufficiently recent.
+o Fixes a bug where a cluster instance could not participate in leader elections
+  after it had resurfaced from a crash.
+o Fixes a bug that could lead to constraints suddenly missing their associated
+  indexes after a mode switch in HA.
+o Fixes a data race bug in the Enterprise (Forseti) LockManager, that could lead
+  to transactions mistakenly failing with IllegalStateExceptions.
+o Fixes a bug in the Enterprise (Forseti) LockManager where explicit shared
+  locks could not be properly upgraded to exclusive locks.
+
 2.1.2
 -----
 o Fixes issue with Forseti lock manager, which could miss grabbing
@@ -69,7 +82,7 @@ o The master instance will now always send out masterIsAvailable messages in res
   SLAVE
 o Master instance now properly blocks transactions from starting after shutdown has started and
   waits on a timeout for running transactions to finish and be pushed to slaves before stopping
-  completely. 
+  completely.
 
 1.9.3
 -----
@@ -103,7 +116,7 @@ o Conflicting server IDs in a cluster will now make the latest joining instance 
 --------------------
 o Lifecycle improvements, with proper removal of listeners on shutdown
 o Cluster snapshot synchronization used for HA cluster membership
-o Implements JMX changes  
+o Implements JMX changes
 o IdGenerators instantiated properly in ModeSwitcher
 o ZooKeeper compatibility layer introduced, allows for rolling upgrades from 1.8
 o Ability to join a cluster even if there's an existing and empty database with a mismatching store ID.
@@ -126,7 +139,7 @@ o Master recovery in clusters with only one instance master capable will now alw
 
 1.8.M06 (2012-07-06)
 --------------------
-o Added transaction push factor that can be configured with amount of slaves to push transactions to. The master will 
+o Added transaction push factor that can be configured with amount of slaves to push transactions to. The master will
   optimistically push each transaction before tx.finish completes to reduce risk of branched data.
 o Added the ability for rolling upgrades from versions 1.5.3 onwards.
 o Changed the way master election notification and data gathering works, leading to massively reduced writing of data to
@@ -216,10 +229,10 @@ o How to handle cases of branched data is configurable: keep all, keep last, kee
 o Rotates logs before internal restart (slave->master or master->slave) to reduce potential recovery (i.e. switch) times.
 o Does some additional repairing of neostore fail after a full store copy from master so that log version is synced.
 
-1.4.M03 (2011-05-26) 
+1.4.M03 (2011-05-26)
 --------------------
 o Fixed bug that did not rollback tx associated with dead channels.
-o Modified master election algo to be more robust against zookeeper hiccups.                          
+o Modified master election algo to be more robust against zookeeper hiccups.
 o Fixed a synchronization bug in ZooClient that could cause waits on wrong monitor.
 
 1.4.M02 (2011-05-12)
@@ -279,4 +292,3 @@ o Shuts down databases after verifying them.
 ------------------------
 
 o initial release
-

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -1,5 +1,23 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
 
+2.1.3
+-----
+Cypher:
+o Adds support for Octal literals (using a preceding 0, e.g. 03517)
+o Adds support for Hexadecimal literals (using a preceding 0x, e.g. 0xF0071E55)
+o Add `exists(...)` predicate function for checking patterns and properties
+o Ensure `toString(...)` only does type conversion
+
+Kernel:
+o Fixed a bug where the BatchInserter would generate inconsistent uniqueness
+  constraints.
+o Fixed a bug where relationships sometimes were not loaded up for nodes that
+  has many relationships in one direction, and none in the other direction.
+o Fixes a memory leak in the object cache when the database was only creating
+  new entities, i.e. when not reading or updating existing entities.
+o Adds support for upgrading directly from 1.9 stores, in addition to the
+  existing ability to upgrade from 2.0 stores.
+
 2.1.2
 -----
 Cypher:
@@ -51,7 +69,7 @@ o Fixes problem where predicates are evaluated wrongly in NOT
 o Fixes problem when WITH introduces a symbol that shadows an existing identifier
 
 2.1.0-RC2
---------- 
+---------
 Kernel:
 o Fixes issue where store upgrade could leave relationship ids to be reused by
   subsequent usage of the database

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -1,5 +1,23 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
 
+2.1.3
+-----
+Cypher:
+o Adds support for Octal literals (using a preceding 0, e.g. 03517)
+o Adds support for Hexadecimal literals (using a preceding 0x, e.g. 0xF0071E55)
+o Add `exists(...)` predicate function for checking patterns and properties
+o Ensure `toString(...)` only does type conversion
+
+Kernel:
+o Fixed a bug where the BatchInserter would generate inconsistent uniqueness
+  constraints.
+o Fixed a bug where relationships sometimes were not loaded up for nodes that
+  has many relationships in one direction, and none in the other direction.
+o Fixes a memory leak in the object cache when the database was only creating
+  new entities, i.e. when not reading or updating existing entities.
+o Adds support for upgrading directly from 1.9 stores, in addition to the
+  existing ability to upgrade from 2.0 stores.
+
 2.1.2
 -----
 Cypher:
@@ -51,7 +69,7 @@ o Fixes problem where predicates are evaluated wrongly in NOT
 o Fixes problem when WITH introduces a symbol that shadows an existing identifier
 
 2.1.0-RC2
---------- 
+---------
 Kernel:
 o Fixes issue where store upgrade could leave relationship ids to be reused by
   subsequent usage of the database

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -1,5 +1,35 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
 
+2.1.3
+-----
+Cypher:
+o Adds support for Octal literals (using a preceding 0, e.g. 03517)
+o Adds support for Hexadecimal literals (using a preceding 0x, e.g. 0xF0071E55)
+o Add `exists(...)` predicate function for checking patterns and properties
+o Ensure `toString(...)` only does type conversion
+
+Kernel:
+o Fixed a bug where the BatchInserter would generate inconsistent uniqueness
+  constraints.
+o Fixed a bug where relationships sometimes were not loaded up for nodes that
+  has many relationships in one direction, and none in the other direction.
+o Fixes a memory leak in the object cache when the database was only creating
+  new entities, i.e. when not reading or updating existing entities.
+o Adds support for upgrading directly from 1.9 stores, in addition to the
+  existing ability to upgrade from 2.0 stores.
+
+HA:
+o Fixes a bug where instances could not join a cluster if their transaction log
+  files were not sufficiently recent.
+o Fixes a bug where a cluster instance could not participate in leader elections
+  after it had resurfaced from a crash.
+o Fixes a bug that could lead to constraints suddenly missing their associated
+  indexes after a mode switch in HA.
+o Fixes a data race bug in the Enterprise (Forseti) LockManager, that could lead
+  to transactions mistakenly failing with IllegalStateExceptions.
+o Fixes a bug in the Enterprise (Forseti) LockManager where explicit shared
+  locks could not be properly upgraded to exclusive locks.
+
 2.1.2
 -----
 Cypher:
@@ -67,7 +97,7 @@ o Slave only instances will not become coordinators under any
   circumstances
 
 2.1.0-RC2
---------- 
+---------
 Kernel:
 o Fixes issue where store upgrade could leave relationship ids to be reused by
   subsequent usage of the database


### PR DESCRIPTION
Apparently also includes removal of a bunch of trailing spaces because the Atom editor felt like doing that.
