### PR TITLE
Recognizes transactions with net zero changes as read-only

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -121,6 +121,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         try
         {
             createTransactionCommands();
+            txState = null;
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -508,6 +508,16 @@ public class XaResourceManager
         if ( onePhase && (!isReadOnly && !xaTransaction.isRecovered()) )
         {
             prepareKernelTx( xaTransaction );
+            
+            /* Hi MP Here. Here's the deal: we track a quick-to-access hasChanges in transaction state which is true
+             * if there are any changes imposed by this transaction. Some changes made inside a transaction undo
+             * previously made changes in that same transaction, and so at some point a transaction may have
+             * changes and at another point, after more changes seemingly, the transaction may not have any changes.
+             * However, to track that "undoing" of the changes is a bit tedious, intrusive and hard to maintain
+             * and get right.... So to really make sure the transaction has changes we re-check after prepare,
+             * where transaction state changes has been reset and converted into actual record changes.
+             */
+            isReadOnly = xaTransaction.isReadOnly();
         }
 
         synchronized ( this )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.state;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.index.DummyIndexExtensionFactory;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestLabels;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class NoChangeWriteTransactionTest
+{
+    @Test
+    public void shouldIdentifyTransactionWithNetZeroChangesAsReadOnly() throws Exception
+    {
+        // GIVEN a transaction that has seen some changes, where all those changes result in a net 0 change set
+        // a good way of producing such state is to add a label to an existing node, and then remove it.
+        GraphDatabaseAPI db = dbr.getGraphDatabaseAPI();
+        NeoStore neoStore = db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate();
+        long startingTxId = neoStore.getLastCommittedTx();
+        Node node = createEmptyNode( db );
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.addLabel( TestLabels.LABEL_ONE );
+            node.removeLabel( TestLabels.LABEL_ONE );
+            tx.success();
+        } // WHEN closing that transaction
+        
+        // THEN it should not have been committed
+        assertEquals( "Expected last txId to be what it started at + 2 (1 for the empty node, and one for the label)",
+                startingTxId+2, neoStore.getLastCommittedTx() );
+    }
+    
+    @Test
+    public void shouldIdentifyTwoPhaseTransactionWhereNeoStoreHasNetZeroChangesAsReadOnlyForNeoStore() throws Exception
+    {
+        // GIVEN a transaction that has seen some changes, where all those changes result in a net 0 change set
+        // a good way of producing such state is to add a label to an existing node, and then remove it.
+        GraphDatabaseAPI db = dbr.getGraphDatabaseAPI();
+        NeoStore neoStore = db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate();
+        long startingTxId = neoStore.getLastCommittedTx();
+        Node node = createEmptyNode( db );
+        Index<Node> index = createNodeIndex( db );
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.addLabel( TestLabels.LABEL_ONE );
+            node.removeLabel( TestLabels.LABEL_ONE );
+            index.add( node, "key", "value" );
+            index.remove( node, "key", "value" );
+            tx.success();
+        } // WHEN closing that transaction
+        
+        // THEN it should not have been committed
+        assertEquals( "Expected last txId to be what it started at + 2 (1 for the empty node, and one for the label)",
+                startingTxId+2, neoStore.getLastCommittedTx() );
+    }
+    
+    private Index<Node> createNodeIndex( GraphDatabaseAPI db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> index = db.index().forNodes( "test", stringMap(
+                    IndexManager.PROVIDER, DummyIndexExtensionFactory.IDENTIFIER ) );
+            tx.success();
+            return index;
+        }
+    }
+
+    private Node createEmptyNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            tx.success();
+            return node;
+        }
+    }
+
+    public final @Rule DatabaseRule dbr = new ImpermanentDatabaseRule();
+}


### PR DESCRIPTION
There was an issue wherea transaction with changes, although net zero
changes, would be treated as a write transaction and be committed. In a
cluster such a transaction would be treated as a read-only transaction and
so there would be a mismatch between the authoring database and the rest
of the cluster in the transaction id sequence.
