### PR TITLE
[2.1] Return null instead of throwing SchemaRuleNotFoundException when index not found

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -915,23 +915,7 @@ public final class Iterables
             @Override
             public Iterator<T> iterator()
             {
-                return new PrefetchingIterator<T>()
-                {
-                    private boolean returned;
-
-                    @Override
-                    protected T fetchNextOrNull()
-                    {
-                        try
-                        {
-                            return !returned ? item : null;
-                        }
-                        finally
-                        {
-                            returned = true;
-                        }
-                    }
-                };
+                return IteratorUtil.iterator( item );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -845,6 +845,43 @@ public abstract class IteratorUtil
         };
     }
 
+    public static <T> Iterator<T> iterator( final T item )
+    {
+        if ( item == null )
+        {
+            return emptyIterator();
+        }
+
+        return new Iterator<T>()
+        {
+            T myItem = item;
+
+            @Override
+            public boolean hasNext()
+            {
+                return myItem != null;
+            }
+
+            @Override
+            public T next()
+            {
+                if ( !hasNext() )
+                {
+                    throw new NoSuchElementException();
+                }
+                T toReturn = myItem;
+                myItem = null;
+                return toReturn;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
     @SafeVarargs
     public static <T> Iterator<T> iterator( T ... items )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -355,7 +355,6 @@ public class CacheLayer implements StoreReadLayer
 
     @Override
     public IndexDescriptor indexesGetForLabelAndPropertyKey( int labelId, int propertyKey )
-            throws SchemaRuleNotFoundException
     {
         return schemaCache.indexDescriptor( labelId, propertyKey );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -239,7 +239,6 @@ public class SchemaCache
     }
 
     public IndexDescriptor indexDescriptor( int labelId, int propertyKey )
-        throws SchemaRuleNotFoundException
     {
         Map<Integer, CommittedIndexDescriptor> byLabel = indexDescriptors.get( labelId );
         if ( byLabel != null )
@@ -250,16 +249,16 @@ public class SchemaCache
                 return committed.getDescriptor();
             }
         }
-        throw new SchemaRuleNotFoundException( labelId, propertyKey, "No such index found" );
+        return null;
     }
 
-    public IndexDescriptor indexDescriptor( long indexId ) throws SchemaRuleNotFoundException
+    public IndexDescriptor indexDescriptor( long indexId )
     {
         SchemaRule rule = rulesByIdMap.get( indexId );
         if ( rule instanceof IndexRule )
         {
             return indexDescriptor( rule.getLabel(), ((IndexRule) rule).getPropertyKey() );
         }
-        throw new SchemaRuleNotFoundException( "No index descriptor for schema rule " + indexId );
+        return null;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -115,11 +115,9 @@ public interface StoreReadLayer
     PrimitiveLongResourceIterator nodesGetFromIndexLookup( KernelStatement state, IndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
-    IndexDescriptor indexesGetForLabelAndPropertyKey( int labelId, int propertyKey )
-                                                                    throws SchemaRuleNotFoundException;
+    IndexDescriptor indexesGetForLabelAndPropertyKey( int labelId, int propertyKey );
 
-    InternalIndexState indexGetState( IndexDescriptor descriptor )
-                                                                            throws IndexNotFoundKernelException;
+    InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     String indexGetFailure( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/SchemaStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/SchemaStorage.java
@@ -108,6 +108,7 @@ public class SchemaStorage implements SchemaRuleAccess
             {
                 if ( foundRule != null )
                 {
+                    // todo: not the best exception type
                     throw new SchemaRuleNotFoundException( labelId, propertyKeyId, String.format("found more than one matching index rule, %s and %s", foundRule, candidate) );
                 }
                 foundRule = candidate;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
@@ -23,9 +23,9 @@ import java.util.Collection;
 
 import org.junit.Test;
 
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
@@ -34,8 +34,8 @@ import static java.util.Arrays.asList;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
@@ -193,21 +193,26 @@ public class SchemaCacheTest
         cache.addSchemaRule( newIndexRule( 3l, 2, 2 ) );
 
         // When
-        try
-        {
-            cache.indexDescriptor( 9, 9 );
-            fail( "Should have thrown exception saying there's no index descriptor for that label/property" );
-        }
-        catch ( SchemaRuleNotFoundException e )
-        {   // Good
-        }
         IndexDescriptor descriptor = cache.indexDescriptor( 1, 3 );
 
         // Then
         assertEquals( 1, descriptor.getLabelId() );
         assertEquals( 3, descriptor.getPropertyKeyId() );
     }
-    
+
+    @Test
+    public void shouldReturnNullWhenNoIndexExists()
+    {
+        // Given
+        SchemaCache schemaCache = new SchemaCache( Iterables.<SchemaRule>empty() );
+
+        // When
+        IndexDescriptor indexDescriptor = schemaCache.indexDescriptor( 1, 1 );
+
+        // Then
+        assertNull( indexDescriptor );
+    }
+
     private IndexRule newIndexRule( long id, int label, int propertyKey )
     {
         return IndexRule.indexRule( id, label, propertyKey, PROVIDER_DESCRIPTOR );


### PR DESCRIPTION
This PR removes throwing of `SchemaRuleNotFoundException` then index not found by `SchemaCache`.
Such lookup was made on every label/property modification of a node.
