### PR TITLE
Batch importer actually flushes the current window when told to

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -20,10 +20,13 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.locks.LockSupport;
 
 import org.junit.Test;
 
@@ -36,18 +39,25 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.nioneo.store.StoreChannel;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.cache.IdMappers;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.staging.DetailedExecutionMonitor;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingWindowPoolFactory.Writer;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingWindowPoolFactory.WriterFactory;
+import org.neo4j.unsafe.impl.batchimport.store.io.IoQueue;
+import org.neo4j.unsafe.impl.batchimport.store.io.Monitor;
+import org.neo4j.unsafe.impl.batchimport.store.io.SimplePool;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.unsafe.impl.batchimport.store.BatchingWindowPoolFactory.SYNCHRONOUS;
 
 public class ParallelBatchImporterTest
 {
@@ -57,11 +67,8 @@ public class ParallelBatchImporterTest
 
     private final File directory = TargetDirectory.forTest( getClass() ).cleanDirectory( "import" );
 
-    @Test
-    public void shouldImportCsvData() throws Exception
+    private void shouldImportCsvData0( WriterFactory delegateWriterFactory ) throws Exception
     {
-        System.out.println( directory.getAbsolutePath() );
-
         // GIVEN
         Configuration config = new Configuration.Default()
         {
@@ -73,7 +80,7 @@ public class ParallelBatchImporterTest
         };
         BatchImporter inserter = new ParallelBatchImporter( directory.getAbsolutePath(),
                 new DefaultFileSystemAbstraction(), config,
-                new DetailedExecutionMonitor() );
+                new DetailedExecutionMonitor(), new IoQueue( config.numberOfIoThreads(), delegateWriterFactory ) );
 
         // WHEN
         int nodeCount = 100_000;
@@ -82,7 +89,6 @@ public class ParallelBatchImporterTest
         inserter.shutdown();
 
         // THEN
-        System.out.println( "Verifying contents" );
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( directory.getAbsolutePath() );
         try ( Transaction tx = db.beginTx() )
         {
@@ -94,6 +100,46 @@ public class ParallelBatchImporterTest
         {
             db.shutdown();
         }
+    }
+
+    @Test
+    public void shouldImportCsvData() throws Exception
+    {
+        shouldImportCsvData0( SYNCHRONOUS );
+    }
+
+    @Test
+    public void shouldImportCsvDataWhenWritesAreSlow() throws Exception
+    {
+        shouldImportCsvData0( new WriterFactory()
+        {
+            @Override
+            public Writer create( final File file, final StoreChannel channel, final Monitor monitor )
+            {
+                return new Writer()
+                {
+                    final Writer delegate = SYNCHRONOUS.create( file, channel, monitor );
+
+                    @Override
+                    public void write( ByteBuffer data, long position, SimplePool<ByteBuffer> pool )
+                            throws IOException
+                    {
+                        LockSupport.parkNanos( 50_000_000 ); // slowness comes from here
+                        delegate.write( data, position, pool );
+                    }
+                };
+            }
+
+            @Override
+            public void awaitEverythingWritten()
+            {   // no-op
+            }
+
+            @Override
+            public void shutdown()
+            {   // no-op
+            }
+        } );
     }
 
     protected void verifyData( int nodeCount, GraphDatabaseService db )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueueTest.java
@@ -47,6 +47,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import static org.neo4j.unsafe.impl.batchimport.store.BatchingWindowPoolFactory.SYNCHRONOUS;
+
 public class IoQueueTest
 {
     @Rule
@@ -62,7 +64,7 @@ public class IoQueueTest
     {
         // GIVEN
         ExecutorService executor = cleanupRule.add( spy( Executors.newFixedThreadPool( 3 ) ) );
-        IoQueue queue = new IoQueue( executor );
+        IoQueue queue = new IoQueue( executor, SYNCHRONOUS );
         File file = new File( directory.directory(), "file" );
         StoreChannel channel = spy( fs.create( file ) );
         Monitor monitor = mock( Monitor.class );
@@ -88,7 +90,7 @@ public class IoQueueTest
     {
         // GIVEN
         ExecutorService executor = cleanupRule.add( spy( Executors.newFixedThreadPool( 3 ) ) );
-        IoQueue queue = new IoQueue( executor );
+        IoQueue queue = new IoQueue( executor, SYNCHRONOUS );
         File file1 = new File( directory.directory(), "file1" );
         StoreChannel channel1 = cleanupRule.add( spy( fs.create( file1 ) ) );
         File file2 = new File( directory.directory(), "file2" );


### PR DESCRIPTION
this to support proper shutdown of the neostore, where pending changes are
flushed and writes awaited so that the store can be closed properly.
