### PR TITLE
[1.9] If a Buffer object is backed by direct buffer, de-allocate it on close.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/BufferTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/BufferTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+import sun.misc.Cleaner;
+import sun.nio.ch.DirectBuffer;
+
+import org.neo4j.test.ReflectionUtil;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class BufferTest
+{
+    @Test
+    public void shouldDisallowAccessAfterClose() throws Exception
+    {
+        // Given
+        Buffer buf = new Buffer( null, ByteBuffer.allocateDirect( 16 ) );
+
+        // When
+        buf.close();
+
+        // Then
+        try
+        {
+            buf.get();
+            fail("Should not have allowed access");
+        }
+        catch(AssertionError e)
+        {
+            // ok
+        }
+    }
+
+    @Test
+    public void shouldCallCleanWhenOnClose() throws Exception
+    {
+        // Given
+        final ByteBuffer directBuffer = ByteBuffer.allocateDirect( 10 );
+        final Cleaner cleaner = spy( ((DirectBuffer) directBuffer).cleaner() );
+        ReflectionUtil.setPrivateField( directBuffer, "cleaner", Cleaner.class, cleaner );
+
+        // When
+        new Buffer( null, directBuffer ).close();
+
+        // Then
+        verify( cleaner, times( 1 ) ).clean();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/ReflectionUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ReflectionUtil.java
@@ -57,6 +57,20 @@ public class ReflectionUtil
         return fieldType.cast( field.get( target ) );
     }
 
+    public static <T> T setPrivateField( Object target, String fieldName, Class<T> fieldType, T value ) throws Exception
+    {
+        Class<?> type = target.getClass();
+        Field field = getField( fieldName, type );
+        if ( !fieldType.isAssignableFrom( field.getType() ) )
+        {
+            throw new IllegalArgumentException( "Field type does not match " + field.getType() + " is no subclass of " +
+                    "" + fieldType );
+        }
+        field.setAccessible( true );
+        field.set( target, value );
+        return fieldType.cast( field.get( target ) );
+    }
+
     private static Field getField( String fieldName, Class<? extends Object> type ) throws NoSuchFieldException
     {
         if ( type == null )


### PR DESCRIPTION
This uses the explicit cleaner mechanism attached to direct buffers, and adds
a set of assertions ensuring buffers are not re-used after this call.

There is no unit test for the cleaner call itself, as I can't think of a
straight-forward way to mock a DirectBuffer+ByteBuffer combo (lots of final
things there) - and because that code is merely four lines, it seems straight
forward enough as it is.

This commit should be possible to verify the effects of by using an external
tool that lists what regions of files the neo process has memory mapped while
it is under significant load (enough to cause a lot of PWP refreshes, but not
enough to trigger full GC).
