### PR TITLE
Sets correct highId when applying recovered transactions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -274,9 +274,6 @@ public abstract class GraphDatabaseSettings
             "i.e., 8 bytes.")
     public static final Setting<Integer> label_block_size = setting("label_block_size", INTEGER, "60",min(1));
 
-    @Description("Mark this database as a backup slave.")
-    public static final Setting<Boolean> backup_slave = setting("backup_slave", BOOLEAN, FALSE );
-
     @Description("An identifier that uniquely identifies this graph database instance within this JVM. " +
             "Defaults to an auto-generated number depending on how many instance are started in this JVM.")
     public static final Setting<String> forced_kernel_id = setting("forced_kernel_id", STRING, NO_DEFAULT, illegalValueMessage( "invalid kernel identifier", matches( "[a-zA-Z0-9]*" ) ));

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
@@ -53,13 +53,28 @@ public class CommandApplierFacade implements NeoCommandHandler, Visitor<Command,
         this.indexApplier = indexApplier;
         this.legacyIndexApplier = legacyIndexApplier;
     }
+    
+    @Override
+    public void apply()
+    {
+        throw new UnsupportedOperationException( "This method should not be called, only I call apply() methods" );
+    }
 
     @Override
     public void close()
     {
-        indexApplier.close();
-        legacyIndexApplier.close();
-        storeApplier.close();
+        try
+        {
+            indexApplier.apply();
+            legacyIndexApplier.apply();
+            storeApplier.apply();
+        }
+        finally
+        {
+            indexApplier.close();
+            legacyIndexApplier.close();
+            storeApplier.close();
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
@@ -120,6 +120,15 @@ public class LegacyIndexApplier extends NeoCommandHandler.Adapter
     }
 
     @Override
+    public void apply()
+    {
+        for ( NeoCommandHandler applier : providerAppliers.values() )
+        {
+            applier.apply();
+        }
+    }
+    
+    @Override
     public void close()
     {
         for ( NeoCommandHandler applier : providerAppliers.values() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -203,7 +203,6 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     {
         long blockId = record.getId();
         long pageId = pageIdForRecord( blockId );
-        registerIdFromUpdateRecord( blockId );
         try ( PageCursor cursor = storeFile.io( pageId, PF_EXCLUSIVE_LOCK ) )
         {
             if ( cursor.next() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -60,34 +60,27 @@ public abstract class CommonAbstractStore implements IdSequence
     {
         public static final Setting<File> store_dir = InternalAbstractGraphDatabase.Configuration.store_dir;
         public static final Setting<File> neo_store = InternalAbstractGraphDatabase.Configuration.neo_store;
-
         public static final Setting<Boolean> read_only = GraphDatabaseSettings.read_only;
-        public static final Setting<Boolean> backup_slave = GraphDatabaseSettings.backup_slave;
     }
 
     public static final String ALL_STORES_VERSION = "v0.A.4";
     public static final String UNKNOWN_VERSION = "Unknown";
 
-    protected Config configuration;
+    protected final Config configuration;
     private final IdGeneratorFactory idGeneratorFactory;
     protected final PageCache pageCache;
     protected FileSystemAbstraction fileSystemAbstraction;
-
     protected final File storageFileName;
     protected final IdType idType;
     protected StringLogger stringLogger;
-    private IdGenerator idGenerator = null;
-    private StoreChannel fileChannel = null;
+    private IdGenerator idGenerator;
+    private StoreChannel fileChannel;
     protected PagedFile storeFile;
     private boolean storeOk = true;
     private Throwable causeOfStoreNotOk;
     private FileLock fileLock;
-
-    private boolean readOnly = false;
-    private boolean backupSlave = false;
-    private long highestUpdateRecordId = -1;
+    private final boolean readOnly;
     private final StoreVersionMismatchHandler versionMismatchHandler;
-    private final Monitors monitors;
 
     /**
      * Opens and validates the store contained in <CODE>fileName</CODE>
@@ -103,6 +96,7 @@ public abstract class CommonAbstractStore implements IdSequence
      * <CODE>initStorage</CODE> method fails
      *
      * @param idType The Id used to index into this store
+     * @param monitors
      */
     public CommonAbstractStore(
             File fileName,
@@ -123,7 +117,7 @@ public abstract class CommonAbstractStore implements IdSequence
         this.idType = idType;
         this.stringLogger = stringLogger;
         this.versionMismatchHandler = versionMismatchHandler;
-        this.monitors = monitors;
+        this.readOnly = configuration.get( Configuration.read_only );
 
         try
         {
@@ -171,8 +165,6 @@ public abstract class CommonAbstractStore implements IdSequence
      */
     protected void checkStorage()
     {
-        readOnly = configuration.get( Configuration.read_only );
-        backupSlave = configuration.get( Configuration.backup_slave );
         if ( !fileSystemAbstraction.fileExists( storageFileName ) )
         {
             throw new StoreNotFoundException( "No such store[" + storageFileName + "] in " + fileSystemAbstraction );
@@ -187,7 +179,7 @@ public abstract class CommonAbstractStore implements IdSequence
         }
         try
         {
-            if ( !readOnly || backupSlave )
+            if ( !readOnly )
             {
                 this.fileLock = fileSystemAbstraction.tryLock( storageFileName, fileChannel );
             }
@@ -285,7 +277,7 @@ public abstract class CommonAbstractStore implements IdSequence
     {
         try
         {
-            if ( !isReadOnly() || isBackupSlave() )
+            if ( !isReadOnly() )
             {
                 openIdGenerator();
             }
@@ -515,17 +507,12 @@ public abstract class CommonAbstractStore implements IdSequence
         return readOnly;
     }
 
-    boolean isBackupSlave()
-    {
-        return backupSlave;
-    }
-
     /**
      * Marks this store as "not ok".
      */
     protected void setStoreNotOk( Throwable cause )
     {
-        if ( readOnly && !isBackupSlave() )
+        if ( readOnly )
         {
             throw new UnderlyingStorageException(
                     "Cannot start up on non clean store as read only" );
@@ -572,26 +559,38 @@ public abstract class CommonAbstractStore implements IdSequence
      */
     public long getHighId()
     {
-        long genHighId = idGenerator != null ? idGenerator.getHighId() : -1;
-        long updateHighId = highestUpdateRecordId;
-        if ( updateHighId > genHighId )
-        {
-            return updateHighId;
-        }
-        return genHighId;
+        return idGenerator != null ? idGenerator.getHighId() : -1;
     }
 
     /**
-     * Sets the highest id in use (use this when rebuilding id generator).
+     * Sets the high id, i.e. highest id in use + 1 (use this when rebuilding id generator).
      *
      * @param highId The high id to set.
      */
     public void setHighId( long highId )
     {
+        // This method might get called during recovery, where we don't have a reliable id generator yet,
+        // so ignore these calls and let rebuildIdGenerators() figure out the high id after recovery.
         if ( idGenerator != null )
         {
-            idGenerator.setHighId( highId );
+            synchronized ( idGenerator )
+            {
+                if ( highId > idGenerator.getHighId() )
+                {
+                    idGenerator.setHighId( highId );
+                }
+            }
         }
+    }
+
+    /**
+     * Sets the highest id in use. After this call highId will be this given id + 1.
+     *
+     * @param highId The highest id in use to set.
+     */
+    public void setHighestPossibleIdInUse( long highId )
+    {
+        setHighId( highId+1 );
     }
 
     /**
@@ -603,7 +602,7 @@ public abstract class CommonAbstractStore implements IdSequence
     {
         if ( !storeOk )
         {
-            if ( readOnly && !backupSlave )
+            if ( readOnly )
             {
                 throw new ReadOnlyDbException();
             }
@@ -615,7 +614,7 @@ public abstract class CommonAbstractStore implements IdSequence
 
     public void rebuildIdGenerators()
     {
-        if ( readOnly && !backupSlave )
+        if ( readOnly )
         {
             throw new ReadOnlyDbException();
         }
@@ -678,12 +677,6 @@ public abstract class CommonAbstractStore implements IdSequence
     protected void openIdGenerator()
     {
         idGenerator = openIdGenerator( new File( storageFileName.getPath() + ".id" ), idType.getGrabSize() );
-        /* MP: 2011-11-23
-         * There may have been some migration done in the startup process, so if there have been some
-         * high id registered during, then update id generators. updateHighId does nothing if
-         * not registerIdFromUpdateRecord have been called.
-         */
-        updateHighId();
     }
 
     /**
@@ -772,7 +765,7 @@ public abstract class CommonAbstractStore implements IdSequence
         {
             throw new UnderlyingStorageException( "Failed to close store file: " + getStorageFileName(), e );
         }
-        if ( (isReadOnly() && !isBackupSlave()) || idGenerator == null || !storeOk )
+        if ( isReadOnly() || idGenerator == null || !storeOk )
         {
             releaseFileLockAndCloseFileChannel();
             return;
@@ -782,7 +775,7 @@ public abstract class CommonAbstractStore implements IdSequence
         idGenerator.close();
         IOException storedIoe = null;
         // hack for WINBLOWS
-        if ( !readOnly || backupSlave )
+        if ( !readOnly )
         {
             try
             {
@@ -858,13 +851,12 @@ public abstract class CommonAbstractStore implements IdSequence
     {
         if ( idGenerator != null )
         {
-            return idGenerator.getHighId() - 1;
+            return idGenerator.getHighestPossibleIdInUse();
         }
-        else
-        {   // If we ask for this before we've recovered we can only make a best-effort guess
-            // about the highest possible id in use.
-            return figureOutHighestIdInUse();
-        }
+        
+        // If we ask for this before we've recovered we can only make a best-effort guess
+        // about the highest possible id in use.
+        return figureOutHighestIdInUse();
     }
 
     /** @return The total number of ids in use. */
@@ -876,21 +868,6 @@ public abstract class CommonAbstractStore implements IdSequence
     public IdType getIdType()
     {
         return idType;
-    }
-
-    protected void registerIdFromUpdateRecord( long id )
-    {
-        highestUpdateRecordId = Math.max( highestUpdateRecordId, id + 1 );
-    }
-
-    protected void updateHighId()
-    {
-        long highId = highestUpdateRecordId;
-        highestUpdateRecordId = -1;
-        if ( highId > getHighId() )
-        {
-            setHighId( highId );
-        }
     }
 
     public void logVersions( StringLogger.LineLogger logger )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/IdGeneratorImpl.java
@@ -249,8 +249,7 @@ public class IdGeneratorImpl implements IdGenerator
      * Sets the next free "high" id. This method should be called when an id
      * generator has been rebuilt. {@code id} must not be higher than {@code max}.
      *
-     * @param id
-     *            The next free id
+     * @param id The next free id returned from {@link #nextId()} if there are no existing free ids.
      */
     @Override
     public void setHighId( long id )
@@ -304,7 +303,7 @@ public class IdGeneratorImpl implements IdGenerator
         }
         if ( id < 0 || id >= highId.get() )
         {
-            throw new IllegalArgumentException( "Illegal id[" + id + "]" );
+            throw new IllegalArgumentException( "Illegal id[" + id + "], highId is " + highId.get() );
         }
         releasedIdList.add( id );
         defraggedIdCount++;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeStore.java
@@ -237,7 +237,6 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
 
     private void writeRecord( NodeRecord record, boolean force )
     {
-        registerIdFromUpdateRecord( record.getId() );
         long recordId = record.getId();
         long pageId = pageIdForRecord( recordId );
         try ( PageCursor cursor = storeFile.io( pageId, PF_EXCLUSIVE_LOCK ) )
@@ -424,11 +423,5 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
     {
         dynamicLabelStore.rebuildIdGenerators();
         super.rebuildIdGenerators();
-    }
-
-    protected void updateIdGenerators()
-    {
-        dynamicLabelStore.updateHighId();
-        super.updateHighId();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -207,7 +207,6 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
     private void updateRecord( PropertyRecord record, PageCursor cursor )
     {
         long id = record.getId();
-        registerIdFromUpdateRecord( id );
         cursor.setOffset( (int) (id * RECORD_SIZE % storeFile.pageSize()) );
         if ( record.inUse() )
         {
@@ -480,14 +479,6 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         stringPropertyStore.rebuildIdGenerators();
         arrayPropertyStore.rebuildIdGenerators();
         super.rebuildIdGenerators();
-    }
-
-    public void updateIdGenerators()
-    {
-        propertyKeyTokenStore.updateIdGenerators();
-        stringPropertyStore.updateHighId();
-        arrayPropertyStore.updateHighId();
-        this.updateHighId();
     }
 
     public static void allocateStringRecords( Collection<DynamicRecord> target, byte[] chars,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipGroupStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipGroupStore.java
@@ -179,7 +179,6 @@ public class RelationshipGroupStore extends AbstractRecordStore<RelationshipGrou
         try
         {
             updateRecord( record );
-            registerIdFromUpdateRecord( record.getId() );
         }
         finally
         {
@@ -190,7 +189,6 @@ public class RelationshipGroupStore extends AbstractRecordStore<RelationshipGrou
     private void updateRecord( RelationshipGroupRecord record, PageCursor cursor, boolean force )
     {
         long id = record.getId();
-        registerIdFromUpdateRecord( id );
         cursor.setOffset( offsetForId( id ) );
         if ( record.inUse() || force )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipStore.java
@@ -227,7 +227,6 @@ public class RelationshipStore extends AbstractRecordStore<RelationshipRecord> i
     {
         long id = record.getId();
         cursor.setOffset( offsetForId( id ) );
-        registerIdFromUpdateRecord( id );
         if ( record.inUse() || force )
         {
             long firstNode = record.getFirstNode();
@@ -375,16 +374,4 @@ public class RelationshipStore extends AbstractRecordStore<RelationshipRecord> i
 
         return getRecord( id, new RelationshipRecord( id ), RecordLoad.NORMAL );
     }
-
-    public void flushAll()
-    {
-        try
-        {
-            storeFile.flush();
-        } catch(IOException e)
-        {
-            throw new UnderlyingStorageException( e );
-        }
-    }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -260,7 +260,7 @@ public class StoreFactory
         /*
         *  created time | random long | backup version | tx id | store version | next prop
         */
-        for ( int i = 0; i < 6; i++ )
+        for ( int i = 0; i < NeoStore.NUMBER_OF_RECORDS; i++ )
         {
             neoStore.nextId();
         }
@@ -270,6 +270,7 @@ public class StoreFactory
         neoStore.setLastCommittedAndClosedTransactionId( BASE_TX_ID );
         neoStore.setStoreVersion( NeoStore.versionStringToLong( CommonAbstractStore.ALL_STORES_VERSION ) );
         neoStore.setGraphNextProp( -1 );
+        neoStore.setLatestConstraintIntroducingTx( 0 );
 
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/TokenStore.java
@@ -107,12 +107,6 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         super.rebuildIdGenerators();
     }
 
-    public void updateIdGenerators()
-    {
-        nameStore.updateHighId();
-        this.updateHighId();
-    }
-
     public void freeId( int id )
     {
         nameStore.freeId( id );
@@ -297,7 +291,6 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     protected void updateRecord( T record, PageCursor cursor )
     {
         int id = record.getId();
-        registerIdFromUpdateRecord( id );
         cursor.setOffset( offsetForId( id ) );
         if ( record.inUse() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -132,6 +132,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.logging.Logging;
 
 import static org.neo4j.helpers.collection.IteratorUtil.loop;
+import static org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier.DEFAULT_HIGH_ID_TRACKING;
 import static org.neo4j.kernel.impl.nioneo.xa.CacheLoaders.nodeLoader;
 import static org.neo4j.kernel.impl.nioneo.xa.CacheLoaders.relationshipLoader;
 import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogHeaderParser.LOG_HEADER_SIZE;
@@ -466,10 +467,11 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
             LogPruneStrategy logPruneStrategy = LogPruneStrategyFactory.fromConfigValue( fs, logFileInformation,
                     logFiles, neoStore, config.get( GraphDatabaseSettings.keep_logical_logs ) );
 
-            final TransactionRepresentationStoreApplier storeApplier = dependencies.satisfyDependency( new
-                    TransactionRepresentationStoreApplier(
-                    indexingService, labelScanStore, neoStore,
-                    cacheAccess, lockService, legacyIndexProviderLookup, indexConfigStore ) );
+            final TransactionRepresentationStoreApplier storeApplier = dependencies.satisfyDependency(
+                    new TransactionRepresentationStoreApplier(
+                            indexingService, labelScanStore, neoStore,
+                            cacheAccess, lockService, legacyIndexProviderLookup, indexConfigStore,
+                            DEFAULT_HIGH_ID_TRACKING ) );
 
             RecoveryVisitor recoveryVisitor = new RecoveryVisitor( neoStore, storeApplier, recoveredCount );
             Visitor<ReadableLogChannel, IOException> logFileRecoverer =

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/HighIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/HighIdTracker.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa.command;
+
+import org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore;
+
+/**
+ * Tracks high ids when apply a transaction. Multiple calls to {@link #track(CommonAbstractStore, long)} can be
+ * expected, to collect candidate high ids per store. Finally a call to {@link #apply()} should update the stores
+ * with the candidate high ids seen in {@link #track(CommonAbstractStore, long)}.
+ */
+public interface HighIdTracker
+{
+    void track( CommonAbstractStore store, long highId );
+    
+    public static final HighIdTracker NO_TRACKING = new HighIdTracker()
+    {
+        @Override
+        public void track( CommonAbstractStore store, long highId )
+        {   // Don't track
+        }
+
+        @Override
+        public void apply()
+        {   // Don't apply anything
+        }
+    };
+
+    void apply();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoTransactionIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoTransactionIndexApplier.java
@@ -84,7 +84,7 @@ public class NeoTransactionIndexApplier extends NeoCommandHandler.Adapter
     }
 
     @Override
-    public void close()
+    public void apply()
     {
         if ( !labelUpdates.isEmpty() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/PhysicalLogNeoCommandReaderV1.java
@@ -718,6 +718,11 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
                 throw new RuntimeException( "Unknown value type " + valueType );
             }
         }
+        
+        @Override
+        public void apply()
+        {   // Nothing to apply
+        }
 
         @Override
         public void close()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/RecoveredHighIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/RecoveredHighIdTracker.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa.command;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore;
+
+public class RecoveredHighIdTracker implements HighIdTracker
+{
+    private final Map<CommonAbstractStore, HighId> highIds = new HashMap<>();
+    
+    @Override
+    public void track( CommonAbstractStore store, long id )
+    {
+        HighId highId = highIds.get( store );
+        if ( highId == null )
+        {
+            highIds.put( store, highId = new HighId( id ) );
+        }
+        else
+        {
+            highId.track( id );
+        }
+    }
+    
+    private static class HighId
+    {
+        private long id;
+
+        public HighId( long id )
+        {
+            this.id = id;
+        }
+        
+        void track( long id )
+        {
+            if ( id > this.id )
+            {
+                this.id = id;
+            }
+        }
+    }
+
+    @Override
+    public void apply()
+    {
+        // Notifies the stores about the recovered ids and will bump those high ids atomically if
+        // they surpass the current high ids
+        for ( Map.Entry<CommonAbstractStore, HighId> highId : highIds.entrySet() )
+        {
+            highId.getKey().setHighestPossibleIdInUse( highId.getValue().id );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/CommandWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/CommandWriter.java
@@ -445,9 +445,14 @@ public class CommandWriter implements NeoCommandHandler
         }
         writeDynamicRecords( record.getDeletedRecords() );
     }
+    
+    @Override
+    public void apply()
+    {   // Nothing to apply
+    }
 
     @Override
     public void close()
-    {
+    {   // Nothing to close
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -644,7 +644,7 @@ public class BatchInserterImpl implements BatchInserter
         long highId = nodeStore.getHighId();
         if ( highId <= id )
         {
-            nodeStore.setHighId( id + 1 );
+            nodeStore.setHighestPossibleIdInUse( id );
         }
         internalCreateNode( id, properties, labels );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
@@ -57,7 +57,7 @@ public class EntityStoreUpdaterStep<T extends PrimitiveRecord> extends ExecutorS
         for ( T entityRecord : batch.getEntityRecords() )
         {
             // +1 since "high id" is the next id to return, i.e. "high id" is "highest id in use"+1
-            entityStore.setHighId( entityRecord.getId()+1 );
+            entityStore.setHighestPossibleIdInUse( entityRecord.getId() );
             entityStore.updateRecord( entityRecord );
         }
         for ( PropertyRecord propertyRecord : batch.getPropertyRecords() )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
@@ -74,7 +74,7 @@ public class RelationshipEncoderStep extends ExecutorServiceStep<List<InputRelat
         for ( InputRelationship batchRelationship : batch )
         {
             long relationshipId = batchRelationship.id();
-            relationshipStore.setHighId( relationshipId+1 );
+            relationshipStore.setHighestPossibleIdInUse( relationshipId );
             int typeId = batchRelationship.hasTypeId() ? batchRelationship.typeId() :
                     relationshipTypeRepository.getOrCreateId( batchRelationship.type() );
             RelationshipRecord relationshipRecord = new RelationshipRecord( relationshipId,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGeneratorRebuilding.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestIdGeneratorRebuilding.java
@@ -96,13 +96,14 @@ public class TestIdGeneratorRebuilding
         // ... that contain a number of records ...
         NodeRecord record = new NodeRecord( 0 );
         record.setInUse( true );
-        for ( int i = 0; i < 50; i++ )
+        int highestId = 50;
+        for ( int i = 0; i < highestId; i++ )
         {
             assertThat( store.nextId(), is( (long) i ) );
             record.setId( i );
             store.updateRecord( record );
         }
-        store.updateHighId(); // This is usually done in the commit path.
+        store.setHighestPossibleIdInUse( highestId );
 
         // ... and some have been deleted
         Long[] idsToFree = {2L, 3L, 5L, 7L};
@@ -151,7 +152,8 @@ public class TestIdGeneratorRebuilding
         // ... that contain a number of records ...
         DynamicRecord record = new DynamicRecord( 1 );
         record.setInUse( true, PropertyType.STRING.intValue() );
-        for ( int i = 1; i <= 50; i++ ) // id '0' is the dynamic store header
+        int highestId = 50;
+        for ( int i = 1; i <= highestId; i++ ) // id '0' is the dynamic store header
         {
             assertThat( store.nextId(), is( (long) i ) );
             record.setId( i );
@@ -163,7 +165,7 @@ public class TestIdGeneratorRebuilding
             record.setData( sb.toString().getBytes( "UTF-16" ) );
             store.updateRecord( record );
         }
-        store.updateHighId();
+        store.setHighestPossibleIdInUse( highestId );
 
         // ... and some have been deleted
         Long[] idsToFree = {2L, 3L, 5L, 7L};
@@ -212,13 +214,14 @@ public class TestIdGeneratorRebuilding
         int recordsPerPage = store.recordsPerPage();
         NodeRecord record = new NodeRecord( 0 );
         record.setInUse( true );
-        for ( int i = 0; i < recordsPerPage * 3; i++ ) // 3 pages worth of records
+        int highestId = recordsPerPage * 3; // 3 pages worth of records
+        for ( int i = 0; i < highestId; i++ )
         {
             assertThat( store.nextId(), is( (long) i ) );
             record.setId( i );
             store.updateRecord( record );
         }
-        store.updateHighId(); // This is usually done in the commit path.
+        store.setHighestPossibleIdInUse( highestId );
 
         // ... and some records at the end of a page have been deleted
         Long[] idsToFree = {recordsPerPage - 2L, recordsPerPage - 1L}; // id's are zero based, hence -2 and -1

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/ApplyRecoveredTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/ApplyRecoveredTransactionsTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.xa;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.CommandApplierFacade;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.locking.LockService;
+import org.neo4j.kernel.impl.nioneo.store.Abstract64BitRecord;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
+import org.neo4j.kernel.impl.nioneo.xa.command.Command;
+import org.neo4j.kernel.impl.nioneo.xa.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.nioneo.xa.command.Command.RelationshipCommand;
+import org.neo4j.kernel.impl.nioneo.xa.command.NeoCommandHandler;
+import org.neo4j.kernel.impl.nioneo.xa.command.NeoTransactionStoreApplier;
+import org.neo4j.kernel.impl.transaction.xaframework.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.PageCacheRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier.DEFAULT_HIGH_ID_TRACKING;
+import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.configForStoreDir;
+import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
+
+public class ApplyRecoveredTransactionsTest
+{
+    @Test
+    public void shouldSetCorrectHighIdWhenApplyingRecoveredTransactions() throws Exception
+    {
+        // WHEN recovering a transaction that creates some data
+        long nodeId = neoStore.getNodeStore().nextId();
+        long relationshipId = neoStore.getRelationshipStore().nextId();
+        int type = 1;
+        applyRecoveredTransaction( 1,
+                nodeCommand( node( nodeId ), inUse( created( node( nodeId ) ) ) ),
+                relationshipCommand( inUse( created( with( relationship( relationshipId ), nodeId, nodeId, type ) ) ) ) );
+        
+        // and when, later on, recovering a transaction deleting some of those
+        applyRecoveredTransaction( 2,
+                nodeCommand( inUse( created( node( nodeId ) ) ), node( nodeId ) ),
+                relationshipCommand( relationship( relationshipId ) ) );
+        
+        // THEN that should be possible and the high ids should be correct, i.e. highest applied + 1
+        assertEquals( nodeId+1, neoStore.getNodeStore().getHighId() );
+        assertEquals( relationshipId+1, neoStore.getRelationshipStore().getHighId() );
+    }
+
+    private RelationshipRecord with( RelationshipRecord relationship, long startNode, long endNode, int type )
+    {
+        relationship.setFirstNode( startNode );
+        relationship.setSecondNode( endNode );
+        relationship.setType( type );
+        return relationship;
+    }
+
+    private Command relationshipCommand( RelationshipRecord relationship )
+    {
+        RelationshipCommand command = new RelationshipCommand();
+        command.init( relationship );
+        return command;
+    }
+
+    private RelationshipRecord relationship( long relationshipId )
+    {
+        return new RelationshipRecord( relationshipId );
+    }
+
+    private void applyRecoveredTransaction( long transactionId, Command...commands ) throws IOException
+    {
+        NeoTransactionStoreApplier applier = new NeoTransactionStoreApplier( neoStore, mock( IndexingService.class ),
+                mock( CacheAccessBackDoor.class ), mock( LockService.class ), transactionId,
+                DEFAULT_HIGH_ID_TRACKING, true );
+        CommandApplierFacade applierFacade = new CommandApplierFacade( applier,
+                mock( NeoCommandHandler.class ), mock( NeoCommandHandler.class ) );
+        new PhysicalTransactionRepresentation( Arrays.asList( commands ) ).accept( applierFacade );
+    }
+    
+    public final @Rule EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();
+    public final @Rule PageCacheRule pageCacheRule = new PageCacheRule();
+    private NeoStore neoStore;
+    
+    @Before
+    public void before()
+    {
+        File storeDir = new File( "dir" );
+        Config config = configForStoreDir( new Config(), storeDir );
+        StoreFactory storeFactory = new StoreFactory( config, new DefaultIdGeneratorFactory(),
+                pageCacheRule.getPageCache( fsr.get(), config ), fsr.get(), DEV_NULL, new Monitors() );
+        neoStore = storeFactory.newNeoStore( true );
+    }
+
+    @After
+    public void after()
+    {
+        neoStore.close();
+    }
+
+    private Command nodeCommand( NodeRecord before, NodeRecord after )
+    {
+        NodeCommand command = new NodeCommand();
+        command.init( before, after );
+        return command;
+    }
+
+    private <RECORD extends Abstract64BitRecord> RECORD inUse( RECORD record )
+    {
+        record.setInUse( true );
+        return record;
+    }
+
+    private <RECORD extends Abstract64BitRecord> RECORD created( RECORD record )
+    {
+        record.setCreated();
+        return record;
+    }
+
+    private NodeRecord node( long id )
+    {
+        return new NodeRecord( id );
+    }
+
+    private long nextNodeId()
+    {
+        return neoStore.getNodeStore().nextId();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
@@ -133,6 +133,7 @@ import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
 import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
+import static org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier.DEFAULT_HIGH_ID_TRACKING;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.impl.nioneo.store.IndexRule.indexRule;
 import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.configForStoreDir;
@@ -1336,7 +1337,7 @@ public class NeoStoreTransactionTest
         LabelScanStore labelScanStore = mock( LabelScanStore.class );
         when (labelScanStore.newWriter()).thenReturn( mock(LabelScanWriter.class) );
         TransactionRepresentationStoreApplier applier = new TransactionRepresentationStoreApplier(
-                indexing, labelScanStore, neoStore, cacheAccessBackDoor, locks, null, null );
+                indexing, labelScanStore, neoStore, cacheAccessBackDoor, locks, null, null, DEFAULT_HIGH_ID_TRACKING );
 
         // Call this just to make sure the counters have been initialized.
         // This is only a problem in a mocked environment like this.
@@ -1399,7 +1400,7 @@ public class NeoStoreTransactionTest
     {
 
         NeoTransactionStoreApplier storeApplier = new NeoTransactionStoreApplier(
-                neoStore, mockIndexing, cacheAccessBackDoor, locks, txId, true );
+                neoStore, mockIndexing, cacheAccessBackDoor, locks, txId, DEFAULT_HIGH_ID_TRACKING, true );
 
         LabelScanStore labelScanStore = mock( LabelScanStore.class );
         when (labelScanStore.newWriter()).thenReturn( mock(LabelScanWriter.class) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/SchemaRuleCommandTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier.DEFAULT_HIGH_ID_TRACKING;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.impl.nioneo.store.UniquenessConstraintRule.uniquenessConstraintRule;
 
@@ -166,7 +167,7 @@ public class SchemaRuleCommandTest
     private final SchemaStore store = mock( SchemaStore.class );
     private final IndexingService indexes = mock( IndexingService.class );
     private final NeoTransactionStoreApplier executor = new NeoTransactionStoreApplier( neoStore, indexes,
-            mock( CacheAccessBackDoor.class ), LockService.NO_LOCK_SERVICE, txId, false );
+            mock( CacheAccessBackDoor.class ), LockService.NO_LOCK_SERVICE, txId, DEFAULT_HIGH_ID_TRACKING, false );
     private final PhysicalLogNeoCommandReaderV1 reader = new PhysicalLogNeoCommandReaderV1();
     private final IndexRule rule = IndexRule.indexRule( id, labelId, propertyKey, PROVIDER_DESCRIPTOR );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionCommandOrderingTest.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,7 +28,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.nioneo.store.AbstractBaseRecord;
 import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.LabelTokenRecord;
@@ -53,6 +51,10 @@ import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.nioneo.xa.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.xaframework.PhysicalTransactionRepresentation;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class WriteTransactionCommandOrderingTest
 {
@@ -246,7 +248,7 @@ public class WriteTransactionCommandOrderingTest
 
         public RecordingPropertyStore( AtomicReference<List<String>> currentRecording )
         {
-            super( null, null, null, null, null, null, null, null, null, null, null );
+            super( null, new Config(), null, null, null, null, null, null, null, null, null );
             this.currentRecording = currentRecording;
         }
 
@@ -274,7 +276,7 @@ public class WriteTransactionCommandOrderingTest
 
         public RecordingNodeStore( AtomicReference<List<String>> currentRecording )
         {
-            super( null, null, null, null, null, null, null, null, null );
+            super( null, new Config(), null, null, null, null, null, null, null );
             this.currentRecording = currentRecording;
         }
 
@@ -309,7 +311,7 @@ public class WriteTransactionCommandOrderingTest
 
         public RecordingRelationshipStore( AtomicReference<List<String>> currentRecording )
         {
-            super( null, null, null, null, null, null, null, null );
+            super( null, new Config(), null, null, null, null, null, null );
             this.currentRecording = currentRecording;
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoTransactionIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoTransactionIndexApplierTest.java
@@ -75,7 +75,7 @@ public class NeoTransactionIndexApplierTest
 
         // when
         final boolean result = applier.visitNodeCommand( command );
-        applier.close();
+        applier.apply();
 
         // then
         assertTrue( result );
@@ -105,7 +105,7 @@ public class NeoTransactionIndexApplierTest
 
         // when
         final boolean result = applier.visitNodeCommand( command );
-        applier.close();
+        applier.apply();
 
         // then
         assertTrue( result );
@@ -137,7 +137,7 @@ public class NeoTransactionIndexApplierTest
 
         // when
         final boolean result = applier.visitPropertyCommand( command );
-        applier.close();
+        applier.apply();
 
         // then
         assertTrue( result );
@@ -165,7 +165,7 @@ public class NeoTransactionIndexApplierTest
 
         // when
         final boolean result = applier.visitPropertyCommand( command );
-        applier.close();
+        applier.apply();
 
         // then
         assertTrue( result );

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
@@ -105,7 +105,7 @@ class CommitContext implements Closeable
             }
         }
     }
-
+    
     @Override
     public void close() throws IOException
     {

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
@@ -114,9 +114,9 @@ public class LuceneCommandApplier extends NeoCommandHandler.Adapter
         dataSource.getWriteLock();
         return true;
     }
-
+    
     @Override
-    public void close()
+    public void apply()
     {
         try
         {
@@ -133,12 +133,14 @@ public class LuceneCommandApplier extends NeoCommandHandler.Adapter
         {
             throw new RuntimeException( "Failure to commit changes to lucene", e );
         }
-        finally
+    }
+
+    @Override
+    public void close()
+    {
+        if ( definitions != null )
         {
-            if ( definitions != null )
-            {
-                dataSource.releaseWriteLock();
-            }
+            dataSource.releaseWriteLock();
         }
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/DenseNodeTransactionTranslator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/DenseNodeTransactionTranslator.java
@@ -58,7 +58,7 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>, 
     private final RelationshipGroupGetter groupGetter;
     private final RelationshipCreator relationshipCreator;
     private final RelationshipDeleter deleter;
-    private DenseNodeTransactionTranslator.TranslatingNeoCommandVisitor commandVisitor = new TranslatingNeoCommandVisitor();
+    private final DenseNodeTransactionTranslator.TranslatingNeoCommandVisitor commandVisitor = new TranslatingNeoCommandVisitor();
 
     public DenseNodeTransactionTranslator( NeoStore neoStore )
     {
@@ -98,9 +98,10 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>, 
         LogEntry done = null;
         for ( LogEntry logEntry : from )
         {
-            if ( logEntry.getVersion() == LogEntryVersions.CURRENT_LOG_ENTRY_VERSION
-                    )
+            if ( logEntry.getVersion() == LogEntryVersions.CURRENT_LOG_ENTRY_VERSION )
+            {
                 throw new RuntimeException( "crap" );
+            }
 
             switch ( logEntry.getType() )
             {
@@ -178,7 +179,7 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>, 
 
         for ( LogEntryCommand commandEntry : commands )
         {
-            Command command = (Command) commandEntry.getXaCommand();
+            Command command = commandEntry.getXaCommand();
             if ( command instanceof Command.RelationshipCommand )
             {
                 long id = ((Command.RelationshipCommand) command).getRecord().getId();
@@ -204,7 +205,7 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>, 
 
     private boolean handleCommand( LogEntryCommand commandEntry ) throws IOException
     {
-        Command command = (Command) commandEntry.getXaCommand();
+        Command command = commandEntry.getXaCommand();
         return command.handle( commandVisitor );
     }
 
@@ -383,11 +384,15 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>, 
         {
             return false;
         }
+        
+        @Override
+        public void apply()
+        {
+        }
 
         @Override
         public void close()
         {
-
         }
 
         private void translateRelationshipCreation( Command.RelationshipCommand command )


### PR DESCRIPTION
When applying recovered transactions to the store the id generators needs
to be notified while applying. That was done, but there was an off-by-one
error where the id generator would be told that the new high id was id of
the created entity, even though "high id" means "the id of the next
created record, given there are no more free ids". So the correct thing to
do is to set high id to the created entity + 1.

Problem became visible when a transaction that create a new record that
got the highest id to date was recovered and applied, followed by another
recovered transaction that deleted that record. The id generator would say
that the id was invalid.

This commit fixes that and introduces a
CommonAbstractStore#setHighestPossibleIdInUse(long) method for that to alleviate
callers to do the +1 on their own everywhere.
