### PR TITLE
[2.1] Don't use exceptions for control flow

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -146,7 +146,6 @@ public class LockingStatementOperations implements
 
     @Override
     public IndexDescriptor indexesGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKey )
-            throws SchemaRuleNotFoundException
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaReadDelegate.indexesGetForLabelAndPropertyKey( state, labelId, propertyKey );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -298,7 +298,13 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws SchemaRuleNotFoundException
     {
         statement.assertOpen();
-        return schemaRead().indexesGetForLabelAndPropertyKey( statement, labelId, propertyKeyId );
+        IndexDescriptor descriptor = schemaRead().indexesGetForLabelAndPropertyKey( statement, labelId, propertyKeyId );
+        if ( descriptor == null )
+        {
+            throw new SchemaRuleNotFoundException( "Index rule for label:" + labelId + " and property:" +
+                                                   propertyKeyId + " not found" );
+        }
+        return descriptor;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
@@ -34,10 +34,8 @@ public interface SchemaReadOperations
 {
     /**
      * Returns the descriptor for the given labelId and propertyKey.
-     * @throws SchemaRuleNotFoundException
      */
-    IndexDescriptor indexesGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKey )
-            throws SchemaRuleNotFoundException;
+    IndexDescriptor indexesGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKey );
 
     /**
      * Get all indexes for a label.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.state;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -193,23 +194,11 @@ public class SchemaTransactionStateTest
         txContext.indexDrop( state, rule );
 
         // WHEN
-        assertException( getIndexRule(), SchemaRuleNotFoundException.class );
+        assertNull( txContext.indexesGetForLabelAndPropertyKey( state, labelId1, key1 ) );
         Iterator<IndexDescriptor> rulesByLabel = txContext.indexesGetForLabel( state, labelId1 );
 
         // THEN
         assertEquals( emptySetOf( IndexDescriptor.class ), asSet( rulesByLabel ) );
-    }
-
-    private ExceptionExpectingFunction<SchemaRuleNotFoundException> getIndexRule()
-    {
-        return new ExceptionExpectingFunction<SchemaRuleNotFoundException>()
-        {
-            @Override
-            public void call() throws SchemaRuleNotFoundException
-            {
-                txContext.indexesGetForLabelAndPropertyKey( state, labelId1, key1 );
-            }
-        };
     }
 
     private interface ExceptionExpectingFunction<E extends Exception>
@@ -223,7 +212,7 @@ public class SchemaTransactionStateTest
         try
         {
             function.call();
-            fail( "Should have thrown " + exception.getClass().getName() + " exception" );
+            fail( "Should have thrown " + exception.getName() + " exception" );
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
Instead of throwing exception from `indexesGetForLabelAndPropertyKey()`, return `null`. This will perform better since null checks are almost free, while throwing exceptions (especially building stack traces) are quite costly.

The problem of signalling index not present through an exception became apparent after we started building up indexed state for indexed label/property combinations in the transaction state.
