### PR TITLE
[2.1] Add build option to skip Cypher module

### DIFF
--- a/community/pom.xml
+++ b/community/pom.xml
@@ -38,7 +38,6 @@
     <module>lucene-index</module>
     <module>graph-algo</module>
     <module>graph-matching</module>
-    <module>cypher</module>
     <module>neo4j</module>
     <module>neo4j-community</module>
     <module>shell</module>
@@ -83,6 +82,17 @@ the relevant Commercial Agreement.
       </activation>
       <modules>
         <module>browser</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>include-cypher</id>
+      <activation>
+        <property>
+          <name>!skipCypher</name>
+        </property>
+      </activation>
+      <modules>
+        <module>cypher</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
If -DskipCypher is given on the command line all the Cypher related build will be skipped
