### PR TITLE
Central transaction repository

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel;
 
-import static org.neo4j.helpers.Listeners.notifyListeners;
-import static org.neo4j.helpers.collection.Iterables.join;
-
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +27,9 @@ import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
+
+import static org.neo4j.helpers.Listeners.notifyListeners;
+import static org.neo4j.helpers.collection.Iterables.join;
 
 /**
  * The availability guard is what ensures that the database will only take calls when it is in an ok state. It allows
@@ -56,6 +56,18 @@ public class AvailabilityGuard
     public interface AvailabilityRequirement
     {
         String description();
+    }
+
+    public static AvailabilityRequirement availabilityRequirement( final String descriptionWhenBlocking )
+    {
+        return new AvailabilityRequirement()
+        {
+            @Override
+            public String description()
+            {
+                return descriptionWhenBlocking;
+            }
+        };
     }
 
     private Iterable<AvailabilityListener> listeners = Listeners.newListeners();

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.kernel;
 
-import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 
 /**
  * This class handles whether the database as a whole is available to use at all.
@@ -61,11 +62,14 @@ public class DatabaseAvailability
         // Deny beginning new transactions
         availabilityGuard.deny(this);
 
-        // TODO make stop-deadline configurable
-        long deadline = Clock.SYSTEM_CLOCK.currentTimeMillis() + 20 * 1000;
+        // Await transactions stopped
+        awaitNoTransactionsOr( 10_000  /* ms */);
+    }
 
-        while ( transactionMonitor.getNumberOfActiveTransactions() > 0 &&
-                Clock.SYSTEM_CLOCK.currentTimeMillis() < deadline)
+    private void awaitNoTransactionsOr( int orUntilDeadline )
+    {
+        long deadline = SYSTEM_CLOCK.currentTimeMillis() + orUntilDeadline;
+        while ( transactionMonitor.getNumberOfActiveTransactions() > 0 && SYSTEM_CLOCK.currentTimeMillis() < deadline)
         {
             Thread.yield();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -19,13 +19,12 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import static java.lang.System.currentTimeMillis;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -59,6 +58,8 @@ import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 
+import static java.lang.System.currentTimeMillis;
+
 /**
  * This class should replace the {@link org.neo4j.kernel.api.KernelTransaction} interface, and take its name, as soon as
  * {@code TransitionalTxManagementKernelTransaction} is gone from {@code server}.
@@ -76,25 +77,26 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private final UpdateableSchemaState schemaState;
     private final StatementOperationParts operations;
     private final boolean readOnly;
+    private Locks.Client locks;
 
     // State
-    private final Locks.Client locks;
-    private TransactionType transactionType = TransactionType.ANY;
-    private boolean closing, closed;
-    private TxStateImpl txState;
-    private TransactionHooks.TransactionHooksState hooksState;
     private final TransactionRecordState recordState;
+    private TxStateImpl txState;
+    private TransactionType transactionType = TransactionType.ANY;
+    private TransactionHooks.TransactionHooksState hooksState;
+    private boolean closing, closed;
     private boolean failure, success;
     private volatile boolean terminated;
 
     // For committing
-    private final TransactionHeaderInformation headerInformation;
+    private TransactionHeaderInformation headerInformation;
     private final TransactionCommitProcess commitProcess;
     private final TransactionMonitor transactionMonitor;
     private final TransactionIdStore transactionIdStore;
     private final PersistenceCache persistenceCache;
     private final StoreReadLayer storeLayer;
     private final LegacyIndexTransactionState legacyIndexTransactionState;
+    private final Pool<KernelTransactionImplementation> pool;
 
     public KernelTransactionImplementation( StatementOperationParts operations, boolean readOnly,
                                             SchemaWriteGuard schemaWriteGuard, LabelScanStore labelScanStore,
@@ -110,7 +112,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             TransactionIdStore transactionIdStore,
                                             PersistenceCache persistenceCache,
                                             StoreReadLayer storeLayer,
-                                            LegacyIndexTransactionState legacyIndexTransaction )
+                                            LegacyIndexTransactionState legacyIndexTransaction,
+                                            Pool<KernelTransactionImplementation> pool)
     {
         this.operations = operations;
         this.readOnly = readOnly;
@@ -130,7 +133,21 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.persistenceCache = persistenceCache;
         this.storeLayer = storeLayer;
         this.legacyIndexTransactionState = legacyIndexTransaction;
+        this.pool = pool;
         this.schemaStorage = new SchemaStorage( neoStore.getSchemaStore() );
+    }
+
+    /** Reset this transaction to a vanilla state, turning it into a logically new transaction. */
+    public KernelTransactionImplementation initialize( TransactionHeaderInformation txHeader, long lastCommittedTx )
+    {
+        this.headerInformation = txHeader;
+        this.terminated = closing = closed = failure = success = false;
+        this.transactionType = TransactionType.ANY;
+        this.hooksState = null;
+        this.txState = null; // TODO: Implement txState.clear() instead, to re-use data structures
+        this.legacyIndexTransactionState.initialize();
+        this.recordState.initialize( lastCommittedTx );
+        return this;
     }
 
     @Override
@@ -160,11 +177,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             terminated = true;
             transactionMonitor.transactionTerminated();
         }
-    }
-
-    private void release()
-    {
-        locks.close();
     }
 
     /** Implements reusing the same underlying {@link KernelStatement} for overlapping statements. */
@@ -650,5 +662,30 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             transactionMonitor.transactionFinished( false );
         }
+    }
+
+    /** Release resources held up by this transaction & return it to the transaction pool. */
+    private void release()
+    {
+        locks.releaseAll();
+        pool.release( this );
+    }
+
+    /**
+     * To be called if this transaction is to be thrown away entirely. This is important, as without this call
+     * lock clients will not be returned to their pool.
+     */
+    public void dispose()
+    {
+        if(locks != null)
+        {
+            locks.close();
+        }
+
+        this.locks = null;
+        this.headerInformation = null;
+        this.transactionType = null;
+        this.hooksState = null;
+        this.txState = null;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.neo4j.collection.pool.LinkedQueuePool;
+import org.neo4j.collection.pool.MarshlandPool;
+import org.neo4j.function.Factory;
+import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.helpers.Provider;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
+import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionState;
+import org.neo4j.kernel.impl.api.store.PersistenceCache;
+import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.xa.IntegrityValidator;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransactionContext;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransactionContextSupplier;
+import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.util.Collections.newSetFromMap;
+
+/**
+ * Central source of transactions in the database.
+ *
+ * This class maintains references to all transactions, a pool of passive kernel transactions, and provides capabilities
+ * for enumerating all running transactions. During normal operation, acquiring new transactions and enumerating live
+ * ones requires no synchronization (although the live list is not guaranteed to be exact).
+ */
+public class KernelTransactions extends LifecycleAdapter implements Factory<KernelTransaction>
+{
+    // Transaction dependencies
+
+    private final NeoStoreTransactionContextSupplier neoStoreTransactionContextSupplier;
+    private final NeoStore neoStore;
+    private final Locks locks;
+    private final IntegrityValidator integrityValidator;
+    private final ConstraintIndexCreator constraintIndexCreator;
+    private final IndexingService indexingService;
+    private final LabelScanStore labelScanStore;
+    private final StatementOperationParts statementOperations;
+    private final UpdateableSchemaState updateableSchemaState;
+    private final SchemaWriteGuard schemaWriteGuard;
+    private final SchemaIndexProviderMap providerMap;
+    private final TransactionHeaderInformationFactory transactionHeaderInformationFactory;
+    private final PersistenceCache persistenceCache;
+    private final StoreReadLayer storeLayer;
+    private final Provider<TransactionCommitProcess> commitProcessProvider;
+    private final IndexConfigStore indexConfigStore;
+    private final LegacyIndexApplier.ProviderLookup legacyIndexProviderLookup;
+    private final TransactionHooks hooks;
+    private final TransactionMonitor transactionMonitor;
+    private final LifeSupport dataSourceLife;
+    private final boolean readOnly;
+
+    // End Tx Dependencies
+
+    /**
+     * Used to enumerate all transactions in the system, active and idle ones.
+     *
+     * This data structure is *only* updated when brand-new transactions are created, or when transactions are disposed
+     * of. During normal operation (where all transactions come from and are returned to the pool), this will be left
+     * in peace, working solely as a collection of references to all transaction objects (idle and active) in the
+     * database.
+     *
+     * As such, it provides a good mechanism for listing all transactions without requiring synchronization when
+     * starting and committing transactions.
+     */
+    private final Set<KernelTransactionImplementation> allTransactions = newSetFromMap(
+            new ConcurrentHashMap<KernelTransactionImplementation, Boolean>() );
+
+    /**
+     * This is the factory that actually builds brand-new instances.
+     */
+    private final Factory<KernelTransactionImplementation> factory = new Factory<KernelTransactionImplementation>()
+    {
+        @Override
+        public KernelTransactionImplementation newInstance()
+        {
+            NeoStoreTransactionContext context = neoStoreTransactionContextSupplier.acquire();
+            Locks.Client locksClient = locks.newClient();
+            context.bind( locksClient );
+            TransactionRecordState neoStoreTransaction = new TransactionRecordState(
+                    neoStore.getLastCommittingTransactionId(), neoStore, integrityValidator, context );
+            LegacyIndexTransactionState legacyIndexTransactionState =
+                    new LegacyIndexTransactionState( indexConfigStore, legacyIndexProviderLookup );
+            KernelTransactionImplementation tx = new KernelTransactionImplementation(
+                    statementOperations, readOnly, schemaWriteGuard,
+                    labelScanStore, indexingService, updateableSchemaState, neoStoreTransaction, providerMap,
+                    neoStore, locksClient, hooks, constraintIndexCreator, transactionHeaderInformationFactory.create(),
+                    commitProcessProvider.instance(), transactionMonitor, neoStore, persistenceCache, storeLayer,
+                    legacyIndexTransactionState, localTxPool );
+
+            allTransactions.add( tx );
+
+            return tx;
+        }
+    };
+
+    /**
+     * Global pool of transactions, wrapped by the thread-local marshland pool and so is not used directly.
+     */
+    private final LinkedQueuePool<KernelTransactionImplementation> globalTxPool
+            = new LinkedQueuePool<KernelTransactionImplementation>( 8, factory )
+    {
+        @Override
+        protected void dispose( KernelTransactionImplementation tx )
+        {
+            allTransactions.remove( tx );
+            tx.dispose();
+            super.dispose( tx );
+        }
+    };
+
+    /**
+     * Pool of unused transactions.
+     */
+    private final MarshlandPool<KernelTransactionImplementation> localTxPool = new MarshlandPool<>( globalTxPool );
+
+    public KernelTransactions( NeoStoreTransactionContextSupplier neoStoreTransactionContextSupplier,
+                               NeoStore neoStore, Locks locks, IntegrityValidator integrityValidator,
+                               ConstraintIndexCreator constraintIndexCreator,
+                               IndexingService indexingService, LabelScanStore labelScanStore,
+                               StatementOperationParts statementOperations,
+                               UpdateableSchemaState updateableSchemaState, SchemaWriteGuard schemaWriteGuard,
+                               SchemaIndexProviderMap providerMap, TransactionHeaderInformationFactory txHeaderFactory,
+                               PersistenceCache persistenceCache, StoreReadLayer storeLayer,
+                               Provider<TransactionCommitProcess> commitProcessProvider,
+                               IndexConfigStore indexConfigStore, LegacyIndexApplier.ProviderLookup legacyIndexProviderLookup,
+                               TransactionHooks hooks, TransactionMonitor transactionMonitor, LifeSupport dataSourceLife, boolean readOnly )
+    {
+        this.neoStoreTransactionContextSupplier = neoStoreTransactionContextSupplier;
+        this.neoStore = neoStore;
+        this.locks = locks;
+        this.integrityValidator = integrityValidator;
+        this.constraintIndexCreator = constraintIndexCreator;
+        this.indexingService = indexingService;
+        this.labelScanStore = labelScanStore;
+        this.statementOperations = statementOperations;
+        this.updateableSchemaState = updateableSchemaState;
+        this.schemaWriteGuard = schemaWriteGuard;
+        this.providerMap = providerMap;
+        this.transactionHeaderInformationFactory = txHeaderFactory;
+        this.persistenceCache = persistenceCache;
+        this.storeLayer = storeLayer;
+        this.commitProcessProvider = commitProcessProvider;
+        this.indexConfigStore = indexConfigStore;
+        this.legacyIndexProviderLookup = legacyIndexProviderLookup;
+        this.hooks = hooks;
+        this.transactionMonitor = transactionMonitor;
+        this.dataSourceLife = dataSourceLife;
+        this.readOnly = readOnly;
+    }
+
+    @Override
+    public KernelTransaction newInstance()
+    {
+        assertDatabaseIsRunning();
+        return localTxPool.acquire().initialize(
+                transactionHeaderInformationFactory.create(),
+                neoStore.getLastCommittingTransactionId());
+    }
+
+    /**
+     * Give an approximate list of all transactions currently running. This is not guaranteed to be exact, as
+     * transactions may stop and start while this list is gathered.
+     */
+    public List<KernelTransaction> activeTransactions()
+    {
+        List<KernelTransaction> output = new ArrayList<>();
+        for ( KernelTransactionImplementation tx : allTransactions )
+        {
+            if(tx.isOpen())
+            {
+                output.add( tx );
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Dispose of all pooled transactions. This is done on shutdown or on internal events (like an HA mode switch) that
+     * require transactions to be re-created.
+     */
+    public void disposeAll()
+    {
+        for ( KernelTransactionImplementation tx : allTransactions )
+        {
+            if(tx.isOpen())
+            {
+                tx.markForTermination();
+            }
+        }
+        localTxPool.disposeAll();
+        globalTxPool.disposeAll();
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        disposeAll();
+    }
+
+    private void assertDatabaseIsRunning()
+    {
+        // TODO: Copied over from original source in NeoXADS - this should probably use DBAvailability, rather than this.
+        // Note, if you change this, you need a separate mechanism to stop transactions from being started during
+        // Kernel#stop().
+        if ( !dataSourceLife.isRunning() )
+        {
+            throw new DatabaseShutdownException();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
+import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -42,11 +43,11 @@ import static java.util.Collections.singleton;
 public class ConstraintIndexCreator
 {
     private final IndexingService indexingService;
-    private final KernelAPI kernel;
+    private final Provider<KernelAPI> kernel;
 
-    public ConstraintIndexCreator( KernelAPI kernel, IndexingService indexingService )
+    public ConstraintIndexCreator( Provider<KernelAPI> kernelProvider, IndexingService indexingService )
     {
-        this.kernel = kernel;
+        this.kernel = kernelProvider;
         this.indexingService = indexingService;
     }
 
@@ -93,7 +94,7 @@ public class ConstraintIndexCreator
     public void dropUniquenessConstraintIndex( IndexDescriptor descriptor )
             throws TransactionFailureException, DropIndexFailureException
     {
-        try ( KernelTransaction transaction = kernel.newTransaction();
+        try ( KernelTransaction transaction = kernel.instance().newTransaction();
              Statement statement = transaction.acquireStatement() )
         {
             // NOTE: This creates the index (obviously) but it DOES NOT grab a schema
@@ -138,7 +139,7 @@ public class ConstraintIndexCreator
 
     public IndexDescriptor createConstraintIndex( final int labelId, final int propertyKeyId )
     {
-        try ( KernelTransaction transaction = kernel.newTransaction();
+        try ( KernelTransaction transaction = kernel.instance().newTransaction();
               Statement statement = transaction.acquireStatement() )
         {
             // NOTE: This creates the index (obviously) but it DOES NOT grab a schema

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionState.java
@@ -240,4 +240,14 @@ public class LegacyIndexTransactionState implements IndexCommandFactory
     {
         return defineCommand == null;
     }
+
+    /** Set this datastructure to it's initial state, allowing it to be re-used as if it had just been new'ed up. */
+    public LegacyIndexTransactionState initialize()
+    {
+        transactions.clear();
+        defineCommand = null;
+        nodeCommands = null;
+        relationshipCommands = null;
+        return this;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -52,9 +53,9 @@ public class LegacyIndexStore
     private final IndexConfigStore indexStore;
     private final Config config;
     private final ProviderLookup indexProviders;
-    private final KernelAPI kernel;
+    private final Provider<KernelAPI> kernel;
 
-    public LegacyIndexStore( Config config, IndexConfigStore indexStore, KernelAPI kernel,
+    public LegacyIndexStore( Config config, IndexConfigStore indexStore, Provider<KernelAPI> kernel,
             LegacyIndexApplier.ProviderLookup indexProviders )
     {
         this.config = config;
@@ -236,7 +237,7 @@ public class LegacyIndexStore
         public Object call()
                 throws Exception
         {
-            try ( KernelTransaction transaction = kernel.newTransaction();
+            try ( KernelTransaction transaction = kernel.instance().newTransaction();
                     Statement statement = transaction.acquireStatement() )
             {
                 transaction.getLegacyIndexTransactionState().createIndex( entityType, indexName, config );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionContext.java
@@ -136,6 +136,11 @@ public class NeoStoreTransactionContext
         locker.setLockClient( locksClient );
     }
 
+    public void initialize()
+    {
+        recordChangeSet.close();
+    }
+
     public void close()
     {
         recordChangeSet.close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.config.Setting;
@@ -37,7 +36,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.graphdb.index.IndexProviders;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.helpers.Factory;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.Visitor;
@@ -45,7 +43,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.TransactionEventHandlers;
 import org.neo4j.kernel.api.KernelAPI;
-import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -55,7 +52,7 @@ import org.neo4j.kernel.impl.api.ConstraintEnforcingEntityOperations;
 import org.neo4j.kernel.impl.api.DataIntegrityValidatingStatementOperations;
 import org.neo4j.kernel.impl.api.GuardingStatementOperations;
 import org.neo4j.kernel.impl.api.Kernel;
-import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.api.LegacyIndexApplier;
 import org.neo4j.kernel.impl.api.LegacyIndexApplier.ProviderLookup;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
@@ -71,7 +68,6 @@ import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
-import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.statistics.StatisticsService;
 import org.neo4j.kernel.impl.api.statistics.StatisticsServiceRepository;
 import org.neo4j.kernel.impl.api.store.CacheLayer;
@@ -113,13 +109,9 @@ import org.neo4j.kernel.impl.nioneo.store.TokenStore;
 import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.transaction.KernelHealth;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntry;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.xaframework.LogFile;
 import org.neo4j.kernel.impl.transaction.xaframework.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.xaframework.LogPosition;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryStart;
-import org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategy;
 import org.neo4j.kernel.impl.transaction.xaframework.LogRotationControl;
 import org.neo4j.kernel.impl.transaction.xaframework.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFile;
@@ -131,7 +123,11 @@ import org.neo4j.kernel.impl.transaction.xaframework.TransactionHeaderInformatio
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMetadataCache;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
+import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntry;
+import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategy;
 import org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -149,6 +145,7 @@ import static org.neo4j.helpers.collection.IteratorUtil.loop;
 public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRotationControl, IndexProviders
 {
     public static final String DEFAULT_DATA_SOURCE_NAME = "nioneodb";
+    private KernelTransactions kernelTransactions;
 
     @SuppressWarnings( "deprecation" )
     public static abstract class Configuration
@@ -175,21 +172,7 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
     private final UpdateableSchemaState updateableSchemaState;
     private final Config config;
     private final LockService lockService;
-    private LifeSupport life;
-    private KernelAPI kernel;
-    private NeoStore neoStore;
-    private IndexingService indexingService;
-    private SchemaIndexProvider indexProvider;
-    private IntegrityValidator integrityValidator;
-    private NeoStoreFileListing fileListing;
-    private File storeDir;
-    private boolean readOnly;
-    private CacheAccessBackDoor cacheAccess;
-    private AutoLoadingCache<NodeImpl> nodeCache;
-    private AutoLoadingCache<RelationshipImpl> relationshipCache;
-    private PersistenceCache persistenceCache;
-    private SchemaCache schemaCache;
-    private LabelScanStore labelScanStore;
+
     private final IndexingService.Monitor indexingServiceMonitor;
     private final FileSystemAbstraction fs;
     private final StoreUpgrader storeMigrationProcess;
@@ -198,25 +181,33 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
     private final TxIdGenerator txIdGenerator;
     private final TransactionHeaderInformationFactory transactionHeaderInformationFactory;
     private final StartupStatisticsProvider startupStatistics;
-    private CacheLayer storeLayer;
     private final Caches cacheProvider;
     private final NodeManager nodeManager;
     private final CommitProcessFactory commitProcessFactory;
 
+    private LifeSupport life;
+    private KernelAPI kernel;
+    private NeoStore neoStore;
+    private IndexingService indexingService;
+    private SchemaIndexProvider indexProvider;
+    private NeoStoreFileListing fileListing;
+    private File storeDir;
+    private boolean readOnly;
+    private AutoLoadingCache<NodeImpl> nodeCache;
+    private AutoLoadingCache<RelationshipImpl> relationshipCache;
+    private SchemaCache schemaCache;
+    private LabelScanStore labelScanStore;
+    private CacheLayer storeLayer;
+
     private LogFile logFile;
-    private LogicalTransactionStore logicalTransactionStore;
-    private TransactionCommitProcess commitProcess;
 
     private final AtomicInteger recoveredCount = new AtomicInteger();
-    private StatementOperationParts statementOperations;
     private final Guard guard;
 
     // Legacy index
     private IndexConfigStore indexConfigStore;
-    private LegacyIndexStore legacyIndexStore;
     private final Map<String, IndexImplementation> indexProviders = new HashMap<>();
     private final ProviderLookup legacyIndexProviderLookup;
-    private TransactionRepresentationStoreApplier storeApplier;
 
     private enum Diagnostics implements DiagnosticsExtractor<NeoStoreXaDataSource>
     {
@@ -408,15 +399,16 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
                 relationshipLoader( neoStore.getRelationshipStore() ) );
         RelationshipLoader relationshipLoader = new RelationshipLoader( relationshipCache, new RelationshipChainLoader(
                 neoStore ) );
-        persistenceCache = new PersistenceCache( nodeCache, relationshipCache, nodeManager,
+        PersistenceCache persistenceCache = new PersistenceCache( nodeCache, relationshipCache, nodeManager,
                 relationshipLoader, propertyKeyTokenHolder, relationshipTypeTokens, labelTokens );
-        cacheAccess = new BridgingCacheAccess( schemaCache, updateableSchemaState, persistenceCache );
+        CacheAccessBackDoor cacheAccess = new BridgingCacheAccess( schemaCache, updateableSchemaState,
+                persistenceCache );
         try
         {
             indexingService = new IndexingService( scheduler, providerMap, new NeoStoreIndexStoreView(
                     lockService, neoStore ), tokenNameLookup, updateableSchemaState, indexRuleLoader(), logging,
                     indexingServiceMonitor ); // TODO 2.2-future What index rules should be
-            integrityValidator = new IntegrityValidator( neoStore, indexingService );
+            final IntegrityValidator integrityValidator = new IntegrityValidator( neoStore, indexingService );
             labelScanStore = dependencyResolver.resolveDependency( LabelScanStoreProvider.class,
                     LabelScanStoreProvider.HIGHEST_PRIORITIZED ).getLabelScanStore();
             fileListing = new NeoStoreFileListing( storeDir, labelScanStore, indexingService,
@@ -479,7 +471,8 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
             LogPruneStrategy logPruneStrategy = LogPruneStrategyFactory.fromConfigValue( fs, logFileInformation,
                     logFiles, neoStore, config.get( GraphDatabaseSettings.keep_logical_logs ) );
 
-            storeApplier = dependencies.satisfyDependency( new TransactionRepresentationStoreApplier(
+            final TransactionRepresentationStoreApplier storeApplier = dependencies.satisfyDependency( new
+                    TransactionRepresentationStoreApplier(
                     indexingService, labelScanStore, neoStore,
                     cacheAccess, lockService, legacyIndexProviderLookup, indexConfigStore ) );
 
@@ -491,45 +484,51 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
                     neoStore, new PhysicalLogFile.LoggingMonitor( logging.getMessagesLog( getClass() ) ),
                     this, transactionMetadataCache, logFileRecoverer ) );
 
-            logicalTransactionStore = dependencies.satisfyDependency( LogicalTransactionStore.class,
-                    new PhysicalLogicalTransactionStore( logFile, txIdGenerator,
-                            transactionMetadataCache, logEntryReader, neoStore ) );
+            final LogicalTransactionStore logicalTransactionStore = dependencies.satisfyDependency(
+                    LogicalTransactionStore.class, new PhysicalLogicalTransactionStore( logFile, txIdGenerator,
+                            transactionMetadataCache, logEntryReader, neoStore ));
 
-
-
-
-            Factory<KernelTransaction> transactionFactory = new Factory<KernelTransaction>()
+            Provider<TransactionCommitProcess> commitProcesProvider = new Provider<TransactionCommitProcess>()
             {
                 @Override
-                public KernelTransaction newInstance()
+                public TransactionCommitProcess instance()
                 {
-                    commitProcess = dependencies.satisfyDependency( TransactionCommitProcess.class,
-                            commitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore, storeApplier,
-                                    new NeoStoreInjectedTransactionValidator( integrityValidator ), false ) );
-
-                    checkIfShutdown();
-                    NeoStoreTransactionContext context = neoStoreTransactionContextSupplier.acquire();
-                    Locks.Client locksClient = locks.newClient();
-                    context.bind( locksClient );
-                    TransactionRecordState neoStoreTransaction = new TransactionRecordState(
-                            neoStore.getLastCommittingTransactionId(), neoStore, integrityValidator, context );
-                    ConstraintIndexCreator constraintIndexCreator =
-                            new ConstraintIndexCreator( kernel, indexingService );
-                    LegacyIndexTransactionState legacyIndexTransactionState =
-                            new LegacyIndexTransactionState( indexConfigStore, legacyIndexProviderLookup );
-                    return new KernelTransactionImplementation( statementOperations, readOnly, schemaWriteGuard,
-                            labelScanStore, indexingService, updateableSchemaState, neoStoreTransaction, providerMap,
-                            neoStore, locksClient, hooks, constraintIndexCreator, transactionHeaderInformationFactory.create(),
-                            commitProcess, transactionMonitor, neoStore, persistenceCache, storeLayer,
-                            legacyIndexTransactionState );
+                    return dependencies.satisfyDependency( TransactionCommitProcess.class,
+                            commitProcessFactory.create( logicalTransactionStore, kernelHealth,
+                                    neoStore, storeApplier,
+                                    new NeoStoreInjectedTransactionValidator( integrityValidator ), false )
+                    );
                 }
             };
 
-            kernel = new Kernel( statisticsService, transactionFactory, hooks, kernelHealth, transactionMonitor );
-            legacyIndexStore = new LegacyIndexStore( config, indexConfigStore, kernel, legacyIndexProviderLookup );
+            /*
+             * This is used by two legacy indexes and constraint indexes whenever a transaction is to be spawned
+             * from within an existing transaction. It smells, and we should look over alternatives when time permits.
+             */
+            Provider<KernelAPI> kernelProvider = new Provider<KernelAPI>()
+            {
+                @Override
+                public KernelAPI instance()
+                {
+                    return kernel;
+                }
+            };
 
-            this.statementOperations = buildStatementOperations( storeLayer, legacyPropertyTrackers,
-                    indexingService, kernel, updateableSchemaState, guard, legacyIndexStore );
+            ConstraintIndexCreator constraintIndexCreator = new ConstraintIndexCreator( kernelProvider, indexingService);
+
+            LegacyIndexStore legacyIndexStore = new LegacyIndexStore( config, indexConfigStore, kernelProvider,
+                    legacyIndexProviderLookup );
+
+            StatementOperationParts statementOperations = buildStatementOperations( storeLayer, legacyPropertyTrackers,
+                    constraintIndexCreator, updateableSchemaState, guard, legacyIndexStore );
+
+            kernelTransactions = life.add(new KernelTransactions( neoStoreTransactionContextSupplier,
+                    neoStore, locks, integrityValidator, constraintIndexCreator, indexingService, labelScanStore,
+                    statementOperations, updateableSchemaState, schemaWriteGuard, providerMap,
+                    transactionHeaderInformationFactory, persistenceCache, storeLayer, commitProcesProvider, indexConfigStore,
+                    legacyIndexProviderLookup, hooks, transactionMonitor, life, readOnly ));
+
+            kernel = new Kernel( statisticsService, kernelTransactions, hooks, kernelHealth, transactionMonitor );
 
             life.add( logFile );
             life.add( logicalTransactionStore );
@@ -806,14 +805,14 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
 
     private StatementOperationParts buildStatementOperations(
             StoreReadLayer storeReadLayer, LegacyPropertyTrackers legacyPropertyTrackers,
-            IndexingService indexingService, KernelAPI kernel, UpdateableSchemaState updateableSchemaState,
+            ConstraintIndexCreator constraintIndexCreator, UpdateableSchemaState updateableSchemaState,
             Guard guard, LegacyIndexStore legacyIndexStore )
     {
         // Bottom layer: Read-access to committed data
         StoreReadLayer storeLayer = storeReadLayer;
         // + Transaction state handling
         StateHandlingStatementOperations stateHandlingContext = new StateHandlingStatementOperations( storeLayer,
-                legacyPropertyTrackers, new ConstraintIndexCreator( kernel, indexingService ),
+                legacyPropertyTrackers, constraintIndexCreator,
                 legacyIndexStore );
         StatementOperationParts parts = new StatementOperationParts( stateHandlingContext, stateHandlingContext,
                 stateHandlingContext, stateHandlingContext, stateHandlingContext, stateHandlingContext,
@@ -843,14 +842,6 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
         return parts;
     }
 
-    private void checkIfShutdown()
-    {
-        if ( !life.isRunning() )
-        {
-            throw new DatabaseShutdownException();
-        }
-    }
-
     @Override
     public void registerIndexProvider( String name, IndexImplementation index )
     {
@@ -868,10 +859,15 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
     }
 
     /**
+     * Hook that must be called whenever there is an HA mode switch (eg master/slave switch).
      * This must only be called when the database is otherwise inaccessible.
      */
-    public void reloadSchemaCache()
+    public void afterModeSwitch()
     {
         loadSchemaCache();
+
+        // Stop all running transactions and get rid of all pooled transactions, as they will otherwise reference
+        // components that have been swapped out during the mode switch.
+        kernelTransactions.disposeAll();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RecordChanges.java
@@ -84,6 +84,7 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
     public void close()
     {
         recordChanges.clear();
+        changeCounter.set(0);
     }
 
     @Override
@@ -166,9 +167,14 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
             ensureHasBeforeRecordImage();
             if ( !this.changed )
             {
-                this.allChanges.put( key, this );
+                RecordChange<KEY, RECORD, ADDITIONAL> previous = this.allChanges.put( key, this );
+
+                if(previous == null || !previous.changed)
+                {
+                    changeCounter.increment();
+                }
+
                 this.changed = true;
-                changeCounter.increment();
             }
             return this.record;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/TransactionRecordState.java
@@ -74,11 +74,12 @@ import static org.neo4j.kernel.impl.nioneo.store.labels.NodeLabelsField.parseLab
  */
 public class TransactionRecordState
 {
-    private RecordChanges<Long, NeoStoreRecord, Void> neoStoreRecord;
-    private final long lastCommittedTxWhenTransactionStarted;
     private final NeoStore neoStore;
     private final IntegrityValidator integrityValidator;
     private final NeoStoreTransactionContext context;
+
+    private RecordChanges<Long, NeoStoreRecord, Void> neoStoreRecord;
+    private long lastCommittedTxWhenTransactionStarted;
     private boolean prepared;
 
     /**
@@ -99,6 +100,16 @@ public class TransactionRecordState
         this.neoStore = neoStore;
         this.integrityValidator = integrityValidator;
         this.context = context;
+    }
+
+    /**
+     * Set this record state to a pristine state, acting as if it had never been used.
+     */
+    public void initialize( long lastCommittedTxWhenTransactionStarted )
+    {
+        this.lastCommittedTxWhenTransactionStarted = lastCommittedTxWhenTransactionStarted;
+        context.initialize();
+        prepared = false;
     }
 
     public boolean isReadOnly()
@@ -125,6 +136,7 @@ public class TransactionRecordState
                            context.getRelationshipTypeTokenRecords().changeSize() +
                            context.getRelGroupRecords().changeSize() +
                            (neoStoreRecord != null ? neoStoreRecord.changeSize() : 0);
+
         List<Command> commands = new ArrayList<>( noOfCommands );
         for ( RecordProxy<Integer, LabelTokenRecord, Void> record : context.getLabelTokenRecords().changes() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/TransactionHeaderInformationFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/TransactionHeaderInformationFactory.java
@@ -28,10 +28,13 @@ public interface TransactionHeaderInformationFactory
     public static final TransactionHeaderInformationFactory DEFAULT =
             new TransactionHeaderInformationFactory()
             {
+                private final TransactionHeaderInformation defaultHeader
+                        = new TransactionHeaderInformation( -1, -1, new byte[0] );
+
                 @Override
                 public TransactionHeaderInformation create()
                 {
-                    return new TransactionHeaderInformation( -1, -1, new byte[0] );
+                    return defaultHeader;
                 }
             };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/README
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/README
@@ -1,2 +1,1 @@
-This package contains some Functional classes, but many of them remain in org.neo4j.helpers. This will be the primary
-package for functional tools, as soon as we can move the current helpers into our internal packages.
+This package is being replaced in favor of org.neo4j.function.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/IntCounter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/statistics/IntCounter.java
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.kernel.impl.util.statistics;
 
 /**
@@ -20,5 +39,10 @@ public class IntCounter
     public void decrement()
     {
         count--;
+    }
+
+    public void set( int value )
+    {
+        this.count = value;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -32,15 +31,12 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static java.lang.String.format;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.graphdb.Neo4jMatchers.contains;
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.createIndex;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
@@ -35,7 +36,7 @@ import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
 import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class KernelTransactionFactory
 {
@@ -51,6 +52,6 @@ public class KernelTransactionFactory
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
                 mock( TransactionIdStore.class ), mock( PersistenceCache.class ),
                 mock( StoreReadLayer.class ),
-                mock( LegacyIndexTransactionState.class ) );
+                mock( LegacyIndexTransactionState.class ), mock( Pool.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
@@ -32,12 +32,8 @@ import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 import org.neo4j.test.DoubleLatch;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class KernelTransactionImplementationTest
 {
@@ -317,6 +313,6 @@ public class KernelTransactionImplementationTest
     {
         return new KernelTransactionImplementation( null, false, null, null, null, null, recordState,
                 null, neoStore, new NoOpClient(), hooks, null, null, null, transactionMonitor, neoStore,
-                null, null, legacyIndexState );
+                null, null, legacyIndexState, mock(Pool.class));
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Test;
+import org.neo4j.helpers.Provider;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransactionContext;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransactionContextSupplier;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitorImpl;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
+
+public class KernelTransactionsTest
+{
+    @Test
+    public void shouldListActiveTransactions() throws Exception
+    {
+        // Given
+        LifeSupport life = new LifeSupport();
+        life.start();
+
+        Locks locks = mock( Locks.class );
+        when(locks.newClient()).thenReturn( mock( Locks.Client.class ) );
+
+        KernelTransactions registry = new KernelTransactions(
+                new MockContextSupplier(), mock(NeoStore.class), locks, null, null, null, null, null, null,
+                null, null, TransactionHeaderInformationFactory.DEFAULT, null, null,  mock(Provider.class), null, null,
+                new TransactionHooks(), new TransactionMonitorImpl(), life, false );
+
+        // When
+        KernelTransaction first  = registry.newInstance();
+        KernelTransaction second = registry.newInstance();
+        KernelTransaction third  = registry.newInstance();
+
+        first.close();
+
+        // Then
+        assertThat( asUniqueSet(registry.activeTransactions()), equalTo(asSet( second, third )) );
+    }
+
+    private static class MockContextSupplier extends NeoStoreTransactionContextSupplier
+    {
+        public MockContextSupplier()
+        {
+            super( null );
+        }
+
+        @Override
+        protected NeoStoreTransactionContext create()
+        {
+            return mock(NeoStoreTransactionContext.class);
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
+import org.neo4j.kernel.impl.util.Providers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -76,7 +77,7 @@ public class ConstraintIndexCreatorTest
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getProxyForRule( 2468l ) ).thenReturn( indexProxy );
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( kernel, indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( Providers.<KernelAPI>singletonProvider(kernel), indexingService );
 
         // when
         long indexId = creator.createUniquenessConstraintIndex( state, constraintCreationContext.schemaReadOperations(), 123, 456 );
@@ -111,7 +112,7 @@ public class ConstraintIndexCreatorTest
         doThrow( new IndexPopulationFailedKernelException( descriptor, "some index", cause) )
                 .when(indexProxy).awaitStoreScanCompleted();
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( kernel, indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( Providers.<KernelAPI>singletonProvider(kernel), indexingService );
 
         // when
         try
@@ -146,7 +147,7 @@ public class ConstraintIndexCreatorTest
 
         IndexDescriptor descriptor = new IndexDescriptor( 123, 456 );
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( kernel, indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( Providers.<KernelAPI>singletonProvider(kernel), indexingService );
 
         // when
         creator.dropUniquenessConstraintIndex( descriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.index;
 import java.util.Set;
 
 import org.junit.Test;
-
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -31,13 +30,10 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
+import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
 
 public class IndexIT extends KernelIntegrationTest
 {
@@ -117,7 +113,7 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldRemoveAConstraintIndexWithoutOwnerInRecovery() throws Exception
     {
         // given
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( kernel, indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( singletonProvider( kernel ), indexingService );
         creator.createConstraintIndex( labelId, propertyKey );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RecordChangesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/RecordChangesTest.java
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.kernel.impl.nioneo.xa;
 
 import org.junit.Test;

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
@@ -193,7 +193,19 @@ public class LinkedQueuePool<R> implements Pool<R>
         }
     }
 
+    /**
+     * Dispose of all pooled objects.
+     */
+    public void disposeAll()
+    {
+        for(R resource = unused.poll(); resource != null; resource = unused.poll())
+        {
+            dispose( resource );
+        }
+    }
+
     public void close( boolean force )
     {
+        disposeAll();
     }
 }

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
@@ -19,18 +19,7 @@
  */
 package org.neo4j.collection.pool;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
 import org.junit.Test;
-import org.neo4j.collection.pool.MarshlandPool;
-import org.neo4j.collection.pool.Pool;
-import org.neo4j.function.Factory;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -76,6 +65,27 @@ public class MarshlandPoolTest
         // Then
         verify( delegatePool, times(3) ).acquire();
         verify( delegatePool, times(2) ).release( any() );
+        verifyNoMoreInteractions( delegatePool );
+    }
+
+    @Test
+    public void shouldReleaseAllSlotsOnClose() throws Exception
+    {
+        // Given
+        Pool<Object> delegatePool = mock(Pool.class);
+        when(delegatePool.acquire()).thenReturn( 1337 );
+
+        final MarshlandPool<Object> pool = new MarshlandPool<>(delegatePool);
+
+        Object first  = pool.acquire();
+        pool.release( first );
+
+        // When
+        pool.close();
+
+        // Then
+        verify( delegatePool, times(1) ).acquire();
+        verify( delegatePool, times(1) ).release( any() );
         verifyNoMoreInteractions( delegatePool );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
@@ -89,7 +89,7 @@ public class SwitchToMaster
 
             idGeneratorFactory.switchToMaster();
             NeoStoreXaDataSource neoStoreXaDataSource = dataSourceManager.getDataSource();
-            neoStoreXaDataSource.reloadSchemaCache();
+            neoStoreXaDataSource.afterModeSwitch();
 
             Monitors monitors = resolver.resolveDependency( Monitors.class );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.getServerId;
-import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -77,6 +74,9 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.getServerId;
+import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
 
 public class SwitchToSlave
 {
@@ -141,6 +141,8 @@ public class SwitchToSlave
         }
 
         NeoStoreXaDataSource nioneoDataSource = resolver.resolveDependency( NeoStoreXaDataSource.class );
+        nioneoDataSource.afterModeSwitch();
+
         checkDataConsistency( resolver.resolveDependency( RequestContextFactory.class ), nioneoDataSource, masterUri );
 
         URI slaveUri = startHaCommunication( haCommunicationLife, nioneoDataSource, me, masterUri );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
@@ -45,14 +45,32 @@ public interface Master
     Response<Integer> createPropertyKey( RequestContext context, String name );
 
     Response<Integer> createLabel( RequestContext context, String name );
-    
+
     /**
-     * Called when the first write operation of lock is performed for a transaction.
+     * This is a misleading method name. This is the only mechanism available for committing ad-hoc transactions
+     * remotely on a master database. Calling this method will validate, persist to log and apply changes to stores on
+     * the master.
+     *
+     * TODO: Change the name of this method
+     */
+    Response<Long> commitSingleResourceTransaction( RequestContext context, TransactionRepresentation channel ) throws IOException, TransactionFailureException;
+
+    /**
+     * This is a misleading method name, it has nothing to do with transactions.
+     * Calling this method will create a lock client on the master that can be used on behalf of the callee to grab
+     * cluster-global locks.
+     *
+     * TODO: Change the name of this
      */
     Response<Void> initializeTx( RequestContext context );
 
-    Response<Long> commitSingleResourceTransaction( RequestContext context, TransactionRepresentation channel ) throws IOException, TransactionFailureException;
-
+    /**
+     * This is a misleading method name it has nothing to do with transactions.
+     * Calling this will release all locks held on the master on the behalf of the
+     * specified context. The "success" parameter is ignored.
+     *
+     * TODO: Change the name of this
+     */
     Response<Void> finishTransaction( RequestContext context, boolean success );
 
     /**

--- a/enterprise/server-enterprise/src/test/java/HALoad.java
+++ b/enterprise/server-enterprise/src/test/java/HALoad.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.util.FastRandom;
+
+public class HALoad
+{
+    public static void main(String ... args) throws Throwable
+    {
+        int iterations = 500_000;
+
+        bench( (long) iterations, 1 );
+        bench( (long) iterations / 2, 2 );
+        bench( (long) iterations / 4, 4 );
+        bench( (long) iterations / 8, 8 );
+    }
+
+    public static void setup() throws IOException
+    {
+        execute(statement("CREATE INDEX ON :User(name)"));
+    }
+
+
+    private static Statement statement( String stmt )
+    {
+        return statement( stmt, Collections.EMPTY_MAP );
+    }
+
+    private static Statement statement( String stmt, Map<String, Object> params )
+    {
+        return new Statement(stmt, params);
+    }
+
+    private static class Statement
+    {
+        private final String stmt;
+        private final Map<String, Object> params;
+
+        public Statement( String stmt, Map<String, Object> params )
+        {
+            this.stmt = stmt;
+            this.params = params;
+        }
+    }
+
+    private static void execute( Statement ... stmts )
+    {
+        List<Map<String, Object>> stmtPayload = new ArrayList<>();
+    }
+
+    static class Worker
+    {
+        private final FastRandom rand = new FastRandom();
+
+        public void operation()
+        {
+//            List<Statement>
+        }
+    }
+
+    public static void teardown()
+    {
+
+    }
+
+
+    private static void bench( long iterations, int concurrency ) throws InterruptedException, ExecutionException,
+            IOException
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool( concurrency );
+
+        setup();
+
+        long start = System.nanoTime();
+        List<Future<Object>> futures = executorService.invokeAll( workers( iterations, concurrency ) );
+        awaitAll( futures );
+        long delta = System.nanoTime() - start;
+
+        System.out.println("With "+ concurrency +" threads: " + (iterations * concurrency) / (delta / 1000_000_000.0) + " ops/s");
+
+        teardown();
+
+        executorService.shutdownNow();
+        executorService.awaitTermination( 10, TimeUnit.SECONDS );
+    }
+
+    private static void awaitAll( List<Future<Object>> futures ) throws InterruptedException, ExecutionException
+    {
+        for ( Future<Object> future : futures )
+        {
+            future.get();
+        }
+    }
+
+    private static List<Callable<Object>> workers( final long iterations, final int numWorkers )
+    {
+        List<Callable<Object>> workers = new ArrayList<>();
+        for ( int i = 0; i < numWorkers; i++ )
+        {
+            final Worker worker = new Worker();
+            workers.add( new Callable<Object>()
+            {
+                @Override
+                public Object call() throws Exception
+                {
+                    for ( int i = 0; i < iterations; i++ )
+                    {
+                        worker.operation();
+                    }
+                    return null;
+                }
+            });
+        }
+        return workers;
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/TxBench.java
+++ b/enterprise/server-enterprise/src/test/java/TxBench.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.impl.util.FastRandom;
+
+public class TxBench
+{
+    public static void main(String ... args) throws Throwable
+    {
+        int iterations = 500_000;
+
+        bench( (long) iterations, 1 );
+        bench( (long) iterations / 2, 2 );
+        bench( (long) iterations / 4, 4 );
+        bench( (long) iterations / 8, 8 );
+    }
+
+
+    private static GraphDatabaseService db;
+    private static ExecutionEngine ee;
+
+    public static void setup() throws IOException
+    {
+        File path = new File( "/tmp/asd" );
+        if( path.exists())
+        {
+            FileUtils.deleteRecursively( path );
+        }
+        db = new GraphDatabaseFactory().newEmbeddedDatabase( path.getAbsolutePath() );
+        ee = new ExecutionEngine( db );
+        try( Transaction tx = db.beginTx() )
+        {
+            ee.execute( "CREATE INDEX ON :User(name)" );
+            tx.success();
+        }
+
+        try( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 10, TimeUnit.SECONDS );
+            tx.success();
+        }
+    }
+
+    static class Worker
+    {
+        private final FastRandom rand = new FastRandom();
+        private final Map<String, Object> params = new HashMap<>();
+
+        public void operation()
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                params.put( "name", rand.next( 100000 ) );
+                ee.execute( "MERGE (n:User {name:{name}}) RETURN n", params );
+                tx.success();
+            }
+        }
+    }
+
+    public static void teardown()
+    {
+        db.shutdown();
+    }
+
+
+    private static void bench( long iterations, int concurrency ) throws InterruptedException, ExecutionException,
+            IOException
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool( concurrency );
+
+        setup();
+
+        long start = System.nanoTime();
+        List<Future<Object>> futures = executorService.invokeAll( workers( iterations, concurrency ) );
+        awaitAll( futures );
+        long delta = System.nanoTime() - start;
+
+        System.out.println("With "+ concurrency +" threads: " + (iterations * concurrency) / (delta / 1000_000_000.0) + " ops/s");
+
+        teardown();
+
+        executorService.shutdownNow();
+        executorService.awaitTermination( 10, TimeUnit.SECONDS );
+    }
+
+    private static void awaitAll( List<Future<Object>> futures ) throws InterruptedException, ExecutionException
+    {
+        for ( Future<Object> future : futures )
+        {
+            future.get();
+        }
+    }
+
+    private static List<Callable<Object>> workers( final long iterations, final int numWorkers )
+    {
+        List<Callable<Object>> workers = new ArrayList<>();
+        for ( int i = 0; i < numWorkers; i++ )
+        {
+            final Worker worker = new Worker();
+            workers.add( new Callable<Object>()
+            {
+                @Override
+                public Object call() throws Exception
+                {
+                    for ( int i = 0; i < iterations; i++ )
+                    {
+                        worker.operation();
+                    }
+                    return null;
+                }
+            });
+        }
+        return workers;
+    }
+
+}


### PR DESCRIPTION
This introduces KernelTransactions, a central repository of transactions. This is used for stopping running transactions on kernel stop, which in turn is meant to resolve a long set of issues related to transactions completing after the kernel is stopped.

The way this works, performance wise, is that transactions are allocated up-front in a marshland pool. References to every transaction created are kept in a global set, but since this is only written to when populating the pool, there is next to no contention on this data structure.

To find running transactions, we iterate over the set, and return the ones that are "running". This list may be out of date, since we may read stale flags to tell if the tx is open (the flags are non-volatile). For our use case, however, this is not a problem. 

Marshland pool significantly improves the cost of creating new transactions, but we will need to expand it to cache more than one transaction per thread I think, or we will see contention on transaction creation in the transactional endpoint in the server as marshland falls back to the linked queue pool. That will come in a separate PR.
