### PR TITLE
Introduce debug capability for request content logging.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -472,8 +472,11 @@ public abstract class AbstractNeoServer implements NeoServer
         {
             return;
         }
+        boolean contentLoggingEnabled = configurator.configuration().getBoolean( Configurator.HTTP_CONTENT_LOGGING,
+                Configurator.DEFAULT_HTTP_CONTENT_LOGGING );
+
         String logLocation = getConfiguration().getString( Configurator.HTTP_LOG_CONFIG_LOCATION );
-        webServer.setHttpLoggingConfiguration( new File( logLocation ) );
+        webServer.setHttpLoggingConfiguration( new File( logLocation ), contentLoggingEnabled );
     }
 
     private void setUpTimeoutFilter()

--- a/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
@@ -101,6 +101,10 @@ public interface Configurator
     String HTTP_LOGGING = "org.neo4j.server.http.log.enabled";
     boolean DEFAULT_HTTP_LOGGING = false;
     String HTTP_LOG_CONFIG_LOCATION = "org.neo4j.server.http.log.config";
+
+    String HTTP_CONTENT_LOGGING = "org.neo4j.server.http.unsafe.content_log.enabled";
+    boolean DEFAULT_HTTP_CONTENT_LOGGING = false;
+
     String WADL_ENABLED = "unsupported_wadl_generation_enabled";
 
     String STARTUP_TIMEOUT = "org.neo4j.server.startup_timeout";

--- a/community/server/src/main/java/org/neo4j/server/web/WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/WebServer.java
@@ -46,7 +46,7 @@ public interface WebServer
 
     void setHttpsCertificateInformation( KeyStoreInformation config );
 
-    void setHttpLoggingConfiguration( File logbackConfig );
+    void setHttpLoggingConfiguration( File logbackConfig, boolean enableContentLogging );
 
     void setMaxThreads( int maxThreads );
 

--- a/community/server/src/test/java/org/neo4j/server/preflight/HTTPLoggingPreparednessRuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/preflight/HTTPLoggingPreparednessRuleTest.java
@@ -147,22 +147,26 @@ public class HTTPLoggingPreparednessRuleTest
 
     public static String createLogbackConfigXml( File logDirectory )
     {
+        return createLogbackConfigXml( logDirectory, "%h %l %user [%t{dd/MMM/yyyy:HH:mm:ss Z}] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\"" );
+    }
 
+    public static String createLogbackConfigXml( File logDirectory, String logPattern )
+    {
         return "<configuration>\n" +
-            "  <appender name=\"FILE\" class=\"ch.qos.logback.core.rolling.RollingFileAppender\">\n" +
-            "    <file>" + logDirectory.getAbsolutePath() + File.separator + "http.log</file>\n" +
-            "    <rollingPolicy class=\"ch.qos.logback.core.rolling.TimeBasedRollingPolicy\">\n" +
-            "      <fileNamePattern>" + logDirectory.getAbsolutePath() + File.separator + "http.%d{yyyy-MM-dd_HH}.log</fileNamePattern>\n" +
-            "      <maxHistory>30</maxHistory>\n" +
-            "    </rollingPolicy>\n" +
-            "\n" +
-            "    <encoder>\n" +
-            "      <!-- Note the deliberate misspelling of \"referer\" in accordance with RFC 2616 -->\n" +
-            "      <pattern>%h %l %user [%t{dd/MMM/yyyy:HH:mm:ss Z}] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\"</pattern>\n" +
-            "    </encoder>\n" +
-            "  </appender>\n" +
-            "\n" +
-            "  <appender-ref ref=\"FILE\" />\n" +
-            "</configuration>";
+                "  <appender name=\"FILE\" class=\"ch.qos.logback.core.rolling.RollingFileAppender\">\n" +
+                "    <file>" + logDirectory.getAbsolutePath() + File.separator + "http.log</file>\n" +
+                "    <rollingPolicy class=\"ch.qos.logback.core.rolling.TimeBasedRollingPolicy\">\n" +
+                "      <fileNamePattern>" + logDirectory.getAbsolutePath() + File.separator + "http.%d{yyyy-MM-dd_HH}.log</fileNamePattern>\n" +
+                "      <maxHistory>30</maxHistory>\n" +
+                "    </rollingPolicy>\n" +
+                "\n" +
+                "    <encoder>\n" +
+                "      <!-- Note the deliberate misspelling of \"referer\" in accordance with RFC 2616 -->\n" +
+                "      <pattern>"+logPattern+"</pattern>\n" +
+                "    </encoder>\n" +
+                "  </appender>\n" +
+                "\n" +
+                "  <appender-ref ref=\"FILE\" />\n" +
+                "</configuration>";
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingDocIT.java
@@ -20,14 +20,13 @@
 package org.neo4j.server.web.logging;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.Scanner;
+import java.io.IOException;
 import java.util.UUID;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
-
+import org.neo4j.kernel.impl.util.Charsets;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.ServerStartupException;
 import org.neo4j.server.configuration.Configurator;
@@ -40,17 +39,15 @@ import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.server.ExclusiveServerTestBase;
+import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.neo4j.helpers.Settings.osIsWindows;
+import static org.neo4j.kernel.impl.util.FileUtils.readTextFile;
 import static org.neo4j.test.AssertEventually.Condition;
 import static org.neo4j.test.AssertEventually.assertEventually;
+import static org.neo4j.test.server.HTTP.RawPayload.rawPayload;
 
 public class HTTPLoggingDocIT extends ExclusiveServerTestBase
 {
@@ -130,13 +127,48 @@ public class HTTPLoggingDocIT extends ExclusiveServerTestBase
             response.close();
 
             // then
-            assertEventually( "request appears in log", 5, new Condition()
-            {
-                public boolean evaluate()
-                {
-                    return occursIn( query, new File( logDirectory, "http.log" ) );
-                }
-            } );
+            assertEventually( "request appears in log", 5, logContains( logDirectory, query ) );
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void givenDebugContentLoggingEnabledShouldLogContent() throws Exception
+    {
+        // given
+        final File logDirectory = TargetDirectory.forTest( this.getClass() ).cleanDirectory(
+                "givenDebugContentLoggingEnabledShouldLogContent-logdir" );
+        FileUtils.forceMkdir( logDirectory );
+        final File confDir = TargetDirectory.forTest( this.getClass() ).cleanDirectory(
+                "givenDebugContentLoggingEnabledShouldLogContent-confdir" );
+        FileUtils.forceMkdir( confDir );
+
+        final File configFile = HTTPLoggingPreparednessRuleTest.createConfigFile(
+                HTTPLoggingPreparednessRuleTest.createLogbackConfigXml( logDirectory, "$requestContent\n%responseContent" ), confDir );
+
+        NeoServer server = CommunityServerBuilder.server().withDefaultDatabaseTuning()
+                .withProperty( Configurator.HTTP_LOGGING, "true" )
+                .withProperty( Configurator.HTTP_CONTENT_LOGGING, "true" )
+                .withProperty( Configurator.HTTP_LOG_CONFIG_LOCATION, configFile.getPath() )
+                .usingDatabaseDir( TargetDirectory.forTest( this.getClass() ).cleanDirectory(
+                        "givenDebugContentLoggingEnabledShouldLogContent-dbdir"
+                ).getAbsolutePath() )
+                .build();
+
+        try
+        {
+            server.start();
+
+            // when
+            HTTP.Response req = HTTP.POST( server.baseUri().resolve( "/db/data/node" ).toString(), rawPayload( "{\"name\":\"Hello, world!\"}" ) );
+            assertEquals( 201, req.status() );
+
+            // then
+            assertEventually( "request appears in log", 5, logContains( logDirectory, "Hello, world!" ) );
+            assertEventually( "request appears in log", 5, logContains( logDirectory, "metadata" ) );
         }
         finally
         {
@@ -184,6 +216,17 @@ public class HTTPLoggingDocIT extends ExclusiveServerTestBase
         }
     }
 
+    private Condition logContains( final File logDirectory, final String query )
+    {
+        return new Condition()
+        {
+            public boolean evaluate()
+            {
+                return occursIn( query, new File( logDirectory, "http.log" ) );
+            }
+        };
+    }
+
     private File createUnwritableDirectory()
     {
         File file;
@@ -210,29 +253,17 @@ public class HTTPLoggingDocIT extends ExclusiveServerTestBase
             return false;
         }
 
-        Scanner scanner = null;
         try
         {
-            scanner = new Scanner( file );
-            while ( scanner.hasNext() )
-            {
-                if ( scanner.next().contains( lookFor ) )
-                {
-                    return true;
-                }
-            }
-            return false;
+            String s = readTextFile( file, Charsets.UTF_8 );
+            System.out.println(s);
+            System.out.println();
+            System.out.println("Does not contain: " + lookFor);
+            return s.contains( lookFor );
         }
-        catch ( FileNotFoundException e )
+        catch ( IOException e )
         {
             throw new RuntimeException( e );
-        }
-        finally
-        {
-            if ( scanner != null )
-            {
-                scanner.close();
-            }
         }
     }
 }


### PR DESCRIPTION
Currently undocumented, this introduces experimental support for logging
full request and response bodies. This is currently enabled by setting:

```
org.neo4j.server.http.unsafe.content_log.enabled=true
```

In neo4j-server.properties, and by specifying the http log to output full
requests and responses:

```
<pattern>%fullRequest\n\n%fullResponse</pattern>
```

As this uses mechanisms to fully duplicate incoming request and response
streams, it is strongly recommended to not run this in a production setting.
However, it should prove very useful for debugging and testing.
