### PR TITLE
[2.0] Solves shortest path end points when they are missing

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/ExecutionPlanBuilder.scala
@@ -210,7 +210,8 @@ The Neo4j Team""")
       new StartPointBuilder,
       new MatchBuilder,
       new UnwindBuilder,
-      new ShortestPathBuilder
+      new ShortestPathBuilder,
+      new DisconnectedShortestPathEndPointsBuilder
     )
   }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilder.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilder.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.executionplan.builders
+
+import org.neo4j.cypher.internal.compiler.v2_0.commands.{Predicate, ShortestPath}
+import org.neo4j.cypher.internal.compiler.v2_0.executionplan.{ExecutionPlanInProgress, PlanBuilder}
+import org.neo4j.cypher.internal.compiler.v2_0.spi.PlanContext
+
+
+class DisconnectedShortestPathEndPointsBuilder extends PlanBuilder {
+  def canWorkWith(plan: ExecutionPlanInProgress, ctx: PlanContext) = unsolvedEndPoints(plan).nonEmpty
+
+  def apply(plan: ExecutionPlanInProgress, ctx: PlanContext): ExecutionPlanInProgress = {
+    val nodesToAdd = unsolvedEndPoints(plan)
+    val allPredicates = plan.query.where.map(_.token)
+
+    val startPoints: Set[RatedStartItem] =
+      nodesToAdd.map(key => NodeFetchStrategy.findStartStrategy(key, allPredicates, ctx, plan.pipe.symbols)).toSet
+
+    val singleNodeToAdd: RatedStartItem = startPoints.toSeq.sortBy(_.rating).head
+
+    val filteredWhere = singleNodeToAdd.solvedPredicates.foldLeft(plan.query.where) {
+      (currentWhere: Seq[QueryToken[Predicate]], predicate: Predicate) =>
+        currentWhere.replace(Unsolved(predicate), Solved(predicate))
+    }
+
+    plan.copy(query = plan.query.copy(start = plan.query.start :+ Unsolved(singleNodeToAdd.s), where = filteredWhere))
+  }
+
+  private def unsolvedEndPoints(plan: ExecutionPlanInProgress): Set[String] = {
+    val shortestPathEndPoints: Set[String] = plan.query.patterns.collect {
+      case Unsolved(ShortestPath(_, start, end, _, _, _, _, _)) => Seq(start.name, end.name)
+    }.flatten.toSet
+
+    shortestPathEndPoints.filter {
+      case p => !plan.query.start.exists(startItem => p == startItem.token.identifierName)
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilderTest.scala
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_0.executionplan.builders
+
+import org.junit.Test
+import org.neo4j.cypher.internal.compiler.v2_0.commands._
+import org.neo4j.cypher.internal.compiler.v2_0.executionplan.PartiallySolvedQuery
+import org.neo4j.cypher.internal.compiler.v2_0.mutation.UpdateAction
+import org.neo4j.graphdb.Direction
+import org.scalatest.mock.MockitoSugar
+
+class DisconnectedShortestPathEndPointsBuilderTest extends BuilderTest with MockitoSugar {
+  def builder = new DisconnectedShortestPathEndPointsBuilder
+
+  val identifier = "n"
+  val otherIdentifier = "p"
+  val shortestPath = ShortestPath("p",
+    SingleNode(identifier), SingleNode(otherIdentifier), Seq.empty, Direction.OUTGOING, None, single = true, None)
+
+  @Test
+  def should_add_nodes_for_shortest_path() {
+    // Given
+    val query = q(
+      patterns = Seq(shortestPath)
+    )
+
+    // When
+    val step1 = assertAccepts(query)
+    // The builder only solves a single node at the time, we we run it through twice
+    val plan = assertAccepts(step1.pipe, step1.query)
+
+    // Then
+    assert(plan.query.start.toList ===
+           Seq(
+             Unsolved(AllNodes(identifier)),
+             Unsolved(AllNodes(otherIdentifier))))
+  }
+
+  @Test
+  def should_not_add_nodes_when_they_already_exist() {
+    // Given
+    val query = q(
+      start = Seq(
+        AllNodes(identifier),
+        AllNodes(otherIdentifier)),
+      patterns = Seq(shortestPath)
+    )
+
+    // When Then
+    assertRejects(query)
+  }
+
+  @Test
+  def should_add_the_missing_nodes_when_one_end_is_done() {
+    // Given
+    val query = q(
+      start = Seq(
+        AllNodes(identifier)
+      ),
+      patterns = Seq(shortestPath)
+    )
+
+    // When
+    val plan = assertAccepts(query)
+
+    // Then
+    assert(plan.query.start.toList ===
+           Seq(
+             Unsolved(AllNodes(identifier)),
+             Unsolved(AllNodes(otherIdentifier))))
+  }
+
+  private def q(start: Seq[StartItem] = Seq(),
+                where: Seq[Predicate] = Seq(),
+                updates: Seq[UpdateAction] = Seq(),
+                patterns: Seq[Pattern] = Seq(),
+                returns: Seq[ReturnColumn] = Seq(),
+                tail: Option[PartiallySolvedQuery] = None) =
+    PartiallySolvedQuery().copy(
+      start = start.map(Unsolved(_)),
+      where = where.map(Unsolved(_)),
+      patterns = patterns.map(Unsolved(_)),
+      returns = returns.map(Unsolved(_)),
+      updates = updates.map(Unsolved(_)),
+      tail = tail
+    )
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1050,4 +1050,19 @@ RETURN x0.name""")
     count should not equal(0)
     count should not equal(100)
   }
+
+  test("should return shortest paths when only one side is bound") {
+    val a = createLabeledNode("A")
+    val b = createLabeledNode("B")
+    val r1 = relate(a, b)
+
+    val result = execute("match (a:A) match p = shortestPath( a-[*]->(b:B) ) return p").toList.head("p").asInstanceOf[Path]
+
+    graph.inTx {
+      result.startNode() should equal(a)
+      result.endNode() should equal(b)
+      result.length() should equal(1)
+      result.lastRelationship() should equal (r1)
+    }
+  }
 }


### PR DESCRIPTION
This commit solves a problem with patterns where only one side
of a shortest path is bound, Neo4j failed to build an execution
plan.
