### PR TITLE
Fix for 'Cluster is not operational' issue

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -49,6 +49,7 @@ import org.neo4j.cluster.protocol.election.ElectionState;
 import org.neo4j.cluster.protocol.election.HeartbeatReelectionListener;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatIAmAliveProcessor;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatJoinListener;
+import org.neo4j.cluster.protocol.heartbeat.HeartbeatLeftListener;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatMessage;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatRefreshProcessor;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatState;
@@ -90,7 +91,7 @@ public class MultiPaxosServerFactory
                                              ObjectInputStreamFactory objectInputStreamFactory,
                                              ObjectOutputStreamFactory objectOutputStreamFactory )
     {
-        DelayedDirectExecutor executor = new DelayedDirectExecutor();
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
 
         // Create state machines
         Timeouts timeouts = new Timeouts( timeoutStrategy );
@@ -172,8 +173,9 @@ public class MultiPaxosServerFactory
         input.addMessageProcessor( new HeartbeatIAmAliveProcessor( stateMachines.getOutgoing(),
                 context.getClusterContext() ) );
 
-        server.newClient( Cluster.class ).addClusterListener( new HeartbeatJoinListener( stateMachines
-                .getOutgoing() ) );
+        Cluster cluster = server.newClient( Cluster.class );
+        cluster.addClusterListener( new HeartbeatJoinListener( stateMachines.getOutgoing() ) );
+        cluster.addClusterListener( new HeartbeatLeftListener( context.getHeartbeatContext(), logging ) );
 
         context.getHeartbeatContext().addHeartbeatListener( new HeartbeatReelectionListener(
                 server.newClient( Election.class ), logging.getMessagesLog( ClusterLeaveReelectionListener.class ) ) );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.heartbeat;
+
+import java.net.URI;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.protocol.cluster.ClusterListener;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.Logging;
+
+public class HeartbeatLeftListener extends ClusterListener.Adapter
+{
+    private final HeartbeatContext heartbeatContext;
+    private final StringLogger log;
+
+    public HeartbeatLeftListener( HeartbeatContext heartbeatContext, Logging logging )
+    {
+        this.heartbeatContext = heartbeatContext;
+        this.log = logging.getMessagesLog( getClass() );
+    }
+
+    @Override
+    public void leftCluster( InstanceId instanceId, URI member )
+    {
+        if ( heartbeatContext.isFailed( instanceId ) )
+        {
+            log.warn( "Instance " + instanceId + " (" + member + ") has left the cluster " +
+                    "but is still treated as failed by HeartbeatContext" );
+
+            heartbeatContext.serverLeftCluster( instanceId );
+        }
+    }
+}

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
@@ -21,6 +21,7 @@ package org.neo4j.cluster;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.neo4j.cluster.com.message.Message;
@@ -35,6 +36,7 @@ import org.neo4j.cluster.statemachine.StateTransitionListener;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
+import org.neo4j.kernel.logging.DefaultLogging;
 
 /**
  * TODO
@@ -57,7 +59,8 @@ public class TestProtocolServer
         this.receiver = new TestMessageSource();
         this.sender = new TestMessageSender();
 
-        stateMachineExecutor = new DelayedDirectExecutor();
+        stateMachineExecutor = new DelayedDirectExecutor(
+                DefaultLogging.createDefaultLogging( Collections.<String, String>emptyMap() ) );
 
         server = factory.newProtocolServer( instanceId, timeoutStrategy, receiver, sender, acceptorInstanceStore,
                 electionCredentialsProvider, stateMachineExecutor, new ObjectStreamFactory(), new ObjectStreamFactory() );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
@@ -95,7 +95,7 @@ class ClusterInstance
 
         InMemoryAcceptorInstanceStore acceptorInstances = new InMemoryAcceptorInstanceStore();
 
-        DelayedDirectExecutor executor = new DelayedDirectExecutor();
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
         final MultiPaxosContext context = new MultiPaxosContext( id,
                 Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( ClusterConfiguration.COORDINATOR ) ),
                 new ClusterConfiguration( configuration.getName(), logging.getMessagesLog( ClusterConfiguration.class ),
@@ -109,8 +109,9 @@ class ClusterInstance
         SnapshotContext snapshotContext = new SnapshotContext( context.getClusterContext(),
                 context.getLearnerContext() );
 
-        ProtocolServer ps = factory.newProtocolServer( id,
-                input, output, DIRECT_EXECUTOR, new DelayedDirectExecutor(), timeouts, context, snapshotContext );
+        DelayedDirectExecutor taskExecutor = new DelayedDirectExecutor( logging );
+        ProtocolServer ps = factory.newProtocolServer(
+                id, input, output, DIRECT_EXECUTOR, taskExecutor, timeouts, context, snapshotContext );
 
         return new ClusterInstance( DIRECT_EXECUTOR, logging, factory, ps, context, acceptorInstances, timeouts,
                 input, output, uri );
@@ -276,7 +277,7 @@ class ClusterInstance
         ClusterInstanceOutput output = new ClusterInstanceOutput( uri );
         ClusterInstanceInput input = new ClusterInstanceInput();
 
-        DelayedDirectExecutor executor = new DelayedDirectExecutor();
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
 
         ObjectStreamFactory objectStreamFactory = new ObjectStreamFactory();
         MultiPaxosContext snapshotCtx = ctx.snapshot( logging, timeoutsSnapshot, executor, snapshotAcceptorInstances,

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
@@ -1017,21 +1017,25 @@ public class ClusterManager
             }
         };
     }
-    
-    private static String printState(ManagedCluster cluster)
+
+    public static String printState( ManagedCluster cluster )
     {
-        StringBuilder buf = new StringBuilder();
+        StringBuilder buf = new StringBuilder( "\n" );
         for ( HighlyAvailableGraphDatabase database : cluster.getAllMembers() )
         {
+            ClusterClient client = database.getDependencyResolver().resolveDependency( ClusterClient.class );
+            buf.append( "Instance " ).append( client.getServerId() )
+                    .append( "(" ).append( client.getClusterServer() ).append( "):" ).append( "\n" );
+
             ClusterMembers members = database.getDependencyResolver().resolveDependency( ClusterMembers.class );
 
             for ( ClusterMember clusterMember : members.getMembers() )
             {
-                buf.append( clusterMember.getInstanceId() ).append( ":" ).append( clusterMember.getHARole() )
-                   .append( "\n" );
+                buf.append( "  " ).append( clusterMember.getInstanceId() ).append( ":" )
+                        .append( clusterMember.getHARole() )
+                        .append( " (is alive = " ).append( clusterMember.isAlive() ).append( ")" )
+                        .append( "\n" );
             }
-
-            buf.append( "\n" );
         }
 
         return buf.toString();


### PR DESCRIPTION
This PR fixes the problem with master election when ClusterConfiguration and HeartbeatContext appears to be in incoherent state. In such state failed machine was already not present in configuration but still present in heartbeat. This led to lack of quorum and failure of new election. HeartbeatLeftListener will now explicitly remove failed instance from heartbeat.
Fixed unsynchronized execute(Runnable)/drain() in DelayedDirectExecutor, which is used from multiple threads.
