### PR TITLE
Fixed logging failure on slave after store copy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.InternalAbstractGraphDatabase.Dependencies;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptorProvider;
+import org.neo4j.kernel.logging.Logging;
 
 import static java.util.Arrays.asList;
 
@@ -169,4 +170,9 @@ public class GraphDatabaseFactory
         return this;
     }
 
+    public GraphDatabaseFactory setLogging( Logging logging )
+    {
+        getCurrentState().setLogging( logging );
+        return this;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/DefaultLogging.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/DefaultLogging.java
@@ -25,8 +25,13 @@ import org.neo4j.kernel.configuration.Config;
 
 import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
 
-public class DefaultLogging
+public final class DefaultLogging
 {
+    private DefaultLogging()
+    {
+        throw new AssertionError( "Not for instantiation!" );
+    }
+
     public static Logging createDefaultLogging( Map<String, String> config )
     {
         return createDefaultLogging( new Config( config ) );
@@ -34,6 +39,6 @@ public class DefaultLogging
 
     public static Logging createDefaultLogging( Config config )
     {
-        return new LogbackWeakDependency().tryLoadLogbackService( config, DEFAULT_TO_CLASSIC );
+        return LogbackWeakDependency.tryLoadLogbackService( config, DEFAULT_TO_CLASSIC );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
@@ -44,11 +44,10 @@ public class LogbackService
         extends LifecycleAdapter
         implements Logging
 {
-    private Config config;
+    private final Config config;
     private final LoggerContext loggerContext;
-    private final String logbackConfigurationFilename;
 
-    private LifeSupport loggingLife = new LifeSupport();
+    private final LifeSupport loggingLife = new LifeSupport();
     protected RestartOnChange restartOnChange;
 
     public LogbackService( Config config, LoggerContext loggerContext )
@@ -61,7 +60,6 @@ public class LogbackService
     {
         this.config = config;
         this.loggerContext = loggerContext;
-        this.logbackConfigurationFilename = logbackConfigurationFilename;
 
         // We do the initialization in the constructor, because some services will use logging during creation phase, before init.
         final File storeDir = config.get( InternalAbstractGraphDatabase.Configuration.store_dir );

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -82,6 +82,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
         return this;
     }
     
+    @Override
     public TestGraphDatabaseFactory setLogging( Logging logging )
     {
         getCurrentState().setLogging( logging );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -125,8 +125,9 @@ class BackupService
         GraphDatabaseAPI targetDb = null;
         try
         {
+            ConsoleLogger consoleLog = new ConsoleLogger( StringLogger.SYSTEM );
             RemoteStoreCopier storeCopier = new RemoteStoreCopier( tuningConfiguration, loadKernelExtensions(),
-                    new ConsoleLogger( StringLogger.SYSTEM ), new DefaultFileSystemAbstraction() );
+                    consoleLog, new DevNullLoggingService(), new DefaultFileSystemAbstraction() );
             storeCopier.copyStore( new RemoteStoreCopier.StoreCopyRequester()
             {
                 private BackupClient client;

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ThirdPartyDSStoreCopyIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ThirdPartyDSStoreCopyIT.java
@@ -61,6 +61,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaConnection;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.impl.util.ResourceIterators;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.impl.util.TestLogging;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.monitoring.BackupMonitor;
@@ -92,8 +93,11 @@ public class ThirdPartyDSStoreCopyIT
         // Given
         final String copyDir = new File(testDir.directory(), "copy").getAbsolutePath();
         final String originalDir = new File(testDir.directory(), "original").getAbsolutePath();
+
         Config config = new Config( MapUtil.stringMap( store_dir.name(), copyDir ) );
-        RemoteStoreCopier copier = new RemoteStoreCopier( config, loadKernelExtensions(), new ConsoleLogger( StringLogger.DEV_NULL ), fs );
+        ConsoleLogger consoleLog = new ConsoleLogger( StringLogger.DEV_NULL );
+        TestLogging logging = new TestLogging();
+        RemoteStoreCopier copier = new RemoteStoreCopier( config, loadKernelExtensions(), consoleLog, logging, fs );
 
         // When
         copier.copyStore( new RemoteStoreCopier.StoreCopyRequester()
@@ -141,7 +145,7 @@ public class ThirdPartyDSStoreCopyIT
     private List<KernelExtensionFactory<?>> loadKernelExtensions()
     {
         List<KernelExtensionFactory<?>> kernelExtensions = new ArrayList<>();
-        for ( KernelExtensionFactory factory : Service.load( KernelExtensionFactory.class ) )
+        for ( KernelExtensionFactory<?> factory : Service.load( KernelExtensionFactory.class ) )
         {
             kernelExtensions.add( factory );
         }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -235,8 +235,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected Logging createLogging()
     {
-        Logging loggingService = life.add( new LogbackWeakDependency().tryLoadLogbackService( config,
-                NEW_LOGGER_CONTEXT,
+        Logging loggingService = life.add( LogbackWeakDependency.tryLoadLogbackService( config, NEW_LOGGER_CONTEXT,
                 DEFAULT_TO_CLASSIC ) );
 
         // Set Netty logger

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
@@ -158,7 +158,7 @@ public class StandaloneClusterClient
         return result;
     }
 
-    private static void moveOver( Map<String, String> from, Map<String, String> to, Setting setting )
+    private static void moveOver( Map<String, String> from, Map<String, String> to, Setting<?> setting )
     {
         String key = setting.name();
         if ( from.containsKey( key ) )
@@ -174,7 +174,7 @@ public class StandaloneClusterClient
                 new File( new File( new File( home, "data" ), "log" ), "arbiter" ).getPath() );
         Config config = new Config( stringMap( InternalAbstractGraphDatabase.Configuration.store_dir.name(), logDir ) );
 
-        return new LogbackWeakDependency().tryLoadLogbackService( config, DEFAULT_TO_CLASSIC );
+        return LogbackWeakDependency.tryLoadLogbackService( config, DEFAULT_TO_CLASSIC );
     }
 
     private static File extractDbTuningProperties( String propertiesFile )


### PR DESCRIPTION
PR fixes broken logging on slave after store copy on first startup. After store being copied slave turns on embedded database to perform recovery, this database use static logger context and close all it's appenders on shutdown.
