### PR TITLE
Invalidates tx position cache in case of checksum mismatch

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransaction.java
@@ -623,7 +623,7 @@ public class NeoStoreTransaction extends XaTransaction
         if ( getCommitTxId() != neoStore.getLastCommittedTx() + 1 )
         {
             throw new RuntimeException( "Tx id: " + getCommitTxId() +
-                                        " not next transaction (" + neoStore.getLastCommittedTx() + ")" );
+                    " not next transaction ( currently at " + neoStore.getLastCommittedTx() + ")" );
         }
 
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBackedXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogBackedXaDataSource.java
@@ -138,9 +138,9 @@ public abstract class LogBackedXaDataSource extends XaDataSource
     }
 
     @Override
-    public Pair<Integer,Long> getMasterForCommittedTx( long txId ) throws IOException
+    public Pair<Integer,Long> getMasterForCommittedTx( long txId, boolean forceRead ) throws IOException
     {
-        return logicalLog.getMasterForCommittedTransaction( txId );
+        return logicalLog.getMasterForCommittedTransaction( txId, forceRead );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/NoOpLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/NoOpLogicalLog.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
 
@@ -177,7 +178,7 @@ public class NoOpLogicalLog extends XaLogicalLog
     }
 
     @Override
-    public synchronized Pair<Integer, Long> getMasterForCommittedTransaction( long txId ) throws IOException
+    public synchronized Pair<Integer, Long> getMasterForCommittedTransaction( long txId, boolean forceRead ) throws IOException
     {
         return null;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaDataSource.java
@@ -268,6 +268,17 @@ public abstract class XaDataSource implements Lifecycle
 
     public Pair<Integer,Long> getMasterForCommittedTx( long txId ) throws IOException
     {
+        return getMasterForCommittedTx( txId, false );
+    }
+    
+    /**
+     * @param txId the transaction id to get the information for.
+     * @param forceRead if {@code true} bypasses any cache and goes to read directly from the source.
+     * @return a master id and checksum for a committed transaction {@code txId}.
+     * @throws IOException if there were problems reading the information.
+     */
+    public Pair<Integer,Long> getMasterForCommittedTx( long txId, boolean forceRead ) throws IOException
+    {
         throw new UnsupportedOperationException( getClass().getName() );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
@@ -38,7 +38,7 @@ public class BranchDetectingTxVerifier implements TxChecksumVerifier
 {
     private final StringLogger logger;
     private XaDataSource dataSource;
-    private DependencyResolver resolver;
+    private final DependencyResolver resolver;
 
     public BranchDetectingTxVerifier( DependencyResolver resolver /* I'd like to get in StringLogger, XaDataSource instead */ )
     {
@@ -62,7 +62,8 @@ public class BranchDetectingTxVerifier implements TxChecksumVerifier
                 throw new BranchedDataException(
                         "The cluster contains two logically different versions of the database. " +
                         "This will be automatically resolved. Details: " + stringify( txId, masterId, checksum ) +
-                        " does not match " + readChecksum );
+                        " does not match " + readChecksum +
+                        ", uncached: " + dataSource().getMasterForCommittedTx( txId, true ) );
             }
         }
         catch ( IOException e )


### PR DESCRIPTION
to try to self-heal the cache if some other problem cause invalid data to
be put there in the first place. Also extends som exception message to
give more information in those cases.
