### PR TITLE
Ensures that incompatible roles are removed from cluster info on availability events

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
@@ -124,6 +125,7 @@ public class ClusterMember
         else if ( role.equals( HighAvailabilityModeSwitcher.SLAVE ) )
         {
             copy.remove( HighAvailabilityModeSwitcher.MASTER );
+            copy.remove( OnlineBackupKernelExtension.BACKUP );
         }
         copy.put( role, roleUri );
         return new ClusterMember( this.memberId, copy, this.alive );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -173,6 +173,18 @@ public class ClusterMembers
                 // Unknown member
             }
         }
+
+        @Override
+        public void memberIsFailed( InstanceId instanceId )
+        {
+            // Make it unavailable for all its current roles
+            ClusterMember member = getMember( instanceId );
+            for ( String role : member.getRoles() )
+            {
+                member = member.unavailableAs( role ); // ClusterMember is copy-on-write
+            }
+            members.put( instanceId, member ); // replace with the new copy
+        }
     }
 
     private class HAMHeartbeatListener extends HeartbeatListener.Adapter


### PR DESCRIPTION
Supersedes #2846.

Given that when an instance fails it does not broadcast unavailability events, it may happen that an instance failing and rejoining can keep the backup role. Also, an instance failing should have its roles removed, as they are no longer relevant. This commit does so by checking in ClusterMember for incompatible roles and removing them. Additionally, it removes all roles from an instance when a failure event is received for it.

Adds tests for these conditions on the ClusterMembers level.
