### PR TITLE
[2.2] Fixed issue with input iterator starting too soon

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/WrappingResourceIterator.java
@@ -21,59 +21,29 @@ package org.neo4j.helpers.collection;
 
 import java.util.Iterator;
 
-import org.neo4j.graphdb.ResourceIterator;
-
-class WrappingResourceIterator<T> implements ResourceIterator<T>
+class WrappingResourceIterator<T> extends PrefetchingResourceIterator<T>
 {
     private final Iterator<T> iterator;
-    boolean hasNext;
 
-    public WrappingResourceIterator( Iterator<T> iterator )
+    WrappingResourceIterator( Iterator<T> iterator )
     {
         this.iterator = iterator;
-        hasNext = iterator.hasNext();
     }
 
     @Override
     public void close()
     {
-        hasNext = false;
-    }
-
-    @Override
-    public boolean hasNext()
-    {
-        return hasNext;
-    }
-
-    @Override
-    public T next()
-    {
-        assertHasNext();
-        T result = iterator.next();
-        hasNext = iterator.hasNext();
-        return result;
     }
 
     @Override
     public void remove()
     {
-        assertHasNext();
-        try
-        {
-            iterator.remove();
-        }
-        finally
-        {
-            hasNext = iterator.hasNext();
-        }
+        iterator.remove();
     }
 
-    private void assertHasNext()
+    @Override
+    protected T fetchNextOrNull()
     {
-        if ( ! hasNext )
-        {
-            throw new IllegalArgumentException( "Iterator already closed" );
-        }
+        return iterator.hasNext() ? iterator.next() : null;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -43,7 +43,7 @@ public abstract class ProducerStep<T> extends AbstractStep<Void>
     @Override
     public long receive( long ticket, Void nothing )
     {
-        new Thread()
+        new Thread( "PRODUCER" )
         {
             @Override
             public void run()

--- a/community/kernel/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/collection/CombiningResourceIteratorTest.java
@@ -20,18 +20,22 @@
 package org.neo4j.helpers.collection;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.ResourceIterator;
 
 import static java.util.Arrays.asList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 
 public class CombiningResourceIteratorTest
 {
-
     @Test
     public void shouldNotCloseDuringIteration() throws Exception
     {
@@ -58,7 +62,10 @@ public class CombiningResourceIteratorTest
 
         // Given I iterate through half of it
         int iterations = 4;
-        while( iterations --> 0 ) combingIterator.next();
+        while( iterations --> 0 )
+        {
+            combingIterator.next();
+        }
 
         // When
         combingIterator.close();
@@ -79,5 +86,4 @@ public class CombiningResourceIteratorTest
         // When I iterate through it, things come back in the right order
         assertThat( IteratorUtil.asList( combingIterator ), equalTo(asList(1l,5l,6l,7l)) );
     }
-
 }


### PR DESCRIPTION
CalculateDenseNodeStage was set up before executing NodeStage, accepting
an iterator of InputRelationship. Calculating the dense node count might
depend on IdMapper to be prepared. IdMapper was prepared after NodeStage
was done. Problem was that the Input used in this test wrapped the
iterator in a resource iterator that retrieved its first item in the
constructor and so made the first InputRelationship pick invalid node ids.

Effect of this would be that the node degree would be off by one for a
select few nodes.

Fixed by using PrefetchingResourceIterator instead which fetches in
hasNext, which is expected in most places.
