### PR TITLE
Remove buttons flashing when typing in editor.

### DIFF
--- a/community/browser/app/views/partials/editor.jade
+++ b/community/browser/app/views/partials/editor.jade
@@ -2,7 +2,7 @@
   .view-editor(ng-mousedown="focusEditor($event)", ng-controller = "EditorCtrl")
     span(ng-class="{'one-line': editorOneLine, 'disable-highlighting': disableHighlighting}")
       .prompt.code-style $
-      textarea('ui-codemirror'="{theme: 'neo', mode: 'cypher', autofocus: true, lineNumbers: true, lineWrapping: true, onLoad: codemirrorLoaded}",
+      div('ui-codemirror'="{theme: 'neo', mode: 'cypher', autofocus: true, lineNumbers: true, lineWrapping: true, onLoad: codemirrorLoaded}",
         ng-model='editor.content',
         placeholder='{{motd.tip}}'
         )


### PR DESCRIPTION
- Load codemirror in div instead of textarea.

Should go to 2.1 as well. Already in 2.2.
