### PR TITLE
[2.2] Tweak selectivity and costs

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/HardcodedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/HardcodedGraphStatistics.scala
@@ -30,7 +30,7 @@ class HardcodedGraphStatisticsValues extends GraphStatistics {
   val NODES_WITH_LABEL_SELECTIVITY = Selectivity(0.2)
   val NODES_WITH_LABEL_CARDINALITY = NODES_CARDINALITY * NODES_WITH_LABEL_SELECTIVITY
   val RELATIONSHIPS_CARDINALITY = Cardinality(50000)
-  val INDEX_SELECTIVITY = Selectivity(.2)
+  val INDEX_SELECTIVITY = Selectivity(.02)
 
   def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
     Some(INDEX_SELECTIVITY)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
@@ -66,6 +66,7 @@ case class Cardinality(amount: Double) extends Ordered[Cardinality] {
 
 case class CostPerRow(cost: Double) {
   def +(other: CostPerRow) = CostPerRow(cost + other.cost)
+  def *(other: Multiplier) = CostPerRow(cost * other.coefficient)
 }
 
 case class Multiplier(coefficient: Double) {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
@@ -93,7 +93,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       LogicalPlanningEnvironment(this).withLogicalPlanningContext(f)
     }
 
-    protected def mapCardinality(pf:PartialFunction[LogicalPlan, Double]): PartialFunction[LogicalPlan, Cardinality] = pf.andThen(Cardinality.apply)
+    protected def mapCardinality(pf: PartialFunction[LogicalPlan, Double]): PartialFunction[LogicalPlan, Cardinality] = pf.andThen(Cardinality.apply)
   }
 
   case class RealLogicalPlanningConfiguration() extends LogicalPlanningConfiguration {
@@ -104,7 +104,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       })
     }
     def costModel(cardinality: CardinalityModel): PartialFunction[LogicalPlan, Cost] = {
-      val model = new SimpleCostModel(cardinality)
+      val model = new CardinalityCostModel(cardinality)
       ({
         case (plan: LogicalPlan) => model(plan)
       })

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CardinalityTestHelper.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CardinalityTestHelper.scala
@@ -229,4 +229,5 @@ trait CardinalityTestHelper extends QueryGraphProducer {
   }
 
   val DEFAULT_PREDICATE_SELECTIVITY = GraphStatistics.DEFAULT_PREDICATE_SELECTIVITY.factor
+  val DEFAULT_EQUALITY_SELECTIVITY = .1
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -68,35 +68,29 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
   }
 
   test("find shortest paths on top of hash joins") {
-    val r1 = PatternRelationship("r1", ("a", "b"), Direction.INCOMING, Seq(), SimplePatternLength)
-    val r2 = PatternRelationship("r2", ("b", "c"), Direction.OUTGOING, Seq(), SimplePatternLength)
+    def myCardinality(plan: LogicalPlan): Cardinality = Cardinality(plan match {
+      case _: NodeIndexSeek                    => 10.0
+      case _: AllNodesScan                     => 10000
+      case _: NodeHashJoin                     => 42
+      case Expand(lhs, _, _, _, _, _, _, _, _) => (myCardinality(lhs) * Multiplier(10)).amount
+      case _: Selection                        => 100.04
+      case _: NodeByLabelScan                  => 100
+      case _                                   => Double.MaxValue
+    })
 
     (new given {
-      cardinality = mapCardinality {
-        case _: AllNodesScan => 200
-        case Expand(_, IdName("b"), _, _, _, _, _, _,_) => 10000
-        case _: Expand => 10
-        case _: NodeHashJoin => 20
-        case _ => Double.MaxValue
-      }
-    } planFor "MATCH (a)<-[r1]-(b)-[r2]->(c), p = shortestPath((a)-[r]->(c)) RETURN p").plan should equal(
-      planRegularProjection(
-        planShortestPaths(
-          planSelection(
-            Vector(NotEquals(Identifier("r1") _, Identifier("r2") _) _),
-            planNodeHashJoin(Set(IdName("b")),
-              planExpand(planAllNodesScan("a", Set.empty), "a", Direction.INCOMING, Direction.INCOMING, Seq(), "b", "r1", SimplePatternLength, r1),
-              planExpand(planAllNodesScan("c", Set.empty), "c", Direction.INCOMING, Direction.OUTGOING, Seq(), "b", "r2", SimplePatternLength, r2)
-            )
-          ),
-          ShortestPathPattern(
-            Some("p"),
-            PatternRelationship("r", ("a", "c"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
-            single = true
-          )(null)
-        ),
-        expressions = Map("p" -> Identifier("p") _)
-      )
+      cardinality = PartialFunction(myCardinality)
+    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").plan.toString should equal(
+      """Projection[p](Map("p" → p))
+        |↳ FindShortestPaths[p,r2,r1,a,b,c,r](p = shortestPath((a)-[r]->(c)))
+        |↳ Selection[r2,r1,a,b,c](ArrayBuffer(NotEquals(r1, r2)))
+        |↳ NodeHashJoin[r2,r1,a,b,c](Set(b))
+        |  ↳ left =
+        |    Expand[a,r1,b](a, INCOMING, INCOMING, ⬨, b, r1, , ArrayBuffer())
+        |    ↳ NodeByLabelScan[a](a, Left("X"), Set())
+        |  ↳ right =
+        |    Expand[c,r2,b](c, INCOMING, OUTGOING, ⬨, b, r2, , ArrayBuffer())
+        |    ↳ NodeByLabelScan[c](c, Left("X"), Set())""".stripMargin
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityModelIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityModelIntegrationTest.scala
@@ -104,8 +104,8 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
     givenPattern("MATCH (a:A) WHERE a.prop = 42").
       withGraphNodes(40).
       withLabel('A -> 30).
-      withIndexSelectivity(('A, 'prop) -> .5).
-      shouldHaveCardinality(30 * .5)
+      withIndexSelectivity(('A, 'prop) -> .05).
+      shouldHaveCardinality(30 * .05)
   }
 
   test("cardinality for label and property equality when index is not present") {
@@ -113,7 +113,7 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
       withGraphNodes(40).
       withKnownProperty('prop).
       withLabel('A -> 10).
-      shouldHaveCardinality(40.0 * Math.min(10.0 / 40, DEFAULT_PREDICATE_SELECTIVITY))
+      shouldHaveCardinality(40.0 * Math.min(10.0 / 40, DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   test("cardinality for label and property equality when index is not present 2") {
@@ -121,7 +121,7 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
       withGraphNodes(40).
       withKnownProperty('prop).
       withLabel('A -> 40).
-      shouldHaveCardinality(40 * DEFAULT_PREDICATE_SELECTIVITY)
+      shouldHaveCardinality(40 * DEFAULT_EQUALITY_SELECTIVITY)
   }
 
   test("cardinality for label and property NOT-equality when index is present") {
@@ -136,8 +136,8 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
     givenPattern("MATCH (a:A) WHERE a.prop = 42 OR a.prop = 43").
       withGraphNodes(40).
       withLabel('A -> 30).
-      withIndexSelectivity(('A, 'prop) -> .3).
-      shouldHaveCardinality(30 * .3 * 2)
+      withIndexSelectivity(('A, 'prop) -> .01).
+      shouldHaveCardinality(30 * .01 * 2)
   }
 
   test("cardinality for multiple OR:ed equality predicates on two indexes") {
@@ -146,7 +146,7 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
       withLabel('A -> 30).
       withIndexSelectivity(('A, 'prop) -> .3).
       withIndexSelectivity(('A, 'bar) -> .4).
-      shouldHaveCardinality(40.0 * Math.min(30.0 / 40, DEFAULT_PREDICATE_SELECTIVITY))
+      shouldHaveCardinality(40.0 * Math.min(30.0 / 40, DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   test("cardinality for multiple OR:ed equality predicates where one is backed by index and one is not") {
@@ -155,7 +155,7 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
       withLabel('A -> 30).
       withIndexSelectivity(('A, 'prop) -> .3).
       withKnownProperty('bar).
-      shouldHaveCardinality(40.0 * Math.min(30.0 / 40 , DEFAULT_PREDICATE_SELECTIVITY))
+      shouldHaveCardinality(40.0 * Math.min(30.0 / 40 , DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   ignore("cardinality for property equality predicate when property name is unknown") { // We can get away with not doing this
@@ -174,18 +174,18 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
     givenPattern("MATCH (a:A) WHERE a.prop = 42 AND a.bar = 43").
       withGraphNodes(40).
       withLabel('A -> 30).
-      withIndexSelectivity(('A, 'prop) -> .3).
-      withIndexSelectivity(('A, 'bar) -> .4).
-      shouldHaveCardinality(30 * Math.min(.3, DEFAULT_PREDICATE_SELECTIVITY))
+      withIndexSelectivity(('A, 'prop) -> .03).
+      withIndexSelectivity(('A, 'bar) -> .04).
+      shouldHaveCardinality(30 * Math.min(.03, DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   test("cardinality for multiple AND:ed equality predicates where one is backed by index and one is not") {
     givenPattern("MATCH (a:A) WHERE a.prop = 42 AND a.bar = 43").
       withGraphNodes(40).
       withLabel('A -> 30).
-      withIndexSelectivity(('A, 'prop) -> .3).
+      withIndexSelectivity(('A, 'prop) -> .03).
       withKnownProperty('bar).
-      shouldHaveCardinality(30 * Math.min(.3, DEFAULT_PREDICATE_SELECTIVITY))
+      shouldHaveCardinality(30 * Math.min(.03, DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   test("cardinality for label and property equality when no index is present") {
@@ -193,7 +193,7 @@ class CardinalityModelIntegrationTest extends CypherFunSuite with LogicalPlannin
       withGraphNodes(40).
       withLabel('A -> 30).
       withKnownProperty('prop).
-      shouldHaveCardinality(40.0 * Math.min(30.0 / 40, DEFAULT_PREDICATE_SELECTIVITY))
+      shouldHaveCardinality(40.0 * Math.min(30.0 / 40, DEFAULT_EQUALITY_SELECTIVITY))
   }
 
   test("relationship cardinality given labels on both sides") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/EstimateSelectivityTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/EstimateSelectivityTest.scala
@@ -80,8 +80,7 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
       shouldHaveSelectivity((25.0 + 25) / (100 * 100))
   }
 
-  ignore("relationship given unknown type and directions, no labels") { // should work
-    ???
+  test("relationship given unknown type and directions, no labels") { // should work
     givenPredicate("(a)-[r]->(b)").
       withGraphNodes(100).
       withLabel('BAR -> 20).
@@ -93,7 +92,7 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
       shouldHaveSelectivity((25.0 + 25 + 50) / (100 * 100))
   }
 
-  ignore("relationship given left label, type and direction") { // Should work
+  test("relationship given left label, type and direction") { // Should work
     givenPredicate("(a:FOO)-[r:TYPE]->(b)").
       withGraphNodes(200).
       withLabel('BAR -> 50).
@@ -103,7 +102,7 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
       shouldHaveSelectivity( 25.0 / (200 * 200) )
   }
 
-  ignore("relationship given left label, type and incoming direction") { // Should work
+  test("relationship given left label, type and incoming direction") { // Should work
     givenPredicate("(a:FOO)<-[r:TYPE]-(b)").
       withGraphNodes(200).
       withLabel('BAR -> 50).
@@ -113,7 +112,7 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
       shouldHaveSelectivity( (25.0 + 30) / (200 * 200) )
   }
 
-  ignore("relationship given right label, type and direction") { // Should work
+  test("relationship given right label, type and direction") { // Should work
     givenPredicate("(a)-[r:TYPE]->(b:FOO)").
       withGraphNodes(200).
       withLabel('BAR -> 50).
@@ -121,5 +120,17 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
       withRelationshipCardinality('BAR -> 'TYPE -> 'FOO -> 25).
       withRelationshipCardinality('FOO -> 'TYPE -> 'FOO -> 30).
       shouldHaveSelectivity( (25.0 + 30) / (200 * 200) )
+  }
+
+  test("equality comparisons on node property") {
+    givenPredicate("(a) WHERE a.prop = 42").
+      withGraphNodes(200).
+      shouldHaveSelectivity( .1 )
+  }
+
+  test("equality comparisons") {
+    givenPredicate("(a) WHERE a = 42").
+    withGraphNodes(200).
+    shouldHaveSelectivity( .75 )
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/GroupPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/GroupPredicatesTest.scala
@@ -75,10 +75,11 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
     // MATCH a WHERE a.prop IN ["foo"] AND a:BAR
     val p1 = ExpressionPredicate(inComparison)
     val p2 = ExpressionPredicate(hasLabelId1)
+    val p3 = ExistsPredicate(IdName(id1.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1, p2)) should equal(
       Set(
-        (PropertyEqualsAndLabelPredicate(property.propertyKey, 1, BAR, Set(p1, p2)), Selectivity(0.2))
+        (PropertyEqualsAndLabelPredicate(property.propertyKey, 1, BAR, Set(p1, p2, p3)), Selectivity(0.2))
       )
     )
   }
@@ -86,10 +87,12 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
   test("pattern gets passed through alone when it's the only one") {
     // MATCH a-->b
     val p1 = PatternPredicate(pattern)
+    val p2 = ExistsPredicate(IdName(id1.name))
+    val p3 = ExistsPredicate(IdName(id2.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1)) should equal(
       Set(
-        (RelationshipWithLabels(None, p1.p, None, Set(p1)), Selectivity(0.3))
+        (RelationshipWithLabels(None, p1.p, None, Set(p1, p2, p3)), Selectivity(0.3))
       ))
   }
 
@@ -97,10 +100,12 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
     // MATCH a-->b WHERE a:Bar
     val p1 = PatternPredicate(pattern)
     val p2 = ExpressionPredicate(hasLabelId1)
+    val p3 = ExistsPredicate(IdName(id1.name))
+    val p4 = ExistsPredicate(IdName(id2.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1, p2)) should equal(
       Set(
-        (RelationshipWithLabels(Some(BAR), p1.p, None, Set(p1, p2)), Selectivity(0.35))
+        (RelationshipWithLabels(Some(BAR), p1.p, None, Set(p1, p2, p3, p4)), Selectivity(0.35))
       ))
   }
 
@@ -109,10 +114,12 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
     val p1 = PatternPredicate(pattern)
     val p2 = ExpressionPredicate(hasLabelId1)
     val p3 = ExpressionPredicate(hasLabelId1Bis)
+    val p4 = ExistsPredicate(IdName(id1.name))
+    val p5 = ExistsPredicate(IdName(id2.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1, p2, p3)) should equal(
       Set(
-        (RelationshipWithLabels(Some(BAR2), pattern, None, Set(p1, p3)), Selectivity(0.3)),
+        (RelationshipWithLabels(Some(BAR2), pattern, None, Set(p1, p3, p4, p5)), Selectivity(0.3)),
         (SingleExpression(p2.e), Selectivity(0.8))
       ))
   }
@@ -121,10 +128,12 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
     // MATCH a-->b WHERE b:Bar
     val p1 = PatternPredicate(pattern)
     val p2 = ExpressionPredicate(hasLabelId2)
+    val p3 = ExistsPredicate(IdName(id1.name))
+    val p4 = ExistsPredicate(IdName(id2.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1, p2)) should equal(
       Set(
-        (RelationshipWithLabels(None, pattern, Some(FOO), Set(p1, p2)), Selectivity(0.3))
+        (RelationshipWithLabels(None, pattern, Some(FOO), Set(p1, p2, p3, p4)), Selectivity(0.3))
       ))
   }
 
@@ -133,10 +142,12 @@ class GroupPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport
     val p1 = PatternPredicate(pattern)
     val p2 = ExpressionPredicate(hasLabelId1)
     val p3 = ExpressionPredicate(hasLabelId2)
+    val p4 = ExistsPredicate(IdName(id1.name))
+    val p5 = ExistsPredicate(IdName(id2.name))
 
     groupPredicates(stubbedEstimateSelectivity)(Set(p1, p2, p3)) should equal(
       Set(
-        (RelationshipWithLabels(Some(BAR), pattern, Some(FOO), Set(p1, p2, p3)), Selectivity(0.35))
+        (RelationshipWithLabels(Some(BAR), pattern, Some(FOO), Set(p1, p2, p3, p4, p5)), Selectivity(0.35))
       ))
   }
 }


### PR DESCRIPTION
- Improved equality comparison selectivity
- Cost model now separates operators between IO and CPU bound
- Tweaked default index selectivity
