### PR TITLE
[1.9] Slave goes through 'switchToSlave' process on every 'masterIsElected' event

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
@@ -279,14 +279,9 @@ public enum HighAvailabilityMemberState
                     {
                         return TO_MASTER;
                     }
-                    if ( masterId.equals( context.getElectedMasterId() ) )
-                    {
-                        return this;
-                    }
-                    else
-                    {
-                        return PENDING;
-                    }
+                    // We need to go through slave switching process once again as
+                    // it is possible that we've missed elections and have stale epoch
+                    return PENDING;
                 }
 
                 @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
@@ -104,6 +104,8 @@ public class TestSlaveOnlyCluster
 
             electedLatch.await();
 
+            clusterManager.getDefaultCluster().await( ClusterManager.allSeesAllAsAvailable() );
+
             HighlyAvailableGraphDatabase slaveDatabase = clusterManager.getDefaultCluster().getAnySlave(  );
             Transaction tx = slaveDatabase.beginTx();
             Node node = slaveDatabase.createNode();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -19,17 +19,26 @@
  */
 package org.neo4j.kernel.ha;
 
+import java.util.concurrent.CountDownLatch;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.com.NetworkReceiver;
+import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.AbstractClusterTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import static org.neo4j.helpers.Predicates.not;
 import static org.neo4j.test.ReflectionUtil.getPrivateField;
 import static org.neo4j.test.ha.ClusterManager.RepairKit;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
@@ -63,6 +72,61 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
         assertEquals( 3, cluster.size() );
     }
 
+    @Test
+    public void slaveShouldServeTxsAfterMasterLostQuorumWentToPendingAndThenQuorumWasRestored() throws Throwable
+    {
+        // GIVEN: cluster with 3 members
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+
+        final HighlyAvailableGraphDatabase slave1 = cluster.getAnySlave();
+        final HighlyAvailableGraphDatabase slave2 = cluster.getAnySlave( slave1 );
+
+        final CountDownLatch slave1Left = new CountDownLatch( 1 );
+        final CountDownLatch slave2Left = new CountDownLatch( 1 );
+
+        clusterClientOf( master ).addHeartbeatListener( new HeartbeatListener.Adapter()
+        {
+            @Override
+            public void failed( InstanceId server )
+            {
+                if ( instanceIdOf( slave1 ).equals( server ) )
+                {
+                    slave1Left.countDown();
+                }
+                else if ( instanceIdOf( slave2 ).equals( server ) )
+                {
+                    slave2Left.countDown();
+                }
+            }
+        } );
+
+        // fail slave1 and await master to spot the failure
+        RepairKit slave1RepairKit = cluster.fail( slave1 );
+        slave1Left.await();
+
+        // fail slave2 and await master to spot the failure
+        RepairKit slave2RepairKit = cluster.fail( slave2 );
+        slave2Left.await();
+
+        // master loses quorum and goes to PENDING, cluster is unavailable
+        cluster.await( not( masterAvailable() ) );
+        assertEquals( HighAvailabilityMemberState.PENDING.toString(), master.getInstanceState() );
+
+        // WHEN: both slaves are repaired, majority restored, quorum can be achieved
+        slave1RepairKit.repair();
+        slave2RepairKit.repair();
+
+        // THEN: whole cluster should be fine, every member should be available
+        cluster.await( masterAvailable() );
+        cluster.await( masterSeesSlavesAsAvailable( 2 ) );
+        cluster.await( allSeesAllAsAvailable() );
+
+        // able to perform transactions on master and slaves
+        assertNotNull( createNodeOn( master ) );
+        assertNotNull( createNodeOn( slave1 ) );
+        assertNotNull( createNodeOn( slave2 ) );
+    }
+
     @Override
     protected void configureClusterMember( GraphDatabaseBuilder builder, String clusterName, InstanceId serverId )
     {
@@ -90,5 +154,32 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
                 service.start();
             }
         }
+    }
+
+    private static ClusterClient clusterClientOf( HighlyAvailableGraphDatabase db )
+    {
+        return db.getDependencyResolver().resolveDependency( ClusterClient.class );
+    }
+
+    private static InstanceId instanceIdOf( HighlyAvailableGraphDatabase db )
+    {
+        return clusterClientOf( db ).getServerId();
+    }
+
+    private static Node createNodeOn( HighlyAvailableGraphDatabase db )
+    {
+        Node node;
+        Transaction tx = db.beginTx();
+        try
+        {
+            node = db.createNode();
+            node.setProperty( "key", String.valueOf( System.currentTimeMillis() ) );
+            tx.success();
+        }
+        finally
+        {
+            tx.finish();
+        }
+        return node;
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
@@ -277,9 +277,9 @@ public class HighAvailabilityMemberStateTest
         HighAvailabilityMemberState newStateCase2 = SLAVE.masterIsElected( context, new InstanceId( 3 ) );
         assertEquals( PENDING, newStateCase2 );
 
-        // CASE 3: It is the current master that got elected again - ignore
+        // CASE 3: It is the current master that got elected again - SLAVE should switch to PENDING
         HighAvailabilityMemberState newStateCase3 = SLAVE.masterIsElected( context, masterInstanceId );
-        assertEquals( SLAVE, newStateCase3 );
+        assertEquals( PENDING, newStateCase3 );
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the problem of slave having stale epoch in `RequestContext` and `RequestContextFactory` after a quorum loss and master reelection.
