### PR TITLE
Removed commit process synchronization

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -50,7 +50,7 @@ public class TransactionRepresentationCommitProcess implements TransactionCommit
     }
 
     @Override
-    public synchronized long commit( TransactionRepresentation representation ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation ) throws TransactionFailureException
     {
         long transactionId = persistTransaction( representation );
         // apply changes to the store

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
@@ -50,7 +50,7 @@ public class MasterTransactionCommitProcess implements TransactionCommitProcess
     }
 
     @Override
-    public synchronized long commit( TransactionRepresentation representation ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation ) throws TransactionFailureException
     {
         final boolean authoredByMeTheMaster = representation.getAuthorId() == representation.getMasterId();
         if ( !authoredByMeTheMaster )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -47,7 +47,7 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
     }
 
     @Override
-    public synchronized long commit( TransactionRepresentation representation ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation ) throws TransactionFailureException
     {
         try
         {


### PR DESCRIPTION
which was added for reducing problems occuring when multiple threads
updated the store simultaneously. Nowadays there's a synchronization on
the store application itself, which guards for even more scenarios than
these ever did, since the store applier is only one instance for a
datbaase instance, whereas commit process instances are aplenty.

Removing these synchronizations also re-enables the ability to implement
batched writes to the transaction log.
