### PR TITLE
Fix flay testserverbuilder test.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/Digests.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Digests.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.test;
 
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -31,11 +30,25 @@ public class Digests
         {
             MessageDigest m = MessageDigest.getInstance( "MD5" );
             m.update( message.getBytes(), 0, message.getBytes().length);
-            return new BigInteger(1, m.digest()).toString( 16 );
+            return hex(m.digest());
         }
         catch ( NoSuchAlgorithmException e )
         {
             throw new RuntimeException( "MD5 hash algorithm is not available on this platform: " + e.getMessage(),e );
         }
+    }
+
+    final protected static char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+    // TODO: Replace with BytePrinter#compactHex once auth work is merged
+    private static String hex(byte[] bytes)
+    {
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -35,11 +35,11 @@ import org.codehaus.jackson.JsonNode;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.test.server.HTTP;
 
 import static junit.framework.TestCase.fail;


### PR DESCRIPTION
Test was flaky because the md5 generator used a broken approach to converting binary md5 digest to a hex string, causing strings of different lengths to be generated.
