### PR TITLE
[2.2] Reinstates the catching up with master before allowing transactions

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -31,6 +31,7 @@ import org.neo4j.com.Server;
 import org.neo4j.com.ServerUtil;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.ResponseUnpacker;
+import org.neo4j.com.storecopy.ResponseUnpacker.TxHandler;
 import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
@@ -69,6 +70,7 @@ import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.store.UnableToCopyStoreFromOldMasterException;
 import org.neo4j.kernel.impl.store.UnavailableMembersException;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.NoSuchLogVersionException;
@@ -298,6 +300,35 @@ public class SwitchToSlave
             checkMyStoreIdAndMastersStoreId( nioneoDataSource, masterIsOld );
             checkDataConsistencyWithMaster( masterUri, masterClient, nioneoDataSource, txIdStore );
             console.log( "Store is consistent" );
+
+            /*
+             * Pull updates, since the store seems happy and everything. No matter how far back we are, this is just
+             * convenient to do before letting through transactions. Otherwise there would be an unexpected long
+             * pause while transactions would await the store to catch up as part of their first contact with
+             * the master, for example for grabbing a lock.
+             */
+            RequestContext catchUpRequestContext = requestContextFactory.newRequestContext();
+            console.log( "Catching up with master. I'm at " + catchUpRequestContext );
+
+            masterClient.pullUpdates( catchUpRequestContext, new TxHandler()
+            {
+                @Override
+                public void accept( CommittedTransactionRepresentation tx )
+                {
+                    long txId = tx.getCommitEntry().getTxId();
+                    if ( txId % 50 == 0 )
+                    {
+                        console.log( "  ...still catching up with master, now at " + txId );
+                    }
+                }
+
+                @Override
+                public void done()
+                {   // We print a message after the pullUpdates call as a whole anyway, so don't do anything here
+                }
+            } );
+
+            console.log( "Now consistent with master" );
         }
         catch ( NoSuchLogVersionException e )
         {


### PR DESCRIPTION
this is to remove an unexpected pause that the first batch of transactions
would potentially run into as part of the store catching up in the
background. Having it explicit like this is more expected behaviour.
