### PR TITLE
[1.9] Threads in executors used by Netty made daemon

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/DaemonThreadFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/DaemonThreadFactory.java
@@ -25,37 +25,31 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Yes, it's yet another daemon thread factory since Executors doesn't provide one. Sigh.
  */
-public class DaemonThreadFactory
-    implements ThreadFactory
+public class DaemonThreadFactory implements ThreadFactory
 {
-    static final AtomicInteger poolNumber = new AtomicInteger( 1 );
-    final ThreadGroup group;
-    final AtomicInteger threadNumber = new AtomicInteger( 1 );
-    final String namePrefix;
+    private static final AtomicInteger poolNumber = new AtomicInteger( 1 );
 
-    public DaemonThreadFactory(String name)
+    private final ThreadGroup group;
+    private final AtomicInteger threadNumber = new AtomicInteger( 1 );
+    private final String namePrefix;
+
+    public DaemonThreadFactory( String name )
     {
         SecurityManager s = System.getSecurityManager();
-        group = ( s != null ) ? s.getThreadGroup() :
-                Thread.currentThread().getThreadGroup();
-        namePrefix = name+"-" +
-                     poolNumber.getAndIncrement() +
-                     "-thread-";
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        namePrefix = name + "-" + poolNumber.getAndIncrement() + "-thread-";
     }
 
-    public Thread newThread( Runnable r )
+    public static DaemonThreadFactory daemon( String name )
     {
-        Thread t = new Thread( group, r,
-                               namePrefix + threadNumber.getAndIncrement(),
-                               0 );
-        if( !t.isDaemon() )
-        {
-            t.setDaemon( true );
-        }
-        if( t.getPriority() != Thread.NORM_PRIORITY )
-        {
-            t.setPriority( Thread.NORM_PRIORITY );
-        }
+        return new DaemonThreadFactory( name );
+    }
+
+    public Thread newThread( Runnable runnable )
+    {
+        Thread t = new Thread( group, runnable, namePrefix + threadNumber.getAndIncrement() );
+        t.setDaemon( true );
+        t.setPriority( Thread.NORM_PRIORITY );
         return t;
     }
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
@@ -52,10 +52,11 @@ import org.neo4j.cluster.com.message.MessageProcessor;
 import org.neo4j.cluster.com.message.MessageSource;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Listeners;
-import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.helpers.DaemonThreadFactory.daemon;
 
 /**
  * TCP version of a Networked Instance. This handles receiving messages to be consumed by local statemachines and
@@ -121,8 +122,8 @@ public class NetworkReceiver
 
         // Listen for incoming connections
         nioChannelFactory = new NioServerSocketChannelFactory(
-                Executors.newCachedThreadPool( new NamedThreadFactory( "Cluster boss" ) ),
-                Executors.newFixedThreadPool( 2, new NamedThreadFactory( "Cluster worker" ) ), 2 );
+                Executors.newCachedThreadPool( daemon( "Cluster boss" ) ),
+                Executors.newFixedThreadPool( 2, daemon( "Cluster worker" ) ), 2 );
         serverBootstrap = new ServerBootstrap( nioChannelFactory );
         serverBootstrap.setOption("child.tcpNoDelay", true);
         serverBootstrap.setPipelineFactory( new NetworkNodePipelineFactory() );


### PR DESCRIPTION
This PR makes threads in executors, used by Netty, daemon threads. It looks like it is better to make them daemon and not rely on `releaseExternalResources()` call.
