### PR TITLE
No leftover dirs during upgrade

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -446,7 +446,7 @@ public abstract class InternalAbstractGraphDatabase
         this.monitors = createMonitors();
 
         storeMigrationProcess = new StoreUpgrader( createUpgradeConfiguration(), fileSystem,
-                monitors.newMonitor( StoreUpgrader.Monitor.class ) );
+                monitors.newMonitor( StoreUpgrader.Monitor.class ), logging );
 
         // Apply autoconfiguration for memory settings
         AutoConfigurator autoConfigurator = new AutoConfigurator( fileSystem,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
@@ -79,11 +79,9 @@ public interface StoreMigrationParticipant extends Resource
      * @param migrationDir directory where the
      * {@link #migrate(FileSystemAbstraction, File, File, DependencyResolver) migration} put its files.
      * @param storeDir directory the store directory of the to move the migrated files to.
-     * @param leftOversDir directory to store files that are no longer applicable to the new version.
      * @throws IOException if unable to move one or more files.
      */
-    void moveMigratedFiles( FileSystemAbstraction fileSystem, File migrationDir, File storeDir,
-            File leftOversDir ) throws IOException;
+    void moveMigratedFiles( FileSystemAbstraction fileSystem, File migrationDir, File storeDir ) throws IOException;
 
     /**
      * Closes any resources kept open by this migration participant.
@@ -135,7 +133,7 @@ public interface StoreMigrationParticipant extends Resource
 
         @Override
         public void moveMigratedFiles( FileSystemAbstraction fileSystem,
-                File migrationDirectory, File workingDirectory, File leftOversDirectory ) throws IOException
+                File migrationDirectory, File workingDirectory ) throws IOException
         {
             throw new UnsupportedOperationException( "Should not have been called" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationTool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationTool.java
@@ -54,7 +54,8 @@ public class StoreMigrationTool
     public void run( String legacyStoreDirectory, Config config, Logging logging, StoreUpgrader.Monitor monitor )
     {
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
-        StoreUpgrader migrationProcess = new StoreUpgrader( new ConfigMapUpgradeConfiguration( config ), fs, monitor );
+        ConfigMapUpgradeConfiguration upgradeConfiguration = new ConfigMapUpgradeConfiguration( config );
+        StoreUpgrader migrationProcess = new StoreUpgrader( upgradeConfiguration, fs, monitor, logging );
 
         // Add the kernel store migrator
         config = StoreFactory.configForStoreDir( config, new File( legacyStoreDirectory ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -358,12 +358,11 @@ public class StoreMigrator extends StoreMigrationParticipant.Adapter
     }
 
     @Override
-    public void moveMigratedFiles( FileSystemAbstraction fileSystem, File migrationDir,
-            File storeDir, File leftOversDir ) throws IOException
+    public void moveMigratedFiles( FileSystemAbstraction fs, File migrationDir, File storeDir ) throws IOException
     {
         // The batch importer will create a whole store. so
         // Disregard the new and empty node/relationship".id" files, i.e. reuse the existing id files
-        StoreFile20.deleteIdFile( fileSystem, migrationDir, allExcept( StoreFile20.RELATIONSHIP_GROUP_STORE ) );
+        StoreFile20.deleteIdFile( fs, migrationDir, allExcept( StoreFile20.RELATIONSHIP_GROUP_STORE ) );
 
         Iterable<StoreFile20> filesToMove;
         if ( versionToUpgradeFrom.equals( Legacy19Store.LEGACY_VERSION ) )
@@ -390,19 +389,13 @@ public class StoreMigrator extends StoreMigrationParticipant.Adapter
                     StoreFile20.RELATIONSHIP_GROUP_STORE);
         }
 
-        // Move the current ones into the leftovers directory
-        StoreFile20.move( fileSystem, storeDir, leftOversDir, filesToMove,
-                true,  // allow to skip non existent source files
-                false, // not allow to overwrite target files
-                StoreFileType.STORE );
-
         // Move the migrated ones into the store directory
-        StoreFile20.move( fileSystem, migrationDir, storeDir, filesToMove,
+        StoreFile20.move( fs, migrationDir, storeDir, filesToMove,
                 true, // allow to skip non existent source files
                 true, // allow to overwrite target files
                 StoreFileType.values() );
 
-        StoreFile20.ensureStoreVersion( fileSystem, storeDir, StoreFile20.currentStoreFiles() );
+        StoreFile20.ensureStoreVersion( fs, storeDir, StoreFile20.currentStoreFiles() );
 
         legacyLogFiles.moveRewrittenNeoLogs( migrationDir, storeDir );
         legacyLogFiles.moveRewrittenLuceneLogs( migrationDir, storeDir );

--- a/community/neo4j/src/test/java/upgrade/StoreMigratorFrom20IT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreMigratorFrom20IT.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.transaction.xaframework.LogEntry;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
@@ -217,7 +218,8 @@ public class StoreMigratorFrom20IT
 
     private StoreUpgrader upgrader( StoreMigrator storeMigrator )
     {
-        StoreUpgrader upgrader = new StoreUpgrader( ALLOW_UPGRADE, fs, StoreUpgrader.NO_MONITOR );
+        DevNullLoggingService logging = new DevNullLoggingService();
+        StoreUpgrader upgrader = new StoreUpgrader( ALLOW_UPGRADE, fs, StoreUpgrader.NO_MONITOR, logging );
         upgrader.addParticipant( storeMigrator );
         return upgrader;
     }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
+import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 
@@ -89,7 +90,8 @@ public class StoreUpgraderInterruptionTestIT
 
     private StoreUpgrader newUpgrader( StoreMigrator migrator )
     {
-        StoreUpgrader upgrader = new StoreUpgrader( ALLOW_UPGRADE, fileSystem, StoreUpgrader.NO_MONITOR );
+        DevNullLoggingService logging = new DevNullLoggingService();
+        StoreUpgrader upgrader = new StoreUpgrader( ALLOW_UPGRADE, fileSystem, StoreUpgrader.NO_MONITOR, logging );
         upgrader.addParticipant( migrator );
         return upgrader;
     }


### PR DESCRIPTION
Migration no longer creates leftover dir containing partial store backup.
Present leftover dirs and abandoned upgrade temporary dirs are cleaned up on startup.
