### PR TITLE
Disable pretty printing ast nodes for now

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ASTNode.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ASTNode.scala
@@ -31,13 +31,11 @@ trait ASTNode
   with PageDocFormatting /* multi line */
   // with LineDocFormatting  /* single line */
   // with SimpleDocHandler.ToString[ASTNode] /* like default toString() */ {
-  with InternalDocHandler.ToString[ASTNode] /* see InternalDocHandler for more choices */
+  // with InternalDocHandler.ToString[ASTNode] /* see InternalDocHandler for more choices */
 {
 
   import org.neo4j.cypher.internal.compiler.v2_2.Foldable._
   import org.neo4j.cypher.internal.compiler.v2_2.Rewritable._
-
-//  val toStringVal = toString()
 
   def position: InputPosition
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/docgen/InternalDocHandler.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/docgen/InternalDocHandler.scala
@@ -28,8 +28,8 @@ case object InternalDocHandler extends CustomDocHandler[Any] {
   // Remove all except for DefaultDocHandler if you hit any problems with pretty printing
   val docGen: DocGen[Any] =
   // Hook in to see both ast and details
-  //    AstStructureDocGen.lift[Any] ++
-    AstDocHandler.docGen.lift[Any] ++
+//    AstStructureDocGen.lift[Any] ++
+//    AstDocHandler.docGen.lift[Any] ++
     logicalPlanDocGen.lift[Any] ++
     plannerDocGen.lift[Any] ++
     DefaultDocHandler.docGen

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/docgen/plannerDocGen.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/docgen/plannerDocGen.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.docgen
 
-import org.neo4j.cypher.internal.compiler.v2_2.ast.{DescSortItem, AscSortItem, Expression, RelTypeName}
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.perty._
 import org.neo4j.cypher.internal.compiler.v2_2.planner._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
@@ -32,6 +32,11 @@ case object plannerDocGen extends CustomDocGen[Any] {
   import org.neo4j.cypher.internal.compiler.v2_2.perty.Doc._
 
   def newDocDrill = mkDocDrill[Any]() {
+    // ast objects (temporary, shouldn't be here, only exist for tests)
+    case Identifier(name) => inner => AstNameConverter(name).asDoc
+    case _: CountStar => inner => "count(*)"
+
+    // planner objects
     case idName: IdName => inner => idName.asDoc
     case predicate: Predicate => inner => predicate.asDoc(inner)
     case selections: Selections => inner => selections.asDoc(inner)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -930,25 +930,47 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
     val result = query.toString
     val expectation =
-      """GIVEN * MATCH (owner) WITH owner AS `owner`, count(*) AS `xyz`
-        |GIVEN owner, xyz WITH owner AS `owner`, xyz > 0 AS `collection`
-        |GIVEN owner, collection
-        |WITH
-        |  owner AS `owner`,
-        |  collection AS `collection`,
-        |  PatternExpression(
-        |    RelationshipsPattern(
-        |      RelationshipChain(
-        |        NodePattern(Some(owner), ⬨, None, false),
-        |        RelationshipPattern(Some(`  UNNAMED89`), false, ⬨, None, None, BOTH),
-        |        NodePattern(Some(`  UNNAMED92`), ⬨, None, false)
-        |      )
-        |    )
-        |  )
-        |  AS `  FRESHID82`
-        |GIVEN owner,   FRESHID82 WHERE Predicate[  FRESHID82](`  FRESHID82`)
-        |RETURN owner AS `owner`""".stripMargin
-
+    """GIVEN * MATCH (owner) WITH owner AS `owner`, count(*) AS `xyz`
+      |GIVEN owner, xyz
+      |WITH
+      |  owner AS `owner`,
+      |  GreaterThan(xyz, SignedDecimalIntegerLiteral("0")) AS `collection`
+      |GIVEN owner, collection
+      |WITH
+      |  owner AS `owner`,
+      |  collection AS `collection`,
+      |  PatternExpression(
+      |    RelationshipsPattern(
+      |      RelationshipChain(
+      |        NodePattern(Some(owner), ⬨, None, false),
+      |        RelationshipPattern(Some(`  UNNAMED89`), false, ⬨, None, None, BOTH),
+      |        NodePattern(Some(`  UNNAMED92`), ⬨, None, false)
+      |      )
+      |    )
+      |  )
+      |  AS `  FRESHID82`
+      |GIVEN owner,   FRESHID82 WHERE Predicate[  FRESHID82](`  FRESHID82`)
+      |RETURN owner AS `owner`""".stripMargin
+// Use once perty is re-enabled
+//    val expectation =
+//      """GIVEN * MATCH (owner) WITH owner AS `owner`, count(*) AS `xyz`
+//        |GIVEN owner, xyz WITH owner AS `owner`, xyz > 0 AS `collection`
+//        |GIVEN owner, collection
+//        |WITH
+//        |  owner AS `owner`,
+//        |  collection AS `collection`,
+//        |  PatternExpression(
+//        |    RelationshipsPattern(
+//        |      RelationshipChain(
+//        |        NodePattern(Some(owner), ⬨, None, false),
+//        |        RelationshipPattern(Some(`  UNNAMED89`), false, ⬨, None, None, BOTH),
+//        |        NodePattern(Some(`  UNNAMED92`), ⬨, None, false)
+//        |      )
+//        |    )
+//        |  )
+//        |  AS `  FRESHID82`
+//        |GIVEN owner,   FRESHID82 WHERE Predicate[  FRESHID82](`  FRESHID82`)
+//        |RETURN owner AS `owner`""".stripMargin
     result should equal(expectation)
   }
 


### PR DESCRIPTION
We need and know how to fix excessive stack useage of perty; now's not the time for it.

If you want it back for debugging, just un-commment in ASTNode.
