### PR TITLE
[2.2] Made the online backup timeout configurable

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Args.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Args.java
@@ -114,6 +114,11 @@ public class Args
         String value = this.map.get( key );
         return value != null ? Double.parseDouble( value ) : defaultValue;
     }
+    
+    public long getDuration(String key, long defaultValueInMillis) {
+        String value = this.map.get( key );
+        return value != null ? TimeUtil.parseTimeMillis.apply(value) : defaultValueInMillis;
+    }
 
     public Boolean getBoolean( String key, Boolean defaultValue )
     {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
@@ -44,13 +44,13 @@ import static org.neo4j.backup.BackupServer.PROTOCOL_VERSION;
 class BackupClient extends Client<TheBackupInterface> implements TheBackupInterface
 {
 
-    private static final int BIG_READ_TIMEOUT = 40 * 1000;
+    static final long BIG_READ_TIMEOUT = 40 * 1000;
 
-    public BackupClient( String hostNameOrIp, int port, Logging logging, StoreId storeId, ResponseUnpacker unpacker,
-                         ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    public BackupClient( String hostNameOrIp, int port, Logging logging, StoreId storeId, long timeout,
+                         ResponseUnpacker unpacker, ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
         super( hostNameOrIp, port, logging, storeId, FRAME_LENGTH,
-                new ProtocolVersion( PROTOCOL_VERSION, ProtocolVersion.INTERNAL_PROTOCOL_VERSION ), BIG_READ_TIMEOUT,
+                new ProtocolVersion( PROTOCOL_VERSION, ProtocolVersion.INTERNAL_PROTOCOL_VERSION ), timeout,
                 Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT, FRAME_LENGTH, unpacker,
                 byteCounterMonitor, requestMonitor );
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -40,6 +40,7 @@ public class OnlineBackup
     private final String hostNameOrIp;
     private final int port;
     private BackupService.BackupOutcome outcome;
+    private long timeoutMillis = BackupClient.BIG_READ_TIMEOUT;
 
     /**
      * Factory method for this class. The OnlineBackup instance returned will perform backup operations against the
@@ -89,7 +90,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory, true,
-                defaultConfig() );
+                defaultConfig(), timeoutMillis);
         return this;
     }
 
@@ -112,7 +113,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory, boolean verification )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
-                verification, defaultConfig() );
+                verification, defaultConfig(), timeoutMillis );
         return this;
     }
 
@@ -133,7 +134,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory, Config tuningConfiguration )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory, true,
-                tuningConfiguration );
+                tuningConfiguration, timeoutMillis );
         return this;
     }
 
@@ -151,13 +152,27 @@ public class OnlineBackup
      * @param targetDirectory A directory holding a complete database previously obtained from the backup server.
      * @param tuningConfiguration The {@link Config} to use when running the consistency check
      * @param verification If true, the verification phase will be run.
-     * @return The same OnlineBackup instance, possible to use for a new backup operation
+     * @return The same OnlineBackup instance, possible to use for a new backup operation.
      */
     public OnlineBackup backup( String targetDirectory, Config tuningConfiguration,
                                 boolean verification )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
-                verification, tuningConfiguration );
+                verification, tuningConfiguration, timeoutMillis );
+        return this;
+    }
+    
+    /**
+     * Use this method to change the default timeout to keep the client waiting for each reply from the server when 
+     * doing online backup. Once the value is changed, then every time when doing online backup, the timeout will be 
+     * reused until this method is called again and a new value is assigned.
+     * 
+     * @param timeoutMillis The time duration in millisecond that keeps the client waiting for each reply from the server.
+     * @return The same OnlineBackup instance, possible to use for a new backup operation.
+     */
+    public OnlineBackup withTimeout( long timeoutMillis )
+    {
+        this.timeoutMillis = timeoutMillis;
         return this;
     }
 
@@ -176,7 +191,8 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup full( String targetDirectory )
     {
-        outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, true, defaultConfig() );
+        outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, true, defaultConfig(),
+                timeoutMillis );
         return this;
     }
 
@@ -197,7 +213,7 @@ public class OnlineBackup
     public OnlineBackup full( String targetDirectory, boolean verification )
     {
         outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, verification,
-                defaultConfig() );
+                defaultConfig(), timeoutMillis );
         return this;
     }
 
@@ -220,7 +236,7 @@ public class OnlineBackup
     public OnlineBackup full( String targetDirectory, boolean verification, Config tuningConfiguration )
     {
         outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, verification,
-                tuningConfiguration );
+                tuningConfiguration, timeoutMillis );
         return this;
     }
 
@@ -240,7 +256,8 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( String targetDirectory )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDirectory, true );
+        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDirectory, true,
+                timeoutMillis );
         return this;
     }
 
@@ -261,7 +278,8 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( String targetDirectory, boolean verification )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDirectory, verification );
+        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDirectory, verification,
+                timeoutMillis );
         return this;
     }
 
@@ -281,7 +299,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( GraphDatabaseAPI targetDb )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDb );
+        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDb, timeoutMillis );
         return this;
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -197,7 +197,8 @@ public class BackupServiceIT
         try
         {
             // when
-            new BackupService( fileSystem ).doFullBackup( "", 0, backupDir.getAbsolutePath(), true, new Config() );
+            new BackupService( fileSystem ).doFullBackup( "", 0, backupDir.getAbsolutePath(), 
+                    true, new Config(), BackupClient.BIG_READ_TIMEOUT );
         }
         catch ( RuntimeException ex )
         {
@@ -215,7 +216,8 @@ public class BackupServiceIT
 
         // when
         BackupService backupService = new BackupService( fileSystem );
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT);
         db.shutdown();
 
         // then
@@ -269,7 +271,7 @@ public class BackupServiceIT
         BackupService backupService = new BackupService( fileSystem );
         BackupService.BackupOutcome outcome = backupService.doFullBackup( BACKUP_HOST, backupPort,
                 backupDir.getAbsolutePath(),
-                true, defaultConfig() );
+                true, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         db.shutdown();
 
@@ -289,7 +291,8 @@ public class BackupServiceIT
 
         // when
         BackupService backupService = new BackupService( fileSystem );
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT);
         db.shutdown();
 
         // then
@@ -307,7 +310,8 @@ public class BackupServiceIT
 
         // when
         BackupService backupService = new BackupService( fileSystem );
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
         db.shutdown();
 
         // then
@@ -332,7 +336,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), BackupClient.BIG_READ_TIMEOUT );
         db.shutdown();
 
         // then
@@ -348,7 +352,8 @@ public class BackupServiceIT
 
         // when
         BackupService backupService = new BackupService( fileSystem );
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
         db.shutdown();
 
         // then
@@ -370,7 +375,8 @@ public class BackupServiceIT
         createAndIndexNode( db, 1 );
 
         // A full backup
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // And the log the backup uses is rotated out
         createAndIndexNode( db, 2 );
@@ -381,7 +387,8 @@ public class BackupServiceIT
         // when
         try
         {
-            backupService.doIncrementalBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false );
+            backupService.doIncrementalBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                    false, BackupClient.BIG_READ_TIMEOUT );
             fail( "Should have thrown exception." );
         }
         // Then
@@ -405,7 +412,8 @@ public class BackupServiceIT
         createAndIndexNode( db, 1 );
 
         // A full backup
-        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+        backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // And the log the backup uses is rotated out
         createAndIndexNode( db, 2 );
@@ -414,7 +422,8 @@ public class BackupServiceIT
 
         // when
         backupService.doIncrementalBackupOrFallbackToFull(
-                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // Then
         db.shutdown();
@@ -434,7 +443,8 @@ public class BackupServiceIT
 
         // A full backup
         backupService.doIncrementalBackupOrFallbackToFull(
-                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // And the log the backup uses is rotated out
         createAndIndexNode( db, 2 );
@@ -445,7 +455,8 @@ public class BackupServiceIT
 
         // when
         backupService.doIncrementalBackupOrFallbackToFull(
-                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // Then
         db.shutdown();
@@ -483,7 +494,8 @@ public class BackupServiceIT
 
         // when
         backupService.doIncrementalBackupOrFallbackToFull(
-                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         // then
         db.shutdown();
@@ -544,7 +556,7 @@ public class BackupServiceIT
                 }
             } );
             BackupService.BackupOutcome backupOutcome = backupService.doFullBackup( BACKUP_HOST, backupPort,
-                    backupDir.getAbsolutePath(), true, new Config( params ) );
+                    backupDir.getAbsolutePath(), true, new Config( params ), BackupClient.BIG_READ_TIMEOUT );
             backup.stop();
             executor.shutdown();
             executor.awaitTermination( 30, TimeUnit.SECONDS );
@@ -568,7 +580,8 @@ public class BackupServiceIT
         createAndIndexNode( db1, 1 );
 
         new BackupService( fileSystem ).doFullBackup(
-                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), 
+                false, defaultConfig(), BackupClient.BIG_READ_TIMEOUT );
 
         db1.shutdown();
 
@@ -584,7 +597,8 @@ public class BackupServiceIT
         try
         {
             new BackupService( fileSystem ).doIncrementalBackupOrFallbackToFull(
-                    BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig() );
+                    BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, defaultConfig(), 
+                    BackupClient.BIG_READ_TIMEOUT );
 
             fail( "Should have thrown exception about mismatching store ids" );
         }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolUrisTest.java
@@ -97,7 +97,8 @@ public class BackupToolUrisTest
                     eq( port ),
                     eq( "/var/backup/graph" ),
                     eq( true ),
-                    any( Config.class )
+                    any( Config.class ),
+                    eq( BackupClient.BIG_READ_TIMEOUT )
             );
         }
     }
@@ -199,7 +200,8 @@ public class BackupToolUrisTest
                     eq( port ),
                     eq( "/var/backup/graph" ),
                     eq( true ),
-                    any( Config.class )
+                    any( Config.class ),
+                    eq( BackupClient.BIG_READ_TIMEOUT )
             );
         }
     }


### PR DESCRIPTION
On the backup client side, a use-specified backup timeout could be passed in when creating a new client instance. The timeout could be passed via command line (BackupTool) or Backup API (OnlineBackup).
