### PR TITLE
Force flush on disk of the new log version after a log rotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NeoStore.java
@@ -492,6 +492,9 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
             {
                 incrementVersion( cursor );
             }
+            // make sure the new version value is persisted
+            // TODO this can be improved by flushing only the page containing that value rather than all pages
+            storeFile.flush();
             return versionField;
         }
         catch ( IOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogVersionRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogVersionRepository.java
@@ -33,8 +33,8 @@ public interface LogVersionRepository
     long getCurrentLogVersion();
 
     /**
-     * Increments and returns the latest log version for this repository. It does so
-     * atomically and can potentially block.
+     * Increments (making sure it is persisted on disk) and returns the latest log version for this repository.
+     * It does so atomically and can potentially block.
      */
     long incrementAndGetVersion() throws IOException;
 }


### PR DESCRIPTION
Fix a problem when recovering caused by the fact that the new log version wasn't flushed on disk after a log rotation.

Reenable tests in IndexRecoveryIT
