### PR TITLE
Make sure we only do the record-in-use check on consistent reads

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -566,16 +566,6 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
         return configuration.get( Configuration.store_dir );
     }
 
-    protected void assertIdExists( long position )
-    {
-        if ( (position > getHighId() || !storeOk) )
-        {
-            throw new InvalidRecordException(
-                    "Position[" + position + "] requested for high id[" + getHighId() +
-                    "], store is ok[" + storeOk + "]", causeOfStoreNotOk );
-        }
-    }
-
     /**
      * Returns the name of this store.
      *

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordSerializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueRecordSerializer.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store.kvstore;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.neo4j.io.pagecache.PageCursor;
@@ -27,7 +28,7 @@ public interface KeyValueRecordSerializer<K extends Comparable<K>, VR>
 {
     boolean visitRecord( ByteBuffer buffer, KeyValueRecordVisitor<K, VR> visitor );
 
-    K readRecord( PageCursor cursor, VR valueRegister );
+    K readRecord( PageCursor cursor, int offset, VR valueRegister ) throws IOException;
 
     void writeDefaultValue( VR valueRegister );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/SortedKeyValueStore.java
@@ -116,19 +116,13 @@ public abstract class SortedKeyValueStore<K extends Comparable<K>, VR> implement
         recordSerializer.writeDefaultValue( value );
     }
 
-    private int compareKeyAndReadValue( PageCursor cursor, K target, int record, VR count )
-            throws IOException
+    private int compareKeyAndReadValue( PageCursor cursor, K target, int record, VR count ) throws IOException
     {
         int pageId = (record * RECORD_SIZE) / pages.pageSize();
         int offset = (record * RECORD_SIZE) % pages.pageSize();
         if ( pageId == cursor.getCurrentPageId() || cursor.next( pageId ) )
         {
-            K key;
-            do
-            {
-                cursor.setOffset( offset );
-                key = recordSerializer.readRecord( cursor, count );
-            } while ( cursor.shouldRetry() );
+            K key = recordSerializer.readRecord( cursor, offset, count );
             return target.compareTo( key );
         }
         else

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
@@ -1,0 +1,558 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.PageCacheRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public abstract class RecordStoreConsistentReadTest<R extends AbstractBaseRecord, S extends RecordStore<R>>
+{
+    // Constants for the contents of the existing record
+    protected static final int ID = 1;
+
+    @ClassRule
+    public static final PageCacheRule pageCacheRule = new PageCacheRule( false );
+
+    private FileSystemAbstraction fs;
+    private AtomicBoolean nextReadIsInconsistent;
+
+    @Before
+    public void setUp()
+    {
+        fs = new EphemeralFileSystemAbstraction();
+        nextReadIsInconsistent = new AtomicBoolean();
+    }
+
+    private NeoStore storeFixture()
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fs, new Config() );
+        pageCache = pageCacheRule.withInconsistentReads( pageCache, nextReadIsInconsistent );
+        File storeDir = new File( "stores" );
+        StringLogger logger = StringLogger.DEV_NULL;
+        StoreFactory factory = new StoreFactory( fs, storeDir, pageCache, logger, new Monitors() );
+        NeoStore neoStore = factory.newNeoStore( true );
+        S store = initialiseStore( neoStore );
+
+        CommonAbstractStore commonAbstractStore = (CommonAbstractStore) store;
+        commonAbstractStore.rebuildIdGenerator();
+        return neoStore;
+    }
+
+    protected S initialiseStore( NeoStore neoStore )
+    {
+        S store = getStore( neoStore );
+        store.updateRecord( createExistingRecord( false, false ) );
+        return store;
+    }
+
+    protected abstract S getStore( NeoStore neoStore );
+
+    protected abstract R createNullRecord( long id );
+
+    protected abstract R createExistingRecord( boolean forced, boolean light );
+
+    protected abstract R getLight( long id, S store );
+
+    protected abstract void assertRecordsEqual( R actualRecord, R expectedRecord );
+
+    protected R getHeavy( S store, int id )
+    {
+        return store.getRecord( id );
+    }
+
+    protected R getForce( S store, int id )
+    {
+        return store.forceGetRecord( id );
+    }
+
+    @Test
+    public void mustReadExistingRecord()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            R record = getHeavy( store, ID );
+            assertRecordsEqual( record, createExistingRecord( false, false ) );
+        }
+    }
+
+    @Test
+    public void mustReadExistingLightRecord()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            R record = getLight( ID, store );
+            assertRecordsEqual( record, createExistingRecord( false, true ) );
+        }
+    }
+
+    @Test
+    public void mustForceReadExistingRecord()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            R record = getForce( store, ID );
+            assertRecordsEqual( record, createExistingRecord( true, false ) );
+        }
+    }
+
+    @Test( expected = InvalidRecordException.class )
+    public void readingNonExistingRecordMustThrow()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            getHeavy( store, ID + 1 );
+        }
+    }
+
+    @Test
+    public void readingNonExistingLightRecordMustReturnNull()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            R record = getLight( ID + 1, store );
+            assertNull( record );
+        }
+    }
+
+    @Test
+    public void forceReadingNonExistingRecordMustReturnEmptyRecordWithThatId()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            R record = getForce( store, ID + 1 );
+            R nullRecord = createNullRecord( ID + 1 );
+            assertRecordsEqual( record, nullRecord );
+        }
+    }
+
+    @Test
+    public void mustRetryInconsistentReads()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            nextReadIsInconsistent.set( true );
+            R record = getHeavy( store, ID );
+            assertRecordsEqual( record, createExistingRecord( false, false ) );
+        }
+    }
+
+    @Test
+    public void mustRetryInconsistentLightReads()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            nextReadIsInconsistent.set( true );
+            R record = getLight( ID, store );
+            assertRecordsEqual( record, createExistingRecord( false, true ) );
+        }
+    }
+
+    @Test
+    public void mustRetryInconsistentForcedReads()
+    {
+        try ( NeoStore neoStore = storeFixture() )
+        {
+            S store = getStore( neoStore );
+            nextReadIsInconsistent.set( true );
+            R record = getForce( store, ID );
+            assertRecordsEqual( record, createExistingRecord( true, false ) );
+        }
+    }
+
+    public static class RelationshipStoreConsistentReadTest extends RecordStoreConsistentReadTest<RelationshipRecord, RelationshipStore>
+    {
+        // Constants for the contents of the existing record
+        private static final int FIRST_NODE = 2;
+        private static final int SECOND_NODE = 3;
+        private static final int TYPE = 4;
+        private static final int FIRST_PREV_REL = 5;
+        private static final int FIRST_NEXT_REL = 6;
+        private static final int SECOND_PREV_REL = 7;
+        private static final int SECOND_NEXT_REL = 8;
+
+        @Override
+        protected RelationshipRecord createNullRecord( long id )
+        {
+            RelationshipRecord record = new RelationshipRecord( id, false, 0, 0, 0, 0, 0, 0, 0, false, false );
+            record.setNextProp( 0 );
+            return record;
+        }
+
+        @Override
+        protected RelationshipRecord createExistingRecord( boolean forced, boolean light )
+        {
+            return new RelationshipRecord(
+                    ID, true, FIRST_NODE, SECOND_NODE, TYPE, FIRST_PREV_REL,
+                    FIRST_NEXT_REL, SECOND_PREV_REL, SECOND_NEXT_REL, true, true );
+        }
+
+        @Override
+        protected RelationshipRecord getLight( long id, RelationshipStore store )
+        {
+            return store.getLightRel( id );
+        }
+
+        @Override
+        protected void assertRecordsEqual( RelationshipRecord actualRecord, RelationshipRecord expectedRecord )
+        {
+            assertNotNull( "actualRecord", actualRecord );
+            assertNotNull( "expectedRecord", expectedRecord );
+            assertThat( "getFirstNextRel", actualRecord.getFirstNextRel(), is( expectedRecord.getFirstNextRel() ) );
+            assertThat( "getFirstNode", actualRecord.getFirstNode(), is( expectedRecord.getFirstNode() ) );
+            assertThat( "getFirstPrevRel", actualRecord.getFirstPrevRel(), is( expectedRecord.getFirstPrevRel() ) );
+            assertThat( "getSecondNextRel", actualRecord.getSecondNextRel(), is( expectedRecord.getSecondNextRel() ) );
+            assertThat( "getSecondNode", actualRecord.getSecondNode(), is( expectedRecord.getSecondNode() ) );
+            assertThat( "getSecondPrevRel", actualRecord.getSecondPrevRel(), is( expectedRecord.getSecondPrevRel() ) );
+            assertThat( "getType", actualRecord.getType(), is( expectedRecord.getType() ) );
+            assertThat( "isFirstInFirstChain", actualRecord.isFirstInFirstChain(), is( expectedRecord.isFirstInFirstChain() ) );
+            assertThat( "isFirstInSecondChain", actualRecord.isFirstInSecondChain(), is( expectedRecord.isFirstInSecondChain() ) );
+            assertThat( "getId", actualRecord.getId(), is( expectedRecord.getId() ) );
+            assertThat( "getLongId", actualRecord.getLongId(), is( expectedRecord.getLongId() ) );
+            assertThat( "getNextProp", actualRecord.getNextProp(), is( expectedRecord.getNextProp() ) );
+            assertThat( "inUse", actualRecord.inUse(), is( expectedRecord.inUse() ) );
+        }
+
+        @Override
+        protected RelationshipStore getStore( NeoStore neoStore )
+        {
+            return neoStore.getRelationshipStore();
+        }
+    }
+
+    public static class LabelTokenStoreConsistentReadTest extends RecordStoreConsistentReadTest<LabelTokenRecord, LabelTokenStore>
+    {
+
+        private static final int NAME_RECORD_ID = 2;
+        private static final byte[] NAME_RECORD_DATA = "TheLabel".getBytes( Charset.forName( "UTF-8" ) );
+
+        @Override
+        protected LabelTokenStore getStore( NeoStore neoStore )
+        {
+            return neoStore.getLabelTokenStore();
+        }
+
+        @Override
+        protected LabelTokenStore initialiseStore( NeoStore neoStore )
+        {
+            LabelTokenStore store = getStore( neoStore );
+            LabelTokenRecord record = createExistingRecord( false, false );
+            DynamicRecord nameRecord = new DynamicRecord( NAME_RECORD_ID );
+            record.getNameRecords().clear();
+            nameRecord.setData( NAME_RECORD_DATA );
+            nameRecord.setInUse( true );
+            record.addNameRecord( nameRecord );
+            store.updateRecord( record );
+            return store;
+        }
+
+        @Override
+        protected LabelTokenRecord createNullRecord( long id )
+        {
+            LabelTokenRecord labelTokenRecord = new LabelTokenRecord( (int) id );
+            labelTokenRecord.setIsLight( true );
+            return labelTokenRecord;
+        }
+
+        @Override
+        protected LabelTokenRecord createExistingRecord( boolean forced, boolean light )
+        {
+            LabelTokenRecord record = new LabelTokenRecord( ID );
+            record.setNameId( NAME_RECORD_ID );
+            record.setInUse( true );
+            record.setIsLight( forced );
+            if ( !forced )
+            {
+                DynamicRecord nameRecord = new DynamicRecord( NAME_RECORD_ID );
+                nameRecord.setLength( NAME_RECORD_DATA.length );
+                nameRecord.setInUse( true );
+                record.addNameRecord( nameRecord );
+            }
+            return record;
+        }
+
+        @Override
+        protected LabelTokenRecord getLight( long id, LabelTokenStore store )
+        {
+            throw new AssumptionViolatedException( "No light loading of LabelTokenRecords" );
+        }
+
+        @Override
+        protected void assertRecordsEqual( LabelTokenRecord actualRecord, LabelTokenRecord expectedRecord )
+        {
+            assertNotNull( "actualRecord", actualRecord );
+            assertNotNull( "expectedRecord", expectedRecord );
+            assertThat( "getNameId", actualRecord.getNameId(), is( expectedRecord.getNameId() ) );
+            assertThat( "getId", actualRecord.getId(), is( expectedRecord.getId() ) );
+            assertThat( "getLongId", actualRecord.getLongId(), is( expectedRecord.getLongId() ) );
+            assertThat( "isLight", actualRecord.isLight(), is( expectedRecord.isLight() ) );
+
+            Collection<DynamicRecord> actualNameRecords = actualRecord.getNameRecords();
+            Collection<DynamicRecord> expectedNameRecords = expectedRecord.getNameRecords();
+            assertThat( "getNameRecords.size", actualNameRecords.size(), is( expectedNameRecords.size() ) );
+            Iterator<DynamicRecord> actualNRs = actualNameRecords.iterator();
+            Iterator<DynamicRecord> expectedNRs = expectedNameRecords.iterator();
+            int i = 0;
+            while ( actualNRs.hasNext() && expectedNRs.hasNext() )
+            {
+                DynamicRecord actualNameRecord = actualNRs.next();
+                DynamicRecord expectedNameRecord = expectedNRs.next();
+
+                assertThat( "[" + i + "]getData", actualNameRecord.getData(), is( expectedNameRecord.getData() ) );
+                assertThat( "[" + i + "]getLength", actualNameRecord.getLength(), is( expectedNameRecord.getLength() ) );
+                assertThat( "[" + i + "]getNextBlock", actualNameRecord.getNextBlock(), is( expectedNameRecord.getNextBlock() ) );
+                assertThat( "[" + i + "]getType", actualNameRecord.getType(), is( expectedNameRecord.getType() ) );
+                assertThat( "[" + i + "]getId", actualNameRecord.getId(), is( expectedNameRecord.getId() ) );
+                assertThat( "[" + i + "]getLongId", actualNameRecord.getLongId(), is( expectedNameRecord.getLongId() ) );
+                assertThat( "[" + i + "]isLight", actualNameRecord.isLight(), is( expectedNameRecord.isLight() ) );
+                assertThat( "[" + i + "]isStartRecord", actualNameRecord.isStartRecord(), is( expectedNameRecord.isStartRecord() ) );
+                assertThat( "[" + i + "]inUse", actualNameRecord.inUse(), is( expectedNameRecord.inUse() ) );
+                i++;
+            }
+        }
+    }
+
+    // This one might be good enough to cover all AbstractDynamicStore subclasses,
+    // including DynamicArrayStore and DynamicStringStore.
+    public static class SchemaStoreConsistentReadTest
+            extends RecordStoreConsistentReadTest<DynamicRecord, SchemaStore>
+    {
+        private static final byte[] EXISTING_RECORD_DATA = "Random bytes".getBytes();
+
+        @Override
+        protected SchemaStore getStore( NeoStore neoStore )
+        {
+            return neoStore.getSchemaStore();
+        }
+
+        @Override
+        protected DynamicRecord createNullRecord( long id )
+        {
+            DynamicRecord record = new DynamicRecord( id );
+            record.setNextBlock( 0 );
+            return record;
+        }
+
+        @Override
+        protected DynamicRecord createExistingRecord( boolean forced, boolean light )
+        {
+            DynamicRecord record = new DynamicRecord( ID );
+            record.setInUse( true );
+            record.setStartRecord( true );
+            record.setLength( EXISTING_RECORD_DATA.length );
+            if ( !light )
+            {
+                record.setData( EXISTING_RECORD_DATA );
+            }
+            return record;
+        }
+
+        @Override
+        protected DynamicRecord getLight( long id, SchemaStore store )
+        {
+            throw new AssumptionViolatedException( "Light loading of DynamicRecords is a little different" );
+        }
+
+        @Override
+        protected void assertRecordsEqual( DynamicRecord actualRecord, DynamicRecord expectedRecord )
+        {
+            assertNotNull( "actualRecord", actualRecord );
+            assertNotNull( "expectedRecord", expectedRecord );
+            assertThat( "getData", actualRecord.getData(), is( expectedRecord.getData() ) );
+            assertThat( "getLength", actualRecord.getLength(), is( expectedRecord.getLength() ) );
+            assertThat( "getNextBlock", actualRecord.getNextBlock(), is( expectedRecord.getNextBlock() ) );
+            assertThat( "getType", actualRecord.getType(), is( expectedRecord.getType() ) );
+            assertThat( "getId", actualRecord.getId(), is( expectedRecord.getId() ) );
+            assertThat( "getLongId", actualRecord.getLongId(), is( expectedRecord.getLongId() ) );
+            assertThat( "isLight", actualRecord.isLight(), is( expectedRecord.isLight() ) );
+            assertThat( "isStartRecord", actualRecord.isStartRecord(), is( expectedRecord.isStartRecord() ) );
+        }
+    }
+
+    public static class PropertyStoreConsistentReadTest
+            extends RecordStoreConsistentReadTest<PropertyRecord, PropertyStore>
+    {
+        @Override
+        protected PropertyStore getStore( NeoStore neoStore )
+        {
+            return neoStore.getPropertyStore();
+        }
+
+        @Override
+        protected PropertyRecord createNullRecord( long id )
+        {
+            PropertyRecord record = new PropertyRecord( id );
+            record.setNextProp( 0 );
+            record.setPrevProp( 0 );
+            return record;
+        }
+
+        @Override
+        protected PropertyRecord createExistingRecord( boolean forced, boolean light )
+        {
+            PropertyRecord record = new PropertyRecord( ID );
+            record.setId( ID );
+            record.setNextProp( 2 );
+            record.setPrevProp( 4 );
+            record.setInUse( true );
+            PropertyBlock block = new PropertyBlock();
+            DynamicRecordAllocator stringAllocator = new DynamicRecordAllocator()
+            {
+                @Override
+                public int dataSize()
+                {
+                    return 64;
+                }
+
+                @Override
+                public DynamicRecord nextUsedRecordOrNew( Iterator<DynamicRecord> recordsToUseFirst )
+                {
+                    DynamicRecord record = new DynamicRecord( 7 );
+                    record.setCreated();
+                    record.setInUse( true );
+                    return record;
+                }
+            };
+            String value = "a string too large to fit in the property block itself";
+            PropertyStore.encodeValue( block, 6, value, stringAllocator, null );
+            if ( forced  || light )
+            {
+                block.getValueRecords().clear();
+            }
+            record.setPropertyBlock( block );
+            return record;
+        }
+
+        @Override
+        protected PropertyRecord getLight( long id, PropertyStore store )
+        {
+            throw new AssumptionViolatedException( "Getting a light non-existing property record will throw." );
+        }
+
+        @Override
+        protected PropertyRecord getHeavy( PropertyStore store, int id )
+        {
+            PropertyRecord record = super.getHeavy( store, id );
+            ensureHeavy( store, record );
+            return record;
+        }
+
+        private void ensureHeavy( PropertyStore store, PropertyRecord record )
+        {
+            for ( PropertyBlock propertyBlock : record.getPropertyBlocks() )
+            {
+                store.ensureHeavy( propertyBlock );
+            }
+        }
+
+        @Override
+        protected void assertRecordsEqual( PropertyRecord actualRecord, PropertyRecord expectedRecord )
+        {
+            assertNotNull( "actualRecord", actualRecord );
+            assertNotNull( "expectedRecord", expectedRecord );
+            assertThat( "getDeletedRecords", actualRecord.getDeletedRecords(), is( expectedRecord.getDeletedRecords() ) );
+            assertThat( "getNextProp", actualRecord.getNextProp(), is( expectedRecord.getNextProp() ) );
+            assertThat( "getNodeId", actualRecord.getNodeId(), is( expectedRecord.getNodeId() ) );
+            assertThat( "getPrevProp", actualRecord.getPrevProp(), is( expectedRecord.getPrevProp() ) );
+            assertThat( "getRelId", actualRecord.getRelId(), is( expectedRecord.getRelId() ) );
+            assertThat( "getId", actualRecord.getId(), is( expectedRecord.getId() ) );
+            assertThat( "getLongId", actualRecord.getLongId(), is( expectedRecord.getLongId() ) );
+
+            List<PropertyBlock> actualBlocks = actualRecord.getPropertyBlocks();
+            List<PropertyBlock> expectedBlocks = expectedRecord.getPropertyBlocks();
+            assertThat( "getPropertyBlocks().size", actualBlocks.size(), is( expectedBlocks.size() ) );
+            for ( int i = 0; i < actualBlocks.size(); i++ )
+            {
+                PropertyBlock actualBlock = actualBlocks.get( i );
+                PropertyBlock expectedBlock = expectedBlocks.get( i );
+                assertPropertyBlocksEqual( i, actualBlock, expectedBlock );
+            }
+        }
+
+        private void assertPropertyBlocksEqual( int index, PropertyBlock actualBlock, PropertyBlock expectedBlock )
+        {
+            assertThat( "[" + index + "]getKeyIndexId", actualBlock.getKeyIndexId(),
+                    is( expectedBlock.getKeyIndexId() ) );
+            assertThat( "[" + index + "]getSingleValueBlock", actualBlock.getSingleValueBlock(), is( expectedBlock.getSingleValueBlock() ) );
+            assertThat( "[" + index + "]getSingleValueByte", actualBlock.getSingleValueByte(), is( expectedBlock.getSingleValueByte() ) );
+            assertThat( "[" + index + "]getSingleValueInt", actualBlock.getSingleValueInt(), is( expectedBlock.getSingleValueInt() ) );
+            assertThat( "[" + index + "]getSingleValueLong", actualBlock.getSingleValueLong(), is( expectedBlock.getSingleValueLong() ) );
+            assertThat( "[" + index + "]getSingleValueShort", actualBlock.getSingleValueShort(), is( expectedBlock.getSingleValueShort() ) );
+            assertThat( "[" + index + "]getSize", actualBlock.getSize(), is( expectedBlock.getSize() ) );
+            assertThat( "[" + index + "]getType", actualBlock.getType(), is( expectedBlock.getType() ) );
+            assertThat( "[" + index + "]isLight", actualBlock.isLight(), is( expectedBlock.isLight() ) );
+
+            List<DynamicRecord> actualValueRecords = actualBlock.getValueRecords();
+            List<DynamicRecord> expectedValueRecords = expectedBlock.getValueRecords();
+            assertThat( "[" + index + "]getValueRecords.size",
+                    actualValueRecords.size(), is( expectedValueRecords.size() ) );
+
+            for ( int i = 0; i < actualValueRecords.size(); i++ )
+            {
+                DynamicRecord actualValueRecord = actualValueRecords.get( i );
+                DynamicRecord expectedValueRecord = expectedValueRecords.get( i );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getData", actualValueRecord.getData(), is( expectedValueRecord.getData() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getLength", actualValueRecord.getLength(), is( expectedValueRecord.getLength() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getNextBlock", actualValueRecord.getNextBlock(), is( expectedValueRecord.getNextBlock() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getType", actualValueRecord.getType(), is( expectedValueRecord.getType() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getId", actualValueRecord.getId(), is( expectedValueRecord.getId() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]getLongId", actualValueRecord.getLongId(), is( expectedValueRecord.getLongId() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]isLight", actualValueRecord.isLight(), is( expectedValueRecord.isLight() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]isStartRecord", actualValueRecord.isStartRecord(), is( expectedValueRecord.isStartRecord() ) );
+                assertThat( "[" + index + "]getValueRecords[" + i + "]inUse", actualValueRecord.inUse(), is( expectedValueRecord.inUse() ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,11 +34,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.MapUtil;
@@ -43,9 +43,6 @@ import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.DynamicArrayStore;
-import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.StoreVersionMismatchHandler;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -55,7 +52,6 @@ import org.neo4j.test.PageCacheRule;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 
 public class TestDynamicStore
@@ -218,11 +214,6 @@ public class TestDynamicStore
                 store.updateRecord( record );
             }
             store.close();
-            /*
-             * try { store.allocateRecords( blockId, new byte[10] ); fail(
-             * "Closed store should throw exception" ); } catch (
-             * RuntimeException e ) { // good }
-             */
             try
             {
                 store.getArrayFor( store.getRecords( blockId ) );
@@ -335,45 +326,6 @@ public class TestDynamicStore
             deleteBothFiles();
         }
     }
-
-//    private static class ByteStore extends AbstractDynamicStore
-//    {
-//        // store version, each store ends with this string (byte encoded)
-//        private static final String VERSION = "DynamicTestVersion v0.1";
-//
-//        public ByteStore( String fileName, IdGeneratorFactory idGenerator, String storeDir )
-//        {
-//            super( fileName, MapUtil.map( "neo_store", fileName,
-//                    IdGeneratorFactory.class, idGenerator, "store_dir", storeDir ), IdType.ARRAY_BLOCK );
-//        }
-//
-//        public String getTypeDescriptor()
-//        {
-//            return VERSION;
-//        }
-//
-//        public static ByteStore createStore( String fileName, int blockSize, String storeDir )
-//        {
-//            createEmptyStore( fileName, blockSize, VERSION, ID_GENERATOR_FACTORY,
-//                    IdType.ARRAY_BLOCK );
-//            return new ByteStore( fileName, ID_GENERATOR_FACTORY, storeDir );
-//        }
-//
-//        public byte[] getBytes( long blockId )
-//        {
-//            return null;
-////            return get( blockId );
-//        }
-//
-//        // public char[] getChars( int blockId ) throws IOException
-//        // {
-//        // return getAsChar( blockId );
-//        // }
-//
-////        public void flush()
-////        {
-////        }
-//    }
 
     private byte[] createBytes( int length )
     {

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -19,22 +19,37 @@
  */
 package org.neo4j.test;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
+import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PageSwapperFactory;
+import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.pagecache.LifecycledPageCache;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
-import org.neo4j.kernel.monitoring.Monitors;
 
 public class PageCacheRule extends ExternalResource
 {
     private Neo4jJobScheduler jobScheduler;
     private LifecycledPageCache pageCache;
+    private boolean automaticallyProduceInconsistentReads;
+
+    public PageCacheRule()
+    {
+        automaticallyProduceInconsistentReads = true;
+    }
+
+    public PageCacheRule( boolean automaticallyProduceInconsistentReads )
+    {
+        this.automaticallyProduceInconsistentReads = automaticallyProduceInconsistentReads;
+    }
 
     public PageCache getPageCache( FileSystemAbstraction fs, Config config )
     {
@@ -54,6 +69,11 @@ public class PageCacheRule extends ExternalResource
         pageCache = new LifecycledPageCache(
                 swapperFactory, jobScheduler, config, PageCacheMonitor.NULL );
         pageCache.start();
+
+        if ( automaticallyProduceInconsistentReads )
+        {
+            return withInconsistentReads( pageCache );
+        }
         return pageCache;
     }
 
@@ -80,5 +100,347 @@ public class PageCacheRule extends ExternalResource
             pageCache = null;
         }
         jobScheduler.shutdown();
+    }
+
+    /**
+     * Returns a decorated PageCache where the next page read from a read page cursor will be
+     * inconsistent if the given AtomicBoolean is set to 'true'. The AtomicBoolean is automatically
+     * switched to 'false' when the inconsistent read is performed, to prevent code from looping
+     * forever.
+     */
+    public PageCache withInconsistentReads( PageCache pageCache, AtomicBoolean nextReadIsInconsistent )
+    {
+        InconsistentReadDecision decision = new AtomicInconsistentReadDecision( nextReadIsInconsistent );
+        return new PossiblyInconsistentPageCache( pageCache, decision );
+    }
+
+    /**
+     * Returns a decorated PageCache where the read page cursors will randomly produce inconsistent
+     * reads with a ~50% probability.
+     */
+    public PageCache withInconsistentReads( PageCache pageCache )
+    {
+        InconsistentReadDecision decision = new RandomInconsistentReadDecision();
+        return new PossiblyInconsistentPageCache( pageCache, decision );
+    }
+
+    private static interface InconsistentReadDecision
+    {
+        boolean isNextReadInconsistent();
+    }
+
+    private static class AtomicInconsistentReadDecision implements InconsistentReadDecision
+    {
+        private final AtomicBoolean nextReadIsInconsistent;
+
+        public AtomicInconsistentReadDecision( AtomicBoolean nextReadIsInconsistent )
+        {
+            this.nextReadIsInconsistent = nextReadIsInconsistent;
+        }
+
+        @Override
+        public boolean isNextReadInconsistent()
+        {
+            return nextReadIsInconsistent.getAndSet( false );
+        }
+    }
+
+    private static class RandomInconsistentReadDecision implements InconsistentReadDecision
+    {
+        @Override
+        public boolean isNextReadInconsistent()
+        {
+            return ThreadLocalRandom.current().nextBoolean();
+        }
+    }
+
+    private static class PossiblyInconsistentPageCache implements PageCache
+    {
+        private final PageCache pageCache;
+        private final InconsistentReadDecision decision;
+
+        public PossiblyInconsistentPageCache( PageCache pageCache, InconsistentReadDecision decision )
+        {
+            this.pageCache = pageCache;
+            this.decision = decision;
+        }
+
+        @Override
+        public PagedFile map( File file, int pageSize ) throws IOException
+        {
+            PagedFile pagedFile = pageCache.map( file, pageSize );
+            return new PossiblyInconsistentPagedFile( pagedFile, decision );
+        }
+
+        @Override
+        public void unmap( File file ) throws IOException
+        {
+            pageCache.unmap( file );
+        }
+
+        @Override
+        public void flush() throws IOException
+        {
+            pageCache.flush();
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            pageCache.close();
+        }
+
+        @Override
+        public int pageSize()
+        {
+            return pageCache.pageSize();
+        }
+
+        @Override
+        public int maxCachedPages()
+        {
+            return pageCache.maxCachedPages();
+        }
+    }
+
+    private static class PossiblyInconsistentPagedFile implements PagedFile
+    {
+        private final PagedFile pagedFile;
+        private final InconsistentReadDecision decision;
+
+        public PossiblyInconsistentPagedFile(
+                PagedFile pagedFile, InconsistentReadDecision decision )
+        {
+            this.pagedFile = pagedFile;
+            this.decision = decision;
+        }
+
+        @Override
+        public PageCursor io( long pageId, int pf_flags ) throws IOException
+        {
+            PageCursor cursor = pagedFile.io( pageId, pf_flags );
+            if ( (pf_flags & PF_SHARED_LOCK) == PF_SHARED_LOCK )
+            {
+                return new PossiblyInconsistentPageCursor( cursor, decision );
+            }
+            return cursor;
+        }
+
+        @Override
+        public int pageSize()
+        {
+            return pagedFile.pageSize();
+        }
+
+        @Override
+        public void flush() throws IOException
+        {
+            pagedFile.flush();
+        }
+
+        @Override
+        public void force() throws IOException
+        {
+            pagedFile.force();
+        }
+
+        @Override
+        public long getLastPageId() throws IOException
+        {
+            return pagedFile.getLastPageId();
+        }
+    }
+
+    private static class PossiblyInconsistentPageCursor implements PageCursor
+    {
+        private final PageCursor cursor;
+        private final InconsistentReadDecision decision;
+        private boolean currentReadIsInconsistent;
+
+        public PossiblyInconsistentPageCursor(
+                PageCursor cursor, InconsistentReadDecision decision )
+        {
+            this.cursor = cursor;
+            this.decision = decision;
+        }
+
+        @Override
+        public byte getByte()
+        {
+            return currentReadIsInconsistent? 0 : cursor.getByte();
+        }
+
+        @Override
+        public byte getByte( int offset )
+        {
+            return currentReadIsInconsistent? 0 : cursor.getByte( offset );
+        }
+
+        @Override
+        public void putByte( byte value )
+        {
+            cursor.putByte( value );
+        }
+
+        @Override
+        public void putByte( int offset, byte value )
+        {
+            cursor.putByte( offset, value );
+        }
+
+        @Override
+        public long getLong()
+        {
+            return currentReadIsInconsistent? 0 : cursor.getLong();
+        }
+
+        @Override
+        public long getLong( int offset )
+        {
+            return currentReadIsInconsistent? 0 : cursor.getLong( offset );
+        }
+
+        @Override
+        public void putLong( long value )
+        {
+            cursor.putLong( value );
+        }
+
+        @Override
+        public void putLong( int offset, long value )
+        {
+            cursor.putLong( offset, value );
+        }
+
+        @Override
+        public int getInt()
+        {
+            return currentReadIsInconsistent? 0 : cursor.getInt();
+        }
+
+        @Override
+        public int getInt( int offset )
+        {
+            return currentReadIsInconsistent? 0 : cursor.getInt( offset );
+        }
+
+        @Override
+        public void putInt( int value )
+        {
+            cursor.putInt( value );
+        }
+
+        @Override
+        public void putInt( int offset, int value )
+        {
+            cursor.putInt( offset, value );
+        }
+
+        @Override
+        public long getUnsignedInt()
+        {
+            return currentReadIsInconsistent? 0 : cursor.getUnsignedInt();
+        }
+
+        @Override
+        public long getUnsignedInt( int offset )
+        {
+            return currentReadIsInconsistent? 0 : cursor.getUnsignedInt( offset );
+        }
+
+        @Override
+        public void getBytes( byte[] data )
+        {
+            if ( !currentReadIsInconsistent )
+            {
+                cursor.getBytes( data );
+            }
+        }
+
+        @Override
+        public void putBytes( byte[] data )
+        {
+            cursor.putBytes( data );
+        }
+
+        @Override
+        public short getShort()
+        {
+            return currentReadIsInconsistent? 0 : cursor.getShort();
+        }
+
+        @Override
+        public short getShort( int offset )
+        {
+            return currentReadIsInconsistent? 0 : cursor.getShort( offset );
+        }
+
+        @Override
+        public void putShort( short value )
+        {
+            cursor.putShort( value );
+        }
+
+        @Override
+        public void putShort( int offset, short value )
+        {
+            cursor.putShort( offset, value );
+        }
+
+        @Override
+        public void setOffset( int offset )
+        {
+            cursor.setOffset( offset );
+        }
+
+        @Override
+        public int getOffset()
+        {
+            return cursor.getOffset();
+        }
+
+        @Override
+        public long getCurrentPageId()
+        {
+            return cursor.getCurrentPageId();
+        }
+
+        @Override
+        public void rewind() throws IOException
+        {
+            cursor.rewind();
+        }
+
+        @Override
+        public boolean next() throws IOException
+        {
+            currentReadIsInconsistent = decision.isNextReadInconsistent();
+            return cursor.next();
+        }
+
+        @Override
+        public boolean next( long pageId ) throws IOException
+        {
+            currentReadIsInconsistent = decision.isNextReadInconsistent();
+            return cursor.next( pageId );
+        }
+
+        @Override
+        public void close()
+        {
+            cursor.close();
+        }
+
+        @Override
+        public boolean shouldRetry() throws IOException
+        {
+            if ( currentReadIsInconsistent )
+            {
+                currentReadIsInconsistent = false;
+                cursor.shouldRetry();
+                return true;
+            }
+            return cursor.shouldRetry();
+        }
     }
 }


### PR DESCRIPTION
This fixes a bug where "Record not in use" exceptions could pop out of the RelationshipGroupStore seemingly at random.
