### PR TITLE
Make ExecutionEngine available to users of Unmanaged Extensions.

### DIFF
--- a/community/server-examples/LICENSES.txt
+++ b/community/server-examples/LICENSES.txt
@@ -10,7 +10,12 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons Lang
   Commons Logging
+  ConcurrentLinkedHashMap
   JTA 1.1
+  Lucene Core
+  opencsv
+  parboiled-core
+  parboiled-scala
 ------------------------------------------------------------------------------
 
                                  Apache License
@@ -214,6 +219,48 @@ Apache Software License, Version 2.0
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+------------------------------------------------------------------------------
+BSD - Scala License
+  Scala Library
+------------------------------------------------------------------------------
+
+SCALA LICENSE
+
+Copyright (c) 2002-2012 EPFL, Lausanne, unless otherwise specified.
+All rights reserved.
+
+This software was developed by the Programming Methods Laboratory of the
+Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland.
+
+Permission to use, copy, modify, and distribute this software in source
+or binary form for any purpose with or without fee is hereby granted,
+provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the EPFL nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 
 ------------------------------------------------------------------------------

--- a/community/server-examples/NOTICE.txt
+++ b/community/server-examples/NOTICE.txt
@@ -33,7 +33,15 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons Lang
   Commons Logging
+  ConcurrentLinkedHashMap
   JTA 1.1
+  Lucene Core
+  opencsv
+  parboiled-core
+  parboiled-scala
+
+BSD - Scala License
+  Scala Library
 
 Common Development and Distribution License Version 1.1
   jersey-client

--- a/community/server-examples/pom.xml
+++ b/community/server-examples/pom.xml
@@ -38,6 +38,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-cypher</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
       <version>1.9</version>

--- a/community/server-examples/src/main/java/org/neo4j/examples/server/unmanaged/HelloWorldResource.java
+++ b/community/server-examples/src/main/java/org/neo4j/examples/server/unmanaged/HelloWorldResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.graphdb.GraphDatabaseService;
 
 //START SNIPPET: HelloWorldResource
@@ -36,10 +37,12 @@ import org.neo4j.graphdb.GraphDatabaseService;
 public class HelloWorldResource
 {
     private final GraphDatabaseService database;
+    private final ExecutionEngine cypher;
 
-    public HelloWorldResource( @Context GraphDatabaseService database )
+    public HelloWorldResource( @Context GraphDatabaseService database, @Context ExecutionEngine cypher )
     {
         this.database = database;
+        this.cypher = cypher;
     }
 
     @GET

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -19,17 +19,28 @@
  */
 package org.neo4j.server;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.Filter;
+
 import org.apache.commons.configuration.Configuration;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
 import org.neo4j.cypher.javacompat.internal.ServerExecutionEngine;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Clock;
+import org.neo4j.helpers.Function;
+import org.neo4j.helpers.RunCarefully;
 import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.guard.Guard;
-import org.neo4j.helpers.Function;
-import org.neo4j.helpers.RunCarefully;
 import org.neo4j.kernel.impl.transaction.xaframework.ForceMode;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -38,7 +49,14 @@ import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.configuration.ConfigurationProvider;
 import org.neo4j.server.configuration.Configurator;
-import org.neo4j.server.database.*;
+import org.neo4j.server.database.CypherExecutor;
+import org.neo4j.server.database.CypherExecutorProvider;
+import org.neo4j.server.database.Database;
+import org.neo4j.server.database.DatabaseProvider;
+import org.neo4j.server.database.ExecutionEngineProvider;
+import org.neo4j.server.database.GraphDatabaseServiceProvider;
+import org.neo4j.server.database.InjectableProvider;
+import org.neo4j.server.database.RrdDbWrapper;
 import org.neo4j.server.guard.GuardingRequestFilter;
 import org.neo4j.server.modules.RESTApiModule;
 import org.neo4j.server.modules.ServerModule;
@@ -50,7 +68,11 @@ import org.neo4j.server.rest.paging.LeaseManager;
 import org.neo4j.server.rest.repr.InputFormatProvider;
 import org.neo4j.server.rest.repr.OutputFormatProvider;
 import org.neo4j.server.rest.repr.RepresentationFormatRepository;
-import org.neo4j.server.rest.transactional.*;
+import org.neo4j.server.rest.transactional.TransactionFacade;
+import org.neo4j.server.rest.transactional.TransactionFilter;
+import org.neo4j.server.rest.transactional.TransactionHandleRegistry;
+import org.neo4j.server.rest.transactional.TransactionRegistry;
+import org.neo4j.server.rest.transactional.TransitionalPeriodTransactionMessContainer;
 import org.neo4j.server.rest.web.DatabaseActions;
 import org.neo4j.server.rrd.RrdDbProvider;
 import org.neo4j.server.rrd.RrdFactory;
@@ -63,12 +85,6 @@ import org.neo4j.server.web.WebServer;
 import org.neo4j.server.web.WebServerProvider;
 import org.neo4j.shell.ShellSettings;
 
-import javax.servlet.Filter;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-
 import static java.lang.Math.round;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -77,7 +93,12 @@ import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.kernel.impl.util.JobScheduler.Group.serverTransactionTimeout;
-import static org.neo4j.server.configuration.Configurator.*;
+import static org.neo4j.server.configuration.Configurator.DATABASE_LOCATION_PROPERTY_KEY;
+import static org.neo4j.server.configuration.Configurator.DEFAULT_DATABASE_LOCATION_PROPERTY_KEY;
+import static org.neo4j.server.configuration.Configurator.DEFAULT_SCRIPT_SANDBOXING_ENABLED;
+import static org.neo4j.server.configuration.Configurator.DEFAULT_TRANSACTION_TIMEOUT;
+import static org.neo4j.server.configuration.Configurator.SCRIPT_SANDBOXING_ENABLED_KEY;
+import static org.neo4j.server.configuration.Configurator.TRANSACTION_TIMEOUT;
 import static org.neo4j.server.database.InjectableProvider.providerForSingleton;
 
 /**
@@ -697,6 +718,8 @@ public abstract class AbstractNeoServer implements NeoServer
         singletons.add( new InputFormatProvider( repository ) );
         singletons.add( new OutputFormatProvider( repository ) );
         singletons.add( new CypherExecutorProvider( cypherExecutor ) );
+        singletons.add( new ExecutionEngineProvider( cypherExecutor ) );
+
         singletons.add( providerForSingleton( transactionFacade, TransactionFacade.class ) );
         singletons.add( new TransactionFilter( database ) );
         singletons.add( new LoggingProvider( logging ) );

--- a/community/server/src/main/java/org/neo4j/server/database/ExecutionEngineProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/ExecutionEngineProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.database;
+
+import javax.ws.rs.ext.Provider;
+
+import com.sun.jersey.api.core.HttpContext;
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+
+/** This exists as a convenience for extension authors, to access the cypher execution engine. */
+@Provider
+public class ExecutionEngineProvider extends InjectableProvider<ExecutionEngine>
+{
+    public CypherExecutor cypherExecutor;
+
+    public ExecutionEngineProvider( CypherExecutor cypherExecutor )
+    {
+        super( ExecutionEngine.class );
+        this.cypherExecutor = cypherExecutor;
+    }
+
+    @Override
+    public ExecutionEngine getValue( HttpContext httpContext )
+    {
+        return cypherExecutor.getExecutionEngine();
+    }
+}


### PR DESCRIPTION
Extensions were built before cypher existed, and there hasn't been a good way to use cypher in them before (since the extension instance gets re-created for each HTTP call). This clears that up a bit by making ExecutionEngine easily injectable into an extension.
- Small doc change to show how to get ExecutionEngine in extensions.
