### PR TITLE
Ensures transaction committed/closed is in same try block

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -50,10 +50,11 @@ public class TransactionRepresentationCommitProcess implements TransactionCommit
     public long commit( TransactionRepresentation transaction, LockGroup locks ) throws TransactionFailureException
     {
         long transactionId = commitTransaction( transaction );
-        
+
         // apply changes to the store
         try
         {
+            transactionIdStore.transactionCommitted( transactionId );
             storeApplier.apply( transaction, locks, transactionId, recovery );
         }
         // TODO catch different types of exceptions here, some which are OK

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/AbstractPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/AbstractPhysicalTransactionAppender.java
@@ -109,23 +109,16 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
 
     private void afterForce( long transactionId, boolean hasLegacyIndexChanges ) throws IOException
     {
-        try
+        if ( hasLegacyIndexChanges )
         {
-            if ( hasLegacyIndexChanges )
+            try
             {
-                try
-                {
-                    legacyIndexTransactionOrdering.waitFor( transactionId );
-                }
-                catch ( InterruptedException e )
-                {
-                    throw new IOException( "Interrupted while waiting for applying legacy index updates", e );
-                }
+                legacyIndexTransactionOrdering.waitFor( transactionId );
             }
-        }
-        finally
-        {
-            transactionIdStore.transactionCommitted( transactionId );
+            catch ( InterruptedException e )
+            {
+                throw new IOException( "Interrupted while waiting for applying legacy index updates", e );
+            }
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
@@ -63,7 +63,7 @@ public class TransactionRepresentationCommitProcessTest
         TransactionRepresentationStoreApplier storeApplier = mock( TransactionRepresentationStoreApplier.class );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess(
                 logicalTransactionStore, kernelHealth, transactionIdStore, storeApplier, false );
-        
+
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
@@ -75,7 +75,7 @@ public class TransactionRepresentationCommitProcessTest
             assertThat( e.getMessage(), containsString( "Could not append transaction representation to log" ) );
             assertTrue( contains( e, rootCause.getMessage(), rootCause.getClass() ) );
         }
-        
+
         verify( transactionIdStore, times( 0 ) ).transactionCommitted( txId );
     }
 
@@ -96,7 +96,7 @@ public class TransactionRepresentationCommitProcessTest
                 any( TransactionRepresentation.class ), any( LockGroup.class ), eq( txId ), eq( false ) );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess(
                 logicalTransactionStore, kernelHealth, transactionIdStore, storeApplier, false );
-        
+
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
@@ -107,8 +107,9 @@ public class TransactionRepresentationCommitProcessTest
             assertThat( e.getMessage(), containsString( "Could not apply the transaction to the store" ) );
             assertTrue( contains( e, rootCause.getMessage(), rootCause.getClass() ) );
         }
-        
+
         // THEN
+        verify( transactionIdStore, times( 1 ) ).transactionCommitted( txId );
         verify( transactionIdStore, times( 1 ) ).transactionClosed( txId );
         verifyNoMoreInteractions( transactionIdStore );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/AppendAndRotationRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/AppendAndRotationRaceIT.java
@@ -227,6 +227,7 @@ public class AppendAndRotationRaceIT
 
                 try
                 {
+                    transactionIdStore.transactionCommitted( transactionId );
                     // apply
                     parkNanos( random.nextInt( 10 ) * 1_000_000 );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/xaframework/PhysicalTransactionAppenderTest.java
@@ -56,8 +56,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -94,8 +92,8 @@ public class PhysicalTransactionAppenderTest
         appender.append( transaction );
 
         // THEN
-        verify( transactionIdStore, times( 1 ) ).transactionCommitted( txId );
-        try(PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader()))
+        try ( PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel,
+                new VersionAwareLogEntryReader() ) )
         {
             reader.next();
             TransactionRepresentation tx = reader.get().getTransactionRepresentation();
@@ -144,7 +142,6 @@ public class PhysicalTransactionAppenderTest
         appender.append( transaction );
 
         // THEN
-        verify( transactionIdStore, times( 1 ) ).transactionCommitted( txId );
         PhysicalTransactionCursor reader = new PhysicalTransactionCursor( channel, new VersionAwareLogEntryReader() );
         reader.next();
         TransactionRepresentation result = reader.get().getTransactionRepresentation();

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -57,15 +57,19 @@ public class TransactionCommittingResponseUnpacker extends ResponseUnpacker.Adap
                 // read all about it at TransactionAppender#append(CommittedTransactionRepresentation)
                 synchronized ( appender )
                 {
+                    long transactionId = transaction.getCommitEntry().getTxId();
                     if ( appender.append( transaction ) )
                     {
-                        final long transactionId = transaction.getCommitEntry().getTxId();
-                        try (LockGroup locks = new LockGroup())
+                        transactionIdStore.transactionCommitted( transactionId );
+                        try
                         {
-                            // TODO recovery=true needed?
-                            storeApplier.apply( transaction.getTransactionRepresentation(), locks,
-                                                transactionId, true );
-                            handler.accept( transaction );
+                            try ( LockGroup locks = new LockGroup() )
+                            {
+                                // TODO recovery=true needed?
+                                storeApplier.apply( transaction.getTransactionRepresentation(), locks,
+                                                    transactionId, true );
+                                handler.accept( transaction );
+                            }
                         }
                         finally
                         {
@@ -81,8 +85,7 @@ public class TransactionCommittingResponseUnpacker extends ResponseUnpacker.Adap
 
     @Override
     public void init() throws Throwable
-    {
-
+    {   // Nothing to init
     }
 
     @Override
@@ -103,7 +106,6 @@ public class TransactionCommittingResponseUnpacker extends ResponseUnpacker.Adap
 
     @Override
     public void shutdown() throws Throwable
-    {
-
+    {   // Nothing to shut down
     }
 }


### PR DESCRIPTION
to absolutely make sure that a transaction id marked as committed will
have its counterpart, marking as closed, sit in the finally block of
the try block marking as committed.
