### PR TITLE
[2.2] Make the page cache cope well with AsynchronousCloseExceptions

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/Page.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/Page.java
@@ -119,6 +119,8 @@ public interface Page
      *                     For instance, if the file has been closed, moved or deleted,
      *                     or if the requested range of data goes beyond the length of the file.
      *                     The possible causes of an IOException is platform dependent.
+     *                     If the channel has been closed, then it must be
+     *                     reopened and the swapIn operation must be retried.
      */
     void swapIn( StoreChannel channel, long offset, int length ) throws IOException;
 
@@ -141,6 +143,8 @@ public interface Page
      *                     For instance, if the storage device is out of space,
      *                     or the file has been moved or deleted.
      *                     The possible causes of an IOException is platform dependent.
+     *                     If the channel has been closed, then it must be
+     *                     reopened and the swapIn operation must be retried.
      */
     void swapOut( StoreChannel channel, long offset, int length ) throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -35,6 +35,11 @@ public interface PageSwapper
      *
      * This should be implemented using the
      * {@link Page#swapIn(org.neo4j.io.fs.StoreChannel, long, int)} method.
+     *
+     * Note: It is possible for the channel to be asynchronously closed while
+     * this operation is taking place. For instance, if the current thread is
+     * interrupted. If this happens, then the implementation must reopen the
+     * channel and the operation must be retried.
      */
     void read( long filePageId, Page page ) throws IOException;
 
@@ -44,6 +49,11 @@ public interface PageSwapper
      *
      * This should be implemented using the
      * {@link Page#swapOut(org.neo4j.io.fs.StoreChannel, long, int)} method.
+     *
+     * Note: It is possible for the channel to be asynchronously closed while
+     * this operation is taking place. For instance, if the current thread is
+     * interrupted. If this happens, then implementation must reopen the
+     * channel and the operation must be retried.
      */
     void write( long filePageId, Page page ) throws IOException;
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -25,6 +25,7 @@ import static org.neo4j.io.pagecache.impl.muninn.UnsafeUtil.storeByteOrderIsNati
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.Page;
@@ -324,6 +325,10 @@ final class MuninnPage extends StampedLock implements Page
             {
                 bufferProxy.put( (byte) 0 );
             }
+        }
+        catch ( ClosedChannelException e )
+        {
+            throw e;
         }
         catch ( Exception e )
         {

--- a/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionInterruptionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionInterruptionTest.java
@@ -19,10 +19,16 @@
  */
 package org.neo4j.io.fs;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 
@@ -32,12 +38,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.test.TargetDirectory;
-
-import static org.junit.Assert.assertTrue;
 
 @RunWith( Parameterized.class )
 public class FileSystemAbstractionInterruptionTest
@@ -93,125 +96,153 @@ public class FileSystemAbstractionInterruptionTest
         fs.mkdirs( testdir.directory() );
         file = testdir.file( "a" );
         fs.create( file ).close();
+        channel = null;
+        channelShouldBeClosed = false;
     }
 
+    private StoreChannel channel;
+    private boolean channelShouldBeClosed;
+
     @After
-    public void verifyInterruptionFlagStillRaised()
+    public void verifyInterruptionAndChannelState() throws IOException
     {
         assertTrue( Thread.interrupted() );
+        assertThat( "channelShouldBeClosed? " + channelShouldBeClosed,
+                channel.isOpen(),
+                is( !channelShouldBeClosed ) );
+
+        if ( channelShouldBeClosed )
+        {
+            try
+            {
+                channel.force( true );
+                fail( "Operating on a closed channel should fail" );
+            }
+            catch ( ClosedChannelException expected )
+            {
+                // This is good. What we expect to see.
+            }
+        }
+    }
+
+    private StoreChannel chan( boolean channelShouldBeClosed ) throws IOException
+    {
+        this.channelShouldBeClosed = channelShouldBeClosed;
+        channel = fs.open( file, "rw" );
+        return channel;
     }
 
     @Test
     public void fs_openClose() throws IOException
     {
-        fs.open( file, "rw" ).close();
+        chan( true ).close();
     }
 
     @Test
     public void fs_tryLock() throws IOException
     {
-        fs.tryLock( file, fs.open( file, "rw" ) ).release();
+        fs.tryLock( file, chan( false ) ).release();
     }
 
     @Test
     public void ch_tryLock() throws IOException
     {
-        fs.open( file, "rw" ).tryLock().release();
+        chan( false ).tryLock().release();
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_setPosition() throws IOException
     {
-        fs.open( file, "rw" ).position( 0 );
+        chan( true ).position( 0 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_getPosition() throws IOException
     {
-        fs.open( file, "rw" ).position();
+        chan( true ).position();
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_truncate() throws IOException
     {
-        fs.open( file, "rw" ).truncate( 0 );
+        chan( true ).truncate( 0 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_force() throws IOException
     {
-        fs.open( file, "rw" ).force( true );
+        chan( true ).force( true );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_writeAll_ByteBuffer() throws IOException
     {
-        fs.open( file, "rw" ).writeAll( ByteBuffer.allocate( 1 ) );
+        chan( true ).writeAll( ByteBuffer.allocate( 1 ) );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_writeAll_ByteBuffer_position() throws IOException
     {
-        fs.open( file, "rw" ).writeAll( ByteBuffer.allocate( 1 ), 1 );
+        chan( true ).writeAll( ByteBuffer.allocate( 1 ), 1 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_write_ByteBuffer_position() throws IOException
     {
-        fs.open( file, "rw" ).write( ByteBuffer.allocate( 1 ), 1 );
+        chan( true ).write( ByteBuffer.allocate( 1 ), 1 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_map() throws IOException
     {
-        fs.open( file, "rw" ).map( FileChannel.MapMode.READ_ONLY, 0, 10 );
+        chan( true ).map( FileChannel.MapMode.READ_ONLY, 0, 10 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_read_ByteBuffer() throws IOException
     {
-        fs.open( file, "rw" ).read( ByteBuffer.allocate( 1 ) );
+        chan( true ).read( ByteBuffer.allocate( 1 ) );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_write_ByteBuffer() throws IOException
     {
-        fs.open( file, "rw" ).write( ByteBuffer.allocate( 1 ) );
+        chan( true ).write( ByteBuffer.allocate( 1 ) );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_size() throws IOException
     {
-        fs.open( file, "rw" ).size();
+        chan( true ).size();
     }
 
     @Test
     public void ch_isOpen() throws IOException
     {
-        fs.open( file, "rw" ).isOpen();
+        chan( false ).isOpen();
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_write_ByteBuffers_offset_length() throws IOException
     {
-        fs.open( file, "rw" ).write( new ByteBuffer[]{ ByteBuffer.allocate( 1 ) }, 0, 1 );
+        chan( true ).write( new ByteBuffer[]{ByteBuffer.allocate( 1 )}, 0, 1 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_write_ByteBuffers() throws IOException
     {
-        fs.open( file, "rw" ).write( new ByteBuffer[]{ ByteBuffer.allocate( 1 ) } );
+        chan( true ).write( new ByteBuffer[]{ByteBuffer.allocate( 1 )} );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_read_ByteBuffers_offset_length() throws IOException
     {
-        fs.open( file, "rw" ).read( new ByteBuffer[]{ ByteBuffer.allocate( 1 ) }, 0, 1 );
+        chan( true ).read( new ByteBuffer[]{ByteBuffer.allocate( 1 )}, 0, 1 );
     }
 
     @Test(expected = ClosedByInterruptException.class)
     public void ch_read_ByteBuffers() throws IOException
     {
-        fs.open( file, "rw" ).read( new ByteBuffer[]{ ByteBuffer.allocate( 1 ) } );
+        chan( true ).read( new ByteBuffer[]{ByteBuffer.allocate( 1 )} );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -3418,7 +3418,6 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
                 try
                 {
                     cursor.next( 0 );
-                    fail( "Page fault did not throw as expected" );
                 }
                 catch ( IOException ignored )
                 {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
@@ -19,14 +19,17 @@
  */
 package org.neo4j.io.pagecache;
 
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.channels.ClosedByInterruptException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -37,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
 
 @RunWith( Parameterized.class )
@@ -103,7 +107,7 @@ public abstract class PageSwappingTest
     }
 
     @Test
-    public void swappingOutMustEitherThrowOrNotSwallowInterrupts() throws IOException
+    public void swappingOutMustNotSwallowInterrupts() throws IOException
     {
         File file = new File( "a" );
         fs.create( file ).close();
@@ -117,16 +121,152 @@ public abstract class PageSwappingTest
         try
         {
             swapper.write( 0, page );
-            System.out.println("poke");
             assertTrue( Thread.currentThread().isInterrupted() );
         }
-        catch ( ClosedByInterruptException exception )
+        finally
         {
-            assertThat( exception, instanceOf( ClosedByInterruptException.class ) );
+            unlockWrite( page, stamp );
+        }
+    }
 
-            // Unlike with InterruptedException, the ClosedByInterruptException
-            // does not imply clearing the interrupted status flag
-            assertTrue( Thread.currentThread().isInterrupted() );
+    @Test
+    public void mustReopenChannelWhenReadFailsWithAsynchronousCloseException() throws IOException
+    {
+        long x = ThreadLocalRandom.current().nextLong();
+        long y = ThreadLocalRandom.current().nextLong();
+        int z = ThreadLocalRandom.current().nextInt();
+
+        int pageSize = 20;
+        Page page = createPage( pageSize );
+        File file = new File( "a" );
+        StoreChannel channel = fs.create( file );
+        ByteBuffer buf = ByteBuffer.allocate( pageSize );
+        buf.putLong( x );
+        buf.putLong( y );
+        buf.putInt( z );
+        buf.flip();
+        channel.writeAll( buf );
+        channel.close();
+
+        PageSwapper swapper = swapperFactory.createPageSwapper( file, pageSize, NO_CALLBACK );
+
+        Thread.currentThread().interrupt();
+
+        long stamp = writeLock( page );
+        try
+        {
+            swapper.read( 0, page );
+        }
+        finally
+        {
+            unlockWrite( page, stamp );
+        }
+
+        // Clear the interrupted flag and assert that it was still raised
+        assertTrue( Thread.interrupted() );
+
+        assertThat( page.getLong( 0 ), is( x ) );
+        assertThat( page.getLong( 8 ), is( y ) );
+        assertThat( page.getInt( 16 ), is( z ) );
+
+        // This must not throw because we should still have a usable channel
+        swapper.force();
+    }
+
+    @Test
+    public void mustReopenChannelWhenWriteFailsWithAsynchronousCloseException() throws IOException
+    {
+        long x = ThreadLocalRandom.current().nextLong();
+        long y = ThreadLocalRandom.current().nextLong();
+        int z = ThreadLocalRandom.current().nextInt();
+
+        int pageSize = 20;
+        Page page = createPage( pageSize );
+        page.putLong( x, 0 );
+        page.putLong( y, 8 );
+        page.putInt( z, 16 );
+        File file = new File( "a" );
+        fs.create( file ).close();
+
+        PageSwapper swapper = swapperFactory.createPageSwapper( file, pageSize, NO_CALLBACK );
+
+        Thread.currentThread().interrupt();
+
+        long stamp = writeLock( page );
+        try
+        {
+            swapper.write( 0, page );
+        }
+        finally
+        {
+            unlockWrite( page, stamp );
+        }
+
+        // Clear the interrupted flag and assert that it was still raised
+        assertTrue( Thread.interrupted() );
+
+        // This must not throw because we should still have a usable channel
+        swapper.force();
+
+        ByteBuffer buf = ByteBuffer.allocate( pageSize );
+        StoreChannel channel = fs.open( file, "r" );
+        int bytesRead = channel.read( buf );
+        channel.close();
+        assertThat( bytesRead, is( pageSize ) );
+        buf.flip();
+        assertThat( buf.getLong(), is( x ) );
+        assertThat( buf.getLong(), is( y ) );
+        assertThat( buf.getInt(), is( z ) );
+    }
+
+    @Test
+    public void readMustNotReopenExplicitlyClosedChannel() throws IOException
+    {
+        File file = new File( "a" );
+        StoreChannel channel = fs.create( file );
+        ByteBuffer buf = ByteBuffer.allocate( 20 );
+        channel.writeAll( buf );
+        channel.close();
+
+        Page page = createPage( 20 );
+        PageSwapper swapper = swapperFactory.createPageSwapper( file, 20, NO_CALLBACK );
+        swapper.close();
+
+        long stamp = writeLock( page );
+        try
+        {
+            swapper.read( 0, page );
+            fail( "Should have thrown because the channel should be closed" );
+        }
+        catch ( ClosedChannelException ignore )
+        {
+            // This is fine.
+        }
+        finally
+        {
+            unlockWrite( page, stamp );
+        }
+    }
+
+    @Test
+    public void writeMustNotReopenExplicitlyClosedChannel() throws IOException
+    {
+        File file = new File( "a" );
+        fs.create( file ).close();
+
+        Page page = createPage( 20 );
+        PageSwapper swapper = swapperFactory.createPageSwapper( file, 20, NO_CALLBACK );
+        swapper.close();
+
+        long stamp = writeLock( page );
+        try
+        {
+            swapper.write( 0, page );
+            fail( "Should have thrown because the channel should be closed" );
+        }
+        catch ( ClosedChannelException ignore )
+        {
+            // This is fine.
         }
         finally
         {


### PR DESCRIPTION
It was possible for a stray interrupt to hit the page cache while in the middle
of a page fault. Such interrupts can cause the victim FileChannel to be closed,
leaving the page cache with a closed StoreChannel without its consent. This can
then cause further complications later on, because PagedFiles are flushed
before they are closed, and so the flushing can throw a ClosedChannelException
and in the end prevent the page cache from being able to shut down.

We now handle this much better, by making sure that the PageSwappers reopen
their StoreChannels whenever one the swapIn or swapOut methods throws a
ClosedChannelException. That is, unless the PageSwapper has been explicitly
closed.
