### PR TITLE
Improvements for plan description output.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandPipe.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
-import org.neo4j.cypher.internal.compiler.v2_2.{InternalException, ExecutionContext}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.compiler.v2_2.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
+import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionContext, InternalException}
 import org.neo4j.graphdb.{Direction, Node, Relationship}
 
 sealed abstract class ExpandPipe[T](source: Pipe,
@@ -58,7 +59,7 @@ sealed abstract class ExpandPipe[T](source: Pipe,
     row.getOrElse(from, throw new InternalException(s"Expected to find a node at $from but found nothing"))
 
   def planDescription = {
-    source.planDescription.andThen(this, "Expand", identifiers)
+    source.planDescription.andThen(this, "Expand", identifiers, ExpandExpression(from, relName, to, dir))
   }
 
   val symbols = source.symbols.add(to, CTNode).add(relName, CTRelationship)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandPipe.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.compiler.v2_2.{InternalException, ExecutionContext}
 import org.neo4j.cypher.internal.compiler.v2_2.commands.Predicate
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
@@ -65,7 +66,7 @@ case class OptionalExpandPipe(source: Pipe, from: String, relName: String, to: S
 
   def planDescription =
     source.planDescription.
-      andThen(this, "OptionalExpand", identifiers)
+      andThen(this, "OptionalExpand", identifiers, ExpandExpression(from, relName, to, dir))
 
   def symbols = source.symbols.add(to, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
-import org.neo4j.cypher.internal.compiler.v2_2.{InternalException, ExecutionContext}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.compiler.v2_2.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
+import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionContext, InternalException}
 import org.neo4j.graphdb.{Direction, Node, Relationship}
 
 import scala.collection.mutable
@@ -92,7 +93,7 @@ sealed abstract class VarLengthExpandPipe[T](source: Pipe,
     row.getOrElse(fromName, throw new InternalException(s"Expected to find a node at $fromName but found nothing"))
 
   def planDescription = source.planDescription.
-    andThen(this, "Var length expand", identifiers)
+    andThen(this, "Var length expand", identifiers, ExpandExpression(fromName, relName, toName, projectedDir, true))
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescription.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 import org.neo4j.cypher.internal.compiler.v2_2.commands
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.{Pipe, RonjaPipe, EntityByIdRhs => PipeEntityByIdRhs}
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments._
+import org.neo4j.graphdb.Direction
 
 /**
  * Abstract description of an execution plan
@@ -85,6 +86,7 @@ object InternalPlanDescription {
     case class Version(value: String) extends Argument {
       override def name = "version"
     }
+    case class ExpandExpression(from: String, relName: String, to: String, direction: Direction, varLength: Boolean = false) extends Argument
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -20,6 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments._
+import org.neo4j.graphdb.Direction
+
 
 object PlanDescriptionArgumentSerializer {
   def serialize(arg: Argument): String = {
@@ -38,6 +40,11 @@ object PlanDescriptionArgumentSerializer {
       case Rows(value) => value.toString
       case EstimatedRows(value) => value.toString
       case Version(version) => version
+      case ExpandExpression(from, rel, to, dir: Direction, varLength) =>
+        val left = if (dir == Direction.INCOMING) "<-[" else "-["
+        val right = if (dir == Direction.OUTGOING) "]->" else "]-"
+        val asterisk = if (varLength) "*" else ""
+        s"($from)$left:$rel$asterisk$right($to)"
 
       // Do not add a fallthrough here - we rely on exhaustive checking to ensure
       // that we don't forget to add new types of arguments here

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable
 
 
 object renderDetails extends (InternalPlanDescription => String) {
+  val UNNAMED_PATTERN = """  (UNNAMED|FRESHID|AGGREGATION)\d+"""
 
   def apply(plan: InternalPlanDescription): String = {
     val plans: Seq[InternalPlanDescription] = plan.flatten
@@ -43,8 +44,9 @@ object renderDetails extends (InternalPlanDescription => String) {
           case x
             if !x.isInstanceOf[Rows] &&
               !x.isInstanceOf[DbHits] &&
-              !x.isInstanceOf[EstimatedRows] => PlanDescriptionArgumentSerializer.serialize(x)
-        }.mkString("; "))
+              !x.isInstanceOf[EstimatedRows] &&
+              !x.isInstanceOf[Version] => PlanDescriptionArgumentSerializer.serialize(x)
+        }.mkString("; ").replaceAll(UNNAMED_PATTERN, ""))
 
         Seq("Operator" -> name, "EstimatedRows" -> estimatedRows, "Rows" -> rows,
           "DbHits" -> dbHits, "Identifiers" -> ids, "Other" -> other)


### PR DESCRIPTION
- Always print the version on top of the description, never in the "Other" column.
- Expand outputs (from)-[:type]->(to) in "Other" column.
- Remove all unnamed identifiers in the printed description.
