### PR TITLE
PhysicalWritableLogChannel reports correct positions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
@@ -61,8 +61,7 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
      */
     private boolean append0( TransactionRepresentation transaction, long transactionId ) throws IOException
     {
-        channel.getCurrentPosition( positionMarker );
-        LogPosition logPosition = positionMarker.newPosition();
+        LogPosition logPosition = channel.getCurrentPosition( positionMarker ).newPosition();
 
         // Reset command writer so that we, after we've written the transaction, can ask it whether or
         // not any legacy index command was written. If so then there's additional ordering to care about below.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
@@ -171,10 +171,11 @@ public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChanne
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker )
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker )
     {
         // Hmm, this would be for the writer.
         positionMarker.mark( 0, asWriter.position() );
+        return positionMarker;
     }
 
     public int positionWriter( int position )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionedStoreChannel.java
@@ -21,6 +21,6 @@ package org.neo4j.kernel.impl.transaction.log;
 
 import org.neo4j.io.fs.StoreChannel;
 
-public interface LogVersionedStoreChannel extends StoreChannel, PositionAwareChannel, VersionableLog
+public interface LogVersionedStoreChannel extends StoreChannel, VersionableLog
 {
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
@@ -181,12 +181,6 @@ public class PhysicalLogVersionedStoreChannel implements LogVersionedStoreChanne
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
-    {
-        positionMarker.mark( version, position() );
-    }
-
-    @Override
     public boolean equals( Object o )
     {
         if ( this == o )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionRepresentation.java
@@ -168,4 +168,22 @@ public class PhysicalTransactionRepresentation implements TransactionRepresentat
         result = 31 * result + (int) (latestCommittedTxWhenStarted ^ (latestCommittedTxWhenStarted >>> 32));
         return result;
     }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder( getClass().getSimpleName() + "[" );
+        builder.append( "masterId:" + masterId + "," );
+        builder.append( "authorId:" + authorId + "," );
+        builder.append( "timeStarted:" + timeStarted + "," );
+        builder.append( "latestCommittedTxWhenStarted:" + latestCommittedTxWhenStarted + "," );
+        builder.append( "timeCommitted:" + timeCommitted + "," );
+        builder.append( "lockSession:" + lockSessionIdentifier + "," );
+        builder.append( "additionalHeader:" + Arrays.toString( additionalHeader ) );
+        for ( Command command : commands )
+        {
+            builder.append( "\n" + command );
+        }
+        return builder.toString();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannel.java
@@ -163,9 +163,10 @@ public class PhysicalWritableLogChannel implements WritableLogChannel
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
     {
-        channel.getCurrentPosition( positionMarker );
+        positionMarker.mark( channel.getVersion(), channel.position() + currentByteBuffer.position() );
+        return positionMarker;
     }
 
     private ByteBuffer bufferWithGuaranteedSpace( int spaceInBytes ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwareChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionAwareChannel.java
@@ -21,9 +21,11 @@ package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
-
+/**
+ * Something that is able to report current position when asked. The supplied {@link LogPositionMarker} is
+ * filled with the details, which later can create a {@link LogPositionMarker#newPosition() new} {@link LogPosition}.
+ */
 public interface PositionAwareChannel
 {
-    void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException;
+    LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
@@ -165,8 +165,9 @@ public class ReadAheadLogChannel implements ReadableVersionableLogChannel
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
     {
         positionMarker.mark( channel.getVersion(), channel.position()-aheadBuffer.remaining() );
+        return positionMarker;
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkReadableLogChannel.java
@@ -128,9 +128,10 @@ public class NetworkReadableLogChannel implements ReadableLogChannel
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
     {
         positionMarker.unspecified();
+        return positionMarker;
     }
 
     @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkWritableLogChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkWritableLogChannel.java
@@ -91,9 +91,10 @@ public class NetworkWritableLogChannel implements WritableLogChannel
     }
 
     @Override
-    public void getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
     {
         positionMarker.unspecified();
+        return positionMarker;
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -182,7 +182,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         life.add( responseUnpacker );
 
         UpdatePuller updatePuller = dependencies.satisfyDependency( life.add(
-                new UpdatePuller( memberStateMachine, requestContextFactory, master, lastUpdateTime, logging ) ) );
+                new UpdatePuller( memberStateMachine, requestContextFactory, master, lastUpdateTime,
+                        logging, serverId ) ) );
         dependencies.satisfyDependency( life.add( new UpdatePullerClient( config.get( HaSettings.pull_interval ),
                 jobScheduler, logging, updatePuller, availabilityGuard ) ) );
         dependencies.satisfyDependency( life.add( new UpdatePullingTransactionObligationFulfiller(

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ConcurrentInstanceStartupIT.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,11 +26,14 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
 import org.junit.Test;
+
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
 
 public class ConcurrentInstanceStartupIT
 {
@@ -99,9 +100,11 @@ public class ConcurrentInstanceStartupIT
                 }
                 masterDone = true;
             }
-            Transaction tx = db.beginTx();
-            db.createNode();
-            tx.success(); tx.finish();
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.createNode();
+                tx.success();
+            }
         }
 
         assertTrue( masterDone );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTest.java
@@ -70,7 +70,7 @@ public class UpdatePullerTest
     private final Logging logging = new DevNullLoggingService();
     private final RequestContextFactory requestContextFactory = mock( RequestContextFactory.class );
     private final UpdatePuller updatePuller = new UpdatePuller( stateMachine, requestContextFactory,
-            master, lastUpdateTime, logging );
+            master, lastUpdateTime, logging, myId );
 
     @Before
     public void setup() throws Throwable


### PR DESCRIPTION
A recent change b549c380817e5be0159698f57743ae10331a6568 changed
transaction appending logic to batch writes to the underlying
StoreChannel, instead of for every append. On slaves in HA which now
applies transactions in batches didn't see any change in log position
until a whole batch had been applied. This had an unexpected effect that
potentially many transactions would be appended with the same position in
its log start entry.

The only actual fix in this commit is that
PhysicalWritableLogChannel#getCurrentPosition() now looks at the
underlying channel AND the buffered data that hasn't been written yet.
