### PR TITLE
[2.1] Re-apply reverted commits

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/CaseExpression.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/CaseExpression.scala
@@ -24,8 +24,10 @@ import org.neo4j.cypher.internal.compiler.v2_1._
 import symbols._
 
 case class CaseExpression(expression: Option[Expression], alternatives: Seq[(Expression, Expression)], default: Option[Expression])(val position: InputPosition) extends Expression {
+  lazy val possibleExpressions = alternatives.map(_._2) ++ default
+
   def semanticCheck(ctx: SemanticContext): SemanticCheck = {
-    val possibleTypes: TypeGenerator = (alternatives.map(_._2) ++ default).mergeUpTypes
+    val possibleTypes: TypeGenerator = possibleExpressions.leastUpperBoundsOfTypes
 
     expression.semanticCheck(ctx) chain
     alternatives.flatMap { a => Seq(a._1, a._2) }.semanticCheck(ctx) chain

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Collection.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Collection.scala
@@ -28,7 +28,7 @@ case class Collection(expressions: Seq[Expression])(val position: InputPosition)
 
   private def possibleTypes: TypeGenerator = state => expressions match {
     case Seq() => CTCollection(CTAny).covariant
-    case _     => expressions.mergeUpTypes(state).wrapInCollection
+    case _     => expressions.leastUpperBoundsOfTypes(state).wrapInCollection
   }
 }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Expression.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/Expression.scala
@@ -46,11 +46,11 @@ object Expression {
   }
 
   implicit class InferrableTypeTraversableOnce[A <: Expression](traversable: TraversableOnce[A]) {
-    def mergeUpTypes: TypeGenerator =
+    def leastUpperBoundsOfTypes: TypeGenerator =
       if (traversable.isEmpty)
         _ => CTAny.invariant
       else
-        (state: SemanticState) => traversable.map { _.types(state) } reduce { _ mergeUp _ }
+        state => traversable.map { _.types(state) } reduce { _ leastUpperBounds _ }
 
     def expectType(possibleTypes: => TypeSpec): SemanticCheck =
       traversable.foldSemanticCheck { _.expectType(possibleTypes) }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/IterableExpressions.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/IterableExpressions.scala
@@ -164,5 +164,5 @@ case class ReduceExpression(accumulator: Identifier, init: Expression, identifie
       accumulator.declare(accType) chain
       expression.semanticCheck(SemanticContext.Simple)
     } chain expression.expectType(init.types, AccumulatorExpressionTypeMismatchMessageGenerator) chain
-    this.specifyType(s => init.types(s) mergeUp expression.types(s))
+    this.specifyType(s => init.types(s) leastUpperBounds expression.types(s))
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Add.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Add.scala
@@ -59,14 +59,14 @@ case class Add(a: Expression, b: Expression) extends Expression with TypeSafeMat
       case _ => (aT, bT) match {
         case (x:StringType, y:NumberType) => CTString
         case (x:NumberType, y:StringType) => CTString
-        case _ => aT.mergeUp(bT)
+        case _ => aT.leastUpperBound(bT)
       }
     }
   }
 
   private def mergeWithCollection(collection: CypherType, singleElement: CypherType):CypherType= {
     val collectionType = collection.asInstanceOf[CollectionType]
-    val mergedInnerType = collectionType.innerType.mergeUp(singleElement)
+    val mergedInnerType = collectionType.innerType.leastUpperBound(singleElement)
     CTCollection(mergedInnerType)
   }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/CoalesceFunction.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/CoalesceFunction.scala
@@ -44,7 +44,7 @@ case class CoalesceFunction(arguments: Expression*) extends Expression {
   def calculateType(symbols: SymbolTable) = {
     arguments.map(_.getType(symbols)) match {
       case Seq() => CTAny
-      case types => types.reduceLeft(_ mergeUp _)
+      case types => types.reduceLeft(_ leastUpperBound _)
     }
   }
 

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Collection.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Collection.scala
@@ -35,7 +35,7 @@ case class Collection(arguments: Expression*) extends Expression {
   def calculateType(symbols: SymbolTable): CypherType =
     arguments.map(_.getType(symbols)) match {
       case Seq() => CTCollection(CTAny)
-      case types => CTCollection(types.reduce(_ mergeUp _))
+      case types => CTCollection(types.reduce(_ leastUpperBound _))
     }
 
   def symbolTableDependencies = arguments.flatMap(_.symbolTableDependencies).toSet

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Expression.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Expression.scala
@@ -68,7 +68,7 @@ abstract class Expression extends Typed with TypeSafe with EffectfulAstNode[Expr
   }
 
   protected def calculateUpperTypeBound(expectedType: CypherType, symbols: SymbolTable, exprs: Seq[Expression]): CypherType =
-    exprs.map(_.evaluateType(expectedType, symbols)).reduce(_ mergeUp _)
+    exprs.map(_.evaluateType(expectedType, symbols)).reduce(_ leastUpperBound _)
 
   override def toString = this match {
     case p: Product => scala.runtime.ScalaRunTime._toString(p)

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Literal.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/Literal.scala
@@ -45,7 +45,7 @@ case class Literal(v: Any) extends Expression {
     case _: Boolean                         => CTBoolean
     case IsMap(_)                           => CTMap
     case IsCollection(coll) if coll.isEmpty => CTCollection(CTAny)
-    case IsCollection(coll)                 => CTCollection(coll.map(deriveType).reduce(_ mergeUp _))
+    case IsCollection(coll)                 => CTCollection(coll.map(deriveType).reduce(_ leastUpperBound _))
     case _                                  => CTAny
   }
 }

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/functions/Coalesce.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/functions/Coalesce.scala
@@ -30,7 +30,7 @@ case object Coalesce extends Function {
   def semanticCheck(ctx: ast.Expression.SemanticContext, invocation: ast.FunctionInvocation): SemanticCheck =
     checkMinArgs(invocation, 1) chain
     invocation.arguments.expectType(CTAny.covariant) chain
-    invocation.specifyType(invocation.arguments.mergeUpTypes)
+    invocation.specifyType(invocation.arguments.leastUpperBoundsOfTypes)
 
   def asCommandExpression(invocation: ast.FunctionInvocation) =
     commandexpressions.CoalesceFunction(invocation.arguments.asCommandExpressions:_*)

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/CollectionType.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/CollectionType.scala
@@ -41,18 +41,18 @@ object CollectionType {
         super.isAssignableFrom(other)
     }
 
-    override def mergeUp(other: CypherType) = other match {
+    override def leastUpperBound(other: CypherType) = other match {
       case otherCollection: CollectionType =>
-        copy(innerType mergeUp otherCollection.innerType)
+        copy(innerType leastUpperBound otherCollection.innerType)
       case _ =>
-        super.mergeUp(other)
+        super.leastUpperBound(other)
     }
 
-    override def mergeDown(other: CypherType) = other match {
+    override def greatestLowerBound(other: CypherType) = other match {
       case otherCollection: CollectionType =>
-        (innerType mergeDown otherCollection.innerType).map(copy)
+        (innerType greatestLowerBound otherCollection.innerType).map(copy)
       case _ =>
-        super.mergeDown(other)
+        super.greatestLowerBound(other)
     }
 
     override def rewrite(f: CypherType => CypherType) = f(copy(innerType.rewrite(f)))

--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/CypherType.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/CypherType.scala
@@ -48,19 +48,19 @@ abstract class CypherType {
 
   def legacyIteratedType: CypherType = this
 
-  def mergeUp(other: CypherType): CypherType =
+  def leastUpperBound(other: CypherType): CypherType =
     if (this.isAssignableFrom(other)) this
     else if (other.isAssignableFrom(this)) other
-    else parentType mergeUp other.parentType
+    else parentType leastUpperBound other.parentType
 
-  def mergeDown(other: CypherType): Option[CypherType] =
+  def greatestLowerBound(other: CypherType): Option[CypherType] =
     if (this.isAssignableFrom(other)) Some(other)
     else if (other.isAssignableFrom(this)) Some(this)
     else None
 
   lazy val covariant: TypeSpec = TypeSpec.all constrain this
   lazy val invariant: TypeSpec = TypeSpec.exact(this)
-  lazy val contravariant: TypeSpec = TypeSpec.all mergeUp this
+  lazy val contravariant: TypeSpec = TypeSpec.all leastUpperBounds this
 
   def rewrite(f: CypherType => CypherType) = f(this)
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/CaseExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/ast/CaseExpressionTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_1.symbols._
 
 class CaseExpressionTest extends CypherFunSuite {
 
-  test("shouldHaveMergedTypesOfAllAlternativesInSimpleCase") {
+  test("Simple: Should merge types of alternatives") {
     val caseExpression = CaseExpression(
       expression = Some(DummyExpression(CTString)),
       alternatives = Seq(
@@ -45,7 +45,7 @@ class CaseExpressionTest extends CypherFunSuite {
     caseExpression.types(result.state) should equal(CTNumber.invariant)
   }
 
-  test("shouldHaveMergedTypesOfAllAlternativesInGenericCase") {
+  test("Generic: Should merge types of alternatives") {
     val caseExpression = CaseExpression(
       None,
       Seq(
@@ -65,7 +65,7 @@ class CaseExpressionTest extends CypherFunSuite {
     caseExpression.types(result.state) should equal(CTNumber | CTAny)
   }
 
-  test("shouldTypeCheckPredicatesInGenericCase") {
+  test("Generic: should type check predicates") {
     val caseExpression = CaseExpression(
       None,
       Seq(

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ExpressionTest.scala
@@ -126,7 +126,7 @@ class ExpressionTest extends CypherFunSuite {
     val result = keys.toSeq.map(k => (a.get(k), b.get(k)) match {
       case (Some(x), None)    => k -> x
       case (None, Some(x))    => k -> x
-      case (Some(x), Some(y)) => k -> x.mergeUp(y)
+      case (Some(x), Some(y)) => k -> x.leastUpperBound(y)
       case (None, None)       => throw new ThisShouldNotHappenError("Andres", "only here to stop warnings")
     }).toMap
 

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/TypeRangeTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/TypeRangeTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 
 class TypeRangeTest extends CypherFunSuite {
 
-  test("typeRangeOfSingleTypeShouldContainOnlyThatType") {
+  test("TypeRange of single type should contain only that type") {
     val rangeOfInteger = TypeRange(CTInteger, CTInteger)
     rangeOfInteger.contains(CTInteger) should equal(true)
     rangeOfInteger.contains(CTNumber) should equal(false)
@@ -48,7 +48,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeOfCollectionAny.contains(CTAny) should equal(false)
   }
 
-  test("unboundedTypeRangeRootedAtAnyShouldContainAll") {
+  test("unbounded TypeRange rooted at CTAny should contain all") {
     val rangeRootedAtAny = TypeRange(CTAny, None)
     rangeRootedAtAny.contains(CTAny) should equal(true)
     rangeRootedAtAny.contains(CTString) should equal(true)
@@ -61,7 +61,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeRootedAtAny.contains(CTCollection(CTCollection(CTFloat))) should equal(true)
   }
 
-  test("unboundedTypeRangeRootedAtLeafTypeShouldContainLeaf") {
+  test("unbounded TypeRange rooted at leaf type should contain leaf") {
     val rangeRootedAtInteger = TypeRange(CTInteger, None)
     rangeRootedAtInteger.contains(CTInteger) should equal(true)
     rangeRootedAtInteger.contains(CTNumber) should equal(false)
@@ -76,7 +76,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeRootedAtCollectionOfNumber.contains(CTAny) should equal(false)
   }
 
-  test("unboundedTypeRangeRootedAtBranchTypeShouldContainAllMoreSpecificTypes") {
+  test("unbounded TypeRange rooted at branch type should contain all more specific types") {
     val rangeRootedAtInteger = TypeRange(CTNumber, None)
     rangeRootedAtInteger.contains(CTInteger) should equal(true)
     rangeRootedAtInteger.contains(CTFloat) should equal(true)
@@ -93,7 +93,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeRootedAtCollectionAny.contains(CTAny) should equal(false)
   }
 
-  test("typeRangeShouldContainOverlappingRange") {
+  test("should contain overlapping range") {
     val rangeRootedAtNumber = TypeRange(CTNumber, None)
     val rangeRootedAtInteger = TypeRange(CTInteger, None)
     rangeRootedAtNumber.contains(rangeRootedAtInteger) should equal(true)
@@ -116,7 +116,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeRootedAtInteger.contains(rangeRootedAtDouble) should equal(false)
   }
 
-  test("intersectRangeWithOverlappingRangeShouldNotChangeRange") {
+  test("intersection of range with overlapping range should not change range") {
     val rangeRootedAtInteger = TypeRange(CTInteger, None)
     rangeRootedAtInteger & TypeRange(CTNumber, None) should equal(Some(rangeRootedAtInteger))
 
@@ -127,7 +127,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeOfNumber & TypeRange(CTNumber, None) should equal(Some(rangeOfNumber))
   }
 
-  test("intersectRangeWithIntersectingRangeShouldReturnIntersection") {
+  test("intersection of range with intersecting range should return intersection") {
     val rangeOfNumber = TypeRange(CTNumber, None)
     rangeOfNumber & TypeRange(CTAny, CTNumber) should equal(Some(TypeRange(CTNumber, CTNumber)))
 
@@ -135,7 +135,7 @@ class TypeRangeTest extends CypherFunSuite {
     rangeToNumber & TypeRange(CTNumber, None) should equal(Some(TypeRange(CTNumber, CTNumber)))
   }
 
-  test("intersectRangeToSubRangeShouldReturnSubRange") {
+  test("intersection of range to sub range should return sub range") {
     val rangeOfAll = TypeRange(CTAny, None)
     rangeOfAll & TypeRange(CTAny, CTNumber) should equal(Some(TypeRange(CTAny, CTNumber)))
     rangeOfAll & TypeRange(CTNumber, CTNumber) should equal(Some(TypeRange(CTNumber, CTNumber)))
@@ -146,13 +146,13 @@ class TypeRangeTest extends CypherFunSuite {
     rangeOfNumberToInteger & TypeRange(CTInteger, CTInteger) should equal(Some(TypeRange(CTInteger, CTInteger)))
   }
 
-  test("intersectRangeWithinCollection") {
+  test("intersection of range within collection") {
     val rangeFromCollectionAny = TypeRange(CTCollection(CTAny), None)
     rangeFromCollectionAny & TypeRange(CTCollection(CTString), None) should equal(Some(TypeRange(CTCollection(CTString), None)))
     rangeFromCollectionAny & TypeRange(CTCollection(CTString), CTCollection(CTString)) should equal(Some(TypeRange(CTCollection(CTString), CTCollection(CTString))))
   }
 
-  test("intersectRangeWithNonOverlappingRangeShouldReturnNone") {
+  test("intersection of range with non overlapping range should return none") {
     val rangeFromNumber = TypeRange(CTNumber, None)
     rangeFromNumber & TypeRange(CTString, None) should equal(None)
 
@@ -167,28 +167,28 @@ class TypeRangeTest extends CypherFunSuite {
     rangeOfNumber & rangeOfAny should equal(None)
   }
 
-  test("mergeUpWithSubType") {
+  test("leastUpperBound with super type") {
     val rangeFromAny = TypeRange(CTAny, None)
     val rangeOfAny = TypeRange(CTAny, CTAny)
-    rangeFromAny.mergeUp(rangeOfAny) should equal(Seq(rangeOfAny))
+    (rangeFromAny leastUpperBounds rangeOfAny) should equal(Seq(rangeOfAny))
 
     val rangeOfInteger = TypeRange(CTInteger, None)
-    rangeOfInteger.mergeUp(rangeOfAny) should equal(Seq(rangeOfAny))
+    (rangeOfInteger leastUpperBounds rangeOfAny) should equal(Seq(rangeOfAny))
 
     val rangeOfNumber = TypeRange(CTNumber, CTNumber)
-    rangeOfInteger.mergeUp(rangeOfNumber) should equal(Seq(rangeOfNumber))
+    (rangeOfInteger leastUpperBounds rangeOfNumber) should equal(Seq(rangeOfNumber))
   }
 
-  test("mergeUpWithNestedType") {
+  test("leastUpperBound with sub type") {
     val rangeFromCollectionAny = TypeRange(CTCollection(CTAny), None)
     val rangeOfCollectionAny = TypeRange(CTCollection(CTAny), CTCollection(CTAny))
-    rangeFromCollectionAny.mergeUp(rangeOfCollectionAny) should equal(Seq(rangeOfCollectionAny))
+    (rangeFromCollectionAny leastUpperBounds rangeOfCollectionAny) should equal(Seq(rangeOfCollectionAny))
 
     val rangeFromCollectionString = TypeRange(CTCollection(CTString), None)
-    rangeFromCollectionAny.mergeUp(rangeFromCollectionString) should equal(Seq(TypeRange(CTCollection(CTAny), CTCollection(CTString)), TypeRange(CTCollection(CTString), None)))
+    (rangeFromCollectionAny leastUpperBounds rangeFromCollectionString) should equal(Seq(TypeRange(CTCollection(CTAny), CTCollection(CTString)), TypeRange(CTCollection(CTString), None)))
   }
 
-  test("shouldHaveIndefiniteSizeWhenAllowingUnboundAnyAtAnyDepth") {
+  test("should have indefinite size when allowing unbound any at any depth") {
     TypeRange(CTAny, None).hasDefiniteSize should equal(false)
     TypeRange(CTCollection(CTAny), None).hasDefiniteSize should equal(false)
 
@@ -201,7 +201,7 @@ class TypeRangeTest extends CypherFunSuite {
     TypeRange(CTCollection(CTCollection(CTString)), None).hasDefiniteSize should equal(true)
   }
 
-  test("shouldReparentIntoCollection") {
+  test("should reparent into collection") {
     TypeRange(CTString, None).reparent(CTCollection) should equal(TypeRange(CTCollection(CTString), None))
     TypeRange(CTAny, CTNumber).reparent(CTCollection) should equal(TypeRange(CTCollection(CTAny), CTCollection(CTNumber)))
   }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/TypeSpecTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/symbols/TypeSpecTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 
 class TypeSpecTest extends CypherFunSuite {
 
-  test("allTypesShouldContainAll") {
+  test("all types should contain all") {
     TypeSpec.all contains CTAny should equal(true)
     TypeSpec.all contains CTString should equal(true)
     TypeSpec.all contains CTNumber should equal(true)
@@ -35,7 +35,7 @@ class TypeSpecTest extends CypherFunSuite {
     TypeSpec.all contains CTCollection(CTCollection(CTFloat)) should equal(true)
   }
 
-  test("shouldReturnTrueIfContains") {
+  test("should return true if contains") {
     CTNumber.covariant contains CTInteger should equal(true)
     CTNumber.covariant contains CTString should equal(false)
 
@@ -48,7 +48,7 @@ class TypeSpecTest extends CypherFunSuite {
     anyCollection contains CTAny should equal(false)
   }
 
-  test("shouldReturnTrueIfContainsAny") {
+  test("should return true if contains CTAny") {
     TypeSpec.all containsAny TypeSpec.all should equal(true)
     TypeSpec.all containsAny CTNumber.covariant should equal(true)
     TypeSpec.all containsAny CTNode.invariant should equal(true)
@@ -63,7 +63,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTNumber.covariant containsAny CTString should equal(false)
   }
 
-  test("shouldUnion") {
+  test("should union") {
     CTNumber.covariant | CTString.covariant should equal(CTNumber | CTFloat | CTInteger | CTString)
     CTNumber.covariant | CTBoolean should equal(CTNumber | CTFloat | CTInteger | CTBoolean)
 
@@ -71,7 +71,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTCollection(CTNumber) union CTCollection(CTString).covariant should equal(CTCollection(CTNumber) | CTCollection(CTString))
   }
 
-  test("shouldIntersect") {
+  test("should intersect") {
     TypeSpec.all & CTInteger should equal(CTInteger.invariant)
     CTNumber.covariant & CTInteger should equal(CTInteger.invariant)
     CTNumber.covariant & CTString should equal(TypeSpec.none)
@@ -85,7 +85,7 @@ class TypeSpecTest extends CypherFunSuite {
     (CTNumber.covariant | CTCollection(CTAny).covariant) intersect (CTNumber.covariant | CTString.covariant) should equal(CTNumber.covariant)
   }
 
-  test("shouldConstrain") {
+  test("should constrain") {
     CTInteger.covariant should equal(CTInteger.invariant)
     CTNumber.covariant should equal(CTNumber | CTFloat | CTInteger)
 
@@ -99,89 +99,89 @@ class TypeSpecTest extends CypherFunSuite {
     (CTInteger | CTCollection(CTString)) constrain CTAny should equal(CTInteger | CTCollection(CTString))
   }
 
-  test("constrainToBranchTypeWithinCollectionContains") {
+  test("constrain to branch type within collection contains") {
     TypeSpec.all constrain CTCollection(CTNumber) should equal(CTCollection(CTNumber) | CTCollection(CTInteger) | CTCollection(CTFloat))
   }
 
-  test("constrainToSubTypeWithinCollection") {
+  test("constrain to sub type within collection") {
     CTCollection(CTAny).covariant constrain CTCollection(CTString) should equal(CTCollection(CTString).invariant)
   }
 
-  test("constrainToAnotherBranch") {
+  test("constrain to another branch") {
     CTNumber.covariant constrain CTString should equal(TypeSpec.none)
 
     CTString.covariant constrain CTNumber should equal(TypeSpec.none)
   }
 
-  test("unionTwoBranches") {
+  test("union two branches") {
     CTNumber.covariant | CTString.covariant should equal(CTNumber | CTInteger | CTFloat | CTString)
   }
 
-  test("constrainToSuperTypeOfSome") {
+  test("constrain to super type of some") {
     (CTInteger | CTString) constrain CTNumber should equal(CTInteger.invariant)
     CTInteger.contravariant constrain CTNumber should equal(CTNumber | CTInteger)
     CTNumber.contravariant constrain CTNumber should equal(CTNumber.invariant)
     CTNumber.contravariant constrain CTAny should equal(CTAny | CTNumber)
   }
 
-  test("constrainToAny") {
+  test("constrain to CTAny") {
     TypeSpec.all constrain CTAny should equal(TypeSpec.all)
     CTNumber.covariant constrain CTAny should equal(CTNumber.covariant)
   }
 
-  test("constrainToSubTypeOfSome") {
+  test("constrain to sub type of some") {
     val constrainedToNumberOrCollectionT = CTNumber.covariant | CTCollection(CTAny).covariant
     constrainedToNumberOrCollectionT constrain CTCollection(CTNumber) should equal(CTCollection(CTNumber) | CTCollection(CTFloat) | CTCollection(CTInteger))
   }
 
-  test("constrainToSuperTypeOfNone") {
+  test("constrain to super type of none") {
     CTNumber.contravariant constrain CTInteger should equal(TypeSpec.none)
     CTNumber.contravariant constrain CTString should equal(TypeSpec.none)
   }
 
-  test("shouldMergeUpTypeSpecs") {
-    (CTNode | CTNumber) mergeUp (CTNode | CTNumber) should equal(CTNode | CTNumber | CTAny)
+  test("should find leastUpperBounds of TypeSpecs") {
+    (CTNode | CTNumber) leastUpperBounds (CTNode | CTNumber) should equal(CTNode | CTNumber | CTAny)
 
-    (CTNode | CTNumber) mergeUp (CTNode | CTNumber) should equal(CTNode | CTNumber | CTAny)
-    (CTNode | CTNumber) mergeUp CTNumber should equal(CTNumber | CTAny)
-    (CTNode | CTNumber) mergeUp (CTNode | CTNumber | CTRelationship) should equal(CTNode | CTNumber | CTMap | CTAny)
-    (CTNode | CTNumber) mergeUp CTAny should equal(CTAny.invariant)
-    CTAny mergeUp (CTNode | CTNumber) should equal(CTAny.invariant)
+    (CTNode | CTNumber) leastUpperBounds (CTNode | CTNumber) should equal(CTNode | CTNumber | CTAny)
+    (CTNode | CTNumber) leastUpperBounds CTNumber should equal(CTNumber | CTAny)
+    (CTNode | CTNumber) leastUpperBounds (CTNode | CTNumber | CTRelationship) should equal(CTNode | CTNumber | CTMap | CTAny)
+    (CTNode | CTNumber) leastUpperBounds CTAny should equal(CTAny.invariant)
+    CTAny leastUpperBounds (CTNode | CTNumber) should equal(CTAny.invariant)
 
-    CTRelationship.invariant mergeUp CTNode.invariant should equal(CTMap.invariant)
-    (CTRelationship | CTInteger) mergeUp (CTNode | CTNumber) should equal(CTMap | CTNumber | CTAny)
+    CTRelationship.invariant leastUpperBounds CTNode.invariant should equal(CTMap.invariant)
+    (CTRelationship | CTInteger) leastUpperBounds (CTNode | CTNumber) should equal(CTMap | CTNumber | CTAny)
 
-    (CTInteger | CTCollection(CTString)) mergeUp (CTNumber | CTCollection(CTInteger)) should equal(CTNumber | CTCollection(CTAny) | CTAny)
+    (CTInteger | CTCollection(CTString)) leastUpperBounds (CTNumber | CTCollection(CTInteger)) should equal(CTNumber | CTCollection(CTAny) | CTAny)
   }
 
-  test("mergeUpToRootType") {
-    TypeSpec.all mergeUp CTAny should equal(CTAny.invariant)
-    CTAny mergeUp TypeSpec.all should equal(CTAny.invariant)
-    CTCollection(CTAny).covariant mergeUp CTAny should equal(CTAny.invariant)
-    CTAny mergeUp CTCollection(CTAny).covariant should equal(CTAny.invariant)
+  test("leastUpperBounds to root type") {
+    TypeSpec.all leastUpperBounds CTAny should equal(CTAny.invariant)
+    CTAny leastUpperBounds TypeSpec.all should equal(CTAny.invariant)
+    CTCollection(CTAny).covariant leastUpperBounds CTAny should equal(CTAny.invariant)
+    CTAny leastUpperBounds CTCollection(CTAny).covariant should equal(CTAny.invariant)
   }
 
-  test("mergeUpWithLeafType") {
-    TypeSpec.all mergeUp CTInteger should equal(CTAny | CTNumber | CTInteger)
+  test("leastUpperBounds with leaf type") {
+    TypeSpec.all leastUpperBounds CTInteger should equal(CTAny | CTNumber | CTInteger)
   }
 
-  test("mergeUpWithCollection") {
-    TypeSpec.all mergeUp CTCollection(CTAny) should equal(CTAny | CTCollection(CTAny))
-    TypeSpec.all mergeUp CTCollection(CTString) should equal(CTAny | CTCollection(CTAny) | CTCollection(CTString))
+  test("leastUpperBounds with collection") {
+    TypeSpec.all leastUpperBounds CTCollection(CTAny) should equal(CTAny | CTCollection(CTAny))
+    TypeSpec.all leastUpperBounds CTCollection(CTString) should equal(CTAny | CTCollection(CTAny) | CTCollection(CTString))
   }
 
-  test("mergeUpWithMultipleTypes") {
-    TypeSpec.all mergeUp (CTInteger | CTString) should equal(CTAny | CTNumber | CTInteger | CTString)
-    TypeSpec.all mergeUp (CTCollection(CTString) | CTInteger) should equal(CTAny | CTNumber | CTInteger | CTCollection(CTAny) | CTCollection(CTString))
+  test("leastUpperBounds with multiple types") {
+    TypeSpec.all leastUpperBounds (CTInteger | CTString) should equal(CTAny | CTNumber | CTInteger | CTString)
+    TypeSpec.all leastUpperBounds (CTCollection(CTString) | CTInteger) should equal(CTAny | CTNumber | CTInteger | CTCollection(CTAny) | CTCollection(CTString))
   }
 
-  test("mergeUpWithSuperTypeOfSome") {
-    (CTCollection(CTString) | CTInteger) mergeUp CTNumber should equal(CTAny | CTNumber)
-    (CTCollection(CTString) | CTInteger) mergeUp CTCollection(CTAny) should equal(CTAny | CTCollection(CTAny))
+  test("leastUpperBounds with some super types") {
+    (CTCollection(CTString) | CTInteger) leastUpperBounds CTNumber should equal(CTAny | CTNumber)
+    (CTCollection(CTString) | CTInteger) leastUpperBounds CTCollection(CTAny) should equal(CTAny | CTCollection(CTAny))
 
-    CTInteger mergeUp CTNumber.covariant should equal(CTNumber | CTInteger)
+    CTInteger leastUpperBounds CTNumber.covariant should equal(CTNumber | CTInteger)
 
-    val mergedSet = CTCollection(CTCollection(CTAny)).covariant mergeUp TypeSpec.all
+    val mergedSet = CTCollection(CTCollection(CTAny)).covariant leastUpperBounds TypeSpec.all
     mergedSet.contains(CTCollection(CTCollection(CTString))) should equal(true)
     mergedSet.contains(CTCollection(CTCollection(CTInteger))) should equal(true)
     mergedSet.contains(CTCollection(CTCollection(CTNumber))) should equal(true)
@@ -193,57 +193,57 @@ class TypeSpecTest extends CypherFunSuite {
     mergedSet.contains(CTNumber) should equal(false)
     mergedSet.contains(CTAny) should equal(true)
 
-    CTNumber.contravariant mergeUp CTInteger.contravariant should equal(CTAny | CTNumber)
+    CTNumber.contravariant leastUpperBounds CTInteger.contravariant should equal(CTAny | CTNumber)
   }
 
-  test("mergeUpWithSubTypeOfSome") {
-    (CTCollection(CTString) | CTNumber) mergeUp CTInteger should equal(CTAny | CTNumber)
-    CTNumber.covariant mergeUp CTInteger should equal(CTInteger | CTNumber)
+  test("leastUpperBounds with some sub types") {
+    (CTCollection(CTString) | CTNumber) leastUpperBounds CTInteger should equal(CTAny | CTNumber)
+    CTNumber.covariant leastUpperBounds CTInteger should equal(CTInteger | CTNumber)
 
     val numberOrCollectionT = CTNumber.covariant | CTCollection(CTAny).covariant
-    numberOrCollectionT mergeUp CTInteger should equal(CTAny | CTNumber | CTInteger)
-    numberOrCollectionT mergeUp CTCollection(CTInteger) should equal(CTAny | CTCollection(CTAny) | CTCollection(CTNumber) | CTCollection(CTInteger))
+    numberOrCollectionT leastUpperBounds CTInteger should equal(CTAny | CTNumber | CTInteger)
+    numberOrCollectionT leastUpperBounds CTCollection(CTInteger) should equal(CTAny | CTCollection(CTAny) | CTCollection(CTNumber) | CTCollection(CTInteger))
 
     val collectionOfCollectionOfAny = CTCollection(CTCollection(CTAny)).covariant
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTString)) should equal(true)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTInteger)) should equal(true)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTNumber)) should equal(true)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTAny)) should equal(true)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTString) should equal(false)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTNumber) should equal(false)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTCollection(CTAny) should equal(true)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTString should equal(false)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTNumber should equal(false)
-    (TypeSpec.all mergeUp collectionOfCollectionOfAny) contains CTAny should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTString)) should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTInteger)) should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTNumber)) should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTCollection(CTAny)) should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTString) should equal(false)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTNumber) should equal(false)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTCollection(CTAny) should equal(true)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTString should equal(false)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTNumber should equal(false)
+    (TypeSpec.all leastUpperBounds collectionOfCollectionOfAny) contains CTAny should equal(true)
   }
 
-  test("mergeUpFromConstrainedBranchToSubType") {
-    CTNumber.covariant mergeUp CTInteger should equal(CTNumber | CTInteger)
+  test("leastUpperBounds of branch with sub type") {
+    CTNumber.covariant leastUpperBounds CTInteger should equal(CTNumber | CTInteger)
   }
 
-  test("mergeUpFromConstrainedBranchToConstraintRoot") {
-    CTNumber.covariant mergeUp CTNumber should equal(CTNumber.invariant)
+  test("leastUpperBounds of branch to branch root") {
+    CTNumber.covariant leastUpperBounds CTNumber should equal(CTNumber.invariant)
   }
 
-  test("mergeUpFromConstrainedBranchToSuperType") {
-    CTInteger.covariant mergeUp CTNumber should equal(CTNumber.invariant)
+  test("leastUpperBounds of branch to super type") {
+    CTInteger.covariant leastUpperBounds CTNumber should equal(CTNumber.invariant)
   }
 
-  test("mergeUpFromConstrainedBranchToUnrelated") {
-    CTNumber.covariant mergeUp CTString should equal(CTAny.invariant)
-    CTInteger.covariant mergeUp CTString should equal(CTAny.invariant)
+  test("leastUpperBounds of branch to unrelated type") {
+    CTNumber.covariant leastUpperBounds CTString should equal(CTAny.invariant)
+    CTInteger.covariant leastUpperBounds CTString should equal(CTAny.invariant)
   }
 
-  test("mergeUpWithEquivalent") {
-    CTNumber.covariant mergeUp (CTNumber | CTInteger | CTFloat) should equal(CTNumber.covariant)
+  test("leastUpperBounds with equivalent") {
+    CTNumber.covariant leastUpperBounds (CTNumber | CTInteger | CTFloat) should equal(CTNumber.covariant)
   }
 
-  test("shouldWrapInCollection") {
+  test("should wrap in collection") {
     (CTString | CTCollection(CTNumber)).wrapInCollection should equal(CTCollection(CTString) | CTCollection(CTCollection(CTNumber)))
     TypeSpec.all.wrapInCollection should equal(CTCollection(CTAny).covariant)
   }
 
-  test("shouldIdentifyCoercions") {
+  test("should identify coercions") {
     CTFloat.covariant.coercions should equal(CTBoolean.invariant)
     CTInteger.covariant.coercions should equal(CTBoolean | CTFloat)
     (CTFloat | CTInteger).coercions should equal(CTBoolean | CTFloat)
@@ -253,7 +253,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTCollection(CTAny).covariant.coercions should equal(CTBoolean.invariant)
   }
 
-  test("shouldIntersectWithCoercions") {
+  test("should intersect with coercions") {
     TypeSpec.all intersectOrCoerce CTInteger should equal(CTInteger.invariant)
     CTInteger intersectOrCoerce CTFloat should equal(CTFloat.invariant)
     CTNumber intersectOrCoerce CTFloat should equal(TypeSpec.none)
@@ -263,7 +263,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTInteger intersectOrCoerce CTString should equal(TypeSpec.none)
   }
 
-  test("shouldConstrainWithCoercions") {
+  test("should constrain with coercions") {
     TypeSpec.all constrainOrCoerce CTInteger should equal(CTInteger.invariant)
     CTInteger constrainOrCoerce CTFloat should equal(CTFloat.invariant)
     CTNumber constrainOrCoerce CTFloat should equal(TypeSpec.none)
@@ -273,7 +273,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTInteger constrainOrCoerce CTString should equal(TypeSpec.none)
   }
 
-  test("equalTypeSpecsShouldEqual") {
+  test("equal TypeSpecs should equal") {
     CTString.invariant should equal(CTString.invariant)
 
     CTString.invariant should equal(CTString.covariant)
@@ -295,7 +295,7 @@ class TypeSpecTest extends CypherFunSuite {
     TypeSpec.all | TypeSpec.all should equal(TypeSpec.all)
   }
 
-  test("differentTypeSpecsShouldNotEqual") {
+  test("different TypeSpecs should not equal") {
     TypeSpec.all should not equal(CTNumber.covariant)
     CTNumber.covariant should not equal(TypeSpec.all)
 
@@ -306,7 +306,7 @@ class TypeSpecTest extends CypherFunSuite {
     TypeSpec.all should not equal(CTNumber.invariant)
   }
 
-  test("shouldHaveIndefiniteSizeWhenAllowingUnconstrainedAnyAtAnyDepth") {
+  test("should have indefinite size when allowing unconstrained any at any depth") {
     TypeSpec.all.hasDefiniteSize should equal(false)
     CTCollection(CTAny).covariant.hasDefiniteSize should equal(false)
 
@@ -317,44 +317,44 @@ class TypeSpecTest extends CypherFunSuite {
     CTCollection(CTCollection(CTString)).covariant.hasDefiniteSize should equal(true)
 
     CTAny.contravariant.hasDefiniteSize should equal(true)
-    (CTCollection(CTAny).covariant mergeUp CTCollection(CTAny)).hasDefiniteSize should equal(true)
+    (CTCollection(CTAny).covariant leastUpperBounds CTCollection(CTAny)).hasDefiniteSize should equal(true)
   }
 
-  test("shouldBeEmptyWhenNoPossibilitiesRemain") {
+  test("should be empty when no possibilities remain") {
     TypeSpec.all.isEmpty should equal(false)
     TypeSpec.none.isEmpty should equal(true)
     (CTNumber.contravariant intersect CTInteger).isEmpty should equal(true)
   }
 
-  test("shouldFormatNone") {
+  test("should format none") {
     TypeSpec.none.mkString("(", ", ", " or ", ")") should equal("()")
   }
 
-  test("shouldFormatSingleType") {
+  test("should format single type") {
     CTAny.invariant.mkString("(", ", ", " or ", ")") should equal("(Any)")
     CTNode.invariant.mkString("<", ", ", " and ", ">") should equal("<Node>")
   }
 
-  test("shouldFormatTwoTypes") {
+  test("should format two types") {
     (CTAny | CTNode).mkString("", ", ", " or ", "") should equal("Any or Node")
     (CTRelationship | CTNode).mkString("-", ", ", " or ", "-") should equal("-Node or Relationship-")
   }
 
-  test("shouldFormatThreeTypes") {
+  test("should format three types") {
     (CTRelationship | CTInteger | CTNode).mkString(", ") should equal("Integer, Node, Relationship")
     (CTRelationship | CTInteger | CTNode).mkString("(", ", ", ")") should equal("(Integer, Node, Relationship)")
     (CTRelationship | CTAny | CTNode).mkString("(", ", ", " or ", ")") should equal("(Any, Node or Relationship)")
     (CTRelationship | CTInteger | CTNode).mkString("[", ", ", " and ", "]") should equal("[Integer, Node and Relationship]")
   }
 
-  test("shouldFormatToStringForIndefiniteSizedSet") {
+  test("should format to string for indefinite sized set") {
     TypeSpec.all.mkString(", ") should equal("T")
     CTCollection(CTAny).covariant.mkString(", ") should equal("Collection<T>")
     (CTCollection(CTAny).covariant | CTBoolean).mkString(", ") should equal("Boolean, Collection<T>")
     (CTCollection(CTCollection(CTAny)).covariant | CTBoolean | CTCollection(CTString)).mkString(", ") should equal("Boolean, Collection<String>, Collection<Collection<T>>")
   }
 
-  test("shouldFormatToStringForDefiniteSizedSet") {
+  test("should format to string for definite sized set") {
     CTAny.invariant.mkString(", ") should equal("Any")
     CTString.invariant.mkString(", ") should equal("String")
     CTNumber.covariant.mkString(", ") should equal("Float, Integer, Number")
@@ -365,7 +365,7 @@ class TypeSpecTest extends CypherFunSuite {
     CTCollection(CTAny).contravariant.mkString(", ") should equal("Any, Collection<Any>")
   }
 
-  test("shouldIterateOverDefiniteSizedSet") {
+  test("should iterate over definite sized set") {
     CTString.invariant.iterator.toSeq should equal(Seq(CTString))
     CTNumber.covariant.iterator.toSeq should equal(Seq(CTFloat, CTInteger, CTNumber))
     (CTNumber.covariant | CTBoolean.covariant).iterator.toSeq should equal(Seq(CTBoolean, CTFloat, CTInteger, CTNumber))


### PR DESCRIPTION
4700f7f653cbb09896bdad6009e175a61808057c:
Convert tests to CypherFunSuite

4501bd22519c07e674e4a8edc5c59daa19f9cc3e:
Rename mergeUp & mergeDown to supremum & infimum
AKA leastUpperBound and greatestLowerBound

c8ce10c2063b3c52d7eab56b0d4598ffe1c13eee:
Make TypeRange and TypeSpec clearer
Adds documentation and cleans up some tests
