### PR TITLE
Updated PID file location to come from configuration

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -96,7 +96,7 @@ LAUNCHD_DIR=~/Library/LaunchAgents/
 
 TIMEOUT=120
 
-PID_FILE=${NEO4J_INSTANCE}/data/neo4j-service.pid
+PID_FILE=${wrapper_pidfile:-"$NEO4J_INSTANCE/data/neo4j-service.pid"}
 buildclasspath() {
   # confirm library jars
   LIBDIR="$NEO4J_HOME"/lib


### PR DESCRIPTION
Partial fix for #2103 where on _NIX platforms the PID file location is hardcoded.
Now it will try and use the PID file defined in `./conf/neo4j-wrapper.conf`, or fallback to the current default of `./data/neo4j-service.pid`.
