### PR TITLE
BACKPORT: Fix inconsistent behavior in diffsets on remove/add combination.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -603,9 +603,9 @@ public class StateHandlingStatementOperations implements
         if ( existingProperty.isDefined() )
         {
             legacyPropertyTrackers.nodeRemoveStoreProperty( nodeId, (DefinedProperty) existingProperty );
+            state.txState().nodeDoRemoveProperty( nodeId, existingProperty );
             state.neoStoreTransaction.nodeRemoveProperty( nodeId, propertyKeyId );
         }
-        state.txState().nodeDoRemoveProperty( nodeId, existingProperty );
         return existingProperty;
     }
 
@@ -618,9 +618,9 @@ public class StateHandlingStatementOperations implements
         {
             legacyPropertyTrackers.relationshipRemoveStoreProperty( relationshipId, (DefinedProperty)
                     existingProperty );
+            state.txState().relationshipDoRemoveProperty( relationshipId, existingProperty );
             state.neoStoreTransaction.relRemoveProperty( relationshipId, propertyKeyId );
         }
-        state.txState().relationshipDoRemoveProperty( relationshipId, existingProperty );
         return existingProperty;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
@@ -94,9 +94,9 @@ public class DiffSets<T>
 
     public boolean add( T elem )
     {
-        boolean result = added( true ).add( elem );
-        removed( false ).remove( elem );
-        return result;
+        boolean wasRemoved = removed( false ).remove( elem );
+        // Add to the addedElements only if it was not removed from the removedElements
+        return wasRemoved || added( true ).add( elem );
     }
 
     public void replace( T toRemove, T toAdd )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -494,26 +494,24 @@ public class LabelsAcceptanceTest
         // GIVEN
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
         final Label label = DynamicLabel.label( "A" );
+        try ( Transaction tx = db.beginTx() )
         {
-            final Transaction tx = db.beginTx();
-            final Node node = db.createNode();
+            Node node = db.createNode();
             node.addLabel( label );
             node.setProperty( "name", "bla" );
             tx.success();
-            tx.finish();
         }
 
         // WHEN
+        try ( Transaction tx = db.beginTx() )
         {
-            final Transaction tx = db.beginTx();
             for ( final Node node : GlobalGraphOperations.at( db ).getAllNodes() )
             {
                 node.removeLabel( label ); // remove Label ...
                 node.delete(); // ... and afterwards the node
             }
             tx.success();
-            tx.finish(); // here comes the exception
-        }
+        } // tx.close(); - here comes the exception
 
         // THEN
         Transaction transaction = db.beginTx();
@@ -533,12 +531,8 @@ public class LabelsAcceptanceTest
         {
             Node node = db.createNode( label1, label2 );
 
-            Iterable<Label> labels = node.getLabels();
-            Iterator<Label> labelIterator = labels.iterator();
-
-            while ( labelIterator.hasNext() )
+            for ( Label next : node.getLabels() )
             {
-                Label next = labelIterator.next();
                 node.removeLabel( next );
             }
             tx.success();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DiffSetsTest.java
@@ -96,7 +96,7 @@ public class DiffSetsTest
         actual.add( 1L );
 
         // THEN
-        assertEquals( asSet( 1L ), actual.getAdded() );
+        assertTrue( actual.getAdded().isEmpty() );
         assertTrue( actual.getRemoved().isEmpty() );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.impl.core.Token;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertThat;
 
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 
 public class LabelIT extends KernelIntegrationTest
@@ -63,5 +64,33 @@ public class LabelIT extends KernelIntegrationTest
             assertThat(asCollection( labelIdsAfterCommit ) ,
                     hasItems( new Token( "label1", label1Id ), new Token( "label2", label2Id ) ));
         }
+    }
+
+    @Test
+    public void addingAndRemovingLabelInSameTxShouldHaveNoEffect() throws Exception
+    {
+        // Given a node with a label
+        int label;
+        long node;
+        {
+            DataWriteOperations stmt = dataWriteOperationsInNewTransaction();
+            label = stmt.labelGetOrCreateForName( "Label 1" );
+            node = stmt.nodeCreate();
+            stmt.nodeAddLabel( node, label );
+            commit();
+        }
+
+        // When I add and remove that label in the same tx
+        {
+            DataWriteOperations stmt = dataWriteOperationsInNewTransaction();
+            stmt.nodeRemoveLabel( node, label );
+            stmt.nodeAddLabel( node, label );
+        }
+
+        // Then commit should not throw exceptions
+        commit();
+
+        // And then the node should have the label
+        assertTrue( readOperationsInNewTransaction().nodeHasLabel( node, label ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -29,9 +29,11 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.core.Token;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertArrayEquals;
@@ -39,8 +41,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.kernel.api.properties.Property.property;
 
 public class PropertyIT extends KernelIntegrationTest
 {
@@ -371,6 +375,132 @@ public class PropertyIT extends KernelIntegrationTest
             // then
             assertThat(asCollection( propIdsAfterCommit ) ,
                     hasItems( new Token( "prop1", (int) prop1 ), new Token( "prop2", (int) prop2 ) ));
+        }
+    }
+
+    @Test
+    public void shouldNotAllowModifyingPropertiesOnDeletedNode() throws Exception
+    {
+        // given
+        int prop1;
+        long node;
+        {
+            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+            prop1 = statement.propertyKeyGetOrCreateForName( "prop1" );
+            node = statement.nodeCreate();
+
+            statement.nodeSetProperty( node, Property.stringProperty( prop1, "As" ) );
+            statement.nodeDelete( node );
+
+            // When
+            try
+            {
+                statement.nodeRemoveProperty( node, prop1 );
+                fail( "Should have failed." );
+            }
+            catch ( IllegalStateException e )
+            {
+                assertThat( e.getMessage(),
+                            equalTo( "Node[" + node + "] has been deleted in this tx" ) );
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotAllowModifyingPropertiesOnDeletedRelationship() throws Exception
+    {
+        // given
+        int prop1;
+        long rel;
+        {
+            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+            prop1 = statement.propertyKeyGetOrCreateForName( "prop1" );
+            int type = statement.relationshipTypeGetOrCreateForName( "RELATED" );
+            rel = statement.relationshipCreate( type, statement.nodeCreate(), statement.nodeCreate() );
+
+            statement.relationshipSetProperty( rel, Property.stringProperty( prop1, "As" ) );
+            statement.relationshipDelete( rel );
+
+            // When
+            try
+            {
+                statement.relationshipRemoveProperty( rel, prop1 );
+                fail( "Should have failed." );
+            }
+            catch ( IllegalStateException e )
+            {
+                assertThat( e.getMessage(),
+                            equalTo( "Relationship[" + rel + "] has been deleted in this tx" ) );
+            }
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToRemoveResetAndTwiceRemovePropertyOnNode() throws Exception
+    {
+        // given
+        long node;
+        int prop;
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            prop = ops.propertyKeyGetOrCreateForName( "foo" );
+
+            node = ops.nodeCreate();
+            ops.nodeSetProperty( node, property( prop, "bar" ) );
+
+            commit();
+        }
+
+        // when
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            ops.nodeRemoveProperty( node, prop );
+            ops.nodeSetProperty( node, property( prop, "bar" ) );
+            ops.nodeRemoveProperty( node, prop );
+            ops.nodeRemoveProperty( node, prop );
+
+            commit();
+        }
+
+        // then
+        {
+            ReadOperations ops = readOperationsInNewTransaction();
+            assertThat( ops.nodeGetProperty( node, prop ), not( isDefinedProperty() ) );
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToRemoveResetAndTwiceRemovePropertyOnRelationship() throws Exception
+    {
+        // given
+        long rel;
+        int prop;
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            prop = ops.propertyKeyGetOrCreateForName( "foo" );
+            int type = ops.relationshipTypeGetOrCreateForName( "RELATED" );
+
+            rel = ops.relationshipCreate( type, ops.nodeCreate(), ops.nodeCreate() );
+            ops.relationshipSetProperty( rel, property( prop, "bar" ) );
+
+            commit();
+        }
+
+        // when
+        {
+            DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+            ops.relationshipRemoveProperty( rel, prop );
+            ops.relationshipSetProperty( rel, property( prop, "bar" ) );
+            ops.relationshipRemoveProperty( rel, prop );
+            ops.relationshipRemoveProperty( rel, prop );
+
+            commit();
+        }
+
+        // then
+        {
+            ReadOperations ops = readOperationsInNewTransaction();
+            assertThat( ops.relationshipGetProperty( rel, prop ), not( isDefinedProperty() ) );
         }
     }
 


### PR DESCRIPTION
This is a backport of 840cd335fe08642b38b622b73d984c9096cecf4c from 2.1 to 2.0, since 2.0 exhibits the same problems.
