### PR TITLE
[2.2] Browser: Disable hover event on node drag.

### DIFF
--- a/community/browser/app/scripts/controllers/D3Graph.coffee
+++ b/community/browser/app/scripts/controllers/D3Graph.coffee
@@ -46,11 +46,9 @@ angular.module('neo4jApp.controllers')
             $scope.$apply(->exp($scope, {'$item': item }))
 
       itemMouseOver = attributeHandlerFactory('onItemMouseOver')
-
       itemMouseOut = attributeHandlerFactory('onItemMouseOut')
-
+      nodeDragToggle = attributeHandlerFactory('onNodeDragToggle')
       onCanvasClicked = attributeHandlerFactory('onCanvasClicked')
-
       selectItem = attributeHandlerFactory('onItemClick')
 
       selectedItem = null
@@ -114,6 +112,7 @@ angular.module('neo4jApp.controllers')
           )
           .on('nodeMouseOver', itemMouseOver)
           .on('nodeMouseOut', itemMouseOut)
+          .on('nodeDragToggle', nodeDragToggle)
           .on('relMouseOver', itemMouseOver)
           .on('relMouseOut', itemMouseOut)
           .on('canvasClicked', ->

--- a/community/browser/app/scripts/controllers/Inspector.coffee
+++ b/community/browser/app/scripts/controllers/Inspector.coffee
@@ -33,7 +33,8 @@ angular.module('neo4jApp.controllers')
       $scope.currentItem = null
       $scope.inspectorContracted = yes
       $scope.inspectorChanged = no
-      
+      $scope.inspectorFixed = no
+
       inspectorItem = (item, type) ->
         data: item
         type: type
@@ -48,6 +49,9 @@ angular.module('neo4jApp.controllers')
           $scope.inspectorChanged = yes
         , 0)
 
+      $scope.onNodeDragToggle = (node) ->
+        $scope.inspectorFixed = !!node
+
       $scope.onItemClick = (item, type) ->
         if item
           $scope.currentItem = inspectorItem(item, type)
@@ -58,6 +62,8 @@ angular.module('neo4jApp.controllers')
         triggerInspectorUIUpdate()
 
       $scope.onItemHover = (item, type) ->
+        return if $scope.inspectorFixed
+
         if item
           $scope.Inspector.reset(inspectorItem(item, type))
         else

--- a/community/browser/app/views/frame-cypher.jade
+++ b/community/browser/app/views/frame-cypher.jade
@@ -11,6 +11,7 @@ div(ng-controller="CypherResultCtrl", fullscreen)
               on-item-click='onItemClick($item, "graphItem")'
               on-item-mouse-over='onItemHover($item, "graphItem")'
               on-item-mouse-out='onItemHover()'
+              on-node-drag-toggle='onNodeDragToggle($item)'
               on-canvas-clicked='onItemClick()'
               ng-controller='D3GraphCtrl'
               style="pointer-events:fill;")

--- a/community/browser/lib/visualization/components/visualization.coffee
+++ b/community/browser/lib/visualization/components/visualization.coffee
@@ -31,6 +31,8 @@ neo.viz = (el, measureSize, graph, layout, style) ->
 
   onNodeDblClick = (node) => viz.trigger('nodeDblClicked', node)
 
+  onNodeDragToggle = (node) -> viz.trigger('nodeDragToggle', node)
+
   onRelationshipClick = (relationship) =>
     d3.event.stopPropagation()
     viz.trigger('relationshipClicked', relationship)
@@ -80,6 +82,13 @@ neo.viz = (el, measureSize, graph, layout, style) ->
 
 
   force = layout.init(render)
+    
+  #Add custom drag event listeners
+  force.drag().on('dragstart.node', (d) -> 
+    onNodeDragToggle(d)
+  ).on('dragend.node', () ->
+    onNodeDragToggle()
+  )
 
   viz.update = ->
     return unless graph


### PR DESCRIPTION
- While dragging a node, inspector stays the same
