### PR TITLE
Fixed wrong consistency check error for deleted property

### DIFF
--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/OwnerChain.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/OwnerChain.java
@@ -108,6 +108,10 @@ enum OwnerChain
                 public void checkReference( PropertyRecord record, PrimitiveRecord owner,
                                             ConsistencyReport.PropertyConsistencyReport report, RecordAccess records )
                 {
+                    if ( !owner.inUse() && !record.inUse() )
+                    {
+                        return;
+                    }
                     if ( !owner.inUse() || Record.NO_NEXT_PROPERTY.is( owner.getNextProp() ) )
                     {
                         wrongOwner( report );

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyRecordCheckTest.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/PropertyRecordCheckTest.java
@@ -668,4 +668,59 @@ public class PropertyRecordCheckTest
         verify( report ).ownerDoesNotReferenceBack();
         verifyOnlyReferenceDispatch( report );
     }
+
+    @Test
+    public void shouldNotReportMissingPropertyForDeletedNodeWithProperty()
+    {
+        // given
+        PropertyRecord oldProperty = add( inUse( new PropertyRecord( 10 ) ) );
+        NodeRecord oldNode = add( inUse( new NodeRecord( 20, 0, 0 ) ) );
+        oldProperty.setNodeId( oldNode.getId() );
+        oldNode.setNextProp( oldProperty.getId() );
+
+        PropertyRecord newProperty = add( notInUse( new PropertyRecord( 10 ) ) );
+        NodeRecord newNode = add( notInUse( new NodeRecord( 20, 0, 0 ) ) );
+        newProperty.setNodeId( newNode.getId() );
+        newNode.setNextProp( newProperty.getId() );
+
+        // when
+        ConsistencyReport.PropertyConsistencyReport report = checkChange( oldProperty, newProperty );
+
+        // then
+        verifyOnlyReferenceDispatch( report );
+    }
+
+    @Test
+    public void shouldNotReportMissingPropertyForDeletedRelationshipWithProperty()
+    {
+        // given
+        NodeRecord oldNode1 = add( inUse( new NodeRecord( 1, NONE, NONE ) ) );
+        NodeRecord oldNode2 = add( inUse( new NodeRecord( 2, NONE, NONE ) ) );
+
+        RelationshipRecord oldRel = add( inUse( new RelationshipRecord( 42, 1, 2, 7 ) ) );
+        oldNode1.setNextRel( oldRel.getId() );
+        oldNode2.setNextRel( oldRel.getId() );
+
+        PropertyRecord oldProperty = add( inUse( new PropertyRecord( 101 ) ) );
+        oldProperty.setRelId( oldRel.getId() );
+        oldRel.setNextProp( oldProperty.getId() );
+
+
+        NodeRecord newNode1 = add( notInUse( new NodeRecord( 1, NONE, NONE ) ) );
+        NodeRecord newNode2 = add( notInUse( new NodeRecord( 2, NONE, NONE ) ) );
+
+        RelationshipRecord newRel = add( notInUse( new RelationshipRecord( 42, 1, 2, 7 ) ) );
+        newNode1.setNextRel( newRel.getId() );
+        newNode2.setNextRel( newRel.getId() );
+
+        PropertyRecord newProperty = add( notInUse( new PropertyRecord( 101 ) ) );
+        newProperty.setRelId( newRel.getId() );
+        newRel.setNextProp( newProperty.getId() );
+
+        // when
+        ConsistencyReport.PropertyConsistencyReport report = checkChange( oldProperty, newProperty );
+
+        // then
+        verifyOnlyReferenceDispatch( report );
+    }
 }


### PR DESCRIPTION
Consistency checker reported error for deleted property, when owning node/relationship was deleted.
