### PR TITLE
Fix bug in EphemeralFileSystem

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
@@ -672,18 +672,19 @@ public class EphemeralFileSystemAbstraction extends LifecycleAdapter implements 
             int wanted = src.limit();
             int pending = wanted;
             byte[] scratchPad = SCRATCH_PAD.get();
-            while ( pending > 0 )
-            {
-                int howMuchToWriteThisTime = min( pending, scratchPad.length );
-                src.get( scratchPad, 0, howMuchToWriteThisTime );
-                long pos = fc.pos();
-                fileAsBuffer.put( (int) pos, scratchPad, 0, howMuchToWriteThisTime );
-                fc.pos( pos += howMuchToWriteThisTime );
-                pending -= howMuchToWriteThisTime;
-            }
 
             synchronized ( fileAsBuffer )
             {
+                while ( pending > 0 )
+                {
+                    int howMuchToWriteThisTime = min( pending, scratchPad.length );
+                    src.get( scratchPad, 0, howMuchToWriteThisTime );
+                    long pos = fc.pos();
+                    fileAsBuffer.put( (int) pos, scratchPad, 0, howMuchToWriteThisTime );
+                    fc.pos( pos + howMuchToWriteThisTime );
+                    pending -= howMuchToWriteThisTime;
+                }
+
                 // If we just made a jump in the file fill the rest of the gap with zeros
                 int newSize = max( size, (int) fc.pos() );
                 int intermediaryBytes = newSize - wanted - size;


### PR DESCRIPTION
When you write beyond the end of a file, the space in between is filled with zeros.
The EphemeralFileSystemAbstraction had insufficient synchronisation in that code, because it allowed
a thread to do a write beyond the end of the file, then another thread would write in the space in
between, and then the first thread would overwrite the new data with zeros.

During the course of debugging this, the PageCacheMonitor has been extended to also observe page
flushes.

This is a cherry-picked backport commit.

Conflicts:
    community/io/src/main/java/org/neo4j/io/pagecache/PageCacheMonitor.java
    community/io/src/main/java/org/neo4j/io/pagecache/impl/common/SingleFilePageSwapper.java
    community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/ClockSweepPageTable.java
    community/io/src/main/java/org/neo4j/io/pagecache/impl/standard/StandardPinnablePage.java
    community/io/src/test/java/org/neo4j/io/pagecache/CountingPageCacheMonitor.java
    community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
    community/io/src/test/java/org/neo4j/io/pagecache/RecordingPageCacheMonitor.java
    enterprise/enterprise-io/src/main/java/org/neo4j/io/enterprise/pagecache/impl/muninn/MuninnPage.java
    enterprise/enterprise-io/src/main/java/org/neo4j/io/enterprise/pagecache/impl/muninn/MuninnPagedFile.java
