### PR TITLE
Removes pooling of kernel transactions

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
@@ -52,6 +51,6 @@ public class KernelTransactionFactory
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
                 mock( PersistenceCache.class ),
                 mock( StoreReadLayer.class ),
-                mock( LegacyIndexTransactionState.class ), mock( Pool.class ), Clock.SYSTEM_CLOCK );
+                mock( LegacyIndexTransactionState.class ), Clock.SYSTEM_CLOCK );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.api;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -352,7 +351,7 @@ public class KernelTransactionImplementationTest
     {
         return new KernelTransactionImplementation( null, false, null, null, null, null, recordState,
                 null, neoStore, new NoOpClient(), hooks, null, headerInformation, commitProcess, transactionMonitor,
-                null, null, legacyIndexState, mock( Pool.class ), clock );
+                null, null, legacyIndexState, clock );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess


### PR DESCRIPTION
as well as whatever instances kernel transactions contains, like lock
clients. This fixes an issue of unknown root cause, causing locks to get
stuck in some scenarios.
