### PR TITLE
Add semantic checking to unique constraints in AST

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/SemanticChecker.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/SemanticChecker.scala
@@ -32,8 +32,6 @@ class SemanticChecker(semanticCheckMonitor: SemanticCheckMonitor) {
     if (semanticErrors.nonEmpty) {
       semanticCheckMonitor.finishSemanticCheckError(queryText, semanticErrors)
     } else {
-      val query = statement.asQuery
-      query.verifySemantics()
       semanticCheckMonitor.finishSemanticCheckSuccess(queryText)
     }
     semanticErrors.map {

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Command.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Command.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_1.ast
 
 import org.neo4j.cypher.internal.compiler.v2_1._
+import symbols._
 
 sealed trait Command extends Statement
 
@@ -31,10 +32,19 @@ case class DropIndex(label: LabelName, property: PropertyKeyName)(val position: 
   def semanticCheck = Seq()
 }
 
-case class CreateUniqueConstraint(id: Identifier, label: LabelName, idForProperty: Identifier, propertyKey: PropertyKeyName)(val position: InputPosition) extends Command {
-  def semanticCheck = Seq()
+trait UniqueConstraintCommand extends Command with SemanticChecking {
+  def identifier: Identifier
+  def label: LabelName
+  def property: Property
+
+  def semanticCheck =
+    identifier.declare(CTNode.covariant) chain
+    property.semanticCheck(Expression.SemanticContext.Simple) chain
+    when (!property.map.isInstanceOf[ast.Identifier]) {
+      SemanticError("Cannot index nested properties", property.position)
+    }
 }
 
-case class DropUniqueConstraint(id: Identifier, label: LabelName, idForProperty: Identifier, propertyKey: PropertyKeyName)(val position: InputPosition) extends Command {
-  def semanticCheck = Seq()
-}
+case class CreateUniqueConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends UniqueConstraintCommand
+
+case class DropUniqueConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends UniqueConstraintCommand

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/convert/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/convert/StatementConverters.scala
@@ -43,16 +43,16 @@ object StatementConverters {
         commands.DropIndex(s.label.name, Seq(s.property.name))
       case s: ast.CreateUniqueConstraint =>
         commands.CreateUniqueConstraint(
-          id = s.id.name,
+          id = s.identifier.name,
           label = s.label.name,
-          idForProperty = s.idForProperty.name,
-          propertyKey = s.propertyKey.name)
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
       case s: ast.DropUniqueConstraint =>
         commands.DropUniqueConstraint(
-          id = s.id.name,
+          id = s.identifier.name,
           label = s.label.name,
-          idForProperty = s.idForProperty.name,
-          propertyKey = s.propertyKey.name)
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
       case _ =>
         throw new ThisShouldNotHappenError("cleishm", s"Unknown statement during transformation ($statement)")
     }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/IndexOperation.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/IndexOperation.scala
@@ -36,11 +36,6 @@ final case class DropIndex(label: String, propertyKeys: Seq[String], queryString
 
 sealed abstract class UniqueConstraintOperation(_id: String, _label: String, _idForProperty: String, _propertyKey: String,
     _queryString: QueryString = QueryString.empty) extends AbstractQuery {
-  override def verifySemantics() {
-    if ( _id != _idForProperty )
-      throw new InvalidSemanticsException( "Unknown identifier `" + _idForProperty + "`, was expecting `" + _id + "`" )
-  }
-
   def id:String
   def label: String
   def idForProperty: String

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/Command.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_1.ast
 import org.parboiled.scala._
 
 trait Command extends Parser
+  with Expressions
   with Literals
   with Base {
 
@@ -42,13 +43,13 @@ trait Command extends Parser
   }
 
   def CreateUniqueConstraint: Rule1[ast.CreateUniqueConstraint] = rule {
-    group(keyword("CREATE") ~~ ConstraintSyntax) ~~>> (ast.CreateUniqueConstraint(_, _, _, _))
+    group(keyword("CREATE") ~~ ConstraintSyntax) ~~>> (ast.CreateUniqueConstraint(_, _, _))
   }
 
   def DropUniqueConstraint: Rule1[ast.DropUniqueConstraint] = rule {
-    group(keyword("DROP") ~~ ConstraintSyntax) ~~>> (ast.DropUniqueConstraint(_, _, _, _))
+    group(keyword("DROP") ~~ ConstraintSyntax) ~~>> (ast.DropUniqueConstraint(_, _, _))
   }
 
   private def ConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
-    optional(keyword("ASSERT")) ~~ Identifier ~~ "." ~~ PropertyKeyName ~~ keyword("IS UNIQUE")
+    optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ConstraintTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ConstraintTest.scala
@@ -48,6 +48,4 @@ class ConstraintTest extends ParserTest[ast.Command, legacyCommands.AbstractQuer
   }
 
   def convert(astNode: ast.Command): legacyCommands.AbstractQuery = astNode.asQuery
-
-  def Expression: Rule1[ast.Expression] = ???
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -160,14 +160,28 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("should be semantically incorrect to refer to unknown identifier in create constraint") {
     executeAndEnsureError(
       "create constraint on (foo:Foo) bar.name is unique",
-      "Unknown identifier `bar`, was expecting `foo`"
+      "bar not defined (line 1, column 32)"
+    )
+  }
+
+  test("should be semantically incorrect to refer to nexted property in create constraint") {
+    executeAndEnsureError(
+      "create constraint on (foo:Foo) foo.bar.name is unique",
+      "Cannot index nested properties (line 1, column 40)"
     )
   }
 
   test("should be semantically incorrect to refer to unknown identifier in drop constraint") {
     executeAndEnsureError(
       "drop constraint on (foo:Foo) bar.name is unique",
-      "Unknown identifier `bar`, was expecting `foo`"
+      "bar not defined (line 1, column 30)"
+    )
+  }
+
+  test("should be semantically incorrect to refer to nested property in drop constraint") {
+    executeAndEnsureError(
+      "drop constraint on (foo:Foo) foo.bar.name is unique",
+      "Cannot index nested properties (line 1, column 38)"
     )
   }
 


### PR DESCRIPTION
This avoids the unnecessary creation of an additional legacy query tree for every statement.
