### PR TITLE
Network byte counter and dependencies/monitor cleanup

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.util.Dependencies;
-import org.neo4j.kernel.impl.util.DependencySatisfier;
 
 /**
  * A migration process to migrate {@link StoreMigrationParticipant migration participants}, if there's
@@ -55,7 +54,7 @@ import org.neo4j.kernel.impl.util.DependencySatisfier;
  *
  * @see StoreMigrationParticipant
  */
-public class StoreUpgrader extends DependencySatisfier.Adapter
+public class StoreUpgrader
 {
     private static final String MIGRATION_DIRECTORY = "upgrade";
     private static final String MIGRATION_STATUS_FILE = "_status";
@@ -117,12 +116,6 @@ public class StoreUpgrader extends DependencySatisfier.Adapter
     {
         assert participant != null;
         this.participants.add( participant );
-    }
-
-    @Override
-    public <T> T satisfyDependency( Class<T> type, T dependency )
-    {
-        return dependencyResolver.satisfyDependency( type, dependency );
     }
 
     public void migrateIfNeeded( File storeDirectory )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependencySatisfier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependencySatisfier.java
@@ -27,16 +27,4 @@ import org.neo4j.graphdb.DependencyResolver;
 public interface DependencySatisfier
 {
     <T> T satisfyDependency( T dependency );
-
-    <T> T satisfyDependency( Class<T> type, T dependency );
-
-    public static abstract class Adapter implements DependencySatisfier
-    {
-        @SuppressWarnings( "unchecked" )
-        @Override
-        public <T> T satisfyDependency( T dependency )
-        {
-            return satisfyDependency( (Class<T>) dependency.getClass(), dependency );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.monitoring;
 
-import static org.neo4j.helpers.collection.Iterables.append;
-import static org.neo4j.helpers.collection.Iterables.toArray;
-
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -36,6 +33,27 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.collection.Iterables;
 
+import static org.neo4j.helpers.collection.Iterables.append;
+import static org.neo4j.helpers.collection.Iterables.toArray;
+
+/**
+ * This can be used to create monitor instances using a Dynamic Proxy, which when invoked can delegate to any number of
+ * listeners. Listeners typically also implement the monitor interface, but it's possible to use a reflective style
+ * to either do generic listeners, or avoid the performance penalty of Method.invoke().
+ *
+ * The creation of monitors and registration of listeners may happen in any order. Listeners can be registered before
+ * creating the actual monitor, and vice versa.
+ *
+ * Typically only the top level component that creates Monitors should have a reference to it. When creating subcomponents
+ * that uses monitors they should get instances of the monitor interface in the constructor, or if they need to create them
+ * on demand then pass in a {@link org.neo4j.function.Factory} for that monitor instead. This allows tests to not have to use
+ * Monitors, and instead can pass in mocks or similar.
+ *
+ * The other type of component that would have direct references to the Monitors instance are those that actually implement
+ * listening functionality, and must call addMonitorListener.
+ *
+ * Monitors is monitorable itself, through the {@link org.neo4j.kernel.monitoring.Monitors.Monitor} monitor interface.
+ */
 public class Monitors
 {
     public interface Monitor

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.fail;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class DependenciesTest
+{
+    @Test
+    public void givenSatisfiedTypeWhenResolveWithTypeThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies dependencies = new Dependencies(  );
+
+        String foo = "foo";
+        dependencies.satisfyDependency( foo );
+
+        // When
+        String instance = dependencies.resolveDependency( String.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenSatisfiedTypeWhenResolveWithSuperTypeThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies dependencies = new Dependencies(  );
+
+        AbstractList foo = new ArrayList( );
+        dependencies.satisfyDependency( foo );
+
+        // When
+        AbstractList instance = dependencies.resolveDependency( AbstractList.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenSatisfiedTypeWhenResolveWithInterfaceThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies dependencies = new Dependencies(  );
+
+        List foo = new ArrayList( );
+        dependencies.satisfyDependency( foo );
+
+        // When
+        List instance = dependencies.resolveDependency( List.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenSatisfiedTypeWhenResolveWithSubInterfaceThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies dependencies = new Dependencies(  );
+
+        Collection foo = new ArrayList( );
+        dependencies.satisfyDependency( foo );
+
+        // When
+        Collection instance = dependencies.resolveDependency( Collection.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenSatisfiedTypeInParentWhenResolveWithTypeInEmptyDependenciesThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies parent = new Dependencies(  );
+        Dependencies dependencies = new Dependencies( parent );
+
+        Collection foo = new ArrayList( );
+        dependencies.satisfyDependency( foo );
+
+        // When
+        Collection instance = dependencies.resolveDependency( Collection.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenSatisfiedTypeInParentAndDependenciesWhenResolveWithTypeInDependenciesThenInstanceReturned() throws Exception
+    {
+        // Given
+        Dependencies parent = new Dependencies(  );
+        Dependencies dependencies = new Dependencies( parent );
+
+        Collection foo = new ArrayList( );
+        dependencies.satisfyDependency( foo );
+        parent.satisfyDependency( new ArrayList());
+
+        // When
+        Collection instance = dependencies.resolveDependency( Collection.class );
+
+        // Then
+        assertThat(instance, equalTo(foo));
+    }
+
+    @Test
+    public void givenEmptyDependenciesWhenResolveWithTypeThenException() throws Exception
+    {
+        // Given
+        Dependencies dependencies = new Dependencies( );
+
+        // When
+        try
+        {
+            dependencies.resolveDependency( Collection.class );
+            fail();
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Then
+        }
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/function/Factory.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/function/Factory.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.function;
 
+/**
+ * A generic factory interface for creating instances that do not need any additional dependencies or parameters.
+ *
+ * @param <T> a new instance
+ */
 public interface Factory<T>
 {
     T newInstance();

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
@@ -27,10 +27,8 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.DefaultGraphDatabaseDependencies;
 import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.WrappingNeoServer;
 import org.neo4j.server.WrappingNeoServerBootstrapper;
 import org.neo4j.server.configuration.Configurator;
@@ -84,23 +82,6 @@ public class TestJetty9WebServer
 			}
 		}
 	}
-
-    private DependencyResolver noLoggingDependencyResolver()
-    {
-        return new DependencyResolver.Adapter()
-        {
-            @Override
-            public <T> T resolveDependency( Class<T> type, SelectionStrategy selector )
-                    throws IllegalArgumentException
-            {
-                if ( Logging.class.isAssignableFrom( type ) )
-                {
-                    return type.cast( DevNullLoggingService.DEV_NULL );
-                }
-                return null;
-            }
-        };
-    }
 
     @Test
     public void shouldBeAbleToSetExecutionLimit() throws Throwable

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
@@ -28,10 +28,12 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.TargetCaller;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.com.storecopy.ToNetworkStoreWriter;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.backup.BackupServer.FRAME_LENGTH;
@@ -39,10 +41,11 @@ import static org.neo4j.backup.BackupServer.PROTOCOL_VERSION;
 
 class BackupClient extends Client<TheBackupInterface> implements TheBackupInterface
 {
-    public BackupClient( String hostNameOrIp, int port, Logging logging, Monitors monitors, StoreId storeId )
+    public BackupClient( String hostNameOrIp, int port, Logging logging, StoreId storeId,
+                         ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, monitors, storeId, FRAME_LENGTH, PROTOCOL_VERSION, 40 * 1000,
-                Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT, FRAME_LENGTH );
+        super( hostNameOrIp, port, logging, storeId, FRAME_LENGTH, PROTOCOL_VERSION, 40 * 1000,
+                Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT, FRAME_LENGTH, byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
@@ -19,11 +19,10 @@
  */
 package org.neo4j.backup;
 
-import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
-
 import java.io.IOException;
 
 import org.jboss.netty.channel.Channel;
+
 import org.neo4j.backup.BackupClient.BackupRequestType;
 import org.neo4j.com.Client;
 import org.neo4j.com.Protocol;
@@ -31,9 +30,12 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Server;
 import org.neo4j.com.TxChecksumVerifier;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 
 class BackupServer extends Server<TheBackupInterface, Object>
 {
@@ -43,7 +45,7 @@ class BackupServer extends Server<TheBackupInterface, Object>
     static final int FRAME_LENGTH = Protocol.MEGA * 4;
 
     public BackupServer( TheBackupInterface requestTarget, final HostnamePort server,
-                         Logging logging, Monitors monitors ) throws IOException
+                         Logging logging, ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor ) throws IOException
     {
         super( requestTarget, new Configuration()
         {
@@ -71,7 +73,7 @@ class BackupServer extends Server<TheBackupInterface, Object>
                 return server;
             }
         }, logging, FRAME_LENGTH, PROTOCOL_VERSION,
-                TxChecksumVerifier.ALWAYS_MATCH, SYSTEM_CLOCK, monitors );
+                TxChecksumVerifier.ALWAYS_MATCH, SYSTEM_CLOCK, byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -30,6 +30,7 @@ import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.cluster.member.ClusterMemberEvents;
 import org.neo4j.cluster.member.ClusterMemberListener;
 import org.neo4j.com.ServerUtil;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -42,6 +43,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.xaframework.LogicalTransactionStore;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.backup.OnlineBackupSettings.online_backup_server;
@@ -113,7 +115,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
             try
             {
                 server = new BackupServer( backupProvider.newBackup(), config.get( online_backup_server ),
-                        logging, monitors );
+                        logging, monitors.newMonitor( ByteCounterMonitor.class, BackupServer.class ), monitors.newMonitor( RequestMonitor.class, BackupServer.class ) );
                 server.init();
                 server.start();
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -33,9 +33,9 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMess
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastState;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerMessage;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerState;
-import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerState;
+import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
 import org.neo4j.cluster.protocol.cluster.Cluster;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
@@ -62,7 +62,6 @@ import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.cluster.com.message.Message.internal;
 
@@ -72,15 +71,15 @@ import static org.neo4j.cluster.com.message.Message.internal;
 public class MultiPaxosServerFactory
         implements ProtocolServerFactory
 {
-    private Monitors monitors;
     private final ClusterConfiguration initialConfig;
     private final Logging logging;
+    private StateMachines.Monitor stateMachinesMonitor;
 
-    public MultiPaxosServerFactory( Monitors monitors, ClusterConfiguration initialConfig, Logging logging )
+    public MultiPaxosServerFactory( ClusterConfiguration initialConfig, Logging logging, StateMachines.Monitor stateMachinesMonitor )
     {
-        this.monitors = monitors;
         this.initialConfig = initialConfig;
         this.logging = logging;
+        this.stateMachinesMonitor = stateMachinesMonitor;
     }
 
     @Override
@@ -149,7 +148,7 @@ public class MultiPaxosServerFactory
                                                                 final MultiPaxosContext context,
                                                                 StateMachine[] machines )
     {
-        StateMachines stateMachines = new StateMachines( monitors.newMonitor( StateMachines.Monitor.class ), input,
+        StateMachines stateMachines = new StateMachines( stateMachinesMonitor, input,
                 output, timeouts, executor, stateMachineExecutor, me );
 
         for ( StateMachine machine : machines )

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
@@ -279,9 +279,8 @@ public class ClusterClient extends LifecycleAdapter
                 .timeout( ClusterMessage.leaveTimedout, config.leaveTimeout() )
                 .timeout( ElectionMessage.electionTimeout, config.electionTimeout() );
 
-        MultiPaxosServerFactory protocolServerFactory = new MultiPaxosServerFactory( monitors,
-                new ClusterConfiguration( config
-                        .getClusterName(), logging.getMessagesLog( ClusterConfiguration.class ) ), logging
+        MultiPaxosServerFactory protocolServerFactory = new MultiPaxosServerFactory( new ClusterConfiguration( config
+                        .getClusterName(), logging.getMessagesLog( ClusterConfiguration.class ) ), logging, monitors.newMonitor( StateMachines.Monitor.class )
         );
 
         InMemoryAcceptorInstanceStore acceptorInstanceStore = new InMemoryAcceptorInstanceStore();

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
@@ -116,8 +116,7 @@ public class NetworkMock
         Logging logging = new LogbackService( new Config( Collections.<String, String>emptyMap(),
                 InternalAbstractGraphDatabase.Configuration.class, GraphDatabaseSettings.class ), loggerContext );
 
-        ProtocolServerFactory protocolServerFactory = new MultiPaxosServerFactory( monitors,
-                new ClusterConfiguration( "default", StringLogger.SYSTEM ), logging );
+        ProtocolServerFactory protocolServerFactory = new MultiPaxosServerFactory( new ClusterConfiguration( "default", StringLogger.SYSTEM ), logging, monitors.newMonitor( StateMachines.Monitor.class ) );
 
         ServerIdElectionCredentialsProvider electionCredentialsProvider = new ServerIdElectionCredentialsProvider();
         electionCredentialsProvider.listeningAt( serverUri );

--- a/enterprise/com/src/main/java/org/neo4j/com/MonitorChannelHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/MonitorChannelHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+/**
+ * This Netty handler will report through a monitor how many bytes are read/written.
+ */
+public class MonitorChannelHandler extends SimpleChannelHandler
+{
+    private ByteCounterMonitor byteCounterMonitor;
+
+    public MonitorChannelHandler( ByteCounterMonitor byteCounterMonitor )
+    {
+        this.byteCounterMonitor = byteCounterMonitor;
+    }
+
+    @Override
+    public void messageReceived( ChannelHandlerContext ctx, MessageEvent e ) throws Exception
+    {
+        if (e.getMessage() instanceof ChannelBuffer )
+        {
+            byteCounterMonitor.bytesRead( ((ChannelBuffer)e.getMessage()).readableBytes() );
+        }
+
+        super.messageReceived( ctx, e );
+    }
+
+    @Override
+    public void writeRequested( ChannelHandlerContext ctx, MessageEvent e ) throws Exception
+    {
+        if (e.getMessage() instanceof ChannelBuffer )
+        {
+            byteCounterMonitor.bytesWritten( ((ChannelBuffer)e.getMessage()).readableBytes() );
+        }
+
+        super.writeRequested( ctx, e );
+    }
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
@@ -28,6 +28,7 @@ import java.nio.channels.ReadableByteChannel;
 import org.jboss.netty.buffer.ChannelBuffer;
 
 import org.neo4j.com.MadeUpServer.MadeUpRequestType;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
@@ -44,10 +45,10 @@ public class MadeUpClient extends Client<MadeUpCommunicationInterface> implement
     public MadeUpClient( int port, StoreId storeIdToExpect,
             byte internalProtocolVersion, byte applicationProtocolVersion, int chunkSize )
     {
-        super( localhost(), port, new DevNullLoggingService(), new Monitors(), storeIdToExpect, FRAME_LENGTH,
+        super( localhost(), port, new DevNullLoggingService(), storeIdToExpect, FRAME_LENGTH,
                 applicationProtocolVersion, Client.DEFAULT_READ_RESPONSE_TIMEOUT_SECONDS * 1000,
                 Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT,
-                chunkSize );
+                chunkSize, new Monitors().newMonitor( ByteCounterMonitor.class), new Monitors().newMonitor( RequestMonitor.class ) );
         this.internalProtocolVersion = internalProtocolVersion;
     }
 

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -23,9 +23,12 @@ import java.io.IOException;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
+
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.com.Protocol.readString;
@@ -67,7 +70,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
                 return new HostnamePort( null, port );
             }
         }, new DevNullLoggingService(), FRAME_LENGTH, applicationProtocolVersion, txVerifier, SYSTEM_CLOCK,
-                new Monitors());
+                new Monitors().newMonitor( ByteCounterMonitor.class ), new Monitors().newMonitor( RequestMonitor.class ));
         this.internalProtocolVersion = internalProtocolVersion;
     }
 

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.com;
 
-import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
-import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -38,9 +27,23 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.junit.Test;
+
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.helpers.TickingClock;
 import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
+import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
 
 public class ServerTest
 {
@@ -108,7 +111,8 @@ public class ServerTest
     private Server<Object, Object> newServer( final TxChecksumVerifier checksumVerifier )
     {
         return new Server<Object, Object>(null, mock( Server.Configuration.class), new DevNullLoggingService(),
-                Protocol.DEFAULT_FRAME_LENGTH, (byte)0, checksumVerifier, new TickingClock( 0, 1 ), mock( Monitors.class) )
+                Protocol.DEFAULT_FRAME_LENGTH, (byte)0, checksumVerifier, new TickingClock( 0, 1 ), mock(
+                ByteCounterMonitor.class), mock( RequestMonitor.class) )
         {
             @Override
             protected RequestType<Object> getRequestContext( byte id )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchDetectingTxVerifier.java
@@ -22,12 +22,9 @@ package org.neo4j.kernel.ha;
 import java.io.IOException;
 
 import org.neo4j.com.TxChecksumVerifier;
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMetadataCache;
 import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.kernel.logging.Logging;
 
 /**
  * Used on the master to verify that slaves are using the same logical database as the master is running. This is done
@@ -36,15 +33,12 @@ import org.neo4j.kernel.logging.Logging;
 public class BranchDetectingTxVerifier implements TxChecksumVerifier
 {
     private final StringLogger logger;
-    private DependencyResolver resolver;
-    private LogicalTransactionStore txStore;
+    private final LogicalTransactionStore txStore;
 
-    public BranchDetectingTxVerifier( DependencyResolver resolver )
+    public BranchDetectingTxVerifier( StringLogger logger, LogicalTransactionStore logicalTransactionStore)
     {
-        this.resolver = resolver;
-        this.logger = resolver.resolveDependency( Logging.class ).getMessagesLog( getClass() );
-        this.txStore = resolver.resolveDependency( NeoStoreXaDataSource.class ).getDependencyResolver().
-                resolveDependency( LogicalTransactionStore.class );
+        this.logger = logger;
+        this.txStore = logicalTransactionStore;
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaCaches.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaCaches.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_array_fraction;
-import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_size;
-import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.relationship_cache_array_fraction;
-import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.relationship_cache_size;
-
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.cache.Cache;
@@ -34,6 +29,11 @@ import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.RelationshipImpl;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_array_fraction;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.node_cache_size;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.relationship_cache_array_fraction;
+import static org.neo4j.kernel.impl.cache.HighPerformanceCacheSettings.relationship_cache_size;
 
 public class HaCaches implements Caches
 {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
@@ -31,6 +31,7 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
@@ -47,7 +48,6 @@ import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
-import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
 import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
@@ -71,15 +71,14 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     public static final byte PROTOCOL_VERSION = 6;
 
     private final long lockReadTimeout;
-    private final ByteCounterMonitor monitor;
 
-    public MasterClient201( String hostNameOrIp, int port, Logging logging, Monitors monitors, StoreId storeId,
-                           long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize )
+    public MasterClient201( String hostNameOrIp, int port, Logging logging, StoreId storeId,
+                           long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize,
+                           ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor)
     {
-        super( hostNameOrIp, port, logging, monitors, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
-                readTimeoutSeconds, maxConcurrentChannels, chunkSize );
+        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
+                readTimeoutSeconds, maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
         this.lockReadTimeout = lockReadTimeout;
-        this.monitor = monitors.newMonitor( ByteCounterMonitor.class, getClass() );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -31,6 +31,7 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
@@ -45,7 +46,6 @@ import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
-import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
 import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
@@ -70,15 +70,14 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     public static final byte PROTOCOL_VERSION = 7;
 
     private final long lockReadTimeout;
-    private final ByteCounterMonitor monitor;
 
-    public MasterClient210( String hostNameOrIp, int port, Logging logging, Monitors monitors, StoreId storeId,
-                            long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize )
+    public MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId,
+                            long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize,
+                            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor)
     {
-        super( hostNameOrIp, port, logging, monitors, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
-                readTimeoutSeconds, maxConcurrentChannels, chunkSize );
+        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
+                readTimeoutSeconds, maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor);
         this.lockReadTimeout = lockReadTimeout;
-        this.monitor = monitors.newMonitor( ByteCounterMonitor.class, getClass() );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/backup/HaBackupProvider.java
@@ -40,6 +40,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.Predicates;
 import org.neo4j.kernel.configuration.Config;
@@ -109,13 +110,14 @@ public final class HaBackupProvider //extends BackupExtensionService
 //                ClusterSettings.class, OnlineBackupSettings.class );
         final Config config = null;
         ObjectStreamFactory objectStreamFactory = new ObjectStreamFactory();
-        final ClusterClient clusterClient = life.add( new ClusterClient( new Monitors(),
+        Monitors monitors = new Monitors();
+        final ClusterClient clusterClient = life.add( new ClusterClient( monitors,
                 ClusterClient.adapt( config ), logging,
                 new NotElectableElectionCredentialsProvider(), objectStreamFactory, objectStreamFactory ) );
         ClusterMemberEvents events = life.add( new PaxosClusterMemberEvents( clusterClient, clusterClient,
                 clusterClient, clusterClient, new SystemOutLogging(),
                 Predicates.<PaxosClusterMemberEvents.ClusterMembersSnapshot>TRUE(), new HANewSnapshotFunction(),
-                objectStreamFactory, objectStreamFactory, new Monitors() ) );
+                objectStreamFactory, objectStreamFactory, monitors.newMonitor( NamedThreadFactory.Monitor.class ) ) );
 
         // Refresh the snapshot once we join
         clusterClient.addClusterListener( new ClusterListener.Adapter()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -51,28 +51,22 @@ import org.neo4j.kernel.impl.transaction.xaframework.CommittedTransactionReprese
 import org.neo4j.kernel.impl.transaction.xaframework.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionMetadataCache;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionRepresentation;
-import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
 
 class DefaultMasterImplSPI implements MasterImpl.SPI
 {
     private static final int ID_GRAB_SIZE = 1000;
     private final DependencyResolver dependencyResolver;
     private final GraphDatabaseAPI graphDb;
-    private final Logging logging;
-    private final Monitors monitors;
     private final LogicalTransactionStore txStore;
     private final TransactionIdStore transactionIdStore;
     private final FileSystemAbstraction fileSystem;
     private final File storeDir;
     private final ResponsePacker responsePacker;
 
-    public DefaultMasterImplSPI( GraphDatabaseAPI graphDb, Logging logging, Monitors monitors )
+    public DefaultMasterImplSPI( GraphDatabaseAPI graphDb )
     {
         this.graphDb = graphDb;
-        this.logging = logging;
         this.dependencyResolver = graphDb.getDependencyResolver();
-        this.monitors = monitors;
 
         // Hmm, fetching the dependencies here instead of handing them in the constructor directly feels bad,
         // but it seems like there's some intricate usage and need for the db's dependency resolver.

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.ha.com.master;
 
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.kernel.ha.cluster.member.ClusterMember;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 public class DefaultSlaveFactory implements SlaveFactory
@@ -42,9 +44,10 @@ public class DefaultSlaveFactory implements SlaveFactory
     public Slave newSlave( ClusterMember clusterMember )
     {
         return new SlaveClient( clusterMember.getInstanceId(), clusterMember.getHAUri().getHost(),
-                clusterMember.getHAUri().getPort(), logging, monitors, storeId,
+                clusterMember.getHAUri().getPort(), logging, storeId,
                 2, // and that's 1 too many, because we push from the master from one thread only anyway
-                chunkSize );
+                chunkSize, monitors.newMonitor( ByteCounterMonitor.class, SlaveClient.class ),
+                monitors.newMonitor( RequestMonitor.class, SlaveClient.class ) );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha.com.master;
 
-import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -29,16 +27,20 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.jboss.netty.channel.Channel;
+
 import org.neo4j.com.Protocol;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Server;
 import org.neo4j.com.TransactionNotPresentOnMasterException;
 import org.neo4j.com.TxChecksumVerifier;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.kernel.ha.HaRequestType210;
 import org.neo4j.kernel.ha.MasterClient210;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 
 /**
  * Sits on the master side, receiving serialized requests from slaves (via
@@ -49,10 +51,11 @@ public class MasterServer extends Server<Master, Void>
     public static final int FRAME_LENGTH = Protocol.DEFAULT_FRAME_LENGTH;
 
     public MasterServer( Master requestTarget, Logging logging, Configuration config,
-                         TxChecksumVerifier txVerifier, Monitors monitors )
+                         TxChecksumVerifier txVerifier, ByteCounterMonitor byteCounterMonitor,
+                         RequestMonitor requestMonitor )
     {
         super( requestTarget, config, logging, FRAME_LENGTH, MasterClient210.PROTOCOL_VERSION, txVerifier,
-                SYSTEM_CLOCK, monitors );
+                SYSTEM_CLOCK, byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
@@ -19,13 +19,10 @@
  */
 package org.neo4j.kernel.ha.com.master;
 
-import static org.neo4j.com.Protocol.VOID_SERIALIZER;
-import static org.neo4j.com.Protocol.readString;
-import static org.neo4j.com.Protocol.writeString;
-
 import java.io.IOException;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+
 import org.neo4j.com.Client;
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.Protocol;
@@ -34,25 +31,31 @@ import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
 import org.neo4j.com.TargetCaller;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.helpers.Functions;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.com.slave.SlaveServer;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreXaDataSource;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static org.neo4j.com.Protocol.VOID_SERIALIZER;
+import static org.neo4j.com.Protocol.readString;
+import static org.neo4j.com.Protocol.writeString;
 
 public class SlaveClient extends Client<Slave> implements Slave
 {
     private final int machineId;
 
-    public SlaveClient( int machineId, String hostNameOrIp, int port, Logging logging, Monitors monitors,
-                        StoreId storeId, int maxConcurrentChannels, int chunkSize )
+    public SlaveClient( int machineId, String hostNameOrIp, int port, Logging logging, StoreId storeId,
+                        int maxConcurrentChannels, int chunkSize,
+                        ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, monitors, storeId, Protocol.DEFAULT_FRAME_LENGTH,
+        super( hostNameOrIp, port, logging, storeId, Protocol.DEFAULT_FRAME_LENGTH,
                 SlaveServer.APPLICATION_PROTOCOL_VERSION,
                 HaSettings.read_timeout.apply( Functions.<String, String>nullFunction() ),
-                maxConcurrentChannels, chunkSize );
+                maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
         this.machineId = machineId;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
@@ -23,11 +23,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.com.MismatchingVersionHandler;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.kernel.ha.MasterClient201;
 import org.neo4j.kernel.ha.MasterClient210;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 public class MasterClientResolver implements MasterClientFactory, MismatchingVersionHandler
@@ -179,8 +181,10 @@ public class MasterClientResolver implements MasterClientFactory, MismatchingVer
         @Override
         public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors, StoreId storeId, LifeSupport life )
         {
-            return life.add( new MasterClient201( hostNameOrIp, port, logging, monitors, storeId,
-                    readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize ) );
+            return life.add( new MasterClient201( hostNameOrIp, port, logging, storeId,
+                    readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize,
+                    monitors.newMonitor( ByteCounterMonitor.class, MasterClient201.class),
+                    monitors.newMonitor( RequestMonitor.class, MasterClient201.class )) );
         }
     }
 
@@ -195,8 +199,10 @@ public class MasterClientResolver implements MasterClientFactory, MismatchingVer
         @Override
         public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors, StoreId storeId, LifeSupport life )
         {
-            return life.add( new MasterClient210( hostNameOrIp, port, logging, monitors, storeId,
-                    readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize ) );
+            return life.add( new MasterClient210( hostNameOrIp, port, logging, storeId,
+                    readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize,
+                    monitors.newMonitor( ByteCounterMonitor.class, MasterClient201.class),
+                    monitors.newMonitor( RequestMonitor.class, MasterClient201.class )) );
         }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -19,28 +19,30 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import static org.neo4j.com.Protocol.DEFAULT_FRAME_LENGTH;
-import static org.neo4j.com.TxChecksumVerifier.ALWAYS_MATCH;
-import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
-
 import org.jboss.netty.channel.Channel;
+
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Server;
+import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.ha.com.master.SlaveClient.SlaveRequestType;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static org.neo4j.com.Protocol.DEFAULT_FRAME_LENGTH;
+import static org.neo4j.com.TxChecksumVerifier.ALWAYS_MATCH;
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 
 
 public class SlaveServer extends Server<Slave, Void>
 {
     public static final byte APPLICATION_PROTOCOL_VERSION = 1;
 
-    public SlaveServer( Slave requestTarget, Configuration config, Logging logging, Monitors monitors )
+    public SlaveServer( Slave requestTarget, Configuration config, Logging logging, ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
         super( requestTarget, config, logging, DEFAULT_FRAME_LENGTH, APPLICATION_PROTOCOL_VERSION, ALWAYS_MATCH,
-                SYSTEM_CLOCK, monitors );
+                SYSTEM_CLOCK, byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
@@ -28,6 +28,7 @@ import org.neo4j.cluster.DelayedDirectExecutor;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.MultiPaxosServerFactory;
 import org.neo4j.cluster.ProtocolServer;
+import org.neo4j.cluster.StateMachines;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageProcessor;
 import org.neo4j.cluster.com.message.MessageSender;
@@ -84,7 +85,7 @@ class ClusterInstance
     public static ClusterInstance newClusterInstance( InstanceId id, URI uri, Monitors monitors,
                                                       ClusterConfiguration configuration, Logging logging )
     {
-        MultiPaxosServerFactory factory = new MultiPaxosServerFactory( monitors, configuration, logging );
+        MultiPaxosServerFactory factory = new MultiPaxosServerFactory( configuration, logging, monitors.newMonitor( StateMachines.Monitor.class ) );
 
         ClusterInstanceInput input = new ClusterInstanceInput();
         ClusterInstanceOutput output = new ClusterInstanceOutput( uri );


### PR DESCRIPTION
Primary purpose of this PR is to add network byte counting to Client/Slave. 

Along the way I also cleaned up usages of DependencyResolver and Monitors, so that dependencies and monitor usage is more explicit. Long-term goal is to have no manual DependencyResolvers, and to have no direct usages of Monitors unless absolutely necessary.
