### PR TITLE
Fix the process number discovering (in detectrunning), broken by the lsof 4.88 version.

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -144,7 +144,7 @@ detectrunning() {
   else
       ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
       ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F p | grep "p")
       newpid=${newpid:1}
   fi
 }


### PR DESCRIPTION
Until 4.87 version, the only field that was always selected by lsof -F
option was 'p' (the process number), but in version 4.88 the 'f'
field (file descriptor) became also always selected. That broke the
process number discovering in function detectrunning.

Instead of asking for the 'T' fields (TCP/TPI information) and greping for
"TST=LISTEN" -B1, I asked for the 'p' field and greped for "p". That works
fine for both lsof versions.
