### PR TITLE
Removes pushTransaction and copyTransactions request types from HA

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/ClockSweepPageTable.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/ClockSweepPageTable.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
 import org.neo4j.io.pagecache.PageCacheMonitor;
-import org.neo4j.io.pagecache.PageLock;
 import org.neo4j.io.pagecache.PagedFile;
 
 import static org.neo4j.io.pagecache.PageCursor.UNBOUND_PAGE_ID;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/PageTable.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/PageTable.java
@@ -21,8 +21,6 @@ package org.neo4j.io.pagecache.impl.standard;
 
 import java.io.IOException;
 
-import org.neo4j.io.pagecache.PageLock;
-
 public interface PageTable
 {
     /**

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/PinnablePage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/PinnablePage.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.io.pagecache.impl.standard;
 
-import org.neo4j.io.pagecache.PageLock;
 import org.neo4j.io.pagecache.impl.common.Page;
 
 public interface PinnablePage extends Page

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/StandardPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/StandardPageCursor.java
@@ -24,9 +24,7 @@ import java.io.IOException;
 import org.neo4j.io.pagecache.PageLock;
 import org.neo4j.io.pagecache.impl.common.OffsetTrackingCursor;
 
-import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
-import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 
 public class StandardPageCursor extends OffsetTrackingCursor
 {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/ClockSweepPageTableTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/ClockSweepPageTableTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.io.pagecache.PageCacheMonitor;
-import org.neo4j.io.pagecache.PageLock;
 import org.neo4j.io.pagecache.PagedFile;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/StandardPagedFileTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/StandardPagedFileTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCacheMonitor;
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PageLock;
 import org.neo4j.io.pagecache.PagedFile;
 
 import static org.hamcrest.Matchers.is;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyRelationshipStoreReader.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
-import org.neo4j.kernel.impl.storemigration.legacystore.v20.LegacyRelationship20StoreReader;
 
 public interface LegacyRelationshipStoreReader extends Closeable
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -49,7 +49,6 @@ import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -43,8 +43,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.helpers.Function;
-import org.neo4j.helpers.Functions;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.CombiningIterable;
@@ -92,7 +90,6 @@ import org.neo4j.kernel.impl.transaction.KernelHealth;
 import org.neo4j.kernel.impl.transaction.xaframework.DefaultTxIdGenerator;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntry;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -109,8 +106,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.configForStoreDir;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -31,7 +31,6 @@ import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.impl.storemigration.legacystore.v19.Legacy19Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v20.Legacy20Store;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorIT.java
@@ -71,7 +71,6 @@ import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 import static org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore.ALL_STORES_VERSION;
 import static org.neo4j.kernel.impl.nioneo.store.NeoStore.versionLongToString;
-import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.PROPERTY_KEY_TOKEN_STORE_NAME;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.find20FormatStoreDirectory;
 import static org.neo4j.kernel.impl.storemigration.UpgradeConfiguration.ALLOW_UPGRADE;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTestIT.java
@@ -38,14 +38,7 @@ import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.truncateFi
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.truncateToFixedLength;
 import static org.neo4j.kernel.impl.storemigration.legacystore.v20.Legacy20Store.LEGACY_VERSION;
 
-import java.io.File;
-import java.io.IOException;
-
-import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Test;
-import org.neo4j.helpers.UTF8;
-import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 public class UpgradableDatabaseTestIT

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadTransactionLogWritingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReadTransactionLogWritingTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Label;
@@ -38,7 +37,6 @@ import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.xaframework.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFile;
-import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntry;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneDataSourceTest.java
@@ -27,14 +27,12 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterAccessor;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
@@ -29,7 +29,6 @@ import java.util.Random;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -21,11 +21,8 @@ package recovery;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +31,6 @@ import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
-import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;

--- a/community/neo4j/src/test/java/synchronization/TestConcurrentRotation.java
+++ b/community/neo4j/src/test/java/synchronization/TestConcurrentRotation.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.lucene.index.IndexWriter;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.neo4j.graphdb.DependencyResolver;

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -24,7 +24,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.codehaus.jackson.JsonFactory;

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -57,7 +57,6 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.index.ReadableIndex;
-import org.neo4j.graphdb.index.ReadableRelationshipIndex;
 import org.neo4j.graphdb.index.UniqueFactory;
 import org.neo4j.graphdb.index.UniqueFactory.UniqueEntity;
 import org.neo4j.graphdb.schema.ConstraintCreator;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -37,7 +37,6 @@ import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.StringLogger;

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -44,9 +44,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.PhysicalTransactionRepresen
 import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryCommand;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryReader;
-import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryWriterv1;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.impl.util.Cursors;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/CommitProcessSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/CommitProcessSwitcher.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.ha;
 import java.net.URI;
 
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
 import org.neo4j.kernel.ha.com.RequestContextFactory;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
@@ -19,16 +19,10 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.com.Protocol.INTEGER_SERIALIZER;
-import static org.neo4j.com.Protocol.LONG_SERIALIZER;
-import static org.neo4j.com.Protocol.VOID_SERIALIZER;
-import static org.neo4j.com.Protocol.readBoolean;
-import static org.neo4j.com.Protocol.readString;
-import static org.neo4j.kernel.ha.com.slave.MasterClient.LOCK_SERIALIZER;
-
 import java.io.IOException;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
@@ -43,6 +37,13 @@ import org.neo4j.kernel.ha.id.IdAllocation;
 import org.neo4j.kernel.ha.lock.LockResult;
 import org.neo4j.kernel.impl.nioneo.store.IdRange;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.com.Protocol.INTEGER_SERIALIZER;
+import static org.neo4j.com.Protocol.LONG_SERIALIZER;
+import static org.neo4j.com.Protocol.VOID_SERIALIZER;
+import static org.neo4j.com.Protocol.readBoolean;
+import static org.neo4j.com.Protocol.readString;
+import static org.neo4j.kernel.ha.com.slave.MasterClient.LOCK_SERIALIZER;
 
 public enum HaRequestType201 implements RequestType<Master>
 {
@@ -250,13 +251,13 @@ public enum HaRequestType201 implements RequestType<Master>
     }, VOID_SERIALIZER ),
 
     // ====
-    COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
+    PLACEHOLDER_FOR_COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
     {
         @Override
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 final ChannelBuffer target )
         {
-            return master.copyTransactions( context, readString( input ), input.readLong(), input.readLong() );
+            throw new UnsupportedOperationException( "Not used anymore, merely here to keep the ordinal ids of the others" );
         }
 
     }, VOID_SERIALIZER ),
@@ -357,7 +358,7 @@ public enum HaRequestType201 implements RequestType<Master>
             throw new ThisShouldNotHappenError( "ChrisG", "Transaction pushing requests are obsolete" );
         }
     }, VOID_SERIALIZER ),
-    
+
     // ====
     CREATE_PROPERTY_KEY( new TargetCaller<Master, Integer>()
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
@@ -19,16 +19,10 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.com.Protocol.INTEGER_SERIALIZER;
-import static org.neo4j.com.Protocol.LONG_SERIALIZER;
-import static org.neo4j.com.Protocol.VOID_SERIALIZER;
-import static org.neo4j.com.Protocol.readBoolean;
-import static org.neo4j.com.Protocol.readString;
-import static org.neo4j.kernel.ha.com.slave.MasterClient.LOCK_SERIALIZER;
-
 import java.io.IOException;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.Protocol;
 import org.neo4j.com.RequestContext;
@@ -47,6 +41,13 @@ import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.nioneo.store.IdRange;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.com.Protocol.INTEGER_SERIALIZER;
+import static org.neo4j.com.Protocol.LONG_SERIALIZER;
+import static org.neo4j.com.Protocol.VOID_SERIALIZER;
+import static org.neo4j.com.Protocol.readBoolean;
+import static org.neo4j.com.Protocol.readString;
+import static org.neo4j.kernel.ha.com.slave.MasterClient.LOCK_SERIALIZER;
 
 public enum HaRequestType210 implements RequestType<Master>
 {
@@ -207,13 +208,13 @@ public enum HaRequestType210 implements RequestType<Master>
     }, VOID_SERIALIZER ),
 
     // ====
-    COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
+    PLACEHOLDER_FOR_COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
     {
         @Override
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 final ChannelBuffer target )
         {
-            return master.copyTransactions( context, readString( input ), input.readLong(), input.readLong() );
+            throw new UnsupportedOperationException( "Not used anymore, merely here to keep the ordinal ids of the others" );
         }
 
     }, VOID_SERIALIZER ),
@@ -230,14 +231,13 @@ public enum HaRequestType210 implements RequestType<Master>
     }, VOID_SERIALIZER ),
 
     // ====
-    PUSH_TRANSACTION( new TargetCaller<Master, Void>()
+    PLACEHOLDER_FOR_PUSH_TRANSACTION( new TargetCaller<Master, Void>()
     {
         @Override
         public Response<Void> call( Master master, RequestContext context, ChannelBuffer input,
                 ChannelBuffer target )
         {
-            readString( input ); // always neostorexadatasource
-            return master.pushTransaction( context, input.readLong() );
+            throw new UnsupportedOperationException( "Not used anymore, merely here to keep the ordinal ids of the others" );
         }
     }, VOID_SERIALIZER ),
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
-import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
-import static org.neo4j.com.Protocol.writeString;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.Client;
 import org.neo4j.com.Deserializer;
 import org.neo4j.com.Protocol;
@@ -47,11 +44,14 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.nioneo.store.IdRange;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
+import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
+import static org.neo4j.com.Protocol.writeString;
 
 /**
  * The {@link Master} a slave should use to communicate with its master. It
@@ -342,39 +342,6 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     {
         return new RequestContext( context.getEpoch(), context.machineId(), context.getEventIdentifier(),
                 0, context.getMasterId(), context.getChecksum() );
-    }
-
-    @Override
-    public Response<Void> copyTransactions( RequestContext context,
-                                            final String ds, final long startTxId, final long endTxId )
-    {
-        context = stripFromTransactions( context );
-        return sendRequest( HaRequestType201.COPY_TRANSACTIONS, context, new Serializer()
-        {
-            @Override
-            public void write( ChannelBuffer buffer )
-                    throws IOException
-            {
-                writeString( buffer, ds );
-                buffer.writeLong( startTxId );
-                buffer.writeLong( endTxId );
-            }
-        }, VOID_DESERIALIZER );
-    }
-
-    @Override
-    public Response<Void> pushTransaction( RequestContext context, final long tx )
-    {
-        context = stripFromTransactions( context );
-        return sendRequest( HaRequestType201.PUSH_TRANSACTION, context, new Serializer()
-        {
-            @Override
-            public void write( ChannelBuffer buffer ) throws IOException
-            {
-                writeString( buffer, NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
-                buffer.writeLong( tx );
-            }
-        }, VOID_DESERIALIZER );
     }
 
     protected static IdAllocation readIdAllocation( ChannelBuffer buffer )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
-import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
-import static org.neo4j.com.Protocol.writeString;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.Client;
 import org.neo4j.com.Deserializer;
 import org.neo4j.com.Protocol;
@@ -45,11 +42,14 @@ import org.neo4j.kernel.ha.lock.LockResult;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.nioneo.store.IdRange;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
+import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
+import static org.neo4j.com.Protocol.writeString;
 
 /**
  * The {@link org.neo4j.kernel.ha.com.master.Master} a slave should use to communicate with its master. It
@@ -283,39 +283,6 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     {
         return new RequestContext( context.getEpoch(), context.machineId(), context.getEventIdentifier(),
                 0, context.getMasterId(), context.getChecksum() );
-    }
-
-    @Override
-    public Response<Void> copyTransactions( RequestContext context,
-                                            final String ds, final long startTxId, final long endTxId )
-    {
-        context = stripFromTransactions( context );
-        return sendRequest( HaRequestType210.COPY_TRANSACTIONS, context, new Serializer()
-        {
-            @Override
-            public void write( ChannelBuffer buffer )
-                    throws IOException
-            {
-                writeString( buffer, ds );
-                buffer.writeLong( startTxId );
-                buffer.writeLong( endTxId );
-            }
-        }, VOID_DESERIALIZER );
-    }
-
-    @Override
-    public Response<Void> pushTransaction( RequestContext context, final long tx )
-    {
-        context = stripFromTransactions( context );
-        return sendRequest( HaRequestType210.PUSH_TRANSACTION, context, new Serializer()
-        {
-            @Override
-            public void write( ChannelBuffer buffer ) throws IOException
-            {
-                writeString( buffer, NeoStoreXaDataSource.DEFAULT_DATA_SOURCE_NAME );
-                buffer.writeLong( tx );
-            }
-        }, VOID_DESERIALIZER );
     }
 
     protected static IdAllocation readIdAllocation( ChannelBuffer buffer )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -157,13 +157,6 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
     }
 
     @Override
-    public Response<Void> copyTransactions( String dsName, long startTxId, long endTxId )
-    {
-        // 2.2-future unnecessary
-        return null;
-    }
-
-    @Override
     public <T> Response<T> packResponse( RequestContext context, T response, Predicate<Long> filter )
     {
         return responsePacker.packResponse( context, response, wrapLongFilter( filter ) );
@@ -181,12 +174,6 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
                 return filter.accept( transaction.getCommitEntry().getTxId() );
             }
         };
-    }
-
-    @Override
-    public void pushTransaction( int eventIdentifier, long tx, int machineId )
-    {
-        // 2.2-future - unnecessary
     }
 
     private <T> T resolve( Class<T> dependencyType )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
@@ -81,15 +81,12 @@ public interface Master
      * @return the master id for a given txId, also a checksum for that tx.
      */
     Response<HandshakeResult> handshake( long txId, StoreId myStoreId );
-    Response<Void> pushTransaction( RequestContext context, long tx );
 
     Response<Void> pullUpdates( RequestContext context );
 
     Response<Void> copyStore( RequestContext context, StoreWriter writer );
 
-    Response<Void> copyTransactions( RequestContext context, String dsName,
-                                     long startTxId, long endTxId );
-
     Response<LockResult> acquireExclusiveLock( RequestContext context, Locks.ResourceType type, long... resourceIds );
+
     Response<LockResult> acquireSharedLock( RequestContext context, Locks.ResourceType type, long... resourceIds );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha.com.master;
 
-import static java.lang.String.format;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,6 +59,8 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.Logging;
 
+import static java.lang.String.format;
+
 /**
  * This is the real master code that executes on a master. The actual
  * communication over network happens in {@link org.neo4j.kernel.ha.com.slave.MasterClient} and
@@ -96,11 +96,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
 
         RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer );
 
-        Response<Void> copyTransactions( String dsName, long startTxId, long endTxId );
-
         <T> Response<T> packResponse( RequestContext context, T response, Predicate<Long> filter );
-
-        void pushTransaction( int eventIdentifier, long tx, int machineId );
 
         int getOrCreateLabel( String name );
 
@@ -338,13 +334,6 @@ public class MasterImpl extends LifecycleAdapter implements Master
     }
 
     @Override
-    public Response<Void> copyTransactions( RequestContext context,
-                                            String dsName, long startTxId, long endTxId )
-    {
-        return spi.copyTransactions( dsName, startTxId, endTxId );
-    }
-
-    @Override
     public Response<LockResult> acquireExclusiveLock( RequestContext context, Locks.ResourceType type, long...
             resourceIds )
     {
@@ -384,13 +373,6 @@ public class MasterImpl extends LifecycleAdapter implements Master
         {
             return packResponse( context, new LockResult( LockStatus.NOT_LOCKED ) );
         }
-    }
-
-    @Override
-    public Response<Void> pushTransaction( RequestContext context, long tx )
-    {
-        // 2.2-future no longer required
-        return null;
     }
 
     // =====================================================================

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import static org.neo4j.com.Protocol.readString;
-import static org.neo4j.com.Protocol.writeString;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.Deserializer;
 import org.neo4j.com.MismatchingVersionHandler;
 import org.neo4j.com.ObjectSerializer;
@@ -37,10 +35,14 @@ import org.neo4j.kernel.ha.lock.LockResult;
 import org.neo4j.kernel.ha.lock.LockStatus;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 
+import static org.neo4j.com.Protocol.readString;
+import static org.neo4j.com.Protocol.writeString;
+
 public interface MasterClient extends Master
 {
     static final ObjectSerializer<LockResult> LOCK_SERIALIZER = new ObjectSerializer<LockResult>()
     {
+        @Override
         public void write( LockResult responseObject, ChannelBuffer result ) throws IOException
         {
             result.writeByte( responseObject.getStatus().ordinal() );
@@ -53,6 +55,7 @@ public interface MasterClient extends Master
 
     static final Deserializer<LockResult> LOCK_RESULT_DESERIALIZER = new Deserializer<LockResult>()
     {
+        @Override
         public LockResult read( ChannelBuffer buffer, ByteBuffer temporaryBuffer ) throws IOException
         {
             LockStatus status = LockStatus.values()[buffer.readByte()];
@@ -60,22 +63,25 @@ public interface MasterClient extends Master
         }
     };
 
+    @Override
     public Response<Integer> createRelationshipType( RequestContext context, final String name );
 
+    @Override
     public Response<Void> initializeTx( RequestContext context );
 
+    @Override
     public Response<Long> commitSingleResourceTransaction( RequestContext context, final TransactionRepresentation channel );
 
+    @Override
     public Response<Void> finishTransaction( RequestContext context, final boolean success );
 
     public void rollbackOngoingTransactions( RequestContext context );
 
+    @Override
     public Response<Void> pullUpdates( RequestContext context );
 
+    @Override
     public Response<Void> copyStore( RequestContext context, final StoreWriter writer );
-
-    public Response<Void> copyTransactions( RequestContext context, final String ds, final long startTxId,
-            final long endTxId );
 
     public void addMismatchingVersionHandler( MismatchingVersionHandler toAdd );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
@@ -31,7 +31,6 @@ import org.neo4j.jmx.impl.ManagementData;
 import org.neo4j.jmx.impl.Neo4jMBean;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
-import org.neo4j.kernel.ha.BranchedDataPolicy;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.management.BranchedStore;

--- a/enterprise/ha/src/test/java/org/neo4j/metrics/MetricsLogExtension.java
+++ b/enterprise/ha/src/test/java/org/neo4j/metrics/MetricsLogExtension.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.cluster.ClusterSettings;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -36,8 +35,6 @@ import org.neo4j.kernel.ha.com.master.MasterServer;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMonitor;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
-
-import static org.neo4j.helpers.collection.Iterables.iterable;
 
 
 public class MetricsLogExtension implements Lifecycle


### PR DESCRIPTION
there were not used anymore in 2.2 code base. Although tombstones are left
in place to keep the same ordinal as before. The ordinal acts as the
request type ID transfered over the wire.
