### PR TITLE
[2.2] Decrease parking time when waiting for force after append.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
@@ -108,18 +108,17 @@ public class BatchingPhysicalTransactionAppender extends AbstractPhysicalTransac
     {
         LockSupport.unpark( forceThread );
 
-        // Stay a while and listen... while:
-        while (  // the forcer hasn't yet caught up with me
-                 (ticket > forceTicket.get() ||
-                 // OR I've wrapped around Long.MAX_VALUE
-                 !haveSameSign( ticket, forceTicket.get() )) &&
-
-                 // AND this appender hasn't yet been shut down
-                 !shutDown &&
-                 // AND the forcer is of good health
-                 forceThread.checkHealth() )
+        // Stay while...
+        while ( // the forcer is of good health
+                forceThread.checkHealth() &&
+                // AND this appender hasn't yet been shut down
+                !shutDown && // AND
+                // EITHER the forcer has caught up with me
+                (ticket > forceTicket.get() ||
+                // OR I've wrapped around Long.MAX_VALUE
+                !haveSameSign( ticket, forceTicket.get())) )
         {
-            LockSupport.parkNanos( 100_000 ); // 0,1 ms
+            LockSupport.parkNanos( 10_000 ); // 10 us
         }
     }
 


### PR DESCRIPTION
The parking time was reasonably balanced but profiling shows an improvement
with even less parking time. Another approach discussed was that of yielding,
but the conclusion was that this will effectively lead to a busy-wait loop
during idle-times which is not desirable, for example because it will show
100 % execution time even though no useful work is being performed and also
since the two methods were shown to improve things about equally much. This
latter point is however hardware dependent and for sure this parking time
will have to be revisited and adjusted in the future.
