### PR TITLE
Synchronizes store application

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -72,7 +72,10 @@ public class TransactionRepresentationStoreApplier
         try ( CommandApplierFacade applier = new CommandApplierFacade(
                 storeApplier, indexApplier, legacyIndexApplier ) )
         {
-            representation.accept( applier );
+            synchronized ( this )
+            {
+                representation.accept( applier );
+            }
         }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -84,6 +84,7 @@ import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.ha.transaction.TransactionPropagator;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.core.Caches;
@@ -405,9 +406,12 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
             public TransactionCommitProcess create( LogicalTransactionStore logicalTransactionStore, KernelHealth
                     kernelHealth, NeoStore neoStore, TransactionRepresentationStoreApplier storeApplier, NeoStoreInjectedTransactionValidator validator, boolean recovery )
             {
+                TransactionRepresentationCommitProcess inner = (TransactionRepresentationCommitProcess)
+                        defaultCommitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore,
+                                storeApplier, validator, recovery );
                 new CommitProcessSwitcher( pusher, master, commitProcessDelegate, requestContextFactory,
                         memberStateMachine, unpacker, logicalTransactionStore, kernelHealth, neoStore, storeApplier,
-                        validator, transactionMonitor );
+                        validator, transactionMonitor, inner );
 
                 return (TransactionCommitProcess) Proxy.newProxyInstance( TransactionCommitProcess.class.getClassLoader(),
                         new Class[]{ TransactionCommitProcess.class }, commitProcessDelegate );


### PR DESCRIPTION
This brings in one more case under synchronization, and that is where a
store applier runs at the same time as a response unpacker. Also less
commit process objects are produced, which means that the synchronization
that guards their commit method does a better job.

bb822c974cdadb333a3f0daeb4ca4d5eca609120 started this work and this commit
takes it a little further. The root cause of why lack of this
synchronization is causing problems has to be found.
