### PR TITLE
Don't skip relationships in the cache on rollback.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransaction.java
@@ -303,8 +303,6 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
                     getRelationshipStore().freeId( record.getId() );
                 }
                 removeRelationshipFromCache( record.getId() );
-                patchDeletedRelationshipNodes( record.getId(), record.getFirstNode(), record.getFirstNextRel(),
-                        record.getSecondNode(), record.getSecondNextRel() );
             }
             if ( neoStoreRecord != null )
             {
@@ -374,12 +372,6 @@ public class WriteTransaction extends XaTransaction implements NeoStoreTransacti
     private void removeRelationshipTypeFromCache( int id )
     {
         state.removeRelationshipTypeFromCache( id );
-    }
-
-    private void patchDeletedRelationshipNodes( long id, long firstNodeId, long firstNodeNextRelId, long secondNodeId,
-                                                long secondNextRelId )
-    {
-        state.patchDeletedRelationshipNodes( id, firstNodeId, firstNodeNextRelId, secondNodeId, secondNextRelId );
     }
 
     private void removeRelationshipFromCache( long id )


### PR DESCRIPTION
When loading relationships for a node, and the relationship chain
has been partially loaded, it was possible for another transaction
to make modifications to the next relationship to be loaded for
that node, but without loading it through that node (by loading it
through the other node of that relationship). If that transaction
rolled back it would make the cache skip loading that relationship.
