### PR TITLE
[2.2] Logs progress catching up to master in HA

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -307,7 +307,7 @@ class BackupService
         DependencyResolver resolver = targetDb.getDependencyResolver();
 
         ProgressTxHandler handler = new ProgressTxHandler();
-        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker( resolver, handler );
+        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker( resolver );
 
         Monitors monitors = resolver.resolveDependency( Monitors.class );
         BackupClient client = new BackupClient( sourceHostNameOrIp, sourcePort,
@@ -321,7 +321,7 @@ class BackupService
             client.start();
             unpacker.start();
 
-            unpacker.unpackResponse( client.incrementalBackup( context ) );
+            unpacker.unpackResponse( client.incrementalBackup( context ), handler );
 
             consistent = true;
         }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
@@ -26,13 +26,17 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 
 public interface ResponseUnpacker
 {
-    void unpackResponse( Response<?> response ) throws IOException;
+    /**
+     * @param txHandler for getting an insight into which transactions gets applied.
+     */
+    void unpackResponse( Response<?> response, TxHandler txHandler ) throws IOException;
 
     public static final ResponseUnpacker NO_OP_RESPONSE_UNPACKER = new ResponseUnpacker()
     {
         @Override
-        public void unpackResponse( Response<?> response ) throws IOException
+        public void unpackResponse( Response<?> response, TxHandler txHandler ) throws IOException
         {
+            txHandler.done();
         }
     };
 

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 public class TransactionCommittingResponseUnpacker implements ResponseUnpacker, Lifecycle
 {
     private final DependencyResolver resolver;
-    private final TxHandler txHandler;
 
     private TransactionAppender appender;
     private TransactionRepresentationStoreApplier storeApplier;
@@ -44,14 +43,13 @@ public class TransactionCommittingResponseUnpacker implements ResponseUnpacker, 
 
     private volatile boolean stopped = false;
 
-    public TransactionCommittingResponseUnpacker( DependencyResolver resolver, TxHandler txHandler )
+    public TransactionCommittingResponseUnpacker( DependencyResolver resolver )
     {
         this.resolver = resolver;
-        this.txHandler = txHandler;
     }
 
     @Override
-    public void unpackResponse( Response<?> response ) throws IOException
+    public void unpackResponse( Response<?> response, final TxHandler txHandler ) throws IOException
     {
         if ( stopped )
         {

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.neo4j.com.storecopy.ResponseUnpacker;
+import org.neo4j.com.storecopy.ResponseUnpacker.TxHandler;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -38,6 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -384,13 +386,13 @@ public class TestCommunication
 
         // Then
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass( Response.class );
-        verify( responseUnpacker ).unpackResponse( captor.capture() );
+        verify( responseUnpacker ).unpackResponse( captor.capture(), any( TxHandler.class ) );
         assertEquals( storeIdToUse, captor.getValue().getStoreId() );
         assertEquals( 42 * 42, captor.getValue().response() );
     }
 
     @Test
-    public void masterResponseShouldNotBeUnpackedIfRequestTypeDoesNotRequire() throws IOException
+    public void masterResponseShouldNotBeUnpackedIfRequestTypeDoesNotRequire()
     {
         // Given
         ResponseUnpacker responseUnpacker = mock( ResponseUnpacker.class );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -40,7 +40,6 @@ import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
 import org.neo4j.com.monitor.RequestMonitor;
-import org.neo4j.com.storecopy.ResponseUnpacker;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.DependencyResolver;
@@ -164,7 +163,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         requestContextFactory = dependencies.satisfyDependency(new RequestContextFactory( serverId, getDependencyResolver() ));
 
         this.responseUnpacker = dependencies.satisfyDependency(
-                new TransactionCommittingResponseUnpacker( dependencyResolver, ResponseUnpacker.NO_OP_TX_HANDLER ) );
+                new TransactionCommittingResponseUnpacker( dependencyResolver ) );
 
         kernelProvider = new Provider<KernelAPI>()
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient201.java
@@ -35,6 +35,7 @@ import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.ResponseUnpacker;
+import org.neo4j.com.storecopy.ResponseUnpacker.TxHandler;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
@@ -314,7 +315,13 @@ public class MasterClient201 extends Client<Master> implements MasterClient
     @Override
     public Response<Void> pullUpdates( RequestContext context )
     {
-        return sendRequest( HaRequestType201.PULL_UPDATES, context, EMPTY_SERIALIZER, VOID_DESERIALIZER );
+        return pullUpdates( context, ResponseUnpacker.NO_OP_TX_HANDLER );
+    }
+
+    @Override
+    public Response<Void> pullUpdates( RequestContext context, TxHandler txHandler )
+    {
+        return sendRequest( HaRequestType201.PULL_UPDATES, context, EMPTY_SERIALIZER, VOID_DESERIALIZER, null, txHandler );
     }
 
     @Override
@@ -335,7 +342,7 @@ public class MasterClient201 extends Client<Master> implements MasterClient
                     {
                         return new HandshakeResult( buffer.readInt(), buffer.readLong(), buffer.readLong() );
                     }
-                }, storeId
+                }, storeId, ResponseUnpacker.NO_OP_TX_HANDLER
         );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -28,19 +28,20 @@ import org.neo4j.com.Client;
 import org.neo4j.com.Deserializer;
 import org.neo4j.com.Protocol;
 import org.neo4j.com.Protocol201;
+import org.neo4j.com.ProtocolVersion;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
 import org.neo4j.com.Response;
 import org.neo4j.com.Serializer;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.ResponseUnpacker;
+import org.neo4j.com.storecopy.ResponseUnpacker.TxHandler;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.MasterServer;
 import org.neo4j.kernel.ha.com.slave.MasterClient;
-import org.neo4j.com.ProtocolVersion;
 import org.neo4j.kernel.ha.id.IdAllocation;
 import org.neo4j.kernel.ha.lock.LockResult;
 import org.neo4j.kernel.impl.locking.Locks;
@@ -266,7 +267,13 @@ public class MasterClient210 extends Client<Master> implements MasterClient
     @Override
     public Response<Void> pullUpdates( RequestContext context )
     {
-        return sendRequest( HaRequestType210.PULL_UPDATES, context, EMPTY_SERIALIZER, VOID_DESERIALIZER );
+        return pullUpdates( context, ResponseUnpacker.NO_OP_TX_HANDLER );
+    }
+
+    @Override
+    public Response<Void> pullUpdates( RequestContext context, TxHandler txHandler )
+    {
+        return sendRequest( HaRequestType210.PULL_UPDATES, context, EMPTY_SERIALIZER, VOID_DESERIALIZER, null, txHandler );
     }
 
     @Override
@@ -287,7 +294,7 @@ public class MasterClient210 extends Client<Master> implements MasterClient
                     {
                         return new HandshakeResult( buffer.readInt(), buffer.readLong(), buffer.readLong() );
                     }
-                }, storeId
+                }, storeId, ResponseUnpacker.NO_OP_TX_HANDLER
         );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -32,6 +32,7 @@ import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.ProtocolVersion;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
+import org.neo4j.com.storecopy.ResponseUnpacker.TxHandler;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.ha.MasterClient214;
@@ -122,6 +123,8 @@ public interface MasterClient extends Master
 
     @Override
     public Response<Void> pullUpdates( RequestContext context );
+
+    public Response<Void> pullUpdates( RequestContext context, TxHandler txHandler );
 
     @Override
     public Response<Void> copyStore( RequestContext context, final StoreWriter writer );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -79,7 +79,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_RESPONSE_UNPACKER;
-import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_TX_HANDLER;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class MasterClientTest
@@ -132,8 +131,7 @@ public class MasterClientTest
         when( txAppender.append( any( CommittedTransactionRepresentation.class ) ) ).thenReturn( true );
         when( txStore.getAppender() ).thenReturn( txAppender );
 
-        ResponseUnpacker unpacker =
-                initAndStart( new TransactionCommittingResponseUnpacker( resolver, NO_OP_TX_HANDLER ) );
+        ResponseUnpacker unpacker = initAndStart( new TransactionCommittingResponseUnpacker( resolver ) );
 
         MasterClient masterClient = cleanupRule.add( newMasterClient214( StoreId.DEFAULT, unpacker ) );
 


### PR DESCRIPTION
Possible after a refactoring where the response unpacker now accepts a
TxHandler in its accept method. This makes it possible to reuse a single
response unpacker for multiple TxHandler purposes, and by extension a
single MasterClient instance for multiple purposes.
