### PR TITLE
[master] Unpacking of transaction logs occurs right after response deserialization

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
@@ -49,7 +49,7 @@ import org.junit.rules.ExternalResource;
  */
 public class CleanupRule extends ExternalResource
 {
-    private static final String[] COMMON_CLOSE_METHOD_NAMES = { "close", "shutdown", "shutDown" };
+    private static final String[] COMMON_CLOSE_METHOD_NAMES = {"close", "stop", "shutdown", "shutDown"};
     private final LinkedList<AutoCloseable> toCloseAfterwards = new LinkedList<>();
 
     @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
@@ -43,7 +43,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readByte();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -56,7 +56,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readShort();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -69,7 +69,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readInt();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -82,7 +82,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readLong();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -95,7 +95,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readFloat();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -108,7 +108,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             return delegate.readDouble();
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }
@@ -121,7 +121,7 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
         {
             delegate.readBytes( bytes, 0, length );
         }
-        catch( IndexOutOfBoundsException e )
+        catch ( IndexOutOfBoundsException e )
         {
             throw ReadPastEndException.INSTANCE;
         }

--- a/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/RequestType.java
@@ -26,4 +26,6 @@ public interface RequestType<M>
     ObjectSerializer getObjectSerializer();
     
     byte id();
+
+    boolean responseShouldBeUnpacked();
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
@@ -26,18 +26,15 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 
 public interface ResponseUnpacker
 {
-    <T> T unpackResponse( Response<T> response ) throws IOException;
+    void unpackResponse( Response<?> response ) throws IOException;
 
-    <T> T unpackResponse( Response<T> response, TxHandler handler ) throws IOException;
-
-    public static abstract class Adapter implements ResponseUnpacker
+    public static final ResponseUnpacker NO_OP_RESPONSE_UNPACKER = new ResponseUnpacker()
     {
         @Override
-        public <T> T unpackResponse( Response<T> response ) throws IOException
+        public void unpackResponse( Response<?> response ) throws IOException
         {
-            return unpackResponse( response, NO_ACTION );
         }
-    }
+    };
 
     public interface TxHandler
     {
@@ -46,7 +43,7 @@ public interface ResponseUnpacker
         void done();
     }
 
-    public static final TxHandler NO_ACTION = new TxHandler()
+    public static final TxHandler NO_OP_TX_HANDLER = new TxHandler()
     {
         @Override
         public void accept( CommittedTransactionRepresentation tx )

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
@@ -28,6 +28,7 @@ import java.nio.channels.ReadableByteChannel;
 import org.jboss.netty.buffer.ChannelBuffer;
 
 import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
@@ -42,13 +43,14 @@ public class MadeUpClient extends Client<MadeUpCommunicationInterface> implement
     private final byte internalProtocolVersion;
 
     public MadeUpClient( int port, StoreId storeIdToExpect, byte internalProtocolVersion,
-                         byte applicationProtocolVersion, int chunkSize )
+                         byte applicationProtocolVersion, int chunkSize, ResponseUnpacker responseUnpacker )
     {
         super( localhost(), port, new DevNullLoggingService(), storeIdToExpect, FRAME_LENGTH,
                 new ProtocolVersion( applicationProtocolVersion, internalProtocolVersion ),
                 Client.DEFAULT_READ_RESPONSE_TIMEOUT_SECONDS * 1000,
                 Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT,
-                chunkSize, new Monitors().newMonitor( ByteCounterMonitor.class ),
+                chunkSize, responseUnpacker,
+                new Monitors().newMonitor( ByteCounterMonitor.class ),
                 new Monitors().newMonitor( RequestMonitor.class ) );
         this.internalProtocolVersion = internalProtocolVersion;
     }

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -164,7 +164,14 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
                     }
                 }
             }
-        }, Protocol.VOID_SERIALIZER ),
+        }, Protocol.VOID_SERIALIZER )
+                {
+                    @Override
+                    public boolean responseShouldBeUnpacked()
+                    {
+                        return false;
+                    }
+                },
 
         THROW_EXCEPTION( new TargetCaller<MadeUpCommunicationInterface, Integer>()
         {
@@ -212,6 +219,12 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
         public byte id()
         {
             return (byte) ordinal();
+        }
+
+        @Override
+        public boolean responseShouldBeUnpacked()
+        {
+            return true;
         }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
@@ -19,11 +19,8 @@
  */
 package org.neo4j.kernel.ha;
 
-import java.io.IOException;
-
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.core.TokenCreator;
@@ -32,28 +29,17 @@ public abstract class AbstractTokenCreator implements TokenCreator
 {
     private final Master master;
     private final RequestContextFactory requestContextFactory;
-    private final TransactionCommittingResponseUnpacker unpacker;
 
-    protected AbstractTokenCreator( Master master, RequestContextFactory requestContextFactory,
-                                 TransactionCommittingResponseUnpacker unpacker )
+    protected AbstractTokenCreator( Master master, RequestContextFactory requestContextFactory )
     {
         this.master = master;
         this.requestContextFactory = requestContextFactory;
-        this.unpacker = unpacker;
     }
 
     @Override
     public final int getOrCreate( String name )
     {
-        Response<Integer> response = create( master, requestContextFactory.newRequestContext(), name );
-        try
-        {
-            return unpacker.unpackResponse( response );
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return create( master, requestContextFactory.newRequestContext(), name ).response();
     }
 
     protected abstract Response<Integer> create( Master master, RequestContext context, String name );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/CommitProcessSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/CommitProcessSwitcher.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.net.URI;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.ha.cluster.AbstractModeSwitcher;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
@@ -41,13 +40,12 @@ public class CommitProcessSwitcher extends AbstractModeSwitcher<TransactionCommi
                                   DelegateInvocationHandler<TransactionCommitProcess> delegate,
                                   RequestContextFactory requestContextFactory,
                                   HighAvailabilityMemberStateMachine memberStateMachine,
-                                  TransactionCommittingResponseUnpacker unpacker,
                                   NeoStoreInjectedTransactionValidator validator,
                                   TransactionRepresentationCommitProcess innerCommitProcess )
     {
         super( memberStateMachine, delegate );
         this.masterImpl = new MasterTransactionCommitProcess( innerCommitProcess, pusher, validator );
-        this.slaveImpl = new SlaveTransactionCommitProcess( master, requestContextFactory, unpacker );
+        this.slaveImpl = new SlaveTransactionCommitProcess( master, requestContextFactory );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType201.java
@@ -248,7 +248,14 @@ public enum HaRequestType201 implements RequestType<Master>
             return master.copyStore( context, new ToNetworkStoreWriter( target, new Monitors() ) );
         }
 
-    }, VOID_SERIALIZER ),
+    }, VOID_SERIALIZER )
+            {
+                @Override
+                public boolean responseShouldBeUnpacked()
+                {
+                    return false;
+                }
+            },
 
     // ====
     PLACEHOLDER_FOR_COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
@@ -456,6 +463,12 @@ public enum HaRequestType201 implements RequestType<Master>
     public byte id()
     {
         return (byte) ordinal();
+    }
+
+    @Override
+    public boolean responseShouldBeUnpacked()
+    {
+        return true;
     }
 
     public boolean isLock()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaRequestType210.java
@@ -205,7 +205,14 @@ public enum HaRequestType210 implements RequestType<Master>
             return master.copyStore( context, new ToNetworkStoreWriter( target, new Monitors() ) );
         }
 
-    }, VOID_SERIALIZER ),
+    }, VOID_SERIALIZER )
+            {
+                @Override
+                public boolean responseShouldBeUnpacked()
+                {
+                    return false;
+                }
+            },
 
     // ====
     PLACEHOLDER_FOR_COPY_TRANSACTIONS( new TargetCaller<Master, Void>()
@@ -293,6 +300,12 @@ public enum HaRequestType210 implements RequestType<Master>
     public byte id()
     {
         return (byte) ordinal();
+    }
+
+    @Override
+    public boolean responseShouldBeUnpacked()
+    {
+        return true;
     }
 
     public boolean isLock()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/LabelTokenCreatorModeSwitcher.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.net.URI;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.api.KernelAPI;
@@ -38,32 +37,29 @@ public class LabelTokenCreatorModeSwitcher extends AbstractModeSwitcher<TokenCre
     private final RequestContextFactory requestContextFactory;
     private final Provider<KernelAPI> kernelProvider;
     private final IdGeneratorFactory idGeneratorFactory;
-    private final TransactionCommittingResponseUnpacker unpacker;
 
     public LabelTokenCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                           DelegateInvocationHandler<TokenCreator> delegate,
                                           DelegateInvocationHandler<Master> master,
                                           RequestContextFactory requestContextFactory,
-                                          Provider<KernelAPI> kernelProvider, IdGeneratorFactory idGeneratorFactory,
-                                          TransactionCommittingResponseUnpacker unpacker )
+                                          Provider<KernelAPI> kernelProvider, IdGeneratorFactory idGeneratorFactory )
     {
         super( stateMachine, delegate );
         this.master = master;
         this.requestContextFactory = requestContextFactory;
         this.kernelProvider = kernelProvider;
         this.idGeneratorFactory = idGeneratorFactory;
-        this.unpacker = unpacker;
     }
 
     @Override
     protected TokenCreator getMasterImpl()
     {
-        return new DefaultLabelIdCreator( kernelProvider, idGeneratorFactory  );
+        return new DefaultLabelIdCreator( kernelProvider, idGeneratorFactory );
     }
 
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveLabelTokenCreator( master.cement(), requestContextFactory, unpacker );
+        return new SlaveLabelTokenCreator( master.cement(), requestContextFactory );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
@@ -34,6 +34,7 @@ import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
 import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
@@ -75,12 +76,12 @@ public class MasterClient201 extends Client<Master> implements MasterClient
 
     private final long lockReadTimeout;
 
-    public MasterClient201( String hostNameOrIp, int port, Logging logging, StoreId storeId,
-                           long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize,
-                           ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor)
+    public MasterClient201( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutSeconds,
+                            long lockReadTimeout, int maxConcurrentChannels, int chunkSize, ResponseUnpacker unpacker,
+                            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
-                readTimeoutSeconds, maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
+        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION, readTimeoutSeconds,
+                maxConcurrentChannels, chunkSize, unpacker, byteCounterMonitor, requestMonitor );
         this.lockReadTimeout = lockReadTimeout;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -33,6 +33,7 @@ import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
 import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
@@ -74,22 +75,23 @@ public class MasterClient210 extends Client<Master> implements MasterClient
 
     private final long lockReadTimeoutMillis;
 
-    public MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId,
-                            long readTimeoutMillis, long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
+    public MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutMillis,
+                            long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
+                            ResponseUnpacker responseUnpacker,
                             ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION,
-                readTimeoutMillis, maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
+        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION, readTimeoutMillis,
+                maxConcurrentChannels, chunkSize, responseUnpacker, byteCounterMonitor, requestMonitor );
         this.lockReadTimeoutMillis = lockReadTimeoutMillis;
     }
 
-    MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId,
-                            long readTimeoutMillis, long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
-                            ProtocolVersion protocolVersion,
-                            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutMillis,
+                     long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
+                     ProtocolVersion protocolVersion, ResponseUnpacker responseUnpacker,
+                     ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
         super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, protocolVersion, readTimeoutMillis,
-                maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
+                maxConcurrentChannels, chunkSize, responseUnpacker, byteCounterMonitor, requestMonitor );
         this.lockReadTimeoutMillis = lockReadTimeoutMillis;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
@@ -23,6 +23,7 @@ import org.neo4j.com.Protocol;
 import org.neo4j.com.Protocol214;
 import org.neo4j.com.ProtocolVersion;
 import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
@@ -33,12 +34,12 @@ public class MasterClient214 extends MasterClient210
 {
     public static final ProtocolVersion PROTOCOL_VERSION = new ProtocolVersion( (byte) 8, INTERNAL_PROTOCOL_VERSION );
 
-    public MasterClient214( String hostNameOrIp, int port, Logging logging, StoreId storeId,
-                            long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels, int chunkSize,
+    public MasterClient214( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutSeconds,
+                            long lockReadTimeout, int maxConcurrentChannels, int chunkSize, ResponseUnpacker unpacker,
                             ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, readTimeoutSeconds, lockReadTimeout,
-                maxConcurrentChannels, chunkSize, PROTOCOL_VERSION, byteCounterMonitor, requestMonitor );
+        super( hostNameOrIp, port, logging, storeId, readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels,
+                chunkSize, PROTOCOL_VERSION, unpacker, byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PropertyKeyCreatorModeSwitcher.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.net.URI;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.api.KernelAPI;
@@ -38,21 +37,18 @@ public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCr
     private final RequestContextFactory requestContextFactory;
     private final Provider<KernelAPI> kernelProvider;
     private final IdGeneratorFactory idGeneratorFactory;
-    private final TransactionCommittingResponseUnpacker unpacker;
 
     public PropertyKeyCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                            DelegateInvocationHandler<TokenCreator> delegate,
                                            DelegateInvocationHandler<Master> master,
                                            RequestContextFactory requestContextFactory,
-                                           Provider<KernelAPI> kernelProvider, IdGeneratorFactory idGeneratorFactory,
-                                           TransactionCommittingResponseUnpacker unpacker )
+                                           Provider<KernelAPI> kernelProvider, IdGeneratorFactory idGeneratorFactory )
     {
         super( stateMachine, delegate );
         this.master = master;
         this.requestContextFactory = requestContextFactory;
         this.kernelProvider = kernelProvider;
         this.idGeneratorFactory = idGeneratorFactory;
-        this.unpacker = unpacker;
     }
 
     @Override
@@ -64,6 +60,6 @@ public class PropertyKeyCreatorModeSwitcher extends AbstractModeSwitcher<TokenCr
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlavePropertyTokenCreator( master.cement(), requestContextFactory, unpacker );
+        return new SlavePropertyTokenCreator( master.cement(), requestContextFactory );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/RelationshipTypeCreatorModeSwitcher.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.net.URI;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.api.KernelAPI;
@@ -38,22 +37,19 @@ public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<To
     private final RequestContextFactory requestContextFactory;
     private final Provider<KernelAPI> kernelProvider;
     private final IdGeneratorFactory idGeneratorFactory;
-    private final TransactionCommittingResponseUnpacker unpacker;
 
     public RelationshipTypeCreatorModeSwitcher( HighAvailabilityMemberStateMachine stateMachine,
                                                 DelegateInvocationHandler<TokenCreator> delegate,
                                                 DelegateInvocationHandler<Master> master,
                                                 RequestContextFactory requestContextFactory,
                                                 Provider<KernelAPI> kernelProvider,
-                                                IdGeneratorFactory idGeneratorFactory,
-                                                TransactionCommittingResponseUnpacker unpacker )
+                                                IdGeneratorFactory idGeneratorFactory )
     {
         super( stateMachine, delegate );
         this.master = master;
         this.requestContextFactory = requestContextFactory;
         this.kernelProvider = kernelProvider;
         this.idGeneratorFactory = idGeneratorFactory;
-        this.unpacker = unpacker;
     }
 
     @Override
@@ -65,6 +61,6 @@ public class RelationshipTypeCreatorModeSwitcher extends AbstractModeSwitcher<To
     @Override
     protected TokenCreator getSlaveImpl( URI serverHaUri )
     {
-        return new SlaveRelationshipTypeCreator( master.cement(), requestContextFactory, unpacker );
+        return new SlaveRelationshipTypeCreator( master.cement(), requestContextFactory );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveLabelTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveLabelTokenCreator.java
@@ -21,16 +21,14 @@ package org.neo4j.kernel.ha;
 
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 
 public class SlaveLabelTokenCreator extends AbstractTokenCreator
 {
-    public SlaveLabelTokenCreator( Master master, RequestContextFactory requestContextFactory,
-                                   TransactionCommittingResponseUnpacker committer )
+    public SlaveLabelTokenCreator( Master master, RequestContextFactory requestContextFactory )
     {
-        super( master, requestContextFactory, committer );
+        super( master, requestContextFactory );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlavePropertyTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlavePropertyTokenCreator.java
@@ -21,16 +21,14 @@ package org.neo4j.kernel.ha;
 
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 
 public class SlavePropertyTokenCreator extends AbstractTokenCreator
 {
-    public SlavePropertyTokenCreator( Master master, RequestContextFactory requestContextFactory,
-                                      TransactionCommittingResponseUnpacker unpacker )
+    public SlavePropertyTokenCreator( Master master, RequestContextFactory requestContextFactory )
     {
-        super( master, requestContextFactory, unpacker );
+        super( master, requestContextFactory );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveRelationshipTypeCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveRelationshipTypeCreator.java
@@ -21,16 +21,14 @@ package org.neo4j.kernel.ha;
 
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 
 public class SlaveRelationshipTypeCreator extends AbstractTokenCreator
 {
-    public SlaveRelationshipTypeCreator( Master master, RequestContextFactory requestContextFactory,
-                                         TransactionCommittingResponseUnpacker unpacker )
+    public SlaveRelationshipTypeCreator( Master master, RequestContextFactory requestContextFactory )
     {
-        super( master, requestContextFactory, unpacker );
+        super( master, requestContextFactory );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha;
 
 import java.io.IOException;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
@@ -37,14 +36,11 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
 {
     private final Master master;
     private final RequestContextFactory requestContextFactory;
-    private final TransactionCommittingResponseUnpacker unpacker;
 
-    public SlaveTransactionCommitProcess( Master master, RequestContextFactory requestContextFactory,
-                                          TransactionCommittingResponseUnpacker unpacker )
+    public SlaveTransactionCommitProcess( Master master, RequestContextFactory requestContextFactory )
     {
         this.master = master;
         this.requestContextFactory = requestContextFactory;
-        this.unpacker = unpacker;
     }
 
     @Override
@@ -52,7 +48,7 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
     {
         try
         {
-            return unpacker.unpackResponse( master.commit( requestContextFactory.newRequestContext(), representation ) );
+            return master.commit( requestContextFactory.newRequestContext(), representation ).response();
         }
         catch ( IOException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
@@ -46,6 +46,7 @@ import static org.neo4j.com.Protocol.VOID_SERIALIZER;
 import static org.neo4j.com.Protocol.readString;
 import static org.neo4j.com.Protocol.writeString;
 import static org.neo4j.com.ProtocolVersion.INTERNAL_PROTOCOL_VERSION;
+import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_RESPONSE_UNPACKER;
 
 public class SlaveClient extends Client<Slave> implements Slave
 {
@@ -58,7 +59,7 @@ public class SlaveClient extends Client<Slave> implements Slave
         super( hostNameOrIp, port, logging, storeId, Protocol.DEFAULT_FRAME_LENGTH,
                 new ProtocolVersion( SlaveServer.APPLICATION_PROTOCOL_VERSION, INTERNAL_PROTOCOL_VERSION ),
                 HaSettings.read_timeout.apply( Functions.<String, String>nullFunction() ),
-                maxConcurrentChannels, chunkSize, byteCounterMonitor, requestMonitor );
+                maxConcurrentChannels, chunkSize, NO_OP_RESPONSE_UNPACKER, byteCounterMonitor, requestMonitor );
         this.machineId = machineId;
     }
 
@@ -114,6 +115,12 @@ public class SlaveClient extends Client<Slave> implements Slave
         public byte id()
         {
             return (byte) ordinal();
+        }
+
+        @Override
+        public boolean responseShouldBeUnpacked()
+        {
+            return false;
         }
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.ha.lock;
 
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
@@ -32,7 +31,6 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
     private final Locks local;
     private final Master master;
     private final AvailabilityGuard availabilityGuard;
-    private final TransactionCommittingResponseUnpacker unpacker;
     private final Configuration config;
 
     public static interface Configuration
@@ -41,11 +39,10 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
     }
 
     public SlaveLockManager( Locks localLocks, RequestContextFactory requestContextFactory, Master master,
-                             AvailabilityGuard availabilityGuard, TransactionCommittingResponseUnpacker unpacker, Configuration config )
+                             AvailabilityGuard availabilityGuard, Configuration config )
     {
         this.requestContextFactory = requestContextFactory;
         this.availabilityGuard = availabilityGuard;
-        this.unpacker = unpacker;
         this.config = config;
         this.local = localLocks;
         this.master = master;
@@ -54,8 +51,8 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
     @Override
     public Client newClient()
     {
-        return new SlaveLocksClient( master, local.newClient(), local, requestContextFactory, availabilityGuard,
-                unpacker, config );
+        return new SlaveLocksClient(
+                master, local.newClient(), local, requestContextFactory, availabilityGuard, config );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -54,7 +54,6 @@ class SlaveLocksClient implements Locks.Client
     private final Locks localLockManager;
     private final RequestContextFactory requestContextFactory;
     private final AvailabilityGuard availabilityGuard;
-    private final TransactionCommittingResponseUnpacker unpacker;
     private final SlaveLockManager.Configuration config;
 
     // Using atomic ints to avoid creating garbage through boxing.
@@ -68,14 +67,13 @@ class SlaveLocksClient implements Locks.Client
             Locks localLockManager,
             RequestContextFactory requestContextFactory,
             AvailabilityGuard availabilityGuard,
-            TransactionCommittingResponseUnpacker unpacker, SlaveLockManager.Configuration config )
+            SlaveLockManager.Configuration config )
     {
         this.master = master;
         this.client = local;
         this.localLockManager = localLockManager;
         this.requestContextFactory = requestContextFactory;
         this.availabilityGuard = availabilityGuard;
-        this.unpacker = unpacker;
         this.config = config;
         sharedLocks = new HashMap<>();
         exclusiveLocks = new HashMap<>();
@@ -288,15 +286,7 @@ class SlaveLocksClient implements Locks.Client
 
     private boolean receiveLockResponse( Response<LockResult> response )
     {
-        LockResult result = null;
-        try
-        {
-            result = unpacker.unpackResponse( response );
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        LockResult result = response.response();
 
         switch ( result.getStatus() )
         {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -24,12 +24,17 @@ import org.junit.Test;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.NetworkReceiver;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.AbstractClusterTest;
+import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.test.ReflectionUtil.getPrivateField;
 import static org.neo4j.test.ha.ClusterManager.RepairKit;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
@@ -38,6 +43,8 @@ import static org.neo4j.test.ha.ClusterManager.masterSeesSlavesAsAvailable;
 
 public class ClusterTopologyChangesIT extends AbstractClusterTest
 {
+    private static final int TEST_NODE_COUNT = 10_000;
+
     @Before
     public void setUp()
     {
@@ -63,16 +70,56 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
         assertEquals( 3, cluster.size() );
     }
 
+    @Test
+    public void slaveShouldCatchUpTransactionLogsOnFirstLockRequestAfterFailure() throws Throwable
+    {
+        // Given
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+
+        Node theNode;
+        try ( Transaction tx = master.beginTx() )
+        {
+            theNode = master.createNode( label( "TheNode" ) );
+            tx.success();
+        }
+        cluster.sync();
+
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+        RepairKit repairKit = cluster.fail( slave );
+
+        try ( Transaction tx = master.beginTx() )
+        {
+            for ( int i = 0; i < TEST_NODE_COUNT; i++ )
+            {
+                master.createNode( label( "Node" + i ) );
+            }
+            tx.success();
+        }
+        cluster.sync();
+
+        // When
+        repairKit.repair();
+        try ( Transaction tx = slave.beginTx() )
+        {
+            slave.getNodeById( theNode.getId() ).addLabel( label( "42" ) );
+            tx.success();
+        }
+
+        // Then
+        assertEquals( 1 + TEST_NODE_COUNT, nodeCountOn( slave ) );
+    }
+
     @Override
     protected void configureClusterMember( GraphDatabaseBuilder builder, String clusterName, InstanceId serverId )
     {
         super.configureClusterMember( builder, clusterName, serverId );
         builder.setConfig( HaSettings.read_timeout, "1s" );
         builder.setConfig( HaSettings.state_switch_timeout, "2s" );
+        builder.setConfig( HaSettings.com_chunk_size, "1024" );
     }
 
     @SuppressWarnings("unchecked")
-    private void repairUsing( RepairKit kit ) throws Throwable
+    private static void repairUsing( RepairKit kit ) throws Throwable
     {
         Iterable<Lifecycle> stoppedServices = getPrivateField( kit, "stoppedServices", Iterable.class );
         for ( Lifecycle service : stoppedServices )
@@ -89,6 +136,14 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
             {
                 service.start();
             }
+        }
+    }
+
+    private static long nodeCountOn( HighlyAvailableGraphDatabase db )
+    {
+        try ( Transaction ignored = db.beginTx() )
+        {
+            return Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() );
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.ha.com.slave;
 
 import org.junit.Test;
 
+import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.kernel.ha.MasterClient210;
 import org.neo4j.kernel.ha.MasterClient214;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -30,6 +31,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import static org.neo4j.com.ProtocolVersion.INTERNAL_PROTOCOL_VERSION;
 import static org.neo4j.kernel.ha.MasterClient210.PROTOCOL_VERSION;
@@ -40,7 +42,8 @@ public class MasterClientResolverTest
     public void shouldResolveMasterClientFactory() throws Exception
     {
         // Given
-        MasterClientResolver resolver = new MasterClientResolver( new DevNullLoggingService(), 1, 1, 1, 1024 );
+        MasterClientResolver resolver =
+                new MasterClientResolver( new DevNullLoggingService(), mock( ResponseUnpacker.class ), 1, 1, 1, 1024 );
 
         LifeSupport life = new LifeSupport();
         try


### PR DESCRIPTION
This PR fixes unpacking of transaction logs that are send with practically all responses. Unread logs remained in netty channels, were read and misinterpreted by next requests.
For example it caused `ArrayIndexOutOfBoundsException` during lock sessions because not all transaction logs were read during `newLockSession` request and following `acquireLock` request read stale data from channel.
