### PR TITLE
Fixes case sensitivity issue in legacy lucene index paths

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
@@ -76,7 +76,7 @@ public class LegacyIndexApplier extends NeoCommandHandler.Adapter
             Map<String, String> config = indexConfigStore.get( entityType.entityClass(), indexName );
             if ( config == null )
             {
-                throw new IllegalStateException( "Unknown " + entityType.name() + " index '" + indexName + "'" );
+                throw new IllegalStateException( "Unknown " + entityType.nameToLowerCase() + " index '" + indexName + "'" );
             }
             String providerName = config.get( PROVIDER );
             applier = providerLookup.lookup( providerName ).newApplier( mode.needsIdempotencyChecks() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
@@ -257,7 +257,7 @@ public abstract class IndexCommand extends Command
         public String toString()
         {
             return format( "Remove%s[index:%d, id:%d, key:%d, value:%s]",
-                    IndexEntityType.byId( entityType ).name(), indexNameId, entityId, keyId, value );
+                    IndexEntityType.byId( entityType ).nameToLowerCase(), indexNameId, entityId, keyId, value );
         }
     }
 
@@ -277,7 +277,7 @@ public abstract class IndexCommand extends Command
         @Override
         public String toString()
         {
-            return "Delete[index:" + indexNameId + ", type:" + IndexEntityType.byId( entityType ).name() + "]";
+            return "Delete[index:" + indexNameId + ", type:" + IndexEntityType.byId( entityType ).nameToLowerCase() + "]";
         }
     }
 
@@ -318,7 +318,7 @@ public abstract class IndexCommand extends Command
         public String toString()
         {
             return format( "Create%sIndex[index:%d, config:%s]",
-                    IndexEntityType.byId( entityType ).name(), indexNameId, config );
+                    IndexEntityType.byId( entityType ).nameToLowerCase(), indexNameId, config );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexEntityType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexEntityType.java
@@ -67,4 +67,9 @@ public enum IndexEntityType
         }
         throw new IllegalArgumentException( "Unknown id " + id );
     }
+
+    public String nameToLowerCase()
+    {
+        return this.name().toLowerCase();
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexEntityTypeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexEntityTypeTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/*
+ This seems like a weird test, but it's necessary because we have a binding between the Enum name
+ and the name on the filesystem. On case-sensitive file systems, we need a consistent lower-cased name
+ for the entity type.
+ */
+public class IndexEntityTypeTest
+{
+    @Test
+    public void shouldLowerCaseEnumName() throws Exception
+    {
+        assertEquals( "node", IndexEntityType.Node.nameToLowerCase() );
+        assertEquals( "relationship", IndexEntityType.Relationship.nameToLowerCase() );
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/IndexIdentifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/IndexIdentifier.java
@@ -62,6 +62,6 @@ class IndexIdentifier
     @Override
     public String toString()
     {
-        return "Index[" + indexName + "," + entityType.name() + "]";
+        return "Index[" + indexName + "," + entityType.nameToLowerCase() + "]";
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -290,7 +290,7 @@ public class LuceneDataSource implements Lifecycle
     static File getFileDirectory( File storeDir, IndexEntityType type )
     {
         File path = new File( storeDir, "lucene" );
-        String extra = type.name();
+        String extra = type.nameToLowerCase();
         return new File( path, extra );
     }
 


### PR DESCRIPTION
The path under which legacy indexes are stored was changed
 to have an uppercase first letter for the entity type that
 is stored by the index (so, Node instead of node, for example).
 This causes migration from previous versions to fail to properly
 pick up copied indexes, including auto indexes, of course only
 on case sensitive filesystems.
This patch reintroduces the old lowercase naming scheme so that
 paths are built and found as before.
