### PR TITLE
[2.2] Refactorings and improvements on batch importer staging

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -126,7 +126,6 @@ public class ParallelBatchImporterTest
         this.writerFactory = writerFactory;
         this.idGenerator = idGenerator;
         this.idMapping = idMapping;
-
     }
 
     @Test

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.collection.NestingIterable;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.store.UniquenessConstraintRule;
 import org.neo4j.kernel.impl.store.record.IndexRule;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -189,7 +189,7 @@ public class ParallelBatchImporter implements BatchImporter
                           BatchingNeoStore neoStore )
         {
             super( logging, "Nodes", config );
-            input( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
+            add( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
 
             NodeStore nodeStore = neoStore.getNodeStore();
             PropertyStore propertyStore = neoStore.getPropertyStore();
@@ -206,7 +206,7 @@ public class ParallelBatchImporter implements BatchImporter
                 IdMapper idMapper )
         {
             super( logging, "Calculate dense nodes", config );
-            input( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
+            add( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
 
             add( new CalculateDenseNodesStep( control(), config.workAheadSize(), nodeRelationshipLink,
                     idMapper, logger ) );
@@ -219,7 +219,7 @@ public class ParallelBatchImporter implements BatchImporter
                                   NodeRelationshipLink nodeRelationshipLink )
         {
             super( logging, "Relationships", config );
-            input( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
+            add( new IteratorBatcherStep<>( control(), "INPUT", config.batchSize(), input ) );
 
             RelationshipStore relationshipStore = neoStore.getRelationshipStore();
             PropertyStore propertyStore = neoStore.getPropertyStore();
@@ -235,7 +235,7 @@ public class ParallelBatchImporter implements BatchImporter
         public NodeFirstRelationshipStage( BatchingNeoStore neoStore, NodeRelationshipLink nodeRelationshipLink )
         {
             super( logging, "Node first rel", config );
-            input( new NodeFirstRelationshipStep( control(), config.batchSize(),
+            add( new NodeFirstRelationshipStep( control(), config.batchSize(),
                     neoStore.getNodeStore(), neoStore.getRelationshipGroupStore(), nodeRelationshipLink ) );
         }
     }
@@ -245,7 +245,7 @@ public class ParallelBatchImporter implements BatchImporter
         public RelationshipLinkbackStage( BatchingNeoStore neoStore, NodeRelationshipLink nodeRelationshipLink )
         {
             super( logging, "Relationship back link", config );
-            input( new RelationshipLinkbackStep( control(), config.batchSize(),
+            add( new RelationshipLinkbackStep( control(), config.batchSize(),
                     neoStore.getRelationshipStore(), nodeRelationshipLink ) );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DetailedExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DetailedExecutionMonitor.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.unsafe.impl.batchimport.staging;
 
-import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.neo4j.helpers.Format.duration;
-
 import java.io.PrintStream;
 
 import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
+
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.helpers.Format.duration;
 
 /**
  * An {@link ExecutionMonitor} that prints very detailed information about each {@link Stage} and the
@@ -37,13 +38,13 @@ public class DetailedExecutionMonitor extends PollingExecutionMonitor
 
     public DetailedExecutionMonitor( PrintStream out )
     {
-        super( SECONDS.toMillis( 2 ) );
-        this.out = out;
+        this( out, SECONDS.toMillis( 2 ) );
     }
 
-    public DetailedExecutionMonitor()
+    public DetailedExecutionMonitor( PrintStream out, long interval )
     {
-        this( System.out );
+        super( interval );
+        this.out = out;
     }
 
     @Override
@@ -82,13 +83,15 @@ public class DetailedExecutionMonitor extends PollingExecutionMonitor
 
     private void printStats( StageExecution execution, boolean first )
     {
+        int bottleNeckIndex = figureOutBottleNeck( execution );
+
         StringBuilder builder = new StringBuilder();
         int i = 0;
         for ( StepStats stats : execution.stats() )
         {
             builder.append( i > 0 ? format( "%n  " ) : (first ? "--" : " -") )
                    .append( stats.toString() )
-                   ;
+                   .append( i == bottleNeckIndex ? "  <== BOTTLE NECK" : "" );
             i++;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
@@ -69,8 +69,6 @@ public abstract class LonelyProcessingStep extends AbstractStep<Void>
     {
         if ( ++batch == batchSize )
         {
-            // Also increments received batches here just to satisfy the default stillWorking() implementation.
-            receivedBatches.incrementAndGet();
             doneBatches.incrementAndGet();
             batch = 0;
             long time = currentTimeMillis();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -95,9 +95,6 @@ public abstract class ProducerStep<T> extends AbstractStep<Void>
 
     private long nextTicket()
     {
-        // Increment both done and received count to have stillWorking() evaluate properly
-        long ticket = doneBatches.incrementAndGet();
-        receivedBatches.incrementAndGet();
-        return ticket;
+        return doneBatches.incrementAndGet();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
@@ -34,18 +34,11 @@ import org.neo4j.unsafe.impl.batchimport.Configuration;
 public class Stage
 {
     private final List<Step<?>> pipeline = new ArrayList<>();
-    private Step<?> inputStep;
     private final StageExecution execution;
 
     public Stage( Logging logging, String name, Configuration config )
     {
         this.execution = new StageExecution( logging, name, config, pipeline );
-    }
-
-    public void input( Step<?> inputStep )
-    {
-        this.inputStep = inputStep;
-        add( inputStep );
     }
 
     protected StageControl control()
@@ -61,7 +54,7 @@ public class Stage
     public StageExecution execute() throws Exception
     {
         linkSteps();
-        inputStep.receive( 1 /*a ticket, ignored anyway*/, null /*serves only as a start signal anyway*/ );
+        pipeline.get( 0 ).receive( 1 /*a ticket, ignored anyway*/, null /*serves only as a start signal anyway*/ );
         execution.start();
         return execution;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Keys.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/Keys.java
@@ -26,12 +26,11 @@ public enum Keys implements Key
 {
     received_batches( ">", "Number of batches received from upstream" ),
     done_batches( "!", "Number of batches processed and done, and sent off downstream" ),
-    total_processing_time( "total", "Total processing time for all done batches" ),
+    total_processing_time( "=", "Total processing time for all done batches" ),
     upstream_idle_time( "^", "Time spent waiting for batch from upstream" ),
     downstream_idle_time( "v", "Time spent waiting for downstream to catch up" ),
     avg_processing_time( "avg", "Average processing time per done batch" ),
-    write_throughput( "W", "Write throughput per second, I/O" ),
-    ;
+    write_throughput( "W", "Write throughput per second, I/O" );
 
     private final String shortName;
     private final String description;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.unsafe.impl.batchimport.Configuration;
+import org.neo4j.unsafe.impl.batchimport.stats.Keys;
+import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
+
+import static org.junit.Assert.assertEquals;
+
+public class StageTest
+{
+    @Test
+    public void shouldReceiveBatchesInOrder() throws Exception
+    {
+        // GIVEN
+        Configuration config = new Configuration.Default();
+        Stage stage = new Stage( new DevNullLoggingService(), "Test stage", config );
+        int batchSize = 10;
+        long batches = 1000;
+        final long items = batches*batchSize;
+        stage.add( new ProducerStep<Object>( stage.control(), "Producer", batchSize )
+        {
+            private long i = 0;
+            private final Object theObject = new Object();
+
+            @Override
+            protected Object nextOrNull()
+            {
+                return ++i > items ? null : theObject;
+            }
+        } );
+
+        for ( int i = 0; i < 3; i++ )
+        {
+            stage.add( new ReceiveOrderAssertingStep( stage.control(), "Step" + i, 20, 2, i ) );
+        }
+
+        stage.add( new LastReceiveOrderAssertingStep( stage.control(), "Final step", 20, 2, 0 ) );
+
+        // WHEN
+        StageExecution execution = stage.execute();
+        new SilentExecutionMonitor().monitor( execution );
+
+        // THEN
+        for ( StepStats stats : execution.stats() )
+        {
+            assertEquals( batches, stats.stat( Keys.done_batches ).asLong() );
+        }
+    }
+
+    private static class ReceiveOrderAssertingStep extends ExecutorServiceStep<Object>
+    {
+        private final AtomicLong lastTicket = new AtomicLong();
+        private final long processingTime;
+
+        ReceiveOrderAssertingStep( StageControl control, String name, int workAheadSize, int numberOfExecutors,
+                long processingTime )
+        {
+            super( control, name, workAheadSize, numberOfExecutors );
+            this.processingTime = processingTime;
+        }
+
+        @Override
+        public long receive( long ticket, Object batch )
+        {
+            assertEquals( lastTicket.incrementAndGet(), ticket );
+            return super.receive( ticket, batch );
+        }
+
+        @Override
+        protected Object process( long ticket, Object batch )
+        {
+            try
+            {
+                Thread.sleep( processingTime );
+            }
+            catch ( InterruptedException e )
+            {
+                throw new RuntimeException( e );
+            }
+            return batch;
+        }
+    }
+
+    private static class LastReceiveOrderAssertingStep extends ReceiveOrderAssertingStep
+    {
+        LastReceiveOrderAssertingStep( StageControl control, String name, int workAheadSize,
+                int numberOfExecutors, long processingTime )
+        {
+            super( control, name, workAheadSize, numberOfExecutors, processingTime );
+        }
+
+        @Override
+        protected Object process( long ticket, Object batch )
+        {
+            super.process( ticket, batch );
+            return null;
+        }
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
@@ -25,11 +25,11 @@ import java.util.Map;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertNotNull;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.server.rest.repr.RepresentationTestAccess.serialize;
-import static org.neo4j.server.rest.repr.RepresentationTestBase.assertRegexpMatches;
 import static org.neo4j.server.rest.repr.RepresentationTestBase.assertUriMatches;
 import static org.neo4j.server.rest.repr.RepresentationTestBase.uriPattern;
 import static org.neo4j.test.mocking.GraphMock.node;
@@ -113,7 +113,7 @@ public class NodeRepresentationTest
         assertNotNull( repr );
         verifySerialisation( repr );
     }
-    
+
     @Test
     public void shouldHaveLabelsLink() throws BadInputException
     {


### PR DESCRIPTION
The staging framework for the ParallelBatchImporter has been
changed to reduce time spent in the framework itself as well
as reporing much more accurate statistics.
- Simplified Stage to only have #add(Step), instead of input/add
- Simplified and streamlined waiting of conditions in individual steps
  where conditions are first busy waited a little while, to then
  back off to a sleep strategy.
- Improved accuracy of statistics of upstream/downstream idling,
  possible since better placed for measuring was found.
- DetailedExecutionMonitor will find and print which step is the
  current most likely step to be the bottle neck in the stage.
- Correctly and efficiently follows the contract of a step, where
  batches must be sent downstream in the order they arrived, which
  implies total ordering as a whole between steps. Previously there
  was too strict checks such that some parallelization was hindered.
