### PR TITLE
[2.1] Recognizes if a node has been indexed multiple times

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeCorrectlyIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeCorrectlyIndexedCheck.java
@@ -121,9 +121,17 @@ public class NodeCorrectlyIndexedCheck implements RecordCheck<NodeRecord, Consis
             IndexRule indexRule,
             IndexReader reader )
     {
-        if ( !reader.hasIndexed( nodeId, propertyValue ) )
+        int count = reader.getIndexedCount( nodeId, propertyValue );
+        if ( count == 0 )
         {
             engine.report().notIndexed( indexRule, propertyValue );
+        }
+        else if ( count == 1 )
+        {   // Nothing to report, all good
+        }
+        else
+        {
+            engine.report().indexedMultipleTimes( indexRule, propertyValue, count );
         }
     }
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -248,6 +248,10 @@ public interface ConsistencyReport
         @Documented
         void notIndexed( IndexRule index, Object propertyValue );
 
+        /** This node was found in the expected index, although multiple times */
+        @Documented
+        void indexedMultipleTimes( IndexRule index, Object propertyValue, int count );
+
         /** There is another node in the unique index with the same property value. */
         @Documented
         void uniqueIndexNotUnique( IndexRule index, Object propertyValue, long duplicateNodeId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexReader.java
@@ -41,9 +41,9 @@ public interface IndexReader extends Resource
         }
 
         @Override
-        public boolean hasIndexed( long nodeId, Object propertyValue )
+        public int getIndexedCount( long nodeId, Object propertyValue )
         {
-            return false;
+            return 0;
         }
 
         @Override
@@ -56,5 +56,5 @@ public interface IndexReader extends Resource
      * Verifies that the given nodeId is indexed with the given property value, and returns true if that's
      * the case. Returns false otherwise.
      */
-    boolean hasIndexed( long nodeId, Object propertyValue );
+    int getIndexedCount( long nodeId, Object propertyValue );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -128,9 +128,9 @@ class HashBasedIndex extends InMemoryIndexImplementation
     }
 
     @Override
-    public boolean hasIndexed( long nodeId, Object propertyValue )
+    public int getIndexedCount( long nodeId, Object propertyValue )
     {
         Set<Long> canditates = data.get( propertyValue );
-        return canditates != null && canditates.contains( nodeId );
+        return canditates != null && canditates.contains( nodeId ) ? 1 : 0;
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
@@ -60,7 +60,7 @@ class LuceneIndexAccessorReader implements IndexReader
     }
 
     @Override
-    public boolean hasIndexed( long nodeId, Object propertyValue )
+    public int getIndexedCount( long nodeId, Object propertyValue )
     {
         Query nodeIdQuery = new TermQuery( documentLogic.newQueryForChangeOrRemove( nodeId ) );
         Query valueQuery = documentLogic.newQuery( propertyValue );
@@ -71,7 +71,7 @@ class LuceneIndexAccessorReader implements IndexReader
         {
             Hits hits = new Hits( searcher, nodeIdAndValueQuery, null );
             // A <label,propertyKeyId,nodeId> tuple should only match at most a single propertyValue
-            return hits.length() == 1;
+            return hits.length();
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
for a given property. Previously a "notIndexed" report would be filed and
communicate the belief that the node wasn't indexed properly.
