### PR TITLE
[1.9] Fixes an issue with high id being too high after recovery

### DIFF
--- a/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/AclExampleDocTest.java
@@ -21,7 +21,6 @@ package org.neo4j.examples;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createCypherSnippet;
-import static org.neo4j.visualization.asciidoc.AsciidocHelper.createGraphViz;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createQueryResultSnippet;
 
 import org.junit.Test;

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/BestFirstSelectorFactory.java
@@ -32,8 +32,6 @@ import org.neo4j.graphdb.traversal.BranchSelector;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
 import org.neo4j.helpers.Function2;
-import org.neo4j.kernel.Traversal;
-
 import static org.neo4j.kernel.StandardExpander.toPathExpander;
 
 public abstract class BestFirstSelectorFactory<P extends Comparable<P>, D>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractNameStore.java
@@ -114,6 +114,18 @@ public abstract class AbstractNameStore<T extends AbstractNameRecord> extends Ab
     }
 
     @Override
+    protected boolean doFastIdGeneratorRebuild()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean reserveIdsDuringRebuild()
+    {
+        return true;
+    }
+
+    @Override
     public void flushAll()
     {
         nameStore.flushAll();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.OverlappingFileLockException;
+import java.util.LinkedList;
 
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.graphdb.factory.GraphDatabaseSetting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.kernel.IdGeneratorFactory;
@@ -49,10 +49,12 @@ public abstract class CommonAbstractStore
     {
         public static final Setting<File> store_dir = InternalAbstractGraphDatabase.Configuration.store_dir;
         public static final Setting<File> neo_store = InternalAbstractGraphDatabase.Configuration.neo_store;
-        
-        public static final GraphDatabaseSetting.BooleanSetting read_only = GraphDatabaseSettings.read_only;
-        public static final GraphDatabaseSetting.BooleanSetting backup_slave = GraphDatabaseSettings.backup_slave;
-        public static final GraphDatabaseSetting.BooleanSetting use_memory_mapped_buffers = GraphDatabaseSettings.use_memory_mapped_buffers;
+
+        public static final Setting<Boolean> read_only = GraphDatabaseSettings.read_only;
+        public static final Setting<Boolean> backup_slave = GraphDatabaseSettings.backup_slave;
+        public static final Setting<Boolean> use_memory_mapped_buffers = GraphDatabaseSettings.use_memory_mapped_buffers;
+
+        public static final Setting<Boolean> rebuild_idgenerators_fast = GraphDatabaseSettings.rebuild_idgenerators_fast;
     }
 
     public static final String ALL_STORES_VERSION = "v0.A.0";
@@ -282,10 +284,109 @@ public abstract class CommonAbstractStore
         }
     }
 
-    /**
-     * Should rebuild the id generator from scratch.
-     */
-    protected abstract void rebuildIdGenerator();
+    /** Should rebuild the id generator from scratch. */
+    protected void rebuildIdGenerator()
+    {
+        if ( isReadOnly() && !isBackupSlave() )
+        {
+            throw new ReadOnlyDbException();
+        }
+
+        stringLogger.debug( "Rebuilding id generator for[" + getStorageFileName() + "] ..." );
+        closeIdGenerator();
+        File idFile = new File( getStorageFileName().getPath() + ".id" );
+        if ( fileSystemAbstraction.fileExists( idFile ) )
+        {
+            boolean success = fileSystemAbstraction.deleteFile( idFile );
+            assert success : "Couldn't delete " + idFile.getPath() + ", still open?";
+        }
+        createIdGenerator( idFile );
+        openIdGenerator( false );
+        setHighId( getNumberOfReservedLowIds() );
+        StoreChannel fileChannel = getFileChannel();
+        boolean fastRebuild = doFastIdGeneratorRebuild();
+        long defraggedCount = 0;
+        try
+        {
+            long fileSize = fileChannel.size();
+            int recordSize = getRecordSize();
+            if ( fastRebuild )
+            {
+                setHighId( findHighIdBackwards() );
+            }
+            else
+            {
+                defraggedCount = fullScanIdRebuild( fileChannel, fileSize, recordSize,
+                        reserveIdsDuringRebuild() );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException(
+                    "Unable to rebuild id generator " + getStorageFileName(), e );
+        }
+        stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
+                " defragged count=" + defraggedCount, true );
+        stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId() +
+                " (defragged=" + defraggedCount + ")" );
+
+        if ( !fastRebuild )
+        {
+            closeIdGenerator();
+            openIdGenerator( false );
+        }
+    }
+
+    protected boolean reserveIdsDuringRebuild()
+    {
+        return false;
+    }
+
+    private long fullScanIdRebuild( StoreChannel fileChannel, long fileSize, int recordSize, boolean justReserveIds )
+            throws IOException
+    {
+        long defraggedCount = 0;
+        ByteBuffer byteBuffer = ByteBuffer.allocate( recordSize );
+        LinkedList<Long> freeIdList = new LinkedList<Long>();
+        for ( long i = getNumberOfReservedLowIds(); i * recordSize < fileSize; i++ )
+        {
+            fileChannel.position( i * recordSize );
+            byteBuffer.clear();
+            fileChannel.read( byteBuffer );
+            byteBuffer.flip();
+            if ( !isRecordInUse( byteBuffer ) )
+            {
+                if ( justReserveIds )
+                {
+                    byteBuffer.clear();
+                    byteBuffer.put( Record.IN_USE.byteValue() ).putInt(
+                        Record.RESERVED.intValue() );
+                    byteBuffer.flip();
+                    fileChannel.write( byteBuffer, i * recordSize );
+                    byteBuffer.clear();
+                }
+                else
+                {
+                    freeIdList.add( i );
+                }
+            }
+            else
+            {
+                setHighId( i + 1 );
+                while ( !freeIdList.isEmpty() )
+                {
+                    freeId( freeIdList.removeFirst() );
+                    defraggedCount++;
+                }
+            }
+        }
+        return defraggedCount;
+    }
+
+    protected boolean doFastIdGeneratorRebuild()
+    {
+        return configuration.get( Configuration.rebuild_idgenerators_fast );
+    }
 
     /**
      * This method should close/release all resources that the implementation of
@@ -503,10 +604,50 @@ public abstract class CommonAbstractStore
 
     protected IdGenerator openIdGenerator( File fileName, int grabSize, boolean firstTime )
     {
-        return idGeneratorFactory.open( fileSystemAbstraction, fileName, grabSize, getIdType(), figureOutHighestIdInUse() );
+        return idGeneratorFactory.open( fileSystemAbstraction, fileName, grabSize,
+                getIdType(), findHighIdBackwards() );
     }
 
-    protected abstract long figureOutHighestIdInUse();
+    protected long findHighIdBackwards()
+    {
+        try
+        {
+            StoreChannel fileChannel = getFileChannel();
+            int recordSize = getRecordSize();
+            long fileSize = fileChannel.size();
+            long highId = fileSize / recordSize;
+            ByteBuffer byteBuffer = ByteBuffer.allocate( bytesRequiredToDetermineInUse() );
+            for ( long i = highId; i >= 0; i-- )
+            {
+                fileChannel.position( i * recordSize );
+                if ( fileChannel.read( byteBuffer ) > 0 )
+                {
+                    byteBuffer.flip();
+                    boolean isInUse = isRecordInUse( byteBuffer );
+                    byteBuffer.clear();
+                    if ( isInUse )
+                    {
+                        return i+1;
+                    }
+                }
+            }
+            return getNumberOfReservedLowIds();
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException(
+                "Unable to rebuild id generator " + getStorageFileName(), e );
+        }
+    }
+
+    public abstract int getRecordSize();
+
+    protected abstract boolean isRecordInUse( ByteBuffer recordData );
+
+    protected int bytesRequiredToDetermineInUse()
+    {   // For most records it's enough with looking at the first byte
+        return 1;
+    }
 
     protected void createIdGenerator( File fileName )
     {
@@ -659,6 +800,15 @@ public abstract class CommonAbstractStore
     public long getNumberOfIdsInUse()
     {
         return idGenerator.getNumberOfIdsInUse();
+    }
+
+    /**
+     * @return the number of records at the beginning of the store file that are reserved for other things
+     * than actual records. Stuff like permanent configuration data.
+     */
+    protected int getNumberOfReservedLowIds()
+    {
+        return 0;
     }
 
     public WindowPoolStats getWindowPoolStats()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicStringStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/DynamicStringStore.java
@@ -49,7 +49,7 @@ public class DynamicStringStore extends AbstractDynamicStore
         super( fileName, configuration, idType, idGeneratorFactory, windowPoolFactory,
                 fileSystemAbstraction, stringLogger);
     }
-    
+
     @Override
     public void accept( RecordStore.Processor processor, DynamicRecord record )
     {
@@ -61,17 +61,4 @@ public class DynamicStringStore extends AbstractDynamicStore
     {
         return TYPE_DESCRIPTOR;
     }
-
-    @Override
-    public void setHighId( long highId )
-    {
-        super.setHighId( highId );
-    }
-
-    @Override
-    public long nextBlockId()
-    {
-        return super.nextBlockId();
-    }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -713,6 +713,12 @@ public class PropertyStore extends AbstractStore implements Store, RecordStore<P
     }
 
     @Override
+    protected int bytesRequiredToDetermineInUse()
+    {
+        return getRecordSize();
+    }
+
+    @Override
     public void logVersions(StringLogger.LineLogger logger )
     {
         super.logVersions( logger );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/ReferenceCacheTest.java
@@ -28,9 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import static java.util.Arrays.asList;
 
 import static org.junit.Assert.assertEquals;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.nioneo.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.UTF8.encode;
+import static org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore.buildTypeDescriptorAndVersion;
+
+public class StoreHighIdInflationTest
+{
+    @Test
+    public void shouldFindActualHighIdWhenStartingOnInflatedStore() throws Exception
+    {
+        // GIVEN
+        FileSystemAbstraction fs = fsr.get();
+        fs.mkdirs( new File( storeDir ) );
+        GraphDatabaseAPI db = (GraphDatabaseAPI)
+                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        long highestCreatedNodeId = createACoupleOfNodes( db, 3 );
+        long highestPropertyStringRecord = getHighestDynamicStringPropertyId( db );
+        db.shutdown();
+        inflateStore( NodeStore.TYPE_DESCRIPTOR, NodeStore.RECORD_SIZE, ".nodestore.db" );
+        inflateStore( DynamicStringStore.TYPE_DESCRIPTOR, DynamicStringStore.BLOCK_HEADER_SIZE, ".nodestore.db" );
+
+        // WHEN
+        db = (GraphDatabaseAPI)
+                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        long nodeIdAfterInflation = createACoupleOfNodes( db, 1 );
+        long stringPropertyIdAfterInflation = getHighestDynamicStringPropertyId( db );
+        db.shutdown();
+
+        // THEN
+        assertEquals( highestCreatedNodeId+1, nodeIdAfterInflation );
+        assertEquals( highestPropertyStringRecord+1, stringPropertyIdAfterInflation );
+    }
+
+    private long getHighestDynamicStringPropertyId( GraphDatabaseAPI db )
+    {
+        return db.getDependencyResolver().resolveDependency( XaDataSourceManager.class )
+                .getNeoStoreDataSource().getNeoStore().getPropertyStore()
+                .getStringStore().getHighestPossibleIdInUse();
+    }
+
+    private void inflateStore( String trailerTypeDescriptor, int recordSize, String store ) throws IOException
+    {
+        int trailerLength = encode( buildTypeDescriptorAndVersion( trailerTypeDescriptor ) ).length;
+        File neoStore = new File( storeDir, NeoStore.DEFAULT_NAME );
+        File storeFile = new File( neoStore.getAbsolutePath() + store );
+        FileSystemAbstraction fs = fsr.get();
+        StoreChannel channel = fs.open( storeFile, "rw" );
+        try
+        {
+            channel.position( channel.size() - trailerLength );
+            channel.write( megabyteWorthOfZeros() );
+        }
+        finally
+        {
+            channel.close();
+        }
+        fs.deleteFile( new File( storeFile, ".id" ) );
+    }
+
+    private ByteBuffer megabyteWorthOfZeros()
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( 1024*1024 );
+        while ( buffer.hasRemaining() )
+        {
+            buffer.put( (byte) 0 );
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    private long createACoupleOfNodes( GraphDatabaseService db, int count )
+    {
+        Transaction tx = db.beginTx();
+        try
+        {
+            long last = 0;
+            for ( int i = 0; i < count; i++ )
+            {
+                Node node = db.createNode();
+                node.setProperty( "key", "A very very very loooooooooooooooooooooooooooooooooooooooooooooong string " +
+                        "that should spill over into a dynamic record" );
+                last = node.getId();
+            }
+            tx.success();
+            return last;
+        }
+        finally
+        {
+            tx.finish();
+        }
+    }
+
+    public final @Rule EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();
+    private final String storeDir = new File( "dir" ).getAbsolutePath();
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -21,7 +21,6 @@ package org.neo4j.com;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.kernel.impl.nioneo.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;


### PR DESCRIPTION
due to giving the IdGenerator the wrong highId in its constructor. It used
to give it fileSize/recordSize, but now gives it the highest inUse record id.

Also deduplicated 3 versions of rebuildIdGenerator, 2 versions of
figureOutHighestIdInUse (which was badly named btw) and some other
deduplication.
