### PR TITLE
Ensures that incompatible roles are removed from cluster info on availability events

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
@@ -124,6 +125,7 @@ public class ClusterMember
         else if ( role.equals( HighAvailabilityModeSwitcher.SLAVE ) )
         {
             copy.remove( HighAvailabilityModeSwitcher.MASTER );
+            copy.remove( OnlineBackupKernelExtension.BACKUP );
         }
         copy.put( role, roleUri );
         return new ClusterMember( this.memberId, copy, this.alive );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -173,6 +173,18 @@ public class ClusterMembers
                 // Unknown member
             }
         }
+
+        @Override
+        public void memberIsFailed( InstanceId instanceId )
+        {
+            // Make it unavailable for all its current roles
+            ClusterMember member = getMember( instanceId );
+            for ( String role : member.getRoles() )
+            {
+                members.put( instanceId, member.unavailableAs( role ) );
+                member = getMember( instanceId ); // The instance is copy on write, need to get it again.
+            }
+        }
     }
 
     private class HAMHeartbeatListener extends HeartbeatListener.Adapter

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
@@ -19,13 +19,25 @@
  */
 package org.neo4j.kernel.ha.cluster.member;
 
+import static java.net.URI.create;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
+import static org.neo4j.kernel.ha.cluster.member.ClusterMemberMatcher.sameMemberAs;
+
 import java.net.URI;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
+import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberEvents;
 import org.neo4j.cluster.member.ClusterMemberListener;
@@ -34,21 +46,8 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.heartbeat.Heartbeat;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.util.StringLogger;
-
-import static java.net.URI.create;
-import static java.util.Arrays.asList;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
-import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
-import static org.neo4j.kernel.ha.cluster.member.ClusterMemberMatcher.sameMemberAs;
 
 public class ClusterMembersTest
 {
@@ -361,6 +360,70 @@ public class ClusterMembersTest
 
         // then
         assertThat( members.getSelf().getHARole(), equalTo( SLAVE ) );
+    }
+
+    @Test
+    public void missingMasterUnavailabilityEventForOtherInstanceStillRemovesBackupRole() throws Exception
+    {
+        // given
+        Cluster cluster = mock(Cluster.class);
+        Heartbeat heartbeat = mock( Heartbeat.class );
+        ClusterMemberEvents clusterMemberEvents = mock(ClusterMemberEvents.class);
+
+        ClusterMembers members = new ClusterMembers( cluster, heartbeat, clusterMemberEvents, clusterId1 );
+
+        ArgumentCaptor<ClusterListener> listener = ArgumentCaptor.forClass( ClusterListener.class );
+        verify( cluster ).addClusterListener( listener.capture() );
+        listener.getValue().enteredCluster( clusterConfiguration( clusterUri1, clusterUri2, clusterUri3 ) );
+
+        ArgumentCaptor<ClusterMemberListener> clusterMemberListener = ArgumentCaptor.forClass( ClusterMemberListener.class );
+        verify( clusterMemberEvents ).addClusterMemberListener( clusterMemberListener.capture() );
+
+        clusterMemberListener.getValue().memberIsAvailable( OnlineBackupKernelExtension.BACKUP, clusterId2, clusterUri2 );
+        clusterMemberListener.getValue().memberIsAvailable( MASTER, clusterId2, clusterUri2 );
+        clusterMemberListener.getValue().memberIsAvailable( SLAVE, clusterId2, clusterUri2 );
+
+        for ( ClusterMember clusterMember : members.getMembers() )
+        {
+            if ( clusterMember.getInstanceId() == clusterId2.toIntegerIndex() )
+            {
+                assertThat( Iterables.count( clusterMember.getRoles() ), equalTo( 1l ) );
+                assertThat( Iterables.single( clusterMember.getRoles() ), equalTo( SLAVE ) );
+                break; // that's the only member we care about
+            }
+        }
+    }
+
+    @Test
+    public void receivingInstanceFailureEventRemovesAllRolesForIt() throws Exception
+    {
+        // given
+        Cluster cluster = mock(Cluster.class);
+        Heartbeat heartbeat = mock( Heartbeat.class );
+        ClusterMemberEvents clusterMemberEvents = mock(ClusterMemberEvents.class);
+
+        ClusterMembers members = new ClusterMembers( cluster, heartbeat, clusterMemberEvents, clusterId1 );
+
+        ArgumentCaptor<ClusterListener> listener = ArgumentCaptor.forClass( ClusterListener.class );
+        verify( cluster ).addClusterListener( listener.capture() );
+        listener.getValue().enteredCluster( clusterConfiguration( clusterUri1, clusterUri2, clusterUri3 ) );
+
+        ArgumentCaptor<ClusterMemberListener> clusterMemberListener = ArgumentCaptor.forClass( ClusterMemberListener.class );
+        verify( clusterMemberEvents ).addClusterMemberListener( clusterMemberListener.capture() );
+
+        clusterMemberListener.getValue().memberIsAvailable( OnlineBackupKernelExtension.BACKUP, clusterId2, clusterUri2 );
+        clusterMemberListener.getValue().memberIsAvailable( MASTER, clusterId2, clusterUri2 );
+
+        clusterMemberListener.getValue().memberIsFailed( clusterId2 );
+
+        for ( ClusterMember clusterMember : members.getMembers() )
+        {
+            if ( clusterMember.getInstanceId() == clusterId2.toIntegerIndex() )
+            {
+                assertThat( Iterables.count( clusterMember.getRoles() ), equalTo( 0l ) );
+                break; // that's the only member we care about
+            }
+        }
     }
 
     private ClusterConfiguration clusterConfiguration( URI... uris )


### PR DESCRIPTION
Given that when an instance fails it does not broadcast unavailability events, it may
 happen that an instance failing and rejoining can keep the backup role. Also, an
 instance failing should have its roles removed, as they are no longer relevant. This
 commit does so by checking in ClusterMember for incompatible roles and removing them.
 Additionally, it removes all roles from an instance when a failure event is received
 for it.
Adds tests for these conditions on the ClusterMembers level.
