### PR TITLE
Fixes bitmask issue in index command header reading

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
@@ -238,7 +238,10 @@ public abstract class IndexCommand extends Command
         public String toString()
         {
             return "AddRelationship[index:" + indexNameId + ", id:" + entityId + ", key:" + keyId +
-                    ", value:" + value + "]";
+                    ", value:" + value + "(" + (value != null ? value.getClass().getSimpleName() : "null") + ")" +
+                    ", startNode:" + startNode +
+                    ", endNode:" + endNode +
+                    "]";
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
@@ -720,7 +720,7 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             boolean entityIdNeedsLong = (headerBytes[0] & 0x1) > 0;
             byte indexNameId = (byte) (headerBytes[1] & 0x3F);
 
-            boolean startNodeNeedsLong = (headerBytes[1] & 0x8) > 0;
+            boolean startNodeNeedsLong = (headerBytes[1] & 0x80) > 0;
             boolean endNodeNeedsLong = (headerBytes[1] & 0x40) > 0;
 
             byte keyId = headerBytes[2];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReader.java
@@ -152,7 +152,8 @@ public class VersionAwareLogEntryReader implements LogEntryReader<ReadableLogCha
                 case LogEntry.EMPTY:
                     return null;
                 default:
-                    throw new IOException( "Unknown entry[" + type + "] at position " + positionMarker.newPosition() );
+                    throw new IOException( "Unknown entry[" + type + "] at position " + positionMarker.newPosition() +
+                            " and entry version " + version );
             }
         }
         catch ( ReadPastEndException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1Test.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa.command;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.index.IndexCommand.AddRelationshipCommand;
+import org.neo4j.kernel.impl.transaction.xaframework.CommandWriter;
+import org.neo4j.kernel.impl.transaction.xaframework.InMemoryLogChannel;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhysicalLogNeoCommandReaderV1Test
+{
+    @Test
+    public void shouldReadIndexCommandHeaderCorrectly() throws Exception
+    {
+        // This bug manifested in header byte[1] {0,1,2}, which contains:
+        // [x   ,    ] start node needs long
+        // [ x  ,    ] end node needs long
+        // [  xx,xxxx] index name id
+        // would have the mask for reading "start node needs long" to 0x8, where it should have been 0x80.
+        // So we need an index name id which has the 0x8 bit set to falsely read that value as "true".
+        // Number 12 will do just fine.
+
+        // GIVEN
+        PhysicalLogNeoCommandReaderV1 reader = new PhysicalLogNeoCommandReaderV1();
+        InMemoryLogChannel data = new InMemoryLogChannel();
+        CommandWriter writer = new CommandWriter( data );
+        AddRelationshipCommand command = new AddRelationshipCommand();
+        byte indexNameId = (byte)12;
+        long entityId = 123;
+        byte keyId = (byte)1;
+        Object value = "test value";
+        long startNode = 14;
+        long endNode = 15;
+
+        // WHEN
+        command.init( indexNameId, entityId, keyId, value, startNode, endNode );
+        writer.visitIndexAddRelationshipCommand( command );
+
+        // THEN
+        AddRelationshipCommand readCommand = (AddRelationshipCommand) reader.read( data );
+        assertEquals( indexNameId, readCommand.getIndexNameId() );
+        assertEquals( entityId, readCommand.getEntityId() );
+        assertEquals( keyId, readCommand.getKeyId() );
+        assertEquals( value, readCommand.getValue() );
+        assertEquals( startNode, readCommand.getStartNode() );
+        assertEquals( endNode, readCommand.getEndNode() );
+    }
+}


### PR DESCRIPTION
observed behaviour would be that the next entry in the log would be
missing a couple of bytes in the beginning, most notably the log entry
version, so that command type would be read into log entry type field
and potentially throw exception saying "unknown entry[X]" or throw an
exception in the vicinity of such command in other interesting ways.
