### PR TITLE
Fixes an issue with high id being too high after recovery

### DIFF
--- a/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
@@ -21,7 +21,6 @@ package org.neo4j.examples;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createCypherSnippet;
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.createGraphViz;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createQueryResultSnippet;
 
 import org.junit.Test;

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
@@ -32,8 +32,6 @@ import org.neo4j.graphdb.traversal.BranchSelector;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
 import org.neo4j.helpers.Function2;
-import org.neo4j.kernel.Traversal;
-
 import static org.neo4j.kernel.StandardExpander.toPathExpander;
 
 public abstract class BestFirstSelectorFactory<P extends Comparable<P>, D>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSetting;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -58,7 +56,6 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     public static abstract class Configuration
         extends CommonAbstractStore.Configuration
     {
-        public static final GraphDatabaseSetting.BooleanSetting rebuild_idgenerators_fast = GraphDatabaseSettings.rebuild_idgenerators_fast;
     }
 
     private Config conf;
@@ -91,6 +88,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     }
 
     @Override
+    protected int getNumberOfReservedLowIds()
+    {
+        return 1;
+    }
+
+    @Override
     protected void verifyFileSizeAndTruncate() throws IOException
     {
         int expectedVersionLength = UTF8.encode( buildTypeDescriptorAndVersion( getTypeDescriptor() ) ).length;
@@ -116,7 +119,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         if ( blockSize <= 0 )
         {
             throw new InvalidRecordException( "Illegal block size: " +
-            blockSize + " in " + getStorageFileName() );
+                    blockSize + " in " + getStorageFileName() );
         }
     }
 
@@ -435,144 +438,6 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
             }
         }
         return recordList;
-    }
-
-    private long findHighIdBackwards() throws IOException
-    {
-        StoreChannel fileChannel = getFileChannel();
-        int recordSize = getBlockSize();
-        long fileSize = fileChannel.size();
-        long highId = fileSize / recordSize;
-        ByteBuffer byteBuffer = ByteBuffer.allocate( 1 );
-        for ( long i = highId; i > 0; i-- )
-        {
-            fileChannel.position( i * recordSize );
-            if ( fileChannel.read( byteBuffer ) > 0 )
-            {
-                byteBuffer.flip();
-                boolean isInUse = isRecordInUse( byteBuffer );
-                byteBuffer.clear();
-                if ( isInUse )
-                {
-                    return i;
-                }
-            }
-        }
-        return 0;
-    }
-
-    /**
-     * Rebuilds the internal id generator keeping track of what blocks are free
-     * or taken.
-     *
-     * @throws IOException
-     *             If unable to rebuild the id generator
-     */
-    @Override
-    protected void rebuildIdGenerator()
-    {
-        if ( getBlockSize() <= 0 )
-        {
-            throw new InvalidRecordException( "Illegal blockSize: " +
-                getBlockSize() );
-        }
-        stringLogger.debug( "Rebuilding id generator for[" + getStorageFileName() + "] ..." );
-        closeIdGenerator();
-        if ( fileSystemAbstraction.fileExists( new File( getStorageFileName().getPath() + ".id" )) )
-        {
-            boolean success = fileSystemAbstraction.deleteFile( new File( getStorageFileName().getPath() + ".id" ));
-            assert success;
-        }
-        createIdGenerator( new File( getStorageFileName().getPath() + ".id" ));
-        openIdGenerator( false );
-        setHighId( 1 ); // reserved first block containing blockSize
-        StoreChannel fileChannel = getFileChannel();
-        long highId = 0;
-        long defraggedCount = 0;
-        try
-        {
-            long fileSize = fileChannel.size();
-            boolean fullRebuild = true;
-
-            if ( (boolean) conf.get( Configuration.rebuild_idgenerators_fast ) )
-            {
-                fullRebuild = false;
-                highId = findHighIdBackwards();
-            }
-
-            ByteBuffer byteBuffer = ByteBuffer.wrap( new byte[1] );
-            LinkedList<Long> freeIdList = new LinkedList<Long>();
-            if ( fullRebuild )
-            {
-                for ( long i = 1; i * getBlockSize() < fileSize; i++ )
-                {
-                    fileChannel.position( i * getBlockSize() );
-                    byteBuffer.clear();
-                    fileChannel.read( byteBuffer );
-                    byteBuffer.flip();
-                    if ( !isRecordInUse( byteBuffer ) )
-                    {
-                        freeIdList.add( i );
-                    }
-                    else
-                    {
-                        highId = i;
-                        setHighId( highId + 1 );
-                        while ( !freeIdList.isEmpty() )
-                        {
-                            freeBlockId( freeIdList.removeFirst() );
-                            defraggedCount++;
-                        }
-                    }
-                }
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException(
-                "Unable to rebuild id generator " + getStorageFileName(), e );
-        }
-        setHighId( highId + 1 );
-        stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId()
-            + " (defragged=" + defraggedCount + ")" );
-        if ( stringLogger != null )
-        {
-            stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
-                    " defragged count=" + defraggedCount, true );
-        }
-        closeIdGenerator();
-        openIdGenerator( false );
-    }
-
-//    @Override
-//    protected void updateHighId()
-//    {
-//        try
-//        {
-//            long highId = getFileChannel().size() / getBlockSize();
-//
-//            if ( highId > getHighId() )
-//            {
-//                setHighId( highId );
-//            }
-//        }
-//        catch ( IOException e )
-//        {
-//            throw new UnderlyingStorageException( e );
-//        }
-//    }
-
-    @Override
-    protected long figureOutHighestIdInUse()
-    {
-        try
-        {
-            return getFileChannel().size()/getBlockSize();
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
@@ -114,6 +114,18 @@ public abstract class AbstractNameStore<T extends AbstractNameRecord> extends Ab
     }
 
     @Override
+    protected boolean doFastIdGeneratorRebuild()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean reserveIdsDuringRebuild()
+    {
+        return true;
+    }
+
+    @Override
     public void flushAll()
     {
         nameStore.flushAll();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -713,6 +713,12 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
     }
 
     @Override
+    protected int bytesRequiredToDetermineInUse()
+    {
+        return getRecordSize();
+    }
+
+    @Override
     public void logVersions(StringLogger.LineLogger logger )
     {
         super.logVersions( logger );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
@@ -28,9 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import static java.util.Arrays.asList;
 
 import static org.junit.Assert.assertEquals;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.UTF8.encode;
+import static org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore.buildTypeDescriptorAndVersion;
+
+public class StoreHighIdInflationTest
+{
+    @Test
+    public void shouldFindActualHighIdWhenStartingOnInflatedStore() throws Exception
+    {
+        // GIVEN
+        FileSystemAbstraction fs = fsr.get();
+        fs.mkdirs( new File( storeDir ) );
+        GraphDatabaseAPI db = (GraphDatabaseAPI)
+                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        long highestCreatedNodeId = createACoupleOfNodes( db, 3 );
+        long highestPropertyStringRecord = getHighestDynamicStringPropertyId( db );
+        db.shutdown();
+        inflateStore( NodeStore.TYPE_DESCRIPTOR, NodeStore.RECORD_SIZE, ".nodestore.db" );
+        inflateStore( DynamicStringStore.TYPE_DESCRIPTOR, DynamicStringStore.BLOCK_HEADER_SIZE, ".nodestore.db" );
+
+        // WHEN
+        db = (GraphDatabaseAPI)
+                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        long nodeIdAfterInflation = createACoupleOfNodes( db, 1 );
+        long stringPropertyIdAfterInflation = getHighestDynamicStringPropertyId( db );
+        db.shutdown();
+
+        // THEN
+        assertEquals( highestCreatedNodeId+1, nodeIdAfterInflation );
+        assertEquals( highestPropertyStringRecord+1, stringPropertyIdAfterInflation );
+    }
+
+    private long getHighestDynamicStringPropertyId( GraphDatabaseAPI db )
+    {
+        return db.getDependencyResolver().resolveDependency( XaDataSourceManager.class )
+                .getNeoStoreDataSource().getNeoStore().getPropertyStore()
+                .getStringStore().getHighestPossibleIdInUse();
+    }
+
+    private void inflateStore( String trailerTypeDescriptor, int recordSize, String store ) throws IOException
+    {
+        int trailerLength = encode( buildTypeDescriptorAndVersion( trailerTypeDescriptor ) ).length;
+        File neoStore = new File( storeDir, NeoStore.DEFAULT_NAME );
+        File storeFile = new File( neoStore.getAbsolutePath() + store );
+        FileSystemAbstraction fs = fsr.get();
+        StoreChannel channel = fs.open( storeFile, "rw" );
+        try
+        {
+            channel.position( channel.size() - trailerLength );
+            channel.write( megabyteWorthOfZeros() );
+        }
+        finally
+        {
+            channel.close();
+        }
+        fs.deleteFile( new File( storeFile, ".id" ) );
+    }
+
+    private ByteBuffer megabyteWorthOfZeros()
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( 1024*1024 );
+        while ( buffer.hasRemaining() )
+        {
+            buffer.put( (byte) 0 );
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    private long createACoupleOfNodes( GraphDatabaseService db, int count )
+    {
+        Transaction tx = db.beginTx();
+        try
+        {
+            long last = 0;
+            for ( int i = 0; i < count; i++ )
+            {
+                Node node = db.createNode();
+                node.setProperty( "key", "A very very very loooooooooooooooooooooooooooooooooooooooooooooong string " +
+                        "that should spill over into a dynamic record" );
+                last = node.getId();
+            }
+            tx.success();
+            return last;
+        }
+        finally
+        {
+            tx.finish();
+        }
+    }
+
+    public final @Rule EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();
+    private final String storeDir = new File( "dir" ).getAbsolutePath();
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -21,7 +21,6 @@ package org.neo4j.com;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.kernel.impl.nioneo.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;


### PR DESCRIPTION
due to giving the IdGenerator the wrong highId in its constructor. It used
to give it fileSize/recordSize, but now gives it the highest inUse record id.

Also deduplicated 3 versions of rebuildIdGenerator, 2 versions of
figureOutHighestIdInUse (which was badly named btw) and some other
deduplication.
