### PR TITLE
Revert "Updated PID file location to come from configuration"

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -96,7 +96,7 @@ LAUNCHD_DIR=~/Library/LaunchAgents/
 
 TIMEOUT=120
 
-PID_FILE=${wrapper_pidfile:-"$NEO4J_INSTANCE/data/neo4j-service.pid"}
+PID_FILE=${NEO4J_INSTANCE}/data/neo4j-service.pid
 buildclasspath() {
   # confirm library jars
   LIBDIR="$NEO4J_HOME"/lib


### PR DESCRIPTION
Reverts neo4j/neo4j#2827. This breaks startup generally.
