### PR TITLE
New -host and -port args, some IPv6 support

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
@@ -22,6 +22,7 @@ package org.neo4j.helpers;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Objects;
 
 import static java.lang.String.format;
 
@@ -36,15 +37,17 @@ public class HostnamePort
 
     public HostnamePort( String hostnamePort ) throws IllegalArgumentException
     {
-        String[] parts = hostnamePort.split( ":" );
+        Objects.requireNonNull( hostnamePort );
+
+        String[] parts = splitHostAndPort( hostnamePort );
         if ( parts.length == 1 )
         {
-            host = zeroLengthMeansNull( parts[0] );
+            host = Strings.defaultIfBlank( parts[0], null );
             ports = new int[]{0, 0};
         }
         else if ( parts.length == 2 )
         {
-            host = zeroLengthMeansNull( parts[0] );
+            host = Strings.defaultIfBlank( parts[0], null );
 
             String[] portStrings = parts[1].split( "-" );
             ports = new int[2];
@@ -63,19 +66,11 @@ public class HostnamePort
                 throw new IllegalArgumentException( format( "Cannot have more than two port ranges: %s",
                         hostnamePort ) );
             }
-
         }
         else
         {
             throw new IllegalArgumentException( hostnamePort );
         }
-    }
-
-    private String zeroLengthMeansNull( String string )
-    {
-        if ( string == null || string.length() == 0 )
-            return null;
-        return string;
     }
 
     public HostnamePort( String host, int port )
@@ -91,8 +86,6 @@ public class HostnamePort
 
     /**
      * The host part, or null if not given.
-     *
-     * @return
      */
     public String getHost()
     {
@@ -101,14 +94,18 @@ public class HostnamePort
 
     public String getHost( String defaultHost )
     {
-        if (host == null)
+        if ( host == null )
+        {
             return defaultHost;
+        }
 
         try
         {
             InetAddress ip = InetAddress.getByName( host );
-            if (ip == null)
+            if ( ip == null )
+            {
                 return defaultHost;
+            }
 
             return ip.getHostAddress();
         }
@@ -121,8 +118,6 @@ public class HostnamePort
     /**
      * The port range as two ints. If only one port given, then both ints have the same value.
      * If no port range is given, then the array has {0,0} as value.
-     *
-     * @return
      */
     public int[] getPorts()
     {
@@ -131,8 +126,6 @@ public class HostnamePort
 
     /**
      * The first port, or 0 if no port was given.
-     *
-     * @return
      */
     public int getPort()
     {
@@ -149,7 +142,7 @@ public class HostnamePort
     {
         return toString( null /*no default host*/ );
     }
-    
+
     public String toString( String defaultHost )
     {
         StringBuilder builder = new StringBuilder();
@@ -196,5 +189,32 @@ public class HostnamePort
         // URI always contains IP, so make sure we convert ours too
 
         return result && getHost(null).equalsIgnoreCase( toMatch.getHost() );
+    }
+
+    private static String[] splitHostAndPort( String hostnamePort )
+    {
+        hostnamePort = hostnamePort.trim();
+
+        int indexOfSchemaSeparator = hostnamePort.indexOf( "://" );
+        if ( indexOfSchemaSeparator != -1 )
+        {
+            hostnamePort = hostnamePort.substring( indexOfSchemaSeparator + 3 );
+        }
+
+        boolean isIPv6HostPort = hostnamePort.startsWith( "[" ) && hostnamePort.contains( "]" );
+        if ( isIPv6HostPort )
+        {
+            int splitIndex = hostnamePort.indexOf( "]" ) + 1;
+
+            String host = hostnamePort.substring( 0, splitIndex );
+            String port = hostnamePort.substring( splitIndex );
+            if ( !Strings.isBlank( port ) )
+            {
+                port = port.substring( 1 ); // remove ':'
+                return new String[]{host, port};
+            }
+            return new String[]{host};
+        }
+        return hostnamePort.split( ":" );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -53,4 +53,25 @@ public final class Strings
             return result.toString();
         }
     };
+
+    public static boolean isBlank( String str )
+    {
+        if ( str == null || str.isEmpty() )
+        {
+            return true;
+        }
+        for ( int i = 0; i < str.length(); i++ )
+        {
+            if ( !Character.isWhitespace( str.charAt( i ) ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static String defaultIfBlank( String str, String defaultStr )
+    {
+        return isBlank( str ) ? defaultStr : str;
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -21,6 +21,7 @@ package org.neo4j.helpers;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 
 import org.junit.Test;
 
@@ -67,7 +68,7 @@ public class HostnamePortTest
         assertThat( hostnamePort.getPort(), equalTo( 1243 ) );
         assertThat( hostnamePort.getPorts(), equalTo( new int[] {1243, 1234} ) );
     }
-    
+
     @Test
     public void testSinglePortOnly() throws Exception
     {
@@ -138,5 +139,57 @@ public class HostnamePortTest
         String hostName = InetAddress.getLocalHost().getHostName();
         HostnamePort hostnamePort = new HostnamePort( hostName, 1234 );
         assertThat( hostnamePort.toString( null ), equalTo( InetAddress.getByName( hostName ).getHostAddress()+":1234" ) );
+    }
+
+    @Test
+    public void testIPv6Address()
+    {
+        HostnamePort hostnamePort = new HostnamePort( "[2001:cdba:0:0:0:0:3257:9652]" );
+
+        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[2001:cdba:0:0:0:0:3257:9652]" ) ) );
+        assertThat( hostnamePort.getPort(), equalTo( 0 ) );
+        assertThat( hostnamePort.getPorts(), equalTo( new int[]{0, 0} ) );
+    }
+
+    @Test
+    public void testIPv6AddressWithSchemeAndPort()
+    {
+        HostnamePort hostnamePort = new HostnamePort( "foo://[ff02::1:1]:9191" );
+
+        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[ff02::1:1]" ) ) );
+        assertThat( hostnamePort.getPort(), equalTo( 9191 ) );
+        assertThat( hostnamePort.getPorts(), equalTo( new int[]{9191, 9191} ) );
+    }
+
+    @Test
+    public void testIPv6Localhost()
+    {
+        HostnamePort hostnamePort = new HostnamePort( "[::1]" );
+
+        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[::1]" ) ) );
+        assertThat( hostnamePort.getPort(), equalTo( 0 ) );
+        assertThat( hostnamePort.getPorts(), equalTo( new int[]{0, 0} ) );
+    }
+
+    @Test
+    public void testIPv6LocalhostWithSchemeAndPort()
+    {
+        HostnamePort hostnamePort = new HostnamePort( "foo://[::1]:6362" );
+
+        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[::1]" ) ) );
+        assertThat( hostnamePort.getPort(), equalTo( 6362 ) );
+        assertThat( hostnamePort.getPorts(), equalTo( new int[]{6362, 6362} ) );
+    }
+
+    private static String resolveHost( String address )
+    {
+        try
+        {
+            return InetAddress.getByName( address ).getHostAddress();
+        }
+        catch ( UnknownHostException e )
+        {
+            throw new RuntimeException( "Unable to resolve host for '" + address + "'", e );
+        }
     }
 }

--- a/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
+++ b/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
@@ -10,7 +10,7 @@ neo4j-backup - Neo4j Backup Tool
 SYNOPSIS
 --------
 
-*neo4j-backup* -from host:port -to target_directory
+*neo4j-backup* -host <host> [-port <port>] -to target_directory
 
 [[neo4j-backup-manpage-description]]
 DESCRIPTION
@@ -40,15 +40,13 @@ SOURCE ADDRESS
 
 Backup sources are given in the following format:
 
-*<host>[:<port>]{,<host>[:<port>]}...*
-
-Note that multiple hosts can be defined.
+*-host <host> [-port <port>]*
 
 *host*::
-  In single mode, the host of a source database; in ha mode, the cluster address of a cluster member. Note that multiple hosts can be given when using High Availability mode.
+  In single mode, the host of a source database; in HA mode, the cluster address of a cluster member.
 
 *port*::
-  In single mode, the port of a source database backup service; in ha mode, the port of a cluster instance. If not given, the default value `6362` will be used for single mode, `5001` for HA
+  In single mode, the port of a source database backup service; in HA mode, the port of a cluster instance. If not given, the default value `6362` will be used for single mode, `5001` for HA.
 
 [[neo4j-backup-manpage-usage-important]]
 IMPORTANT
@@ -72,19 +70,19 @@ EXAMPLES
 ----
 # Performing a backup the first time: create a blank directory and run the backup tool
 mkdir /mnt/backup/neo4j-backup
-neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
+neo4j-backup -host 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Subsequent backups using the same _target_-directory will be incremental and therefore quick
-neo4j-backup -from freja -to /mnt/backup/neo4j-backup
+neo4j-backup -host freja -to /mnt/backup/neo4j-backup
 
 # Performing a backup where the service is registered on a custom port
-neo4j-backup -from freja:9999 -to /mnt/backup/neo4j-backup
+neo4j-backup -host freja -port 9999 -to /mnt/backup/neo4j-backup
 
-# Performing a backup from HA cluster, specifying only one cluster member
-./neo4j-backup -from oden:5002 -to /mnt/backup/neo4j-backup
+# Performing a backup from HA cluster, specifying a cluster member
+./neo4j-backup -host oden -to /mnt/backup/neo4j-backup
 
-# Performing a backup from HA cluster, specifying two cluster members
-./neo4j-backup -from oden:5001,loke:5002 -to /mnt/backup/neo4j-backup
+# Performing a backup from HA cluster, specifying a cluster member registered on custom port
+./neo4j-backup -host oden -port 9191 -to /mnt/backup/neo4j-backup
 ----
 
 [[neo4j-backup-manpage-restore]]

--- a/enterprise/backup/src/docs/ops/backup.asciidoc
+++ b/enterprise/backup/src/docs/ops/backup.asciidoc
@@ -24,11 +24,9 @@ Regardless of the mode a backup is created with, the resulting files represent a
 
 The database to be backed up is specified using an address with syntax
 
-<host>[:port]{,<host>[:port]}...
+-host <host> [-port <port>]
 
-The <host>[:<port>] part
-points to a host running the database, on port _port_ if not the default. The additional _host:port_ arguments
-are useful for passing multiple cluster members.
+Address represented by <host> and <port> points to a host running the database, on port _port_ if not the default.
 
 [IMPORTANT]
 As of version 1.9, backups are enabled by default. That means that the configuration parameter `online_backup_enabled` defaults to true and that
@@ -43,19 +41,19 @@ To perform a backup from a running embedded or server database run:
 ----
 # Performing a full backup: create a blank directory and run the backup tool
 mkdir /mnt/backup/neo4j-backup
-./neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
+./neo4j-backup -host 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Performing an incremental backup: just specify the location of your previous backup
-./neo4j-backup -from 192.168.1.34 -to /mnt/backup/neo4j-backup
+./neo4j-backup -host 192.168.1.34 -to /mnt/backup/neo4j-backup
 
 # Performing an incremental backup where the service is registered on a custom port
-./neo4j-backup -from 192.168.1.34:9999 -to /mnt/backup/neo4j-backup
+./neo4j-backup -host 192.168.1.34 -port 9999 -to /mnt/backup/neo4j-backup
 ----
 
 [[backup-java]]
 == Online Backup from Java ==
 
-In order to programmatically backup your data full or subsequently incremental from a 
+In order to programmatically backup your data full or subsequently incremental from a
 JVM based program, you need to write Java code like
 
 [snippet,java]
@@ -72,17 +70,17 @@ OnlineBackup]
 [[backup-ha]]
 == High Availability ==
 
-To perform a backup on an HA cluster you specify one or more members of the target HA cluster.
-Note that the addresses you must provide are the cluster server addresses and not the HA server addresses.
+To perform a backup on an HA cluster you specify one member of the target HA cluster.
+Note that the address you must provide is a cluster server address and not an HA server address.
 That is, use the value of the +ha.cluster_server+ setting in the configuration.
 
 [source,shell]
 ----
-# Performing a backup from HA cluster, specifying only one cluster member
-./neo4j-backup -from 192.168.1.15:6362 -to /mnt/backup/neo4j-backup
+# Performing a backup from HA cluster, specifying cluster member with default port
+./neo4j-backup -host 192.168.1.15 -to /mnt/backup/neo4j-backup
 
-# Performing a backup from HA cluster, specifying two possible cluster members
-./neo4j-backup -from 192.168.1.15:5001,192.168.1.16:5002 -to /mnt/backup/neo4j-backup
+# Performing a backup from HA cluster, specifying cluster member with custom port
+./neo4j-backup -host 192.168.1.15 -port 9191 -to /mnt/backup/neo4j-backup
 ----
 
 [[backup-restoring]]

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupExtensionService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupExtensionService.java
@@ -61,10 +61,10 @@ public abstract class BackupExtensionService extends Service
     /**
      * The source specific target to valid backup host translation method.
      * 
-     * @param from The URI as passed in the command line
+     * @param address Cluster address as passed in the command line
      * @param arguments all arguments to the backup command
      * @return A URI where the scheme is the service's name and there exist host
      *         and port parts that point to a backup source.
      */
-    public abstract URI resolve( URI from, Args arguments, Logging logging );
+    public abstract URI resolve( String address, Args arguments, Logging logging );
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -34,6 +34,7 @@ import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
@@ -55,19 +56,29 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class BackupTool
 {
     private static final String TO = "to";
+    private static final String HOST = "host";
+    private static final String PORT = "port";
+
+    @Deprecated // preferred -host and -port separately
     private static final String FROM = "from";
+
     private static final String VERIFY = "verify";
+
     private static final String CONFIG = "config";
     public static final String DEFAULT_SCHEME = "single";
-
     static final String MISMATCHED_STORE_ID = "You tried to perform a backup from database %s, " +
             "but the target directory contained a backup from database %s. ";
 
     static final String WRONG_FROM_ADDRESS_SYNTAX = "Please properly specify a location to backup in the" +
-            " form <host>[:<port>]{,<host>[:<port>]}...";
+            " form " + dash( HOST ) + " <host> " + dash( PORT ) + " <port>";
 
     static final String UNKNOWN_SCHEMA_MESSAGE_PATTERN = "%s was specified as a backup module but it was not found. " +
             "Please make sure that the implementing service is on the classpath.";
+
+    static final String NO_SOURCE_SPECIFIED = "Please specify " + dash( HOST ) + " and optionally " + dash( PORT ) +
+            ", examples:\n" +
+            "  " + dash( HOST ) + " 192.168.1.34\n" +
+            "  " + dash( HOST ) + " 192.168.1.34 " + dash( PORT ) + " 1234";
 
     public static void main( String[] args )
     {
@@ -97,32 +108,77 @@ public class BackupTool
     {
         Args arguments = new Args( args );
 
-        checkArguments( arguments );
-
-        String from = arguments.get( FROM, null );
-        String to = arguments.get( TO, null );
-        boolean verify = arguments.getBoolean( VERIFY, true, true );
-        Config tuningConfiguration = readTuningConfiguration( TO, arguments );
-
-        URI backupURI = resolveBackupUri( from.trim(), arguments, tuningConfiguration );
-        if ( backupURI == null || backupURI.getHost() == null )
+        if ( !arguments.hasNonNull( TO ) )
         {
-            throw new ToolFailureException( WRONG_FROM_ADDRESS_SYNTAX );
+            throw new ToolFailureException( "Specify target location with " + dash( TO ) + " <target-directory>" );
         }
 
+        if ( arguments.hasNonNull( FROM ) && !arguments.has( HOST ) && !arguments.has( PORT ) )
+        {
+            runBackupWithLegacyArgs( arguments );
+        }
+        else if ( arguments.hasNonNull( HOST ) )
+        {
+            runBackup( arguments );
+        }
+        else
+        {
+            throw new ToolFailureException( NO_SOURCE_SPECIFIED );
+        }
+    }
+
+    private void runBackupWithLegacyArgs( Args args ) throws ToolFailureException
+    {
+        String from = args.get( FROM ).trim();
+        String to = args.get( TO ).trim();
+        boolean verify = args.getBoolean( VERIFY, true, true );
+        Config tuningConfiguration = readTuningConfiguration( TO, args );
+
+        URI backupURI = resolveBackupUri( from, args, tuningConfiguration );
+
+        HostnamePort hostnamePort = newHostnamePort( backupURI );
+
+        executeBackup( hostnamePort, to, verify, tuningConfiguration );
+    }
+
+    private void runBackup( Args args ) throws ToolFailureException
+    {
+        String host = args.get( HOST ).trim();
+        int port = args.getNumber( PORT, BackupServer.DEFAULT_PORT ).intValue();
+        String to = args.get( TO ).trim();
+        boolean verify = args.getBoolean( VERIFY, true, true );
+        Config tuningConfiguration = readTuningConfiguration( TO, args );
+
+        if ( host.contains( ":" ) )
+        {
+            if ( !host.startsWith( "[" ) )
+            {
+                host = "[" + host;
+            }
+            if ( !host.endsWith( "]" ) )
+            {
+                host += "]";
+            }
+        }
+
+        URI backupURI = newURI( DEFAULT_SCHEME + "://" + host + ":" + port ); // a bit of validation
+
+        HostnamePort hostnamePort = newHostnamePort( backupURI );
+
+        executeBackup( hostnamePort, to, verify, tuningConfiguration );
+    }
+
+    private void executeBackup( HostnamePort hostnamePort, String to,
+                                boolean verify, Config tuningConfiguration ) throws ToolFailureException
+    {
         try
         {
-            String str = backupURI.toASCIIString();
-            if ( str.contains( "://" ) )
-            {
-                str = str.split( "://" )[1];
-            }
-            systemOut.println( "Performing backup from '" + str + "'" );
-            doBackup( backupURI, to, verify, tuningConfiguration );
+            systemOut.println( "Performing backup from '" + hostnamePort + "'" );
+            doBackup( hostnamePort, to, verify, tuningConfiguration );
         }
-        catch ( TransactionFailureException e )
+        catch ( TransactionFailureException tfe )
         {
-            if ( e.getCause() instanceof UpgradeNotAllowedByConfigurationException )
+            if ( tfe.getCause() instanceof UpgradeNotAllowedByConfigurationException )
             {
                 try
                 {
@@ -131,36 +187,40 @@ public class BackupTool
                     moveExistingDatabase( fs, to );
 
                 }
-                catch ( IOException e1 )
+                catch ( IOException e )
                 {
                     throw new ToolFailureException( "There was a problem moving the old database out of the way" +
                             " - cannot continue, aborting.", e );
                 }
 
-                doBackup( backupURI, to, verify, tuningConfiguration );
+                doBackup( hostnamePort, to, verify, tuningConfiguration );
             }
             else
             {
                 throw new ToolFailureException( "TransactionFailureException " +
-                        "from existing backup at '" + from + "'.", e );
+                        "from existing backup at '" + hostnamePort + "'.", tfe );
             }
         }
     }
 
-    private static void checkArguments( Args arguments ) throws ToolFailureException
+    private void doBackup( HostnamePort hostnamePort, String to,
+                           boolean checkConsistency, Config config ) throws ToolFailureException
     {
-        if ( arguments.get( FROM, null ) == null )
+        try
         {
-            throw new ToolFailureException( "Please specify " + dash( FROM ) + ", examples:\n" +
-                    "  " + dash( FROM ) + " 192.168.1.34\n" +
-                    "  " + dash( FROM ) + " 192.168.1.34:1234\n" +
-                    "  " + dash( FROM ) + " 192.168.1.15:2181,192.168.1.16:2181" );
+            String host = hostnamePort.getHost();
+            int port = hostnamePort.getPort();
+            backupService.doIncrementalBackupOrFallbackToFull( host, port, to, checkConsistency, config );
+            systemOut.println( "Done" );
         }
-
-        if ( arguments.get( TO, null ) == null )
+        catch ( MismatchingStoreIdException e )
         {
-            throw new ToolFailureException( "Specify target location with " + dash( TO )
-                    + " <target-directory>" );
+            systemOut.println( "Backup failed." );
+            throw new ToolFailureException( String.format( MISMATCHED_STORE_ID, e.getExpected(), e.getEncountered() ) );
+        }
+        catch ( ComException e )
+        {
+            throw new ToolFailureException( "Couldn't connect to '" + hostnamePort + "'", e );
         }
     }
 
@@ -229,26 +289,39 @@ public class BackupTool
     private static URI resolveUriWithProvider( String providerName, String from, Args args, Config config )
             throws ToolFailureException
     {
-        URI uri = newURI( from );
-
         BackupExtensionService service;
         try
         {
             service = Service.load( BackupExtensionService.class, providerName );
         }
-        catch ( NoSuchElementException e1 )
+        catch ( NoSuchElementException e )
         {
             throw new ToolFailureException( String.format( UNKNOWN_SCHEMA_MESSAGE_PATTERN, providerName ) );
         }
 
         try
         {
-            return service.resolve( uri, args, newLogging( config ) );
+            return service.resolve( from, args, newLogging( config ) );
         }
         catch ( Throwable t )
         {
             throw new ToolFailureException( t.getMessage() );
         }
+    }
+
+    private static HostnamePort newHostnamePort( URI backupURI ) throws ToolFailureException
+    {
+        if ( backupURI == null || backupURI.getHost() == null )
+        {
+            throw new ToolFailureException( WRONG_FROM_ADDRESS_SYNTAX );
+        }
+        String host = backupURI.getHost();
+        int port = backupURI.getPort();
+        if ( port == -1 )
+        {
+            port = BackupServer.DEFAULT_PORT;
+        }
+        return new HostnamePort( host, port );
     }
 
     private static Logging newLogging( Config config )
@@ -272,46 +345,21 @@ public class BackupTool
         return logging;
     }
 
-    private void doBackup( URI from, String to, boolean checkConsistency, Config config ) throws ToolFailureException
-    {
-        try
-        {
-            backupService.doIncrementalBackupOrFallbackToFull( from.getHost(), extractPort( from ), to,
-                    checkConsistency, config );
-            systemOut.println( "Done" );
-        }
-        catch ( MismatchingStoreIdException e )
-        {
-            systemOut.println( "Backup failed." );
-            throw new ToolFailureException( String.format( MISMATCHED_STORE_ID, e.getExpected(), e.getEncountered() ) );
-        }
-        catch ( ComException e )
-        {
-            throw new ToolFailureException( "Couldn't connect to '" + from + "'", e );
-        }
-    }
-
-    private static int extractPort( URI from )
-    {
-        int port = from.getPort();
-        if ( port == -1 )
-        {
-            port = BackupServer.DEFAULT_PORT;
-        }
-        return port;
-    }
-
     private static void moveExistingDatabase( FileSystemAbstraction fs, String to ) throws IOException
     {
         File toDir = new File( to );
         File backupDir = new File( toDir, "old-version" );
         if ( !fs.mkdir( backupDir ) )
         {
-            throw new IOException( "Trouble making target backup directory "
-                    + backupDir.getAbsolutePath() );
+            throw new IOException( "Trouble making target backup directory " + backupDir.getAbsolutePath() );
         }
         StoreFile.move( fs, toDir, backupDir, StoreFile.legacyStoreFiles() );
         LogFiles.move( fs, toDir, backupDir );
+    }
+
+    private static String dash( String name )
+    {
+        return "-" + name;
     }
 
     static class ToolFailureException extends Exception
@@ -335,10 +383,5 @@ public class BackupTool
             }
             System.exit( 1 );
         }
-    }
-
-    private static String dash( String name )
-    {
-        return "-" + name;
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
@@ -78,7 +78,8 @@ public class BackupToolUrisTest
                     uri( "single://localhost" ),
                     uri( "single://127.0.0.1", 6264 ),
                     uri( "ha://test.server" ),
-                    uri( "ha://test.server", 1212 ) );
+                    uri( "ha://test.server", 1212 )
+            );
         }
 
         @Test
@@ -117,9 +118,6 @@ public class BackupToolUrisTest
                     uri( "single://localhost,ha://not-localhost" ),
                     uri( "single://127.0.0.1:6361,single://127.0.0.1:6362" ),
                     uri( "300.400.500.600" ),
-                    uri( "ha://82.94.100.12\\1212,127.0.0.*:1213" ),
-                    uri( "single://127.0.0.1,ha://127.0.0.2" ),
-                    uri( "single:/\\/20.30.40.50:11,60.70.80.90:22" ),
                     uri( "host-name_with*wrong$chars.com" ),
                     uri( "dir://my" ),
                     uri( "dir://my", 10 ),
@@ -127,7 +125,8 @@ public class BackupToolUrisTest
                     uri( "foo://127.0.1.1", 6567 ),
                     uri( "cat://localhost" ),
                     uri( "cat://localhost", 4444 ),
-                    uri( "notHA://instance1:,instance2:,instance3", 5454 ) );
+                    uri( "notHA://instance1:,instance2:,instance3", 5454 )
+            );
         }
 
         @Test
@@ -149,6 +148,59 @@ public class BackupToolUrisTest
             }
 
             verifyZeroInteractions( backupService, systemOut );
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class IPv6UriTests extends UriTests
+    {
+        public IPv6UriTests( String host, Integer port )
+        {
+            super( host, port );
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> data()
+        {
+            return asList(
+                    uri( "[2001:cdba:0000:0000:0000:0000:3257:9652]" ),
+                    uri( "[2001:cdba:0000:0000:0000:0000:3257:9652]", 5656 ),
+                    uri( "[2001:cdba:0:0:0:0:3257:9652]" ),
+                    uri( "[2001:cdba:0:0:0:0:3257:9652]", 9091 ),
+                    uri( "[2001:cdba::3257:9652]" ),
+                    uri( "[2001:cdba::3257:9652]", 20 ),
+                    uri( "[2001:db8::1]", 9991 ),
+                    uri( "[2001:db8::1]", 1990 ),
+                    uri( "[::1]" ),
+                    uri( "[::1]", 8989 ),
+                    uri( "[fe80::]" ),
+                    uri( "[fe80::]", 1209 ),
+                    uri( "[::ffff:0:0]" ),
+                    uri( "[::ffff:0:0]", 4545 ),
+                    uri( "[ff02::1:1]" ),
+                    uri( "[ff02::1:1]", 6767 ),
+                    uri( "[2002::]" ),
+                    uri( "[2002::]", 3040 )
+            );
+        }
+
+        @Test
+        public void shouldExecuteBackupWithValidUri() throws Exception
+        {
+            // Given
+            String[] args = new String[]{"-host", host, "-port", String.valueOf( port ), "-to", "/var/backup/graph"};
+
+            // When
+            newBackupTool().run( args );
+
+            // Then
+            verify( backupService ).doIncrementalBackupOrFallbackToFull(
+                    eq( host ),
+                    eq( port ),
+                    eq( "/var/backup/graph" ),
+                    eq( true ),
+                    any( Config.class )
+            );
         }
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
@@ -64,12 +64,11 @@ public final class HaBackupProvider extends BackupExtensionService
     }
 
     @Override
-    public URI resolve( URI address, Args args, Logging logging )
+    public URI resolve( String address, Args args, Logging logging )
     {
-        String master = null;
+        String master;
         StringLogger logger = logging.getMessagesLog( HaBackupProvider.class );
-        logger.debug( "Asking cluster member(s) at '" + address
-                + "' for master" );
+        logger.debug( "Asking cluster member(s) at '" + address + "' for master" );
 
         String clusterName = args.get( ClusterSettings.cluster_name.name(), null );
         if ( clusterName == null )
@@ -79,8 +78,7 @@ public final class HaBackupProvider extends BackupExtensionService
 
         try
         {
-            master = getMasterServerInCluster( address.getSchemeSpecificPart().substring(
-                    2 ), clusterName, logging ); // skip the "//" part
+            master = getMasterServerInCluster( normalizeAddress( address ), clusterName, logging );
 
             logger.debug( "Found master '" + master + "' in cluster" );
             return URI.create( master );
@@ -89,6 +87,16 @@ public final class HaBackupProvider extends BackupExtensionService
         {
             throw new RuntimeException( e.getMessage() );
         }
+    }
+
+    private static String normalizeAddress( String address )
+    {
+        int index = address.indexOf( "://" );
+        if ( index != -1 )
+        {
+            return address.substring( index + 3 );
+        }
+        return address;
     }
 
     private String getMasterServerInCluster( String from, String clusterName, final Logging logging )


### PR DESCRIPTION
This PR deprecates '-from' argument to backup tool and adds two new args '-host', '-port' instead of it.
Also it adds a bit of IPv6 support to backup tool and HostnamePort class.
