### PR TITLE
Fixes bug around flattening of plan descriptions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderAsTree.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderAsTree.scala
@@ -61,7 +61,7 @@ object renderAsTree extends (InternalPlanDescription => String) {
   }
 
   def createUniqueNames(plan: InternalPlanDescription): Map[InternalPlanDescription, String] =
-    plan.toSeq.groupBy(_.name).flatMap {
+    plan.flatten.groupBy(_.name).flatMap {
       case (name, plans) if plans.size == 1 =>
         Some(plans.head -> name)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
@@ -29,7 +29,7 @@ object renderDetails extends (InternalPlanDescription => String) {
 
 
   def apply(plan: InternalPlanDescription): String = {
-    val plans: Seq[InternalPlanDescription] = plan.toSeq
+    val plans: Seq[InternalPlanDescription] = plan.flatten
     val names = renderAsTree.createUniqueNames(plan)
 
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescriptionTest.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planDescription
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.Pipe
+
+class InternalPlanDescriptionTest extends CypherFunSuite {
+
+  def pipe: Pipe = mock[Pipe]
+
+  test("flatten behaves like expected for plan with two children") {
+    val child1 = PlanDescriptionImpl(pipe, "child1", NoChildren, Seq.empty)
+    val child2 = PlanDescriptionImpl(pipe, "child2", NoChildren, Seq.empty)
+    val top = PlanDescriptionImpl(pipe, "top", TwoChildren(child1, child2), Seq.empty)
+
+    top.flatten should equal(Seq(top, child1, child2))
+  }
+
+  test("single plan flattened stays single") {
+    val single = PlanDescriptionImpl(pipe, "single", NoChildren, Seq.empty)
+
+    single.flatten should equal(Seq(single))
+  }
+
+  test("left leaning plan should also flatten out nicely") {
+    val leaf = PlanDescriptionImpl(pipe, "leaf", NoChildren, Seq.empty)
+    val lvl1 = PlanDescriptionImpl(pipe, "lvl1", SingleChild(leaf), Seq.empty)
+    val lvl2 = PlanDescriptionImpl(pipe, "lvl2", SingleChild(lvl1), Seq.empty)
+    val root = PlanDescriptionImpl(pipe, "root", SingleChild(lvl2), Seq.empty)
+
+    root.flatten should equal(Seq(root, lvl2, lvl1, leaf))
+  }
+
+  test("bushy tree flattens correctly") {
+    /*
+                  A
+             B1      B2
+           C1  C2  C3  C4
+     */
+    val C4 = PlanDescriptionImpl(pipe, "C4", NoChildren, Seq.empty)
+    val C3 = PlanDescriptionImpl(pipe, "C3", NoChildren, Seq.empty)
+    val C2 = PlanDescriptionImpl(pipe, "C2", NoChildren, Seq.empty)
+    val C1 = PlanDescriptionImpl(pipe, "C1", NoChildren, Seq.empty)
+    val B2 = PlanDescriptionImpl(pipe, "B2", TwoChildren(C3, C4), Seq.empty)
+    val B1 = PlanDescriptionImpl(pipe, "B1", TwoChildren(C1, C2), Seq.empty)
+    val A  = PlanDescriptionImpl(pipe, "A" , TwoChildren(B1, B2), Seq.empty)
+
+    A.flatten should equal(Seq(A, B1, C1, C2, B2, C3, C4))
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -274,7 +274,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = planner("profile " + q, params)
     assert(result.planDescriptionRequested, "result not marked with planDescriptionRequested")
     val planDescription: v2_2.planDescription.InternalPlanDescription = result.executionPlanDescription()
-    planDescription.toSeq.foreach {
+    planDescription.flatten.foreach {
       p =>
         if (!p.arguments.exists(_.isInstanceOf[DbHits])) {
           fail("Found plan that was not profiled with DbHits: " + p.name)
@@ -298,7 +298,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.toList
     val description = result.executionPlanDescription()
     if (names.isEmpty)
-      description.toSeq
+      description.flatten
     else {
       names.flatMap {
         name => description.find(name)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReplanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReplanTest.scala
@@ -41,7 +41,7 @@ class ReplanTest extends ExecutionEngineFunSuite {
 
     val oldPlans = {
       val result = profile("MATCH (x:L)-[r:X]->(y:T) WHERE r.prop = 42 RETURN x, y")
-      result.executionPlanDescription().pipe.planDescription.toSeq.map(plan => plan.name -> plan.arguments)
+      result.executionPlanDescription().pipe.planDescription.flatten.map(plan => plan.name -> plan.arguments)
     }
 
     graph.inTx {
@@ -55,7 +55,7 @@ class ReplanTest extends ExecutionEngineFunSuite {
 
     val newPlans = {
       val result = profile("MATCH (x:L)-[r:X]->(y:T) WHERE r.prop = 42 RETURN x, y")
-      result.executionPlanDescription().pipe.planDescription.toSeq.map(plan => plan.name -> plan.arguments)
+      result.executionPlanDescription().pipe.planDescription.flatten.map(plan => plan.name -> plan.arguments)
     }
 
     newPlans should not equal oldPlans


### PR DESCRIPTION
InternalPlanDescription toSeq method was returning a flattened list of all plans, but doing so by
relying on children.toSeq to flatten all children. This was incorrect behavior for Children.toSeq, which
was corrected to only return a Seq of the children, and then the InternalPlanDescription.toSeq was
replaced with a correctly behaving flatten method.
