### PR TITLE
[2.1] Introduce cache.memory_ratio configuration for HPCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ out
 .mailmap
 .java-version
 community/server/data
+enterprise/server-enterprise/data

--- a/community/kernel/src/docs/ops/cache.asciidoc
+++ b/community/kernel/src/docs/ops/cache.asciidoc
@@ -156,8 +156,31 @@ The available cache types are:
 
 === High-Performance Cache ===
 
-Since the High-Performance Cache operates with a maximum size in the JVM it may be configured per use case for optimal performance.
-There are two aspects of the cache size.
+How much memory to allocate to the High Performance Cache can be fine tuned to suit your use case.
+There are two ways to configure memory usage for it.
+
+*Standard configuration*
+
+For most use cases, simply specifying a percentage of the memory available for caching to use is enough to tune the High-Performance Cache.
+
+Allocating more memory to the cache gives faster querying speed, but takes memory away from other components and may put strain on the JVM garbage collector.
+
+The max amount of memory available for caching depends on which garbage collector you are using.
+For CMS and G1 collectors (CMS is the Neo4j default), it will be equal to the max size of the old generation. How big
+the old generation is is platform-dependent, but can for CMS and G1 be configured using the "NewRatio" JVM configuration
+option.
+For other collectors, it will be half of the total heap size.
+
+[options="header",cols="<25m,<65,<10m"]
+|==========================================
+| `configuration option`   | Description (what it controls)                                                           | Example value
+| cache.memory_ratio       | Percentage, 0-100, of memory available for caching to use for caching. Default is 50%.   | 50.0
+|==========================================
+
+*Advanced configuration*
+
+The advanced configuration gives more fine-grained control of how much memory to allocate specific parts of the cache.
+There are two aspects to this configuration.
 
 One is the size of the array referencing the objects that are put in the cache.
 It is specified as a fraction of the heap, for example specifying +5+ will let that array itself take up 5% out of the entire heap.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/config/InvalidSettingException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/config/InvalidSettingException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.config;
+
+/**
+ * Thrown when a configuration setting is, for one reason or another, invalid.
+ */
+public class InvalidSettingException extends RuntimeException
+{
+    private final String name;
+
+    public InvalidSettingException( String name, String value, String message )
+    {
+        super(String.format( "Bad value '%s' for setting '%s': %s", value, name, message ));
+        this.name = name;
+    }
+
+    public InvalidSettingException( String name, String message )
+    {
+        super(message);
+        this.name = name;
+    }
+
+    public String settingName()
+    {
+        return name;
+    }
+
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
@@ -27,6 +27,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.configuration.Config;
@@ -804,7 +805,7 @@ public final class Settings
             }
             catch ( IllegalArgumentException e )
             {
-                throw new IllegalArgumentException( String.format( "Bad value '%s' for setting '%s': %s", value, name(), e.getMessage() ) );
+                throw new InvalidSettingException( name(), value, e.getMessage() );
             }
 
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optional.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optional.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.function;
+
+/**
+ * Represents a value that may or may not exist.
+ */
+public interface Optional<TYPE>
+{
+    TYPE get();
+    boolean isPresent();
+
+    Optional<TYPE> or(Optional<TYPE> secondChoice);
+    Optional<TYPE> or(TYPE secondChoice);
+}
+

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.function;
+
+public class Optionals
+{
+    public static final Optional NONE = new Optional(){
+
+        @Override
+        public Object get() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+
+        @Override
+        public Optional or( Optional secondChoice ) {
+            return secondChoice;
+        }
+
+        @Override
+        public Optional or( Object secondChoice ) {
+            return some( secondChoice );
+        }
+    };
+
+    public static <TYPE> Optional<TYPE> none()
+    {
+        return NONE;
+    }
+
+    public static <TYPE> Optional<TYPE> some( final TYPE obj )
+    {
+        return new Optional<TYPE>(){
+
+            @Override
+            public TYPE get() {
+                return obj;
+            }
+
+            @Override
+            public boolean isPresent() {
+                return true;
+            }
+
+            @Override
+            public Optional<TYPE> or( Optional<TYPE> secondChoice ) {
+                return this;
+            }
+
+            @Override
+            public Optional<TYPE> or( TYPE secondChoice ) {
+                return this;
+            }
+        };
+    }
+
+    public static abstract class LazyOptional<TYPE> implements Optional<TYPE>
+    {
+        private TYPE value;
+        private boolean evaluated = false;
+
+        protected abstract TYPE evaluate();
+
+        @Override
+        public TYPE get()
+        {
+            if(!isPresent())
+            {
+                throw new UnsupportedOperationException();
+            }
+            return value();
+        }
+
+        @Override
+        public boolean isPresent()
+        {
+            return value() != null;
+        }
+
+        @Override
+        public Optional<TYPE> or( Optional<TYPE> secondChoice )
+        {
+            return isPresent() ? this : secondChoice;
+        }
+
+        @Override
+        public Optional<TYPE> or( TYPE secondChoice )
+        {
+            return isPresent() ? this : some(secondChoice);
+        }
+
+        private TYPE value()
+        {
+            if(!evaluated) value = evaluate();
+            return value;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
@@ -66,7 +67,7 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "bar" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
@@ -99,7 +100,7 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "1" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
@@ -120,7 +121,7 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "7" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
@@ -140,7 +141,7 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "1" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
@@ -150,7 +151,7 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "6" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
@@ -170,13 +171,13 @@ public class SettingsTest
             setting.apply( map( stringMap( "foo", "cba" ) ) );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
             // Ok
         }
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = InvalidSettingException.class )
     public void testDurationWithBrokenDefault()
     {
         // Notice that the default value is less that the minimum
@@ -184,7 +185,7 @@ public class SettingsTest
         setting.apply( map( stringMap() ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = InvalidSettingException.class )
     public void testDurationWithValueNotWithinConstraint()
     {
         Setting<Long> setting = setting( "foo.bar", DURATION, "3s", min( DURATION.apply( "3s" ) ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfig.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfig.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.Settings;
 
@@ -99,7 +100,7 @@ public class TestConfig
 
             fail( "Expected validation to fail." );
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
         }
     }
@@ -113,7 +114,7 @@ public class TestConfig
 
             fail( "Expected validation to fail." );
         }
-        catch ( IllegalArgumentException e )
+        catch ( InvalidSettingException e )
         {
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/function/OptionalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/function/OptionalTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.function;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OptionalTest
+{
+    @Test
+    public void shouldFallbackIfNone() throws Exception
+    {
+        // Given
+        Optional<Object> none = Optionals.none();
+
+        // When & then
+        assertFalse( none.isPresent() );
+        assertTrue( none.or( 1 ).isPresent() );
+        assertEquals( none.or(1).get(), 1);
+        assertEquals( none.or(none).or(2).get(), 2);
+    }
+
+    @Test
+    public void simpleOptionalProvidesUserSuppliedValue() throws Exception
+    {
+        // Given
+        Optionals.LazyOptional<Object> some = new Optionals.LazyOptional<Object>()
+        {
+            @Override
+            protected Object evaluate()
+            {
+                return 1;
+            }
+        };
+
+        // When & then
+        assertTrue( some.isPresent() );
+        assertTrue( some.or( 1 ).isPresent() );
+        assertEquals( some.or(2).get(), 1);
+        assertEquals( some.or(some).or(2).get(), 1);
+    }
+
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HPCMemoryConfig.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HPCMemoryConfig.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+public class HPCMemoryConfig
+{
+    private final long nodeCacheSize;
+    private final long relCacheSize;
+    private final float nodeLookupTableFraction;
+    private final float relLookupTableFraction;
+    private final Source source;
+
+    /**
+     * Used to track how this configuration came about, which is in turn used to trigger some user warnings if she
+     * is inadvertently overriding her own settings.
+     */
+    public enum Source
+    {
+        /** Config is complete vanilla, the user has not specified anything. */
+        DEFAULT_MEMORY_RATIO,
+        /** Config comes from user specifying only the memory ratio to allocate to caching. */
+        EXPLICIT_MEMORY_RATIO,
+        /** Specific settings for each cache part provided by user, and ratio was not specified by user. */
+        SPECIFIC,
+        /** Highlighting that ratio is configured as well, but was overridden by explicit config. */
+        SPECIFIC_OVERRIDING_RATIO
+    }
+
+    public HPCMemoryConfig( long nodeCacheSize, long relCacheSize,
+                            float nodeLookupTableFraction, float relLookupTableFraction, Source source )
+    {
+        this.nodeCacheSize = nodeCacheSize;
+        this.relCacheSize = relCacheSize;
+        this.nodeLookupTableFraction = nodeLookupTableFraction;
+        this.relLookupTableFraction = relLookupTableFraction;
+        this.source = source;
+    }
+
+    public Source source()
+    {
+        return source;
+    }
+
+    public long nodeCacheSize()
+    {
+        return nodeCacheSize;
+    }
+
+    public long relCacheSize()
+    {
+        return relCacheSize;
+    }
+
+    public float nodeLookupTableFraction()
+    {
+        return nodeLookupTableFraction;
+    }
+
+    public float relLookupTableFraction()
+    {
+        return relLookupTableFraction;
+    }
+
+    public long total()
+    {
+        return (long) (nodeCacheSize + relCacheSize +
+                (((relLookupTableFraction + nodeLookupTableFraction) / 100)) * Runtime.getRuntime().maxMemory());
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HPCSettingFunctions.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HPCSettingFunctions.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeDataSupport;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Function2;
+import org.neo4j.kernel.impl.util.function.Optional;
+import org.neo4j.kernel.impl.util.function.Optionals;
+
+import static org.neo4j.helpers.Settings.BYTES;
+import static org.neo4j.helpers.Settings.FLOAT;
+
+public class HPCSettingFunctions
+{
+    @SuppressWarnings("RedundantStringConstructorCall")
+    static String DEFAULT = new String("__DEFAULT__"); // Note explicit object creation to allow instance equality check
+
+    /** Config parser that provides HPCMemoryConfig from a ratio-of-old-gen config setting. */
+    static Function<String, HPCMemoryConfig> CACHE_MEMORY_RATIO = new Function<String, HPCMemoryConfig>()
+    {
+        @Override
+        public HPCMemoryConfig apply( String s )
+        {
+            HPCMemoryConfig.Source source = HPCMemoryConfig.Source.EXPLICIT_MEMORY_RATIO;
+            //noinspection StringEquality
+            if ( s == DEFAULT ) // Note instance equality check is on purpose
+            {
+                s = "50.0" ;
+                source = HPCMemoryConfig.Source.DEFAULT_MEMORY_RATIO;
+            }
+
+            long oldGenSize = memoryPoolMax( "java.lang:type=MemoryPool,name=G1 Old Gen" )
+                    .or( memoryPoolMax( "java.lang:type=MemoryPool,name=PS Old Gen" ) )
+                    .or( heap() / 2 ) // Conservative, to be on the safe side
+                    .get();
+
+            long allocated = (long)((FLOAT.apply( s ) / 100.0) * oldGenSize);
+
+            return new HPCMemoryConfig(
+                    /* Node cache size */ (long)(allocated * 0.3),
+                    /* Rel cache size  */ (long)(allocated * 0.4),
+                    /* Node lookup table */ asPercentageOfHeap( allocated * 0.1 ),
+                    /* Rel lookup table  */ asPercentageOfHeap( allocated * 0.1 ), source );
+        }
+
+        private float asPercentageOfHeap( double bytes )
+        {
+            return (float) ((bytes / heap()) * 100);
+        }
+    };
+    /** Overrides another hpc config setting if any explicit config is specified. */
+    static Function2<HPCMemoryConfig, Function<String, String>, HPCMemoryConfig> OTHER_CACHE_SETTINGS_OVERRIDE = new Function2<HPCMemoryConfig, Function<String, String>, HPCMemoryConfig>()
+    {
+        @Override
+        public HPCMemoryConfig apply( HPCMemoryConfig basedOnRatio, Function<String, String> settings )
+        {
+            String explicitNodeCacheSize     = settings.apply( HighPerformanceCacheSettings.node_cache_size.name() );
+            String explicitRelCacheSize      = settings.apply( HighPerformanceCacheSettings.relationship_cache_size.name() );
+            String explicitNodeArrayFraction = settings.apply( HighPerformanceCacheSettings.node_cache_array_fraction.name() );
+            String explicitRelArrayFraction  = settings.apply( HighPerformanceCacheSettings.relationship_cache_array_fraction.name() );
+
+            if( explicitNodeCacheSize != null
+                    || explicitRelCacheSize != null
+                    || explicitNodeArrayFraction != null
+                    || explicitRelArrayFraction != null )
+            {
+                // At least one explicit config set, swap to explicit mode
+                long nodeCacheBytes = explicitNodeCacheSize != null ? BYTES.apply( explicitNodeCacheSize ) : heap() / 8;
+                long relCacheBytes  = explicitRelCacheSize  != null ? BYTES.apply( explicitRelCacheSize )  : heap() / 8;
+                float nodeArrRatio = explicitNodeArrayFraction != null ? FLOAT.apply( explicitNodeArrayFraction) : 1.0f;
+                float relArrRatio  = explicitRelArrayFraction  != null ? FLOAT.apply( explicitRelArrayFraction ) : 1.0f;
+
+                // Figure out if user is inadvertently overwriting her own configuration
+                HPCMemoryConfig.Source source = basedOnRatio.source() == HPCMemoryConfig.Source.DEFAULT_MEMORY_RATIO ? HPCMemoryConfig.Source.SPECIFIC :
+                        HPCMemoryConfig.Source.SPECIFIC_OVERRIDING_RATIO;
+                return new HPCMemoryConfig( nodeCacheBytes, relCacheBytes, nodeArrRatio, relArrRatio, source);
+            }
+
+            return basedOnRatio;
+        }
+    };
+    /** Disallows cache total size to go beyond the available heap. */
+    static Function2<HPCMemoryConfig, Function<String, String>, HPCMemoryConfig> TOTAL_NOT_ALLOWED_ABOVE_HEAP = new Function2<HPCMemoryConfig, Function<String, String>, HPCMemoryConfig>()
+    {
+        @Override
+        public HPCMemoryConfig apply( HPCMemoryConfig input, Function<String, String> settings )
+        {
+            if(input.total() > (heap() * 0.8))
+            {
+                throw new InvalidSettingException( HighPerformanceCacheSettings.cache_memory.name(),
+                        String.format( "Configured object cache memory limits (node=%s, relationship=%s, " +
+                                "total=%s) exceeds 80%% of available heap space (%s)",
+                        input.nodeCacheSize(), input.relCacheSize(), input.total(), heap() ) );
+            }
+            return input;
+        }
+    };
+
+    private static Optional<Long> memoryPoolMax( final String bean )
+    {
+        return new Optionals.LazyOptional<Long>()
+        {
+            @Override
+            protected Long evaluate()
+            {
+                try
+                {
+                    return (long) ((CompositeDataSupport) ManagementFactory.getPlatformMBeanServer()
+                            .getAttribute( new ObjectName( bean ), "Usage" )).get( "max" );
+                }
+                catch(Exception e)
+                {
+                    return null;
+                }
+            }
+        };
+    }
+
+    private static long heap()
+    {
+        return Runtime.getRuntime().maxMemory();
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheSettings.java
@@ -20,8 +20,9 @@
 package org.neo4j.kernel.impl.cache;
 
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.helpers.Settings;
+import org.neo4j.graphdb.factory.Description;
 
+import static org.neo4j.helpers.Settings.BYTES;
 import static org.neo4j.helpers.Settings.DURATION;
 import static org.neo4j.helpers.Settings.FLOAT;
 import static org.neo4j.helpers.Settings.NO_DEFAULT;
@@ -34,9 +35,9 @@ import static org.neo4j.helpers.Settings.setting;
  */
 public class HighPerformanceCacheSettings
 {
-    public static final Setting<Long> node_cache_size = setting( "node_cache_size", Settings.BYTES, NO_DEFAULT );
-    public static final Setting<Long> relationship_cache_size =
-            setting( "relationship_cache_size", Settings.BYTES,NO_DEFAULT );
+
+    public static final Setting<Long> node_cache_size = setting( "node_cache_size", BYTES, NO_DEFAULT );
+    public static final Setting<Long> relationship_cache_size = setting( "relationship_cache_size", BYTES,NO_DEFAULT );
 
     @SuppressWarnings("unchecked")
     public static final Setting<Float> node_cache_array_fraction =
@@ -46,5 +47,16 @@ public class HighPerformanceCacheSettings
     public static final Setting<Float> relationship_cache_array_fraction =
             setting("relationship_cache_array_fraction", FLOAT, "1.0", range( 1.0f, 10.0f ) );
 
+    @Description("Set the amount of usable memory to allocate to the high-level object cache, a value between " +
+            "0 and 100. It is recommended to not have this value exceed 70. This cannot be used in conjunction with " +
+            "other object cache size settings.")
+    @SuppressWarnings("unchecked")
+    public static final Setting<HPCMemoryConfig> cache_memory =
+            setting( "cache.memory_ratio", HPCSettingFunctions.CACHE_MEMORY_RATIO, HPCSettingFunctions.DEFAULT,
+                    HPCSettingFunctions.OTHER_CACHE_SETTINGS_OVERRIDE, HPCSettingFunctions.TOTAL_NOT_ALLOWED_ABOVE_HEAP );
+
     public static final Setting<Long> log_interval = setting( "high_performance_cache_min_log_interval", DURATION, "60s" );
+
+
+
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheProviderTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheProviderTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import org.junit.Test;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.TestLogger;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.cache_memory;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_size;
+
+public class HighPerformanceCacheProviderTest
+{
+    @Test
+    public void shouldWarnIfUserOverridesHerOwnConfig() throws Exception
+    {
+        // Given
+        TestLogger logger = new TestLogger();
+        Config configWithOverridenMemoryRatio = new Config( stringMap(
+                cache_memory.name(), "25",
+                node_cache_size.name(), "10M" ), HighPerformanceCacheSettings.class );
+
+        // When
+        new HighPerformanceCacheProvider().newNodeCache( logger, configWithOverridenMemoryRatio, new Monitors() );
+
+        // Then
+        logger.assertExactly( TestLogger.LogCall.warn("Explicit cache memory ratio configuration is ignored, " +
+                "because advanced cache memory configuration has been specified. Please specify either only the " +
+                "ratio configuration, or only the advanced configuration.") );
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheSettingsTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/cache/HighPerformanceCacheSettingsTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import org.junit.Test;
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.kernel.configuration.Config;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.cache.HPCSettingFunctions.CACHE_MEMORY_RATIO;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.cache_memory;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_size;
+
+public class HighPerformanceCacheSettingsTest
+{
+    @Test
+    public void cacheMemoryRatioShouldCalculateSaneRatio() throws Exception
+    {
+        // Given
+        HPCMemoryConfig config = CACHE_MEMORY_RATIO.apply( "100.0" );
+
+        // Then
+        assertThat( config.nodeCacheSize(), greaterThan( 0l ) );
+        assertThat( config.relCacheSize(), greaterThan( 0l ) );
+        assertThat( config.nodeLookupTableFraction(), greaterThan( 0f ) );
+        assertThat( config.relLookupTableFraction(), greaterThan( 0f ) );
+
+        // And when I give a different ratio
+        HPCMemoryConfig otherRatio = CACHE_MEMORY_RATIO.apply( "50.0" );
+
+        // Then
+        assertThat( (double)otherRatio.nodeCacheSize(),           closeTo( config.nodeCacheSize() / 2, 10.0 ));
+        assertThat( (double)otherRatio.relCacheSize(),            closeTo( config.relCacheSize() / 2, 10.0 ));
+        assertThat( (double)otherRatio.nodeLookupTableFraction(), closeTo(config.nodeLookupTableFraction()/2, 10.0));
+        assertThat( (double)otherRatio.relLookupTableFraction(),  closeTo(config.relLookupTableFraction()/2, 10.0));
+    }
+
+    @Test
+    public void explicitCacheConfigShouldOverrideRatioDefaults() throws Exception
+    {
+        // Given
+        Config conf = new Config(stringMap( node_cache_size.name(), "200M" ), HighPerformanceCacheSettings.class );
+
+        // When
+        HPCMemoryConfig memoryConfig = conf.get( cache_memory );
+
+        // Then
+        assertThat(memoryConfig.source(), equalTo( HPCMemoryConfig.Source.SPECIFIC ));
+        assertThat(memoryConfig.nodeCacheSize(), equalTo(209715200L));
+
+        assertThat((double)memoryConfig.relCacheSize(), closeTo( Runtime.getRuntime().maxMemory() / 8, 100.0 ));
+        assertThat(memoryConfig.relLookupTableFraction(), equalTo( 1.0f ));
+        assertThat(memoryConfig.nodeLookupTableFraction(), equalTo(1.0f));
+    }
+
+    @Test
+    public void explicitCacheConfigShouldOverrideExplicitRatio() throws Exception
+    {
+        // Given
+        Config conf = new Config(stringMap(
+                node_cache_size.name(), "200M",
+                cache_memory.name(), "25" ), HighPerformanceCacheSettings.class );
+
+        // When
+        HPCMemoryConfig memoryConfig = conf.get( cache_memory );
+
+        // Then
+        assertThat(memoryConfig.source(), equalTo( HPCMemoryConfig.Source.SPECIFIC_OVERRIDING_RATIO ));
+        assertThat(memoryConfig.nodeCacheSize(), equalTo(209715200L));
+
+        assertThat((double)memoryConfig.relCacheSize(), closeTo(Runtime.getRuntime().maxMemory() / 8, 100.0));
+        assertThat(memoryConfig.relLookupTableFraction(), equalTo(1.0f));
+        assertThat(memoryConfig.nodeLookupTableFraction(), equalTo(1.0f));
+    }
+
+    @Test
+    public void totalConfigLargerThanHeapIsNotAllowed() throws Exception
+    {
+        // When
+        try
+        {
+            new Config(stringMap(node_cache_size.name(), "" + (Runtime.getRuntime().maxMemory() * 100)),
+                    HighPerformanceCacheSettings.class );
+            fail("Should not have allowed getting this config.");
+        // Then
+        } catch(InvalidSettingException e)
+        {
+            assertThat(e.getMessage(), containsString( "Configured object cache memory limits" ));
+            assertThat(e.getMessage(), containsString( "exceeds 80% of available heap space" ));
+        }
+    }
+}


### PR DESCRIPTION
New set-and-forget configuration that specifies cache size as a ratio of the
old generation max size. Memory division across internal components of the cache
is handled by fixed ratios.

If any of the old config (now referred to as "advanced config") is set, it will
override the memory_ratio configuration.
