### PR TITLE
Make more extensive request metadata available in batch requests.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/batch/NonStreamingBatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/NonStreamingBatchOperations.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.net.URI;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
@@ -42,10 +43,10 @@ public class NonStreamingBatchOperations extends BatchOperations
         super( webServer );
     }
 
-    public BatchOperationResults performBatchJobs( UriInfo uriInfo, HttpHeaders httpHeaders, InputStream body ) throws IOException, ServletException
+    public BatchOperationResults performBatchJobs( UriInfo uriInfo, HttpHeaders httpHeaders, HttpServletRequest req, InputStream body ) throws IOException, ServletException
     {
         results = new BatchOperationResults();
-        parseAndPerform( uriInfo, httpHeaders, body, results.getLocations() );
+        parseAndPerform( uriInfo, httpHeaders, req, body, results.getLocations() );
         return results;
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.jetty.http.HttpURI;
@@ -40,7 +41,6 @@ import org.eclipse.jetty.server.Response;
 
 public class InternalJettyServletRequest extends Request
 {
-
     private class Input extends ServletInputStream
     {
 
@@ -85,9 +85,18 @@ public class InternalJettyServletRequest extends Request
     private final String method;
     private final InternalJettyServletResponse response;
 
+    /** Optional, another HttpServletRequest to use to pull metadata, like remote address and port, out of. */
+    private HttpServletRequest outerRequest;
+
     public InternalJettyServletRequest( String method, String uri, String body, InternalJettyServletResponse res ) throws UnsupportedEncodingException
     {
         this( method, new HttpURI( uri ), body, new Cookie[] {}, MediaType.APPLICATION_JSON, "UTF-8", res );
+    }
+
+    public InternalJettyServletRequest( String method, String uri, String body, InternalJettyServletResponse res, HttpServletRequest outerReq ) throws UnsupportedEncodingException
+    {
+        this( method, new HttpURI( uri ), body, new Cookie[] {}, MediaType.APPLICATION_JSON, "UTF-8", res);
+        this.outerRequest = outerReq;
     }
 
     public InternalJettyServletRequest( String method, HttpURI uri, String body, Cookie[] cookies, String contentType, String encoding, InternalJettyServletResponse res )
@@ -157,49 +166,49 @@ public class InternalJettyServletRequest extends Request
     @Override
     public String getRemoteAddr()
     {
-        return null;
+        return outerRequest == null ? null : outerRequest.getRemoteAddr();
     }
 
     @Override
     public String getRemoteHost()
     {
-        return null;
+        return outerRequest == null ? null : outerRequest.getRemoteHost();
     }
 
     @Override
     public boolean isSecure()
     {
-        return false;
+        return outerRequest != null && outerRequest.isSecure();
     }
 
     @Override
     public int getRemotePort()
     {
-        return 0;
+        return outerRequest == null ? -1 : outerRequest.getRemotePort();
     }
 
     @Override
     public String getLocalName()
     {
-        return null;
+        return outerRequest == null ? null : outerRequest.getLocalName();
     }
 
     @Override
     public String getLocalAddr()
     {
-        return null;
+        return outerRequest == null ? null : outerRequest.getLocalAddr();
     }
 
     @Override
     public int getLocalPort()
     {
-        return 0;
+        return outerRequest == null ? -1 : outerRequest.getLocalPort();
     }
 
     @Override
     public String getAuthType()
     {
-        return null;
+        return outerRequest == null ? null : outerRequest.getAuthType();
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
@@ -51,10 +52,11 @@ public class StreamingBatchOperations extends BatchOperations
         super( webServer );
     }
 
-    public void readAndExecuteOperations( UriInfo uriInfo, HttpHeaders httpHeaders, InputStream body, ServletOutputStream output ) throws IOException, ServletException {
+    public void readAndExecuteOperations( UriInfo uriInfo, HttpHeaders httpHeaders, HttpServletRequest req,
+                                          InputStream body, ServletOutputStream output ) throws IOException, ServletException {
         results = new StreamingBatchOperationResults(jsonFactory.createJsonGenerator(output),output);
         Map<Integer, String> locations = results.getLocations();
-        parseAndPerform( uriInfo, httpHeaders, body, locations );
+        parseAndPerform( uriInfo, httpHeaders, req, body, locations );
         results.close();
     }
 /*

--- a/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
@@ -26,12 +26,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
 import org.neo4j.server.rest.web.InternalJettyServletRequest;
 import org.neo4j.server.rest.web.InternalJettyServletResponse;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BatchOperationsTest {
 
@@ -69,5 +72,32 @@ public class BatchOperationsTest {
 
         // then
         assertEquals("https",req.getScheme());
+    }
+
+    @Test
+    public void shouldForwardMetadataFromOuterRequest() throws Exception
+    {
+        // Given
+        HttpServletRequest mock = mock( HttpServletRequest.class );
+
+        when(mock.getAuthType()).thenReturn( "auth" );
+        when(mock.getRemoteAddr()).thenReturn( "127.0.0.1" );
+        when(mock.getRemoteHost()).thenReturn( "localhost" );
+        when(mock.getRemotePort()).thenReturn( 1 );
+        when(mock.getLocalAddr()).thenReturn( "129.0.0.1" );
+        when(mock.getLocalPort()).thenReturn( 2 );
+
+        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST",
+                "https://localhost:7473/db/data/node", "", new InternalJettyServletResponse(),
+                mock );
+
+        // When & then
+        assertEquals( "auth", req.getAuthType());
+        assertEquals( "127.0.0.1", req.getRemoteAddr());
+        assertEquals( "localhost", req.getRemoteHost());
+        assertEquals( 1, req.getRemotePort());
+        assertEquals( 2, req.getLocalPort());
+        assertEquals( "129.0.0.1", req.getLocalAddr());
+
     }
 }


### PR DESCRIPTION
This ensures that remote host, port, https and other metadata is made available in the internal requests made by the batch http service.
