### PR TITLE
Less hacky way to disable generating ComponentVersion

### DIFF
--- a/community/io/pom.xml
+++ b/community/io/pom.xml
@@ -9,7 +9,6 @@
 
   <properties>
     <short-name>io</short-name>
-    <version-package>io</version-package>
     <bundle.namespace>org.neo4j.io</bundle.namespace>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <docs.url>http://docs.neo4j.org/chunked/${project.version}/primitive-collections.html</docs.url>
@@ -18,7 +17,6 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-io</artifactId>
-  <groupId>org.neo4j</groupId>
   <version>2.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
@@ -94,16 +92,6 @@ the relevant Commercial Agreement.
 
   <build>
     <plugins>
-      <!-- Disable the ComponentVersion generation -->
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-            <id>generate-version</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
         <configuration>

--- a/community/primitive-collections/pom.xml
+++ b/community/primitive-collections/pom.xml
@@ -9,7 +9,6 @@
 
   <properties>
     <short-name>primitive-collections</short-name>
-    <version-package>util.primitive.collection</version-package>
     <bundle.namespace>org.neo4j.util.primitive.collection</bundle.namespace>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
@@ -17,7 +16,6 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-primitive-collections</artifactId>
-  <groupId>org.neo4j</groupId>
   <version>2.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
@@ -65,26 +63,5 @@ the relevant Commercial Agreement.
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
-<!--<dependency>
-      <groupId>net.sf.trove4j</groupId>
-      <artifactId>trove4j</artifactId>
-      <version>3.0.3</version>
-      <scope>test</scope>
-    </dependency>-->
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- Disable the ComponentVersion generation -->
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-            <id>generate-version</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
The `io` and `primitive-collections` modules are earlier in the build than the
kernel, and therefore cannot have ComponentVersions.

The generation of the ComponentVersion class can be disabled by simply not
having a `version-package` property in the pom file.
Lots better than going out of our way to sabotage the ant-run plugin.
