### PR TITLE
[2.2] Fixes tests that left threads behind after run

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
@@ -29,9 +29,8 @@ import org.neo4j.io.fs.StoreChannel;
 
 public class LimitedFileChannel implements StoreChannel
 {
-
     private final StoreChannel inner;
-    private LimitedFilesystemAbstraction fs;
+    private final LimitedFilesystemAbstraction fs;
 
     public LimitedFileChannel( StoreChannel inner, LimitedFilesystemAbstraction limitedFilesystemAbstraction )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingForceThread.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingForceThread.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.transaction.log;
 import java.io.IOException;
 import java.util.concurrent.locks.LockSupport;
 
+import static org.neo4j.kernel.impl.util.DebugUtil.trackTest;
+
 /**
  * Background thread that goes together with {@link ParallelBatchingPhysicalTransactionAppender} and performs
  * and {@link Operation} as fast as it can as until it's {@link #halt() halted}.
@@ -36,23 +38,23 @@ class BatchingForceThread extends Thread
          */
         boolean force() throws IOException;
     }
-    
+
     private volatile boolean run = true;
     private final Operation operation;
     private volatile IOException failure;
-    
+
     BatchingForceThread( Operation operation )
     {
-        super( "BatchingWrites thread" );
+        super( "BatchingWrites thread" + trackTest() );
         this.operation = operation;
         setDaemon( true );
     }
-    
+
     public void halt()
     {
         run = false;
     }
-    
+
     @Override
     public void run()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
 import static org.neo4j.helpers.NamedThreadFactory.daemon;
+import static org.neo4j.kernel.impl.util.DebugUtil.trackTest;
 
 public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
 {
@@ -50,8 +51,8 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     @Override
     public void init()
     {
-        this.executor = newCachedThreadPool( daemon( "Neo4j " + id ) );
-        this.scheduledExecutor = new ScheduledThreadPoolExecutor( 2, daemon( "Scheduled Neo4j " + id ) );
+        this.executor = newCachedThreadPool( daemon( "Neo4j " + id + trackTest() ) );
+        this.scheduledExecutor = new ScheduledThreadPoolExecutor( 2, daemon( "Scheduled Neo4j " + id + trackTest() ) );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/graphdb/RunOutOfDiskSpaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/RunOutOfDiskSpaceIT.java
@@ -21,10 +21,12 @@ package org.neo4j.graphdb;
 
 import java.io.IOException;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.graphdb.mockfs.LimitedFileSystemGraphDatabase;
 import org.neo4j.helpers.Exceptions;
+import org.neo4j.test.CleanupRule;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -39,7 +41,7 @@ public class RunOutOfDiskSpaceIT
     {
         // Given
         TransactionFailureException exceptionThrown = null;
-        LimitedFileSystemGraphDatabase db = new LimitedFileSystemGraphDatabase();
+        LimitedFileSystemGraphDatabase db = cleanup.add( new LimitedFileSystemGraphDatabase() );
 
         db.runOutOfDiskSpaceNao();
 
@@ -60,6 +62,7 @@ public class RunOutOfDiskSpaceIT
 
         // Then
         assertTrue( Exceptions.contains( exceptionThrown, IOException.class ) );
+        db.somehowGainMoreDiskSpace(); // to help shutting down the db
     }
 
     @Test
@@ -67,7 +70,7 @@ public class RunOutOfDiskSpaceIT
     {
         // Given
         TransactionFailureException errorCaught = null;
-        LimitedFileSystemGraphDatabase db = new LimitedFileSystemGraphDatabase();
+        LimitedFileSystemGraphDatabase db = cleanup.add( new LimitedFileSystemGraphDatabase() );
 
         db.runOutOfDiskSpaceNao();
 
@@ -98,5 +101,8 @@ public class RunOutOfDiskSpaceIT
 
         // Then
         assertThat( errorCaught.getCause(), is( instanceOf( org.neo4j.kernel.api.exceptions.TransactionFailureException.class ) ) );
+        db.somehowGainMoreDiskSpace(); // to help shutting down the db
     }
+
+    public final @Rule CleanupRule cleanup = new CleanupRule();
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileSystemGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileSystemGraphDatabase.java
@@ -37,4 +37,9 @@ public class LimitedFileSystemGraphDatabase extends ImpermanentGraphDatabase
     {
         this.fs.runOutOfDiskSpace( true );
     }
+
+    public void somehowGainMoreDiskSpace()
+    {
+        this.fs.runOutOfDiskSpace( false );
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -57,6 +58,7 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.impl.util.TestLogger;
 import org.neo4j.kernel.logging.SingleLoggingService;
+import org.neo4j.test.CleanupRule;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.OtherThreadExecutor;
@@ -237,8 +239,8 @@ public class IndexPopulationJobTest
         final IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, storeView,
                 StringLogger.DEV_NULL );
 
-        OtherThreadExecutor<Void> populationJobRunner = new OtherThreadExecutor<>(
-                "Population job test runner", null );
+        OtherThreadExecutor<Void> populationJobRunner = cleanup.add( new OtherThreadExecutor<Void>(
+                "Population job test runner", null ) );
         Future<Void> runFuture = populationJobRunner.executeDontWait( new WorkerCommand<Void, Void>()
         {
             @Override
@@ -528,6 +530,7 @@ public class IndexPopulationJobTest
     private KernelSchemaStateStore stateHolder;
 
     private int labelId;
+    public final @Rule CleanupRule cleanup = new CleanupRule();
 
     @Before
     public void before() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LegacyDeadlockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LegacyDeadlockCompatibility.java
@@ -28,11 +28,14 @@ import javax.transaction.Transaction;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.kernel.DeadlockDetectedException;
 
 import static java.lang.System.currentTimeMillis;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 @Ignore("Not a test, part of a compatibility suite.")
 // This is the legacy deadlock detection tests
@@ -132,6 +135,13 @@ public class LegacyDeadlockCompatibility extends LockingCompatibilityTestSuite.C
             File file = new LockWorkFailureDump( getClass() ).dumpState( locks, new LockWorker[] { t1, t2, t3, t4 } );
             throw new RuntimeException( "Failed, forensics information dumped to " + file.getAbsolutePath(), e );
         }
+        finally
+        {
+            t1.close();
+            t2.close();
+            t3.close();
+            t4.close();
+        }
     }
 
     public static class StressThread extends Thread
@@ -143,7 +153,9 @@ public class LegacyDeadlockCompatibility extends LockingCompatibilityTestSuite.C
         static
         {
             for ( int i = 0; i < resources.length; i++ )
+            {
                 resources[i] = i;
+            }
         }
         private final CountDownLatch startSignal;
         private final String name;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCacheTest.java
@@ -54,8 +54,9 @@ public class LifecycledPageCacheTest
 
         // When
         PageSwapperFactory swapperFactory = new SingleFilePageSwapperFactory( fsRule.get() );
+        Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
         PageCache cache = new LifecycledPageCache(
-                swapperFactory, new Neo4jJobScheduler(), config, new Monitors().newMonitor( PageCacheMonitor.class ) );
+                swapperFactory, scheduler, config, new Monitors().newMonitor( PageCacheMonitor.class ) );
 
         // Then
         assertThat(cache.pageSize(), equalTo(4096));

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/AppendAndRotationRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/AppendAndRotationRaceIT.java
@@ -120,6 +120,7 @@ public class AppendAndRotationRaceIT
         {
             committer.await();
         }
+        life.shutdown();
         // doing Committer#await() above is enough since errors, as well as assertion failures that
         // has happened in any of the committers will be exposed there
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
@@ -49,7 +49,7 @@ public class ManualAcquireLockTest
     @Rule public TestRule chain = RuleChain.outerRule( db ).around( tx );
 
     private Worker worker;
-    
+
     @Before
     public void doBefore() throws Exception
     {
@@ -61,7 +61,7 @@ public class ManualAcquireLockTest
     {
         worker.close();
     }
-    
+
     @Test
     public void releaseReleaseManually() throws Exception
     {
@@ -70,7 +70,6 @@ public class ManualAcquireLockTest
 
         tx.success();
         Transaction current = tx.begin();
-        Worker worker = new Worker();
         Lock nodeLock = current.acquireWriteLock( node );
         worker.beginTx();
         try
@@ -112,7 +111,7 @@ public class ManualAcquireLockTest
         { // Good
         }
     }
-    
+
     @Test
     public void makeSureNodeStaysLockedEvenAfterManualRelease() throws Exception
     {
@@ -124,8 +123,7 @@ public class ManualAcquireLockTest
         Lock nodeLock = current.acquireWriteLock( node );
         node.setProperty( key, "value" );
         nodeLock.release();
-        
-        Worker worker = new Worker();
+
         worker.beginTx();
         try
         {
@@ -148,7 +146,7 @@ public class ManualAcquireLockTest
             // Ok, interrupting the thread while it's waiting for a lock will lead to tx failure.
         }
     }
-    
+
     private GraphDatabaseService getGraphDb()
     {
         return db.getGraphDatabaseService();
@@ -158,20 +156,20 @@ public class ManualAcquireLockTest
     {
         private final GraphDatabaseService graphDb;
         private Transaction tx;
-        
+
         public State( GraphDatabaseService graphDb )
         {
             this.graphDb = graphDb;
         }
     }
-    
+
     private class Worker extends OtherThreadExecutor<State>
     {
         public Worker()
         {
             super( "other thread", new State( getGraphDb() ) );
         }
-        
+
         void beginTx() throws Exception
         {
             execute( new WorkerCommand<State, Void>()
@@ -184,7 +182,7 @@ public class ManualAcquireLockTest
                 }
             } );
         }
-        
+
         void finishTx() throws Exception
         {
             execute( new WorkerCommand<State, Void>()
@@ -198,7 +196,7 @@ public class ManualAcquireLockTest
                 }
             } );
         }
-        
+
         void setProperty( final Node node, final String key, final Object value ) throws Exception
         {
             execute( new WorkerCommand<State, Object>()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DebugUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DebugUtilTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class DebugUtilTest
+{
+    public final @Rule TestName testName = new TestName();
+
+    @Test
+    public void shouldFigureOutThatThisIsATest()
+    {
+        assertThat( DebugUtil.trackTest(), containsString( testName.getMethodName() ) );
+        assertThat( DebugUtil.trackTest(), containsString( getClass().getSimpleName() ) );
+    }
+
+    @Test
+    public void shouldFigureOutThatWeStartedInATest() throws Exception
+    {
+        new Noise().white();
+    }
+
+    private class Noise
+    {
+        void white()
+        {
+            assertThat( DebugUtil.trackTest(), containsString( testName.getMethodName() ) );
+            assertThat( DebugUtil.trackTest(), containsString( DebugUtilTest.class.getSimpleName() ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
@@ -462,6 +462,7 @@ public class BatchInsertTest
 
         // THEN
         assertFalse( batchInserter.getNodeProperties( nodeId ).containsKey( key ) );
+        batchInserter.shutdown();
     }
 
     @Test
@@ -480,6 +481,7 @@ public class BatchInsertTest
 
         // THEN
         assertTrue( Arrays.equals( secondValue, (String[]) batchInserter.getNodeProperties( nodeId ).get( key ) ) );
+        batchInserter.shutdown();
     }
 
     @Test
@@ -543,7 +545,8 @@ public class BatchInsertTest
             assertEquals( asSet( realSelfRelationship, realRelationship ), asSet( realStartNode.getRelationships( Direction.OUTGOING ) ) );
             assertEquals( asSet( realSelfRelationship, realRelationship ), asSet( realStartNode.getRelationships() ) );
         }
-        finally {
+        finally
+        {
             db.shutdown();
         }
     }
@@ -755,6 +758,7 @@ public class BatchInsertTest
         assertTrue( inserter.nodeHasLabel( node, Labels.FIRST ) );
         assertTrue( inserter.nodeHasLabel( node, Labels.SECOND ) );
         assertFalse( inserter.nodeHasLabel( node, Labels.THIRD ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -769,6 +773,7 @@ public class BatchInsertTest
 
         // THEN
         assertEquals( asSet( Labels.FIRST.name(), Labels.THIRD.name() ), asSet( labelNames ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -784,6 +789,7 @@ public class BatchInsertTest
 
         // THEN
         assertEquals( labels.other(), asSet( labelNames ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -800,6 +806,7 @@ public class BatchInsertTest
         // THEN
         Iterable<String> labelNames = asNames( inserter.getNodeLabels( node ) );
         assertEquals( labels.other(), asSet( labelNames ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -815,6 +822,7 @@ public class BatchInsertTest
         // THEN
         Iterable<String> labelNames = asNames( inserter.getNodeLabels( node ) );
         assertEquals( asSet( Labels.FIRST.name() ), asSet( labelNames ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -829,6 +837,7 @@ public class BatchInsertTest
         // THEN
         assertEquals( "Hacker", definition.getLabel().name() );
         assertEquals( asCollection( iterator( "handle" ) ), asCollection( definition.getPropertyKeys() ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -845,6 +854,7 @@ public class BatchInsertTest
         assertEquals( "Hacker", definition.getLabel().name() );
         assertEquals( ConstraintType.UNIQUENESS, definition.getConstraintType() );
         assertEquals( asSet( "handle" ), asSet( definition.getPropertyKeys() ) );
+        inserter.shutdown();
     }
 
     @Test
@@ -1164,6 +1174,7 @@ public class BatchInsertTest
 
         // THEN
         assertEquals( 21, gottenRelationships.size() );
+        inserter.shutdown();
     }
 
     private void createRelationships( BatchInserter inserter, long node, RelationshipType relType,

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
@@ -69,6 +69,7 @@ public class StageTest
         {
             assertEquals( batches, stats.stat( Keys.done_batches ).asLong() );
         }
+        stage.close();
     }
 
     private static class ReceiveOrderAssertingStep extends ExecutorServiceStep<Object>

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
@@ -49,6 +50,7 @@ import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.LogMarker;
+import org.neo4j.test.CleanupRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -57,7 +59,6 @@ import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.kernel.ha.com.master.SlavePriorities.givenOrder;
 import static org.neo4j.kernel.ha.com.master.SlavePriorities.roundRobin;
-
 
 public class TestMasterCommittingAtSlave
 {
@@ -226,7 +227,7 @@ public class TestMasterCommittingAtSlave
         log = new FakeStringLogger();
         Config config = new Config( MapUtil.stringMap(
                 HaSettings.tx_push_factor.name(), "" + replication, ClusterSettings.server_id.name(), "" + MasterServerId ) );
-        Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
+        Neo4jJobScheduler scheduler = cleanup.add( new Neo4jJobScheduler() );
         TransactionPropagator result = new TransactionPropagator( TransactionPropagator.from( config, slavePriority ),
                 log, new Slaves()
         {
@@ -263,6 +264,7 @@ public class TestMasterCommittingAtSlave
     }
 
     private static final FileSystemAbstraction FS = new DefaultFileSystemAbstraction();
+    public final @Rule CleanupRule cleanup = new CleanupRule();
 
     private static class FakeSlave implements Slave
     {


### PR DESCRIPTION
introduced a simple tracking method that can be used for labelling
threads, only active if assertions are enabled.
