### PR TITLE
Improve type error message in cypher `reduce(...)`

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/IterableExpressions.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/IterableExpressions.scala
@@ -143,7 +143,13 @@ case class SingleIterablePredicate(identifier: Identifier, expression: Expressio
   val name = "single"
 }
 
+object ReduceExpression {
+  val AccumulatorExpressionTypeMismatchMessageGenerator = (expected: String, existing: String) => s"accumulator is $expected but expression has type $existing"
+}
+
 case class ReduceExpression(accumulator: Identifier, init: Expression, identifier: Identifier, collection: Expression, expression: Expression)(val position: InputPosition) extends Expression {
+  import ReduceExpression._
+
   def semanticCheck(ctx: SemanticContext): SemanticCheck =
     init.semanticCheck(ctx) then
     collection.semanticCheck(ctx) then
@@ -156,6 +162,7 @@ case class ReduceExpression(accumulator: Identifier, init: Expression, identifie
       identifier.declare(indexType) then
       accumulator.declare(accType) then
       expression.semanticCheck(SemanticContext.Simple)
-    } then expression.expectType(init.types) then
+    } then
+    expression.expectType(init.types, AccumulatorExpressionTypeMismatchMessageGenerator) then
     this.specifyType(s => init.types(s) mergeUp expression.types(s))
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ExpressionTest.scala
@@ -57,6 +57,20 @@ class ExpressionTest extends Assertions {
 
     assert(result.errors.size === 1)
     assert(result.errors.head.position === expression.position)
+    assert(result.errors.head.msg == "Type mismatch: expected String but was Integer or Node")
+    assert(expression.types(result.state).isEmpty)
+  }
+
+  @Test
+  def shouldRaiseTypeErrorWithCustomMessageWhenMismatchBetweenSpecifiedTypeAndExpectedType() {
+    val result = (
+      expression.specifyType(CTNode | CTInteger) then
+      expression.expectType(CTString.covariant, (expected: String, existing: String) => s"lhs was $expected yet rhs was $existing")
+    )(SemanticState.clean)
+
+    assert(result.errors.size === 1)
+    assert(result.errors.head.position === expression.position)
+    assert(result.errors.head.msg == "Type mismatch: lhs was String yet rhs was Integer or Node")
     assert(expression.types(result.state).isEmpty)
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReduceExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/ReduceExpressionTest.scala
@@ -102,7 +102,7 @@ class ReduceExpressionTest extends Assertions {
 
     val result = filter.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
     assert(result.errors.size === 1)
-    assert(result.errors.head.msg === "Type mismatch: expected Number or String but was Node")
+    assert(result.errors.head.msg === "Type mismatch: accumulator is Number or String but expression has type Node")
     assert(result.errors.head.position === reduceExpression.position)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -399,6 +399,13 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineJUnitSuite {
     )
   }
 
+  @Test def shouldReturnCustomTypeErrorForReduce() {
+    test(
+      "RETURN reduce(x = 0, y IN [1,2,3] | x + y^2)",
+      "Type mismatch: accumulator is Integer but expression has type Float (line 1, column 39)"
+    )
+  }
+
   def test(query: String, message: String) {
     try {
       val result = execute(query)


### PR DESCRIPTION
For the case where the accumulator and the expression have mismatching types, it was not clear that the type error was for that reason. This change improves the message for that case.
