### PR TITLE
Fix a bug in the rsdr program

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
@@ -197,6 +197,10 @@ public class RsdrMain
                 buf.clear();
                 long offset = recordSize * i;
                 int count = channel.read( buf, offset );
+                if ( count == -1 )
+                {
+                    break;
+                }
                 byte[] bytes = new byte[count];
                 buf.clear();
                 buf.get( bytes );


### PR DESCRIPTION
When a store has a size that is an exact multiple of the record size, rsdr would throw an exception because it could accidentally try to read past the end.
