### PR TITLE
[2.1] Backup tool should exit with error if consistency check fails.

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -184,6 +184,7 @@ class BackupService
             }
             catch ( ConsistencyCheckIncompleteException e )
             {
+                consistent = false;
                 logger.error( "Consistency check incomplete", e );
             }
             finally


### PR DESCRIPTION
A failed consistency check is now transported all the way up to the user with
a print and the return code is 1.
