### PR TITLE
Initial work on having DiskLayer implement the full StoreReadLayer API.

### DIFF
--- a/advanced/management/src/test/java/org/neo4j/management/TestCacheBeans.java
+++ b/advanced/management/src/test/java/org/neo4j/management/TestCacheBeans.java
@@ -27,16 +27,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.jmx.impl.JmxKernelExtension;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.core.Caches;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.neo4j.graphdb.DynamicLabel.label;
 
 public class TestCacheBeans
 {
@@ -74,16 +73,17 @@ public class TestCacheBeans
     @Test
     public void canMeasureSizeOfCache() throws Exception
     {
+        Label label = label( "ANode" );
         long[] before = get( CacheBean.CACHE_SIZE );
         long nodeId;
         try ( Transaction tx = graphDb.beginTx() )
         {
-            nodeId = graphDb.createNode().getId();
+            nodeId = graphDb.createNode( label ).getId();
             tx.success();
         }
         try ( Transaction tx = graphDb.beginTx() )
         {
-            graphDb.getNodeById( nodeId );
+            graphDb.getNodeById( nodeId ).hasLabel(label);
         }
 
         assertChanged( "cache size not updated", before, get( CacheBean.CACHE_SIZE ) );
@@ -92,9 +92,10 @@ public class TestCacheBeans
     @Test
     public void canMeasureAmountsOfHitsAndMisses() throws Exception
     {
+        Label label = label( "ANode" );
         try(Transaction tx = graphDb.beginTx())
         {
-            graphDb.createNode();
+            graphDb.createNode(label);
             tx.success();
         }
 
@@ -103,8 +104,8 @@ public class TestCacheBeans
         long[] hits = get( CacheBean.HIT_COUNT ), miss = get( CacheBean.MISS_COUNT );
         try ( Transaction transaction = graphDb.beginTx() )
         {
-            graphDb.getNodeById(0);
-            graphDb.getNodeById(0);
+            graphDb.getNodeById(0).hasLabel( label );
+            graphDb.getNodeById(0).hasLabel( label );
             transaction.success();
         }
         assertChanged( "hit count not updated", hits, get( CacheBean.HIT_COUNT ) );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.GraphDatabaseConfigurationMigrator;
 import org.neo4j.kernel.configuration.Migrator;
 import org.neo4j.kernel.configuration.Title;
+import org.neo4j.kernel.impl.api.store.CacheLayer;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.cache.MonitorGc;
 
@@ -299,6 +300,10 @@ public abstract class GraphDatabaseSettings
         {
             available.add( cacheProvider.getName() );
         }
+
+        // Temporary hidden config to turn off cache layer entirely
+        available.add( CacheLayer.EXPERIMENTAL_OFF );
+
                                            // --- higher prio ---->
         for ( String prioritized : new String[] { "soft", "hpc" } )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -92,9 +92,11 @@ import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
+import org.neo4j.kernel.impl.api.store.CacheLayer;
 import org.neo4j.kernel.impl.cache.BridgingCacheAccess;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.cache.MonitorGc;
+import org.neo4j.kernel.impl.cache.NoCacheProvider;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.Caches;
 import org.neo4j.kernel.impl.core.DefaultCaches;
@@ -422,11 +424,21 @@ public abstract class InternalAbstractGraphDatabase
         CacheProvider cacheProvider = cacheProviders.get( cacheTypeName );
         if ( cacheProvider == null )
         {
-            throw new IllegalArgumentException( "No provider for cache type '" + cacheTypeName + "'. " +
-                    "Cache providers are loaded using java service loading where they " +
-                    "register themselves in resource (plain-text) files found on the class path under " +
-                    "META-INF/services/" + CacheProvider.class.getName() + ". This missing provider may have " +
-                    "been caused by either such a missing registration, or by the lack of the provider class itself." );
+            // Temporarily here to allow experimentally turning off the cache layer entirely. This is different
+            // from cache_type=none in that it *completely* bypasses the caching layer.
+            if( config.get(Configuration.cache_type).equals( CacheLayer.EXPERIMENTAL_OFF ) )
+            {
+                cacheProvider = new NoCacheProvider();
+            }
+            else
+            {
+                throw new IllegalArgumentException( "No provider for cache type '" + cacheTypeName + "'. " +
+                        "Cache providers are loaded using java service loading where they " +
+                        "register themselves in resource (plain-text) files found on the class path under " +
+                        "META-INF/services/" + CacheProvider.class.getName() + ". This missing provider may have " +
+                        "been caused by either such a missing registration, or by the lack of the provider class itself." );
+
+            }
         }
 
         jobScheduler = life.add( new Neo4jJobScheduler( this.toString() ));

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -94,6 +94,10 @@ public class CacheLayer implements StoreReadLayer
             return new IndexDescriptor( rule.getLabel(), rule.getPropertyKey() );
         }
     };
+
+    /* Experimental cache_type setting for disabling this cache layer entirely. */
+    public static final String EXPERIMENTAL_OFF = "experimental-off";
+
     private final CacheLoader<Iterator<DefinedProperty>> nodePropertyLoader = new CacheLoader<Iterator<DefinedProperty>>()
     {
         @Override
@@ -147,16 +151,7 @@ public class CacheLayer implements StoreReadLayer
     @Override
     public boolean nodeExists( long nodeId )
     {
-        // Write a proper implementation later
-        try
-        {
-            persistenceCache.getNode( nodeId );
-            return true;
-        }
-        catch ( EntityNotFoundException e )
-        {
-            return false;
-        }
+        return diskLayer.nodeExists( nodeId );
     }
 
     @Override
@@ -231,7 +226,7 @@ public class CacheLayer implements StoreReadLayer
         {
             return rule.getId();
         }
-        return diskLayer.indexGetCommittedId( index );
+        return diskLayer.indexGetCommittedId( index, kind );
     }
 
     @Override
@@ -403,13 +398,13 @@ public class CacheLayer implements StoreReadLayer
     @Override
     public Iterator<Token> propertyKeyGetAllTokens()
     {
-        return diskLayer.propertyKeyGetAllTokens().iterator();
+        return diskLayer.propertyKeyGetAllTokens();
     }
 
     @Override
     public Iterator<Token> labelsGetAllTokens()
     {
-        return diskLayer.labelGetAllTokens().iterator();
+        return diskLayer.labelsGetAllTokens();
     }
 
     @Override
@@ -501,15 +496,6 @@ public class CacheLayer implements StoreReadLayer
     @Override
     public boolean relationshipExists( long relationshipId )
     {
-        // Write a proper implementation later
-        try
-        {
-            persistenceCache.getRelationship( relationshipId );
-            return true;
-        }
-        catch ( EntityNotFoundException e )
-        {
-            return false;
-        }
+        return diskLayer.relationshipExists( relationshipId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
@@ -50,6 +50,12 @@ public class NodeRecord extends PrimitiveRecord
         this.dense = dense;
     }
 
+    public NodeRecord( long id, boolean dense, long nextRel, long nextProp, boolean inUse )
+    {
+        this(id, dense, nextRel, nextProp);
+        setInUse( inUse );
+    }
+
     public long getNextRel()
     {
         return nextRel;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipStore.java
@@ -168,6 +168,30 @@ public class RelationshipStore extends AbstractRecordStore<RelationshipRecord> i
         }
     }
 
+    public boolean inUse( long id )
+    {
+        long pageId = pageIdForRecord( id );
+        int offset = offsetForId( id );
+
+        try ( PageCursor cursor = storeFile.io( pageId, PF_SHARED_LOCK ) )
+        {
+            boolean recordIsInUse = false;
+            if ( cursor.next() )
+            {
+                do
+                {
+                    cursor.setOffset( offset );
+                    recordIsInUse = isInUse( cursor.getByte() );
+                } while ( cursor.retry() );
+            }
+            return recordIsInUse;
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+    }
+
     @Override
     public void forceUpdateRecord( RelationshipRecord record )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -194,7 +194,8 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
     private AutoLoadingCache<RelationshipImpl> relationshipCache;
     private SchemaCache schemaCache;
     private LabelScanStore labelScanStore;
-    private CacheLayer storeLayer;
+
+    private StoreReadLayer storeLayer;
     private LogFile logFile;
 
     private final AtomicInteger recoveredCount = new AtomicInteger();
@@ -430,9 +431,19 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
                     return getNeoStore();
                 }
             };
-            storeLayer = new CacheLayer( new DiskLayer( propertyKeyTokenHolder, labelTokens, relationshipTypeTokens,
-                    new SchemaStorage( neoStore.getSchemaStore() ), neoStoreProvider, indexingService ),
-                    persistenceCache, indexingService, schemaCache );
+
+            if(config.get( GraphDatabaseSettings.cache_type ).equals( CacheLayer.EXPERIMENTAL_OFF ))
+            {
+                storeLayer = new DiskLayer( propertyKeyTokenHolder, labelTokens, relationshipTypeTokens,
+                        new SchemaStorage( neoStore.getSchemaStore() ), neoStoreProvider, indexingService );
+            }
+            else
+            {
+                storeLayer = new CacheLayer( new DiskLayer( propertyKeyTokenHolder, labelTokens, relationshipTypeTokens,
+                        new SchemaStorage( neoStore.getSchemaStore() ), neoStoreProvider, indexingService ),
+                        persistenceCache, indexingService, schemaCache
+                );
+            }
 
             LegacyPropertyTrackers legacyPropertyTrackers = new LegacyPropertyTrackers( propertyKeyTokenHolder,
                     nodeManager.getNodePropertyTrackers(), nodeManager.getRelationshipPropertyTrackers(), nodeManager );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerIndexTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+
+import static org.junit.Assert.*;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+/**
+ * Test read-access to committed index data.
+ */
+public class DiskLayerIndexTest extends DiskLayerTest
+{
+    @Test
+    public void should_find_nodes_with_given_label_and_property_via_index() throws Exception
+    {
+        // GIVEN
+        createIndexAndAwaitOnline( label1, propertyKey );
+
+        String name = "Mr. Taylor";
+        Node mrTaylor = createLabeledNode( db, map( propertyKey, name ), label1 );
+        try ( Transaction ignored = db.beginTx() )
+        {
+            // WHEN
+            Set<Long> foundNodes = asUniqueSet( disk.nodesGetFromIndexLookup( state, 1l, name ) );
+
+            // THEN
+            assertEquals( asSet( mrTaylor.getId() ), foundNodes );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.util.HashSet;
+
+import org.junit.Test;
+import org.neo4j.collection.primitive.PrimitiveIntIterator;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
+import static org.neo4j.graphdb.Neo4jMatchers.getPropertyKeys;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cache_type;
+import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+/**
+ * Test read access to committed label data.
+ */
+public class DiskLayerLabelTest extends DiskLayerTest
+{
+    @Test
+    public void should_be_able_to_list_labels_for_node() throws Exception
+    {
+        // GIVEN
+        long nodeId;
+        int labelId1, labelId2;
+        try ( Transaction tx = db.beginTx() )
+        {
+            nodeId = db.createNode( label1, label2 ).getId();
+            String labelName1 = label1.name(), labelName2 = label2.name();
+            labelId1 = disk.labelGetForName( labelName1 );
+            labelId2 = disk.labelGetOrCreateForName( labelName2 );
+            tx.success();
+        }
+
+        // THEN
+        PrimitiveIntIterator readLabels = disk.nodeGetLabels( nodeId );
+        assertEquals( new HashSet<>( asList( labelId1, labelId2 ) ),
+                addToCollection( readLabels, new HashSet<Integer>() ) );
+    }
+
+    @Test
+    public void should_be_able_to_get_label_name_for_label() throws Exception
+    {
+        // GIVEN
+        String labelName = label1.name();
+        int labelId = disk.labelGetOrCreateForName( labelName );
+
+        // WHEN
+        String readLabelName = disk.labelGetName( labelId );
+
+        // THEN
+        assertEquals( labelName, readLabelName );
+    }
+
+    /*
+     * This test doesn't really belong here, but OTOH it does, as it has to do with this specific
+     * store solution. It creates its own IGD with cache_type:none to try reproduce to trigger the problem.
+     */
+    @Test
+    public void labels_should_not_leak_out_as_properties() throws Exception
+    {
+        // GIVEN
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .setConfig( cache_type, "none" ).newGraphDatabase();
+        Node node = createLabeledNode( db, map( "name", "Node" ), label1 );
+
+        // WHEN THEN
+        assertThat( getPropertyKeys( db, node ), containsOnly( "name" ) );
+
+        db.shutdown();
+    }
+
+    @Test
+    public void should_return_all_nodes_with_label() throws Exception
+    {
+        // GIVEN
+        Node node1 = createLabeledNode( db, map( "name", "First", "age", 1L ), label1 );
+        Node node2 = createLabeledNode( db, map( "type", "Node", "count", 10 ), label1, label2 );
+        int labelId1 = disk.labelGetForName( label1.name() );
+        int labelId2 = disk.labelGetForName( label2.name() );
+
+        // WHEN
+        PrimitiveLongIterator nodesForLabel1 = disk.nodesGetForLabel( state, labelId1 );
+        PrimitiveLongIterator nodesForLabel2 = disk.nodesGetForLabel( state, labelId2 );
+
+        // THEN
+        assertEquals( asSet( node1.getId(), node2.getId() ), IteratorUtil.asSet( nodesForLabel1 ) );
+        assertEquals( asSet( node2.getId() ), IteratorUtil.asSet( nodesForLabel2 ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+/**
+ * Test reading committed node and relationships from disk.
+ */
+public class DiskLayerNodeAndRelTest extends DiskLayerTest
+{
+    @Test
+    public void shouldTellIfNodeExists() throws Exception
+    {
+        // Given
+        long created = createLabeledNode( db, map() ).getId();
+        long createdAndRemoved = createLabeledNode( db, map() ).getId();
+        long neverExisted = createdAndRemoved + 99;
+
+        try( Transaction tx = db.beginTx() )
+        {
+            db.getNodeById( createdAndRemoved ).delete();
+            tx.success();
+        }
+
+        // When & then
+        assertTrue(  disk.nodeExists( created ));
+        assertFalse( disk.nodeExists( createdAndRemoved ) );
+        assertFalse( disk.nodeExists( neverExisted ) );
+    }
+
+    @Test
+    public void shouldTellIfRelExists() throws Exception
+    {
+        // Given
+        long node = createLabeledNode( db, map() ).getId();
+        long created, createdAndRemoved, neverExisted;
+
+        try( Transaction tx = db.beginTx() )
+        {
+            created = db.createNode().createRelationshipTo( db.createNode(), withName( "Banana" ) ).getId();
+            createdAndRemoved = db.createNode().createRelationshipTo( db.createNode(), withName( "Banana" ) ).getId();
+            tx.success();
+        }
+
+        try( Transaction tx = db.beginTx() )
+        {
+            db.getRelationshipById( createdAndRemoved ).delete();
+            tx.success();
+        }
+
+        neverExisted = created + 99;
+
+        // When & then
+        assertTrue(  disk.relationshipExists( node ));
+        assertFalse( disk.relationshipExists( createdAndRemoved ) );
+        assertFalse( disk.relationshipExists( neverExisted ) );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.lang.reflect.Array;
+
+import org.junit.Test;
+import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+/**
+ * Test read access to committed properties.
+ */
+public class DiskLayerPropertyTest extends DiskLayerTest
+{
+    @Test
+    public void should_get_all_node_properties() throws Exception
+    {
+        // GIVEN
+        String longString =
+                "AlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalong";
+        Object[] properties = {
+                longString,
+                createNew( String.class ),
+                createNew( long.class ),
+                createNew( int.class ),
+                createNew( byte.class ),
+                createNew( short.class ),
+                createNew( boolean.class ),
+                createNew( char.class ),
+                createNew( float.class ),
+                createNew( double.class ),
+                array( 0, String.class ),
+                array( 0, long.class ),
+                array( 0, int.class ),
+                array( 0, byte.class ),
+                array( 0, short.class ),
+                array( 0, boolean.class ),
+                array( 0, char.class ),
+                array( 0, float.class ),
+                array( 0, double.class ),
+                array( 1, String.class ),
+                array( 1, long.class ),
+                array( 1, int.class ),
+                array( 1, byte.class ),
+                array( 1, short.class ),
+                array( 1, boolean.class ),
+                array( 1, char.class ),
+                array( 1, float.class ),
+                array( 1, double.class ),
+                array( 256, String.class ),
+                array( 256, long.class ),
+                array( 256, int.class ),
+                array( 256, byte.class ),
+                array( 256, short.class ),
+                array( 256, boolean.class ),
+                array( 256, char.class ),
+                array( 256, float.class ),
+                array( 256, double.class ),
+        };
+
+        for ( Object value : properties )
+        {
+            // given
+            long nodeId = createLabeledNode( db, singletonMap( "prop", value ), label1 ).getId();
+
+            // when
+            Property property = single( disk.nodeGetAllProperties( nodeId ) );
+
+            //then
+            assertTrue( property + ".valueEquals(" + value + ")", property.valueEquals( value ) );
+        }
+    }
+
+    @Test
+    public void should_create_property_key_if_not_exists() throws Exception
+    {
+        // WHEN
+        long id = disk.propertyKeyGetOrCreateForName( propertyKey );
+
+        // THEN
+        assertTrue( "Should have created a non-negative id", id >= 0 );
+    }
+
+    @Test
+    public void should_get_previously_created_property_key() throws Exception
+    {
+        // GIVEN
+        long id = disk.propertyKeyGetOrCreateForName( propertyKey );
+
+        // WHEN
+        long secondId = disk.propertyKeyGetForName( propertyKey );
+
+        // THEN
+        assertEquals( id, secondId );
+    }
+
+    @Test
+    public void should_be_able_to_get_or_create_previously_created_property_key() throws Exception
+    {
+        // GIVEN
+        long id = disk.propertyKeyGetOrCreateForName( propertyKey );
+
+        // WHEN
+        long secondId = disk.propertyKeyGetOrCreateForName( propertyKey );
+
+        // THEN
+        assertEquals( id, secondId );
+    }
+
+    @Test
+    public void should_fail_if_get_non_existent_property_key() throws Exception
+    {
+        // WHEN
+        int propertyKey = disk.propertyKeyGetForName( "non-existent-property-key" );
+
+        // THEN
+        assertEquals( KeyReadOperations.NO_SUCH_PROPERTY_KEY, propertyKey );
+    }
+
+    private Object array( int length, Class<?> componentType )
+    {
+        Object array = Array.newInstance( componentType, length );
+        for ( int i = 0; i < length; i++ )
+        {
+            Array.set( array, i, createNew( componentType ) );
+        }
+        return array;
+    }
+
+    private Object createNew( Class<?> type )
+    {
+        if ( type == int.class )
+        {
+            return 666;
+        }
+        if ( type == long.class )
+        {
+            return 17l;
+        }
+        if ( type == double.class )
+        {
+            return 6.28318530717958647692d;
+        }
+        if ( type == float.class )
+        {
+            return 3.14f;
+        }
+        if ( type == short.class )
+        {
+            return (short) 8733;
+        }
+        if ( type == byte.class )
+        {
+            return (byte) 123;
+        }
+        if ( type == boolean.class )
+        {
+            return false;
+        }
+        if ( type == char.class )
+        {
+            return 'Z';
+        }
+        if ( type == String.class )
+        {
+            return "hello world";
+        }
+        throw new IllegalArgumentException( type.getName() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -19,32 +19,22 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
-import java.lang.reflect.Array;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
-
-import org.neo4j.collection.primitive.PrimitiveIntIterator;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.index.IndexingService;
-import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
@@ -53,225 +43,20 @@ import org.neo4j.kernel.impl.nioneo.store.SchemaStorage;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
-import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
-import static org.neo4j.graphdb.Neo4jMatchers.getPropertyKeys;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cache_type;
-import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
-import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
 
+/**
+ * Base class for disk layer tests, which test read-access to committed data.
+ */
 public class DiskLayerTest
 {
-    @Test
-    public void should_be_able_to_list_labels_for_node() throws Exception
-    {
-        // GIVEN
-        long nodeId;
-        int labelId1, labelId2;
-        try ( Transaction tx = db.beginTx() )
-        {
-            nodeId = db.createNode( label1, label2 ).getId();
-            String labelName1 = label1.name(), labelName2 = label2.name();
-            labelId1 = statement.labelGetForName( labelName1 );
-            labelId2 = statement.labelGetOrCreateForName( labelName2 );
-            tx.success();
-        }
-
-        // THEN
-        PrimitiveIntIterator readLabels = statement.nodeGetLabels( nodeId );
-        assertEquals( new HashSet<>( asList( labelId1, labelId2 ) ),
-                addToCollection( readLabels, new HashSet<Integer>() ) );
-    }
-
-    @Test
-    public void should_be_able_to_get_label_name_for_label() throws Exception
-    {
-        // GIVEN
-        String labelName = label1.name();
-        int labelId = statement.labelGetOrCreateForName( labelName );
-
-        // WHEN
-        String readLabelName = statement.labelGetName( labelId );
-
-        // THEN
-        assertEquals( labelName, readLabelName );
-    }
-
-    /*
-     * This test doesn't really belong here, but OTOH it does, as it has to do with this specific
-     * store solution. It creates its own IGD with cache_type:none to try reproduce to trigger the problem.
-     */
-    @Test
-    public void labels_should_not_leak_out_as_properties() throws Exception
-    {
-        // GIVEN
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-                .setConfig( cache_type, "none" ).newGraphDatabase();
-        Node node = createLabeledNode( db, map( "name", "Node" ), label1 );
-
-        // WHEN THEN
-        assertThat( getPropertyKeys( db, node ), containsOnly( "name" ) );
-
-        db.shutdown();
-    }
-
-    @Test
-    public void should_return_all_nodes_with_label() throws Exception
-    {
-        // GIVEN
-        Node node1 = createLabeledNode( db, map( "name", "First", "age", 1L ), label1 );
-        Node node2 = createLabeledNode( db, map( "type", "Node", "count", 10 ), label1, label2 );
-        int labelId1 = statement.labelGetForName( label1.name() );
-        int labelId2 = statement.labelGetForName( label2.name() );
-
-        // WHEN
-        PrimitiveLongIterator nodesForLabel1 = statement.nodesGetForLabel( state, labelId1 );
-        PrimitiveLongIterator nodesForLabel2 = statement.nodesGetForLabel( state, labelId2 );
-
-        // THEN
-        assertEquals( asSet( node1.getId(), node2.getId() ), IteratorUtil.asSet( nodesForLabel1 ) );
-        assertEquals( asSet( node2.getId() ), IteratorUtil.asSet( nodesForLabel2 ) );
-    }
-
-    @Test
-    public void should_get_all_node_properties() throws Exception
-    {
-        // GIVEN
-        String longString =
-                "AlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalong";
-        Object[] properties = {
-                longString,
-                gimme( String.class ),
-                gimme( long.class ),
-                gimme( int.class ),
-                gimme( byte.class ),
-                gimme( short.class ),
-                gimme( boolean.class ),
-                gimme( char.class ),
-                gimme( float.class ),
-                gimme( double.class ),
-                array( 0, String.class ),
-                array( 0, long.class ),
-                array( 0, int.class ),
-                array( 0, byte.class ),
-                array( 0, short.class ),
-                array( 0, boolean.class ),
-                array( 0, char.class ),
-                array( 0, float.class ),
-                array( 0, double.class ),
-                array( 1, String.class ),
-                array( 1, long.class ),
-                array( 1, int.class ),
-                array( 1, byte.class ),
-                array( 1, short.class ),
-                array( 1, boolean.class ),
-                array( 1, char.class ),
-                array( 1, float.class ),
-                array( 1, double.class ),
-                array( 256, String.class ),
-                array( 256, long.class ),
-                array( 256, int.class ),
-                array( 256, byte.class ),
-                array( 256, short.class ),
-                array( 256, boolean.class ),
-                array( 256, char.class ),
-                array( 256, float.class ),
-                array( 256, double.class ),
-        };
-
-        for ( Object value : properties )
-        {
-            // given
-            long nodeId = createLabeledNode( db, singletonMap( "prop", value ), label1 ).getId();
-
-            // when
-            Property property = single( statement.nodeGetAllProperties( nodeId ) );
-
-            //then
-            assertTrue( property + ".valueEquals(" + value + ")", property.valueEquals( value ) );
-        }
-    }
-
-    @Test
-    public void should_create_property_key_if_not_exists() throws Exception
-    {
-        // WHEN
-        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
-
-        // THEN
-        assertTrue( "Should have created a non-negative id", id >= 0 );
-    }
-
-    @Test
-    public void should_get_previously_created_property_key() throws Exception
-    {
-        // GIVEN
-        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
-
-        // WHEN
-        long secondId = statement.propertyKeyGetForName( propertyKey );
-
-        // THEN
-        assertEquals( id, secondId );
-    }
-
-    @Test
-    public void should_be_able_to_get_or_create_previously_created_property_key() throws Exception
-    {
-        // GIVEN
-        long id = statement.propertyKeyGetOrCreateForName( propertyKey );
-
-        // WHEN
-        long secondId = statement.propertyKeyGetOrCreateForName( propertyKey );
-
-        // THEN
-        assertEquals( id, secondId );
-    }
-
-    @Test
-    public void should_fail_if_get_non_existent_property_key() throws Exception
-    {
-        // WHEN
-        int propertyKey = statement.propertyKeyGetForName( "non-existent-property-key" );
-
-        // THEN
-        assertEquals( KeyReadOperations.NO_SUCH_PROPERTY_KEY, propertyKey );
-    }
-
-    @Test
-    public void should_find_nodes_with_given_label_and_property_via_index() throws Exception
-    {
-        // GIVEN
-        IndexDescriptor index = createIndexAndAwaitOnline( label1, propertyKey );
-        String name = "Mr. Taylor";
-        Node mrTaylor = createLabeledNode( db, map( propertyKey, name ), label1 );
-        try ( Transaction ignored = db.beginTx() )
-        {
-            // WHEN
-            Set<Long> foundNodes = asUniqueSet( statement.nodesGetFromIndexLookup( state, 1l, name ) );
-
-            // THEN
-            assertEquals( asSet( mrTaylor.getId() ), foundNodes );
-        }
-    }
-
-    @SuppressWarnings("deprecation") private GraphDatabaseAPI db;
-    private final Label label1 = label( "first-label" ), label2 = label( "second-label" );
-    private final String propertyKey = "name";
-    private KernelStatement state;
-    private DiskLayer statement;
+    @SuppressWarnings("deprecation") protected GraphDatabaseAPI db;
+    protected final Label label1 = label( "first-label" ), label2 = label( "second-label" );
+    protected final String propertyKey = "name";
+    protected KernelStatement state;
+    protected DiskLayer disk;
 
     @SuppressWarnings("deprecation")
     @Before
@@ -281,7 +66,7 @@ public class DiskLayerTest
         DependencyResolver resolver = db.getDependencyResolver();
         IndexingService indexingService = resolver.resolveDependency( IndexingService.class );
         NeoStore neoStore = resolver.resolveDependency( NeoStoreProvider.class ).evaluate();
-        this.statement = new DiskLayer(
+        this.disk = new DiskLayer(
                 resolver.resolveDependency( PropertyKeyTokenHolder.class ),
                 resolver.resolveDependency( LabelTokenHolder.class ),
                 resolver.resolveDependency( RelationshipTypeTokenHolder.class ),
@@ -299,7 +84,7 @@ public class DiskLayerTest
         db.shutdown();
     }
 
-    private static Node createLabeledNode( GraphDatabaseService db, Map<String, Object> properties, Label... labels )
+    protected static Node createLabeledNode( GraphDatabaseService db, Map<String, Object> properties, Label... labels )
     {
         try ( Transaction tx = db.beginTx() )
         {
@@ -313,7 +98,7 @@ public class DiskLayerTest
         }
     }
 
-    private IndexDescriptor createIndexAndAwaitOnline( Label label, String propertyKey ) throws Exception
+    protected IndexDescriptor createIndexAndAwaitOnline( Label label, String propertyKey ) throws Exception
     {
         IndexDefinition index;
         try ( Transaction tx = db.beginTx() )
@@ -325,59 +110,8 @@ public class DiskLayerTest
         try ( Transaction ignored = db.beginTx() )
         {
             db.schema().awaitIndexOnline( index, 10, SECONDS );
-            return statement.indexesGetForLabelAndPropertyKey( statement.labelGetForName( label.name() ),
-                    statement.propertyKeyGetForName( propertyKey ) );
+            return disk.indexesGetForLabelAndPropertyKey( disk.labelGetForName( label.name() ),
+                    disk.propertyKeyGetForName( propertyKey ) );
         }
-    }
-
-    private Object array( int length, Class<?> componentType )
-    {
-        Object array = Array.newInstance( componentType, length );
-        for ( int i = 0; i < length; i++ )
-        {
-            Array.set( array, i, gimme( componentType ) );
-        }
-        return array;
-    }
-
-    private Object gimme( Class<?> type )
-    {
-        if ( type == int.class )
-        {
-            return 666;
-        }
-        if ( type == long.class )
-        {
-            return 17l;
-        }
-        if ( type == double.class )
-        {
-            return 6.28318530717958647692d;
-        }
-        if ( type == float.class )
-        {
-            return 3.14f;
-        }
-        if ( type == short.class )
-        {
-            return (short) 8733;
-        }
-        if ( type == byte.class )
-        {
-            return (byte) 123;
-        }
-        if ( type == boolean.class )
-        {
-            return false;
-        }
-        if ( type == char.class )
-        {
-            return 'Z';
-        }
-        if ( type == String.class )
-        {
-            return "hello world";
-        }
-        throw new IllegalArgumentException( type.getName() );
     }
 }


### PR DESCRIPTION
This introduces mainly a set of unsupported operations into DiskLayer, and
introduces a hidden config option to disable the cache layer entirely. Some
operations, like nodeExists and relExists, have been implemented.

This would be a first step for assessing database performance
without the object cache.
