### PR TITLE
More concise CSV header format for nodes and relationships

### DIFF
--- a/community/batch-import-tool/src/main/java/org/neo4j/tooling/batchimport/CsvDataGenerator.java
+++ b/community/batch-import-tool/src/main/java/org/neo4j/tooling/batchimport/CsvDataGenerator.java
@@ -88,7 +88,7 @@ public class CsvDataGenerator
         case IGNORE:
             return;
         default:
-            value = entry.name() + ":" + entry.type().name();
+            value = (entry.name() != null ? entry.name() : "") + ":" + entry.type().name();
             break;
         }
         builder.append( value );
@@ -143,10 +143,10 @@ public class CsvDataGenerator
         case LABEL:
             randomLabels( builder, config.arrayDelimiter() );
             break;
-        case START_NODE: case END_NODE:
+        case START_ID: case END_ID:
             builder.append( random.nextInt( highNodeId ) );
             break;
-        case RELATIONSHIP_TYPE:
+        case TYPE:
             builder.append( "TYPE_" ).append( random.nextInt( 4 ) );
             break;
         default:
@@ -212,16 +212,16 @@ public class CsvDataGenerator
         Configuration config = Configuration.COMMAS;
         Extractors extractors = new Extractors( config.arrayDelimiter() );
         Header nodeHeader = new Header( new Entry[] {
-                new Entry( "id", Type.ID, extractors.string() ),
+                new Entry( null, Type.ID, extractors.string() ),
                 new Entry( "name", Type.PROPERTY, extractors.string() ),
                 new Entry( "age", Type.PROPERTY, extractors.int_() ),
                 new Entry( "something", Type.PROPERTY, extractors.string() ),
-                new Entry( "label", Type.LABEL, extractors.stringArray() ),
+                new Entry( null, Type.LABEL, extractors.stringArray() ),
         } );
         Header relationshipHeader = new Header( new Entry[] {
-                new Entry( "start", Type.START_NODE, extractors.string() ),
-                new Entry( "end", Type.END_NODE, extractors.string() ),
-                new Entry( "type", Type.RELATIONSHIP_TYPE, extractors.string() )
+                new Entry( null, Type.START_ID, extractors.string() ),
+                new Entry( null, Type.END_ID, extractors.string() ),
+                new Entry( null, Type.TYPE, extractors.string() )
         } );
 
         ProgressListener progress = textual( System.out ).singlePart( "Generating", nodeCount + relationshipCount );

--- a/community/batch-import-tool/src/test/java/org/neo4j/tooling/batchimport/BatchImporterToolTest.java
+++ b/community/batch-import-tool/src/test/java/org/neo4j/tooling/batchimport/BatchImporterToolTest.java
@@ -40,6 +40,7 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Type;
 
 import static java.io.File.pathSeparator;
 import static java.lang.System.currentTimeMillis;
@@ -256,7 +257,8 @@ public class BatchImporterToolTest
     private void writeRelationshipHeader( PrintStream writer, Configuration config )
     {
         char delimiter = config.delimiter();
-        writer.println( "start" + delimiter + "end" + delimiter + "type" + delimiter + "created:long" );
+        writer.println( ":" + Type.START_ID + delimiter + ":" + Type.END_ID + delimiter +
+                        ":" + Type.TYPE + delimiter + "created:long" );
     }
 
     private void writeRelationshipData( PrintStream writer, Configuration config, List<String> nodeIds,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
@@ -110,7 +110,12 @@ public class Header
                 return false;
             }
             Entry other = (Entry) obj;
-            return name.equals( other.name ) && type == other.type && extractorEquals( extractor, other.extractor );
+            return nullSafeEquals( name, other.name ) && type == other.type && extractorEquals( extractor, other.extractor );
+        }
+
+        private boolean nullSafeEquals( Object o1, Object o2 )
+        {
+            return o1 == null || o2 == null ? o1 == o2 : o1.equals( o2 );
         }
 
         private boolean extractorEquals( Extractor<?> first, Extractor<?> other )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
@@ -44,13 +44,13 @@ class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelatio
     {
         switch ( entry.type() )
         {
-        case RELATIONSHIP_TYPE:
+        case TYPE:
             type = (String) value;
             break;
-        case START_NODE:
+        case START_ID:
             startNode = value;
             break;
-        case END_NODE:
+        case END_ID:
             endNode = value;
             break;
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Type.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Type.java
@@ -29,8 +29,8 @@ public enum Type
     ID,
     PROPERTY,
     LABEL,
-    RELATIONSHIP_TYPE,
-    START_NODE,
-    END_NODE,
+    TYPE,
+    START_ID,
+    END_ID,
     IGNORE;
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -159,7 +159,7 @@ public class CsvInputBatchImportIT
         try ( Writer writer = fs.openAsWriter( file, "utf-8", false ) )
         {
             // Header
-            println( writer, "start,end,type" );
+            println( writer, ":start_id,:end_id,:type" );
 
             // Data
             for ( InputRelationship relationship : relationshipData )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -77,9 +77,9 @@ public class CsvInputTest
         Input input = new CsvInput( null, null,
                 dataIterable( data( "node1,node2,KNOWS,1234567\n" +
                       "node2,node10,HACKS,987654" ) ),
-                header( entry( "from", Type.START_NODE, idType.extractor( extractors ) ),
-                        entry( "to", Type.END_NODE, idType.extractor( extractors ) ),
-                        entry( "type", Type.RELATIONSHIP_TYPE, extractors.string() ),
+                header( entry( "from", Type.START_ID, idType.extractor( extractors ) ),
+                        entry( "to", Type.END_ID, idType.extractor( extractors ) ),
+                        entry( "type", Type.TYPE, extractors.string() ),
                         entry( "since", Type.PROPERTY, extractors.long_() ) ), idType, COMMAS );
 
         // WHEN/THEN

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -73,7 +73,7 @@ public class DataFactoriesTest
     {
         // GIVEN
         CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "node one\tnode two\ttype\tdate:long\tmore:long[]" ) );
+                ":START_ID\t:END_ID\ttype:TYPE\tdate:long\tmore:long[]" ) );
         IdType idType = IdType.ACTUAL;
         Extractors extractors = new Extractors( '\t' );
 
@@ -82,9 +82,9 @@ public class DataFactoriesTest
 
         // THEN
         assertArrayEquals( array(
-                entry( "node one", Type.START_NODE, idType.extractor( extractors ) ),
-                entry( "node two", Type.END_NODE, idType.extractor( extractors ) ),
-                entry( "type", Type.RELATIONSHIP_TYPE, extractors.string() ),
+                entry( null, Type.START_ID, idType.extractor( extractors ) ),
+                entry( null, Type.END_ID, idType.extractor( extractors ) ),
+                entry( "type", Type.TYPE, extractors.string() ),
                 entry( "date", Type.PROPERTY, extractors.long_() ),
                 entry( "more", Type.PROPERTY, extractors.longArray() ) ), header.entries() );
         seeker.close();


### PR DESCRIPTION
where header entries with semantic data, like node ids, relationship type
and labels must be specified with their corresponding types, no longer
relying in their position in the header. At the same time removed the need
for naming these columns.

Previously some header entries relied on position and some relied on type
being specified.

So, now a node header might look like:
:ID,name,:LABEL,year_of_birth:int

and a relationship header like:
:START_ID,:TYPE,:END_ID,some_property:String
