### PR TITLE
[2.2] Fix failure of backing up store upgraded from old backup.

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -69,20 +69,9 @@ class BackupImpl implements TheBackupInterface
             ResponsePacker responsePacker = new StoreCopyResponsePacker( logicalTransactionStore,
                     transactionIdStore, logFileInformation, storeId,
                     copyStartContext.lastAppliedTransaction() + 1 ); // mandatory transaction id
-            long optionalTransactionId = boBackACoupleOfTransactionsIfRequired(
-                    copyStartContext.lastAppliedTransaction() ); // optional transaction id
+            long optionalTransactionId = copyStartContext.lastAppliedTransaction();
             return responsePacker.packResponse( anonymous( optionalTransactionId ), null/*no response object*/ );
         }
-    }
-
-    private long boBackACoupleOfTransactionsIfRequired( long transactionWhenStartingCopy )
-    {
-        int atLeast = 10;
-        if ( transactionIdStore.getLastCommittedTransactionId() - transactionWhenStartingCopy < atLeast )
-        {
-            return max( 1, transactionIdStore.getLastCommittedTransactionId() - atLeast );
-        }
-        return transactionWhenStartingCopy;
     }
 
     @Override


### PR DESCRIPTION
Trying to get more than one transaction during backup from
an upgraded store might fail since they might contain only
a single transaction in its backed up log. This is the case
for 1.9 stores currently.

The commit basically reverts this mismatch and only tries to
backup a single transaction. A more robust and flexible solution
could look at the logs and backup a reasonable amount of them
if available, which might be good for debugability.
