### PR TITLE
Spoil identifiers in WHERE during inlining

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/inliningContextCreator.scala
@@ -26,6 +26,9 @@ object inliningContextCreator extends (ast.Statement => InliningContext) {
 
   def apply(input: ast.Statement): InliningContext = {
     input.treeFold(InliningContext()) {
+      case (With(false, ListedReturnItems(items), _, _, _, Some(Where(where: Identifier)))) =>
+        (context, children) => children(context.enterQueryPart(aliasedReturnItems(items)).spoilIdentifier(where))
+
       case (With(false, ListedReturnItems(items), _, _, _, _)) =>
         (context, children) => children(context.enterQueryPart(aliasedReturnItems(items)))
 


### PR DESCRIPTION
Rewriting `MATCH a, b, c WITH length(c.prop) AS d, b WITH b, d WHERE b.bar RETURN d` was creating a `WITH` with duplicate aliases. This PR fixes that, by spoiling identifiers in `WHERE` (in addition to the current spoiling of identifiers in `ORDER BY`).
