### PR TITLE
Delays node/rel record changes until commit time

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContextTest.scala
@@ -37,7 +37,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     super.beforeEach ()
     graph = new ImpermanentGraphDatabase
     outerTx = mock[Transaction]
-    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, null, null, null)
+    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, null, null)
   }
 
     test ("should_mark_transaction_successful_if_successful") {

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -730,7 +730,7 @@ public abstract class InternalAbstractGraphDatabase
                     new RelationshipVisitor<RuntimeException>()
             {
                 @Override
-                public void visit( long relId, long startNode, long endNode, int type )
+                public void visit( long relId, int type, long startNode, long endNode )
                 {
                     relationshipData.get().set( startNode, endNode, type );
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataWrite.java
@@ -21,20 +21,20 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
-import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 
 interface DataWrite
 {
     long nodeCreate();
 
-    void nodeDelete( long nodeId );
+    void nodeDelete( long nodeId ) throws EntityNotFoundException;
 
     long relationshipCreate( int relationshipTypeId, long startNodeId, long endNodeId )
             throws RelationshipTypeIdNotFoundKernelException, EntityNotFoundException;
 
-    void relationshipDelete( long relationshipId );
+    void relationshipDelete( long relationshipId ) throws EntityNotFoundException;
 
     /**
      * Labels a node with the label corresponding to the given label id.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TxState.java
@@ -108,7 +108,13 @@ public interface TxState
     public interface Visitor
     {
         void visitCreatedNode( long id );
-        
+
+        void visitDeletedNode( long id );
+
+        void visitCreatedRelationship( long id, int type, long startNode, long endNode );
+
+        void visitDeletedRelationship( long id );
+
         void visitNodePropertyChanges( long id, Iterator<DefinedProperty> added, Iterator<DefinedProperty> changed,
                                        Iterator<Integer> removed );
 
@@ -138,7 +144,22 @@ public interface TxState
         public void visitCreatedNode( long id )
         {   // Ignore
         }
-        
+
+        @Override
+        public void visitDeletedNode( long id )
+        {   // Ignore
+        }
+
+        @Override
+        public void visitCreatedRelationship( long id, int type, long startNode, long endNode )
+        {   // Ignore
+        }
+
+        @Override
+        public void visitDeletedRelationship( long id )
+        {   // Ignore
+        }
+
         @Override
         public void visitNodePropertyChanges( long id, Iterator<DefinedProperty> added,
                 Iterator<DefinedProperty> changed, Iterator<Integer> removed )
@@ -246,7 +267,7 @@ public interface TxState
 
     UpdateTriState labelState( long nodeId, int labelId );
 
-    void relationshipDoDelete( long relationshipId, long startNode, long endNode, int type );
+    void relationshipDoDelete( long relationshipId, int type, long startNode, long endNode );
 
     void relationshipDoDeleteAddedInThisTx( long relationshipId );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/EntityNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/EntityNotFoundException.java
@@ -23,18 +23,45 @@ import org.neo4j.kernel.api.EntityType;
 
 public class EntityNotFoundException extends KernelException
 {
+    private final EntityType entityType;
+    private final long entityId;
+
     public EntityNotFoundException( EntityType entityType, long entityId, Throwable cause )
     {
         super( Status.Statement.EntityNotFound, cause, "Unable to load %s with id %s.", entityType.name(), entityId );
+        this.entityType = entityType;
+        this.entityId = entityId;
     }
 
     public EntityNotFoundException( EntityType entityType, long entityId )
     {
         super( Status.Statement.EntityNotFound, "Unable to load %s with id %s.", entityType.name(), entityId );
+        this.entityType = entityType;
+        this.entityId = entityId;
     }
 
     public EntityNotFoundException( String msg )
     {
         super( Status.Statement.EntityNotFound, msg );
+        this.entityType = null;
+        this.entityId = -1;
+    }
+
+    public EntityType entityType()
+    {
+        if ( entityType == null )
+        {
+            throw new IllegalStateException( "No entity type specified for this exception", this );
+        }
+        return entityType;
+    }
+
+    public long entityId()
+    {
+        if ( entityId == -1 )
+        {
+            throw new IllegalStateException( "No entity id specified for this exception", this );
+        }
+        return entityId;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -145,19 +145,20 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations
     // Simply delegate the rest of the invocations
 
     @Override
-    public void nodeDelete( KernelStatement state, long nodeId )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         entityWriteOperations.nodeDelete( state, nodeId );
     }
 
     @Override
     public long relationshipCreate( KernelStatement statement, int relationshipTypeId, long startNodeId, long endNodeId )
+            throws EntityNotFoundException
     {
         return entityWriteOperations.relationshipCreate( statement, relationshipTypeId, startNodeId, endNodeId );
     }
 
     @Override
-    public void relationshipDelete( KernelStatement state, long relationshipId )
+    public void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         entityWriteOperations.relationshipDelete( state, relationshipId );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -58,6 +58,7 @@ public class GuardingStatementOperations implements
 
     @Override
     public long relationshipCreate( KernelStatement statement, int relationshipTypeId, long startNodeId, long endNodeId )
+            throws EntityNotFoundException
     {
         guard.check();
         return entityWriteDelegate.relationshipCreate( statement, relationshipTypeId, startNodeId, endNodeId );
@@ -71,14 +72,14 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public void nodeDelete( KernelStatement state, long nodeId )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         guard.check();
         entityWriteDelegate.nodeDelete( state, nodeId );
     }
 
     @Override
-    public void relationshipDelete( KernelStatement state, long relationshipId )
+    public void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         guard.check();
         entityWriteDelegate.relationshipDelete( state, relationshipId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 public class KernelStatement implements TxState.Holder, Statement
 {
@@ -44,7 +43,6 @@ public class KernelStatement implements TxState.Holder, Statement
     protected final TxState.Holder txStateHolder;
     protected final IndexReaderFactory indexReaderFactory;
     protected final LabelScanStore labelScanStore;
-    private final TransactionRecordState recordState;
     private final LegacyIndexTransactionState legacyIndexTransactionState;
 
     private LabelScanReader labelScanReader;
@@ -55,14 +53,13 @@ public class KernelStatement implements TxState.Holder, Statement
     public KernelStatement( KernelTransactionImplementation transaction, IndexReaderFactory indexReaderFactory,
                             LabelScanStore labelScanStore,
                             TxState.Holder txStateHolder, Locks.Client locks, StatementOperationParts operations,
-                            TransactionRecordState recordState, LegacyIndexTransactionState legacyIndexTransactionState )
+                            LegacyIndexTransactionState legacyIndexTransactionState )
     {
         this.transaction = transaction;
         this.locks = locks;
         this.indexReaderFactory = indexReaderFactory;
         this.txStateHolder = txStateHolder;
         this.labelScanStore = labelScanStore;
-        this.recordState = recordState;
         this.legacyIndexTransactionState = legacyIndexTransactionState;
         this.facade = new OperationsFacade( this, operations );
     }
@@ -112,11 +109,6 @@ public class KernelStatement implements TxState.Holder, Statement
     public boolean hasTxStateWithChanges()
     {
         return txStateHolder.hasTxStateWithChanges();
-    }
-
-    protected TransactionRecordState recordState()
-    {
-        return recordState;
     }
 
     protected LegacyIndexTransactionState legacyIndexTransactionState()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -207,9 +207,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         if ( currentStatement == null )
         {
             currentStatement = new KernelStatement( this, new IndexReaderFactory.Caching( indexService ),
-                    labelScanStore, this, locks, operations,
-                    // Just use forReading since read/write has been decided prior to this
-                    recordState, legacyIndexTransactionState );
+                    labelScanStore, this, locks, operations, legacyIndexTransactionState );
         }
         currentStatement.acquire();
         return currentStatement;
@@ -333,6 +331,30 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             final AtomicBoolean clearState = new AtomicBoolean( false );
             txState().accept( new TxState.VisitorAdapter()
             {
+                @Override
+                public void visitCreatedNode( long id )
+                {
+                    recordState.nodeCreate( id );
+                }
+
+                @Override
+                public void visitDeletedNode( long id )
+                {
+                    recordState.nodeDelete( id );
+                }
+
+                @Override
+                public void visitCreatedRelationship( long id, int type, long startNode, long endNode )
+                {
+                    recordState.relCreate( id, type, startNode, endNode );
+                }
+
+                @Override
+                public void visitDeletedRelationship( long id )
+                {
+                    recordState.relDelete( id );
+                }
+
                 @Override
                 public void visitNodePropertyChanges( long id, Iterator<DefinedProperty> added, Iterator<DefinedProperty> changed, Iterator<Integer> removed )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -200,7 +200,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void nodeDelete( KernelStatement state, long nodeId )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         state.locks().acquireExclusive( ResourceTypes.NODE, nodeId );
         entityWriteDelegate.nodeDelete( state, nodeId );
@@ -214,6 +214,7 @@ public class LockingStatementOperations implements
 
     @Override
     public long relationshipCreate( KernelStatement state, int relationshipTypeId, long startNodeId, long endNodeId )
+            throws EntityNotFoundException
     {   // TODO 2.2-future Don't lock it, it's a new relationship so it isn't seen by anyone else anyway
         state.locks().acquireExclusive( ResourceTypes.NODE, startNodeId );
         state.locks().acquireExclusive( ResourceTypes.NODE, endNodeId );
@@ -221,14 +222,14 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void relationshipDelete( final KernelStatement state, long relationshipId )
+    public void relationshipDelete( final KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         try
         {
             entityReadDelegate.relationshipVisit( state, relationshipId, new RelationshipVisitor<RuntimeException>()
             {
                 @Override
-                public void visit( long relId, long startNode, long endNode, int type )
+                public void visit( long relId, int type, long startNode, long endNode )
                 {
                     state.locks().acquireExclusive( ResourceTypes.NODE, startNode );
                     state.locks().acquireExclusive( ResourceTypes.NODE, endNode );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -525,7 +525,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void nodeDelete( long nodeId )
+    public void nodeDelete( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         dataWrite().nodeDelete( statement, nodeId );
@@ -540,7 +540,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void relationshipDelete( long relationshipId )
+    public void relationshipDelete( long relationshipId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         dataWrite().relationshipDelete( statement, relationshipId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
@@ -21,5 +21,5 @@ package org.neo4j.kernel.impl.api;
 
 public interface RelationshipVisitor<EXCEPTION extends Exception>
 {
-    void visit( long relId, long startNode, long endNode, int type ) throws EXCEPTION;
+    void visit( long relId, int type, long startNode, long endNode ) throws EXCEPTION;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
@@ -19,23 +19,23 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
-import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
-import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
+import org.neo4j.kernel.impl.api.KernelStatement;
 
 public interface EntityWriteOperations
 {
     // Currently, of course, most relevant operations here are still in the old core API implementation.
 
-    long relationshipCreate( KernelStatement statement, int relationshipTypeId, long startNodeId, long endNodeId );
+    long relationshipCreate( KernelStatement statement, int relationshipTypeId, long startNodeId, long endNodeId ) throws EntityNotFoundException;
 
     long nodeCreate( KernelStatement statement );
 
-    void nodeDelete( KernelStatement state, long nodeId );
+    void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException;
 
-    void relationshipDelete( KernelStatement state, long relationshipId );
+    void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException;
 
     /**
      * Labels a node with the label corresponding to the given label id.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/AugmentWithLocalStateExpandCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/AugmentWithLocalStateExpandCursor.java
@@ -89,7 +89,7 @@ public class AugmentWithLocalStateExpandCursor implements Cursor
     private final RelationshipVisitor<RuntimeException> neighborFetcher = new RelationshipVisitor<RuntimeException>()
     {
         @Override
-        public void visit( long id, long startNode, long endNode, int type ) throws RuntimeException
+        public void visit( long id, int type, long startNode, long endNode ) throws RuntimeException
         {
             relId.write( id );
             long origin = nodeId.read();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -474,8 +474,8 @@ public class CacheLayer implements StoreReadLayer
             RelationshipVisitor<EXCEPTION> relationshipVisitor ) throws EntityNotFoundException, EXCEPTION
     {
         RelationshipImpl relationship = persistenceCache.getRelationship( relationshipId );
-        relationshipVisitor.visit( relationshipId, relationship.getStartNodeId(), relationship.getEndNodeId(),
-                relationship.getTypeId());
+        relationshipVisitor.visit( relationshipId, relationship.getTypeId(), relationship.getStartNodeId(),
+                relationship.getEndNodeId());
     }
 
     @Override
@@ -510,12 +510,18 @@ public class CacheLayer implements StoreReadLayer
     {
         return diskLayer.relationshipExists( relationshipId );
     }
-    
+
     @Override
     public long reserveNode()
     {
         long nodeId = diskLayer.reserveNode();
         persistenceCache.reserveNode( nodeId );
         return nodeId;
+    }
+
+    @Override
+    public long reserveRelationship()
+    {
+        return diskLayer.reserveRelationship();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -767,9 +767,16 @@ public class DiskLayer implements StoreReadLayer
         };
     }
 
+    @Override
     public long reserveNode()
     {
         return nodeStore.nextId();
+    }
+
+    @Override
+    public long reserveRelationship()
+    {
+        return relationshipStore.nextId();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreExpandCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreExpandCursor.java
@@ -49,7 +49,7 @@ public class StoreExpandCursor implements Cursor
     private final RelationshipVisitor<RuntimeException> neighborFetcher = new RelationshipVisitor<RuntimeException>()
     {
         @Override
-        public void visit( long relId, long startNode, long endNode, int type ) throws RuntimeException
+        public void visit( long relId, int type, long startNode, long endNode ) throws RuntimeException
         {
             long origin = nodeId.read();
             if( startNode == endNode)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -172,6 +172,11 @@ public interface StoreReadLayer
      */
     long reserveNode();
 
+    /**
+     * Reserves a relationship id for future use.
+     */
+    long reserveRelationship();
+
     Cursor expand( Cursor inputCursor, NeoRegister.Node.In nodeId, Register.Object.In<int[]> types,
                    Register.Object.In<Direction> expandDirection, NeoRegister.Relationship.Out relId,
                    NeoRegister.RelType.Out relType, Register.Object.Out<Direction> direction,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -123,6 +123,11 @@ public class NodeProxy implements Node
         {
             throw new ReadOnlyDbException();
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new IllegalStateException( "Unable to delete Node[" + nodeId +
+                    "] since it has already been deleted." );
+        }
     }
 
     @Override
@@ -453,7 +458,8 @@ public class NodeProxy implements Node
         }
         catch ( EntityNotFoundException e )
         {
-            throw new NotFoundException( e );
+            throw new IllegalStateException( "Node[" + e.entityId() +
+                    "] is deleted and cannot be used to create a relationship" );
         }
         catch ( InvalidTransactionTypeKernelException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -94,6 +94,11 @@ public class RelationshipProxy implements Relationship
         {
             throw new ReadOnlyDbException();
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new IllegalStateException( "Unable to delete relationship[" +
+                    relId + "] since it is already deleted." );
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/NodeRecord.java
@@ -32,7 +32,7 @@ import static org.neo4j.kernel.impl.nioneo.store.labels.NodeLabelsField.parseLab
 
 public class NodeRecord extends PrimitiveRecord
 {
-    private long nextRel;
+    private long nextRel = Record.NO_NEXT_RELATIONSHIP.intValue();
     private long labels;
     private Collection<DynamicRecord> dynamicLabelRecords = emptyList();
     private boolean isLight = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreFactory.java
@@ -29,7 +29,6 @@ import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -85,10 +84,11 @@ public class StoreFactory
     private final Monitors monitors;
     private final PageCache pageCache;
 
-    public StoreFactory( File storeDir, PageCache pageCache, StringLogger logger, Monitors monitors )
+    public StoreFactory( FileSystemAbstraction fileSystem, File storeDir, PageCache pageCache, StringLogger logger,
+            Monitors monitors )
     {
         this( configForStoreDir( new Config(), storeDir ),
-                new DefaultIdGeneratorFactory(), pageCache, new DefaultFileSystemAbstraction(),
+                new DefaultIdGeneratorFactory(), pageCache, fileSystem,
                 logger, monitors, StoreVersionMismatchHandler.THROW_EXCEPTION );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreator.java
@@ -56,17 +56,7 @@ public class RelationshipCreator
     {
         // TODO could be unnecessary to mark as changed here already, dense nodes may not need to change
         NodeRecord firstNode = recordChangeSet.getNodeRecords().getOrLoad( firstNodeId, null ).forChangingLinkage();
-        if ( !firstNode.inUse() )
-        {
-            throw new IllegalStateException( "First node[" + firstNodeId +
-                    "] is deleted and cannot be used to create a relationship" );
-        }
         NodeRecord secondNode = recordChangeSet.getNodeRecords().getOrLoad( secondNodeId, null ).forChangingLinkage();
-        if ( !secondNode.inUse() )
-        {
-            throw new IllegalStateException( "Second node[" + secondNodeId +
-                    "] is deleted and cannot be used to create a relationship" );
-        }
         convertNodeToDenseIfNecessary( firstNode, recordChangeSet.getRelRecords(),
                 recordChangeSet.getRelGroupRecords() );
         convertNodeToDenseIfNecessary( secondNode, recordChangeSet.getRelRecords(),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipDeleter.java
@@ -56,11 +56,6 @@ public class RelationshipDeleter
     public ArrayMap<Integer, DefinedProperty> relDelete( long id, RecordAccessSet recordChanges )
     {
         RelationshipRecord record = recordChanges.getRelRecords().getOrLoad( id, null ).forChangingLinkage();
-        if ( !record.inUse() )
-        {
-            throw new IllegalStateException( "Unable to delete relationship[" +
-                    id + "] since it is already deleted." );
-        }
         ArrayMap<Integer, DefinedProperty> propertyMap =
                 propertyChainDeleter.getAndDeletePropertyChain( record, recordChanges.getPropertyRecords() );
         disconnectRelationship( record, recordChanges );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffSets.java
@@ -51,6 +51,19 @@ public class DiffSets<T>
         void visitRemoved( T element );
     }
 
+    public static class VisitorAdapter<T> implements Visitor<T>
+    {
+        @Override
+        public void visitAdded( T element )
+        {   // Ignore
+        }
+
+        @Override
+        public void visitRemoved( T element )
+        {   // Ignore
+        }
+    }
+
     @SuppressWarnings(
             {"rawtypes", "unchecked"})
     private static final DiffSets EMPTY = new DiffSets( Collections.emptySet(), Collections.emptySet() )
@@ -276,8 +289,14 @@ public class DiffSets<T>
 
     public void clear()
     {
-        if(addedElements != null) addedElements.clear();
-        if(removedElements != null) removedElements.clear();
+        if(addedElements != null)
+        {
+            addedElements.clear();
+        }
+        if(removedElements != null)
+        {
+            removedElements.clear();
+        }
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -44,7 +44,7 @@ public class KernelStatementTest
         KernelStatement statement =
             new KernelStatement(
                 mock( KernelTransactionImplementation.class ),
-                mock( IndexReaderFactory.class ), scanStore, null, null, null, null, null );
+                mock( IndexReaderFactory.class ), scanStore, null, null, null, null );
 
         statement.acquire();
 
@@ -73,7 +73,7 @@ public class KernelStatementTest
 
         KernelStatement statement = new KernelStatement(
             transaction, mock( IndexReaderFactory.class ),
-                mock( LabelScanStore.class ), null, null, null, null, null
+                mock( LabelScanStore.class ), null, null, null, null
         );
 
         statement.readOperations().nodeExists( 0 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -50,7 +51,7 @@ public class LockingStatementOperationsTest
     private final SchemaWriteOperations schemaWriteOps;
     private final Locks.Client locks = mock( Locks.Client.class );
     private final InOrder order;
-    private final KernelStatement state = new KernelStatement( null, null, null, null, locks, null, null, null );
+    private final KernelStatement state = new KernelStatement( null, null, null, null, locks, null, null );
 
     public LockingStatementOperationsTest()
     {
@@ -125,7 +126,7 @@ public class LockingStatementOperationsTest
     }
 
     @Test
-    public void shouldAcquireEntityWriteLockBeforeDeletingNode()
+    public void shouldAcquireEntityWriteLockBeforeDeletingNode() throws EntityNotFoundException
     {
         // WHEN
         lockingOps.nodeDelete( state, 123 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/NodeCommitAndReadRaceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/NodeCommitAndReadRaceTest.java
@@ -62,7 +62,6 @@ import org.neo4j.kernel.impl.nioneo.xa.RecordAccessSet;
 import org.neo4j.kernel.impl.nioneo.xa.RelationshipChainLoader;
 import org.neo4j.kernel.impl.nioneo.xa.RelationshipCreator;
 import org.neo4j.kernel.impl.nioneo.xa.RelationshipLocker;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
@@ -91,14 +90,14 @@ public class NodeCommitAndReadRaceTest
          * Fix is to put a node reservation in cache when the user transaction creates the node, with the
          * sole purpose to communicate this fact to readers. The committer will then switch the reservation
          * for a normal node on commit. */
-        
+
         // GIVEN
         // ... a created, but not yet fully committed, node
         KernelStatement creationStatement = mockedStatement();
         long nodeId = operations.nodeCreate( creationStatement );
         // ... and we pretend that this is during commit and so the node exists in the store
         createNodeWithSomeRelationships( nodeId );
-        
+
         // WHEN a reader comes in and tries to read that node, it should not be able to see it
         KernelStatement readerStatement = mockedStatement();
         try
@@ -111,14 +110,14 @@ public class NodeCommitAndReadRaceTest
             // THEN we're all good
         }
     }
-    
+
     private void createNodeWithSomeRelationships( long nodeId )
     {
         RecordAccessSet recordAccess = new DirectRecordAccessSet( neoStore );
         NodeRecord node = recordAccess.getNodeRecords().create( nodeId, null ).forChangingData();
         node.setInUse( true );
         node.setCreated();
-        
+
         int type = relationshipTokenHolder.getOrCreateId( "TYPE" );
         RelationshipCreator relationshipCreator = new RelationshipCreator( RelationshipLocker.NO_LOCKING, null, 100 );
         for ( int i = 0; i < 2; i++ )
@@ -132,9 +131,7 @@ public class NodeCommitAndReadRaceTest
     private KernelStatement mockedStatement()
     {
         KernelStatement statement = mock( KernelStatement.class );
-        TransactionRecordState recordState = mock( TransactionRecordState.class );
         TxState txState = new TxStateImpl( mock( LegacyIndexTransactionState.class ) );
-        when( statement.recordState() ).thenReturn( recordState );
         when( statement.txState() ).thenReturn( txState );
         return statement;
     }
@@ -144,7 +141,7 @@ public class NodeCommitAndReadRaceTest
     private StateHandlingStatementOperations operations;
     private NeoStore neoStore;
     private RelationshipTypeTokenHolder relationshipTokenHolder;
-    
+
     @Before
     @SuppressWarnings( { "unchecked", "deprecation" } )
     public void before()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -31,7 +31,7 @@ public class StatementLifecycleTest
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
         KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null,
-                null, null, null, null, null );
+                null, null, null, null );
         statement.acquire();
 
         // when
@@ -47,7 +47,7 @@ public class StatementLifecycleTest
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
         KernelStatement statement = new KernelStatement( transaction, mock( IndexReaderFactory.class ), null,
-                null, null, null, null, null );
+                null, null, null, null );
         statement.acquire();
         statement.acquire();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.nioneo.xa.TransactionRecordState;
 
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -90,8 +89,6 @@ public abstract class StatementOperationsTestHelper
             }
         } );
         when( state.locks() ).thenReturn( lockHolder );
-        TransactionRecordState recordState = mock( TransactionRecordState.class );
-        when( state.recordState() ).thenReturn( recordState );
         return state;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/AugmentWithLocalStateExpandCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/AugmentWithLocalStateExpandCursorTest.java
@@ -153,11 +153,11 @@ public class AugmentWithLocalStateExpandCursorTest
                 {
                     if(r.direction == INCOMING)
                     {
-                        ((RelationshipVisitor) invocation.getArguments()[1]).visit( r.relId, r.neighborId, r.startId, r.type );
+                        ((RelationshipVisitor) invocation.getArguments()[1]).visit( r.relId, r.type, r.neighborId, r.startId );
                     }
                     else
                     {
-                        ((RelationshipVisitor) invocation.getArguments()[1]).visit( r.relId, r.startId, r.neighborId, r.type );
+                        ((RelationshipVisitor) invocation.getArguments()[1]).visit( r.relId, r.type, r.startId, r.neighborId );
                     }
                     return true;
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -323,6 +323,7 @@ public class IndexQueryTransactionStateTest
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
         when( store.constraintsGetForLabel( labelId ) ).thenReturn( Collections.<UniquenessConstraint>emptyIterator() );
+        when( store.nodeExists( anyLong() ) ).thenReturn( true );
 
         StateHandlingStatementOperations stateHandlingOperations = new StateHandlingStatementOperations(
                 store,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -44,6 +45,7 @@ import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.kernel.impl.util.Providers.singletonProvider;
 
@@ -75,7 +77,7 @@ public class DiskLayerTest
                 indexingService );
         this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ),
                 resolver.resolveDependency( LabelScanStore.class ), null,
-                null, null, null, null );
+                null, null, null );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreExpandCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreExpandCursorTest.java
@@ -57,7 +57,7 @@ public class StoreExpandCursorTest
             public Object answer( InvocationOnMock invocation ) throws Throwable
             {
                 RelationshipVisitor visitor = (RelationshipVisitor) invocation.getArguments()[1];
-                visitor.visit( (Long)invocation.getArguments()[0], 1337, 2, 0 );
+                visitor.visit( (Long)invocation.getArguments()[0], 0, 1337, 2 );
                 return null;
             }
         }  ).when(cache).relationshipVisit( anyLong(), any(RelationshipVisitor.class) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -106,8 +106,9 @@ public class ManyPropertyKeysIT
 
     private GraphDatabaseAPI databaseWithManyPropertyKeys( int propertyKeyCount ) throws IOException
     {
-        PageCache pageCache = new StandardPageCache( new DefaultFileSystemAbstraction(), 1000, 1024*4 );
-        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, StringLogger.DEV_NULL, new Monitors() );
+        DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+        PageCache pageCache = new StandardPageCache( fs, 1000, 1024*4 );
+        StoreFactory storeFactory = new StoreFactory( fs, storeDir, pageCache, StringLogger.DEV_NULL, new Monitors() );
         NeoStore neoStore = storeFactory.newNeoStore( true );
         PropertyKeyTokenStore store = neoStore.getPropertyKeyTokenStore();
         for ( int i = 0; i < propertyKeyCount; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -115,8 +115,8 @@ public class TxStateTransactionDataViewTest
     public void showsRemovedRelationships() throws Exception
     {
         // Given
-        state.relationshipDoDelete( 1l, 1l, 2l, 1 );
-        state.relationshipDoDelete( 2l, 1l, 1l, 1 );
+        state.relationshipDoDelete( 1l, 1, 1l, 2l );
+        state.relationshipDoDelete( 2l, 1, 1l, 1l );
 
         when(ops.relationshipGetAllProperties( 1l )).thenReturn( IteratorUtil.<DefinedProperty>emptyIterator() );
         when(ops.relationshipGetAllProperties( 2l )).thenReturn( asList( Property.stringProperty( 1, "p" ) ).iterator() );
@@ -146,7 +146,7 @@ public class TxStateTransactionDataViewTest
     public void correctlySaysRelIsDeleted() throws Exception
     {
         // Given
-        state.relationshipDoDelete( 1l, 1l, 2l, 1 );
+        state.relationshipDoDelete( 1l, 1, 1l, 2l );
 
         Relationship rel = mock( Relationship.class );
         when(rel.getId()).thenReturn( 1l );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -380,9 +380,9 @@ public class TestNeoStore
         String typeName2 = "relationshiptype2";
         transaction.createRelationshipTypeToken( relType2, typeName2 );
         long rel1 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel1, relType1, node1, node2 );
+        transaction.relCreate( rel1, relType1, node1, node2 );
         long rel2 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel2, relType2, node2, node1 );
+        transaction.relCreate( rel2, relType2, node2, node1 );
 
         DefinedProperty r1prop1 = transaction.relAddProperty(
                 rel1, index( "prop1" ), "string1" );
@@ -447,7 +447,7 @@ public class TestNeoStore
         for ( int i = 0; i < 2; i++ )
         {
             long id = nextId( Relationship.class );
-            transaction.relationshipCreate( id, relType1, nodeIds[i], nodeIds[i + 1] );
+            transaction.relCreate( id, relType1, nodeIds[i], nodeIds[i + 1] );
             transaction.relDelete( id );
         }
         for ( int i = 0; i < 3; i++ )
@@ -746,7 +746,7 @@ public class TestNeoStore
             storeLayer.relationshipVisit( rel, new RelationshipVisitor<RuntimeException>()
             {
                 @Override
-                public void visit( long relId, long startNode, long endNode, int type )
+                public void visit( long relId, int type, long startNode, long endNode )
                 {
                     assertEquals( firstNode, startNode );
                     assertEquals( secondNode, endNode );
@@ -1072,7 +1072,7 @@ public class TestNeoStore
         }
         for ( int i = 0; i < 2; i++ )
         {
-            transaction.relationshipCreate( nextId( Relationship.class ),
+            transaction.relCreate( nextId( Relationship.class ),
                     relType1, nodeIds[i], nodeIds[i + 1] );
         }
         commitTx();
@@ -1109,10 +1109,10 @@ public class TestNeoStore
         }
         for ( int i = 0; i < 2; i++ )
         {
-            transaction.relationshipCreate( nextId( Relationship.class ),
+            transaction.relCreate( nextId( Relationship.class ),
                     relType1, nodeIds[i], nodeIds[i + 1] );
         }
-        transaction.relationshipCreate( nextId( Relationship.class ),
+        transaction.relCreate( nextId( Relationship.class ),
                 relType1, nodeIds[0], nodeIds[2] );
         commitTx();
         startTx();
@@ -1145,23 +1145,23 @@ public class TestNeoStore
         }
         for ( int i = 0; i < nodeIds.length / 2; i++ )
         {
-            transaction.relationshipCreate( nextId( Relationship.class ),
+            transaction.relCreate( nextId( Relationship.class ),
                     relType1, nodeIds[i], nodeIds[i * 2] );
         }
         long rel5 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel5, relType1, nodeIds[0], nodeIds[5] );
+        transaction.relCreate( rel5, relType1, nodeIds[0], nodeIds[5] );
         long rel2 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel2, relType1, nodeIds[1], nodeIds[2] );
+        transaction.relCreate( rel2, relType1, nodeIds[1], nodeIds[2] );
         long rel3 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel3, relType1, nodeIds[1], nodeIds[3] );
+        transaction.relCreate( rel3, relType1, nodeIds[1], nodeIds[3] );
         long rel6 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel6, relType1, nodeIds[1], nodeIds[6] );
+        transaction.relCreate( rel6, relType1, nodeIds[1], nodeIds[6] );
         long rel1 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel1, relType1, nodeIds[0], nodeIds[1] );
+        transaction.relCreate( rel1, relType1, nodeIds[0], nodeIds[1] );
         long rel4 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel4, relType1, nodeIds[0], nodeIds[4] );
+        transaction.relCreate( rel4, relType1, nodeIds[0], nodeIds[4] );
         long rel7 = nextId( Relationship.class );
-        transaction.relationshipCreate( rel7, relType1, nodeIds[0], nodeIds[7] );
+        transaction.relCreate( rel7, relType1, nodeIds[0], nodeIds[7] );
         commitTx();
         startTx();
         transaction.relDelete( rel7 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreTransactionTest.java
@@ -629,7 +629,7 @@ public class NeoStoreTransactionTest
         // WHEN
         tx.nodeCreate( nodeId );
         tx.createRelationshipTypeToken( relationshipType, "type" );
-        tx.relationshipCreate( relId, 0, nodeId, nodeId );
+        tx.relCreate( relId, 0, nodeId, nodeId );
         tx.relAddProperty( relId, propertyKeyId,
                 new long[] {1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60, 1l << 60} );
         tx.createPropertyKeyToken( "key", propertyKeyId );
@@ -1115,9 +1115,9 @@ public class NeoStoreTransactionTest
             tx.nodeCreate( nodeId );
             tx.nodeCreate( otherNode1Id );
             tx.nodeCreate( otherNode2Id );
-            tx.relationshipCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode1Id );
+            tx.relCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode1Id );
             // This relationship will cause the switch to dense
-            tx.relationshipCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode2Id );
+            tx.relCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode2Id );
             commitProcess().commit(transactionRepresentationOf( tx ));
             // Just a little validation of assumptions
             assertRelationshipGroupsInOrder( nodeId, type10 );
@@ -1128,7 +1128,7 @@ public class NeoStoreTransactionTest
             TransactionRecordState tx = newWriteTransaction().first();
             long otherNodeId = neoStore.getNodeStore().nextId();
             tx.nodeCreate( otherNodeId );
-            tx.relationshipCreate( neoStore.getRelationshipStore().nextId(), type5, nodeId, otherNodeId );
+            tx.relCreate( neoStore.getRelationshipStore().nextId(), type5, nodeId, otherNodeId );
             commitProcess().commit(transactionRepresentationOf( tx ));
         }
 
@@ -1140,7 +1140,7 @@ public class NeoStoreTransactionTest
             TransactionRecordState tx = newWriteTransaction().first();
             long otherNodeId = neoStore.getNodeStore().nextId();
             tx.nodeCreate( otherNodeId );
-            tx.relationshipCreate( neoStore.getRelationshipStore().nextId(), type15, nodeId, otherNodeId );
+            tx.relCreate( neoStore.getRelationshipStore().nextId(), type15, nodeId, otherNodeId );
             commitProcess().commit(transactionRepresentationOf( tx ));
         }
 
@@ -1228,7 +1228,7 @@ public class NeoStoreTransactionTest
             long other = direction == INCOMING ? nodeId : otherNodeId;
             long relId = nextId( RELATIONSHIP );
             result[i] = relId;
-            tx.relationshipCreate( relId, type, first, other );
+            tx.relCreate( relId, type, first, other );
         }
         return result;
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/TraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TraverserDocIT.java
@@ -20,6 +20,7 @@
 package org.neo4j.server.rest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -231,8 +232,13 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
         assertThat( nodes.size(), is( 5 ) );
         assertThat( getName( nodes.get( 0 ) ), is( "Root" ) );
         assertThat( getName( nodes.get( 1 ) ), is( "Cork" ) );
-        assertThat( getName( nodes.get( 2 ) ), is( "Johan" ) );
-        assertThat( getName( nodes.get( 3 ) ), is( "Mattias" ) );
+
+        // We don't really care about the ordering between Johan and Mattias, we just assert that they
+        // both are there, in between Root/Cork and Banana
+        Set<String> knowsNodes = new HashSet<>( Arrays.asList( "Johan", "Mattias" ) );
+        assertTrue( knowsNodes.remove( getName( nodes.get( 2 ) ) ) );
+        assertTrue( knowsNodes.remove( getName( nodes.get( 3 ) ) ) );
+
         assertThat( getName( nodes.get( 4 ) ), is( "Banana" ) );
     }
 


### PR DESCRIPTION
This completes the move from changing record state at the point of making
that change in the transaction to the point where the transaction is
committed. A side effect of that is that KernelStatement no longer needs
access to TransactionRecordState and so the abstractions gets clearer.

The issue provoking this change was that a transaction could create a
relationship and delete it in the same transaction, with the outcome that
a command was created saying to delete that relationship, even though it
didn't exist before the transaction started. Then if replaying a log
containing such a transaction there would be an exception thrown applying
that transaction where the id of that record couldn't be freed since it
was above highId.

This commit also removes duplicate and unexpected checks for if records
exists at the point of converting transaction state into record state. All
those checks now exist in the KernelAPI, and so they were removed from
TransactionRecordState.
