### PR TITLE
Rename methods in Master interface to reflect reality.

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
@@ -213,7 +213,7 @@ public enum HaRequestType201 implements RequestType<Master>
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 ChannelBuffer target )
         {
-            return master.finishTransaction( context, readBoolean( input ) );
+            return master.endLockSession( context, readBoolean( input ) );
         }
     }, VOID_SERIALIZER ),
 
@@ -269,7 +269,7 @@ public enum HaRequestType201 implements RequestType<Master>
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 ChannelBuffer target )
         {
-            return master.initializeTx( context );
+            return master.newLockSession( context );
         }
     }, VOID_SERIALIZER ),
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
@@ -149,7 +149,7 @@ public enum HaRequestType210 implements RequestType<Master>
                 throw new RuntimeException( e );
             }
 
-            return master.commitSingleResourceTransaction( context, tx );
+            return master.commit( context, tx );
         }
     }, LONG_SERIALIZER ),
 
@@ -165,13 +165,13 @@ public enum HaRequestType210 implements RequestType<Master>
     }, VOID_SERIALIZER ),
 
     // ====
-    FINISH( new TargetCaller<Master, Void>()
+    END_LOCK_SESSION( new TargetCaller<Master, Void>()
     {
         @Override
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 ChannelBuffer target )
         {
-            return master.finishTransaction( context, readBoolean( input ) );
+            return master.endLockSession( context, readBoolean( input ) );
         }
     }, VOID_SERIALIZER ),
 
@@ -220,13 +220,13 @@ public enum HaRequestType210 implements RequestType<Master>
     }, VOID_SERIALIZER ),
 
     // ====
-    INITIALIZE_TX( new TargetCaller<Master, Void>()
+    NEW_LOCK_SESSION( new TargetCaller<Master, Void>()
     {
         @Override
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 ChannelBuffer target )
         {
-            return master.initializeTx( context );
+            return master.newLockSession( context );
         }
     }, VOID_SERIALIZER ),
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
@@ -188,7 +188,7 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Void> initializeTx( RequestContext context )
+    public Response<Void> newLockSession( RequestContext context )
     {
         return sendRequest( HaRequestType201.INITIALIZE_TX, context, EMPTY_SERIALIZER, VOID_DESERIALIZER );
     }
@@ -256,7 +256,7 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Long> commitSingleResourceTransaction( RequestContext context, final TransactionRepresentation tx )
+    public Response<Long> commit( RequestContext context, final TransactionRepresentation tx )
     {
 //        return sendRequest( HaRequestType201.COMMIT, context, new Serializer()
 //                {
@@ -284,7 +284,7 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Void> finishTransaction( RequestContext context, final boolean success )
+    public Response<Void> endLockSession( RequestContext context, final boolean success )
     {
         return sendRequest( HaRequestType201.FINISH, context, new Serializer()
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -187,9 +187,9 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Void> initializeTx( RequestContext context )
+    public Response<Void> newLockSession( RequestContext context )
     {
-        return sendRequest( HaRequestType210.INITIALIZE_TX, context, EMPTY_SERIALIZER, VOID_DESERIALIZER );
+        return sendRequest( HaRequestType210.NEW_LOCK_SESSION, context, EMPTY_SERIALIZER, VOID_DESERIALIZER );
     }
 
     @Override
@@ -209,7 +209,7 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Long> commitSingleResourceTransaction( RequestContext context, TransactionRepresentation tx )
+    public Response<Long> commit( RequestContext context, TransactionRepresentation tx )
     {
         return sendRequest( HaRequestType210.COMMIT, context, new Protocol.TransactionSerializer( tx ),
                 new Deserializer<Long>()
@@ -225,9 +225,9 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     }
 
     @Override
-    public Response<Void> finishTransaction( RequestContext context, final boolean success )
+    public Response<Void> endLockSession( RequestContext context, final boolean success )
     {
-        return sendRequest( HaRequestType210.FINISH, context, new Serializer()
+        return sendRequest( HaRequestType210.END_LOCK_SESSION, context, new Serializer()
         {
             @Override
             public void write( ChannelBuffer buffer ) throws IOException

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -47,7 +47,7 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
     {
         try
         {
-            return unpacker.unpackResponse( master.commitSingleResourceTransaction( requestContextFactory.newRequestContext(), representation ) );
+            return unpacker.unpackResponse( master.commit( requestContextFactory.newRequestContext(), representation ) );
         }
         catch ( IOException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
@@ -47,31 +47,22 @@ public interface Master
     Response<Integer> createLabel( RequestContext context, String name );
 
     /**
-     * This is a misleading method name. This is the only mechanism available for committing ad-hoc transactions
-     * remotely on a master database. Calling this method will validate, persist to log and apply changes to stores on
+     * Calling this method will validate, persist to log and apply changes to stores on
      * the master.
-     *
-     * TODO: Change the name of this method
      */
-    Response<Long> commitSingleResourceTransaction( RequestContext context, TransactionRepresentation channel ) throws IOException, TransactionFailureException;
+    Response<Long> commit( RequestContext context, TransactionRepresentation channel ) throws IOException, TransactionFailureException;
 
     /**
-     * This is a misleading method name, it has nothing to do with transactions.
-     * Calling this method will create a lock client on the master that can be used on behalf of the callee to grab
-     * cluster-global locks.
-     *
-     * TODO: Change the name of this
+     * Calling this method will create a new session with the cluster lock manager and associate that
+     * session with the provided {@link RequestContext}.
      */
-    Response<Void> initializeTx( RequestContext context );
+    Response<Void> newLockSession( RequestContext context );
 
     /**
-     * This is a misleading method name it has nothing to do with transactions.
-     * Calling this will release all locks held on the master on the behalf of the
-     * specified context. The "success" parameter is ignored.
-     *
-     * TODO: Change the name of this
+     * Calling this will end the current lock session (identified by the {@link RequestContext}),
+     * releasing all cluster-global locks held.
      */
-    Response<Void> finishTransaction( RequestContext context, boolean success );
+    Response<Void> endLockSession( RequestContext context, boolean success );
 
     /**
      * Gets the master id for a given txId, also a checksum for that tx.

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -149,7 +149,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
     }
 
     @Override
-    public Response<Void> initializeTx( RequestContext context )
+    public Response<Void> newLockSession( RequestContext context )
     {
         monitor.initializeTx( context );
 
@@ -235,8 +235,8 @@ public class MasterImpl extends LifecycleAdapter implements Master
     }
 
     @Override
-    public Response<Long> commitSingleResourceTransaction( RequestContext context,
-                                                           TransactionRepresentation preparedTransaction ) throws
+    public Response<Long> commit( RequestContext context,
+                                  TransactionRepresentation preparedTransaction ) throws
             IOException, org.neo4j.kernel.api.exceptions.TransactionFailureException
     {
         assertCorrectEpoch( context );
@@ -245,7 +245,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
 }
 
     @Override
-    public Response<Void> finishTransaction( RequestContext context, boolean success )
+    public Response<Void> endLockSession( RequestContext context, boolean success )
     {
         assertCorrectEpoch( context );
         // TODO 2.2-future verify the same thing

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -66,7 +66,7 @@ public class MasterServer extends Server<Master, Void>
     {
         try
         {
-            getRequestTarget().finishTransaction( context, false );
+            getRequestTarget().endLockSession( context, false );
         }
         catch ( TransactionNotPresentOnMasterException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -67,13 +67,13 @@ public interface MasterClient extends Master
     public Response<Integer> createRelationshipType( RequestContext context, final String name );
 
     @Override
-    public Response<Void> initializeTx( RequestContext context );
+    public Response<Void> newLockSession( RequestContext context );
 
     @Override
-    public Response<Long> commitSingleResourceTransaction( RequestContext context, final TransactionRepresentation channel );
+    public Response<Long> commit( RequestContext context, final TransactionRepresentation channel );
 
     @Override
-    public Response<Void> finishTransaction( RequestContext context, final boolean success );
+    public Response<Void> endLockSession( RequestContext context, final boolean success );
 
     public void rollbackOngoingTransactions( RequestContext context );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -238,7 +238,7 @@ class SlaveLocksClient implements Locks.Client
         exclusiveLocks.clear();
         if ( initialized )
         {
-            master.finishTransaction( requestContextFactory.newRequestContext( (int) client.getIdentifier() ), true );
+            master.endLockSession( requestContextFactory.newRequestContext( (int) client.getIdentifier() ), true );
             initialized = false;
         }
         client.releaseAll();
@@ -251,7 +251,7 @@ class SlaveLocksClient implements Locks.Client
         exclusiveLocks.clear();
         if ( initialized )
         {
-            master.finishTransaction( requestContextFactory.newRequestContext( (int) client.getIdentifier() ), true );
+            master.endLockSession( requestContextFactory.newRequestContext( (int) client.getIdentifier() ), true );
         }
         client.close();
     }
@@ -323,7 +323,7 @@ class SlaveLocksClient implements Locks.Client
         }
         if ( !initialized )
         {
-            master.initializeTx( requestContextFactory.newRequestContext( (int) client.getIdentifier() ) );
+            master.newLockSession( requestContextFactory.newRequestContext( (int) client.getIdentifier() ) );
             initialized = true;
         }
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -59,7 +59,7 @@ public class MasterImplTest
         // When
         try
         {
-            instance.initializeTx( new RequestContext( 0, 1, 2, 0, 1, 0 ) );
+            instance.newLockSession( new RequestContext( 0, 1, 2, 0, 1, 0 ) );
             fail();
         }
         catch ( TransactionFailureException e )
@@ -87,7 +87,7 @@ public class MasterImplTest
         // When
         try
         {
-            instance.initializeTx( new RequestContext( handshake.epoch(), 1, 2, 0, 1, 0 ) );
+            instance.newLockSession( new RequestContext( handshake.epoch(), 1, 2, 0, 1, 0 ) );
         }
         catch ( Exception e )
         {
@@ -114,7 +114,7 @@ public class MasterImplTest
         // When
         try
         {
-            instance.initializeTx( new RequestContext( handshake.epoch(), 1, 2, 0, 1, 0 ) );
+            instance.newLockSession( new RequestContext( handshake.epoch(), 1, 2, 0, 1, 0 ) );
             fail("Should have failed.");
         }
         catch ( Exception e )


### PR DESCRIPTION
After the refactoring in 2.2, the Master interface is much simpler, but the
method names still reflect the old mechanisms. This changes them to be more
clear as to what they do.
