### PR TITLE
Last committed transaction refers to last forcefully appended to log

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/ReadOnlyTransactionIdStore.java
@@ -34,11 +34,17 @@ public class ReadOnlyTransactionIdStore implements TransactionIdStore
     }
 
     @Override
-    public long nextCommittedTransactionId()
+    public long nextCommittingTransactionId()
     {
         throw new UnsupportedOperationException( "Read-only transaction ID store" );
     }
 
+    @Override
+    public void transactionCommitted( long transactionId )
+    {
+        throw new UnsupportedOperationException( "Read-only transaction ID store" );
+    }
+    
     @Override
     public long getLastCommittedTransactionId()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/AbstractPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/AbstractPhysicalTransactionAppender.java
@@ -80,6 +80,7 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
             }
             
             force( ticket );
+            transactionIdStore.transactionCommitted( transactionId );
             return transactionId;
         }
         catch ( Exception e )
@@ -127,6 +128,7 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
                 }
             }
             force( ticket );
+            transactionIdStore.transactionCommitted( transactionId );
             return result;
         }
         catch ( Exception e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DefaultTxIdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/DefaultTxIdGenerator.java
@@ -34,6 +34,6 @@ public class DefaultTxIdGenerator implements TxIdGenerator
     @Override
     public long generate( TransactionRepresentation transaction )
     {
-        return transactionIdStore.instance().nextCommittedTransactionId();
+        return transactionIdStore.instance().nextCommittingTransactionId();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
@@ -1341,7 +1341,7 @@ public class NeoStoreTransactionTest
 
         // Call this just to make sure the counters have been initialized.
         // This is only a problem in a mocked environment like this.
-        neoStore.nextCommittedTransactionId();
+        neoStore.nextCommittingTransactionId();
 
         return new TransactionRepresentationCommitProcess( txStoreMock, mock( KernelHealth.class ),
                 neoStore, applier, false );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/DeadSimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/DeadSimpleTransactionIdStore.java
@@ -24,43 +24,48 @@ import org.neo4j.kernel.impl.nioneo.store.TransactionIdStore;
 public class DeadSimpleTransactionIdStore implements TransactionIdStore
 {
     private long transactionId;
-    private long appliedTransactionId;
+    private long committedTransactionId;
+    private long closedTransactionId;
 
     public DeadSimpleTransactionIdStore( long initialTransactionId )
     {
-        this.transactionId = initialTransactionId;
-        this.appliedTransactionId = initialTransactionId;
+        setLastCommittedAndClosedTransactionId( initialTransactionId );
     }
 
     @Override
-    public long nextCommittedTransactionId()
+    public long nextCommittingTransactionId()
     {
         return ++transactionId;
+    }
+    
+    @Override
+    public void transactionCommitted( long transactionId )
+    {
+        committedTransactionId = transactionId;
     }
 
     @Override
     public long getLastCommittedTransactionId()
     {
-        return transactionId;
+        return committedTransactionId;
     }
 
     @Override
     public void setLastCommittedAndClosedTransactionId( long transactionId )
     {
-        this.transactionId = transactionId;
-        this.appliedTransactionId = transactionId;
+        this.transactionId = this.committedTransactionId = this.closedTransactionId = transactionId;
     }
 
     @Override
     public void transactionClosed( long transactionId )
     {
-        appliedTransactionId = transactionId;
+        closedTransactionId = transactionId;
     }
 
     @Override
     public boolean closedTransactionIdIsOnParWithCommittedTransactionId()
     {
-        return appliedTransactionId == transactionId;
+        return closedTransactionId == committedTransactionId;
     }
 
     @Override


### PR DESCRIPTION
There was a race condition where
TransactionIdStore#getLastCommittedTransactionId() might return a
transaction id higher than existed in the log on disk, actually even even
before even appended to the log buffer. This resulted in a temporary
condition where a thread would query for last committed transaction id and
then try to retreive those transactions and would fail with an exception
saying that the requested transaction didn't exist.

So this commit introduces a phase before 'committed' which is 'committing'
and those are marked as committed when they have been forcefully committed
to the log. So TransactionIdStore#getLastCommittedTransactionId() method
name is unchanged, but its behaviour is changed to return the last
(highest) truly committed transaction, not the last committing.
