### PR TITLE
Reduces object allocation per read log entry

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/CommandReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/CommandReaderFactory.java
@@ -19,17 +19,43 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
+import java.util.Collection;
+
+import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
+import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
+import org.neo4j.kernel.impl.nioneo.store.PropertyKeyTokenRecord;
+import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
 import org.neo4j.kernel.impl.nioneo.xa.command.PhysicalLogNeoCommandReaderV0;
 import org.neo4j.kernel.impl.nioneo.xa.command.PhysicalLogNeoCommandReaderV1;
 
-public interface CommandReaderFactory
+public abstract class CommandReaderFactory
 {
-    CommandReader newInstance( byte logEntryVersion );
+    public abstract CommandReader newInstance( byte logEntryVersion );
 
-    public static final CommandReaderFactory DEFAULT = new CommandReaderFactory()
+    public static class Default extends CommandReaderFactory
     {
+        // Remember the last version of the last reader returned. Don't use a map because of it the overhead
+        // of it. Typically lots of log entries of the same version comes together.
+        private byte lastVersion;
+        private CommandReader lastReader;
+
+        public Default()
+        {
+        }
+
         @Override
         public CommandReader newInstance( byte logEntryVersion )
+        {
+            if ( logEntryVersion == lastVersion && lastReader != null )
+            {
+                return lastReader;
+            }
+
+            lastVersion = logEntryVersion;
+            return (lastReader = figureOutCorrectReader( logEntryVersion ));
+        }
+
+        private CommandReader figureOutCorrectReader( byte logEntryVersion )
         {
             switch ( logEntryVersion )
             {
@@ -41,6 +67,53 @@ public interface CommandReaderFactory
                 default:
                     throw new IllegalArgumentException( "Unknown log entry version " + logEntryVersion );
             }
+        }
+    }
+
+    public interface DynamicRecordAdder<T>
+    {
+        void add( T target, DynamicRecord record );
+    }
+
+    public static final DynamicRecordAdder<PropertyBlock> PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER =
+            new DynamicRecordAdder<PropertyBlock>()
+    {
+        @Override
+        public void add( PropertyBlock target, DynamicRecord record )
+        {
+            record.setCreated();
+            target.addValueRecord( record );
+        }
+    };
+
+    public static final DynamicRecordAdder<Collection<DynamicRecord>> COLLECTION_DYNAMIC_RECORD_ADDER =
+            new DynamicRecordAdder<Collection<DynamicRecord>>()
+    {
+        @Override
+        public void add( Collection<DynamicRecord> target, DynamicRecord record )
+        {
+            target.add( record );
+        }
+    };
+
+    public static final DynamicRecordAdder<PropertyRecord> PROPERTY_DELETED_DYNAMIC_RECORD_ADDER =
+            new DynamicRecordAdder<PropertyRecord>()
+    {
+        @Override
+        public void add( PropertyRecord target, DynamicRecord record )
+        {
+            assert !record.inUse() : record + " is kinda weird";
+            target.addDeletedRecord( record );
+        }
+    };
+
+    public static final DynamicRecordAdder<PropertyKeyTokenRecord> PROPERTY_INDEX_DYNAMIC_RECORD_ADDER =
+            new DynamicRecordAdder<PropertyKeyTokenRecord>()
+    {
+        @Override
+        public void add( PropertyKeyTokenRecord target, DynamicRecord record )
+        {
+            target.addNameRecord( record );
         }
     };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LogDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/LogDeserializer.java
@@ -32,6 +32,11 @@ public class LogDeserializer implements LogReader<ReadableLogChannel>
 {
     private final LogEntryReader<ReadableLogChannel> logEntryReader;
 
+    public LogDeserializer()
+    {
+        this( new CommandReaderFactory.Default() );
+    }
+
     public LogDeserializer( CommandReaderFactory commandReaderFactory )
     {
         logEntryReader = new VersionAwareLogEntryReader( commandReaderFactory );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
@@ -49,22 +49,24 @@ import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
 import org.neo4j.kernel.impl.nioneo.xa.CommandReader;
+import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.DynamicRecordAdder;
 import org.neo4j.kernel.impl.transaction.xaframework.ReadPastEndException;
 import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
 
 import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.COLLECTION_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.PROPERTY_INDEX_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
 
 public class PhysicalLogNeoCommandReaderV1 implements CommandReader
 {
-    private interface DynamicRecordAdder<T>
-    {
-        void add( T target, DynamicRecord record );
-    }
-
+    private final PhysicalNeoCommandReader reader = new PhysicalNeoCommandReader();
     private ReadableLogChannel channel;
+    private IndexCommandHeader indexCommandHeader;
 
     @Override
     public Command read( ReadableLogChannel channel ) throws IOException
@@ -76,7 +78,6 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
         {
             commandType = channel.get();
         }
-        PhysicalNeoCommandReader reader = new PhysicalNeoCommandReader();
         Command command;
         switch ( commandType )
         {
@@ -476,25 +477,6 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             return numberOfRecords;
         }
 
-        private final DynamicRecordAdder<PropertyBlock> PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER = new DynamicRecordAdder<PropertyBlock>()
-        {
-            @Override
-            public void add( PropertyBlock target, DynamicRecord record )
-            {
-                record.setCreated();
-                target.addValueRecord( record );
-            }
-        };
-
-        private final DynamicRecordAdder<Collection<DynamicRecord>> COLLECTION_DYNAMIC_RECORD_ADDER = new DynamicRecordAdder<Collection<DynamicRecord>>()
-        {
-            @Override
-            public void add( Collection<DynamicRecord> target, DynamicRecord record )
-            {
-                target.add( record );
-            }
-        };
-
         private PropertyRecord readPropertyRecord( long id ) throws IOException
         {
             // in_use(byte)+type(int)+key_indexId(int)+prop_blockId(long)+
@@ -616,24 +598,6 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             return rule;
         }
 
-        private final DynamicRecordAdder<PropertyRecord> PROPERTY_DELETED_DYNAMIC_RECORD_ADDER = new DynamicRecordAdder<PropertyRecord>()
-        {
-            @Override
-            public void add( PropertyRecord target, DynamicRecord record )
-            {
-                assert !record.inUse() : record + " is kinda weird";
-                target.addDeletedRecord( record );
-            }
-        };
-        private final DynamicRecordAdder<PropertyKeyTokenRecord> PROPERTY_INDEX_DYNAMIC_RECORD_ADDER = new DynamicRecordAdder<PropertyKeyTokenRecord>()
-        {
-            @Override
-            public void add( PropertyKeyTokenRecord target, DynamicRecord record )
-            {
-                target.addNameRecord( record );
-            }
-        };
-
         @Override
         public boolean visitIndexAddNodeCommand( AddNodeCommand command ) throws IOException
         {
@@ -724,7 +688,11 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             boolean endNodeNeedsLong = (headerBytes[1] & 0x40) > 0;
 
             byte keyId = headerBytes[2];
-            return new IndexCommandHeader( valueType, entityType, entityIdNeedsLong,
+            if ( indexCommandHeader == null )
+            {
+                indexCommandHeader = new IndexCommandHeader();
+            }
+            return indexCommandHeader.set( valueType, entityType, entityIdNeedsLong,
                     indexNameId, startNodeNeedsLong, endNodeNeedsLong, keyId );
         }
 
@@ -759,15 +727,15 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
 
     private static final class IndexCommandHeader
     {
-        final byte valueType;
-        final byte entityType;
-        final boolean entityIdNeedsLong;
-        final byte indexNameId;
-        final boolean startNodeNeedsLong;
-        final boolean endNodeNeedsLong;
-        final byte keyId;
+        byte valueType;
+        byte entityType;
+        boolean entityIdNeedsLong;
+        byte indexNameId;
+        boolean startNodeNeedsLong;
+        boolean endNodeNeedsLong;
+        byte keyId;
 
-        IndexCommandHeader( byte valueType, byte entityType, boolean entityIdNeedsLong,
+        IndexCommandHeader set( byte valueType, byte entityType, boolean entityIdNeedsLong,
                 byte indexNameId, boolean startNodeNeedsLong, boolean endNodeNeedsLong, byte keyId )
         {
             this.valueType = valueType;
@@ -777,6 +745,7 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             this.startNodeNeedsLong = startNodeNeedsLong;
             this.endNodeNeedsLong = endNodeNeedsLong;
             this.keyId = keyId;
+            return this;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReader.java
@@ -49,6 +49,12 @@ public class VersionAwareLogEntryReader implements LogEntryReader<ReadableLogCha
     public static final int LOG_HEADER_SIZE = 16;
 
     private final CommandReaderFactory commandReaderFactory;
+    private final LogPositionMarker positionMarker = new LogPositionMarker();
+
+    public VersionAwareLogEntryReader()
+    {
+        this( new CommandReaderFactory.Default() );
+    }
 
     public VersionAwareLogEntryReader( CommandReaderFactory commandReaderFactory )
     {
@@ -125,10 +131,6 @@ public class VersionAwareLogEntryReader implements LogEntryReader<ReadableLogCha
     {
         try
         {
-            // TODO: This means we end up creating one additional object per entry we read from the log.
-            // However, we already create a ton of objects during deserialization here. This whole section
-            // needs going over to figure out how to lower (preferrably remove) object allocation entirely.
-            LogPositionMarker positionMarker = new LogPositionMarker();
             channel.getCurrentPosition( positionMarker );
 
             /*

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.TimeZone;
 import java.util.TreeSet;
+
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Args;
@@ -109,7 +110,7 @@ public class DumpLogicalLog
 
     protected CommandReaderFactory instantiateCommandReaderFactory()
     {
-        return CommandReaderFactory.DEFAULT;
+        return new CommandReaderFactory.Default();
     }
 
     protected String getLogPrefix()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.transaction.xa.Xid;
 import javax.xml.bind.DatatypeConverter;
 
@@ -42,7 +43,6 @@ import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.nioneo.store.RecordStore;
 import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.pagecache.LifecycledPageCache;
 import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
@@ -261,7 +261,7 @@ public class RsdrMain
         console.printf( "Logical log version: %s with prev committed tx[%s]%n",
                 logVersion, prevLastCommittedTx );
 
-        LogDeserializer deserializer = new LogDeserializer( CommandReaderFactory.DEFAULT );
+        LogDeserializer deserializer = new LogDeserializer();
 
         PhysicalLogVersionedStoreChannel channel =
                 new PhysicalLogVersionedStoreChannel( fileChannel, logVersion );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/CommandReaderFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/CommandReaderFactoryTest.java
@@ -33,7 +33,7 @@ public class CommandReaderFactoryTest
     public void testReturnsV0ReaderForVersion0() throws Exception
     {
         // GIVEN
-        CommandReaderFactory factory = CommandReaderFactory.DEFAULT;
+        CommandReaderFactory factory = new CommandReaderFactory.Default();
 
         // WHEN
         CommandReader reader = factory.newInstance( (byte) 0 );
@@ -46,7 +46,7 @@ public class CommandReaderFactoryTest
     public void testReturnsV1ReaderForVersion1() throws Exception
     {
         // GIVEN
-        CommandReaderFactory factory = CommandReaderFactory.DEFAULT;
+        CommandReaderFactory factory = new CommandReaderFactory.Default();
 
         // WHEN
         CommandReader reader = factory.newInstance( (byte) -1 );
@@ -59,7 +59,7 @@ public class CommandReaderFactoryTest
     public void testThrowsExceptionForNonExistingVersion() throws Exception
     {
         // GIVEN
-        CommandReaderFactory factory = CommandReaderFactory.DEFAULT;
+        CommandReaderFactory factory = new CommandReaderFactory.Default();
 
         // WHEN
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/LogTruncationTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.kernel.impl.nioneo.store.DynamicRecord.dynamicRecord;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.index.IndexCommand;
@@ -56,6 +52,13 @@ import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryCommand;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryWriterv1;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader;
 
+import static java.util.Arrays.asList;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.kernel.impl.nioneo.store.DynamicRecord.dynamicRecord;
+
 /**
  * At any point, a power outage may stop us from writing to the log, which means that, at any point, all our commands
  * need to be able to handle the log ending mid-way through reading it.
@@ -63,8 +66,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEn
 public class LogTruncationTest
 {
     private final InMemoryLogChannel inMemoryChannel = new InMemoryLogChannel();
-    private final VersionAwareLogEntryReader logEntryReader = new VersionAwareLogEntryReader(
-            CommandReaderFactory.DEFAULT );
+    private final VersionAwareLogEntryReader logEntryReader = new VersionAwareLogEntryReader();
     private final CommandWriter serializer = new CommandWriter( inMemoryChannel );
     private final LogEntryWriterv1 writer = new LogEntryWriterv1( inMemoryChannel, serializer );
     /** Stores all known commands, and an arbitrary set of different permutations for them */

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/LogMatchers.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.transaction.xaframework;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
 import javax.transaction.xa.Xid;
 
 import org.hamcrest.Description;
@@ -32,7 +33,6 @@ import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntry;
@@ -61,7 +61,7 @@ public class LogMatchers
         VersionAwareLogEntryReader.readLogHeader( buffer, fileChannel, true );
 
         // Read all log entries
-        LogDeserializer deserializer = new LogDeserializer( CommandReaderFactory.DEFAULT );
+        LogDeserializer deserializer = new LogDeserializer();
 
         ReadableLogChannel logChannel = new ReadAheadLogChannel(
                 new PhysicalLogVersionedStoreChannel( fileChannel ), LogVersionBridge.NO_MORE_CHANNELS, 4096 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
@@ -33,7 +33,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogFileRecoverer;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFile.Monitor;
@@ -77,8 +76,7 @@ public class PhysicalLogicalTransactionStoreTest
                 transactionIdStore, mock( LogVersionRepository.class), monitor, logRotationControl,
                 positionCache, noRecoveryAsserter() ) );
         TxIdGenerator txIdGenerator = new DefaultTxIdGenerator( singletonProvider( transactionIdStore ) );
-        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache,
-                new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT ), transactionIdStore ) );
+        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache, transactionIdStore ) );
 
         try
         {
@@ -124,7 +122,7 @@ public class PhysicalLogicalTransactionStoreTest
         final AtomicInteger recoveredTransactions = new AtomicInteger();
         logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000, NO_PRUNING,
                         transactionIdStore, mock( LogVersionRepository.class), monitor, logRotationControl,
-                        positionCache, new LogFileRecoverer( new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT ),
+                        positionCache, new LogFileRecoverer( new VersionAwareLogEntryReader(),
                                 new Visitor<CommittedTransactionRepresentation, IOException>()
         {
             @Override
@@ -141,8 +139,7 @@ public class PhysicalLogicalTransactionStoreTest
             }
         } ) ) );
 
-        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache, new VersionAwareLogEntryReader(
-                CommandReaderFactory.DEFAULT ), transactionIdStore ) );
+        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache, transactionIdStore ) );
 
         // WHEN
         try
@@ -191,7 +188,7 @@ public class PhysicalLogicalTransactionStoreTest
         final AtomicInteger recoveredTransactions = new AtomicInteger();
         logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000, NO_PRUNING,
                 transactionIdStore, mock( LogVersionRepository.class), monitor, logRotationControl,
-                positionCache, new LogFileRecoverer( new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT ),
+                positionCache, new LogFileRecoverer( new VersionAwareLogEntryReader(),
                         new Visitor<CommittedTransactionRepresentation, IOException>()
         {
             @Override
@@ -209,7 +206,7 @@ public class PhysicalLogicalTransactionStoreTest
         } )));
 
         LogicalTransactionStore store = life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator,
-                positionCache, new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT ), transactionIdStore ) );
+                positionCache, transactionIdStore ) );
 
         // WHEN
         life.start();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppenderTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryStart;
@@ -66,7 +65,7 @@ public class PhysicalTransactionAppenderTest
         appender.append( transaction );
 
         // THEN
-        try(PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader(CommandReaderFactory.DEFAULT)))
+        try(PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader()))
         {
             reader.next();
             TransactionRepresentation tx = reader.get().getTransactionRepresentation();
@@ -112,8 +111,7 @@ public class PhysicalTransactionAppenderTest
         appender.append( transaction );
 
         // THEN
-        PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader(
-                CommandReaderFactory.DEFAULT ) );
+        PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader() );
         reader.next();
         TransactionRepresentation result = reader.get().getTransactionRepresentation();
         assertArrayEquals( additionalHeader, result.additionalHeader() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/log/entry/VersionAwareLogEntryReaderTest.java
@@ -54,7 +54,7 @@ import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwa
 
 public class VersionAwareLogEntryReaderTest
 {
-    private final CommandReaderFactory commandReaderFactory = CommandReaderFactory.DEFAULT;
+    private final CommandReaderFactory commandReaderFactory = new CommandReaderFactory.Default();
     private final byte version = (byte) -1;
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/log/pruning/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/log/pruning/TestLogPruning.java
@@ -19,13 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework.log.pruning;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_log_rotation_threshold;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader.LOG_HEADER_SIZE;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,13 +26,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogFileRecoverer;
 import org.neo4j.kernel.impl.transaction.xaframework.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge;
@@ -51,6 +44,14 @@ import org.neo4j.kernel.impl.transaction.xaframework.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.VersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.test.ImpermanentGraphDatabase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_log_rotation_threshold;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.VersionAwareLogEntryReader.LOG_HEADER_SIZE;
 
 public class TestLogPruning
 {
@@ -240,7 +241,7 @@ public class TestLogPruning
             {
                 final AtomicInteger counter = new AtomicInteger();
                 LogFileRecoverer reader = new LogFileRecoverer(
-                        new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT ),
+                        new VersionAwareLogEntryReader(),
                         new Visitor<CommittedTransactionRepresentation, IOException>()
                         {
                             @Override

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -24,13 +24,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.transaction.xa.Xid;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.transaction.xaframework.CommandWriter;
 import org.neo4j.kernel.impl.transaction.xaframework.IOCursor;
@@ -119,7 +119,7 @@ public class LogTestUtils
             VersionAwareLogEntryReader.readLogHeader( buffer, fileChannel, true );
 
             // Read all log entries
-            LogDeserializer deserializer = new LogDeserializer( CommandReaderFactory.DEFAULT );
+            LogDeserializer deserializer = new LogDeserializer();
 
             ReadableLogChannel logChannel = new ReadAheadLogChannel(new PhysicalLogVersionedStoreChannel(fileChannel), LogVersionBridge.NO_MORE_CHANNELS, 4096);
 
@@ -191,8 +191,7 @@ public class LogTestUtils
 
             ReadableLogChannel inBuffer = new ReadAheadLogChannel( new PhysicalLogVersionedStoreChannel( in ),
                     LogVersionBridge.NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
-            LogEntryReader<ReadableLogChannel> entryReader = new VersionAwareLogEntryReader(
-                    CommandReaderFactory.DEFAULT );
+            LogEntryReader<ReadableLogChannel> entryReader = new VersionAwareLogEntryReader();
             LogEntry entry;
             while ( (entry = entryReader.readLogEntry( inBuffer )) != null )
             {

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/IndexCreationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/IndexCreationTest.java
@@ -38,7 +38,6 @@ import org.neo4j.helpers.collection.FilteringIterator;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.LogDeserializer;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
@@ -134,7 +133,7 @@ public class IndexCreationTest
 
         ReadableLogChannel logFileChannel = pLogFile.getReader( new LogPosition( version, LOG_HEADER_SIZE ) );
 
-        LogDeserializer deserializer = new LogDeserializer( CommandReaderFactory.DEFAULT );
+        LogDeserializer deserializer = new LogDeserializer();
 
         final AtomicBoolean success = new AtomicBoolean( false );
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
@@ -54,7 +54,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import static java.lang.String.format;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory.DEFAULT;
 import static org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.xaframework.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 
@@ -84,7 +83,8 @@ class RebuildFromLogs
                 new PhysicalLogVersionedStoreChannel( FS.open( logFile, "R" ), startVersion ),
                 versionBridge, DEFAULT_READ_AHEAD_SIZE );
 
-        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel,new VersionAwareLogEntryReader( DEFAULT ) ) )
+        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel,
+                new VersionAwareLogEntryReader() ) )
         {
             while (cursor.next())
             {
@@ -187,7 +187,8 @@ class RebuildFromLogs
 
         long lastTransactionId = -1;
 
-        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel, new VersionAwareLogEntryReader( DEFAULT )))
+        try (IOCursor<CommittedTransactionRepresentation> cursor = new PhysicalTransactionCursor( logChannel,
+                new VersionAwareLogEntryReader() ))
         {
             while (cursor.next())
             {

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -34,7 +34,6 @@ import org.jboss.netty.handler.queue.BlockingReadHandler;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
-import org.neo4j.kernel.impl.nioneo.xa.CommandReaderFactory;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.transaction.xaframework.CommandWriter;
@@ -96,12 +95,15 @@ public class Protocol
             @Override
             public void accept( Visitor<CommittedTransactionRepresentation, IOException> visitor ) throws IOException
             {
-                LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT );
+                LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader();
                 NetworkReadableLogChannel channel = new NetworkReadableLogChannel( dechunkingBuffer );
 
                 try (PhysicalTransactionCursor cursor = new PhysicalTransactionCursor( channel, reader ))
                 {
-                    while (cursor.next() && visitor.visit( cursor.get() ));
+                    while (cursor.next() && visitor.visit( cursor.get() ))
+                    {
+                        ;
+                    }
                 }
             }
         };
@@ -265,7 +267,7 @@ public class Protocol
         public TransactionRepresentation read( ChannelBuffer buffer, ByteBuffer temporaryBuffer ) throws
                 IOException
         {
-            LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT );
+            LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader();
             NetworkReadableLogChannel channel = new NetworkReadableLogChannel( buffer );
 
             int authorId = channel.getInt();
@@ -298,7 +300,7 @@ public class Protocol
         public Iterable<CommittedTransactionRepresentation> read( ChannelBuffer buffer, ByteBuffer temporaryBuffer )
                 throws IOException
         {
-            LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader( CommandReaderFactory.DEFAULT );
+            LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader();
             NetworkReadableLogChannel channel = new NetworkReadableLogChannel( buffer );
             return Cursors.iterable( new PhysicalTransactionCursor( channel, reader ) );
         }

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -21,7 +21,6 @@ package org.neo4j.com;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.nioneo.store.MismatchingStoreIdException;


### PR DESCRIPTION
Removes 8, or so, objects allocated per log entry read, but adds one more
object allocation per reader. A reader is used for reading one or more
transactions, i.e. multiple log entries, depending on use case.

Also fixes an issue with a VersionAwareLogEntryReader which was shared
between multiple threads, the one used in transaction cursors, so partly
reverts ee82d018901ad74546724e1af9ce230e2964b698 since it's no longer
needed.
