### PR TITLE
Fix an issue reading transaction logs over network.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/InMemoryLogChannel.java
@@ -185,7 +185,7 @@ public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChanne
     {
         if ( asReader.remaining() < i )
         {
-            throw new ReadPastEndException();
+            throw ReadPastEndException.INSTANCE;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadAheadLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadAheadLogChannel.java
@@ -143,7 +143,7 @@ public class ReadAheadLogChannel implements ReadableLogChannel
                 if ( nextChannel == channel )
                 {
                     // no more channels so we cannot satisfy the requested number of bytes
-                    throw new ReadPastEndException();
+                    throw ReadPastEndException.INSTANCE;
                 }
                 channel = nextChannel;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadPastEndException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/ReadPastEndException.java
@@ -27,10 +27,17 @@ import java.nio.channels.ReadableByteChannel;
  * Thrown when reading from a {@link ReadableByteChannel} into a buffer
  * and not enough bytes ({@link ByteBuffer#limit()}) could be read.
  */
-public class ReadPastEndException extends IOException
+public final class ReadPastEndException extends IOException
 {
-    public ReadPastEndException()
+    public static final ReadPastEndException INSTANCE = new ReadPastEndException();
+
+    private ReadPastEndException()
     {
-        super();
+    }
+
+    @Override
+    public Throwable fillInStackTrace()
+    {
+        return this;
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
@@ -48,71 +48,92 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
     @Override
     public byte get() throws IOException
     {
-        if ( delegate.readableBytes() < 1 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readByte();
         }
-        return delegate.readByte();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public short getShort() throws IOException
     {
-        if ( delegate.readableBytes() < 2 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readShort();
         }
-        return delegate.readShort();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public int getInt() throws IOException
     {
-        if ( delegate.readableBytes() < 4 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readInt();
         }
-        return delegate.readInt();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public long getLong() throws IOException
     {
-        if ( delegate.readableBytes() < 8 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readLong();
         }
-        return delegate.readLong();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public float getFloat() throws IOException
     {
-        if ( delegate.readableBytes() < 4 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readFloat();
         }
-        return delegate.readFloat();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public double getDouble() throws IOException
     {
-        if ( delegate.readableBytes() < 8 )
+        try
         {
-            throw new ReadPastEndException();
+            return delegate.readDouble();
         }
-        return delegate.readDouble();
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override
     public void get( byte[] bytes, int length ) throws IOException
     {
-        if ( delegate.readableBytes() < length )
+        try
         {
-            throw new ReadPastEndException();
+            delegate.readBytes( bytes, 0, length );
         }
-        delegate.readBytes( bytes, 0, length );
+        catch( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 
@@ -215,7 +214,6 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     public Response<LockResult> acquireSharedLock( RequestContext context, Locks.ResourceType type, long...
             resourceIds )
     {
-        msgLog.info( "@@@ acquireSharedLock: type: " + type + " resources: " + Arrays.toString( resourceIds ) );
         return sendRequest( HaRequestType210.ACQUIRE_SHARED_LOCK, context,
                 new AcquireLockSerializer( type, resourceIds ), LOCK_RESULT_DESERIALIZER );
     }
@@ -224,8 +222,6 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     public Response<LockResult> acquireExclusiveLock( RequestContext context, Locks.ResourceType type, long...
             resourceIds )
     {
-        msgLog.info( "@@@ acquireExclusiveLock: type: " + type + " resources: " + Arrays.toString( resourceIds ) );
-
         return sendRequest( HaRequestType210.ACQUIRE_EXCLUSIVE_LOCK, context,
                 new AcquireLockSerializer( type, resourceIds ), LOCK_RESULT_DESERIALIZER );
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha.com.master;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -357,9 +356,6 @@ public class MasterImpl extends LifecycleAdapter implements Master
     public Response<LockResult> acquireExclusiveLock( RequestContext context, Locks.ResourceType type,
                                                       long... resourceIds )
     {
-        msgLog.info( "@@@ acquireExclusiveLock: IN: from: " + context.machineId() + " type: " + type + " resources: " +
-                Arrays.toString( resourceIds ) );
-
         assertCorrectEpoch( context );
         LockSession session = resume( context );
         try
@@ -367,26 +363,17 @@ public class MasterImpl extends LifecycleAdapter implements Master
             session.client().acquireExclusive( type, resourceIds );
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( LockStatus.OK_LOCKED ) );
 
-            msgLog.info( "@@@ acquireExclusiveLock: OK: from: " + context.machineId() + " type: " + type + " " +
-                    "resources: " + Arrays.toString( resourceIds ) );
-
             return lockResultResponse;
         }
         catch ( DeadlockDetectedException e )
         {
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( e.getMessage() ) );
 
-            msgLog.info( "@@@ acquireExclusiveLock: NOK: from: " + context.machineId() + " type: " + type + " " +
-                    "resources: " + Arrays.toString( resourceIds ) );
-
             return lockResultResponse;
         }
         catch ( IllegalResourceException e )
         {
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( LockStatus.NOT_LOCKED ) );
-
-            msgLog.info( "@@@ acquireExclusiveLock: NOK: from: " + context.machineId() + " type: " + type + " " +
-                    "resources: " + Arrays.toString( resourceIds ) );
 
             return lockResultResponse;
         }
@@ -427,9 +414,6 @@ public class MasterImpl extends LifecycleAdapter implements Master
     public Response<LockResult> acquireSharedLock( RequestContext context, Locks.ResourceType type,
                                                    long... resourceIds )
     {
-        msgLog.info( "@@@ acquireSharedLock: IN: from: " + context.machineId() + " type: " + type + " resources: " +
-                Arrays.toString( resourceIds ) );
-
         assertCorrectEpoch( context );
         LockSession session = resume( context );
         try
@@ -437,26 +421,17 @@ public class MasterImpl extends LifecycleAdapter implements Master
             session.client().acquireShared( type, resourceIds );
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( LockStatus.OK_LOCKED ) );
 
-            msgLog.info( "@@@ acquireSharedLock: OK: from: " + context.machineId() + " type: " + type + " resources: " +
-                    Arrays.toString( resourceIds ) );
-
             return lockResultResponse;
         }
         catch ( DeadlockDetectedException e )
         {
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( e.getMessage() ) );
 
-            msgLog.info( "@@@ acquireSharedLock: NOK:deadlock from: " + context.machineId() + " type: " + type +
-                    " resources: " + Arrays.toString( resourceIds ) );
-
             return lockResultResponse;
         }
         catch ( IllegalResourceException e )
         {
             Response<LockResult> lockResultResponse = packResponse( context, new LockResult( LockStatus.NOT_LOCKED ) );
-
-            msgLog.info( "@@@ acquireSharedLock: NOK:error from: " + context.machineId() + " type: " + type + " " +
-                    "resources: " + Arrays.toString( resourceIds ) );
 
             return lockResultResponse;
         }


### PR DESCRIPTION
NetworkReadableLogChannel should not check if there is enough data available before reading.
Netty will throw an IndexOutOfBoundsException if the network stream doesn't supply enough data
to match the requested type.

The buffer sent over the Netty-channel should be compacted so that only used bytes are sent.

Also removed some logging previously added for debugging this issue.
