### PR TITLE
[1.9] Backup tool should exit with error if consistency check fails.

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -256,6 +256,7 @@ class BackupService
                 }
                 catch ( ConsistencyCheckIncompleteException e )
                 {
+                    consistent = false;
                     logger.error( "Consistency check incomplete", e );
                 }
                 finally

--- a/enterprise/backup/src/test/java/org/neo4j/backup/ExitCodeTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/ExitCodeTest.java
@@ -27,7 +27,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(BackupTool.ToolFailureException.class)
+@PrepareForTest(BackupTool.class)
 public class ExitCodeTest {
 
     @Test
@@ -37,7 +37,7 @@ public class ExitCodeTest {
         PowerMockito.mockStatic(System.class);
 
         // when
-        new BackupTool.ToolFailureException("tool failed").haltJVM();
+        BackupTool.exitFailure( "tool failed" );
 
         // then
         PowerMockito.verifyStatic();


### PR DESCRIPTION
A failed consistency check is now transported all the way up to the user with a print and the return code is 1.
