### PR TITLE
Consider all possible result types from `CASE`

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpression.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpression.scala
@@ -27,7 +27,7 @@ case class CaseExpression(expression: Option[Expression], alternatives: Seq[(Exp
   lazy val possibleExpressions = alternatives.map(_._2) ++ default
 
   def semanticCheck(ctx: SemanticContext): SemanticCheck = {
-    val possibleTypes: TypeGenerator = possibleExpressions.leastUpperBoundsOfTypes
+    val possibleTypes = possibleExpressions.unionOfTypes
 
     expression.semanticCheck(ctx) then
     alternatives.flatMap { a => Seq(a._1, a._2) }.semanticCheck(ctx) then

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Expression.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Expression.scala
@@ -46,6 +46,9 @@ object Expression {
   }
 
   implicit class InferrableTypeTraversableOnce[A <: Expression](traversable: TraversableOnce[A]) {
+    def unionOfTypes: TypeGenerator = state =>
+      TypeSpec.union(traversable.map(_.types(state)).toSeq: _*)
+
     def leastUpperBoundsOfTypes: TypeGenerator =
       if (traversable.isEmpty)
         _ => CTAny.invariant

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpec.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/symbols/TypeSpec.scala
@@ -24,6 +24,7 @@ object TypeSpec {
   def exact[T <: CypherType](traversable: TraversableOnce[T]): TypeSpec = TypeSpec(traversable.map(t => TypeRange(t, t)))
   val all: TypeSpec = TypeSpec(TypeRange(CTAny, None))
   val none: TypeSpec = new TypeSpec(Vector.empty)
+  def union(typeSpecs: TypeSpec*): TypeSpec = TypeSpec(typeSpecs.flatMap(_.ranges))
 
   private val simpleTypes = Vector(
     CTAny,

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpressionTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/CaseExpressionTest.scala
@@ -25,7 +25,7 @@ import symbols._
 
 class CaseExpressionTest extends CypherFunSuite {
 
-  test("Simple: Should merge types of alternatives") {
+  test("Simple: Should combine types of alternatives") {
     val caseExpression = CaseExpression(
       expression = Some(DummyExpression(CTString)),
       alternatives = Seq(
@@ -42,10 +42,10 @@ class CaseExpressionTest extends CypherFunSuite {
 
     val result = caseExpression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
     assert(result.errors === Seq())
-    assert(caseExpression.types(result.state) === CTNumber.invariant)
+    assert(caseExpression.types(result.state) === (CTInteger | CTFloat))
   }
 
-  test("Generic: Should merge types of alternatives") {
+  test("Generic: Should combine types of alternatives") {
     val caseExpression = CaseExpression(
       None,
       Seq(
@@ -62,7 +62,7 @@ class CaseExpressionTest extends CypherFunSuite {
 
     val result = caseExpression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
     assert(result.errors === Seq())
-    assert(caseExpression.types(result.state) === (CTNumber | CTAny))
+    assert(caseExpression.types(result.state) === (CTInteger | CTFloat | CTString | CTNode))
   }
 
   test("Generic: should type check predicates") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/FunctionsAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/FunctionsAcceptanceTest.scala
@@ -82,4 +82,30 @@ class FunctionsAcceptanceTest extends ExecutionEngineJUnitSuite {
     assert(result === "4")
   }
 
+  @Test
+  def case_should_handle_mixed_number_types() {
+    val query =
+      """WITH 0.5 AS x
+        |WITH (CASE WHEN x < 1 THEN 1 ELSE 2.0 END) AS x
+        |RETURN x + 1
+      """.stripMargin
+
+      val result = executeScalar[Long](query)
+
+      assert(result === 2)
+  }
+
+  @Test
+  def case_should_handle_mixed_types() {
+    val query =
+      """WITH 0.5 AS x
+        |WITH (CASE WHEN x < 1 THEN "wow" ELSE true END) AS x
+        |RETURN x + "!"
+      """.stripMargin
+
+    val result = executeScalar[String](query)
+
+    assert(result === "wow!")
+  }
+
 }


### PR DESCRIPTION
Rather than finding the leastUpperBound between all the different expression types, consider them all as equal possibilities.
