### PR TITLE
Fix races on shutdown in Muninn

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -57,6 +57,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -69,7 +70,7 @@ import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.test.ByteArrayMatcher.byteArray;
 
-public abstract class PageCacheTest<T extends PageCache>
+public abstract class PageCacheTest<T extends RunnablePageCache>
 {
     protected static ExecutorService executor;
 
@@ -106,6 +107,7 @@ public abstract class PageCacheTest<T extends PageCache>
     protected abstract void tearDownPageCache( T pageCache ) throws IOException;
 
     private T pageCache;
+    private Future<?> pageCacheFuture;
 
     protected final T getPageCache(
             FileSystemAbstraction fs,
@@ -116,8 +118,10 @@ public abstract class PageCacheTest<T extends PageCache>
         if ( pageCache != null )
         {
             tearDownPageCache( pageCache );
+            pageCacheFuture.cancel( true );
         }
         pageCache = createPageCache( fs, maxPages, pageSize, monitor );
+        pageCacheFuture = executor.submit( pageCache );
         return pageCache;
     }
 
@@ -2939,5 +2943,52 @@ public abstract class PageCacheTest<T extends PageCache>
         }
 
         pageCache.unmap( file );
+    }
+
+    @Test
+    public void evictionThreadMustGracefullyShutDown() throws Exception
+    {
+        // TODO this test takes significantly longer to complete with Muninn, than it does with the StandardPageCache -- investigate why!
+        int iterations = 1000;
+        final AtomicReference<Throwable> caughtException = new AtomicReference<>();
+        Thread.UncaughtExceptionHandler exceptionHandler = new Thread.UncaughtExceptionHandler()
+        {
+            @Override
+            public void uncaughtException( Thread t, Throwable e )
+            {
+                e.printStackTrace();
+                caughtException.set( e );
+            }
+        };
+
+        generateFileWithRecords( file, recordCount, recordSize );
+        int filePagesInTotal = recordCount / recordsPerFilePage;
+
+        for ( int i = 0; i < iterations; i++ )
+        {
+            RunnablePageCache cache = createPageCache( fs, maxPages, pageCachePageSize, PageCacheMonitor.NULL );
+            String evictionThreadName = cache.getClass().getSimpleName() + "-Eviction-Thread-" + i;
+            Thread evictionThread = new Thread( cache, evictionThreadName );
+            evictionThread.setUncaughtExceptionHandler( exceptionHandler );
+            evictionThread.start();
+
+            // Touch all the pages
+            PagedFile pagedFile = cache.map( file, filePageSize );
+            try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_LOCK ) )
+            {
+                for ( int j = 0; j < filePagesInTotal; j++ )
+                {
+                    assertTrue( cursor.next() );
+                }
+            }
+
+            // We're now likely racing with the eviction thread
+            cache.unmap( file );
+            cache.close();
+            evictionThread.interrupt();
+            evictionThread.join();
+
+            assertThat( caughtException.get(), is( nullValue() ) );
+        }
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/StandardPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/standard/StandardPageCacheTest.java
@@ -20,14 +20,10 @@
 package org.neo4j.io.pagecache.impl.standard;
 
 import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 
 import org.junit.Test;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCacheMonitor;
 import org.neo4j.io.pagecache.PageCacheTest;
 import org.neo4j.io.pagecache.PageCursor;
@@ -40,8 +36,6 @@ import static org.junit.Assert.assertThat;
 
 public class StandardPageCacheTest extends PageCacheTest<StandardPageCache>
 {
-    private static final ConcurrentMap<PageCache, Future<?>> futures = new ConcurrentHashMap<>();
-
     @Override
     protected StandardPageCache createPageCache(
             FileSystemAbstraction fs,
@@ -49,21 +43,13 @@ public class StandardPageCacheTest extends PageCacheTest<StandardPageCache>
             int pageSize,
             PageCacheMonitor monitor )
     {
-        StandardPageCache pageCache = new StandardPageCache( fs, maxPages, pageSize, monitor );
-        Future<?> future = executor.submit( pageCache );
-        futures.put( pageCache, future );
-        return pageCache;
+        return new StandardPageCache( fs, maxPages, pageSize, monitor );
     }
 
     @Override
     protected void tearDownPageCache( StandardPageCache pageCache ) throws IOException
     {
         pageCache.close();
-        Future<?> future = futures.remove( pageCache );
-        if ( future != null )
-        {
-            future.cancel( true );
-        }
     }
 
     @Test

--- a/enterprise/enterprise-io/src/test/java/org/neo4j/io/enterprise/pagecache/impl/muninn/MuninnPageCacheTest.java
+++ b/enterprise/enterprise-io/src/test/java/org/neo4j/io/enterprise/pagecache/impl/muninn/MuninnPageCacheTest.java
@@ -22,8 +22,6 @@ package org.neo4j.io.enterprise.pagecache.impl.muninn;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
 import org.junit.Test;
@@ -32,7 +30,6 @@ import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongIntMap;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCacheMonitor;
 import org.neo4j.io.pagecache.PageCacheTest;
 import org.neo4j.io.pagecache.PageCursor;
@@ -53,7 +50,6 @@ import static org.neo4j.io.pagecache.RecordingPageCacheMonitor.Fault;
 
 public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
 {
-    private static final ConcurrentMap<PageCache, Future<?>> futures = new ConcurrentHashMap<>();
     private final long x = 0xCAFEBABEDEADBEEFL;
     private final long y = 0xDECAFC0FFEEDECAFL;
 
@@ -64,21 +60,13 @@ public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
             int pageSize,
             PageCacheMonitor monitor )
     {
-        MuninnPageCache pageCache = new MuninnPageCache( fs, maxPages, pageSize, monitor );
-        Future<?> future = executor.submit( pageCache );
-        futures.put( pageCache, future );
-        return pageCache;
+        return new MuninnPageCache( fs, maxPages, pageSize, monitor );
     }
 
     @Override
     protected void tearDownPageCache( MuninnPageCache pageCache ) throws IOException
     {
         pageCache.close();
-        Future<?> future = futures.remove( pageCache );
-        if ( future != null )
-        {
-            future.cancel( true );
-        }
     }
 
     @Test


### PR DESCRIPTION
The Muninn eviction thread did not anticipate that closing the page cache would
set all the MuninnPage references in the `pages` array to `null`, and so it
could die with a NullPointerException.

It now interprets the precense of a `null` value as a signal to shut down.
