### PR TITLE
Fix cypher compiler 2.1 dependency version

### DIFF
--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.1</artifactId>
-      <version>2.2-SNAPSHOT</version>
+      <version>2.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>


### PR DESCRIPTION
Error:
The POM for org.neo4j:neo4j-cypher-compiler-2.1:jar:2.2-SNAPSHOT is missing, no dependency information available
