### PR TITLE
[2.2] Counts Store refactor to be based on a generic KV-Store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsKey.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api;
 
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.register.Register;
 
 public abstract class CountsKey implements Comparable<CountsKey>
 {
@@ -47,7 +48,7 @@ public abstract class CountsKey implements Comparable<CountsKey>
     @Override
     public abstract String toString();
 
-    public abstract void accept( CountsVisitor visitor, long count );
+    public abstract void accept( CountsVisitor visitor, Register.LongRegister count );
 
     public static final class NodeKey extends CountsKey
     {
@@ -76,9 +77,9 @@ public abstract class CountsKey implements Comparable<CountsKey>
         }
 
         @Override
-        public void accept( CountsVisitor visitor, long count )
+        public void accept( CountsVisitor visitor, Register.LongRegister count )
         {
-            visitor.visitNodeCount( labelId, count );
+            visitor.visitNodeCount( labelId, count.read() );
         }
 
         @Override
@@ -153,9 +154,9 @@ public abstract class CountsKey implements Comparable<CountsKey>
         }
 
         @Override
-        public void accept( CountsVisitor visitor, long count )
+        public void accept( CountsVisitor visitor, Register.LongRegister count )
         {
-            visitor.visitRelationshipCount( startLabelId, typeId, endLabelId, count );
+            visitor.visitRelationshipCount( startLabelId, typeId, endLabelId, count.read() );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsState.java
@@ -19,19 +19,19 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
+import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
+import static org.neo4j.kernel.impl.api.CountsKey.nodeKey;
+import static org.neo4j.kernel.impl.api.CountsKey.relationshipKey;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.neo4j.kernel.impl.transaction.command.Command;
-
-import static java.util.Objects.requireNonNull;
-
-import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
-import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
-import static org.neo4j.kernel.impl.api.CountsKey.nodeKey;
-import static org.neo4j.kernel.impl.api.CountsKey.relationshipKey;
+import org.neo4j.register.Register;
 
 public class CountsState implements CountsVisitor.Visitable, CountsAcceptor
 {
@@ -72,7 +72,7 @@ public class CountsState implements CountsVisitor.Visitable, CountsAcceptor
     {
         for ( Map.Entry<CountsKey, Count> entry : counts.entrySet() )
         {
-            entry.getKey().accept( visitor, entry.getValue().value );
+            entry.getKey().accept( visitor, entry.getValue() );
         }
     }
 
@@ -189,9 +189,9 @@ public class CountsState implements CountsVisitor.Visitable, CountsAcceptor
         return count;
     }
 
-    private static class Count
+    private static class Count implements Register.LongRegister
     {
-        long value;
+        private long value;
 
         void update( long delta )
         {
@@ -202,6 +202,18 @@ public class CountsState implements CountsVisitor.Visitable, CountsAcceptor
         public String toString()
         {
             return Long.toString( value );
+        }
+
+        @Override
+        public long read()
+        {
+            return value;
+        }
+
+        @Override
+        public void write( long value )
+        {
+            this.value = value;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
@@ -19,70 +19,37 @@
  */
 package org.neo4j.kernel.impl.store.counts;
 
-import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
-
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.api.CountsKey;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.kvstore.SortedKeyValueStore;
+import org.neo4j.kernel.impl.store.kvstore.SortedKeyValueStoreHeader;
+import org.neo4j.register.Register;
 
-class CountsStore<K extends Comparable<K>, VR> implements Closeable
+public class CountsStore extends SortedKeyValueStore<CountsKey, Register.LongRegister>
 {
-    interface Writer<K extends Comparable<K>, VR> extends RecordVisitor<K>, Closeable
+    private static final CountsRecordSerializer RECORD_SERIALIZER = new CountsRecordSerializer();
+    private static final CountsStoreWriter.Factory WRITER_FACTORY = new CountsStoreWriter.Factory();
+
+    public CountsStore( FileSystemAbstraction fs, PageCache pageCache, File file, PagedFile pages,
+                        SortedKeyValueStoreHeader header )
     {
-        CountsStore<K, VR> openForReading() throws IOException;
+        super( fs, pageCache, file, pages, header, RECORD_SERIALIZER, WRITER_FACTORY );
     }
 
-    interface WriterFactory<K extends Comparable<K>, VR>
-    {
-        Writer<K, VR> create( FileSystemAbstraction fs, PageCache pageCache, CountsStoreHeader header,
-                              File targetFile, long lastCommittedTxId ) throws IOException;
-    }
-
-    static final int RECORD_SIZE /*bytes*/ = 16 /*key*/ + 16 /*value*/;
-    private final FileSystemAbstraction fs;
-    private final PageCache pageCache;
-    private final File file;
-    private final PagedFile pages;
-    private final CountsStoreHeader header;
-    private final int totalRecords;
-    private final RecordSerializer<K, VR> recordSerializer;
-    private final WriterFactory<K, VR> writerFactory;
-
-    CountsStore( FileSystemAbstraction fs, PageCache pageCache, File file, PagedFile pages, CountsStoreHeader header,
-                 RecordSerializer<K, VR> recordSerializer, WriterFactory<K, VR> writerFactory )
-    {
-        this.fs = fs;
-        this.pageCache = pageCache;
-        this.file = file;
-        this.pages = pages;
-        this.header = header;
-        this.recordSerializer = recordSerializer;
-        this.writerFactory = writerFactory;
-        this.totalRecords = header.dataRecords();
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "%s[file=%s,%s]", getClass().getSimpleName(), file, header );
-    }
-
-    static void createEmpty( PageCache pageCache, File storeFile, String version )
+    public static void createEmpty( PageCache pageCache, File storeFile, String version )
     {
         try
         {
             PagedFile pages = mapCountsStore( pageCache, storeFile );
             try
             {
-                CountsStoreHeader.empty( version ).write( pages );
+                SortedKeyValueStoreHeader.empty( version ).write( pages );
             }
             finally
             {
@@ -96,16 +63,12 @@ class CountsStore<K extends Comparable<K>, VR> implements Closeable
         }
     }
 
-    static <K extends Comparable<K>, VR> CountsStore<K, VR> open( FileSystemAbstraction fs,
-                                                                  PageCache pageCache,
-                                                                  File storeFile,
-                                                                  RecordSerializer<K, VR> recordSerializer,
-                                                                  WriterFactory<K, VR> writerFactory )
+    public static CountsStore open( FileSystemAbstraction fs, PageCache pageCache, File storeFile )
             throws IOException
     {
         PagedFile pages = mapCountsStore( pageCache, storeFile );
-        CountsStoreHeader header = CountsStoreHeader.read( pages );
-        return new CountsStore<>( fs, pageCache, storeFile, pages, header, recordSerializer, writerFactory );
+        SortedKeyValueStoreHeader header = SortedKeyValueStoreHeader.read( pages );
+        return new CountsStore( fs, pageCache, storeFile, pages, header );
     }
 
     private static PagedFile mapCountsStore( PageCache pageCache, File storeFile ) throws IOException
@@ -113,112 +76,4 @@ class CountsStore<K extends Comparable<K>, VR> implements Closeable
         int pageSize = pageCache.pageSize() - (pageCache.pageSize() % RECORD_SIZE);
         return pageCache.map( storeFile, pageSize );
     }
-
-    public void get( K key, VR value )
-    {
-        int min = header.headerRecords();
-        int max = min + totalRecords - 1;
-        int mid;
-        try ( PageCursor cursor = pages.io( 0, PF_SHARED_LOCK ) )
-        {
-            while ( min <= max )
-            {
-                mid = min + (max - min) / 2;
-                int cmp = compareKeyAndReadValue( cursor, key, mid, value );
-                if ( cmp == 0 )
-                {
-                    return;
-                }
-                else if ( cmp < 0 )
-                {
-                    max = mid - 1;
-                }
-                else
-                {
-                    min = mid + 1;
-                }
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-        recordSerializer.writeDefaultValue( value );
-    }
-
-    private int compareKeyAndReadValue( PageCursor cursor, K target, int record, VR count )
-            throws IOException
-    {
-        int pageId = (record * RECORD_SIZE) / pages.pageSize();
-        int offset = (record * RECORD_SIZE) % pages.pageSize();
-        if ( pageId == cursor.getCurrentPageId() || cursor.next( pageId ) )
-        {
-            K key;
-            do
-            {
-                cursor.setOffset( offset );
-                key = recordSerializer.readRecord( cursor, count );
-            } while ( cursor.shouldRetry() );
-            return target.compareTo( key );
-        }
-        else
-        {
-            throw new IllegalStateException( "Could not fetch page: " + pageId );
-        }
-    }
-
-    public File file()
-    {
-        return file;
-    }
-
-    public long lastTxId()
-    {
-        return header.lastTxId();
-    }
-    public long totalRecordsStored()
-    {
-        return header.dataRecords();
-    }
-
-    public void accept( RecordVisitor<K> visitor )
-    {
-        try ( InputStream in = fs.openAsInputStream( file ) )
-        {
-            // skip the header
-            for ( long bytes = header.headerRecords() * RECORD_SIZE; bytes != 0; )
-            {
-                bytes -= in.skip( bytes );
-            }
-            byte[] record = new byte[RECORD_SIZE];
-            ByteBuffer buffer = ByteBuffer.wrap( record );
-            boolean readNext = true;
-            for ( int read, offset = 0; readNext && (read = in.read( record, offset, record.length - offset )) != -1; )
-            {
-                if ( read != record.length )
-                {
-                    offset = read;
-                    continue;
-                }
-                buffer.position( 0 );
-                readNext = recordSerializer.visitRecord( buffer, visitor );
-                offset = 0;
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-    }
-
-    public Writer<K, VR> newWriter( File targetFile, long lastCommittedTxId ) throws IOException
-    {
-        return writerFactory.create( fs, pageCache, header, targetFile, lastCommittedTxId );
-    }
-
-    public void close() throws IOException
-    {
-        pageCache.unmap( file );
-    }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordSerializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordSerializer.java
@@ -17,9 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.counts;
+package org.neo4j.kernel.impl.store.kvstore;
 
-interface RecordVisitor<K extends Comparable<K>>
+import java.nio.ByteBuffer;
+
+import org.neo4j.io.pagecache.PageCursor;
+
+public interface KeyValueRecordSerializer<K extends Comparable<K>, VR>
 {
-    void visit( K key, long value );
+    boolean visitRecord( ByteBuffer buffer, KeyValueRecordVisitor<K, VR> visitor );
+
+    K readRecord( PageCursor cursor, VR valueRegister );
+
+    void writeDefaultValue( VR valueRegister );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordVisitor.java
@@ -17,17 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.counts;
+package org.neo4j.kernel.impl.store.kvstore;
 
-import java.nio.ByteBuffer;
-
-import org.neo4j.io.pagecache.PageCursor;
-
-public interface RecordSerializer<K extends Comparable<K>, VR>
+public interface KeyValueRecordVisitor<K extends Comparable<K>, VR>
 {
-    boolean visitRecord( ByteBuffer buffer, RecordVisitor<K> visitor );
-
-    K readRecord( PageCursor cursor, VR valueRegister );
-
-    void writeDefaultValue( VR valueRegister );
+    VR valueRegister();
+    void visit( K key );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStore.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.kvstore;
+
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+
+/*
+ * Implementation of  a key value store based on storing a sequence of records sorted
+ * by key. To update, the store typically is recreated completely. It's main use
+ * currently is CountsStore and CountsTracker which keep an in-mem map of updates
+ * that is merged into a new store file on log rotation.
+ *
+ * This class is tested by it's use as CountsStore
+ */
+public abstract class SortedKeyValueStore<K extends Comparable<K>, VR> implements Closeable
+{
+    public interface Writer<K extends Comparable<K>, VR> extends KeyValueRecordVisitor<K, VR>, Closeable
+    {
+        SortedKeyValueStore<K, VR> openForReading() throws IOException;
+    }
+
+    public interface WriterFactory<K extends Comparable<K>, VR>
+    {
+        Writer<K, VR> create( FileSystemAbstraction fs, PageCache pageCache, SortedKeyValueStoreHeader header,
+                              File targetFile, long lastCommittedTxId ) throws IOException;
+    }
+
+    public static final int RECORD_SIZE /*bytes*/ = 16 /*key*/ + 16 /*value*/;
+    private final FileSystemAbstraction fs;
+    private final PageCache pageCache;
+    private final File file;
+    private final PagedFile pages;
+    private final SortedKeyValueStoreHeader header;
+    private final int totalRecords;
+    private final KeyValueRecordSerializer<K, VR> recordSerializer;
+    private final WriterFactory<K, VR> writerFactory;
+
+    public SortedKeyValueStore( FileSystemAbstraction fs, PageCache pageCache, File file, PagedFile pages,
+                                SortedKeyValueStoreHeader header, KeyValueRecordSerializer<K, VR> recordSerializer,
+                                WriterFactory<K, VR> writerFactory )
+    {
+        this.fs = fs;
+        this.pageCache = pageCache;
+        this.file = file;
+        this.pages = pages;
+        this.header = header;
+        this.recordSerializer = recordSerializer;
+        this.writerFactory = writerFactory;
+        this.totalRecords = header.dataRecords();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "%s[file=%s,%s]", getClass().getSimpleName(), file, header );
+    }
+
+    public void get( K key, VR value )
+    {
+        int min = header.headerRecords();
+        int max = min + totalRecords - 1;
+        int mid;
+        try ( PageCursor cursor = pages.io( 0, PF_SHARED_LOCK ) )
+        {
+            while ( min <= max )
+            {
+                mid = min + (max - min) / 2;
+                int cmp = compareKeyAndReadValue( cursor, key, mid, value );
+                if ( cmp == 0 )
+                {
+                    return;
+                }
+                else if ( cmp < 0 )
+                {
+                    max = mid - 1;
+                }
+                else
+                {
+                    min = mid + 1;
+                }
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+        recordSerializer.writeDefaultValue( value );
+    }
+
+    private int compareKeyAndReadValue( PageCursor cursor, K target, int record, VR count )
+            throws IOException
+    {
+        int pageId = (record * RECORD_SIZE) / pages.pageSize();
+        int offset = (record * RECORD_SIZE) % pages.pageSize();
+        if ( pageId == cursor.getCurrentPageId() || cursor.next( pageId ) )
+        {
+            K key;
+            do
+            {
+                cursor.setOffset( offset );
+                key = recordSerializer.readRecord( cursor, count );
+            } while ( cursor.shouldRetry() );
+            return target.compareTo( key );
+        }
+        else
+        {
+            throw new IllegalStateException( "Could not fetch page: " + pageId );
+        }
+    }
+
+    public File file()
+    {
+        return file;
+    }
+
+    public long lastTxId()
+    {
+        return header.lastTxId();
+    }
+    public long totalRecordsStored()
+    {
+        return header.dataRecords();
+    }
+
+    public void accept( KeyValueRecordVisitor<K, VR> visitor )
+    {
+        try ( InputStream in = fs.openAsInputStream( file ) )
+        {
+            // skip the header
+            for ( long bytes = header.headerRecords() * RECORD_SIZE; bytes != 0; )
+            {
+                bytes -= in.skip( bytes );
+            }
+            byte[] record = new byte[RECORD_SIZE];
+            ByteBuffer buffer = ByteBuffer.wrap( record );
+            boolean readNext = true;
+            for ( int read, offset = 0; readNext && (read = in.read( record, offset, record.length - offset )) != -1; )
+            {
+                if ( read != record.length )
+                {
+                    offset = read;
+                    continue;
+                }
+                buffer.position( 0 );
+                readNext = recordSerializer.visitRecord( buffer, visitor );
+                offset = 0;
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+    }
+
+    public Writer<K, VR> newWriter( File targetFile, long lastCommittedTxId ) throws IOException
+    {
+        return writerFactory.create( fs, pageCache, header, targetFile, lastCommittedTxId );
+    }
+
+    public void close() throws IOException
+    {
+        pageCache.unmap( file );
+    }
+
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStoreHeader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStoreHeader.java
@@ -17,10 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.counts;
+package org.neo4j.kernel.impl.store.kvstore;
 
 import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
-import static org.neo4j.kernel.impl.store.counts.CountsStore.RECORD_SIZE;
+import static org.neo4j.kernel.impl.store.kvstore.SortedKeyValueStore.RECORD_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
 import java.io.IOException;
@@ -30,15 +30,15 @@ import org.neo4j.helpers.UTF8;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
-final class CountsStoreHeader
+public final class SortedKeyValueStoreHeader
 {
-    static CountsStoreHeader empty( String storeFormatVersion )
+    public static SortedKeyValueStoreHeader empty( String storeFormatVersion )
     {
         if ( storeFormatVersion == null )
         {
             throw new IllegalArgumentException( "store format version cannot be null" );
         }
-        return new CountsStoreHeader( UTF8.encode( storeFormatVersion ), 0, BASE_TX_ID );
+        return new SortedKeyValueStoreHeader( UTF8.encode( storeFormatVersion ), 0, BASE_TX_ID );
     }
 
     private static final int META_HEADER_SIZE = 2/*headerRecords*/ + 2/*versionLen*/ + 4/*dataRecords*/ + 8/*lastTxId*/;
@@ -46,7 +46,7 @@ final class CountsStoreHeader
     private final int dataRecords;
     private final long lastTxId;
 
-    private CountsStoreHeader( byte[] storeFormatVersion, int dataRecords, long lastTxId )
+    private SortedKeyValueStoreHeader( byte[] storeFormatVersion, int dataRecords, long lastTxId )
     {
         this.storeFormatVersion = storeFormatVersion;
         this.dataRecords = dataRecords;
@@ -65,7 +65,7 @@ final class CountsStoreHeader
             return false;
         }
 
-        CountsStoreHeader that = (CountsStoreHeader) o;
+        SortedKeyValueStoreHeader that = (SortedKeyValueStoreHeader) o;
 
         if ( dataRecords != that.dataRecords )
         {
@@ -99,9 +99,9 @@ final class CountsStoreHeader
                               getClass().getSimpleName(), storeFormatVersion(), dataRecords, lastTxId );
     }
 
-    CountsStoreHeader update( int dataRecords, long lastTxId )
+    public SortedKeyValueStoreHeader update( int dataRecords, long lastTxId )
     {
-        return new CountsStoreHeader( storeFormatVersion, dataRecords, lastTxId );
+        return new SortedKeyValueStoreHeader( storeFormatVersion, dataRecords, lastTxId );
     }
 
     String storeFormatVersion()
@@ -109,7 +109,7 @@ final class CountsStoreHeader
         return UTF8.decode( storeFormatVersion );
     }
 
-    int headerRecords()
+    public int headerRecords()
     {
         int headerBytes = META_HEADER_SIZE + storeFormatVersion.length;
         headerBytes += RECORD_SIZE - (headerBytes % RECORD_SIZE);
@@ -126,7 +126,7 @@ final class CountsStoreHeader
         return lastTxId;
     }
 
-    static CountsStoreHeader read( PagedFile pagedFile ) throws IOException
+    public static SortedKeyValueStoreHeader read( PagedFile pagedFile ) throws IOException
     {
         try ( PageCursor page = pagedFile.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
@@ -160,7 +160,7 @@ final class CountsStoreHeader
                         }
                     }
                 } while ( page.shouldRetry() );
-                return new CountsStoreHeader( storeFormatVersion, dataRecords, lastTxId );
+                return new SortedKeyValueStoreHeader( storeFormatVersion, dataRecords, lastTxId );
             }
             else
             {
@@ -169,7 +169,7 @@ final class CountsStoreHeader
         }
     }
 
-    void write( PagedFile pagedFile ) throws IOException
+    public void write( PagedFile pagedFile ) throws IOException
     {
         try ( PageCursor page = pagedFile.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
@@ -184,7 +184,7 @@ final class CountsStoreHeader
         }
     }
 
-    void write( PageCursor page ) throws IOException
+    public void write( PageCursor page ) throws IOException
     {
         do
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -69,8 +69,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, alphaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, alphaStoreFile() ) )
         {
             // a transaction for creating the label and a transaction for the node
             assertEquals( BASE_TX_ID, store.lastTxId() );
@@ -98,8 +97,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, betaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, betaStoreFile() ) )
         {
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1, store.lastTxId() );
             assertEquals( 4, store.totalRecordsStored() );
@@ -132,8 +130,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, betaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, betaStoreFile() ) )
         {
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1, store.lastTxId() );
             assertEquals( 3, store.totalRecordsStored() );
@@ -166,8 +163,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, betaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, betaStoreFile() ) )
         {
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1, store.lastTxId() );
             assertEquals( 11, store.totalRecordsStored() );
@@ -204,8 +200,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, betaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, betaStoreFile() ) )
         {
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1 + 1, store.lastTxId() );
             assertEquals( 15, store.totalRecordsStored() );
@@ -249,8 +244,7 @@ public class CountsComputerTest
 
         rebuildCounts( countsState, lastCommittedTransactionId );
 
-        try ( CountsStore<CountsKey, Register.Long.Out> store =
-                      CountsStore.open( fs, pageCache, betaStoreFile(), RECORD_SERIALIZER, WRITER_FACTORY ) )
+        try ( CountsStore store = CountsStore.open( fs, pageCache, betaStoreFile() ) )
         {
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1, store.lastTxId() );
             assertEquals( 30, store.totalRecordsStored() );
@@ -297,8 +291,6 @@ public class CountsComputerTest
     }
 
     private static final String COUNTS_STORE_BASE = NeoStore.DEFAULT_NAME + StoreFactory.COUNTS_STORE;
-    private static final CountsRecordSerializer RECORD_SERIALIZER = new CountsRecordSerializer();
-    private static final CountsStoreWriter.Factory WRITER_FACTORY = new CountsStoreWriter.Factory();
 
     private File alphaStoreFile()
     {
@@ -332,7 +324,7 @@ public class CountsComputerTest
         tracker.close();
     }
 
-    private <K extends Comparable<K>> long get( CountsStore<K, Register.Long.Out> store, K key )
+    private long get( CountsStore store, CountsKey key )
     {
         Register.LongRegister value = Registers.newLongRegister();
         store.get( key, value );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStoreHeaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStoreHeaderTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.counts;
+package org.neo4j.kernel.impl.store.kvstore;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.store.CommonAbstractStore.ALL_STORES_VERSION;
@@ -36,13 +36,13 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 
-public class CountsStoreHeaderTest
+public class SortedKeyValueStoreHeaderTest
 {
     @Test
     public void shouldCreateAnEmptyHeader()
     {
         // when
-        CountsStoreHeader header = CountsStoreHeader.empty( ALL_STORES_VERSION );
+        SortedKeyValueStoreHeader header = SortedKeyValueStoreHeader.empty( ALL_STORES_VERSION );
 
         // then
         assertEquals( BASE_TX_ID, header.lastTxId() );
@@ -55,10 +55,10 @@ public class CountsStoreHeaderTest
     public void shouldUpdateHeader()
     {
         // given
-        CountsStoreHeader header = CountsStoreHeader.empty( ALL_STORES_VERSION );
+        SortedKeyValueStoreHeader header = SortedKeyValueStoreHeader.empty( ALL_STORES_VERSION );
 
         // when
-        CountsStoreHeader newHeader = header.update( 42, 24 );
+        SortedKeyValueStoreHeader newHeader = header.update( 42, 24 );
 
         // then
         assertEquals( 24, newHeader.lastTxId() );
@@ -71,7 +71,7 @@ public class CountsStoreHeaderTest
     public void shouldWriteHeaderInPageFile() throws IOException
     {
         // given
-        CountsStoreHeader header = CountsStoreHeader.empty( ALL_STORES_VERSION ).update( 42, 24 );
+        SortedKeyValueStoreHeader header = SortedKeyValueStoreHeader.empty( ALL_STORES_VERSION ).update( 42, 24 );
 
         // when
         try
@@ -81,7 +81,7 @@ public class CountsStoreHeaderTest
             pagedFile.flush();
 
             // then
-            assertEquals( header, CountsStoreHeader.read( pagedFile ) );
+            assertEquals( header, SortedKeyValueStoreHeader.read( pagedFile ) );
         }
         finally
         {


### PR DESCRIPTION
CountsStore is backed by a generic KV-Store which stores key and value of 16 bytes each.

The encoding of the keys and values have changed to match the new back-end. In particular the key encoding contains a byte which specifies the type of the entry. This will simplify the introduction of new keys for new counts.

Revert the caching on read in ConcurrentTrackerState since the underlying PageCache does the caching and we have potentially less work to do when merging in-memory state and values in the store.

More test coverage and fix a bug in the binary search when reading entries ordered by key.

When visiting records we return a boolean to notice when we encounter an empty record and so stop reading.

Increased usage of registers rather than passing around longs.
