### PR TITLE
[2.2] Random byte[] for start entry header to randomise tx checksum

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -388,13 +388,13 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     @Override
     protected TransactionHeaderInformationFactory createHeaderInformationFactory()
     {
-        return new TransactionHeaderInformationFactory()
+        return new TransactionHeaderInformationFactory.WithRandomBytes()
         {
             @Override
-            public TransactionHeaderInformation create()
+            protected TransactionHeaderInformation createUsing( byte[] additionalHeader )
             {
                 return new TransactionHeaderInformation( memberContext.getElectedMasterId().toIntegerIndex(),
-                        memberContext.getMyId().toIntegerIndex(), new byte[0] );
+                        memberContext.getMyId().toIntegerIndex(), additionalHeader );
             }
         };
     }


### PR DESCRIPTION
This PR adds a random `byte[]` to transaction start entry's additional header field to randomise checksum. This is needed because current checksum is calculated only from txMasterId, txAuthorId.
