### PR TITLE
[2.2] Fix test DatabaseRegistryTest#shouldAwaitRunningQueriesBeforeDropping

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/database/DatabaseRegistry.java
+++ b/community/server/src/main/java/org/neo4j/server/database/DatabaseRegistry.java
@@ -22,7 +22,7 @@ package org.neo4j.server.database;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.neo4j.helpers.Function;
+import org.neo4j.function.Function;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;

--- a/community/server/src/test/java/org/neo4j/server/database/DatabaseRegistryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/database/DatabaseRegistryTest.java
@@ -24,10 +24,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.helpers.Functions;
+
+import org.neo4j.function.Functions;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.TestLogging;
 import org.neo4j.kernel.logging.Logging;
@@ -35,27 +37,18 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class DatabaseRegistryTest
 {
-    private static final String EMBEDDED = "embedded";
-    private final Database northwind = mock(Database.class);
-
-    @Rule
-    public OtherThreadRule<Object> threadOne = new OtherThreadRule<>();
-
-    @Rule
-    public OtherThreadRule<Object> threadTwo = new OtherThreadRule<>();
-
     @Test
     public void shouldAllowCreatingAndVisitingDatabase() throws Throwable
     {
         // Given
-        DatabaseRegistry registry = newRegistryWithEmbeddedProvider();
-        final AtomicReference<Database> dbProvidedToVisitor = new AtomicReference<>(  );
-        registry.create( new DatabaseDefinition( "northwind", EMBEDDED, DatabaseHosting.Mode.EXTERNAL, new Config() ));
+        final AtomicReference<Database> dbProvidedToVisitor = new AtomicReference<>();
 
         // When
         registry.visit( "northwind", new DatabaseRegistry.Visitor()
@@ -68,26 +61,22 @@ public class DatabaseRegistryTest
         } );
 
         // Then
-        assertThat(dbProvidedToVisitor.get(), equalTo(northwind));
-        verify( northwind ).init();
-        verify( northwind ).start();
+        assertThat( dbProvidedToVisitor.get(), equalTo( database ) );
+        verify( database ).init();
+        verify( database ).start();
     }
 
     @Test
     public void shouldShutdownDatabaseOnDrop() throws Throwable
     {
-        // Given
-        DatabaseRegistry registry = newRegistryWithEmbeddedProvider();
-        registry.create( new DatabaseDefinition( "northwind", EMBEDDED, DatabaseHosting.Mode.EXTERNAL, new Config()) );
-
         // When
-        registry.drop( "northwind" );
+        registry.drop( NORTH_WIND );
 
         // Then
-        verify( northwind ).init();
-        verify( northwind ).start();
-        verify( northwind ).stop();
-        verify( northwind ).shutdown();
+        verify( database ).init();
+        verify( database ).start();
+        verify( database ).stop();
+        verify( database ).shutdown();
     }
 
     @Ignore("Saw this fail in the assertion at line 109. This component is unused and JH will remove it")
@@ -95,27 +84,26 @@ public class DatabaseRegistryTest
     public void shouldAwaitRunningQueriesBeforeDropping() throws Throwable
     {
         // Given
-        DatabaseRegistry registry = newRegistryWithEmbeddedProvider();
-        registry.create( new DatabaseDefinition("northwind", EMBEDDED, DatabaseHosting.Mode.EXTERNAL, new Config()) );
-
-        CountDownLatch visitingDbLatch = new CountDownLatch( 1 );
-        threadOne.execute( visitAndAwaitLatch( "northwind", registry, visitingDbLatch ) );
+        final CountDownLatch visitingDbLatch = new CountDownLatch( 1 );
+        final CountDownLatch doneVisitingLatch = new CountDownLatch( 1 );
+        threadOne.execute( visitAndAwaitLatch( NORTH_WIND, registry, visitingDbLatch, doneVisitingLatch ) );
 
         // When
-        Future<Object> threadTwoCompletion = threadTwo.execute( drop( "northwind", registry ) );
+        visitingDbLatch.await();
+        Future<Object> threadTwoCompletion = threadTwo.execute( drop( NORTH_WIND, registry ) );
 
         // Then, even if I wait a while, the database should not be shut down
         Thread.sleep( 100 );
-        verify( northwind, never() ).stop();
-        verify( northwind, never() ).shutdown();
+        verify( database, never() ).stop();
+        verify( database, never() ).shutdown();
 
         // But when
-        visitingDbLatch.countDown();
+        doneVisitingLatch.countDown();
         threadTwoCompletion.get( 10, TimeUnit.SECONDS );
 
         // Then
-        verify(northwind).stop();
-        verify(northwind).shutdown();
+        verify( database ).stop();
+        verify( database ).shutdown();
     }
 
     private OtherThreadExecutor.WorkerCommand<Object, Object> drop( final String dbKey, final DatabaseRegistry registry )
@@ -133,6 +121,7 @@ public class DatabaseRegistryTest
 
     private OtherThreadExecutor.WorkerCommand<Object, Object> visitAndAwaitLatch( final String dbKey,
                                                                                   final DatabaseRegistry registry,
+                                                                                  final CountDownLatch latchToUse,
                                                                                   final CountDownLatch latchToAwait )
     {
         return new OtherThreadExecutor.WorkerCommand<Object, Object>()
@@ -145,6 +134,7 @@ public class DatabaseRegistryTest
                     @Override
                     public void visit( Database db )
                     {
+                        latchToUse.countDown();
                         try
                         {
                             latchToAwait.await( 10, TimeUnit.SECONDS );
@@ -160,13 +150,27 @@ public class DatabaseRegistryTest
         };
     }
 
-    private DatabaseRegistry newRegistryWithEmbeddedProvider()
+
+    private static final String EMBEDDED = "embedded";
+    private static final String NORTH_WIND = "northwind";
+    private final Database database = mock( Database.class );
+    private DatabaseRegistry registry;
+
+    @Rule
+    public OtherThreadRule<Object> threadOne = new OtherThreadRule<>();
+
+    @Rule
+    public OtherThreadRule<Object> threadTwo = new OtherThreadRule<>();
+
+    @Before
+    public void setUp() throws NoSuchDatabaseProviderException
     {
-        DatabaseRegistry registry = new DatabaseRegistry( Functions.<Config, Logging>constant( new TestLogging() ) );
-        registry.addProvider( EMBEDDED, singletonDatabase( northwind ) );
+        registry = new DatabaseRegistry( Functions.<Config, Logging>constant( new TestLogging() ) );
+        registry.addProvider( EMBEDDED, singletonDatabase( database ) );
         registry.init();
         registry.start();
-        return registry;
+
+        registry.create( new DatabaseDefinition( NORTH_WIND, EMBEDDED, DatabaseHosting.Mode.EXTERNAL, new Config() ) );
     }
 
     public static Database.Factory singletonDatabase( final Database db )


### PR DESCRIPTION
Rationale:
It may happen that the threads in the test are not properly synchronized and
the one shutting down the db is faster than the first one to grap a reference to it.
Hence it might happen that the test fails.

Details:
- A new latch has been introduced to make sure that the thread are properly sunchronized.
- Test class has been cleaned up by introducing a @Before method.
- Fixed 2 deprecation warnings.
