### PR TITLE
Fix a transaction state bug for property remove+add combo

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxStateImpl.java
@@ -488,7 +488,9 @@ public final class TxStateImpl implements TxState
         }
         else
         {
-            getOrCreateNodeState( nodeId ).addProperty( newProperty );
+            NodeState nodeState = getOrCreateNodeState( nodeId );
+//            nodeState.
+            nodeState.addProperty( newProperty );
             nodePropertyChanges().addProperty(nodeId, newProperty.propertyKeyId(), newProperty.value());
         }
         legacyState.nodeSetProperty( nodeId, newProperty );
@@ -528,7 +530,7 @@ public final class TxStateImpl implements TxState
     @Override
     public void nodeDoRemoveProperty( long nodeId, DefinedProperty removedProperty )
     {
-        getOrCreateNodeState( nodeId ).removeProperty( removedProperty.propertyKeyId() );
+        getOrCreateNodeState( nodeId ).removeProperty( removedProperty );
         nodePropertyChanges().removeProperty( nodeId, removedProperty.propertyKeyId(),
                 removedProperty.value() );
         legacyState.nodeRemoveProperty( nodeId, removedProperty );
@@ -538,7 +540,7 @@ public final class TxStateImpl implements TxState
     @Override
     public void relationshipDoRemoveProperty( long relationshipId, DefinedProperty removedProperty )
     {
-        getOrCreateRelationshipState( relationshipId ).removeProperty( removedProperty.propertyKeyId() );
+        getOrCreateRelationshipState( relationshipId ).removeProperty( removedProperty );
         legacyState.relationshipRemoveProperty( relationshipId, removedProperty );
         hasChanges = true;
     }
@@ -546,7 +548,7 @@ public final class TxStateImpl implements TxState
     @Override
     public void graphDoRemoveProperty( DefinedProperty removedProperty )
     {
-        getOrCreateGraphState().removeProperty( removedProperty.propertyKeyId() );
+        getOrCreateGraphState().removeProperty( removedProperty );
         legacyState.graphRemoveProperty( removedProperty );
         hasChanges = true;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/PropertyContainerStateTest.java
@@ -32,7 +32,6 @@ import static org.neo4j.kernel.api.properties.Property.stringProperty;
 
 public class PropertyContainerStateTest
 {
-
     @Test
     public void shouldListAddedProperties() throws Exception
     {
@@ -40,7 +39,7 @@ public class PropertyContainerStateTest
         PropertyContainerState state = new PropertyContainerState( 1 );
         state.addProperty( stringProperty( 1, "Hello" ) );
         state.addProperty( stringProperty( 2, "Hello" ) );
-        state.removeProperty( 1 );
+        state.removeProperty( stringProperty( 1, "Hello" ) );
 
         // When
         Iterator<DefinedProperty> added  = state.addedProperties();
@@ -74,7 +73,7 @@ public class PropertyContainerStateTest
         PropertyContainerState state = new PropertyContainerState( 1 );
         state.addProperty( stringProperty( 1, "Hello" ) );
         state.addProperty( stringProperty( 2, "Hello" ) );
-        state.removeProperty( 3 );
+        state.removeProperty( stringProperty( 3, "ShouldBeRemoved" ) );
 
         // When
         Iterator<DefinedProperty> props = state.augmentProperties( IteratorUtil.iterator(
@@ -85,6 +84,23 @@ public class PropertyContainerStateTest
         assertThat( IteratorUtil.asList( props ),
                 equalTo(asList( stringProperty( 4, "ShouldShowUp" ), stringProperty( 1, "Hello" ),
                                 stringProperty( 2, "Hello" ))) );
+    }
+
+    @Test
+    public void shouldConvertAddRemoveToChange() throws Exception
+    {
+        // Given
+        PropertyContainerState state = new PropertyContainerState( 1 );
+
+        // When
+        state.removeProperty( stringProperty( 4, "a value" ) );
+        state.addProperty(    stringProperty( 4, "another value" ) );
+
+        // Then
+        assertThat( IteratorUtil.asList( state.changedProperties() ),
+                equalTo(asList( stringProperty( 4, "another value" ) )) );
+        assertFalse( state.addedProperties().hasNext() );
+        assertFalse( state.removedProperties().hasNext() );
     }
 
 }


### PR DESCRIPTION
Resolve an issue where discrete remove+add operations on an existing property
is not properly translated to a change operation, but rather is translated to
an add operation.
