### PR TITLE
Ensure Ronja only hash joins on node ids

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/join.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/join.scala
@@ -33,9 +33,9 @@ object join extends CandidateGenerator[PlanTable] {
     } yield {
       val shared = (left.availableSymbols & right.availableSymbols).toList
       shared match {
-        case id :: Nil => Some(planNodeHashJoin(id, left, right))
-        case Nil => None
-        case _ => None
+        case id :: Nil if queryGraph.patternNodes(id) => Some(planNodeHashJoin(id, left, right))
+        case Nil                                      => None
+        case _                                        => None
       }
     }).flatten
     CandidateList(joinPlans)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/JoinTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/JoinTest.scala
@@ -31,7 +31,8 @@ class JoinTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
 
-  private def createQuery(rels: PatternRelationship*) = QueryGraph(patternRelationships = rels.toSet)
+  private def createQuery(rels: PatternRelationship*) = QueryGraph.empty.addPatternRels(rels)
+
   val aNode = IdName("a")
   val bNode = IdName("b")
   val cNode = IdName("c")
@@ -112,6 +113,21 @@ class JoinTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     val qg = createQuery()
 
+    join(planTable, qg) should equal(CandidateList())
+  }
+
+  test("does not join relationships") {
+    implicit val context = newMockedLogicalPlanningContext(
+      planContext = newMockedPlanContext
+    )
+    val left = newMockedQueryPlanWithPatterns(Set(r1Name, aNode))
+    val right = newMockedQueryPlanWithPatterns(Set(r1Name, bNode))
+    val planTable = PlanTable(Map(
+      Set(r1Name, aNode) -> left,
+      Set(r1Name, bNode) -> right
+    ))
+
+    val qg = createQuery(r1Rel)
     join(planTable, qg) should equal(CandidateList())
   }
 }


### PR DESCRIPTION
Conflicts:
    community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/join.scala
