### PR TITLE
[2.2] Ensures that Relationship commands in upgraded logs have proper first in chain flags

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriter.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.storemigration.legacylogs;
 
+import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogVersion;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,6 +30,8 @@ import java.util.List;
 import org.neo4j.function.Function;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.CommandWriter;
 import org.neo4j.kernel.impl.transaction.log.IOCursor;
@@ -43,9 +48,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriterv1;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter;
-
-import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogVersion;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 class LegacyLogEntryWriter
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV0_20.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV0_20.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.kernel.impl.transaction.command;
 
+import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.COLLECTION_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
+import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_INDEX_DYNAMIC_RECORD_ADDER;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -41,13 +48,6 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.DynamicRecordAdder;
 import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
-
-import static org.neo4j.helpers.Exceptions.launderedException;
-import static org.neo4j.helpers.collection.IteratorUtil.first;
-import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.COLLECTION_DYNAMIC_RECORD_ADDER;
-import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
-import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
-import static org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.PROPERTY_INDEX_DYNAMIC_RECORD_ADDER;
 
 public class PhysicalLogNeoCommandReaderV0_20 implements CommandReader
 {
@@ -180,6 +180,18 @@ public class PhysicalLogNeoCommandReaderV0_20 implements CommandReader
                 record.setSecondPrevRel( channel.getLong() );
                 record.setSecondNextRel( channel.getLong() );
                 record.setNextProp( channel.getLong() );
+
+                /*
+                 * Logs for version 2.0 do not contain the proper values for the following two flags. Also,
+                 * the defaults won't do, because the pointers for prev in the fist record will not be interpreted
+                 * properly. So we need to set the flags explicitly here.
+                 *
+                 * Note that this leaves the prev field for the first record in the chain having a value of -1,
+                 * which is not correct, as it should contain the relationship count instead. However, we cannot
+                 * determine this value from the contents of the log alone.
+                 */
+                record.setFirstInFirstChain( record.getFirstPrevRel() == Record.NO_PREV_RELATIONSHIP.intValue() );
+                record.setFirstInSecondChain( record.getSecondPrevRel() == Record.NO_PREV_RELATIONSHIP.intValue() );
             }
             else
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriterTest.java
@@ -19,12 +19,22 @@
  */
 package org.neo4j.kernel.impl.storemigration.legacylogs;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogFilename;
+import static org.neo4j.kernel.impl.transaction.log.LogPosition.UNSPECIFIED;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.EMPTY_ADDITIONAL_ARRAY;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
 import org.junit.Test;
-
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -41,17 +51,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogFilename;
-import static org.neo4j.kernel.impl.transaction.log.LogPosition.UNSPECIFIED;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.EMPTY_ADDITIONAL_ARRAY;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 public class LegacyLogEntryWriterTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalNeoCommandReaderV0_19Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalNeoCommandReaderV0_19Test.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.command;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+
+public class PhysicalNeoCommandReaderV0_19Test
+{
+    @Test
+    public void testReturnsRelationshipCommandsWithProperFirstInChainFlags() throws Exception
+    {
+        PhysicalLogNeoCommandReaderV0_19 reader = new PhysicalLogNeoCommandReaderV0_19();
+
+        RelationshipRecord writtenRecord = new RelationshipRecord( 1, 2, 3, 4 );
+        writtenRecord.setInUse( true );
+        writtenRecord.setSecondPrevRel( 3 );
+        writtenRecord.setFirstPrevRel( Record.NO_PREV_RELATIONSHIP.intValue() );
+        writtenRecord.setFirstInSecondChain( false ); // this is for OCD reasons, doesn't affect test
+        ReadableLogChannel mockChannel = mock( ReadableLogChannel.class );
+        when( mockChannel.get() ).thenReturn( NeoCommandType.REL_COMMAND ).thenReturn( (byte) 1 );
+        when( mockChannel.getLong() )
+                .thenReturn( writtenRecord.getId() )
+                .thenReturn( writtenRecord.getFirstNode() )
+                .thenReturn( writtenRecord.getSecondNode() )
+                .thenReturn( writtenRecord.getFirstPrevRel() )
+                .thenReturn( writtenRecord.getFirstNextRel() )
+                .thenReturn( writtenRecord.getSecondPrevRel() )
+                .thenReturn( writtenRecord.getSecondNextRel() )
+                .thenReturn( writtenRecord.getNextProp() )
+                ;
+        when( mockChannel.getInt() ).thenReturn( writtenRecord.getType() );
+
+        Command result = reader.read( mockChannel );
+
+        assertTrue( result instanceof Command.RelationshipCommand );
+
+        Command.RelationshipCommand relCommand = (Command.RelationshipCommand) result;
+        RelationshipRecord readRecord = relCommand.getRecord();
+        assertTrue( readRecord.isFirstInFirstChain() );
+        assertFalse( readRecord.isFirstInSecondChain() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalNeoCommandReaderV0_20Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalNeoCommandReaderV0_20Test.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.command;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+
+public class PhysicalNeoCommandReaderV0_20Test
+{
+    @Test
+    public void testReturnsRelationshipCommandsWithProperFirstInChainFlags() throws Exception
+    {
+        PhysicalLogNeoCommandReaderV0_20 reader = new PhysicalLogNeoCommandReaderV0_20();
+
+        RelationshipRecord writtenRecord = new RelationshipRecord( 1, 2, 3, 4 );
+        writtenRecord.setInUse( true );
+        writtenRecord.setSecondPrevRel( 3 );
+        writtenRecord.setFirstPrevRel( Record.NO_PREV_RELATIONSHIP.intValue() );
+        writtenRecord.setFirstInSecondChain( false ); // this is for OCD reasons, doesn't affect test
+        ReadableLogChannel mockChannel = mock( ReadableLogChannel.class );
+        when( mockChannel.get() ).thenReturn( NeoCommandType.REL_COMMAND ).thenReturn( (byte) 1 );
+        when( mockChannel.getLong() )
+                .thenReturn( writtenRecord.getId() )
+                .thenReturn( writtenRecord.getFirstNode() )
+                .thenReturn( writtenRecord.getSecondNode() )
+                .thenReturn( writtenRecord.getFirstPrevRel() )
+                .thenReturn( writtenRecord.getFirstNextRel() )
+                .thenReturn( writtenRecord.getSecondPrevRel() )
+                .thenReturn( writtenRecord.getSecondNextRel() )
+                .thenReturn( writtenRecord.getNextProp() )
+                ;
+        when( mockChannel.getInt() ).thenReturn( writtenRecord.getType() );
+
+        Command result = reader.read( mockChannel );
+
+        assertTrue( result instanceof Command.RelationshipCommand );
+
+        Command.RelationshipCommand relCommand = (Command.RelationshipCommand) result;
+        RelationshipRecord readRecord = relCommand.getRecord();
+        assertTrue( readRecord.isFirstInFirstChain() );
+        assertFalse( readRecord.isFirstInSecondChain() );
+    }
+}


### PR DESCRIPTION
Previously upgraded logs would simply copy over relationships commands, leaving
 default values for the firstInFirstChain and firstInSecondChain fields. This
 could result in pointer chasing errors if these transactions were applied to an
 otherwise properly upgraded store, a scenario that comes up in backup. In
 particular, backup will copy the store and then the upgraded transactions,
 which would update the relevant relationship records to have
 wrong values for those flags, affecting pointer following.
 This commit checks if the currently transferred LogEntry holds
 a RelationshipCommand and if so it sets up the first in chain flags
 properly.
This approach, while improving on the problem, does not completely solve it.
 While the pointers will be interpreted correctly, the first record in a
 relationship chain will still have its previous pointer set to -1, which
 will overwrite the current value that represents the relationship count
 for this chain. This issue affects backups that are created
 immediately after an upgrade from 1.9 or 2.0.
