### PR TITLE
Reintroduce tracking of active transactions on master side

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadRule.java
@@ -98,6 +98,11 @@ public class OtherThreadRule<STATE> implements TestRule
             }
         };
     }
+    
+    public OtherThreadExecutor<STATE> get()
+    {
+        return executor;
+    }
 
     public void interrupt()
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/LockSessionAlreadyActiveException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/LockSessionAlreadyActiveException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+public class LockSessionAlreadyActiveException extends IllegalStateException
+{
+}


### PR DESCRIPTION
to fix an issue where locks could get stuck. The problem was that a
rollback on the slave due to lock timeout would go over to the master and
end the lock session too early, before the last acquiring thread might
have finished its waiting. So when the pending lock acquisition would
complete the lock would be registered and then never released since the
lock client had already been closed.

With this commit, when the slave rolls back, the lock session on the master will be
closed if there is no thread awaiting a lock acquisition. If there is a
thread awaiting a lock acquisition the session will just be marked as
"please finish asap" and the session reaper will close it as soon as the
lock acquisition has completed.

This exact behaviour existed in 2.1 and in previous versions, but was
removed by mistake in 2.2 due to suboptimal understanding of the scenario
described above.
