### PR TITLE
Fixed relationship id generator issue in multiple input groups

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -26,6 +26,7 @@ import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapping;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingIdSequence;
 
 /**
  * Provides {@link Input} from data contained in tabular/csv form. Expects factories for instantiating
@@ -42,6 +43,7 @@ public class CsvInput implements Input
     private final IdMapping idMapping;
     private final Configuration config;
     private final int[] delimiter;
+    private final BatchingIdSequence relationshipIds = new BatchingIdSequence();
 
     /**
      * @param nodeDataFactory multiple {@link DataFactory} instances providing data, each {@link DataFactory}
@@ -100,6 +102,7 @@ public class CsvInput implements Input
             @Override
             public ResourceIterator<InputRelationship> iterator()
             {
+                relationshipIds.reset();
                 return new InputGroupsDeserializer<InputRelationship>( relationshipDataFactory.iterator(),
                                                                        relationshipHeaderFactory, config, idType )
                 {
@@ -107,7 +110,7 @@ public class CsvInput implements Input
                     protected ResourceIterator<InputRelationship> entityDeserializer( CharSeeker dataStream,
                                                                                       Header dataHeader )
                     {
-                        return new InputRelationshipDeserializer( dataHeader, dataStream, delimiter );
+                        return new InputRelationshipDeserializer( dataHeader, dataStream, delimiter, relationshipIds );
                     }
                 };
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
 import org.neo4j.csv.reader.CharSeeker;
+import org.neo4j.kernel.impl.store.id.IdSequence;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
 /**
@@ -28,15 +29,18 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
  */
 class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelationship>
 {
+    private final IdSequence idSequence;
+
     // Additional data
     private long id;
     private String type;
     private Object startNode;
     private Object endNode;
 
-    InputRelationshipDeserializer( Header header, CharSeeker data, int[] delimiter )
+    InputRelationshipDeserializer( Header header, CharSeeker data, int[] delimiter, IdSequence idSequence )
     {
         super( header, data, delimiter );
+        this.idSequence = idSequence;
     }
 
     @Override
@@ -59,6 +63,6 @@ class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelatio
     @Override
     protected InputRelationship convertToInputEntity( Object[] properties )
     {
-        return new InputRelationship( id++, properties, null, startNode, endNode, type, null );
+        return new InputRelationship( idSequence.nextId(), properties, null, startNode, endNode, type, null );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdSequence.java
@@ -39,4 +39,9 @@ public class BatchingIdSequence implements IdSequence
         }
         return result;
     }
+
+    public void reset()
+    {
+        nextId = 0;
+    }
 }


### PR DESCRIPTION
Previously multiple input groups would have the id sequence of
relationships restarted from 0.
