### PR TITLE
Re-allow communication with SubProcess through stdIO

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
@@ -214,10 +214,7 @@ public abstract class SubProcess<T, P> implements Serializable
 
     private static Process start( String... args )
     {
-        // The inheritIO() call means that stdout, stderr and stdin from the
-        // parent (this) process is reused for the child. This means that
-        // e.g. System.out.println()'s work in the child process.
-        ProcessBuilder builder = new ProcessBuilder( args ).inheritIO();
+        ProcessBuilder builder = new ProcessBuilder( args );
         try
         {
             return builder.start();


### PR DESCRIPTION
We have tests that rely on being able to communicate with subprocesses through stdin and stdout. Simply letting the subprocess inheriting the IO streams from the parent process does not allow such communication.

This PR reverts the change that made SubProcess inherit IO.
