### PR TITLE
[2.2] Fixed the serialization of PlanDescription.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -33,11 +33,11 @@ object PlanDescriptionArgumentSerializer {
       case LabelName(label) => s":$label"
       case KeyNames(keys) => keys.mkString(SEPARATOR)
       case KeyExpressions(expressions) => expressions.mkString(SEPARATOR)
-      case _: DbHits => arg.toString
+      case DbHits(value) => value.toString
       case _: EntityByIdRhs => arg.toString
-      case _: IntroducedIdentifier => arg.toString
-      case _: Rows => arg.toString
-      case _: EstimatedRows => arg.toString
+      case IntroducedIdentifier(n) => n
+      case Rows(value) => value.toString
+      case EstimatedRows(value) => value.toString
 
       // Do not add a fallthrough here - we rely on exhaustive checking to ensure
       // that we don't forget to add new types of arguments here

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/AmendedRootPlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/AmendedRootPlanDescription.scala
@@ -47,7 +47,7 @@ class AmendedRootPlanDescription(child: PlanDescription, version: CypherVersion)
       java.util.Collections.unmodifiableMap[String, AnyRef](newArgs)
     }
 
-    val getChildren = List(childAsJava).asJava
+    val getChildren = childAsJava.getChildren
 
     override def toString = self.toString
   }


### PR DESCRIPTION
Prior to this fix, DbHits, Rows, EstimatedRows and IntroducedIdentifier were not serialized
correctly, e.g. DbHits(5) was serialized as "DbHits(5)" instead of just "5". The child plan descriptions
were also incorrectly handled and has been adressed by this fix.
