### PR TITLE
[2.2] Fixed a slow id generator rebuild high id issue

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
@@ -403,5 +404,12 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
     {
         dynamicLabelStore.makeStoreOk();
         super.makeStoreOk();
+    }
+
+    @Override
+    public void visitStore( Visitor<CommonAbstractStore, RuntimeException> visitor )
+    {
+        dynamicLabelStore.visitStore( visitor );
+        visitor.visit( this );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
@@ -466,6 +467,15 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         stringPropertyStore.makeStoreOk();
         arrayPropertyStore.makeStoreOk();
         super.makeStoreOk();
+    }
+
+    @Override
+    public void visitStore( Visitor<CommonAbstractStore, RuntimeException> visitor )
+    {
+        propertyKeyTokenStore.visitStore( visitor );
+        stringPropertyStore.visitStore( visitor );
+        arrayPropertyStore.visitStore( visitor );
+        visitor.visit( this );
     }
 
     public static void allocateStringRecords( Collection<DynamicRecord> target, byte[] chars,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 
+import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
@@ -87,6 +88,13 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     {
         nameStore.makeStoreOk();
         super.makeStoreOk();
+    }
+
+    @Override
+    public void visitStore( Visitor<CommonAbstractStore, RuntimeException> visitor )
+    {
+        nameStore.visitStore( visitor );
+        visitor.visit( this );
     }
 
     public void freeId( int id )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.junit.Assert.fail;
+
+public class IdGeneratorImplTest
+{
+    @Test
+    public void shouldNotAcceptMinusOne() throws Exception
+    {
+        // GIVEN
+        IdGeneratorImpl.createGenerator( fsr.get(), file );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, 0 );
+
+        // WHEN
+        try
+        {
+            idGenerator.setHighId( -1 );
+            fail( "Should have failed" );
+        }
+        catch ( UnderlyingStorageException e )
+        {   // OK
+        }
+    }
+
+    public final @Rule EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();
+    private final File file = new File( "ids" );
+}


### PR DESCRIPTION
where the high id would be set too high.
Also removes a test that, using complicated breakpoint testing, basically
tested that IdGeneratorImpl#setHighId throws exception when given -1 as
high Id. Replaced with a unit test.
