### PR TITLE
[2.1] Revert "Remove metadata/id from the representation"

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
@@ -151,7 +151,7 @@ public final class NodeRepresentation extends ObjectRepresentation implements Ex
                 return label.name();
             }
         });
-        return new MapRepresentation( map( "labels" , labels ) );
+        return new MapRepresentation( map( "id", node.getId(), "labels" , labels ) );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/RelationshipRepresentation.java
@@ -95,7 +95,7 @@ public final class RelationshipRepresentation extends ObjectRepresentation imple
     @Mapping( "metadata" )
     public MapRepresentation metadata()
     {
-        return new MapRepresentation( map( "type", rel.getType().name() ) );
+        return new MapRepresentation( map( "id", rel.getId(), "type", rel.getType().name() ) );
     }
 
     @Override

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/NodeRepresentationTest.java
@@ -152,5 +152,6 @@ public class NodeRepresentationTest
         Map metadata = (Map) noderep.get( "metadata" );
         List labels = (List) metadata.get( "labels" );
         assertTrue( labels.isEmpty() || labels.equals( asList( "Label" ) ) );
+        assertTrue( ( (Number) metadata.get("id") ).longValue() >= 0 );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RelationshipRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RelationshipRepresentationTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.server.rest.repr.RepresentationTestAccess.serialize;
 import static org.neo4j.server.rest.repr.RepresentationTestBase.*;
 import static org.neo4j.test.mocking.GraphMock.node;
@@ -99,5 +100,6 @@ public class RelationshipRepresentationTest
         assertNotNull( relrep.get( "metadata" ) );
         Map metadata = (Map) relrep.get( "metadata" );
         assertNotNull( metadata.get("type") );
+        assertTrue( ( (Number) metadata.get("id") ).longValue() >= 0 );
     }
 }


### PR DESCRIPTION
This reverts commit 786bbd63768d316c8633bdfb60bfaee2808210a0, and
converts the metadata/id representation to a Long.
