### PR TITLE
Throwing the wrong exception.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
@@ -34,6 +34,10 @@ class UniquePathNotUniqueException(message: String) extends CypherException {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.uniquePathNotUniqueException(message)
 }
 
+class FailedIndexException(indexName: String) extends CypherException {
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.failedIndexException(indexName)
+}
+
 class EntityNotFoundException(message: String, cause: Throwable = null) extends CypherException(cause) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.entityNotFoundException(message, cause)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
@@ -22,6 +22,8 @@ package org.neo4j.cypher.internal.compiler.v2_2.spi
 import org.neo4j.cypher.internal.compiler.v2_2.CypherException
 
 trait MapToPublicExceptions[T <: Throwable] {
+  def failedIndexException(indexName: String): T
+
   def periodicCommitInOpenTransactionException(): T
 
   def syntaxException(message: String, query: String, offset: Option[Int]): T

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatability/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatability/CompatibilityFor2_2.scala
@@ -98,6 +98,8 @@ object exceptionHandlerFor2_2 extends MapToPublicExceptions[CypherException] {
       case e: CypherException_v2_2 => throw e.mapToPublic(exceptionHandlerFor2_2)
     }
   }
+
+  def failedIndexException(indexName: String): CypherException = throw new FailedIndexException(indexName)
 }
 
 trait CompatibilityFor2_2 {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -19,27 +19,26 @@
  */
 package org.neo4j.cypher.internal.spi.v2_2
 
-import org.neo4j.graphdb._
-import org.neo4j.kernel.impl.api.KernelStatement
-import org.neo4j.kernel.impl.util.register.NeoRegister.RelType
-import org.neo4j.kernel.{InternalAbstractGraphDatabase, GraphDatabaseAPI}
-import collection.JavaConverters._
-import collection.mutable
-import scala.collection.Iterator
-import org.neo4j.graphdb.DynamicRelationshipType._
+import org.neo4j.collection.primitive.PrimitiveLongIterator
+import org.neo4j.cypher.internal.compiler.v2_2.{EntityNotFoundException, FailedIndexException}
+import org.neo4j.cypher.internal.compiler.v2_2.spi._
 import org.neo4j.cypher.internal.helpers.JavaConversionSupport
 import org.neo4j.cypher.internal.helpers.JavaConversionSupport._
+import org.neo4j.graphdb.DynamicRelationshipType._
+import org.neo4j.graphdb._
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.helpers.collection.IteratorUtil
 import org.neo4j.kernel.api._
-import org.neo4j.cypher.{FailedIndexException, EntityNotFoundException}
-import org.neo4j.tooling.GlobalGraphOperations
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
-import org.neo4j.helpers.collection.IteratorUtil
-import org.neo4j.cypher.internal.compiler.v2_2.spi._
-import org.neo4j.collection.primitive.PrimitiveLongIterator
+import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
-import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.kernel.{GraphDatabaseAPI, InternalAbstractGraphDatabase}
+import org.neo4j.tooling.GlobalGraphOperations
+
+import scala.collection.JavaConverters._
+import scala.collection.{Iterator, mutable}
 
 final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
                                          var tx: Transaction,


### PR DESCRIPTION
We were not throwing and catching the same exception, this lead to exceptions
leaking out to end user when using node index seek with a non-existing id.
