### PR TITLE
[2.2] Guards for concurrent shutdown when applying batches on slaves

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
@@ -131,14 +131,7 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
     @Override
     public void force() throws IOException
     {
-        boolean rotated;
-        synchronized ( logFile )
-        {
-            rotated = logFile.checkRotation();
-        }
-
         forceChannel();
-        pruneIfRotated( rotated );
     }
 
     protected abstract long getCurrentTicket();

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -56,6 +56,7 @@ import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.LogFile;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
@@ -126,10 +127,12 @@ public class MasterClientTest
         TransactionRepresentationStoreApplier txApplier = mock( TransactionRepresentationStoreApplier.class );
         TransactionIdStore txIdStore = mock( TransactionIdStore.class );
         TransactionAppender txAppender = mock( TransactionAppender.class );
+        LogFile logFile = mock( LogFile.class );
 
         when( resolver.resolveDependency( LogicalTransactionStore.class ) ).thenReturn( txStore );
         when( resolver.resolveDependency( TransactionRepresentationStoreApplier.class ) ).thenReturn( txApplier );
         when( resolver.resolveDependency( TransactionIdStore.class ) ).thenReturn( txIdStore );
+        when( resolver.resolveDependency( LogFile.class ) ).thenReturn( logFile );
         when( txStore.getAppender() ).thenReturn( txAppender );
 
         ResponseUnpacker unpacker = initAndStart( new TransactionCommittingResponseUnpacker( resolver ) );


### PR DESCRIPTION
Committing and applying a batch of transactions in
TransactionCommittingResponseUnpacker would:
- 1. append a batch of transactions
- 2. force
- 3. then finally mark as committed and apply each one

If there would occur a clean shutdown during or after 1 or 2, but before 3
there might be transactions appended to the log, but never applied, not
even the next start of the db, since there would be no recovery performed.
A similar problem could occur for rotation where force (2) would check
rotation which would effectively exhibit very similar problems.

This commit adds synchronized using the same monitor as append and shutdown
for one whole transaction batch to guard for concurrent shutdown. Also
TransactionAppender#force (2) is changed to not check rotation, and
instead the TransactionCommittingResponseUnpacker checking rotation before
committing and applying each batch, i.e. no possibility of rotation
happening in between append and commit-and-apply.
