### PR TITLE
Fix inconsistent behavior in diffsets on remove/add combination.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -391,6 +391,15 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 @Override
                 public void visitNodeLabelChanges( long id, Iterator<Integer> added, Iterator<Integer> removed )
                 {
+                    while(removed.hasNext())
+                    {
+                        persistenceManager.removeLabelFromNode( removed.next(), id );
+                    }
+
+                    while(added.hasNext())
+                    {
+                        persistenceManager.addLabelToNode( added.next(), id );
+                    }
                 }
 
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -640,9 +640,6 @@ public class StateHandlingStatementOperations implements
         if ( existingProperty.isDefined() )
         {
             legacyPropertyTrackers.nodeRemoveStoreProperty( nodeId, (DefinedProperty) existingProperty );
-        }
-        if(existingProperty instanceof DefinedProperty)
-        {
             state.txState().nodeDoRemoveProperty( nodeId, (DefinedProperty)existingProperty );
         }
         return existingProperty;
@@ -657,9 +654,6 @@ public class StateHandlingStatementOperations implements
         {
             legacyPropertyTrackers.relationshipRemoveStoreProperty( relationshipId, (DefinedProperty)
                     existingProperty );
-        }
-        if(existingProperty instanceof DefinedProperty)
-        {
             state.txState().relationshipDoRemoveProperty( relationshipId, (DefinedProperty)existingProperty );
         }
         return existingProperty;
@@ -669,7 +663,7 @@ public class StateHandlingStatementOperations implements
     public Property graphRemoveProperty( KernelStatement state, int propertyKeyId )
     {
         Property existingProperty = graphGetProperty( state, propertyKeyId );
-        if(existingProperty instanceof DefinedProperty)
+        if(existingProperty.isDefined())
         {
             state.txState().graphDoRemoveProperty( (DefinedProperty)existingProperty );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -553,7 +553,6 @@ public final class TxStateImpl implements TxState
     {
         labelStateNodeDiffSets( labelId ).add( nodeId );
         nodeStateLabelDiffSets( nodeId ).add( labelId );
-        persistenceManager.addLabelToNode( labelId, nodeId );
         hasChanges = true;
     }
 
@@ -562,7 +561,6 @@ public final class TxStateImpl implements TxState
     {
         labelStateNodeDiffSets( labelId ).remove( nodeId );
         nodeStateLabelDiffSets( nodeId ).remove( labelId );
-        persistenceManager.removeLabelFromNode( labelId, nodeId );
         hasChanges = true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
@@ -97,9 +97,9 @@ public class DiffSets<T>
 
     public boolean add( T elem )
     {
-        boolean result = added( true ).add( elem );
-        removed( false ).remove( elem );
-        return result;
+        boolean wasRemoved = removed( false ).remove( elem );
+        // Add to the addedElements only if it was not removed from the removedElements
+        return wasRemoved || added( true ).add( elem );
     }
 
     public void replace( T toRemove, T toAdd )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
@@ -96,7 +96,7 @@ public class DiffSetsTest
         actual.add( 1L );
 
         // THEN
-        assertEquals( asSet( 1L ), actual.getAdded() );
+        assertTrue( actual.getAdded().isEmpty() );
         assertTrue( actual.getRemoved().isEmpty() );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.impl.core.Token;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertThat;
 
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 
 public class LabelIT extends KernelIntegrationTest
@@ -63,5 +64,33 @@ public class LabelIT extends KernelIntegrationTest
             assertThat(asCollection( labelIdsAfterCommit ) ,
                     hasItems( new Token( "label1", label1Id ), new Token( "label2", label2Id ) ));
         }
+    }
+
+    @Test
+    public void addingAndRemovingLabelInSameTxShouldHaveNoEffect() throws Exception
+    {
+        // Given a node with a label
+        int label;
+        long node;
+        {
+            DataWriteOperations stmt = dataWriteOperationsInNewTransaction();
+            label = stmt.labelGetOrCreateForName( "Label 1" );
+            node = stmt.nodeCreate();
+            stmt.nodeAddLabel( node, label );
+            commit();
+        }
+
+        // When I add and remove that label in the same tx
+        {
+            DataWriteOperations stmt = dataWriteOperationsInNewTransaction();
+            stmt.nodeRemoveLabel( node, label );
+            stmt.nodeAddLabel( node, label );
+        }
+
+        // Then commit should not throw exceptions
+        commit();
+
+        // And then the node should have the label
+        assertTrue( readOperationsInNewTransaction().nodeHasLabel( node, label ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -28,6 +28,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.core.Token;
 
@@ -37,6 +38,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.kernel.api.properties.Property.property;
 
 public class PropertyIT extends KernelIntegrationTest
 {
@@ -394,13 +396,47 @@ public class PropertyIT extends KernelIntegrationTest
             try
             {
                 statement.nodeRemoveProperty( node, prop1 );
-                fail("Should have failed.");
+                fail( "Should have failed." );
             }
-            catch(IllegalStateException e)
+            catch ( IllegalStateException e )
             {
-                assertThat(e.getMessage(),
-                        equalTo("Node " + node + " has been deleted"));
+                assertThat( e.getMessage(),
+                        equalTo( "Node " + node + " has been deleted" ) );
             }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToRemoveResetAndTwiceRemoveProperty() throws Exception
+    {
+        // given
+        long node;
+        int prop;
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            prop = ops.propertyKeyGetOrCreateForName( "foo" );
+
+            node = ops.nodeCreate();
+            ops.nodeSetProperty( node, property( prop, "bar" ) );
+
+            commit();
+        }
+
+        // when
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            ops.nodeRemoveProperty( node, prop );
+            ops.nodeSetProperty( node, property( prop, "bar" ) );
+            ops.nodeRemoveProperty( node, prop );
+            ops.nodeRemoveProperty( node, prop );
+
+            commit();
+        }
+
+        // then
+        {
+            ReadOperations ops = readOperationsInNewTransaction();
+            assertFalse(ops.nodeGetProperty( node, prop ).isDefined());
         }
     }
 


### PR DESCRIPTION
Previously, remove+add would result in an item added, while add+remove
would result in no net changes. This fixes this inconsistency, leading to net
no changes in both cases.

This resolves two bugs in property and label changing, where one would remove
and add the same label or property multiple times in the same transaction.
