### PR TITLE
Fix bug in tx state management for labels.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -281,7 +281,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         if ( !hasTxState() )
         {
-            txState = new TxStateImpl( recordState, legacyIndexTransactionState );
+            txState = new TxStateImpl( legacyIndexTransactionState );
         }
         return txState;
     }
@@ -349,6 +349,19 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                     {
                         DefinedProperty prop = added.next();
                         recordState.nodeAddProperty( id, prop.propertyKeyId(), prop.value() );
+                    }
+                }
+
+                @Override
+                public void visitNodeLabelChanges( long nodeId, Iterator<Integer> added, Iterator<Integer> removed )
+                {
+                    while(removed.hasNext())
+                    {
+                        recordState.removeLabelFromNode( removed.next(), nodeId );
+                    }
+                    while(added.hasNext())
+                    {
+                        recordState.addLabelToNode( added.next(), nodeId );
                     }
                 }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -42,7 +42,6 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.util.DiffSets;
 
 import static org.neo4j.helpers.collection.Iterables.map;
@@ -140,17 +139,14 @@ public final class TxStateImpl implements TxState
 
     private Map<UniquenessConstraint, Long> createdConstraintIndexesByConstraint;
 
-    private final TransactionRecordState neoStoreTransaction;
     private final LegacyIndexTransactionState legacyChangesIndexProvider;
     private Map<String, LegacyIndex> nodeLegacyIndexChanges;
     private Map<String, LegacyIndex> relationshipLegacyIndexChanges;
 
     private boolean hasChanges;
 
-    public TxStateImpl( TransactionRecordState neoStoreTransaction,
-            LegacyIndexTransactionState legacyChangesIndexProvider )
+    public TxStateImpl( LegacyIndexTransactionState legacyChangesIndexProvider )
     {
-        this.neoStoreTransaction = neoStoreTransaction;
         this.legacyChangesIndexProvider = legacyChangesIndexProvider;
     }
 
@@ -550,7 +546,6 @@ public final class TxStateImpl implements TxState
     {
         labelStateNodeDiffSets( labelId ).add( nodeId );
         nodeStateLabelDiffSets( nodeId ).add( labelId );
-        neoStoreTransaction.addLabelToNode( labelId, nodeId );
         hasChanges = true;
     }
 
@@ -559,7 +554,6 @@ public final class TxStateImpl implements TxState
     {
         labelStateNodeDiffSets( labelId ).remove( nodeId );
         nodeStateLabelDiffSets( nodeId ).remove( labelId );
-        neoStoreTransaction.removeLabelFromNode( labelId, nodeId );
         hasChanges = true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
@@ -95,11 +95,14 @@ public class DiffSets<T>
         }
     }
 
+    /**
+     * Add an element. If this element is marked as removed already, the net effect will be no changes.
+     */
     public boolean add( T elem )
     {
-        boolean result = added( true ).add( elem );
-        removed( false ).remove( elem );
-        return result;
+        boolean wasRemoved = removed( false ).remove( elem );
+        // Add to the addedElements only if it was not removed from the removedElements
+        return wasRemoved || added( true ).add( elem );
     }
 
     public void replace( T toRemove, T toAdd )
@@ -115,6 +118,9 @@ public class DiffSets<T>
         }
     }
 
+    /**
+     * Remove an element. If this element was previously added to the set, the net effect will be no changes.
+     */
     public boolean remove( T elem )
     {
         boolean removedFromAddedElements = added( false ).remove( elem );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
@@ -96,7 +96,7 @@ public class DiffSetsTest
         actual.add( 1L );
 
         // THEN
-        assertEquals( asSet( 1L ), actual.getAdded() );
+        assertTrue( actual.getAdded().isEmpty() );
         assertTrue( actual.getRemoved().isEmpty() );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -42,7 +42,6 @@ import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
 import org.neo4j.kernel.impl.api.operations.EntityOperations;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.util.PrimitiveLongResourceIterator;
 
 import static java.util.Arrays.asList;
@@ -312,7 +311,7 @@ public class IndexQueryTransactionStateTest
     @Before
     public void before() throws Exception
     {
-        TxState txState = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class ) );
+        TxState txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
         state = StatementOperationsTestHelper.mockedState( txState );
 
         int labelId1 = 10, labelId2 = 12;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -278,7 +277,7 @@ public class LabelTransactionStateTest
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
 
-        txState = new TxStateImpl( mock( TransactionRecordState.class ),
+        txState = new TxStateImpl(
                 mock( LegacyIndexTransactionState.class ) );
         state = StatementOperationsTestHelper.mockedState( txState );
         txContext = new StateHandlingStatementOperations( store, mock( LegacyPropertyTrackers.class ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationsTestHelper;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -250,8 +249,7 @@ public class SchemaTransactionStateTest
     @Before
     public void before() throws Exception
     {
-        txState = new TxStateImpl( mock( TransactionRecordState.class ),
-                mock( LegacyIndexTransactionState.class ) );
+        txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
         state = StatementOperationsTestHelper.mockedState( txState );
 
         store = mock( StoreReadLayer.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.util.DiffSets;
 
 import static java.util.Arrays.asList;
@@ -109,7 +108,7 @@ public class StateHandlingStatementOperationsTest
     {
         // given
         UniquenessConstraint constraint = new UniquenessConstraint( 10, 66 );
-        TxState txState = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class ) );
+        TxState txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
         KernelStatement state = mockedState( txState );
         when( inner.constraintsGetForLabelAndPropertyKey( 10, 66 ) )
             .thenAnswer( asAnswer( Collections.emptyList() ) );
@@ -131,7 +130,7 @@ public class StateHandlingStatementOperationsTest
         UniquenessConstraint constraint1 = new UniquenessConstraint( 11, 66 );
         UniquenessConstraint constraint2 = new UniquenessConstraint( 11, 99 );
 
-        TxState txState = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class ) );
+        TxState txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
         KernelStatement state = mockedState( txState );
         when( inner.constraintsGetForLabelAndPropertyKey( 10, 66 ) )
             .thenAnswer( asAnswer( Collections.emptyList() ) );
@@ -159,7 +158,7 @@ public class StateHandlingStatementOperationsTest
         UniquenessConstraint constraint1 = new UniquenessConstraint( 10, 66 );
         UniquenessConstraint constraint2 = new UniquenessConstraint( 11, 99 );
 
-        TxState txState = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class ) );
+        TxState txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
         KernelStatement state = mockedState( txState );
         when( inner.constraintsGetForLabelAndPropertyKey( 10, 66 ) )
             .thenAnswer( asAnswer( Collections.emptyList() ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -31,7 +31,6 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.TxState;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.impl.util.DiffSets;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -369,7 +368,7 @@ public class TxStateTest
     @Before
     public void before() throws Exception
     {
-        state = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class )
+        state = new TxStateImpl( mock( LegacyIndexTransactionState.class )
         );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateVisitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateVisitorTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.TxState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 import static java.util.Arrays.asList;
 
@@ -79,7 +78,7 @@ public class TxStateVisitorTest
     @Before
     public void before() throws Exception
     {
-        state = new TxStateImpl( mock( TransactionRecordState.class ), mock( LegacyIndexTransactionState.class ) );
+        state = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
     }
 
     static class GatheringVisitor extends TxState.VisitorAdapter

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.core.NodeProxy;
 import org.neo4j.kernel.impl.core.RelationshipProxy;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 import static java.util.Arrays.asList;
 
@@ -60,7 +59,7 @@ public class TxStateTransactionDataViewTest
     private final ThreadToStatementContextBridge bridge = mock(ThreadToStatementContextBridge.class);
     private final Statement stmt = mock(Statement.class);
     private final StoreReadLayer ops = mock(StoreReadLayer.class);
-    private final TxState state = new TxStateImpl( mock( TransactionRecordState.class ),
+    private final TxState state = new TxStateImpl(
             mock( LegacyIndexTransactionState.class) );
 
 


### PR DESCRIPTION
When performing multiple add/remove operations for the same node/label tuple,
the tx state would hiccup, because DiffSet had a discreptancy between how
remove+add and add+remove stacked. Add+remove would lead to a net zero change,
while remove+add would lead to an element added. Now both orderings of
operations lead to a net zero changeset.

Also move population of recordchangeset out of TxState, it should not be there.
Instead, populate recordchangeset at commit time with the end-result changes
as calculated by txstate.
