### PR TITLE
Fixed race in CommitPusher, minor refactoring

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/MasterTxIdGenerator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/MasterTxIdGenerator.java
@@ -279,12 +279,12 @@ public class MasterTxIdGenerator implements TxIdGenerator, Lifecycle
 
     private Iterator<Slave> filter( Iterator<Slave> slaves, final Integer externalAuthorServerId )
     {
-        return externalAuthorServerId == null ? slaves : new FilteringIterator<Slave>( slaves, new Predicate<Slave>()
+        return externalAuthorServerId == null ? slaves : new FilteringIterator<>( slaves, new Predicate<Slave>()
         {
             @Override
             public boolean accept( Slave item )
             {
-                return item.getServerId() != externalAuthorServerId.intValue();
+                return item.getServerId() != externalAuthorServerId;
             }
         } );
     }
@@ -378,6 +378,7 @@ public class MasterTxIdGenerator implements TxIdGenerator, Lifecycle
         };
     }
 
+    @Override
     public int getCurrentMasterId()
     {
         return config.getServerId().toIntegerIndex();

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
@@ -40,6 +40,7 @@ import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
@@ -330,7 +331,7 @@ public class ClusterTest
 
         try
         {
-            System.out.println(db.isAvailable( 10 ));
+            assertTrue( "Single instance cluster was not formed in time", db.isAvailable( 1_000 ) );
         }
         finally
         {


### PR DESCRIPTION
Calls to get/put of `CommitPusher.pullUpdateQueues` map can happen concurrently. Get call was not synchronized.
