### PR TITLE
Removed annoying compiler warnings.

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LegacyPipeBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LegacyPipeBuilderTest.scala
@@ -38,7 +38,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.{Planner, PlanningMonitor
 import org.neo4j.cypher.internal.compiler.v2_2.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 import org.neo4j.cypher.internal.spi.v2_2.TransactionBoundQueryContext
-import org.neo4j.cypher.{GraphDatabaseTestSupport, InternalException}
+import org.neo4j.cypher.{GraphDatabaseTestSupport}
 import org.neo4j.graphdb.DynamicLabel
 import org.scalatest.mock.MockitoSugar
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/MutationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/MutationTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2
 import commands.expressions.{Expression, Literal}
 import mutation.{RelationshipEndpoint, CreateRelationship, CreateNode, DeleteEntityAction}
 import symbols._
-import org.neo4j.cypher.{ExecutionEngineFunSuite, CypherTypeException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite}
 import org.neo4j.graphdb.{Node, NotFoundException}
 import collection.mutable.{Map => MutableMap}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.{PipeMonitor, QueryState, ExecuteUpdateCommandsPipe, NullPipe}


### PR DESCRIPTION
No more `warning: imported `InternalException' is permanently hidden by definition of object InternalException in package v2_2`
