### PR TITLE
[2.2] Reduces contention in ArrayQueueOutOfOrderSequence#get

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -112,7 +112,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             SchemaWriteGuard schemaWriteGuard, LabelScanStore labelScanStore,
                                             IndexingService indexService,
                                             UpdateableSchemaState schemaState,
-                                            TransactionRecordState neoStoreTransaction,
+                                            TransactionRecordState recordState,
                                             SchemaIndexProviderMap providerMap, NeoStore neoStore,
                                             Locks.Client locks, TransactionHooks hooks,
                                             ConstraintIndexCreator constraintIndexCreator,
@@ -129,7 +129,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.schemaWriteGuard = schemaWriteGuard;
         this.labelScanStore = labelScanStore;
         this.indexService = indexService;
-        this.recordState = neoStoreTransaction;
+        this.recordState = recordState;
         this.providerMap = providerMap;
         this.schemaState = schemaState;
         this.hooks = hooks;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -101,13 +101,13 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
             NeoStoreTransactionContext context = neoStoreTransactionContextSupplier.acquire();
             Locks.Client locksClient = locks.newClient();
             context.bind( locksClient );
-            TransactionRecordState neoStoreTransaction = new TransactionRecordState(
-                    neoStore.getLastCommittedTransactionId(), neoStore, integrityValidator, context );
+            TransactionRecordState recordState = new TransactionRecordState(
+                    neoStore, integrityValidator, context );
             LegacyIndexTransactionState legacyIndexTransactionState =
                     new LegacyIndexTransactionState( indexConfigStore, legacyIndexProviderLookup );
             KernelTransactionImplementation tx = new KernelTransactionImplementation(
                     statementOperations, readOnly, schemaWriteGuard,
-                    labelScanStore, indexingService, updateableSchemaState, neoStoreTransaction, providerMap,
+                    labelScanStore, indexingService, updateableSchemaState, recordState, providerMap,
                     neoStore, locksClient, hooks, constraintIndexCreator, transactionHeaderInformationFactory.create(),
                     transactionCommitProcess, transactionMonitor, persistenceCache, storeLayer,
                     legacyIndexTransactionState, Clock.SYSTEM_CLOCK )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -82,21 +82,9 @@ public class TransactionRecordState
     private long lastCommittedTxWhenTransactionStarted;
     private boolean prepared;
 
-    /**
-     * @param lastCommittedTxWhenTransactionStarted is the highest committed transaction id when this transaction
-     *                                              begun. No operations in this transaction are allowed to have
-     *                                              taken place before that transaction id. This is used by
-     *                                              constraint validation - if a constraint was not online when this
-     *                                              transaction begun, it will be verified during prepare. If you are
-     *                                              writing code against this API and are unsure about what to set
-     *                                              this value to, 0 is a safe choice. That will ensure all
-     *                                              constraints are checked.
-     */
-    public TransactionRecordState( long lastCommittedTxWhenTransactionStarted,
-                         NeoStore neoStore, IntegrityValidator integrityValidator,
+    public TransactionRecordState( NeoStore neoStore, IntegrityValidator integrityValidator,
                          NeoStoreTransactionContext context )
     {
-        this.lastCommittedTxWhenTransactionStarted = lastCommittedTxWhenTransactionStarted;
         this.neoStore = neoStore;
         this.integrityValidator = integrityValidator;
         this.context = context;
@@ -104,6 +92,15 @@ public class TransactionRecordState
 
     /**
      * Set this record state to a pristine state, acting as if it had never been used.
+     *
+     * @param lastCommittedTxWhenTransactionStarted is the highest committed transaction id when this transaction
+     *                                       begun. No operations in this transaction are allowed to have
+     *                                       taken place before that transaction id. This is used by
+     *                                       constraint validation - if a constraint was not online when this
+     *                                       transaction begun, it will be verified during prepare. If you are
+     *                                       writing code against this API and are unsure about what to set
+     *                                       this value to, 0 is a safe choice. That will ensure all
+     *                                       constraints are checked.
      */
     public void initialize( long lastCommittedTxWhenTransactionStarted )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
  */
 public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
 {
-    private long highestGapFreeNumber;
+    private volatile long highestGapFreeNumber;
     private final SortedArray outOfOrderQueue;
 
     public ArrayQueueOutOfOrderSequence( long startingNumber, int initialArraySize )
@@ -50,7 +50,7 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
     }
 
     @Override
-    public synchronized long get()
+    public long get()
     {
         return highestGapFreeNumber;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -1467,7 +1467,7 @@ public class NeoStoreTransactionTest
         NeoStoreTransactionContext context =
                 new NeoStoreTransactionContext( mock( NeoStoreTransactionContextSupplier.class ), neoStore );
         context.bind( mock( Locks.Client.class ) );
-        TransactionRecordState result = new TransactionRecordState( 0l, neoStore,
+        TransactionRecordState result = new TransactionRecordState( neoStore,
                 new IntegrityValidator( neoStore, indexing ), context );
 
         return Pair.of( result, context );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -180,7 +180,7 @@ public class TransactionRecordStateTest
 
     private TransactionRecordState recordState( NeoStore store, NeoStoreTransactionContext context )
     {
-        return new TransactionRecordState( 1, store,
+        return new TransactionRecordState( store,
                 new IntegrityValidator( store, mock( IndexingService.class ) ), context );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
@@ -47,13 +47,9 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.command.Command;
-import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
-import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreTransactionContext;
-import org.neo4j.kernel.impl.transaction.state.RecordChanges;
-import org.neo4j.kernel.impl.transaction.state.TransactionRecordState;
 import org.neo4j.kernel.impl.transaction.state.RecordChanges.RecordChange;
 
 import static org.junit.Assert.assertFalse;
@@ -146,10 +142,7 @@ public class WriteTransactionCommandOrderingTest
         when( relationshipGroupChanges.changes() ).thenReturn( Collections.<RecordChanges.RecordChange<Long,RelationshipGroupRecord,Integer>>emptyList() );
         when( schemaRuleChanges.changes() ).thenReturn( Collections.<RecordChanges.RecordChange<Long,Collection<DynamicRecord>,SchemaRule>>emptyList() );
 
-
-
-
-        return new TransactionRecordState( 1, mock( NeoStore.class), mock( IntegrityValidator.class), context );
+        return new TransactionRecordState( mock( NeoStore.class), mock( IntegrityValidator.class), context );
 
 //
 //        Command.PropertyCommand updatedProp = new Command.PropertyCommand();


### PR DESCRIPTION
by removing synchronized on the method and letting the member variable
containing the high id by volatile.
