### PR TITLE
[1.9] Solves issue with election results from a rejoining elector being dropped

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/InstanceId.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/InstanceId.java
@@ -19,16 +19,25 @@
  */
 package org.neo4j.cluster;
 
+import static org.neo4j.helpers.Uris.parameter;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.net.URI;
 
-import static org.neo4j.helpers.Uris.parameter;
-
+/**
+ * Represents the concept of the cluster wide unique id of an instance. The
+ * main requirement is total order over the instances of the class, currently
+ * implemented by an encapsulated integer.
+ * It is also expected to be serializable, as it's transmitted over the wire
+ * as part of messages between instances.
+ */
 public class InstanceId implements Externalizable, Comparable<InstanceId>
 {
+    public static final InstanceId NONE = new InstanceId( Integer.MIN_VALUE );
+
     private int serverId;
 
     public InstanceId()

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
+import static org.neo4j.helpers.Predicates.in;
+import static org.neo4j.helpers.Predicates.not;
+import static org.neo4j.helpers.Uris.parameter;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,14 +40,11 @@ import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
+import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.logging.Logging;
-
-import static org.neo4j.helpers.Predicates.in;
-import static org.neo4j.helpers.Predicates.not;
-import static org.neo4j.helpers.Uris.parameter;
 
 class ClusterContextImpl
     extends AbstractContextImpl
@@ -57,7 +58,6 @@ class ClusterContextImpl
     private ClusterMessage.ConfigurationResponseState joinDeniedConfigurationResponseState;
     private final Map<InstanceId, URI> currentlyJoiningInstances =
             new HashMap<InstanceId, URI>();
-
 
     private final Executor executor;
     private final ObjectOutputStreamFactory objectOutputStreamFactory;
@@ -81,6 +81,30 @@ class ClusterContextImpl
         this.objectInputStreamFactory = objectInputStreamFactory;
         this.learnerContext = learnerContext;
         this.heartbeatContext = heartbeatContext;
+        heartbeatContext.addHeartbeatListener(
+
+                /*
+                 * Here for invalidating the elector if it fails, so when it comes back, if no elections
+                 * happened in the meantime it can resume sending election results
+                 */
+                new HeartbeatListener.Adapter()
+                {
+                    @Override
+                    public void failed( InstanceId server )
+                    {
+                        invalidateElectorIfNecessary( server );
+                    }
+                }
+        );
+    }
+
+    private void invalidateElectorIfNecessary( InstanceId server )
+    {
+        if ( server.equals( lastElector ) )
+        {
+            lastElector = InstanceId.NONE;
+            electorVersion = NO_ELECTOR_VERSION;
+        }
     }
 
     public long getLastElectorVersion()
@@ -194,6 +218,7 @@ class ClusterContextImpl
         //   of join messages is a little out of whack.
 
         currentlyJoiningInstances.remove( instanceId );
+        invalidateElectorIfNecessary( instanceId );
     }
 
     @Override
@@ -201,6 +226,7 @@ class ClusterContextImpl
     {
         final URI member = commonState.configuration().getUriForId( node );
         commonState.configuration().left( node );
+        invalidateElectorIfNecessary( node );
         Listeners.notifyListeners( clusterListeners, executor, new Listeners.Notification<ClusterListener>()
         {
             @Override
@@ -214,7 +240,7 @@ class ClusterContextImpl
     @Override
     public void elected( final String roleName, final InstanceId instanceId )
     {
-        elected( roleName, instanceId, null, -1 );
+        elected( roleName, instanceId, InstanceId.NONE, NO_ELECTOR_VERSION );
     }
 
     @Override
@@ -261,7 +287,7 @@ class ClusterContextImpl
     @Override
     public void unelected( final String roleName, final org.neo4j.cluster.InstanceId instanceId )
     {
-        unelected( roleName, instanceId, null, -1 );
+        unelected( roleName, instanceId, InstanceId.NONE, NO_ELECTOR_VERSION );
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -32,13 +32,16 @@ import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationResponseState;
 
 /**
- * Context for cluster API state machine
+ * Represents the context necessary for cluster operations. Includes instance membership calls, election
+ * facilities and liveness detection. This is expected to be used from a variety of cluster components
+ * as part of their state.
  *
  * @see ClusterState
  */
 public interface ClusterContext
     extends LoggingContext, TimeoutsContext, ConfigurationContext
 {
+    public static final int NO_ELECTOR_VERSION = -1;
 
     // Cluster API
     void addClusterListener( ClusterListener listener );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.concurrent.Executor;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
+import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
+import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerContext;
+import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
+import org.neo4j.cluster.protocol.cluster.ClusterContext;
+import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
+import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
+import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.logging.Logging;
+
+public class ClusterContextImplTest
+{
+    /*
+     * This test ensures that an instance that cleanly leaves the cluster is no longer assumed to be an elector. This
+     * has the effect that when it rejoins its elector version will be reset and its results will go through
+     */
+    @Test
+    public void electorLeavingTheClusterMustBeRemovedAsElector() throws Throwable
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+
+        ClusterConfiguration clusterConfiguration = mock(ClusterConfiguration.class);
+        when( clusterConfiguration.getUriForId( elector ) ).thenReturn( URI.create("cluster://instance2") );
+
+        CommonContextState commonContextState = mock( CommonContextState.class );
+        when( commonContextState.configuration() ).thenReturn( clusterConfiguration );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, mock( Logging.class ),
+                mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+
+          // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        context.left( elector );
+
+        // Then
+        assertEquals( context.getLastElector(), InstanceId.NONE );
+        assertEquals( context.getLastElectorVersion(), -1 );
+    }
+
+    /*
+     * This test ensures that an instance that cleanly leaves the cluster but is not the elector has no effect on
+     * elector id and last version
+     */
+    @Test
+    public void nonElectorLeavingTheClusterMustNotAffectElectorInformation() throws Throwable
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+        InstanceId other = new InstanceId( 3 );
+
+        ClusterConfiguration clusterConfiguration = mock(ClusterConfiguration.class);
+        when( clusterConfiguration.getUriForId( other ) ).thenReturn( URI.create("cluster://instance2") );
+
+        CommonContextState commonContextState = mock( CommonContextState.class );
+        when( commonContextState.configuration() ).thenReturn( clusterConfiguration );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, mock( Logging.class ),
+                mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+
+          // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        context.left( other );
+
+        // Then
+        assertEquals( context.getLastElector(), elector );
+        assertEquals( context.getLastElectorVersion(), 8 );
+    }
+
+    /*
+     * This test ensures that an instance that enters the cluster has its elector version reset. That means that
+     * if it was the elector before its version is now reset so results can be applied. This and the previous tests
+     * actually perform the same things at different events, one covering for the other.
+     */
+    @Test
+    public void instanceEnteringTheClusterMustBeRemovedAsElector() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, mock( Logging.class ),
+                mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+
+        // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        context.joined( elector, URI.create( "cluster://elector" ) );
+
+        // Then
+        assertEquals( context.getLastElector(), InstanceId.NONE );
+        assertEquals( context.getLastElectorVersion(), -1 );
+    }
+
+    /*
+     * This test ensures that a joining instance that was not marked as elector before does not affect the
+     * current elector version. This is the complement of the previous test.
+     */
+    @Test
+    public void instanceEnteringTheClusterMustBeNotAffectElectorStatusIfItWasNotElectorBefore() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+        InstanceId other = new InstanceId( 3 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, mock( Logging.class ),
+                mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+
+        // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        context.joined( other, URI.create( "cluster://other" ) );
+
+        // Then
+        assertEquals( context.getLastElector(), elector );
+        assertEquals( context.getLastElectorVersion(), 8 );
+    }
+
+    /*
+     * This test ensures that an instance that is marked as failed has its elector version reset. This means that
+     * the instance, once it comes back, will still be able to do elections even if it lost state
+     */
+    @Test
+    public void electorFailingMustCauseElectorVersionToBeReset() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+        Logging logging = mock( Logging.class );
+        Timeouts timeouts = mock( Timeouts.class );
+        Executor executor = mock( Executor.class );
+
+        HeartbeatContext heartbeatContext = mock ( HeartbeatContext.class );
+
+        ArgumentCaptor<HeartbeatListener> listenerCaptor = ArgumentCaptor.forClass( HeartbeatListener.class );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, logging,
+                timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+
+        verify( heartbeatContext ).addHeartbeatListener( listenerCaptor.capture() );
+
+        HeartbeatListener theListener = listenerCaptor.getValue();
+
+        // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        theListener.failed( elector );
+
+        // Then
+        assertEquals( context.getLastElector(), InstanceId.NONE );
+        assertEquals( context.getLastElectorVersion(), ClusterContextImpl.NO_ELECTOR_VERSION );
+    }
+
+    /*
+     * This test ensures that an instance that is marked as failed has its elector version reset. This means that
+     * the instance, once it comes back, will still be able to do elections even if it lost state
+     */
+    @Test
+    public void nonElectorFailingMustNotCauseElectorVersionToBeReset() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId elector = new InstanceId( 2 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+        Logging logging = mock( Logging.class );
+        Timeouts timeouts = mock( Timeouts.class );
+        Executor executor = mock( Executor.class );
+
+        HeartbeatContext heartbeatContext = mock ( HeartbeatContext.class );
+
+        ArgumentCaptor<HeartbeatListener> listenerCaptor = ArgumentCaptor.forClass( HeartbeatListener.class );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, logging,
+                timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+
+        verify( heartbeatContext ).addHeartbeatListener( listenerCaptor.capture() );
+
+        HeartbeatListener theListener = listenerCaptor.getValue();
+
+        // This means instance 2 was the elector at version 8
+        context.setLastElector( elector );
+        context.setLastElectorVersion( 8 );
+
+        // When
+        theListener.failed( new InstanceId( 3 ) );
+
+        // Then
+        assertEquals( context.getLastElector(), elector );
+        assertEquals( context.getLastElectorVersion(), 8 );
+    }
+}


### PR DESCRIPTION
Previously, the elector version would not be reset when the elector left
 the cluster or it failed for some reason. The result was that
 the election results from that elector, which presumably would lose
 state and start counting election versions from 1, would be dropped
 by receivers since the version is now smaller than what they expected.
 This patch solves this by having all instances invalidate the known
 elector when it leaves the cluster or is marked as failed
