### PR TITLE
[2.2] Counts command now always writes the command type header

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountStoreApplier.java
@@ -109,11 +109,8 @@ public class CountStoreApplier extends NeoCommandHandler.Adapter
     public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
     {
         long delta = command.delta();
-        if ( delta != 0 )
-        { // only apply commands that will make a difference
-            countsStore.updateCountsForRelationship(
-                    command.startLabelId(), command.typeId(), command.endLabelId(), delta );
-        }
+        countsStore.updateCountsForRelationship(
+                command.startLabelId(), command.typeId(), command.endLabelId(), delta );
         return true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsState.java
@@ -179,7 +179,10 @@ public class CountsState implements CountsVisitor.Visitable
         @Override
         public void visitRelationshipCount( int startLabelId, int typeId, int endLabelId, long count )
         {
-            commands.add( new Command.CountsCommand().init( startLabelId, typeId, endLabelId, count ) );
+            if ( count != 0 )
+            {   // Only add commands for counts that actually change
+                commands.add( new Command.CountsCommand().init( startLabelId, typeId, endLabelId, count ) );
+            }
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
@@ -574,6 +574,7 @@ public abstract class Command
                     "CountsCommand should only be used for composite counts. " +
                     "The key may contain at most one wildcard label. startLabelId=%s, typeId=%s, endLabelId=%s",
                     startLabelId, typeId, endLabelId );
+            assert delta != 0 : "Tried to create a CountsCommand for something that didn't change any count";
             this.startLabelId = startLabelId;
             this.typeId = typeId;
             this.endLabelId = endLabelId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV1.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.DynamicRecordAdder;
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
 import org.neo4j.kernel.impl.transaction.log.ReadPastEndException;
 import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
 
@@ -169,7 +170,9 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
         }
         default:
         {
-            throw new IOException( "Unknown command type[" + commandType + "]" );
+            LogPositionMarker position = new LogPositionMarker();
+            channel.getCurrentPosition( position );
+            throw new IOException( "Unknown command type[" + commandType + "] near " + position.newPosition() );
         }
         }
         if ( command != null && !command.handle( reader ) )
@@ -739,7 +742,7 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
                 throw new RuntimeException( "Unknown value type " + valueType );
             }
         }
-        
+
         @Override
         public void apply()
         {   // Nothing to apply

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
@@ -249,7 +249,7 @@ public class CommandWriter implements NeoCommandHandler
     @Override
     public boolean visitIndexDefineCommand( IndexDefineCommand command ) throws IOException
     {
-        channel.put(  NeoCommandType.INDEX_DEFINE_COMMAND );
+        channel.put( NeoCommandType.INDEX_DEFINE_COMMAND );
         byte zero = 0;
         writeIndexCommandHeader( zero, zero, zero, zero, zero, zero, zero );
         writeMap( command.getIndexNameIdRange() );
@@ -260,15 +260,11 @@ public class CommandWriter implements NeoCommandHandler
     @Override
     public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
     {
-        long delta = command.delta();
-        if ( delta != 0 )
-        { // only write commands that will make a difference
-            channel.put( NeoCommandType.UPDATE_COUNTS_COMMAND )
-                   .putInt( command.startLabelId() )
-                   .putInt( command.typeId() )
-                   .putInt( command.endLabelId() )
-                   .putLong( delta );
-        }
+        channel.put( NeoCommandType.UPDATE_COUNTS_COMMAND );
+        channel.putInt( command.startLabelId() )
+               .putInt( command.typeId() )
+               .putInt( command.endLabelId() )
+               .putLong( command.delta() );
         return true;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -19,14 +19,12 @@
  */
 package org.neo4j.kernel.ha.lock;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.com.Response;
-import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;


### PR DESCRIPTION
and will not even exist as a command in the transaction if the delta was
0. This fixes a problem where the reader, always expecting a command type
after a command log entry header to be there, failing to read that
command.
