### PR TITLE
[1.9] Fix backup service incorrectly initializing new log with -1 txId.

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -201,7 +201,7 @@ class BackupService
                                     ds.getFileName( logVersion ),
                                     "rw" ).getChannel();
                             newLog.truncate( 0 );
-                            LogIoUtils.writeLogHeader( scratch, logVersion, -1 );
+                            LogIoUtils.writeLogHeader( scratch, logVersion, tx.second() - 1 );
                             // scratch buffer is flipped by writeLogHeader
                             newLog.write( scratch );
                             ReadableByteChannel received = tx.third().extract();

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -21,6 +21,8 @@ package org.neo4j.backup;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +37,7 @@ import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -51,6 +54,7 @@ import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
 import org.neo4j.kernel.impl.storemigration.StoreFiles;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
+import org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.BackupMonitor;
@@ -58,6 +62,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.TargetDirectory;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -178,6 +183,27 @@ public class BackupServiceIT
         assertEquals( DbRepresentation.of( storeDir ), DbRepresentation.of( backupDir ) );
 
         assertNotNull( getLastMasterForCommittedTx( DEFAULT_DATA_SOURCE_NAME ) );
+    }
+
+    @Test
+    public void shouldFindValidPreviousCommittedTxIdInFirstNeoStoreLog() throws Throwable
+    {
+        // given
+        GraphDatabaseService db = createDb( storeDir, defaultBackupPortHostParams() );
+        createAndIndexNode( db, 1 );
+        createAndIndexNode( db, 2 );
+        createAndIndexNode( db, 3 );
+        createAndIndexNode( db, 4 );
+
+        // when
+        BackupService backupService = new BackupService( fileSystem );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
+                new Config( defaultBackupPortHostParams() ) );
+        db.shutdown();
+
+        // then
+        checkPreviousCommittedTxIdFromFirstLog( DEFAULT_DATA_SOURCE_NAME ); // neo store
+        checkPreviousCommittedTxIdFromFirstLog( DEFAULT_NAME ); // lucene
     }
 
     @Test
@@ -521,6 +547,30 @@ public class BackupServiceIT
                 description.appendText( String.format( "[%s] in list of copied files", fileName ) );
             }
         };
+    }
+
+    private void checkPreviousCommittedTxIdFromFirstLog( String dataSourceName ) throws IOException
+    {
+        GraphDatabaseAPI db = (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabase(
+                backupDir.getAbsolutePath() );
+        try
+        {
+            XaDataSourceManager xaDataSourceManager = db.getDependencyResolver().resolveDependency(
+                    XaDataSourceManager.class );
+            XaDataSource dataSource = xaDataSourceManager.getXaDataSource( dataSourceName );
+            ReadableByteChannel logicalLog = dataSource.getLogicalLog( 0 );
+
+            ByteBuffer buffer = ByteBuffer.allocate( 64 );
+            long[] headerData = LogIoUtils.readLogHeader( buffer, logicalLog, true );
+
+            long previousCommittedTxIdFromFirstLog = headerData[1];
+
+            assertEquals( previousCommittedTxIdFromFirstLog, dataSource.getLastCommittedTxId() - 1 );
+        }
+        finally
+        {
+            db.shutdown();
+        }
     }
 
     private Pair<Integer,Long> getLastMasterForCommittedTx( String dataSourceName ) throws IOException


### PR DESCRIPTION
The backup service receives a transaction (the last one) and should initialize
the log header with its txId minus one.
