### PR TITLE
[2.2] Yield instead of parking for a fixed time while waiting for force after append.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
@@ -108,18 +108,17 @@ public class BatchingPhysicalTransactionAppender extends AbstractPhysicalTransac
     {
         LockSupport.unpark( forceThread );
 
-        // Stay a while and listen... while:
-        while (  // the forcer hasn't yet caught up with me
-                 (ticket > forceTicket.get() ||
-                 // OR I've wrapped around Long.MAX_VALUE
-                 !haveSameSign( ticket, forceTicket.get() )) &&
-
-                 // AND this appender hasn't yet been shut down
-                 !shutDown &&
-                 // AND the forcer is of good health
-                 forceThread.checkHealth() )
+        // Stay while...
+        while ( // the forcer is of good health
+                forceThread.checkHealth() &&
+                // AND this appender hasn't yet been shut down
+                !shutDown && // AND
+                // EITHER the forcer has caught up with me
+                (ticket > forceTicket.get() ||
+                // OR I've wrapped around Long.MAX_VALUE
+                !haveSameSign( ticket, forceTicket.get())) )
         {
-            LockSupport.parkNanos( 100_000 ); // 0,1 ms
+            Thread.yield();
         }
     }
 


### PR DESCRIPTION
This was profiled on my MBP using a simple "repeated small write transactions from multiple threads" test and it spends upwards 25% less time in this function. I get the same improvement using a 0,01 ms park instead of 0,1 ms. I think that yielding more truthfully expresses the desired behaviour and can scale better.

I also changed the order of the checks in the while-loop putting the real thing we are waiting for as late as possible which might have a minor concurrency benefit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/neo4j/neo4j/3286)

<!-- Reviewable:end -->
