### PR TITLE
Java subprocesses that we launch must be headless.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
@@ -137,13 +137,14 @@ public abstract class SubProcess<T, P> implements Serializable
             {
                 if ( debugger != null )
                 {
-                    process = start( "java", "-Xmx1G", debugger.listen(), "-cp",
-                            classPath( System.getProperty( "java.class.path" ) ), SubProcess.class.getName(),
-                            serialize( callback ) );
+                    process = start( "java", "-Xmx1G", debugger.listen(), "-Djava.awt.headless=true",
+                            "-cp", classPath( System.getProperty( "java.class.path" ) ),
+                            SubProcess.class.getName(), serialize( callback ) );
                 }
                 else
                 {
-                    process = start( "java", "-Xmx1G", "-cp", classPath( System.getProperty( "java.class.path" ) ),
+                    process = start( "java", "-Xmx1G", "-Djava.awt.headless=true",
+                            "-cp", classPath( System.getProperty( "java.class.path" ) ),
                             SubProcess.class.getName(), serialize( callback ) );
                 }
                 pid = getPid( process );

--- a/community/neo4j/src/test/java/recovery/CreateTransactionsAndDie.java
+++ b/community/neo4j/src/test/java/recovery/CreateTransactionsAndDie.java
@@ -103,8 +103,8 @@ public class CreateTransactionsAndDie
     private static int createUncleanDb( String dir, int nrOf2PcTransactionsToRecover ) throws Exception
     {
         Process process = Runtime.getRuntime().exec( new String[]{
-            "java", "-cp", System.getProperty( "java.class.path" ), CreateTransactionsAndDie.class.getName(),
-            dir, "" + nrOf2PcTransactionsToRecover
+                "java", "-cp", System.getProperty( "java.class.path" ), "-Djava.awt.headless=true",
+                CreateTransactionsAndDie.class.getName(), dir, "" + nrOf2PcTransactionsToRecover
         } );
 
         return new ProcessStreamHandler( process, true ).waitForResult();

--- a/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
@@ -55,8 +55,9 @@ public class TestRecoveryMultipleDataSources
     {
         // Given (create transactions and kill process, leaving it needing for recovery)
         deleteRecursively( new File( dir ) );
-        assertEquals( 0, getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
-                getClass().getName() } ).waitFor() );
+        assertEquals( 0, getRuntime().exec( new String[] {
+                "java", "-Djava.awt.headless=true",  "-cp", getProperty( "java.class.path" ), getClass().getName()
+        } ).waitFor() );
         
         // When
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( dir );

--- a/community/neo4j/src/test/java/recovery/TestRecoveryNotHappening.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryNotHappening.java
@@ -79,8 +79,10 @@ public class TestRecoveryNotHappening
 
     private void create2PCTransactionAndShutDownNonClean() throws Exception
     {
-        assertEquals( 0, getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
-                getClass().getName(), storeDirectory.getAbsolutePath() } ).waitFor() );
+        assertEquals( 0, getRuntime().exec( new String[] {
+                "java", "-cp", getProperty( "java.class.path" ), "-Djava.awt.headless=true",
+                getClass().getName(), storeDirectory.getAbsolutePath()
+        } ).waitFor() );
     }
     
     private void modifyTransactionMakingItLookPreparedAndUncompleted() throws Exception

--- a/community/shell/src/test/java/org/neo4j/shell/TestRmiPublication.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestRmiPublication.java
@@ -45,7 +45,7 @@ public class TestRmiPublication
     {
         String dir = forTest( getClass() ).directory( "client", true ).getAbsolutePath();
         return waitForExit( getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
-                mainClass.getName(), dir } ), 20 );
+                "-Djava.awt.headless=true", mainClass.getName(), dir } ), 20 );
     }
 
     private int waitForExit( Process process, int maxSeconds ) throws InterruptedException


### PR DESCRIPTION
This is necessary for running tests on the build agents. This only
affects 1.9 because that runs against Java 6 where JMX insists on
starting up AWT even when it doesn't need a GUI.
