### PR TITLE
[2.1] Tweak for number of files opened by Lucene

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
-
 import org.neo4j.index.impl.lucene.LuceneDataSource;
 import org.neo4j.index.impl.lucene.MultipleBackupDeletionPolicy;
 
@@ -42,6 +42,14 @@ public class IndexWriterFactories
                 writerConfig.setMaxBufferedDocs( 100000 ); // TODO figure out depending on environment?
                 writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
                 writerConfig.setTermIndexInterval( 14 );
+
+                LogByteSizeMergePolicy mergePolicy = new LogByteSizeMergePolicy();
+                mergePolicy.setUseCompoundFile( true );
+                mergePolicy.setNoCFSRatio( 1.0 );
+                mergePolicy.setMinMergeMB( 0.1 );
+                mergePolicy.setMergeFactor( 2 );
+                writerConfig.setMergePolicy( mergePolicy );
+
                 return new IndexWriter( directory, writerConfig );
             }
         };

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
@@ -198,8 +198,10 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         }
 
         @Override
-        public void close() throws IOException, IndexEntryConflictException
+        public synchronized void close() throws IOException, IndexEntryConflictException
         {
+            // This method should be synchronized because we need every thread to perform actual refresh
+            // and not just skip it because some other refresh is in progress
             searcherManager.maybeRefresh();
         }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
@@ -56,17 +56,9 @@ public class LuceneIndexIT
         accessor.force();
 
         // When & Then
-        try(ResourceIterator<File> snapshot = accessor.snapshotFiles())
+        try ( ResourceIterator<File> snapshot = accessor.snapshotFiles() )
         {
-            assertThat( asUniqueSetOfNames( snapshot ), equalTo( asSet(
-                    "_0.nrm",
-                    "_0.tis",
-                    "_0.fnm",
-                    "_0.tii",
-                    "segments_1",
-                    "_0.frq",
-                    "_0.fdx",
-                    "_0.fdt" ) ) );
+            assertThat( asUniqueSetOfNames( snapshot ), equalTo( asSet( "_0.cfs", "segments_1" ) ) );
         }
     }
 


### PR DESCRIPTION
Added explicit merge policy to lucene index writers. This policy tries to be very conservative about number of opened files.
