### PR TITLE
Changes store application synchronization

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -72,10 +72,7 @@ public class TransactionRepresentationStoreApplier
         try ( CommandApplierFacade applier = new CommandApplierFacade(
                 storeApplier, indexApplier, legacyIndexApplier ) )
         {
-            synchronized ( this )
-            {
-                representation.accept( applier );
-            }
+            representation.accept( applier );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogFile.java
@@ -34,10 +34,10 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static org.neo4j.kernel.impl.transaction.xaframework.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.xaframework.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
-import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogVersions.CURRENT_LOG_VERSION;
 import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogHeaderParser.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogHeaderParser.readLogHeader;
 import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogHeaderParser.writeLogHeader;
+import static org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 /**
  * {@link LogFile} backed by one or more files in a {@link FileSystemAbstraction}.
@@ -147,13 +147,20 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
     }
 
     @Override
-    public synchronized void checkRotation() throws IOException
+    public void checkRotation() throws IOException
     {
         // Whereas channel.size() should be fine, we're safer calling position() due to possibility
         // of this file being memory mapped or whatever.
         if ( channel.position() >= rotateAtSize )
         {
-            forceRotate();
+            synchronized ( this )
+            {
+                // Good old double-checked locking
+                if ( channel.position() >= rotateAtSize )
+                {
+                    forceRotate();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
this opens the flood gates for potential problems, unexpected problems
that we want to see at this stage.

This commit also introduces synchronization on label scan store and schema
indexing application, something that the (above) removed synchronization
actually didn't include, hence the cause of recent problems seen in label
scan store and schema indexes in 2.2.
