### PR TITLE
[2.2] Reduce probability of false failure of pageFaultForRead* test

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2658,7 +2658,7 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
         }
     }
 
-    @Test( timeout = 1000, expected = IOException.class )
+    @Test( timeout = 20000, expected = IOException.class )
     public void pageFaultForReadMustThrowIfOutOfStorageSpace() throws IOException
     {
         generateFileWithRecords( file, recordCount, recordSize );


### PR DESCRIPTION
The problem is that it can race with the optimistic "self-healing" of the cache
and therefor have a highly variable run time.

It would be better to stabilise the running time, but my attempts at doing that
have thus far only led to subtly breaking other things.
So this needs further investigation. In the mean time, this will break fewer
pull request builds.
