### PR TITLE
[2.2] Browser: Wrap text in editor before the buttons.

### DIFF
--- a/community/browser/app/styles/codemirror.styl
+++ b/community/browser/app/styles/codemirror.styl
@@ -40,7 +40,7 @@ left-margin = 16px
       margin-right: left-margin
   .CodeMirror
     background-color: transparent
-    margin: 25px 116px 25px left-margin
+    margin: 25px 168px 25px left-margin
     transist: all
     @extend .code-style
     pre


### PR DESCRIPTION
- Adds 52 px margin-right
- Fixes #3223 

Before:  
![oskar4j 2014-10-06 kl 22 04 56](https://cloud.githubusercontent.com/assets/570998/4532579/2781770e-4d94-11e4-855c-013198ac8745.png)

After:  
![oskar4j 2014-10-06 kl 22 05 14](https://cloud.githubusercontent.com/assets/570998/4532583/2d6c55b2-4d94-11e4-87c1-832a90b23842.png)
