### PR TITLE
[master] Do id freeing on rollback

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -780,6 +780,25 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                         "Could not drop created constraint indexes" );
             }
 
+            // Free any acquired id's
+            if (txState != null)
+            {
+                txState.accept( new TxState.VisitorAdapter()
+                {
+                    @Override
+                    public void visitCreatedNode( long id )
+                    {
+                        storeLayer.releaseNode(id);
+                    }
+
+                    @Override
+                    public void visitCreatedRelationship( long id, int type, long startNode, long endNode )
+                    {
+                        storeLayer.releaseRelationship( id );
+                    }
+                } );
+            }
+
             if ( hasTxStateWithChanges() )
             {
                 persistenceCache.invalidate( txState );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -543,4 +543,17 @@ public class CacheLayer implements StoreReadLayer
     {
         return diskLayer.reserveRelationship();
     }
+
+    @Override
+    public void releaseNode( long id )
+    {
+        diskLayer.releaseNode( id );
+        persistenceCache.releaseNode(id);
+    }
+
+    @Override
+    public void releaseRelationship( long id )
+    {
+        diskLayer.releaseRelationship( id );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -791,6 +791,18 @@ public class DiskLayer implements StoreReadLayer
     }
 
     @Override
+    public void releaseNode( long id )
+    {
+        nodeStore.freeId( id );
+    }
+
+    @Override
+    public void releaseRelationship( long id )
+    {
+        relationshipStore.freeId( id );
+    }
+
+    @Override
     public Cursor expand( Cursor inputCursor, NeoRegister.Node.In nodeId, Register.Object.In<int[]> types, Register
             .Object.In<Direction> expandDirection, NeoRegister.Relationship.Out relId, NeoRegister.RelType.Out
             relType, Register.Object.Out<Direction> direction, NeoRegister.Node.Out startNodeId, NeoRegister.Node.Out

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
@@ -496,6 +496,11 @@ public class PersistenceCache
         nodeCache.put( new NodeImplReservation( nodeId ) );
     }
 
+    public void releaseNode(long nodeId)
+    {
+        nodeCache.remove( nodeId );
+    }
+
     /**
      * Used when rolling back a transaction. Node reservations are put in cache up front, so those have
      * to be removed when rolling back.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -181,6 +181,10 @@ public interface StoreReadLayer
      */
     long reserveRelationship();
 
+    void releaseNode( long id );
+
+    void releaseRelationship( long id );
+
     Cursor expand( Cursor inputCursor, NeoRegister.Node.In nodeId, Register.Object.In<int[]> types,
                    Register.Object.In<Direction> expandDirection, NeoRegister.Relationship.Out relId,
                    NeoRegister.RelType.Out relType, Register.Object.Out<Direction> direction,

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IdReuseTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IdReuseTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class IdReuseTest
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder(  );
+
+    @Test
+    public void shouldReuseNodeIdsFromRolledBackTransaction() throws Exception
+    {
+        // Given
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( folder.getRoot().getAbsolutePath() );
+        try (Transaction tx = db.beginTx())
+        {
+            db.createNode();
+
+            tx.failure();
+        }
+
+        db.shutdown();
+        db = new GraphDatabaseFactory().newEmbeddedDatabase( folder.getRoot().getAbsolutePath() );
+
+        // When
+        Node node;
+        try (Transaction tx = db.beginTx())
+        {
+            node = db.createNode();
+
+            tx.success();
+        }
+
+        // Then
+        assertThat(node.getId(), equalTo(0L));
+    }
+
+    @Test
+    public void shouldReuseRelationshipIdsFromRolledBackTransaction() throws Exception
+    {
+        // Given
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( folder.getRoot().getAbsolutePath() );
+        Node node1, node2;
+        try (Transaction tx = db.beginTx())
+        {
+            node1 = db.createNode();
+            node2 = db.createNode();
+
+            tx.success();
+        }
+
+        try (Transaction tx = db.beginTx())
+        {
+            node1.createRelationshipTo( node2, DynamicRelationshipType.withName( "LIKE" ) );
+
+            tx.failure();
+        }
+
+        db.shutdown();
+        db = new GraphDatabaseFactory().newEmbeddedDatabase( folder.getRoot().getAbsolutePath() );
+
+        // When
+        Relationship relationship;
+        try (Transaction tx = db.beginTx())
+        {
+            node1 = db.getNodeById(node1.getId());
+            node2 = db.getNodeById(node2.getId());
+            relationship = node1.createRelationshipTo( node2, DynamicRelationshipType.withName( "LIKE" ) );
+
+            tx.success();
+        }
+
+        // Then
+        assertThat(relationship.getId(), equalTo(0L));
+    }
+}


### PR DESCRIPTION
This PR fixes so that transaction rollbacks free up the node and relationship id's that were allocated during the transaction. They will only be reused on restart though, as before.
