### PR TITLE
[1.9] A tool for dumping the content of a store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DumpStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DumpStore.java
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+public class DumpStore<RECORD extends AbstractBaseRecord, STORE extends CommonAbstractStore & RecordStore<RECORD>>
+{
+    public static void main( String... args ) throws Exception
+    {
+        if ( args == null || args.length == 0 )
+        {
+            System.err.println( "WARNING: no files specified..." );
+            return;
+        }
+        StoreFactory storeFactory = new StoreFactory(
+                new Config(), new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(),
+                new DefaultFileSystemAbstraction(), logger(), null );
+        for ( String arg : args )
+        {
+            File file = new File( arg );
+            if ( !file.isFile() )
+            {
+                throw new IllegalArgumentException( "No such file: " + arg );
+            }
+            if ( "neostore.nodestore.db".equals( file.getName() ) )
+            {
+                dumpNodeStore( file, storeFactory );
+            }
+            else if ( "neostore.relationshipstore.db".equals( file.getName() ) )
+            {
+                dumpRelationshipStore( file, storeFactory );
+            }
+            else if ( "neostore.propertystore.db".equals( file.getName() ) )
+            {
+                dumpPropertyStore( file, storeFactory );
+            }
+            else if ( "neostore.propertystore.db.index".equals( file.getName() ) )
+            {
+                dumpPropertyKeys( file, storeFactory );
+            }
+            else if ( "neostore.relationshiptypestore.db".equals( file.getName() ) )
+            {
+                dumpRelationshipTypes( file, storeFactory );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Unknown store file: " + arg );
+            }
+        }
+    }
+
+    private static StringLogger logger()
+    {
+        return Boolean.getBoolean( "logger" ) ? StringLogger.SYSTEM : StringLogger.DEV_NULL;
+    }
+
+    private static void dumpPropertyKeys( File file, StoreFactory storeFactory ) throws Exception
+    {
+        dumpTokens( storeFactory.newPropertyIndexStore( file ) );
+    }
+
+    private static void dumpRelationshipTypes( File file, StoreFactory storeFactory ) throws Exception
+    {
+        dumpTokens( storeFactory.newRelationshipTypeStore( file ) );
+    }
+
+    private static <T extends AbstractNameRecord> void dumpTokens( final AbstractNameStore<T> store ) throws Exception
+    {
+        try
+        {
+            new DumpStore<T, AbstractNameStore<T>>( System.out )
+            {
+                @Override
+                protected Object transform( T record ) throws Exception
+                {
+                    if ( record.inUse() )
+                    {
+                        store.makeHeavy( record );
+                        return record.getId() + ": \"" + store.getStringFor( record ) + "\": " + record;
+                    }
+                    return null;
+                }
+            }.dump( store );
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private static void dumpRelationshipStore( File file, StoreFactory storeFactory ) throws Exception
+    {
+        RelationshipStore store = storeFactory.newRelationshipStore( file );
+        try
+        {
+            new DumpStore<RelationshipRecord, RelationshipStore>( System.out ).dump( store );
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private static void dumpPropertyStore( File file, StoreFactory storeFactory ) throws Exception
+    {
+        PropertyStore store = storeFactory.newPropertyStore( file );
+        try
+        {
+            new DumpStore<PropertyRecord, PropertyStore>( System.out ).dump( store );
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private static void dumpNodeStore( File file, StoreFactory storeFactory ) throws Exception
+    {
+        NodeStore store = storeFactory.newNodeStore( file );
+        try
+        {
+            new DumpStore<NodeRecord, NodeStore>( System.out )
+            {
+                @Override
+                protected Object transform( NodeRecord record ) throws Exception
+                {
+                    return record.inUse() ? record : "";
+                }
+            }.dump( store );
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private final PrintStream out;
+
+    protected DumpStore( PrintStream out )
+    {
+        this.out = out;
+    }
+
+    public final void dump( STORE store ) throws Exception
+    {
+        store.makeStoreOk();
+        int size = store.getRecordSize();
+        StoreChannel fileChannel = store.getFileChannel();
+        ByteBuffer buffer = ByteBuffer.allocate( size );
+        out.println( "store.getRecordSize() = " + size );
+        out.println( "<dump>" );
+        long used = 0;
+        for ( long i = 1, high = store.getHighestPossibleIdInUse(); i <= high; i++ )
+        {
+            RECORD record = store.forceGetRecord( i );
+            if ( record.inUse() )
+            {
+                used++;
+            }
+            Object transform = transform( record );
+            if ( transform != null )
+            {
+                if ( !"".equals( transform ) )
+                {
+                    out.println( transform );
+                }
+            }
+            else
+            {
+                out.print( record );
+                buffer.clear();
+                fileChannel.read( buffer, i * size );
+                buffer.flip();
+                if ( record.inUse() )
+                {
+                    dumpHex( buffer, i * size );
+                }
+                else if ( allZero( buffer ) )
+                {
+                    out.printf( ": all zeros @ 0x%x - 0x%x%n", i * size, (i + 1) * size );
+                }
+                else
+                {
+                    dumpHex( buffer, i * size );
+                }
+            }
+        }
+        out.println( "</dump>" );
+        out.printf( "used = %s / highId = %s (%.2f%%)%n", used, store.getHighId(), used * 100.0 / store.getHighId() );
+    }
+
+    private boolean allZero( ByteBuffer buffer )
+    {
+        int pos = buffer.position();
+        try
+        {
+            while ( buffer.remaining() > 0 )
+            {
+                if ( buffer.get() != 0 )
+                {
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            buffer.position( pos );
+        }
+        return true;
+    }
+
+    protected Object transform( RECORD record ) throws Exception
+    {
+        return record.inUse() ? record : null;
+    }
+
+    private void dumpHex( ByteBuffer buffer, long offset )
+    {
+        for ( int count = 0; buffer.remaining() > 0; count++, offset++ )
+        {
+            int b = buffer.get();
+            if ( count % 16 == 0 )
+            {
+                out.printf( "%n    @ 0x%08x: ", offset );
+            }
+            else if ( count % 4 == 0 )
+            {
+                out.print( " " );
+            }
+            out.printf( " %x%x", 0xF & (b >> 4), 0xF & b );
+        }
+        out.println();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DumpStoreChain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DumpStoreChain.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.helpers.Args;
+import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+public abstract class DumpStoreChain<RECORD extends AbstractBaseRecord>
+{
+    private static final String REVERSE = "reverse", NODE = "node", FIRST = "first", RELS = "relationships", PROPS = "properties";
+    private static final String RELSTORE = "neostore.relationshipstore.db";
+    private static final String PROPSTORE = "neostore.propertystore.db";
+    private static final String NODESTORE = "neostore.nodestore.db";
+
+    public static void main( String... args ) throws Exception
+    {
+        Args arguments = new Args( args );
+        List<String> orphans = arguments.orphans();
+        if ( orphans.size() != 1 )
+        {
+            throw invalidUsage( "no store file given" );
+        }
+        File storeFile = new File( orphans.get( 0 ) );
+        DumpStoreChain tool;
+        if ( storeFile.isDirectory() )
+        {
+            verifyFilesExists( new File( storeFile, NODESTORE ),
+                               new File( storeFile, RELSTORE ),
+                               new File( storeFile, PROPSTORE ) );
+            tool = chainForNode( arguments );
+        }
+        else
+        {
+            verifyFilesExists( storeFile );
+            if ( RELSTORE.equals( storeFile.getName() ) )
+            {
+                tool = relationshipChain( arguments );
+            }
+            else if ( PROPSTORE.equals( storeFile.getName() ) )
+            {
+                tool = propertyChain( arguments );
+            }
+            else
+            {
+                throw invalidUsage( "not a chain store: " + storeFile.getName() );
+            }
+        }
+        tool.dump( storeFile );
+    }
+
+    long first;
+
+    private DumpStoreChain( long first )
+    {
+        this.first = first;
+    }
+
+    private static StringLogger logger()
+    {
+        return Boolean.getBoolean( "logger" ) ? StringLogger.SYSTEM : StringLogger.DEV_NULL;
+    }
+
+    void dump( File storeFile )
+    {
+        RecordStore<RECORD> store = store( new StoreFactory(
+                new Config(), new DefaultIdGeneratorFactory(), new DefaultWindowPoolFactory(),
+                new DefaultFileSystemAbstraction(), logger(), null ), storeFile );
+        try
+        {
+            for ( long next = first; next != -1; )
+            {
+                RECORD record = store.forceGetRecord( next );
+                System.out.println( record );
+                next = next( record );
+            }
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    abstract long next( RECORD record );
+
+    abstract RecordStore<RECORD> store( StoreFactory factory, File storeFile );
+
+    private static DumpStoreChain propertyChain( Args args )
+    {
+        boolean reverse = verifyParametersAndCheckReverse( args, FIRST );
+        return new DumpPropertyChain( Long.parseLong( args.get( FIRST, null ) ), reverse );
+    }
+
+    private static DumpStoreChain relationshipChain( Args args )
+    {
+        boolean reverse = verifyParametersAndCheckReverse( args, FIRST, NODE );
+        long node = Long.parseLong( args.get( NODE, null ) );
+        return new DumpRelationshipChain( Long.parseLong( args.get( FIRST, null ) ), node, reverse );
+    }
+
+    private static DumpStoreChain chainForNode( Args args )
+    {
+        Set<String> kwArgs = args.asMap().keySet();
+        verifyParameters( kwArgs, kwArgs.contains( RELS ) ? RELS : PROPS, NODE );
+        final long node = Long.parseLong( args.get( NODE, null ) );
+        if ( args.getBoolean( RELS, false, true ) )
+        {
+            return new DumpRelationshipChain( -1, node, false )
+            {
+                @Override
+                RelationshipStore store( StoreFactory factory, File storeFile )
+                {
+                    first = nodeRecord( factory, storeFile, node ).getNextRel();
+                    return super.store( factory, new File( storeFile, RELSTORE ) );
+                }
+            };
+        }
+        else if ( args.getBoolean( PROPS, false, true ) )
+        {
+            return new DumpPropertyChain( -1, false )
+            {
+                @Override
+                PropertyStore store( StoreFactory factory, File storeFile )
+                {
+                    first = nodeRecord( factory, storeFile, node ).getNextProp();
+                    return super.store( factory, new File( storeFile, PROPSTORE ) );
+                }
+            };
+        }
+        else
+        {
+            throw invalidUsage( String.format( "Must be either -%s or -%s", RELS, PROPS ) );
+        }
+    }
+
+    private static NodeRecord nodeRecord( StoreFactory factory, File storeDir, long id )
+    {
+        NodeStore store = factory.newNodeStore( new File( storeDir, NODESTORE ) );
+        try
+        {
+            return store.forceGetRecord( id );
+        }
+        finally
+        {
+            store.close();
+        }
+    }
+
+    private static void verifyFilesExists( File... files )
+    {
+        for ( File file : files )
+        {
+            if ( !file.isFile() )
+            {
+                throw invalidUsage( file + " does not exist" );
+            }
+        }
+    }
+
+    private static boolean verifyParametersAndCheckReverse( Args args, String... parameters )
+    {
+        Set<String> kwArgs = args.asMap().keySet();
+        if ( kwArgs.contains( REVERSE ) )
+        {
+            parameters = Arrays.copyOf( parameters, parameters.length + 1 );
+            parameters[parameters.length - 1] = REVERSE;
+        }
+        verifyParameters( kwArgs, parameters );
+        return args.getBoolean( REVERSE, false, true );
+    }
+
+    private static void verifyParameters( Set<String> args, String... parameters )
+    {
+        if ( args.size() != parameters.length )
+        {
+            throw invalidUsage( "accepted/required parameters: " + Arrays.toString( parameters ) );
+        }
+        for ( String parameter : parameters )
+        {
+            if ( !args.contains( parameter ) )
+            {
+                throw invalidUsage( "accepted/required parameters: " + Arrays.toString( parameters ) );
+            }
+        }
+    }
+
+    private static Error invalidUsage( String message )
+    {
+        System.err.println( "invalid usage: " + message );
+        System.exit( 1 );
+        return null;
+    }
+
+    private static class DumpPropertyChain extends DumpStoreChain<PropertyRecord>
+    {
+        private final boolean reverse;
+
+        DumpPropertyChain( long first, boolean reverse )
+        {
+            super( first );
+            this.reverse = reverse;
+        }
+
+        @Override
+        PropertyStore store( StoreFactory factory, File storeFile )
+        {
+            return factory.newPropertyStore( storeFile );
+        }
+
+        @Override
+        long next( PropertyRecord record )
+        {
+            return reverse ? record.getPrevProp() : record.getNextProp();
+        }
+    }
+
+    private static class DumpRelationshipChain extends DumpStoreChain<RelationshipRecord>
+    {
+        private final long node;
+        private final boolean reverse;
+
+        DumpRelationshipChain( long first, long node, boolean reverse )
+        {
+            super( first );
+            this.node = node;
+            this.reverse = reverse;
+        }
+
+        @Override
+        RelationshipStore store( StoreFactory factory, File storeFile )
+        {
+            return factory.newRelationshipStore( storeFile );
+        }
+
+        @Override
+        long next( RelationshipRecord record )
+        {
+            if ( record.getFirstNode() == node )
+            {
+                return reverse ? record.getFirstPrevRel() : record.getFirstNextRel();
+            }
+            else if ( record.getSecondNode() == node )
+            {
+                return reverse ? record.getSecondPrevRel() : record.getSecondNextRel();
+            }
+            else
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -123,14 +123,14 @@ public class StoreFactory
                 fileSystemAbstraction, stringLogger);
     }
 
-    private RelationshipTypeStore newRelationshipTypeStore(File baseFileName)
+    RelationshipTypeStore newRelationshipTypeStore(File baseFileName)
     {
         DynamicStringStore nameStore = newDynamicStringStore( new File( baseFileName.getPath() + ".names"), IdType.RELATIONSHIP_TYPE_BLOCK );
         return new RelationshipTypeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger, nameStore );
     }
 
-    private PropertyStore newPropertyStore(File baseFileName)
+    PropertyStore newPropertyStore(File baseFileName)
     {
         DynamicStringStore stringPropertyStore = newDynamicStringStore(new File( baseFileName.getPath() + ".strings"), IdType.STRING_BLOCK);
         PropertyIndexStore propertyIndexStore = newPropertyIndexStore(new File( baseFileName.getPath() + ".index"));
@@ -139,14 +139,14 @@ public class StoreFactory
                 stringPropertyStore, propertyIndexStore, arrayPropertyStore);
     }
 
-    private PropertyIndexStore newPropertyIndexStore(File baseFileName)
+    PropertyIndexStore newPropertyIndexStore(File baseFileName)
     {
         DynamicStringStore nameStore = newDynamicStringStore(new File( baseFileName.getPath() + ".keys"), IdType.PROPERTY_INDEX_BLOCK);
         return new PropertyIndexStore( baseFileName, config, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger, nameStore );
     }
 
-    private RelationshipStore newRelationshipStore(File baseFileName)
+    public RelationshipStore newRelationshipStore(File baseFileName)
     {
         return new RelationshipStore( baseFileName, config, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger);
@@ -158,7 +158,7 @@ public class StoreFactory
                 fileSystemAbstraction, stringLogger);
     }
 
-    private NodeStore newNodeStore(File baseFileName)
+    NodeStore newNodeStore(File baseFileName)
     {
         return new NodeStore( baseFileName, config, idGeneratorFactory, windowPoolFactory, fileSystemAbstraction, stringLogger );
     }


### PR DESCRIPTION
Adding some internal diagnostics tools that I've been finding very useful for debugging various issues.

`DumpStore` prints all records in a store.

`DumpChainStore` traverses a chain in either the property store or the relationship store, printing the records in the chain.
