### PR TITLE
[2.2] Performs log pruning outside of append monitors

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFile.java
@@ -50,7 +50,15 @@ public interface LogFile extends Lifecycle
 
     void accept( LogHeaderVisitor visitor ) throws IOException;
 
-    void checkRotation() throws IOException;
+    /**
+     * @return {@code true} if a rotation indeed happened.
+     */
+    boolean checkRotation() throws IOException;
+
+    /**
+     * Prunes historical log versions.
+     */
+    void prune();
 
     File currentLogFile();
 }


### PR DESCRIPTION
so that log pruning, which isn't critical functionality in and around
transaction appends and rotations, outside of any monitors held by
append/rotate. This will make the pauses introduced by rotation smaller so
that other transactions can still append when a log pruning is happening.
