### PR TITLE
Abbreviate common connection closed error.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -32,6 +32,7 @@ import org.codehaus.jackson.JsonGenerator;
 
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.cypher.javacompat.QueryStatistics;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.repr.util.RFC1123;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
@@ -326,7 +327,14 @@ public class ExecutionResultSerializer
 
     private IOException loggedIOException( IOException exception )
     {
-        log.error( "Failed to generate JSON output.", exception );
+        if(Exceptions.contains(exception, "Broken pipe", IOException.class ))
+        {
+            log.error( "Unable to reply to request, because the client has closed the connection (Broken pipe)." );
+        }
+        else
+        {
+            log.error( "Failed to generate JSON output.", exception );
+        }
         return exception;
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -570,6 +570,21 @@ public class ExecutionResultSerializerTest
         log.assertExactly( error( "Failed to generate JSON output.", failure ) );
     }
 
+    @Test
+    public void shouldAbbreviateWellKnownIOErrors() throws Exception
+    {
+        // given
+        OutputStream output = mock( OutputStream.class, new ThrowsException( new IOException("Broken pipe") ) );
+        TestLogger log = new TestLogger();
+        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, log );
+
+        // when
+        serializer.finish();
+
+        // then
+        log.assertExactly( error( "Unable to reply to request, because the client has closed the connection (Broken pipe)." ) );
+    }
+
     @SafeVarargs
     private static ExecutionResult mockExecutionResult( Map<String, Object>... rows )
     {

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkSender.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkSender.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.channels.ClosedChannelException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,6 +58,7 @@ import org.jboss.netty.util.ThreadRenamingRunnable;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageSender;
 import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -292,7 +294,14 @@ public class NetworkSender
                 }
                 catch ( Exception e )
                 {
-                    msgLog.warn( "Could not send message", e );
+                    if( Exceptions.contains(e, ClosedChannelException.class ))
+                    {
+                        msgLog.warn( "Could not send message, because the connection has been closed." );
+                    }
+                    else
+                    {
+                        msgLog.warn( "Could not send message", e );
+                    }
                     channel.close();
                 }
             }


### PR DESCRIPTION
When the client closes a connection to the server before recieving the full
reply, the server currently prints a lengthy stack trace to the log. This
stack trace is not helpful, because we already do the right thing here.

Replace stack trace with one-line log message noting the client closed the
connection.
