### PR TITLE
Fixes unstable NetworkSenderReceiverTest

### DIFF
--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverTest.java
@@ -101,7 +101,16 @@ public class NetworkSenderReceiverTest
     {
         /*
          * This test verifies that a closed channel from a sender to a receiver is removed from the connections
-         * mapping in the sender. It starts a sender, connects it to a receiver and sends a message
+         * mapping in the sender. It starts a sender, connects it to a receiver and sends a message.
+         *
+         * We should be testing this without resorting to using a NetworkReceiver. But, as prophets Mick Jagger and
+         * Keith Richards mention in their scriptures, you can't always get what you want. In this case,
+         * NetworkSender creates on its own the things required to communicate with the outside world, and this
+         * means it creates actual sockets. To interact with it then, we need to setup listeners for those sockets
+         * and respond properly. Hence, NetworkReceiver. Yes, this means that this test requires to open actual
+         * network sockets.
+         *
+         * Read on for further hacks in place.
          */
         NetworkSender sender = null;
         NetworkReceiver receiver = null;
@@ -113,12 +122,37 @@ public class NetworkSenderReceiverTest
 
             final Semaphore sem = new Semaphore( 0 );
 
+            /*
+             * A semaphore AND a boolean? Weird, you may think, as the purpose is clearly to step through the
+             * connection setup/teardown process. So, let's discuss what happens here more clearly.
+             *
+             * The sender and receiver are started. Trapped by the semaphore release on listeningAt()
+             * The sender sends through the first message, it is received by the receiver. Trapped by the semaphore
+             *      release on listeningAt() which is triggered on the first message receive on the receiver
+             * The receiver is stopped, trapped by the overridden stop() method of the logging service.
+             * The sender sends a message through, which will trigger the ChannelClosedException. This is where it
+             *      gets tricky. See, normally, since we waited for the semaphore on NetworkReceiver.stop() and an
+             *      happensBefore edge exists and all these good things, it should be certain that the Receiver is
+             *      actually stopped and the message would fail to be sent. That would be too easy though. In reality,
+             *      netty will not wait for all listening threads to stop before returning, so the receiver is not
+             *      guaranteed to not be listening for incoming connections when stop() returns. This happens rarely,
+             *      but the result is that the message "HelloWorld2" should fail with an exception (triggering the warn
+             *      method on the logger) but it doesn't. So we can't block, but we must retry until we know the
+             *      message failed to be sent and the exception happened, which is what this test is all about. We do
+             *      that with a boolean that is tested upon continuously with sent messages until the error happens.
+             *      Then we proceed with...
+             * The receiver is started. Trapped by the listeningAt() callback.
+             * The sender sends a message.
+             * The receiver receives it, trapped by the dummy processor added to the receiver.
+             */
+            final AtomicBoolean senderChannelClosed = new AtomicBoolean( false );
+
             doAnswer( new Answer<Object>()
             {
                 @Override
                 public Object answer( InvocationOnMock invocation ) throws Throwable
                 {
-                    sem.release();
+                    senderChannelClosed.set( true );
                     return null;
                 }
             } ).when( loggerMock ).warn( anyString() );
@@ -218,10 +252,27 @@ public class NetworkSenderReceiverTest
 
             sem.acquire(); // wait for overridden stop method in receiver
 
-            sender.process( Message.to( TestMessage.helloWorld, URI.create( "cluster://127.0.0.1:1235" ),
-                    "Hello World2" ) );
 
-            sem.acquire(); // wait for the warn from the sender
+            /*
+             * This is the infernal loop of doom. We keep sending messages until one fails with a ClosedChannelException
+             * which we have no better way to grab other than through the logger.warn() call which will occur.
+             *
+             * This code will hang if the warn we rely on is removed or if the receiver never stops - in general, if
+             * the closed channel exception is not thrown. This is not an ideal failure mode but it's the best we can
+             * do, given that NetworkSender is provided with very few things from its environment.
+             */
+            while ( !senderChannelClosed.get() )
+            {
+                sender.process( Message.to( TestMessage.helloWorld, URI.create( "cluster://127.0.0.1:1235" ),
+                        "Hello World2" ) );
+                /*
+                 * This sleep is not necessary, it's just nice. If it's ommitted, everything will work, but we'll
+                 * spam messages over the network as fast as possible. Even when the race between send and
+                 * receiver.stop() does not occur, we will still send 3-4 messages through at full speed. If it
+                 * does occur, then we are looking at hundreds. So we just back off a bit and let things work out.
+                 */
+                Thread.sleep( 5 );
+            }
 
             receiver.start();
 


### PR DESCRIPTION
The test occasionally failed because of a race condition between
 sending a message from NetworkSender and stopping a NetworkReceiver
 instance. The test depended on the message sent to result in a
 ClosedChannelException which occasionally did not happen, because
 NetworkReceiver.stop() does not block waiting for all listening
 threads to exit. The result is that the message would be received
 and the expected exception would not happen.
The fix adds a retry loop that keeps sending messages until the
 exception manifests. Then it goes on to verify the actual
 functionality
