### PR TITLE
Fixed update puller unpausing during switch to slave and concurrent master election

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -432,10 +432,9 @@ public class SwitchToSlave
         RequestContext catchUpRequestContext = requestContextFactory.newRequestContext();
         console.log( "Catching up with master. I'm at " + catchUpRequestContext );
 
-        // This is the only place we unpause the update puller, when we know that we are a slave
-        // and we just started our communication with our master.
+        // Unpause the update puller, because we know that we are a slave that just started communication with master.
         UpdatePuller updatePuller = resolver.resolveDependency( UpdatePuller.class );
-        updatePuller.pause( false );
+        updatePuller.unpause();
         updatePuller.await( UpdatePuller.NEXT_TICKET );
 
         console.log( "Now caught up with master" );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
@@ -75,6 +75,10 @@ public abstract class SlavePriorities
             public Iterable<Slave> prioritize( final Iterable<Slave> slaves )
             {
                 final List<Slave> slaveList = sortSlaves( slaves, true );
+                if ( slaveList.isEmpty() )
+                {
+                    return Iterables.empty();
+                }
                 return new Iterable<Slave>()
                 {
                     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerTest.java
@@ -122,7 +122,7 @@ public class UpdatePullerTest
         assertNotNull( scheduler.getJob() );
 
         puller.start();
-        updatePuller.pause( false );
+        updatePuller.unpause();
         scheduler.runJob();
 
         verify( lastUpdateTime, times( 1 ) ).setLastUpdateTime( anyLong() );
@@ -149,7 +149,7 @@ public class UpdatePullerTest
         // WHEN
         puller.init();
         puller.start();
-        updatePuller.pause( false );
+        updatePuller.unpause();
         scheduler.runJob();
 
         // THEN
@@ -178,7 +178,7 @@ public class UpdatePullerTest
         // WHEN
         puller.init();
         puller.start();
-        updatePuller.pause( false );
+        updatePuller.unpause();
         scheduler.runJob();
 
         // THEN
@@ -207,7 +207,7 @@ public class UpdatePullerTest
         // WHEN
         puller.init();
         puller.start();
-        updatePuller.pause( false );
+        updatePuller.unpause();
         scheduler.runJob();
 
         // THEN
@@ -220,7 +220,7 @@ public class UpdatePullerTest
         // This job should be ignored, since I'm now master
         scheduler.runJob();
 
-        updatePuller.pause( false );
+        updatePuller.unpause();
 
         scheduler.runJob();
 
@@ -241,7 +241,7 @@ public class UpdatePullerTest
 
         puller.init();
         puller.start();
-        updatePuller.pause( false );
+        updatePuller.unpause();
         scheduler.runJob();
 
         verify( lastUpdateTime, times( 1 ) ).setLastUpdateTime( anyLong() );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/SlavePrioritiesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/SlavePrioritiesTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SlavePrioritiesTest
+{
+    @Test
+    public void roundRobinWithTwoSlavesAndPushFactorTwo()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Iterator<Slave> slaves = roundRobin.prioritize( slaves( 2, 3 ) ).iterator();
+
+        // Then
+        assertEquals( 2, slaves.next().getServerId() );
+        assertEquals( 3, slaves.next().getServerId() );
+    }
+
+    @Test
+    public void roundRobinWithTwoSlavesAndPushFactorOne()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Slave slave1 = roundRobin.prioritize( slaves( 2, 3 ) ).iterator().next();
+        Slave slave2 = roundRobin.prioritize( slaves( 2, 3 ) ).iterator().next();
+
+        // Then
+        assertEquals( 2, slave1.getServerId() );
+        assertEquals( 3, slave2.getServerId() );
+    }
+
+    @Test
+    public void roundRobinWithTwoSlavesAndPushFactorOneWhenSlaveIsAdded()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Slave slave1 = roundRobin.prioritize( slaves( 2, 3 ) ).iterator().next();
+        Slave slave2 = roundRobin.prioritize( slaves( 2, 3 ) ).iterator().next();
+        Slave slave3 = roundRobin.prioritize( slaves( 2, 3, 4 ) ).iterator().next();
+
+        // Then
+        assertEquals( 2, slave1.getServerId() );
+        assertEquals( 3, slave2.getServerId() );
+        assertEquals( 4, slave3.getServerId() );
+    }
+
+    @Test
+    public void roundRobinWithTwoSlavesAndPushFactorOneWhenSlaveIsRemoved()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Slave slave1 = roundRobin.prioritize( slaves( 2, 3, 4 ) ).iterator().next();
+        Slave slave2 = roundRobin.prioritize( slaves( 2, 3, 4 ) ).iterator().next();
+        Slave slave3 = roundRobin.prioritize( slaves( 2, 3 ) ).iterator().next();
+
+        // Then
+        assertEquals( 2, slave1.getServerId() );
+        assertEquals( 3, slave2.getServerId() );
+        assertEquals( 2, slave3.getServerId() );
+    }
+
+    @Test
+    public void roundRobinWithSingleSlave()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Iterator<Slave> slaves = roundRobin.prioritize( slaves( 2 ) ).iterator();
+
+        // Then
+        assertEquals( 2, slaves.next().getServerId() );
+    }
+
+    @Test
+    public void roundRobinWithNoSlaves()
+    {
+        // Given
+        SlavePriority roundRobin = SlavePriorities.roundRobin();
+
+        // When
+        Iterator<Slave> slaves = roundRobin.prioritize( slaves() ).iterator();
+
+        // Then
+        assertFalse( slaves.hasNext() );
+    }
+
+    private static Iterable<Slave> slaves( int... ids )
+    {
+        List<Slave> slaves = new ArrayList<>( ids.length );
+        for ( int id : ids )
+        {
+            Slave slaveMock = mock( Slave.class );
+            when( slaveMock.getServerId() ).thenReturn( id );
+            slaves.add( slaveMock );
+        }
+        return slaves;
+    }
+}


### PR DESCRIPTION
It could so happen that masterIsAvailable event, which pauses update puller, is fired during switch to slave is in progress. This could lead to a situation when update puller was unpaused by slave switch and then immediately paused by masterIsAvailable. Such race left update puller paused until next election.
This PR adds unpausing of update puller when cluster member sees itself as available slave.
