### PR TITLE
[1.9] Make AutoConfigurator more resilient to unknown physical memory size

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AutoConfigurator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AutoConfigurator.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,7 +45,11 @@ public class AutoConfigurator
     AutoConfigurator( FileSystemAbstraction fs, File dbPath, boolean useMemoryMapped, long physicalMemory, long vmMemory,
                       ConsoleLogger logger )
     {
-        if (physicalMemory < vmMemory)
+        if ( physicalMemory == -1 )
+        {
+            logger.warn( "Could not determine the size of the physical memory. Continuing but without memory mapped buffers." );
+        }
+        else if ( physicalMemory < vmMemory )
         {
             logger.log( "WARNING! Physical memory("+(physicalMemory/(1024*1000))+"MB) is less than assigned JVM memory("+(vmMemory/(1024*1000))+"MB). Continuing but with available JVM memory set to available physical memory" );
             vmMemory = physicalMemory;
@@ -67,26 +70,23 @@ public class AutoConfigurator
         maxVmUsageMb = (int) (vmMemory / 1024 / 1024);
     }
 
-    private static long physicalMemory()
+    static long physicalMemory()
     {
-        OperatingSystemMXBean osBean =
-                ManagementFactory.getOperatingSystemMXBean();
-        long mem = -1;
-        try
+        OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+        for ( Class<?> beanClass : osBean.getClass().getInterfaces() )
         {
-            Class<?> beanClass =
-                    Thread.currentThread().getContextClassLoader()
-                          .loadClass( "com.sun.management.OperatingSystemMXBean" );
-            Method method = beanClass.getMethod( "getTotalPhysicalMemorySize" );
-            mem = (Long) method.invoke( osBean );
+            try
+            {
+                return (Long) beanClass.getMethod( "getTotalPhysicalMemorySize" ).invoke( osBean );
+            }
+            catch ( Exception e )
+            { // ok we tried but probably 1.5 JVM or other class library implementation
+            }
+            catch ( LinkageError e )
+            { // ok we tried but probably 1.5 JVM or other class library implementation
+            }
         }
-        catch ( Exception e )
-        { // ok we tried but probably 1.5 JVM or other class library implementation
-        }
-        catch ( LinkageError e )
-        { // ok we tried but probably 1.5 JVM or other class library implementation
-        }
-        return mem;
+        return -1;
     }
 
     public String getNiceMemoryInformation()

--- a/community/kernel/src/test/java/org/neo4j/kernel/AutoConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/AutoConfiguratorTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
@@ -36,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,29 @@ public class AutoConfiguratorTest
     public void given()
     {
         storeDir = TargetDirectory.forTest( getClass() ).directory( testName.getMethodName() );
+    }
+
+    @Test
+    public void shouldNotConfigureMemoryMappingWhenUnableToAccessPhysicalMemorySize() throws Exception
+    {
+        // given
+        FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
+        ConsoleLogger logger = Mockito.mock( ConsoleLogger.class );
+        mockFileSize( fs, "nodestore.db", 200 * GiB );
+        mockFileSize( fs, "relationshipstore.db", 200 * GiB );
+        mockFileSize( fs, "propertystore.db", 200 * GiB );
+        mockFileSize( fs, "propertystore.db.strings", 200 * GiB );
+        mockFileSize( fs, "propertystore.db.arrays", 200 * GiB );
+        long vmMemory = 512 * MiB;
+        long physicalMemory = -1;
+
+        // when
+        AutoConfigurator autoConf = new AutoConfigurator( fs, storeDir, true, physicalMemory, vmMemory, logger );
+
+        // then
+        verify( logger ).warn( "Could not determine the size of the physical memory. Continuing but without memory mapped buffers." );
+        verifyNoMoreInteractions( logger );
+        assertEquals( Collections.<String, String>emptyMap(), autoConf.configure() );
     }
 
     @Test


### PR DESCRIPTION
1. Makes figuring out the physicalMemory in the AutoConfigurator more resilient to ClassLoader restrictions that would prevent loading the interface that has the getTotalPhysicalMemorySize method.
2. Makes AutoConfigurator handle being unable to detect the physical memory behave in a better way, by still trusting the heap size and not treating it as if the heap has been configured too large.
