### PR TITLE
Browser: Fix fullscreen editor.

### DIFF
--- a/community/browser/app/index.jade
+++ b/community/browser/app/index.jade
@@ -18,7 +18,7 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     link(rel="stylesheet", href="styles/main.css")
     //endbuild
 
-  body(ng-class="{'connection-error': offline, 'show-drawer': isDrawerShown, 'modal-shown': isPopupShown}", ng-controller="LayoutCtrl", keydown="globalKey($event)")
+  body(ng-class="{'connection-error': offline, 'show-drawer': isDrawerShown, 'modal-shown': isPopupShown}", ng-controller="LayoutCtrl", keyup="globalKey($event)")
 
 
     //if lt IE 9
@@ -101,7 +101,7 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     script(src='scripts/init/commandInterpreters.js')
     script(src='scripts/controllers/Stream.js')
     script(src='scripts/controllers/Layout.js')
-    script(src='scripts/directives/keydown.js')
+    script(src='scripts/directives/keyup.js')
     script(src='scripts/filters/uncomment.js')
     script(src='scripts/filters/autotitle.js')
     // script(src='scripts/filters/couldBeCommand.js')

--- a/community/browser/app/scripts/controllers/Layout.coffee
+++ b/community/browser/app/scripts/controllers/Layout.coffee
@@ -64,6 +64,13 @@ angular.module('neo4jApp.controllers')
 
         _codeMirror.on "change", (cm) ->
           $scope.editorChanged(cm)
+
+        _codeMirror.on 'keyup', (cm, e) ->
+          return unless e.keyCode is 27 #esc
+          $timeout(->
+            cm.refresh()
+          , 0)
+
         _codeMirror.on "focus", (cm) ->
           $scope.editorChanged(cm)
 

--- a/community/browser/app/scripts/directives/keyup.coffee
+++ b/community/browser/app/scripts/directives/keyup.coffee
@@ -21,13 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 angular.module('neo4jApp.directives')
-  .directive('keydown', [
+  .directive('keyup', [
     '$parse',
     ($parse) ->
       restrict: 'A',
       link: (scope, elem, attr, ctrl) ->
-        elem.bind('keydown', (e)->
-          exp = $parse(attr.keydown)
+        elem.bind('keyup', (e)->
+          exp = $parse(attr.keyup)
           scope.$apply(->exp(scope, {'$event': e}))
         )
   ])


### PR DESCRIPTION
- Toggle with 'esc' key (as before).
- Refresh Codemirror editor upon release of esc key.
- Adding new directive to handle global keyup events.
- Listening on 'keyup' instead of 'keydown'.
  'keydown' triggers lots of times when keep pressing key.
- Delete keydown directive file since it's not used.
