### PR TITLE
[2.1] Ensure that we get the same index hits when looking up from tx state as when we look up from the committed index

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TxState.java
@@ -264,5 +264,5 @@ public interface TxState
 
     DiffSets<Long> indexUpdates( IndexDescriptor index, Object value );
 
-    void indexUpdateProperty( IndexDescriptor descriptor, long nodeId, Object valueBefore, Object valueAfter );
+    void indexUpdateProperty( IndexDescriptor descriptor, long nodeId, DefinedProperty before, DefinedProperty after );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ArrayValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ArrayValue.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.properties;
+
+interface ArrayValue
+{
+    int length();
+
+    interface IntegralArray extends ArrayValue
+    {
+        long longValue( int index );
+    }
+
+    interface FloatingPointArray extends ArrayValue
+    {
+        double doubleValue( int index );
+    }
+
+    // <pre>
+    final class ByteArray implements IntegralArray
+    {
+        private final byte[] value; ByteArray( byte[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public long longValue( int index )     { return value[index]; }
+    }
+    final class ShortArray implements IntegralArray
+    {
+        private final short[] value; ShortArray( short[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public long longValue( int index )     { return value[index]; }
+    }
+    final class IntArray implements IntegralArray
+    {
+        private final int[] value; IntArray( int[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public long longValue( int index )     { return value[index]; }
+    }
+    final class LongArray implements IntegralArray
+    {
+        private final long[] value; LongArray( long[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public long longValue( int index )     { return value[index]; }
+    }
+    final class FloatArray implements FloatingPointArray
+    {
+        private final float[] value; FloatArray( float[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public double doubleValue( int index ) { return value[index]; }
+    }
+    final class DoubleArray implements FloatingPointArray
+    {
+        private final double[] value; DoubleArray( double[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public double doubleValue( int index ) { return value[index]; }
+    }
+    final class NumberArray implements IntegralArray, FloatingPointArray
+    {
+        static IntegralArray asIntegral( Number[] value )           { return new NumberArray( value ); }
+        static FloatingPointArray asFloatingPoint( Number[] value ) { return new NumberArray( value ); }
+        private final Number[] value; private NumberArray( Number[] value ) { this.value = value; }
+        @Override public int length()                    { return value.length; }
+        @Override public long longValue( int index )     { return value[index].longValue(); }
+        @Override public double doubleValue( int index ) { return value[index].doubleValue(); }
+    }
+    //</pre>
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanArrayProperty.java
@@ -43,17 +43,44 @@ class BooleanArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public boolean valueEquals( Object other )
     {
-        if ( value instanceof boolean[] )
+        return valueEquals( this.value, other );
+    }
+
+    static boolean valueEquals( boolean[] value, Object other )
+    {
+        if ( other instanceof boolean[] )
         {
-            return Arrays.equals( this.value, (boolean[]) value );
+            return Arrays.equals( value, (boolean[]) other );
         }
-        return valueCompare( this.value, value );
+        if ( other instanceof Boolean[] )
+        {
+            Boolean[] that = (Boolean[]) other;
+            int length = value.length;
+            if ( length == that.length )
+            {
+                for ( int i = 0; i < length; i++ )
+                {
+                    Boolean bool = that[i];
+                    if ( bool == null || bool != value[i] )
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
     int valueHash()
+    {
+        return hash( value );
+    }
+
+    static int hash( boolean[] value )
     {
         return Arrays.hashCode( value );
     }
@@ -61,7 +88,7 @@ class BooleanArrayProperty extends DefinedProperty
     @Override
     boolean hasEqualValue( DefinedProperty that )
     {
-        return Arrays.equals( this.value, ((BooleanArrayProperty)that).value );
+        return that instanceof BooleanArrayProperty && Arrays.equals( this.value, ((BooleanArrayProperty) that).value );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/BooleanProperty.java
@@ -57,19 +57,7 @@ final class BooleanProperty extends DefinedProperty
     @Override
     boolean hasEqualValue( DefinedProperty that )
     {
-        return value == ((BooleanProperty) that).value;
-    }
-
-    @Override
-    public boolean booleanValue()
-    {
-        return value;
-    }
-
-    @Override
-    public boolean booleanValue( boolean defaultValue )
-    {
-        return value;
+        return that instanceof BooleanProperty && value == ((BooleanProperty) that).value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class ByteArrayProperty extends DefinedProperty
+class ByteArrayProperty extends IntegralArrayProperty
 {
     private final byte[] value;
 
@@ -43,25 +41,15 @@ class ByteArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public int length()
     {
-        if ( value instanceof byte[] )
-        {
-            return Arrays.equals( this.value, (byte[]) value );
-        }
-        return valueCompare( this.value, value );
+        return value.length;
     }
 
     @Override
-    int valueHash()
+    public long longValue( int index )
     {
-        return Arrays.hashCode( value );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Arrays.equals( this.value, ((ByteArrayProperty)that).value );
+        return value[index];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ByteProperty.java
@@ -25,7 +25,7 @@ import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
  * This does not extend AbstractProperty since the JVM can take advantage of the 4 byte initial field alignment if
  * we don't extend a class that has fields.
  */
-final class ByteProperty extends DefinedProperty
+final class ByteProperty extends IntegralNumberProperty
 {
     private final byte value;
 
@@ -36,42 +36,13 @@ final class ByteProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
-    {
-        if ( other instanceof Byte )
-        {
-            return ((Byte)other).byteValue() == value;
-        }
-        return valueCompare( value, other );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return value == ((ByteProperty) that).value;
-    }
-
-    @Override
     public Byte value()
     {
         return value;
     }
 
     @Override
-    int valueHash()
-    {
-        return value;
-    }
-
-    @Override
-    public int intValue()
-    {
-        return value;
-    }
-
-    @Override
-    public long longValue()
+    long longValue()
     {
         return value;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/CharProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/CharProperty.java
@@ -27,7 +27,7 @@ import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
  */
 final class CharProperty extends DefinedProperty
 {
-    private final char value;
+    final char value;
 
     CharProperty( int propertyKeyId, char value )
     {
@@ -43,7 +43,12 @@ final class CharProperty extends DefinedProperty
         {
             return value == ((Character) other).charValue();
         }
-        return valueCompare( value, other );
+        if ( other instanceof String )
+        {
+            String that = (String) other;
+            return that.length() == 1 && that.charAt( 0 ) == value;
+        }
+        return false;
     }
 
     @Override
@@ -61,7 +66,19 @@ final class CharProperty extends DefinedProperty
     @Override
     boolean hasEqualValue( DefinedProperty that )
     {
-        return value == ((CharProperty) that).value;
+        if ( that instanceof CharProperty )
+        {
+            return value == ((CharProperty) that).value;
+        }
+        else if ( that instanceof StringProperty )
+        {
+            String str = ((StringProperty) that).value();
+            return str.length() == 1 && value == str.charAt( 0 );
+        }
+        else
+        {
+            return false;
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class DoubleArrayProperty extends DefinedProperty
+class DoubleArrayProperty extends FloatingPointArrayProperty
 {
     private final double[] value;
 
@@ -43,26 +41,15 @@ class DoubleArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public int length()
     {
-        if ( value instanceof double[] )
-        {
-            return Arrays.equals( this.value, (double[]) value );
-        }
-        return valueCompare( this.value, value );
-    }
-
-
-    @Override
-    int valueHash()
-    {
-        return Arrays.hashCode( value );
+        return value.length;
     }
 
     @Override
-    boolean hasEqualValue( DefinedProperty that )
+    public double doubleValue( int index )
     {
-        return Arrays.equals( this.value, ((DoubleArrayProperty)that).value );
+        return value[index];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/DoubleProperty.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api.properties;
 
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 
-final class DoubleProperty extends DefinedProperty
+final class DoubleProperty extends FloatingPointNumberProperty
 {
     private final double value;
 
@@ -32,33 +32,15 @@ final class DoubleProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
+    double doubleValue()
     {
-        if ( other instanceof Double )
-        {
-            return value == ((Double) other).doubleValue();
-        }
-        return valueCompare( value, other );
+        return value;
     }
 
     @Override
     public Double value()
     {
         return value;
-    }
-
-    @Override
-    int valueHash()
-    {
-        long temp = Double.doubleToLongBits( value );
-        return (int) (temp ^ (temp >>> 32));
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Double.compare( this.value, ((DoubleProperty) that).value ) == 0;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class FloatArrayProperty extends DefinedProperty
+class FloatArrayProperty extends FloatingPointArrayProperty
 {
     private final float[] value;
 
@@ -37,31 +35,21 @@ class FloatArrayProperty extends DefinedProperty
     }
 
     @Override
+    public int length()
+    {
+        return value.length;
+    }
+
+    @Override
+    public double doubleValue( int index )
+    {
+        return value[index];
+    }
+
+    @Override
     public float[] value()
     {
         return value.clone();
-    }
-
-    @Override
-    public boolean valueEquals( Object value )
-    {
-        if ( value instanceof float[] )
-        {
-            return Arrays.equals( this.value, (float[]) value );
-        }
-        return valueCompare( this.value, value );
-    }
-
-    @Override
-    int valueHash()
-    {
-        return Arrays.hashCode( value );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Arrays.equals( this.value, ((FloatArrayProperty)that).value );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatProperty.java
@@ -23,7 +23,7 @@ import static java.lang.Float.floatToIntBits;
 
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 
-final class FloatProperty extends DefinedProperty
+final class FloatProperty extends FloatingPointNumberProperty
 {
     private final float value;
 
@@ -34,32 +34,15 @@ final class FloatProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
-    {
-        if ( other instanceof Float )
-        {
-            return value == ((Float) other).floatValue();
-        }
-        return valueCompare( value, other );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return value == ((FloatProperty) that).value;
-    }
-
-    @Override
-    public Number value()
+    double doubleValue()
     {
         return value;
     }
 
     @Override
-    int valueHash()
+    public Float value()
     {
-        return floatToIntBits( value );
+        return value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatingPointArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatingPointArrayProperty.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.properties;
+
+abstract class FloatingPointArrayProperty extends DefinedProperty implements ArrayValue.FloatingPointArray
+{
+    FloatingPointArrayProperty( int propertyKeyId )
+    {
+        super( propertyKeyId );
+    }
+
+    public abstract int length();
+
+    public abstract double doubleValue( int index );
+
+    @Override
+    final int valueHash()
+    {
+        return hash( this );
+    }
+
+    static int hash( FloatingPointArray value )
+    {
+        int result = 1;
+        for ( int i = 0, len = value.length(); i < len; i++ )
+        {
+            long element = (long) value.doubleValue( i );
+            int elementHash = (int) (element ^ (element >>> 32));
+            result = 31 * result + elementHash;
+        }
+        return result;
+    }
+
+    @Override
+    public final boolean valueEquals( Object other )
+    {
+        return valueEquals( this, other );
+    }
+
+    static boolean valueEquals( FloatingPointArray value, Object other )
+    {
+        if ( other instanceof double[] )
+        {
+            return numbersEqual( value, new DoubleArray( (double[]) other ) );
+        }
+        else if ( other instanceof float[] )
+        {
+            return numbersEqual( value, new FloatArray( (float[]) other ) );
+        }
+        else if ( other instanceof Number[] )
+        {
+            Number[] that = (Number[]) other;
+            if ( that.length == value.length() )
+            {
+                if ( other instanceof Double[] || other instanceof Float[] )
+                {
+                    return numbersEqual( value, NumberArray.asFloatingPoint( that ) );
+                }
+                else
+                {
+                    return numbersEqual( value, NumberArray.asIntegral( that ) );
+                }
+            }
+        }
+        else if ( other instanceof long[] )
+        {
+            return numbersEqual( value, new LongArray( (long[]) other ) );
+        }
+        else if ( other instanceof int[] )
+        {
+            return numbersEqual( value, new IntArray( (int[]) other ) );
+        }
+        else if ( other instanceof short[] )
+        {
+            return numbersEqual( value, new ShortArray( (short[]) other ) );
+        }
+        else if ( other instanceof byte[] )
+        {
+            return numbersEqual( value, new ByteArray( (byte[]) other ) );
+        }
+        return false;
+    }
+
+    @Override
+    final boolean hasEqualValue( DefinedProperty other )
+    {
+        if ( other instanceof FloatingPointArrayProperty )
+        {
+            FloatingPointArrayProperty that = (FloatingPointArrayProperty) other;
+            return numbersEqual( this, that );
+        }
+        else if ( other instanceof IntegralArrayProperty )
+        {
+            IntegralArrayProperty that = (IntegralArrayProperty) other;
+            return numbersEqual( this, that );
+        }
+        return false;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatingPointNumberProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/FloatingPointNumberProperty.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.properties;
+
+abstract class FloatingPointNumberProperty extends DefinedProperty
+{
+    FloatingPointNumberProperty( int propertyKeyId )
+    {
+        super( propertyKeyId );
+    }
+
+    abstract double doubleValue();
+
+    @Override
+    final int valueHash()
+    {
+        long value = (long) doubleValue();
+        return (int) (value ^ (value >>> 32));
+    }
+
+    @Override
+    public final boolean valueEquals( Object other )
+    {
+        if ( other instanceof Number )
+        {
+            Number that = (Number) other;
+            if ( other instanceof Double || other instanceof Float )
+            {
+                return this.doubleValue() == that.doubleValue();
+            }
+            else
+            {
+                return numbersEqual( this.doubleValue(), that.longValue() );
+            }
+        }
+        return false;
+    }
+
+    @Override
+    final boolean hasEqualValue( DefinedProperty other )
+    {
+        if ( other instanceof FloatingPointNumberProperty )
+        {
+            FloatingPointNumberProperty that = (FloatingPointNumberProperty) other;
+            return this.doubleValue() == that.doubleValue();
+        }
+        else if ( other instanceof IntegralNumberProperty )
+        {
+            IntegralNumberProperty that = (IntegralNumberProperty) other;
+            return numbersEqual( this.doubleValue(), that.longValue() );
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class IntArrayProperty extends DefinedProperty
+class IntArrayProperty extends IntegralArrayProperty
 {
     private final int[] value;
 
@@ -43,30 +41,20 @@ class IntArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public int length()
     {
-        if ( value instanceof int[] )
-        {
-            return Arrays.equals( this.value, (int[]) value );
-        }
-        return valueCompare( this.value, value );
+        return value.length;
     }
 
     @Override
-    int valueHash()
+    public long longValue( int index )
     {
-        return Arrays.hashCode( value );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Arrays.equals( this.value, ((IntArrayProperty) that).value );
+        return value[index];
     }
 
     @Override
     public int sizeOfObjectInBytesIncludingOverhead()
     {
-        return withObjectOverhead( withReference( withArrayOverhead( value.length*4 ) ) );
+        return withObjectOverhead( withReference( withArrayOverhead( value.length * 4 ) ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntProperty.java
@@ -25,7 +25,7 @@ import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
  * This does not extend AbstractProperty since the JVM can take advantage of the 4 byte initial field alignment if
  * we don't extend a class that has fields.
  */
-final class IntProperty extends DefinedProperty
+final class IntProperty extends IntegralNumberProperty
 {
     private final int value;
 
@@ -36,42 +36,13 @@ final class IntProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
-    {
-        if ( other instanceof Integer )
-        {
-            return value == ((Integer)other).intValue();
-        }
-        return valueCompare( value, other );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return value == ((IntProperty) that).value;
-    }
-
-    @Override
     public Integer value()
     {
         return value;
     }
 
     @Override
-    int valueHash()
-    {
-        return value;
-    }
-
-    @Override
-    public int intValue()
-    {
-        return value;
-    }
-
-    @Override
-    public long longValue()
+    long longValue()
     {
         return value;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralArrayProperty.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.properties;
+
+abstract class IntegralArrayProperty extends DefinedProperty implements ArrayValue.IntegralArray
+{
+    IntegralArrayProperty( int propertyKeyId )
+    {
+        super( propertyKeyId );
+    }
+
+    public abstract int length();
+
+    public abstract long longValue( int index );
+
+    @Override
+    final int valueHash()
+    {
+        return hash( this );
+    }
+
+    static int hash( IntegralArray value )
+    {
+        int result = 1;
+        for ( int i = 0, len = value.length(); i < len; i++ )
+        {
+            long element = value.longValue( i );
+            int elementHash = (int) (element ^ (element >>> 32));
+            result = 31 * result + elementHash;
+        }
+        return result;
+    }
+
+    @Override
+    public final boolean valueEquals( Object other )
+    {
+        return valueEquals( this, other );
+    }
+
+    static boolean valueEquals( IntegralArray value, Object other )
+    {
+        if ( other instanceof long[] )
+        {
+            return numbersEqual( value, new LongArray( (long[]) other ) );
+        }
+        else if ( other instanceof int[] )
+        {
+            return numbersEqual( value, new IntArray( (int[]) other ) );
+        }
+        else if ( other instanceof short[] )
+        {
+            return numbersEqual( value, new ShortArray( (short[]) other ) );
+        }
+        else if ( other instanceof byte[] )
+        {
+            return numbersEqual( value, new ByteArray( (byte[]) other ) );
+        }
+        else if ( other instanceof Number[] )
+        {
+            Number[] that = (Number[]) other;
+            if ( that.length == value.length() )
+            {
+                if ( other instanceof Double[] || other instanceof Float[] )
+                {
+                    return numbersEqual( NumberArray.asFloatingPoint( that ), value );
+                }
+                else
+                {
+                    return numbersEqual( value, NumberArray.asIntegral( that ) );
+                }
+            }
+        }
+        else if ( other instanceof double[] )
+        {
+            return numbersEqual( new DoubleArray( (double[]) other ), value );
+        }
+        else if ( other instanceof float[] )
+        {
+            return numbersEqual( new FloatArray( (float[]) other ), value );
+        }
+        return false;
+    }
+
+    @Override
+    final boolean hasEqualValue( DefinedProperty other )
+    {
+        if ( other instanceof IntegralArrayProperty )
+        {
+            IntegralArrayProperty that = (IntegralArrayProperty) other;
+            return numbersEqual( this, that );
+        }
+        else if ( other instanceof FloatingPointArrayProperty )
+        {
+            FloatingPointArrayProperty that = (FloatingPointArrayProperty) other;
+            return numbersEqual( that, this );
+        }
+        return false;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralNumberProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralNumberProperty.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.properties;
+
+abstract class IntegralNumberProperty extends DefinedProperty
+{
+    IntegralNumberProperty( int propertyKeyId )
+    {
+        super( propertyKeyId );
+    }
+
+    abstract long longValue();
+
+    @Override
+    final int valueHash()
+    {
+        long value = longValue();
+        return (int) (value ^ (value >>> 32));
+    }
+
+    @Override
+    public final boolean valueEquals( Object other )
+    {
+        if ( other instanceof Number )
+        {
+            Number that = (Number) other;
+            if ( other instanceof Double || other instanceof Float )
+            {
+                return numbersEqual( that.doubleValue(), this.longValue() );
+            }
+            else
+            {
+                return this.longValue() == that.longValue();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    final boolean hasEqualValue( DefinedProperty other )
+    {
+        if ( other instanceof IntegralNumberProperty )
+        {
+            IntegralNumberProperty that = (IntegralNumberProperty) other;
+            return this.longValue() == that.longValue();
+        }
+        else if ( other instanceof FloatingPointNumberProperty )
+        {
+            FloatingPointNumberProperty that = (FloatingPointNumberProperty) other;
+            return numbersEqual( that.doubleValue(), this.longValue() );
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyArrayProperty.java
@@ -88,19 +88,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (int[]) array );
+                return IntegralArrayProperty.hash( new ArrayValue.IntArray( (int[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof int[] && Arrays.equals( (int[]) array1, (int[]) array2 );
+                return IntegralArrayProperty.valueEquals( new ArrayValue.IntArray( (int[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((int[])array).clone();
+                return ((int[]) array).clone();
             }
         },
         LONG
@@ -108,19 +108,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (long[]) array );
+                return IntegralArrayProperty.hash( new ArrayValue.LongArray( (long[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof long[] && Arrays.equals( (long[]) array1, (long[]) array2 );
+                return IntegralArrayProperty.valueEquals( new ArrayValue.LongArray( (long[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((long[])array).clone();
+                return ((long[]) array).clone();
             }
         },
         BOOLEAN
@@ -128,19 +128,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (boolean[]) array );
+                return BooleanArrayProperty.hash( (boolean[]) array );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof boolean[] && Arrays.equals( (boolean[]) array1, (boolean[]) array2 );
+                return BooleanArrayProperty.valueEquals( (boolean[]) value, other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((boolean[])array).clone();
+                return ((boolean[]) array).clone();
             }
         },
         BYTE
@@ -148,19 +148,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (byte[]) array );
+                return IntegralArrayProperty.hash( new ArrayValue.ByteArray( (byte[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof byte[] && Arrays.equals( (byte[]) array1, (byte[]) array2 );
+                return IntegralArrayProperty.valueEquals( new ArrayValue.ByteArray( (byte[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((byte[])array).clone();
+                return ((byte[]) array).clone();
             }
         },
         DOUBLE
@@ -168,19 +168,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (double[]) array );
+                return FloatingPointArrayProperty.hash( new ArrayValue.DoubleArray( (double[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof double[] && Arrays.equals( (double[]) array1, (double[]) array2 );
+                return FloatingPointArrayProperty.valueEquals( new ArrayValue.DoubleArray( (double[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((double[])array).clone();
+                return ((double[]) array).clone();
             }
         },
         STRING
@@ -188,19 +188,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (String[]) array );
+                return StringArrayProperty.hash( (String[]) array );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof String[] && Arrays.equals( (String[]) array1, (String[]) array2 );
+                return StringArrayProperty.valueEquals( (String[]) value, other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((String[])array).clone();
+                return ((String[]) array).clone();
             }
         },
         SHORT
@@ -208,19 +208,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (short[]) array );
+                return IntegralArrayProperty.hash( new ArrayValue.ShortArray( (short[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof short[] && Arrays.equals( (short[]) array1, (short[]) array2 );
+                return IntegralArrayProperty.valueEquals( new ArrayValue.ShortArray( (short[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((short[])array).clone();
+                return ((short[]) array).clone();
             }
         },
         CHAR
@@ -228,19 +228,19 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (char[]) array );
+                return CharArrayProperty.hash( (char[]) array );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof char[] && Arrays.equals( (char[]) array1, (char[]) array2 );
+                return CharArrayProperty.valueEquals( (char[]) value, other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((char[])array).clone();
+                return ((char[]) array).clone();
             }
         },
         FLOAT
@@ -248,25 +248,25 @@ class LazyArrayProperty extends LazyProperty<Object>
             @Override
             int hashCode( Object array )
             {
-                return Arrays.hashCode( (float[]) array );
+                return FloatingPointArrayProperty.hash( new ArrayValue.FloatArray( (float[]) array ) );
             }
 
             @Override
-            boolean equals( Object array1, Object array2 )
+            boolean equals( Object value, Object other )
             {
-                return array2 instanceof float[] && Arrays.equals( (float[]) array1, (float[]) array2 );
+                return FloatingPointArrayProperty.valueEquals( new ArrayValue.FloatArray( (float[]) value ), other );
             }
 
             @Override
             Object clone( Object array )
             {
-                return ((float[])array).clone();
+                return ((float[]) array).clone();
             }
         };
 
         abstract int hashCode( Object array );
 
-        abstract boolean equals( Object array1, Object array2 );
+        abstract boolean equals( Object value, Object other );
 
         abstract Object clone( Object array );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyProperty.java
@@ -38,7 +38,7 @@ abstract class LazyProperty<T> extends DefinedProperty
     @Override
     final boolean hasEqualValue( DefinedProperty that )
     {
-        return valueEquals( ((LazyProperty<?>)that).value() );
+        return valueEquals( that.value() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyStringProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LazyStringProperty.java
@@ -31,7 +31,7 @@ class LazyStringProperty extends LazyProperty<String>
     @Override
     public boolean valueEquals( Object value )
     {
-        return value().equals( value );
+        return StringProperty.valueEquals( value(), value );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class LongArrayProperty extends DefinedProperty
+class LongArrayProperty extends IntegralArrayProperty
 {
     private final long[] value;
 
@@ -43,25 +41,15 @@ class LongArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public int length()
     {
-        if ( value instanceof long[] )
-        {
-            return Arrays.equals( this.value, (long[]) value );
-        }
-        return valueCompare( this.value, value );
+        return value.length;
     }
 
     @Override
-    int valueHash()
+    public long longValue( int index )
     {
-        return Arrays.hashCode( value );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Arrays.equals( this.value, ((LongArrayProperty)that).value );
+        return value[index];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/LongProperty.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api.properties;
 
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 
-final class LongProperty extends DefinedProperty
+final class LongProperty extends IntegralNumberProperty
 {
     private final long value;
 
@@ -32,44 +32,15 @@ final class LongProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
-    {
-        if ( other instanceof Long )
-        {
-            return value == ((Long)other).longValue();
-        }
-        return valueCompare( value, other );
-    }
-
-    @Override
     public Long value()
     {
         return value;
     }
 
     @Override
-    public int intValue()
-    {
-        throw new ClassCastException( String.format( "[%s:long] is not small enough to fit into an int.", value ) );
-    }
-
-    @Override
-    public long longValue()
+    long longValue()
     {
         return value;
-    }
-
-    @Override
-    int valueHash()
-    {
-        return (int) (value ^ (value >>> 32));
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return value == ((LongProperty) that).value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/NoProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/NoProperty.java
@@ -82,73 +82,13 @@ final class NoProperty extends Property
     }
 
     @Override
-    public String stringValue( String defaultValue )
-    {
-        return defaultValue;
-    }
-
-    @Override
     public String valueAsString() throws PropertyNotFoundException
     {
         throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
     }
 
     @Override
-    public Number numberValue( Number defaultValue )
-    {
-        return defaultValue;
-    }
-
-    @Override
-    public int intValue( int defaultValue )
-    {
-        return defaultValue;
-    }
-
-    @Override
-    public long longValue( long defaultValue )
-    {
-        return defaultValue;
-    }
-
-    @Override
-    public boolean booleanValue( boolean defaultValue )
-    {
-        return defaultValue;
-    }
-
-    @Override
     public Object value() throws PropertyNotFoundException
-    {
-        throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
-    }
-
-    @Override
-    public String stringValue() throws PropertyNotFoundException
-    {
-        throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
-    }
-
-    @Override
-    public boolean booleanValue() throws PropertyNotFoundException
-    {
-        throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
-    }
-
-    @Override
-    public Number numberValue() throws PropertyNotFoundException
-    {
-        throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
-    }
-
-    @Override
-    public int intValue() throws PropertyNotFoundException
-    {
-        throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
-    }
-
-    @Override
-    public long longValue() throws PropertyNotFoundException
     {
         throw new PropertyNotFoundException( propertyKeyId, entityType, entityId );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/Property.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/Property.java
@@ -69,27 +69,7 @@ public abstract class Property
 
     public abstract Object value( Object defaultValue );
 
-    public abstract String stringValue() throws PropertyNotFoundException;
-
-    public abstract String stringValue( String defaultValue );
-
     public abstract String valueAsString() throws PropertyNotFoundException;
-
-    public abstract Number numberValue() throws PropertyNotFoundException;
-
-    public abstract Number numberValue( Number defaultValue );
-
-    public abstract int intValue() throws PropertyNotFoundException;
-
-    public abstract int intValue( int defaultValue );
-
-    public abstract long longValue() throws PropertyNotFoundException;
-
-    public abstract long longValue( long defaultValue );
-
-    public abstract boolean booleanValue() throws PropertyNotFoundException;
-
-    public abstract boolean booleanValue( boolean defaultValue );
 
     @Override
     public abstract boolean equals( Object obj );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortArrayProperty.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import java.util.Arrays;
-
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
-class ShortArrayProperty extends DefinedProperty
+class ShortArrayProperty extends IntegralArrayProperty
 {
     private final short[] value;
 
@@ -43,25 +41,15 @@ class ShortArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public int length()
     {
-        if ( value instanceof short[] )
-        {
-            return Arrays.equals( this.value, (short[]) value );
-        }
-        return valueCompare( value, this.value );
+        return value.length;
     }
 
     @Override
-    int valueHash()
+    public long longValue( int index )
     {
-        return Arrays.hashCode( value );
-    }
-
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return Arrays.equals( this.value, ((ShortArrayProperty)that).value );
+        return value[index];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/ShortProperty.java
@@ -25,7 +25,7 @@ import static org.neo4j.kernel.impl.cache.SizeOfs.withObjectOverhead;
  * This does not extend AbstractProperty since the JVM can take advantage of the 4 byte initial field alignment if
  * we don't extend a class that has fields.
  */
-final class ShortProperty extends DefinedProperty
+final class ShortProperty extends IntegralNumberProperty
 {
     private final short value;
 
@@ -36,41 +36,13 @@ final class ShortProperty extends DefinedProperty
     }
 
     @Override
-    @SuppressWarnings("UnnecessaryUnboxing")
-    public boolean valueEquals( Object other )
-    {
-        if ( other instanceof Short )
-        {
-            return value == ((Short)other).shortValue();
-        }
-        return valueCompare( value, other );
-    }
-    @Override
-    boolean hasEqualValue( DefinedProperty that )
-    {
-        return value == ((ShortProperty) that).value;
-    }
-
-    @Override
     public Short value()
     {
         return value;
     }
 
     @Override
-    int valueHash()
-    {
-        return value;
-    }
-
-    @Override
-    public int intValue()
-    {
-        return value;
-    }
-
-    @Override
-    public long longValue()
+    long longValue()
     {
         return value;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringArrayProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringArrayProperty.java
@@ -27,7 +27,7 @@ import static org.neo4j.kernel.impl.cache.SizeOfs.withReference;
 
 class StringArrayProperty extends DefinedProperty
 {
-    private final String[] value;
+    final String[] value;
 
     StringArrayProperty( int propertyKeyId, String[] value )
     {
@@ -43,25 +43,68 @@ class StringArrayProperty extends DefinedProperty
     }
 
     @Override
-    public boolean valueEquals( Object value )
+    public boolean valueEquals( Object other )
     {
-        if ( value instanceof String[] )
+        String[] value = this.value;
+        return valueEquals( value, other );
+    }
+
+    static boolean valueEquals( String[] value, Object other )
+    {
+        if ( other instanceof String[] )
         {
-            return Arrays.equals( this.value, (String[]) value );
+            return Arrays.equals( value, (String[]) other );
         }
-        return valueCompare( this.value, value );
+        if ( other instanceof char[] )
+        {
+            return CharArrayProperty.eq( value, (char[]) other );
+        }
+        else if ( other instanceof Character[] )
+        {
+            Character[] that = (Character[]) other;
+            if ( value.length == that.length )
+            {
+                for ( int i = 0; i < that.length; i++ )
+                {
+                    String str = value[i];
+                    Character character = that[i];
+                    if ( character == null || str.length() != 1 || str.charAt( 0 ) != character )
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+        return false;
     }
 
     @Override
     int valueHash()
     {
+        return hash( value );
+    }
+
+    static int hash( String[] value )
+    {
         return Arrays.hashCode( value );
     }
 
     @Override
-    boolean hasEqualValue( DefinedProperty that )
+    boolean hasEqualValue( DefinedProperty other )
     {
-        return Arrays.equals( this.value, ((StringArrayProperty)that).value );
+        if ( other instanceof StringArrayProperty )
+        {
+            StringArrayProperty that = (StringArrayProperty) other;
+            return Arrays.equals( this.value, that.value );
+        }
+        if ( other instanceof CharArrayProperty )
+        {
+            CharArrayProperty that = (CharArrayProperty) other;
+            return CharArrayProperty.eq( this.value, that.value );
+        }
+        return false;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/StringProperty.java
@@ -37,12 +37,21 @@ final class StringProperty extends DefinedProperty
     @Override
     public boolean valueEquals( Object other )
     {
+        return valueEquals( value, other );
+    }
+
+    static boolean valueEquals( String value, Object other )
+    {
         if ( other instanceof String )
         {
             return value.equals( other );
         }
-
-        return valueCompare( value, other );
+        if ( other instanceof Character )
+        {
+            Character that = (Character) other;
+            return value.length() == 1 && value.charAt( 0 ) == that;
+        }
+        return false;
     }
 
     @Override
@@ -58,9 +67,19 @@ final class StringProperty extends DefinedProperty
     }
 
     @Override
-    boolean hasEqualValue( DefinedProperty that )
+    boolean hasEqualValue( DefinedProperty other )
     {
-        return value.equals( ((StringProperty) that).value );
+        if ( other instanceof StringProperty )
+        {
+            StringProperty that = (StringProperty) other;
+            return value.equals( that.value );
+        }
+        if ( other instanceof CharProperty )
+        {
+            CharProperty that = (CharProperty) other;
+            return value.length() == 1 && that.value == value.charAt( 0 );
+        }
+        return false;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -221,7 +221,7 @@ public class StateHandlingStatementOperations implements
         for ( Iterator<DefinedProperty> properties = nodeGetAllProperties( state, nodeId ); properties.hasNext(); )
         {
             DefinedProperty property = properties.next();
-            indexUpdateProperty( state, nodeId, labelId, property.propertyKeyId(), null, property.value() );
+            indexUpdateProperty( state, nodeId, labelId, property.propertyKeyId(), null, property );
         }
         return true;
     }
@@ -239,7 +239,7 @@ public class StateHandlingStatementOperations implements
         for ( Iterator<DefinedProperty> properties = nodeGetAllProperties( state, nodeId ); properties.hasNext(); )
         {
             DefinedProperty property = properties.next();
-            indexUpdateProperty( state, nodeId, labelId, property.propertyKeyId(), property.value(), null );
+            indexUpdateProperty( state, nodeId, labelId, property.propertyKeyId(), property, null );
         }
         return true;
     }
@@ -605,8 +605,9 @@ public class StateHandlingStatementOperations implements
             legacyPropertyTrackers.nodeChangeStoreProperty( nodeId, (DefinedProperty) existingProperty, property );
         }
         state.txState().nodeDoReplaceProperty( nodeId, existingProperty, property );
-        indexesUpdateProperty( state, nodeId, property.propertyKeyId(), existingProperty.value( null ),
-                               property.value() );
+        indexesUpdateProperty( state, nodeId, property.propertyKeyId(),
+                               existingProperty instanceof DefinedProperty ? (DefinedProperty) existingProperty : null,
+                               property );
         return existingProperty;
     }
 
@@ -645,7 +646,7 @@ public class StateHandlingStatementOperations implements
         {
             legacyPropertyTrackers.nodeRemoveStoreProperty( nodeId, (DefinedProperty) existingProperty );
             state.txState().nodeDoRemoveProperty( nodeId, (DefinedProperty)existingProperty );
-            indexesUpdateProperty( state, nodeId, propertyKeyId, ((DefinedProperty) existingProperty).value(), null );
+            indexesUpdateProperty( state, nodeId, propertyKeyId, (DefinedProperty) existingProperty, null );
         }
         return existingProperty;
     }
@@ -676,21 +677,21 @@ public class StateHandlingStatementOperations implements
     }
 
     private void indexesUpdateProperty( KernelStatement state, long nodeId, int propertyKey,
-                                        Object valueBefore, Object valueAfter ) throws EntityNotFoundException
+                                        DefinedProperty before, DefinedProperty after ) throws EntityNotFoundException
     {
         for ( PrimitiveIntIterator labels = nodeGetLabels( state, nodeId ); labels.hasNext(); )
         {
-            indexUpdateProperty( state, nodeId, labels.next(), propertyKey, valueBefore, valueAfter );
+            indexUpdateProperty( state, nodeId, labels.next(), propertyKey, before, after );
         }
     }
 
     private void indexUpdateProperty( KernelStatement state, long nodeId, int labelId, int propertyKey,
-                                      Object valueBefore, Object valueAfter )
+                                      DefinedProperty before, DefinedProperty after )
     {
         IndexDescriptor descriptor = indexesGetForLabelAndPropertyKey( state, labelId, propertyKey );
         if ( descriptor != null )
         {
-            state.txState().indexUpdateProperty( descriptor, nodeId, valueBefore, valueAfter );
+            state.txState().indexUpdateProperty( descriptor, nodeId, before, after );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/properties/LazyPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/properties/LazyPropertyTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 public class LazyPropertyTest
 {
+
     @Test
     public void shouldLoadLazyStringProperty() throws Exception
     {
@@ -53,56 +54,60 @@ public class LazyPropertyTest
     @Test
     public void shouldExhibitCorrectEqualityForBooleanArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new boolean[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new boolean[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForByteArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new byte[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new byte[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForShortArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new short[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new short[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForCharArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new char[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new char[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForIntArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new int[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new int[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForLongArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new long[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new long[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForFloatArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new float[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new float[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForDoubleArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new double[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new double[]{} );
     }
 
     @Test
     public void shouldExhibitCorrectEqualityForStringArray() throws Exception
     {
-        verifyCorrectValueEqualityForLazyArrayProperty( new String[] {} );
+        verifyCorrectValueEqualityForLazyArrayProperty( new String[]{} );
     }
+
+    public static final Object[] ENPTY_ARRAYS = new Object[]{
+            new boolean[]{}, new char[]{}, new String[]{}, new float[]{}, new double[]{},
+            new byte[]{}, new short[]{}, new int[]{}, new long[]{},};
 
     private static void verifyCorrectValueEqualityForLazyArrayProperty( Object array )
     {
@@ -111,15 +116,52 @@ public class LazyPropertyTest
         // when/then
         assertTrue( "value should be reported equal with same type", property.valueEquals( array ) );
         // when
-        for ( Object value : new Object[] { new boolean[] {}, new byte[] {}, new short[] {}, new char[] {},
-                new int[] {}, new long[] {}, new float[] {}, new double[] {}, new String[] {}, } )
+        for ( Object value : ENPTY_ARRAYS )
         {
-            if ( value.getClass() == array.getClass() )
+            if ( coercible( value.getClass(), array.getClass() ) )
             {
                 continue;
             }
             // then
             assertFalse( "value should be reported inequal with different type", property.valueEquals( value ) );
+        }
+    }
+
+    private static boolean coercible( Class<?> lhs, Class<?> rhs )
+    {
+        if ( lhs == rhs )
+        {
+            return true;
+        }
+        if ( lhs.isArray() && rhs.isArray() )
+        {
+            return coercible( lhs.getComponentType(), rhs.getComponentType() );
+        }
+        if ( lhs.isArray() || rhs.isArray() )
+        {
+            return false;
+        }
+        switch ( lhs.getName() )
+        {
+        case "boolean":
+            return rhs == boolean.class;
+        case "char":
+        case "java.lang.String":
+            return rhs == char.class || rhs == String.class;
+        case "float":
+        case "double":
+        case "byte":
+        case "short":
+        case "int":
+        case "long":
+            return rhs == float.class ||
+                   rhs == double.class ||
+                   rhs == byte.class ||
+                   rhs == short.class ||
+                   rhs == int.class ||
+                   rhs == long.class;
+        default:
+            return false;
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/properties/PropertyEqualityTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/properties/PropertyEqualityTest.java
@@ -98,7 +98,7 @@ public class PropertyEqualityTest
                 shouldNotMatch( 23L, 23.5 ),
                 shouldNotMatch( 23L, 23.5f ),
                 shouldMatch(9007199254740992L, 9007199254740992D),
-                shouldMatch(9007199254740993L, 9007199254740992D),
+                // shouldMatch(9007199254740993L, 9007199254740992D), // is stupid, m'kay?!
 
                 // floats goddamnit
                 shouldMatch( 11f, (byte) 11 ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -391,7 +391,8 @@ public class PropertyIT extends KernelIntegrationTest
             // THEN
             assertTrue( statement.nodeGetProperty( nodeId, propertyKeyId ).getClass().getSimpleName().equals( "LazyArrayProperty" ) );
             assertArrayEquals( value, (int[]) statement.nodeGetProperty( nodeId, propertyKeyId ).value() );
-            assertEquals( Arrays.hashCode( value ), statement.nodeGetProperty( nodeId, propertyKeyId ).hashCode() );
+            assertEquals( Property.intArrayProperty( propertyKeyId, value ).hashCode(),
+                          statement.nodeGetProperty( nodeId, propertyKeyId ).hashCode() );
             assertTrue( statement.nodeGetProperty( nodeId, propertyKeyId ).valueEquals( value ) );
         }
     }

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+
+@RunWith(Parameterized.class)
+public class IndexTxStateLookupTest
+{
+    private static final String TRIGGER_LAZY = "this is supposed to be a really long property to trigger lazy loading";
+    private static final Random random = new Random();
+
+    @SuppressWarnings("RedundantStringConstructorCall")
+    @Parameterized.Parameters(name = "store=<{0}> lookup=<{1}>")
+    public static Iterable<Object[]> parameters()
+    {
+        List<Object[]> parameters = new ArrayList<>();
+        parameters.addAll( asList(
+                new Object[]{new String( "name" ), new String( "name" )},
+                new Object[]{7, 7L},
+                new Object[]{9L, 9},
+                new Object[]{2, 2.0},
+                new Object[]{3L, 3.0},
+                new Object[]{4, 4.0f},
+                new Object[]{5L, 5.0f},
+                new Object[]{12.0, 12},
+                new Object[]{13.0, 13L},
+                new Object[]{14.0f, 14},
+                new Object[]{15.0f, 15L},
+                new Object[]{2.5f, 2.5},
+                new Object[]{16.25, 16.25f},
+                new Object[]{new String[]{"a", "b", "c"}, new char[]{'a', 'b', 'c'}},
+                new Object[]{new char[]{'d', 'e', 'f'}, new String[]{"d", "e", "f"}},
+                new Object[]{splitStrings( TRIGGER_LAZY ), splitChars( TRIGGER_LAZY )},
+                new Object[]{splitChars( TRIGGER_LAZY ), splitStrings( TRIGGER_LAZY )},
+                new Object[]{new String[]{"foo", "bar"}, new String[]{"foo", "bar"}} ) );
+        Class[] numberTypes = {byte.class, short.class, int.class, long.class, float.class, double.class};
+        for ( Class lhs : numberTypes )
+        {
+            for ( Class rhs : numberTypes )
+            {
+                parameters.add( randomNumbers( 3, lhs, rhs ) );
+                parameters.add( randomNumbers( 200, lhs, rhs ) );
+            }
+        }
+        return parameters;
+    }
+
+    private static Object[] randomNumbers( int length, Class<?> lhsType, Class<?> rhsType )
+    {
+        Object lhs = Array.newInstance( lhsType, length ), rhs = Array.newInstance( rhsType, length );
+        for ( int i = 0; i < length; i++ )
+        {
+            int value = random.nextInt( 128 );
+            Array.set( lhs, i, convert( value, lhsType ) );
+            Array.set( rhs, i, convert( value, rhsType ) );
+        }
+        return new Object[]{lhs, rhs};
+    }
+
+    private static Object convert( int value, Class<?> type )
+    {
+        switch ( type.getName() )
+        {
+        case "byte":
+            return (byte) value;
+        case "short":
+            return (short) value;
+        case "int":
+            return value;
+        case "long":
+            return (long) value;
+        case "float":
+            return (float) value;
+        case "double":
+            return (double) value;
+        default:
+            return value;
+        }
+    }
+
+    private static String[] splitStrings( String string )
+    {
+        char[] chars = splitChars( string );
+        String[] result = new String[chars.length];
+        for ( int i = 0; i < chars.length; i++ )
+        {
+            result[i] = Character.toString( chars[i] );
+        }
+        return result;
+    }
+
+    private static char[] splitChars( String string )
+    {
+        char[] result = new char[string.length()];
+        string.getChars( 0, result.length, result, 0 );
+        return result;
+    }
+
+    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+
+    private final Object store;
+    private final Object lookup;
+    private GraphDatabaseService graphDb;
+
+    public IndexTxStateLookupTest( Object store, Object lookup )
+    {
+        this.store = store;
+        this.lookup = lookup;
+    }
+
+    @Before
+    public void given()
+    {
+        graphDb = db.getGraphDatabaseService();
+        // database with an index on `(:Node).prop`
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.schema().indexFor( label( "Node" ) ).on( "prop" ).create();
+            tx.success();
+        }
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.schema().awaitIndexesOnline( 1, SECONDS );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void lookupWithinTransaction() throws Exception
+    {
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            // when
+            graphDb.createNode( label( "Node" ) ).setProperty( "prop", store );
+
+            // then
+            assertEquals( 1, count( graphDb.findNodesByLabelAndProperty( label( "Node" ), "prop", lookup ) ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void lookupWithinTransactionWithCacheEviction() throws Exception
+    {
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            // when
+            graphDb.createNode( label( "Node" ) ).setProperty( "prop", store );
+            db.clearCache();
+
+            // then
+            assertEquals( 1, count( graphDb.findNodesByLabelAndProperty( label( "Node" ), "prop", lookup ) ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void lookupWithoutTransaction() throws Exception
+    {
+        // when
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.createNode( label( "Node" ) ).setProperty( "prop", store );
+            tx.success();
+        }
+        // then
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            assertEquals( 1, count( graphDb.findNodesByLabelAndProperty( label( "Node" ), "prop", lookup ) ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void lookupWithoutTransactionWithCacheEviction() throws Exception
+    {
+        // when
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            graphDb.createNode( label( "Node" ) ).setProperty( "prop", store );
+            tx.success();
+        }
+        db.clearCache();
+        // then
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            assertEquals( 1, count( graphDb.findNodesByLabelAndProperty( label( "Node" ), "prop", lookup ) ) );
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
When looking up indexed nodes from the transaction state, we need to do
the same type coercions of property values that we do when looking up
nodes from the committed indexes. This is done by using the equality
defined in DefinedProperty.

Along with this the coercions made in DefinedProperty have been made
more explicit, and comparisons between integral numbers and floating
point numbers have been made more strict, so that only exact comparison
is ever made.
