### PR TITLE
[2.2] Fix an ABA bug in the page cache

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -129,7 +129,9 @@ public interface PageCursor extends AutoCloseable
 
     /**
      * Returns true if the page has entered an inconsistent state since the
-     * last call to next() or retry().
+     * last call to next() or shouldRetry().
+     * If this method returns true, the in-page offset of the cursor will be
+     * reset to zero.
      *
      * @throws IOException If the page was evicted while doing IO, the cursor will have
      *                     to do a page fault to get the page back.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.impl.muninn;
+
+/**
+ * A free page in the MuninnPageCache.freelist.
+ *
+ * The next pointers are always other FreePage instances.
+ */
+final class FreePage
+{
+    final MuninnPage page;
+    int count;
+    FreePage next;
+
+    public FreePage( MuninnPage page )
+    {
+        this.page = page;
+    }
+
+    void setNext( FreePage next )
+    {
+        this.next = next;
+        this.count = next == null? 1 : 1 + next.count;
+    }
+}

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePageWaiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePageWaiter.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.LockSupport;
  * support, and is used in MuninnPageCache.unparkEvictor on behalf of the page
  * faulting threads.
  */
-class FreePageWaiter
+final class FreePageWaiter
 {
     // A special poison-pill value that is used to tell FreePageWaiters that they should
     // stop waiting and that there is no free page for them, because the page cache is
@@ -114,5 +114,16 @@ class FreePageWaiter
         this.exception = exception;
         this.page = exceptionSignal;
         LockSupport.unpark( waiter );
+    }
+
+    @Override
+    public String toString()
+    {
+        return shortString() + " -> " + (next == null ? "null" : next.shortString());
+    }
+
+    private String shortString()
+    {
+        return "FreePageWaiter@" + Integer.toHexString( hashCode() ) + "[t:" + waiter.getId() + "]";
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MonitoredPageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MonitoredPageSwapper.java
@@ -78,4 +78,10 @@ final class MonitoredPageSwapper implements PageSwapper
     {
         return pageSwapper.getLastPageId();
     }
+
+    @Override
+    public String toString()
+    {
+        return pageSwapper.toString() + "[*Monitored]";
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -20,7 +20,6 @@
 package org.neo4j.io.pagecache.impl.muninn;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.io.pagecache.PageSwapper;
@@ -78,7 +77,6 @@ final class MuninnReadPageCursor extends MuninnPageCursor
         StampedLock translationTableLock = pagedFile.translationTableLocks[stripe];
         PrimitiveLongObjectMap<MuninnPage> translationTable = pagedFile.translationTables[stripe];
         PageSwapper swapper = pagedFile.swapper;
-        AtomicReference<MuninnPage> freelist = pagedFile.freelist;
         MuninnPage page;
 
         long stamp = translationTableLock.tryOptimisticRead();
@@ -113,11 +111,7 @@ final class MuninnReadPageCursor extends MuninnPageCursor
                 {
                     // Our translation table is still outdated. Go ahead and page
                     // fault.
-                    pageFault(
-                            filePageId,
-                            translationTable,
-                            freelist,
-                            swapper );
+                    pageFault( filePageId, translationTable, swapper );
                     return;
                 }
                 // Another thread completed the page fault ahead of us.
@@ -173,11 +167,7 @@ final class MuninnReadPageCursor extends MuninnPageCursor
             }
             // The page is definitely no good, and our translation table is
             // definitely out of date.
-            pageFault(
-                    filePageId,
-                    translationTable,
-                    freelist,
-                    swapper );
+            pageFault( filePageId, translationTable, swapper );
         }
         finally
         {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
@@ -20,12 +20,11 @@
 package org.neo4j.io.pagecache.impl.muninn;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
-import org.neo4j.io.pagecache.impl.muninn.jsr166e.StampedLock;
 import org.neo4j.io.pagecache.PageSwapper;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.muninn.jsr166e.StampedLock;
 
 final class MuninnWritePageCursor extends MuninnPageCursor
 {
@@ -77,7 +76,6 @@ final class MuninnWritePageCursor extends MuninnPageCursor
         StampedLock translationTableLock = pagedFile.translationTableLocks[stripe];
         PrimitiveLongObjectMap<MuninnPage> translationTable = pagedFile.translationTables[stripe];
         PageSwapper swapper = pagedFile.swapper;
-        AtomicReference<MuninnPage> freelist = pagedFile.freelist;
         MuninnPage page;
 
         long stamp = translationTableLock.tryOptimisticRead();
@@ -112,11 +110,7 @@ final class MuninnWritePageCursor extends MuninnPageCursor
                 {
                     // Our translation table is still outdated. Go ahead and page
                     // fault.
-                    pageFault(
-                            filePageId,
-                            translationTable,
-                            freelist,
-                            swapper );
+                    pageFault( filePageId, translationTable, swapper );
                     return;
                 }
                 // Another thread completed the page fault ahead of us.
@@ -171,11 +165,7 @@ final class MuninnWritePageCursor extends MuninnPageCursor
             }
             // The page is definitely no good, and our translation table is
             // definitely out of date.
-            pageFault(
-                    filePageId,
-                    translationTable,
-                    freelist,
-                    swapper );
+            pageFault( filePageId, translationTable, swapper );
         }
         finally
         {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
@@ -19,6 +19,19 @@
  */
 package org.neo4j.io.pagecache.impl.muninn;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
+import static org.neo4j.io.pagecache.RecordingPageCacheMonitor.Evict;
+import static org.neo4j.io.pagecache.RecordingPageCacheMonitor.Fault;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -29,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
-
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongIntMap;
 import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
@@ -41,20 +53,6 @@ import org.neo4j.io.pagecache.PageCacheTest;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.RecordingPageCacheMonitor;
-
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
-import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
-import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
-import static org.neo4j.io.pagecache.RecordingPageCacheMonitor.Evict;
-import static org.neo4j.io.pagecache.RecordingPageCacheMonitor.Fault;
 
 public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
 {
@@ -187,7 +185,7 @@ public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
         writeInitialDataTo( file );
         RecordingPageCacheMonitor monitor = new RecordingPageCacheMonitor();
 
-        MuninnPageCache pageCache = new MuninnPageCache( fs, 10, 8, monitor );
+        MuninnPageCache pageCache = new MuninnPageCache( fs, 4, 8, monitor );
         PagedFile pagedFile = pageCache.map( file, 8 );
 
         try ( PageCursor cursor = pagedFile.io( 0, PF_EXCLUSIVE_LOCK | PF_NO_GROW ) )

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
@@ -112,6 +112,7 @@ public class PageCacheStressTest
             thread2.interrupt();
             thread1.join();
             thread2.join();
+            pageCacheUnderTest.close();
         }
     }
 


### PR DESCRIPTION
We were reusing the MuninnPage objects in the MuninnPageCache.freelist.
This could lead to cycles in the freelist through an ABA-bug.

The test that exposed that bug is ignored for now, because it is exposing
another bug that I thought was just a different manifestation of the ABA-bug.
