### PR TITLE
[2.0] TxManager used to commit/rollback transactions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/TopLevelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/TopLevelTransaction.java
@@ -70,6 +70,7 @@ public class TopLevelTransaction implements Transaction
     private final AbstractTransactionManager transactionManager;
     protected final TransactionOutcome transactionOutcome = new TransactionOutcome();
     private final TransactionState state;
+    private boolean closed;
 
     public TopLevelTransaction( PersistenceManager persistenceManager, AbstractTransactionManager transactionManager,
             TransactionState state )
@@ -110,23 +111,23 @@ public class TopLevelTransaction implements Transaction
     {
         close();
     }
-    
+
     @Override
     public void close()
     {
+        if ( closed )
+        {
+            return;
+        }
         try
         {
-            javax.transaction.Transaction transaction = transactionManager.getTransaction();
-            if ( transaction != null )
+            if ( transactionOutcome.canCommit() )
             {
-                if ( transactionOutcome.canCommit()  )
-                {
-                    transaction.commit();
-                }
-                else
-                {
-                    transaction.rollback();
-                }
+                transactionManager.commit();
+            }
+            else
+            {
+                transactionManager.rollback();
             }
         }
         catch ( RollbackException e )
@@ -144,8 +145,12 @@ public class TopLevelTransaction implements Transaction
                 throw new TransactionFailureException( "Unable to rollback transaction", e );
             }
         }
+        finally
+        {
+            closed = true;
+        }
     }
-    
+
     @Override
     public Lock acquireWriteLock( PropertyContainer entity )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TxManager.java
@@ -622,7 +622,7 @@ public class TxManager extends AbstractTransactionManager implements Lifecycle
         TransactionImpl tx = txThreadMap.get();
         if ( tx == null )
         {
-            throw logAndReturn( "TM error tx commit",
+            throw logAndReturn( "TM error tx rollback",
                     new IllegalStateException( "Not in transaction. Thread: " + Thread.currentThread() ) );
         }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import javax.transaction.SystemException;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.transaction.LockManager;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.Exceptions.rootCause;
+
+public class GraphDatabaseShutdownTest
+{
+    @Test
+    public void transactionShouldReleaseLocksWhenGraphDbIsBeingShutdown() throws Exception
+    {
+        // GIVEN
+        final GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final LockManager lockManager = db.getDependencyResolver().resolveDependency( LockManager.class );
+        assertThat( lockManager.getAllLocks(), empty() );
+        Exception exceptionThrownByTxClose = null;
+
+        // WHEN
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            assertThat( lockManager.getAllLocks(), hasSize( 1 ) );
+
+            db.shutdown();
+
+            db.createNode();
+            tx.success();
+        }
+        catch ( Exception e )
+        {
+            exceptionThrownByTxClose = e;
+        }
+
+        // THEN
+        assertThat( exceptionThrownByTxClose, instanceOf( DatabaseShutdownException.class ) );
+        assertFalse( db.isAvailable( 1 ) );
+        assertThat( lockManager.getAllLocks(), empty() );
+    }
+
+    @Test
+    public void shouldBeAbleToShutdownWhenThereAreTransactionsWaitingForLocks() throws Exception
+    {
+        // GIVEN
+        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+
+        final Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            tx.success();
+        }
+
+        final CountDownLatch nodeLockedLatch = new CountDownLatch( 1 );
+
+        // WHEN
+        // one thread locks previously create node and initiates graph db shutdown
+        newSingleThreadExecutor().submit( new Callable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    node.addLabel( label( "ABC" ) );
+                    nodeLockedLatch.countDown();
+                    Thread.sleep( 1_000 ); // Let the second thread attempt to lock same node
+                    db.shutdown();
+                    tx.success();
+                }
+                return null;
+            }
+        } );
+
+        // other thread tries to lock the same node while it has been locked and graph db is being shutdown
+        Future<Void> secondTxResult = newSingleThreadExecutor().submit( new Callable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    nodeLockedLatch.await();
+                    node.addLabel( label( "DEF" ) );
+                    tx.success();
+                }
+                return null;
+            }
+        } );
+
+        // THEN
+        // tx in second thread should fail in reasonable time
+        try
+        {
+            secondTxResult.get( 60, SECONDS );
+        }
+        catch ( Exception e )
+        {
+            assertThat( rootCause( e ), instanceOf( SystemException.class ) );
+        }
+    }
+}

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -159,18 +159,16 @@ public class ShellDocTest
     @Test
     public void testDumpCypherResultSimple() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
         final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db, false );
 
-        try ( Transaction tx = db.beginTx() )
-        {
-            Documenter doc = new Documenter( "simple cypher result dump", server );
-            doc.add( "mknode --cd --np \"{'name':'Neo'}\"", "", "create a new node and go to it" );
-            doc.add( "mkrel -c -d i -t LIKES --np \"{'app':'foobar'}\"", "", "create a relationship" );
-            doc.add( "dump START n=node({self}) MATCH (n)-[r]-(m) return n,r,m;",
-                    "create (_0 {`name`:\"Neo\"})", "Export the cypher statement results" );
-            doc.run();
-        }
+        Documenter doc = new Documenter( "simple cypher result dump", server );
+        doc.add( "mknode --cd --np \"{'name':'Neo'}\"", "", "create a new node and go to it" );
+        doc.add( "mkrel -c -d i -t LIKES --np \"{'app':'foobar'}\"", "", "create a relationship" );
+        doc.add( "dump START n=node({self}) MATCH (n)-[r]-(m) return n,r,m;",
+                "create (_0 {`name`:\"Neo\"})", "Export the cypher statement results" );
+        doc.run();
+
         server.shutdown();
         db.shutdown();
     }


### PR DESCRIPTION
Previously, if transaction was closed during database shutdown and TxManager was already turned off, call to close() failed trying to obtain current transaction and TxManager.rollback was not called. This left not released locks. Other threads were waiting for those locks and did not give database a chance to shutdown.
With this PR TxManager is used directly to close the transaction, so locks are released in finally block.
