### PR TITLE
[2.2] Browser: Wrap text in editor before the buttons.

### DIFF
--- a/community/browser/app/styles/codemirror.styl
+++ b/community/browser/app/styles/codemirror.styl
@@ -40,7 +40,7 @@ left-margin = 16px
       margin-right: left-margin
   .CodeMirror
     background-color: transparent
-    margin: 25px 116px 25px left-margin
+    margin: 25px 168px 25px left-margin
     transist: all
     @extend .code-style
     pre


### PR DESCRIPTION
- Adds 52 px margin-right
- Fixes #3223 

Before:  
![2781770e-4d94-11e4-855c-013198ac8745](https://cloud.githubusercontent.com/assets/570998/4547538/f182b04a-4e4d-11e4-9f24-7450b01e7b30.png)

After:  
![2d6c55b2-4d94-11e4-87c1-832a90b23842](https://cloud.githubusercontent.com/assets/570998/4547541/f80a5594-4e4d-11e4-8da4-ed7075b80332.png)
