### PR TITLE
[2.1] Revert of "Remove non-versioned elections (2602)" pull request

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
@@ -251,11 +251,26 @@ public enum ElectionState
                         {
                             Object request = message.getPayload();
 
-                            ElectionContext.VoteRequest voteRequest = (ElectionContext.VoteRequest) request;
-                            outgoing.offer( Message.respond( ElectionMessage.voted, message,
-                                    new ElectionMessage.VersionedVotedData( voteRequest.getRole(), context.getMyId(),
-                                            context.getCredentialsForRole( voteRequest.getRole() ),
-                                            voteRequest.getVersion() ) ) );
+                            if ( request instanceof ElectionContext.VoteRequest )
+                            {
+                                ElectionContext.VoteRequest voteRequest = (ElectionContext.VoteRequest) request;
+                                outgoing.offer( Message.respond( ElectionMessage.voted, message,
+                                        new ElectionMessage.VersionedVotedData( voteRequest.getRole(),
+                                                context.getMyId(),
+                                                context.getCredentialsForRole( voteRequest.getRole() ),
+                                                voteRequest.getVersion() ) ) );
+                            }
+                            else if ( request instanceof String )
+                            {
+                                String role = (String) request;
+                                outgoing.offer( Message.respond( ElectionMessage.voted, message,
+                                        new ElectionMessage.VotedData( role, context.getMyId(),
+                                                context.getCredentialsForRole( role ) ) ) );
+                            }
+                            else
+                            {
+                                context.getLogger( getClass() ).error( "Unknown vote request message " + request );
+                            }
                             break;
                         }
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
@@ -257,4 +257,31 @@ public class ElectionStateTest
         ElectionMessage.VersionedVotedData payload = (ElectionMessage.VersionedVotedData) response.getPayload();
         assertEquals( version, payload.getVersion() );
     }
+
+    @Test
+    public void voteResponseShouldBeBackwardsCompatible() throws Throwable
+    {
+        final List<Message> messages = new ArrayList<Message>( 1 );
+        MessageHolder holder = new MessageHolder()
+        {
+            @Override
+            public void offer( Message<? extends MessageType> message )
+            {
+                messages.add( message );
+            }
+        };
+
+        ElectionContext context = mock( ElectionContext.class );
+
+        Message voteRequest = Message.to( ElectionMessage.vote, URI.create( "some://instance" ),
+                "coordinator" );
+        voteRequest.setHeader( Message.FROM, "some://other" );
+
+        election.handle( context, voteRequest, holder );
+
+        assertEquals( 1, messages.size() );
+        Message response = messages.get( 0 );
+        assertEquals( ElectionMessage.voted, response.getMessageType() );
+        assertEquals( ElectionMessage.VotedData.class, response.getPayload().getClass() );
+    }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
@@ -33,6 +33,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import org.neo4j.backup.OnlineBackup;
 import org.neo4j.backup.OnlineBackupSettings;
@@ -69,10 +72,9 @@ import static org.neo4j.ha.upgrade.Utils.assembleClassPathFromPackage;
 import static org.neo4j.ha.upgrade.Utils.downloadAndUnpack;
 import static org.neo4j.kernel.ha.HaSettings.ha_server;
 
+@RunWith(Parameterized.class)
 public class RollingUpgradeIT
 {
-    private static final String OLD_VERSION = "2.0.4";
-
     private static final int CLUSTER_SIZE = 3;
 
     public static final RelationshipType type1 = DynamicRelationshipType.withName( "type1" );
@@ -84,6 +86,24 @@ public class RollingUpgradeIT
     private LegacyDatabase[] legacyDbs;
     private GraphDatabaseAPI[] newDbs;
     private long centralNode;
+
+    private final String oldVersion;
+
+    public RollingUpgradeIT( String oldVersion )
+    {
+        this.oldVersion = oldVersion;
+    }
+
+    @Parameters
+    public static Iterable<Object[]> oldVersions()
+    {
+        return Arrays.asList( new Object[][]{
+                {"2.0.1"},
+                {"2.0.2"},
+                {"2.0.3"},
+                {"2.0.4"}
+        } );
+    }
 
     @Test
     public void doRollingUpgradeFromPreviousVersionWithMasterLast() throws Throwable
@@ -105,10 +125,6 @@ public class RollingUpgradeIT
          * 3.3 Restart one slave
          * 3.4 Take down the instances and do consistency check */
 
-        /*
-         *
-         */
-
         try
         {
             startOldVersionCluster();
@@ -127,8 +143,11 @@ public class RollingUpgradeIT
         Collection<String> storeDirs = new ArrayList<>( newDbs.length );
         for ( GraphDatabaseAPI item : newDbs )
         {
-            storeDirs.add( item.getStoreDir() );
-            item.shutdown();
+            if ( item != null )
+            {
+                storeDirs.add( item.getStoreDir() );
+                item.shutdown();
+            }
         }
 
         ConsistencyCheckService service = new ConsistencyCheckService();
@@ -171,19 +190,22 @@ public class RollingUpgradeIT
         {
             for ( GraphDatabaseService db : newDbs )
             {
-                db.shutdown();
+                if ( db != null )
+                {
+                    db.shutdown();
+                }
             }
         }
     }
 
     private void startOldVersionCluster() throws Exception
     {
-        debug( "Downloading " + OLD_VERSION + " package" );
+        debug( "Downloading " + oldVersion + " package" );
         File oldVersionPackage = downloadAndUnpack(
-                "http://neo4j.com/customer/download/neo4j-enterprise-" + OLD_VERSION + "-windows.zip",
-                DIR.cacheDirectory( "download" ), OLD_VERSION + "-enterprise" );
+                "http://neo4j.com/customer/download/neo4j-enterprise-" + oldVersion + "-windows.zip",
+                DIR.cacheDirectory( "download" ), oldVersion + "-enterprise" );
         String classpath = assembleClassPathFromPackage( oldVersionPackage );
-        debug( "Starting " + OLD_VERSION + " cluster in separate jvms" );
+        debug( "Starting " + oldVersion + " cluster in separate jvms" );
         List<Future<LegacyDatabase>> legacyDbFutures = new ArrayList<>( CLUSTER_SIZE );
         for ( int i = 0; i < CLUSTER_SIZE; i++ )
         {
@@ -211,7 +233,7 @@ public class RollingUpgradeIT
                 db.verifyNodeExists( node );
             }
         }
-        debug( OLD_VERSION + " cluster fully operational" );
+        debug( oldVersion + " cluster fully operational" );
 
         centralNode = legacyDbs[0].initialize();
     }
@@ -277,7 +299,6 @@ public class RollingUpgradeIT
             storeDir += "new";
         }
         stop( i );
-        Thread.sleep( 30000 );
 
         File storeDirFile = new File( storeDir );
         debug( "Starting " + i + " as current version" );


### PR DESCRIPTION
This PR brings back backwards compatibility for vote messages. Ability to handle both `ElectionContext.VoteRequest` and `String` vote messages is needed for rolling upgrades.
