### PR TITLE
Store application ordering of transactions w/ legacy index changes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/OutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/OutOfOrderSequence.java
@@ -22,8 +22,8 @@ package org.neo4j.kernel.impl.nioneo.store;
 /**
  * The thinking behind an out-of-order sequence is that, to the outside, there's one "last number"
  * which will will never be decremented between times of looking at it. It can move in bigger strides
- * than 1 though. That is because multiple threads can tell it that a certain number is "done",
- * a number that not necessarily is the last one plus one. So if a gap is observed then the number
+ * than 1 though. That is because multiple threads can {@link #offer(long) tell} it that a certain number is "done",
+ * a number that not necessarily is the previously last one plus one. So if a gap is observed then the number
  * that is the logical next one, whenever that arrives, will move the externally visible number to
  * the highest gap-free number set.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoCommandHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/NeoCommandHandler.java
@@ -188,6 +188,118 @@ public interface NeoCommandHandler extends AutoCloseable
         }
     }
 
+    public static class Delegator implements NeoCommandHandler
+    {
+        private final NeoCommandHandler delegate;
+
+        public Delegator( NeoCommandHandler delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean visitNodeCommand( NodeCommand command ) throws IOException
+        {
+            return delegate.visitNodeCommand( command );
+        }
+
+        @Override
+        public boolean visitRelationshipCommand( RelationshipCommand command ) throws IOException
+        {
+            return delegate.visitRelationshipCommand( command );
+        }
+
+        @Override
+        public boolean visitPropertyCommand( PropertyCommand command ) throws IOException
+        {
+            return delegate.visitPropertyCommand( command );
+        }
+
+        @Override
+        public boolean visitRelationshipGroupCommand( RelationshipGroupCommand command ) throws IOException
+        {
+            return delegate.visitRelationshipGroupCommand( command );
+        }
+
+        @Override
+        public boolean visitRelationshipTypeTokenCommand( RelationshipTypeTokenCommand command ) throws IOException
+        {
+            return delegate.visitRelationshipTypeTokenCommand( command );
+        }
+
+        @Override
+        public boolean visitLabelTokenCommand( LabelTokenCommand command ) throws IOException
+        {
+            return delegate.visitLabelTokenCommand( command );
+        }
+
+        @Override
+        public boolean visitPropertyKeyTokenCommand( PropertyKeyTokenCommand command ) throws IOException
+        {
+            return delegate.visitPropertyKeyTokenCommand( command );
+        }
+
+        @Override
+        public boolean visitSchemaRuleCommand( SchemaRuleCommand command ) throws IOException
+        {
+            return delegate.visitSchemaRuleCommand( command );
+        }
+
+        @Override
+        public boolean visitNeoStoreCommand( NeoStoreCommand command ) throws IOException
+        {
+            return delegate.visitNeoStoreCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexAddNodeCommand( AddNodeCommand command ) throws IOException
+        {
+            return delegate.visitIndexAddNodeCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexAddRelationshipCommand( AddRelationshipCommand command ) throws IOException
+        {
+            return delegate.visitIndexAddRelationshipCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexRemoveCommand( RemoveCommand command ) throws IOException
+        {
+            return delegate.visitIndexRemoveCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexDeleteCommand( DeleteCommand command ) throws IOException
+        {
+            return delegate.visitIndexDeleteCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexCreateCommand( CreateCommand command ) throws IOException
+        {
+            return delegate.visitIndexCreateCommand( command );
+        }
+
+        @Override
+        public boolean visitIndexDefineCommand( IndexDefineCommand command ) throws IOException
+        {
+            return delegate.visitIndexDefineCommand( command );
+        }
+
+        @Override
+        public void apply()
+        {
+            delegate.apply();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+    }
+
     public static class HandlerVisitor implements Visitor<Command, IOException>
     {
         private final NeoCommandHandler handler;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/BatchingPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/BatchingPhysicalTransactionAppender.java
@@ -38,9 +38,10 @@ public class BatchingPhysicalTransactionAppender extends AbstractPhysicalTransac
     private final BatchingForceThread forceThread;
     
     public BatchingPhysicalTransactionAppender( LogFile logFile, TxIdGenerator txIdGenerator,
-            TransactionMetadataCache transactionMetadataCache, final TransactionIdStore transactionIdStore )
+            TransactionMetadataCache transactionMetadataCache, final TransactionIdStore transactionIdStore,
+            IdOrderingQueue legacyIndexTransactionOrdering )
     {
-        super( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore );
+        super( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering );
         forceThread = new BatchingForceThread( new BatchingForceThread.Operation()
         {
             private long lastSeenTransactionId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/CommandWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/CommandWriter.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.transaction.xaframework;
 
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.write2bLengthAndString;
+import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.write3bLengthAndString;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
@@ -43,10 +47,6 @@ import org.neo4j.kernel.impl.nioneo.store.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.nioneo.xa.command.Command;
 import org.neo4j.kernel.impl.nioneo.xa.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.nioneo.xa.command.NeoCommandType;
-
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.write2bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.write3bLengthAndString;
 
 public class CommandWriter implements NeoCommandHandler
 {
@@ -445,7 +445,7 @@ public class CommandWriter implements NeoCommandHandler
         }
         writeDynamicRecords( record.getDeletedRecords() );
     }
-    
+
     @Override
     public void apply()
     {   // Nothing to apply

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/IdOrderingQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/IdOrderingQueue.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+/**
+ * A non continuous, strictly monotonic queue of transaction ids. Equivalently, a queue where the head is always
+ * the minimum value.
+ *
+ * Threads can wait for the minimal value to reach a specific value, upon which event they are woken up and can
+ * act. This notification happens only when the current minimal value (head) is removed, so care should be taken
+ * to remove it when done.
+ *
+ * @author Mattias Persson
+ */
+public interface IdOrderingQueue
+{
+    /**
+     * Adds this id at the tail of the queue. The argument must be larger than all previous arguments
+     * passed to this method.
+     * @param value The id to add
+     */
+    void offer( long value );
+
+    /**
+     * Waits for the argument to become the head of the queue. This is a blocking operation and as such it may
+     * throw InterruptedException.
+     * @param value The id to wait for to become the head of the queue
+     * @throws InterruptedException
+     */
+    void waitFor( long value ) throws InterruptedException;
+
+    /**
+     * Remove the current minimum value, while ensuring that it the expected value.
+     * @param expectedValue The value the minimum value is supposed to be - if the check fails,
+     *                      an IllegalStateException will be thrown and the notification of waiting threads will not
+     *                      happen.
+     */
+    void removeChecked( long expectedValue );
+
+    boolean isEmpty();
+
+    public static final IdOrderingQueue BYPASS = new IdOrderingQueue()
+    {
+        @Override
+        public void offer( long value )
+        {   // Just ignore, it's fine
+        }
+
+        @Override
+        public void waitFor( long value )
+        {   // Just ignore, it's fine
+        }
+
+        @Override
+        public void removeChecked( long expectedValue )
+        {   // Just ignore, it's fine
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return true;
+        }
+    };
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStore.java
@@ -43,15 +43,18 @@ public class PhysicalLogicalTransactionStore extends LifecycleAdapter implements
     private TransactionAppender appender;
     private final TransactionIdStore transactionIdStore;
     private final boolean batchedWrites;
+    private final IdOrderingQueue legacyIndexTransactionOrdering;
 
     public PhysicalLogicalTransactionStore( LogFile logFile, TxIdGenerator txIdGenerator,
             TransactionMetadataCache transactionMetadataCache,
-            TransactionIdStore transactionIdStore, boolean batchedWrites )
+            TransactionIdStore transactionIdStore, IdOrderingQueue legacyIndexTransactionOrdering,
+            boolean batchedWrites )
     {
         this.logFile = logFile;
         this.txIdGenerator = txIdGenerator;
         this.transactionMetadataCache = transactionMetadataCache;
         this.transactionIdStore = transactionIdStore;
+        this.legacyIndexTransactionOrdering = legacyIndexTransactionOrdering;
         this.batchedWrites = batchedWrites;
     }
 
@@ -59,8 +62,10 @@ public class PhysicalLogicalTransactionStore extends LifecycleAdapter implements
     public void init() throws Throwable
     {
         this.appender = batchedWrites ?
-                new BatchingPhysicalTransactionAppender( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore ) :
-                new PhysicalTransactionAppender( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore );
+                new BatchingPhysicalTransactionAppender( logFile, txIdGenerator,
+                        transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering ) :
+                new PhysicalTransactionAppender( logFile, txIdGenerator,
+                        transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering );
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppender.java
@@ -26,9 +26,10 @@ import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
 public class PhysicalTransactionAppender extends AbstractPhysicalTransactionAppender
 {
     public PhysicalTransactionAppender( LogFile logFile, TxIdGenerator txIdGenerator,
-            TransactionMetadataCache transactionMetadataCache, TransactionIdStore transactionIdStore )
+            TransactionMetadataCache transactionMetadataCache, TransactionIdStore transactionIdStore,
+            IdOrderingQueue legacyIndexTransactionOrdering )
     {
-        super( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore );
+        super( logFile, txIdGenerator, transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionRepresentation.java
@@ -36,7 +36,6 @@ public class PhysicalTransactionRepresentation implements TransactionRepresentat
     private long latestCommittedTxWhenStarted;
     private long timeCommitted;
 
-    // TODO 2.2-future recovered could be an aspect instead
     public PhysicalTransactionRepresentation( Collection<Command> commands )
     {
         this.commands = commands;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadOnlyTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadOnlyTransactionStore.java
@@ -31,6 +31,8 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.Monitors;
 
+import static org.neo4j.kernel.impl.transaction.xaframework.IdOrderingQueue.BYPASS;
+
 /**
  * Used for reading transactions off of file.
  */
@@ -63,7 +65,7 @@ public class ReadOnlyTransactionStore extends LifecycleAdapter implements Logica
             {
                 throw new UnsupportedOperationException(  );
             }
-        }, transactionMetadataCache, transactionIdStore, false ) );
+        }, transactionMetadataCache, transactionIdStore, BYPASS, false ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueue.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+public class SynchronizedArrayIdOrderingQueue implements IdOrderingQueue
+{
+    private long[] queue;
+    private int offerIndex, headIndex; // absolute indexes, mod:ed on access
+
+    public SynchronizedArrayIdOrderingQueue( int initialMaxSize )
+    {
+        this.queue = new long[initialMaxSize];
+    }
+
+    @Override
+    public synchronized void offer( long value )
+    {
+        if ( offerIndex - headIndex >= queue.length )
+        {
+            extendArray();
+        }
+        assert offerIndex == headIndex || (offerIndex-1)%queue.length < value : "Was offered ids out-of-order, " + value +
+                " whereas last offered was " + ((offerIndex-1)%queue.length);
+        queue[(offerIndex++)%queue.length] = value;
+    }
+
+    @Override
+    public synchronized void waitFor( long value ) throws InterruptedException
+    {
+        while ( offerIndex == headIndex /*empty*/ || queue[headIndex%queue.length] != value /*head is not our id*/ )
+        {
+            wait();
+        }
+    }
+
+    @Override
+    public synchronized void removeChecked( long expectedValue )
+    {
+        if ( queue[headIndex%queue.length] != expectedValue )
+        {
+            throw new IllegalStateException( "Was about to remove head and expected it to be " +
+                    expectedValue + ", but it was " + queue[headIndex] );
+        }
+        headIndex++;
+        notifyAll();
+    }
+
+    @Override
+    public synchronized boolean isEmpty()
+    {
+        return offerIndex == headIndex;
+    }
+
+    private void extendArray()
+    {
+        long[] newQueue = new long[queue.length << 1];
+        int length = offerIndex-headIndex;
+        for ( int i = 0; i < length; i++ )
+        {
+            newQueue[i] = queue[(headIndex+i)%queue.length];
+        }
+
+        queue = newQueue;
+        offerIndex = length;
+        headIndex = 0;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
@@ -61,11 +61,15 @@ public class Dependencies extends DependencyResolver.Adapter implements Dependen
         List<?> options = typeDependencies.get( type );
 
         if (options != null)
+        {
             return selector.select( type, (Iterable<T>) options);
+        }
 
         // Try parent
         if (parent != null)
+        {
             return parent.instance().resolveDependency( type, selector );
+        }
 
         // Out of options
         throw new IllegalArgumentException(
@@ -109,7 +113,7 @@ public class Dependencies extends DependencyResolver.Adapter implements Dependen
                 deps = new ArrayList<>(  );
                 typeDependencies.put(type, deps);
             }
-            deps.add(dependency);
+            deps.add( dependency );
 
             // Add as all interfaces
             Class[] interfaces = type.getInterfaces();
@@ -131,7 +135,7 @@ public class Dependencies extends DependencyResolver.Adapter implements Dependen
                 deps = new ArrayList<>(  );
                 typeDependencies.put(type, deps);
             }
-            deps.add(dependency);
+            deps.add( dependency );
 
             // Add as all sub-interfaces
             addInterfaces(type.getInterfaces(), dependency);

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
@@ -1337,7 +1337,8 @@ public class NeoStoreTransactionTest
         LabelScanStore labelScanStore = mock( LabelScanStore.class );
         when (labelScanStore.newWriter()).thenReturn( mock(LabelScanWriter.class) );
         TransactionRepresentationStoreApplier applier = new TransactionRepresentationStoreApplier(
-                indexing, labelScanStore, neoStore, cacheAccessBackDoor, locks, null, null, DEFAULT_HIGH_ID_TRACKING );
+                indexing, labelScanStore, neoStore, cacheAccessBackDoor, locks, null, null,
+                DEFAULT_HIGH_ID_TRACKING, null );
 
         // Call this just to make sure the counters have been initialized.
         // This is only a problem in a mocked environment like this.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestStoreRecoverer.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestStoreRecoverer.java
@@ -120,7 +120,7 @@ public class TestStoreRecoverer
         {
             TransactionAppender appender = new PhysicalTransactionAppender( logFile,
                     new DefaultTxIdGenerator( Providers.<TransactionIdStore>singletonProvider( transactionIdStore ) ),
-                    positionCache, transactionIdStore );
+                    positionCache, transactionIdStore, null );
             appender.append( singleNodeTransaction() );
         }
         finally

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/AppendAndRotationRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/AppendAndRotationRaceIT.java
@@ -292,7 +292,7 @@ public class AppendAndRotationRaceIT
                 TransactionMetadataCache metadataCache, TransactionIdStore transactionIdStore )
         {
             return new PhysicalTransactionAppender( logFile, txIdGenerator,
-                    metadataCache, transactionIdStore );
+                    metadataCache, transactionIdStore, IdOrderingQueue.BYPASS );
         }
     };
 
@@ -303,7 +303,7 @@ public class AppendAndRotationRaceIT
                 TransactionMetadataCache metadataCache, TransactionIdStore transactionIdStore )
         {
             return new BatchingPhysicalTransactionAppender( logFile, txIdGenerator,
-                    metadataCache, transactionIdStore );
+                    metadataCache, transactionIdStore, IdOrderingQueue.BYPASS );
         }
     };
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalLogicalTransactionStoreTest.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import static org.neo4j.kernel.impl.transaction.xaframework.IdOrderingQueue.BYPASS;
 import static org.neo4j.kernel.impl.transaction.xaframework.PhysicalLogFile.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.transaction.xaframework.log.pruning.LogPruneStrategyFactory.NO_PRUNING;
 import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
@@ -76,7 +77,8 @@ public class PhysicalLogicalTransactionStoreTest
                 transactionIdStore, mock( LogVersionRepository.class), monitor, logRotationControl,
                 positionCache, noRecoveryAsserter() ) );
         TxIdGenerator txIdGenerator = new DefaultTxIdGenerator( singletonProvider( transactionIdStore ) );
-        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache, transactionIdStore, true ) );
+        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache,
+                transactionIdStore, BYPASS, true ) );
 
         try
         {
@@ -140,7 +142,8 @@ public class PhysicalLogicalTransactionStoreTest
             }
         } ) ) );
 
-        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache, transactionIdStore, true ) );
+        life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator, positionCache,
+                transactionIdStore, BYPASS, true ) );
 
         // WHEN
         try
@@ -208,7 +211,7 @@ public class PhysicalLogicalTransactionStoreTest
         } )));
 
         LogicalTransactionStore store = life.add( new PhysicalLogicalTransactionStore( logFile, txIdGenerator,
-                positionCache, transactionIdStore, true ) );
+                positionCache, transactionIdStore, BYPASS, true ) );
 
         // WHEN
         life.start();
@@ -231,7 +234,7 @@ public class PhysicalLogicalTransactionStoreTest
                                            long latestCommittedTxWhenStarted, long timeCommitted ) throws IOException
     {
         TransactionAppender appender = new PhysicalTransactionAppender(
-                logFile, txIdGenerator, positionCache, transactionIdStore );
+                logFile, txIdGenerator, positionCache, transactionIdStore, BYPASS );
         PhysicalTransactionRepresentation transaction =
                 new PhysicalTransactionRepresentation( singleCreateNodeCommand() );
         transaction.setHeader( additionalHeader, masterId, authorId, timeStarted, latestCommittedTxWhenStarted,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueueStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueueStressTest.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.test.DoubleLatch.awaitLatch;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+
+public class SynchronizedArrayIdOrderingQueueStressTest
+{
+    @Test
+    public void shouldWithstandHighStressAndStillKeepOrder() throws Exception
+    {
+        // GIVEN an ordering queue w/ low initial size as to also exercise resize under stress
+        VerifyingIdOrderingQueue queue = new VerifyingIdOrderingQueue(
+                new SynchronizedArrayIdOrderingQueue( 5 ) );
+        Committer[] committers = new Committer[20];
+        CountDownLatch readySignal = new CountDownLatch( committers.length );
+        AtomicLong endTime = new AtomicLong();
+        CountDownLatch startSignal = new CountDownLatch( 1 );
+        PrimitiveLongIterator idSource = neverEndingIdStream();
+        for ( int i = 0; i < committers.length; i++ )
+        {
+            committers[i] = new Committer( queue, idSource, endTime, readySignal, startSignal );
+        }
+
+        // WHEN GO!
+        readySignal.await();
+        endTime.set( currentTimeMillis() + SECONDS.toMillis( 3 ) );
+        startSignal.countDown();
+        for ( Committer committer : committers )
+        {
+            committer.awaitFinish();
+        }
+
+        // THEN there should have been at least a few ids processed. The order of those
+        // are verified as they go, by the VerifyingIdOrderingQueue
+        assertTrue( "Would have wanted at least a few ids to be processed, but only saw " +
+                queue.getNumberOfOrderlyRemovedIds(), queue.getNumberOfOrderlyRemovedIds() > 50 );
+    }
+
+    private static class VerifyingIdOrderingQueue implements IdOrderingQueue
+    {
+        private final IdOrderingQueue delegate;
+        private final AtomicInteger removedCount = new AtomicInteger();
+        private volatile long previousId = -1;
+
+        public VerifyingIdOrderingQueue( IdOrderingQueue delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void removeChecked( long expectedValue )
+        {
+            if ( expectedValue < previousId )
+            {   // Just to bypass the string creation every check
+                assertTrue( "Expected to remove head " + expectedValue +
+                        ", which should have been greater than previously seen id " + previousId, expectedValue > previousId );
+            }
+            previousId = expectedValue;
+            delegate.removeChecked( expectedValue );
+            removedCount.incrementAndGet();
+        }
+
+        @Override
+        public void offer( long value )
+        {
+            delegate.offer( value );
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public void waitFor( long value ) throws InterruptedException
+        {
+            delegate.waitFor( value );
+        }
+
+        public int getNumberOfOrderlyRemovedIds()
+        {
+            return removedCount.get();
+        }
+    }
+
+    private PrimitiveLongIterator neverEndingIdStream()
+    {
+        return new PrimitiveLongIterator()
+        {
+            private final Stride stride = new Stride();
+            private long next;
+
+            @Override
+            public boolean hasNext()
+            {
+                return true;
+            }
+
+            @Override
+            public long next()
+            {
+                try
+                {
+                    return next;
+                }
+                finally
+                {
+                    next += stride.next();
+                }
+            }
+        };
+    }
+
+    private static class Committer extends Thread
+    {
+        private final Random random = new Random();
+        private final IdOrderingQueue queue;
+        private final AtomicLong endTime;
+        private final CountDownLatch startSignal;
+        private final PrimitiveLongIterator idSource;
+        private final CountDownLatch readySignal;
+        private volatile Exception exception;
+
+        public Committer( IdOrderingQueue queue, PrimitiveLongIterator idSource,
+                AtomicLong endTime, CountDownLatch readySignal, CountDownLatch startSignal )
+        {
+            this.queue = queue;
+            this.idSource = idSource;
+            this.endTime = endTime;
+            this.readySignal = readySignal;
+            this.startSignal = startSignal;
+            start();
+        }
+
+        public void awaitFinish() throws Exception
+        {
+            join();
+            if ( exception != null )
+            {
+                throw exception;
+            }
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                readySignal.countDown();
+                awaitLatch( startSignal );
+                while ( currentTimeMillis() < endTime.get() )
+                {
+                    long id;
+
+                    // Ids must be offered in order
+                    synchronized ( queue )
+                    {
+                        id = idSource.next();
+                        queue.offer( id );
+                    }
+
+                    queue.waitFor( id );
+                    for ( int i = 0, max = random.nextInt( 10_000 ); i < max; i++ )
+                    {
+                        // Jit - please don't take this loop away. Look busy... check queue for empty, or something!
+                        queue.isEmpty();
+                    }
+                    queue.removeChecked( id );
+                }
+            }
+            catch ( Exception e )
+            {
+                this.exception = e;
+            }
+        }
+    }
+
+    /**
+     * Strides predictably: 1, 2, 3, ..., MAX, 1, 2, 3, ... a.s.o
+     */
+    private static class Stride
+    {
+        private int stride;
+        private final int max = 5;
+
+        public int next()
+        {
+            return (stride++%max) + 1;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/SynchronizedArrayIdOrderingQueueTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Future;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.CleanupRule;
+import org.neo4j.test.OtherThreadExecutor;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
+
+public class SynchronizedArrayIdOrderingQueueTest
+{
+    @Test
+    public void shouldOfferQueueABunchOfIds() throws Exception
+    {
+        // GIVEN
+        IdOrderingQueue queue = new SynchronizedArrayIdOrderingQueue( 5 );
+
+        // WHEN
+        for ( int i = 0; i < 7; i++ )
+        {
+            queue.offer( i );
+        }
+
+        // THEN
+        for ( int i = 0; i < 7; i++ )
+        {
+            assertFalse( queue.isEmpty() );
+            queue.waitFor( i );
+            queue.removeChecked( i );
+        }
+        assertTrue( queue.isEmpty() );
+    }
+
+    @Test
+    public void shouldOfferAwaitAndRemoveRoundAndRound() throws Exception
+    {
+        // GIVEN
+        IdOrderingQueue queue = new SynchronizedArrayIdOrderingQueue( 5 );
+        long offeredId = 0, awaitedId = 0;
+        queue.offer( offeredId++ );
+        queue.offer( offeredId++ );
+
+        // WHEN
+        for ( int i = 0; i < 20; i++ )
+        {
+            queue.waitFor( awaitedId );
+            queue.removeChecked( awaitedId++ );
+            queue.offer( offeredId++ );
+            assertFalse( queue.isEmpty() );
+        }
+
+        // THEN
+        queue.removeChecked( awaitedId++ );
+        queue.removeChecked( awaitedId++ );
+        assertTrue( queue.isEmpty() );
+    }
+
+    @Test
+    public void shouldHaveOneThreadWaitForARemoval() throws Exception
+    {
+        // GIVEN
+        IdOrderingQueue queue = new SynchronizedArrayIdOrderingQueue( 5 );
+        queue.offer( 3 );
+        queue.offer( 5 );
+
+        // WHEN another thread comes in and awaits 5
+        OtherThreadExecutor<Void> t2 = cleanup.add( new OtherThreadExecutor<Void>( "T2", null ) );
+        Future<Object> await5 = t2.executeDontWait( awaitHead( queue, 5 ) );
+        t2.waitUntilWaiting();
+        // ... and head (3) gets removed
+        queue.removeChecked( 3 );
+
+        // THEN the other thread should be OK to continue
+        await5.get();
+    }
+
+    @Test
+    public void shouldExtendArrayWhenIdsAreWrappingAround() throws Exception
+    {
+        // GIVEN
+        IdOrderingQueue queue = new SynchronizedArrayIdOrderingQueue( 5 );
+        for ( int i = 0; i < 3; i++ )
+        {
+            queue.offer( i );
+            queue.removeChecked( i );
+        }
+        // Now we're at [0,1,2,0,0]
+        //                     ^-- headIndex and offerIndex
+        for ( int i = 3; i < 8; i++ )
+        {
+            queue.offer( i );
+        }
+        // Now we're at [5,6,2,3,4]
+        //                     ^-- headIndex and offerIndex%length
+
+        // WHEN offering one more, so that the queue is forced to resize
+        queue.offer( 8 );
+
+        // THEN it should have been offered as well as all the previous ids should be intact
+        for ( int i = 3; i <= 8; i++ )
+        {
+            assertFalse( queue.isEmpty() );
+            queue.removeChecked( i );
+        }
+        assertTrue( queue.isEmpty() );
+    }
+
+    private WorkerCommand<Void, Object> awaitHead( final IdOrderingQueue queue, final long id )
+    {
+        return new WorkerCommand<Void, Object>()
+        {
+            @Override
+            public Object doWork( Void state ) throws Exception
+            {
+                queue.waitFor( id );
+                return null;
+            }
+        };
+    }
+
+    public final @Rule CleanupRule cleanup = new CleanupRule();
+}


### PR DESCRIPTION
Only a single transaction at a time can append to the log buffer, but
multiple transactions can apply changes onto the store simultaneously in
2.2. For graph and schema indexing changes there are the high level
entity locks that guarantee correct ordering of transactions wanting to
change the same records. However for legacy indexes there are no such
ordering. This might result in for example a REMOVE+ADD turning into an
ADD+REMOVE, i.e. two different end results.

So, this commit introduces ordering of transactions making any legacy
index changes so that such transactions gets applied in the same order
as they were appended to the log. Transactions that doesn't change
any legacy indexes will not be ordered like this and will pay no cost
whatsoever for the ordering introduces here.

This commit also adds apply() to NeoCommandHandler such that
CommandApplierFacade can call a round of apply() to all appliers and the
another round of close(). This fixes an issue where store application
locks would be released too soon.
Previously:
- apply graph changes
- release graph update locks
- apply schema index changes
- apply legacy index changes

Now:
- apply graph changes
- apply schema index changes
- apply legacy index changes
- release graph update locks
