### PR TITLE
Aligning the GDB Factories

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
@@ -30,24 +30,51 @@ import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 public class HighlyAvailableGraphDatabaseFactory extends GraphDatabaseFactory
 {
 
-    public GraphDatabaseService newHighlyAvailableDatabase( String path )
+    @Override
+    public GraphDatabaseService newEmbeddedDatabase( final String path )
     {
-        return newHighlyAvailableDatabaseBuilder( path ).newGraphDatabase();
+        return newEmbeddedDatabaseBuilder( path ).newGraphDatabase();
     }
 
-    public GraphDatabaseBuilder newHighlyAvailableDatabaseBuilder( final String path )
+    @Override
+    public GraphDatabaseBuilder newEmbeddedDatabaseBuilder( final String path )
     {
         final GraphDatabaseFactoryState state = getStateCopy();
 
         return new GraphDatabaseBuilder( new GraphDatabaseBuilder.DatabaseCreator()
         {
+
             @Override
-            public GraphDatabaseService newDatabase( Map<String, String> config )
+            public GraphDatabaseService newDatabase( final Map<String, String> config )
             {
                 config.put( "ephemeral", "false" );
 
                 return new HighlyAvailableGraphDatabase( path, config, state.databaseDependencies() );
             }
         } );
+    }
+
+    /**
+     * @deprecated By using
+     *             {@link HighlyAvailableGraphDatabaseFactory#newEmbeddedDatabase(String)}
+     *             you get an abstraction of this factory, so you can either use
+     *             this factory or {@link GraphDatabaseFactory}.
+     */
+    @Deprecated
+    public GraphDatabaseService newHighlyAvailableDatabase( final String path )
+    {
+        return newEmbeddedDatabase( path );
+    }
+
+    /**
+     * @deprecated By using
+     *             {@link HighlyAvailableGraphDatabaseFactory#newEmbeddedDatabaseBuilder(String)}
+     *             you get an abstraction of this factory, so you can either use
+     *             this factory or {@link GraphDatabaseFactory}.
+     */
+    @Deprecated
+    public GraphDatabaseBuilder newHighlyAvailableDatabaseBuilder( final String path )
+    {
+        return newEmbeddedDatabaseBuilder( path );
     }
 }


### PR DESCRIPTION
The HA Graph Database Factory adds to new methods rather than overriding the existing builders.  This is what I tried to solve here. I left the old methods there, but deprecated them for backwards compatibility.

To be complete, also the class TestGraphDatabaseFactory should be adapted and there should be an interface for these factories.

This is important for many reasons, users using neo4j in embedded mode can e.g. easily use a different implementation of the factory for their testing purposes.  I'm happy to receive comments and further update this pull request
