### PR TITLE
Fixed the handling of missing data in plan descriptions.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
@@ -91,11 +91,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite {
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments)
 
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
-        |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |             1 |    ? |      ? |           n |       |
-        |+----------+---------------+------+--------+-------------+-------+
+      """+----------+---------------+-------------+-------+
+        || Operator | EstimatedRows | Identifiers | Other |
+        |+----------+---------------+-------------+-------+
+        ||     NAME |             1 |           n |       |
+        |+----------+---------------+-------------+-------+
         |""".stripMargin)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -244,6 +244,11 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     a.executionPlanDescription().toString should not include "Eager"
   }
 
+  test("should not show  EstimatedRows in legacy profiling") {
+    val result =legacyProfile("create()")
+    result.executionPlanDescription().toString should not include("EstimatedRows")
+  }
+
   private def assertRows(expectedRows: Int)(result: InternalExecutionResult)(names: String*) {
     getPlanDescriptions(result, names).foreach {
       plan => assert(expectedRows === getArgument[Rows](plan).value, s" wrong row count for plan: ${plan.name}")

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -955,7 +955,7 @@ public class TestApps extends AbstractShellTest
     @Test
     public void shouldAllowExplainAsStartForACypherQuery() throws Exception
     {
-        executeCommand( "EXPLAIN OPTIONAL MATCH (n) RETURN n;", "DbHits", "No data returned" );
+        executeCommand( "EXPLAIN OPTIONAL MATCH (n) RETURN n;", "No data returned" );
     }
 
     @Test


### PR DESCRIPTION
```
1. Do not show columns that contain no data at all
2. Use '-' instead of '?' for missing values
```
