### PR TITLE
Change log deserializer to be thread safe.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStore.java
@@ -66,7 +66,7 @@ public class PhysicalLogicalTransactionStore extends LifecycleAdapter implements
 
     @Override
     public IOCursor<CommittedTransactionRepresentation> getTransactions( final long transactionIdToStartFrom )
-            throws NoSuchTransactionException, IOException
+            throws IOException
     {
         // look up in position cache
         try

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -306,33 +306,6 @@ public class Protocol
         }
     };
 
-    public static class CommittedTransactionRepresentationSerializer implements Serializer
-    {
-        private final Iterable<CommittedTransactionRepresentation> txs;
-
-        public CommittedTransactionRepresentationSerializer( Iterable<CommittedTransactionRepresentation> txs )
-        {
-            this.txs = txs;
-        }
-
-        @Override
-        public void write( ChannelBuffer buffer ) throws IOException
-        {
-            NetworkWritableLogChannel channel = new NetworkWritableLogChannel( buffer );
-            LogEntryWriterv1 writer = new LogEntryWriterv1( channel, new CommandWriter( channel ) );
-            for ( CommittedTransactionRepresentation tx : txs )
-            {
-                LogEntryStart startEntry = tx.getStartEntry();
-                writer.writeStartEntry( startEntry.getMasterId(), startEntry.getLocalId(),
-                        startEntry.getTimeWritten(), startEntry.getLastCommittedTxWhenTransactionStarted(),
-                        startEntry.getAdditionalHeader() );
-                writer.serialize( tx.getTransactionRepresentation() );
-                LogEntryCommit commitEntry = tx.getCommitEntry();
-                writer.writeCommitEntry( commitEntry.getTxId(), commitEntry.getTimeWritten() );
-            }
-        }
-    }
-
     public static void addLengthFieldPipes( ChannelPipeline pipeline, int frameLength )
     {
         pipeline.addLast( "frameDecoder",


### PR DESCRIPTION
Log deserializer used to re-use a PositionMarker to lower the amount of object
allocation needed for deserialization. However, this was not done in a thread
safe way, which lead to complex errors in high concurrent load. This makes it
thread safe again, and leaves a note about re-visiting approaches for lowering
object allocation.
