### PR TITLE
Logs if awaiting transactions to be closed

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/ArrayQueueOutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/ArrayQueueOutOfOrderSequence.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.nioneo.store;
 
 import static java.lang.Math.max;
+import static java.lang.String.format;
 
 /**
  * A crude, synchronized implementation of OutOfOrderSequence. Please implement a faster one if need be.
@@ -59,6 +60,12 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
     {
         highestGapFreeNumber = number;
         outOfOrderQueue.clear();
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return format( "out-of-order-sequence:%d [%s]", highestGapFreeNumber, outOfOrderQueue );
     }
 
     private static class SortedArray
@@ -134,6 +141,21 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
                 array = newArray;
                 cursor = 0;
             }
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder builder = new StringBuilder();
+            for ( int i = 0; i < length; i++ )
+            {
+                long value = array[(cursor+i)%array.length];
+                if ( value != UNSET )
+                {
+                    builder.append( builder.length() > 0 ? "," : "" ).append( value );
+                }
+            }
+            return builder.toString();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/NeoStoreXaDataSource.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.ResourceIterator;
@@ -463,7 +464,7 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
                                     return -1;
                                 }
                             }) );
-            
+
             LogPruneStrategy logPruneStrategy = LogPruneStrategyFactory.fromConfigValue( fs, logFileInformation,
                     logFiles, neoStore, config.get( GraphDatabaseSettings.keep_logical_logs ) );
 
@@ -723,14 +724,7 @@ public class NeoStoreXaDataSource implements NeoStoreProvider, Lifecycle, LogRot
         // TODO 2.2-future what if this will never happen?
         while ( !neoStore.closedTransactionIdIsOnParWithCommittedTransactionId() )
         {
-            try
-            {
-                Thread.sleep( 1 );
-            }
-            catch ( InterruptedException e )
-            {
-                break;
-            }
+            LockSupport.parkNanos( 1_000_000 ); // 1 ms
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/ArrayQueueOutOfOrderSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/ArrayQueueOutOfOrderSequenceTest.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
-import static java.lang.Thread.sleep;
-import static java.lang.Thread.yield;
-import static org.junit.Assert.assertEquals;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
+
+import static java.lang.Thread.sleep;
+import static java.lang.Thread.yield;
+
+import static org.junit.Assert.assertEquals;
 
 public class ArrayQueueOutOfOrderSequenceTest
 {


### PR DESCRIPTION
Maximum every 30 seconds. Can happen when rotating the log or shutting
down. An issue has been observed where there has been an indefinite wait
for closed transactions to catch up on committed transactions and logging
has been put in to help debugging that issue.
