### PR TITLE
Update cardinality estimation for Apply

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/CachedFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/CachedFunction.scala
@@ -35,4 +35,7 @@ object CachedFunction {
 
   def byIdentity[A, B, C](f: (A, B) => C): (A, B) => C =
     Function.untupled(byIdentity(f.tupled))
+
+  def byIdentity[A, B, C, D](f: (A, B, C) => D): (A, B, C) => D =
+    Function.untupled(byIdentity(f.tupled))
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
@@ -64,9 +64,9 @@ case class Planner(monitors: Monitors,
     tokenResolver.resolve(ast)(semanticTable, planContext)
     val unionQuery = ast.asUnionQuery
 
-    val metrics = metricsFactory.newMetrics(planContext.statistics, semanticTable)
-
-    val context = LogicalPlanningContext(planContext, metrics, semanticTable, queryGraphSolver)
+    val relativeMetricsFactory = (cardinality: Cardinality) => metricsFactory.newMetrics(planContext.statistics, cardinality, semanticTable)
+    val metrics = relativeMetricsFactory(Cardinality(1))
+    val context = LogicalPlanningContext(planContext, metrics, relativeMetricsFactory, semanticTable, queryGraphSolver)
     val plan = strategy.plan(unionQuery)(context)
 
     val pipeBuildContext = PipeExecutionBuilderContext((e: PatternExpression) => {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CachedMetricsFactory.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CachedMetricsFactory.scala
@@ -32,8 +32,8 @@ case class CachedMetricsFactory(metricsFactory: MetricsFactory) extends MetricsF
   def newCostModel(cardinality: CardinalityModel) =
     CachedFunction.byIdentity(metricsFactory.newCostModel(cardinality))
 
-  def newQueryGraphCardinalityModel(statistics: GraphStatistics, semanticTable: SemanticTable) =
-    CachedFunction.byIdentity(metricsFactory.newQueryGraphCardinalityModel(statistics, semanticTable))
+  def newQueryGraphCardinalityModel(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable) =
+    CachedFunction.byIdentity(metricsFactory.newQueryGraphCardinalityModel(statistics, inboundCardinality, semanticTable))
 
   def newCandidateListCreator(): (Seq[LogicalPlan]) => CandidateList =
     metricsFactory.newCandidateListCreator()

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CandidateList.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CandidateList.scala
@@ -39,7 +39,7 @@ case class CandidateList(plans: Seq[LogicalPlan] = Seq.empty) {
       if (sortedPlans.size > 1) {
         println("Get best of:")
         for (plan <- sortedPlans) {
-          println("* " + plan.toString + s"\t${costs(plan)}\n")
+          println("* " + plan.toString + s"\n${costs(plan)}\n")
         }
 
         println("Best is:")

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CardinalityCostModel.scala
@@ -67,6 +67,17 @@ case class CardinalityCostModel(cardinality: CardinalityModel) extends CostModel
     case CartesianProduct(lhs, rhs) =>
       apply(lhs) + cardinality(lhs) * apply(rhs)
 
+    case Apply(lhs, rhs) =>
+      val lCost = apply(lhs)
+      val lCardinality = cardinality(lhs)
+      val rCost = apply(rhs)
+      lCost + lCardinality * rCost
+
+    case OuterHashJoin(_, lhs, rhs) =>
+      val lCost = apply(lhs)
+      val rCost = apply(rhs)
+      lCost + rCost
+
     case _ =>
       val lhsCost = plan.lhs.map(apply).getOrElse(Cost(0))
       val rhsCost = plan.rhs.map(apply).getOrElse(Cost(0))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphSolvingContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphSolvingContext.scala
@@ -27,8 +27,10 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.IdName
 
 case class LogicalPlanningContext(planContext: PlanContext,
                                   metrics: Metrics,
+                                  metricsFactory: (Cardinality) => Metrics,
                                   semanticTable: SemanticTable,
                                   strategy: QueryGraphSolver) {
+  def relativeMetrics(cardinality: Cardinality): Metrics = metricsFactory(cardinality)
 
   def statistics = planContext.statistics
   def cost = metrics.cost

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/SimpleMetricsFactory.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/SimpleMetricsFactory.scala
@@ -32,8 +32,8 @@ object SimpleMetricsFactory extends MetricsFactory {
   def newCardinalityEstimator(queryGraphCardinalityModel: QueryGraphCardinalityModel)
   : CardinalityModel = new StatisticsBackedCardinalityModel(queryGraphCardinalityModel)
 
-  def newQueryGraphCardinalityModel(statistics: GraphStatistics, semanticTable: SemanticTable) =
-    QueryGraphCardinalityModel.default(statistics, semanticTable)
+  def newQueryGraphCardinalityModel(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable) =
+    QueryGraphCardinalityModel.default(statistics, inboundCardinality, semanticTable)
 
   def newCandidateListCreator(): (Seq[LogicalPlan]) => CandidateList = plans => CandidateList(plans)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/QueryGraphCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/QueryGraphCardinalityModel.scala
@@ -20,11 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality
 
 import org.neo4j.cypher.internal.compiler.v2_2.planner.SemanticTable
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Cardinality
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics.QueryGraphCardinalityModel
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality.assumeIndependence.{AssumeIndependenceQueryGraphCardinalityModel, IndependenceCombiner}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.GraphStatistics
 
 object QueryGraphCardinalityModel {
-  def default(statistics: GraphStatistics, semanticTable: SemanticTable): QueryGraphCardinalityModel =
-    AssumeIndependenceQueryGraphCardinalityModel(statistics, semanticTable, IndependenceCombiner)
+  def default(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable): QueryGraphCardinalityModel =
+    AssumeIndependenceQueryGraphCardinalityModel(statistics, inboundCardinality, semanticTable, IndependenceCombiner)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/ExpressionSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/ExpressionSelectivityCalculator.scala
@@ -63,12 +63,12 @@ case class ExpressionSelectivityCalculator(stats: GraphStatistics, combiner: Sel
       if func.function == Some(functions.Id) =>
       c.expressions.size / stats.nodesWithLabelCardinality(None)
 
-    case _ => Selectivity(1)
+    case _ => Selectivity(.5)
   }
 
   private def calculateSelectivityForLabel(label: Option[LabelId]): Selectivity = {
     val nodeCardinality: Cardinality = stats.nodesWithLabelCardinality(None)
-    if (nodeCardinality == Cardinality(0.0)) {
+    if (nodeCardinality == Cardinality.EMPTY) {
       return 1.0
     }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
@@ -46,7 +46,7 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
     val maxRelCount = lhsCardinality * rhsCardinality
     val types = mapToRelTokenSpecs(pattern.types)
 
-    if (maxRelCount == Cardinality(0))
+    if (maxRelCount == Cardinality.EMPTY)
       Selectivity(1)
     else
       calculateRelSelectivity(types, labelsOnLhs, labelsOnRhs, pattern.dir, maxRelCount)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/solveOptionalMatches.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/solveOptionalMatches.scala
@@ -42,6 +42,7 @@ case class solveOptionalMatches(solvers: Seq[OptionalSolver]) {
           case (lhs: LogicalPlan, optionalQg: QueryGraph) =>
             val plans = solvers.flatMap(_.apply(optionalQg, lhs))
             assert(plans.map(_.solved).distinct.size == 1) // All plans are solving the same query
+
             CandidateList(plans).bestPlan(context.cost).get
         }
         table + newPlan
@@ -83,8 +84,9 @@ object solveOptionalMatches extends LogicalPlanningFunction2[PlanTable, QueryGra
 }
 
 case object applyOptional extends OptionalSolver {
-  def apply(optionalQg: QueryGraph, lhs: LogicalPlan)(implicit context: LogicalPlanningContext) =
+  def apply(optionalQg: QueryGraph, lhs: LogicalPlan)(implicit context: LogicalPlanningContext) = {
     Some(planApply(lhs, planOptional(context.strategy.plan(optionalQg))))
+  }
 }
 
 case object outerHashJoin extends OptionalSolver {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
@@ -56,8 +56,8 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       SimpleMetricsFactory.newCardinalityEstimator(queryGraphCardinalityModel)
     def newCostModel(cardinality: CardinalityModel) =
       SimpleMetricsFactory.newCostModel(cardinality)
-    def newQueryGraphCardinalityModel(statistics: GraphStatistics, semanticTable: SemanticTable): QueryGraphCardinalityModel =
-      SimpleMetricsFactory.newQueryGraphCardinalityModel(statistics, semanticTable)
+    def newQueryGraphCardinalityModel(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable): QueryGraphCardinalityModel =
+      SimpleMetricsFactory.newQueryGraphCardinalityModel(statistics, inboundCardinality, semanticTable)
 
     def newCandidateListCreator(): (Seq[LogicalPlan]) => CandidateList = SimpleMetricsFactory.newCandidateListCreator()
 
@@ -82,7 +82,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
   def newMetricsFactory = SimpleMetricsFactory
 
   def newSimpleMetrics(stats: GraphStatistics = newMockedGraphStatistics, semanticTable: SemanticTable) =
-    newMetricsFactory.newMetrics(stats, semanticTable)
+    newMetricsFactory.newMetrics(stats, Cardinality(1), semanticTable)
 
   def newMockedGraphStatistics = mock[GraphStatistics]
 
@@ -110,7 +110,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
                                         metrics: Metrics = mockedMetrics,
                                         semanticTable: SemanticTable = newMockedSemanticTable,
                                         strategy: QueryGraphSolver = new GreedyQueryGraphSolver()): LogicalPlanningContext =
-    LogicalPlanningContext(planContext, metrics, semanticTable, strategy)
+    LogicalPlanningContext(planContext, metrics, (_) => metrics, semanticTable, strategy)
 
   implicit class RichLogicalPlan(plan: LogicalPlan) {
     def asTableEntry = plan.availableSymbols -> plan

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CandidateListTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CandidateListTest.scala
@@ -93,7 +93,7 @@ class CandidateListTest extends CypherFunSuite with LogicalPlanningTestSupport2 
 
   private def assertTopPlan(winner: LogicalPlan, candidates: LogicalPlan*)(GIVEN: given) {
     val environment = LogicalPlanningEnvironment(GIVEN)
-    val costs = environment.metricsFactory.newMetrics(GIVEN.graphStatistics, environment.semanticTable).cost
+    val costs = environment.metricsFactory.newMetrics(GIVEN.graphStatistics, Cardinality(1), environment.semanticTable).cost
     CandidateList(candidates).bestPlan(costs) should equal(Some(winner))
     CandidateList(candidates.reverse).bestPlan(costs) should equal(Some(winner))
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModelTest.scala
@@ -59,7 +59,6 @@ class StatisticsBackedCardinalityModelTest extends CypherFunSuite with LogicalPl
   }
 
   test("query containing a WITH and aggregation") {
-
     val patternNodeCrossProduct = allNodes * allNodes
     val labelSelectivity = personCount / allNodes
     val maxRelCount = patternNodeCrossProduct * labelSelectivity
@@ -80,6 +79,6 @@ class StatisticsBackedCardinalityModelTest extends CypherFunSuite with LogicalPl
   def produceCardinalityModel(in: QueryGraphCardinalityModel): Metrics.CardinalityModel =
     new StatisticsBackedCardinalityModel(in)
 
-  def createCardinalityModel(stats: GraphStatistics, semanticTable: SemanticTable): QueryGraphCardinalityModel =
-    AssumeIndependenceQueryGraphCardinalityModel(stats, semanticTable, IndependenceCombiner)
+  def createCardinalityModel(stats: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable): QueryGraphCardinalityModel =
+    AssumeIndependenceQueryGraphCardinalityModel(stats, inboundCardinality, semanticTable, IndependenceCombiner)
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/AssumeDependenceCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/AssumeDependenceCardinalityModelTest.scala
@@ -22,7 +22,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics.QueryGrap
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality.assumeDependence._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.IdName
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{SemanticTable, LogicalPlanningTestSupport}
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.CardinalityTestHelper
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Cardinality, CardinalityTestHelper}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.GraphStatistics
 
 class AssumeDependenceCardinalityModelTest extends CypherFunSuite with LogicalPlanningTestSupport with CardinalityTestHelper {
@@ -309,6 +309,6 @@ class AssumeDependenceCardinalityModelTest extends CypherFunSuite with LogicalPl
       shouldHaveQueryGraphCardinality(1000.0 * Math.min(500.0 / 1000 , 3.0 / 1000))
   }
 
-  def createCardinalityModel(stats: GraphStatistics, semanticTable: SemanticTable): QueryGraphCardinalityModel =
+  def createCardinalityModel(stats: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable): QueryGraphCardinalityModel =
     AssumeDependenceQueryGraphCardinalityModel(stats, producePredicates, groupPredicates(estimateSelectivity(stats, semanticTable)), combinePredicates.assumeDependence)
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/EstimateSelectivityTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/EstimateSelectivityTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality.assumeDependence._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{QueryGraph, SemanticTable, LogicalPlanningTestSupport}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{IdName, PatternRelationship, SimplePatternLength}
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{CardinalityTestHelper, QueryGraphProducer}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Cardinality, CardinalityTestHelper, QueryGraphProducer}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.GraphStatistics
 import org.neo4j.graphdb.Direction
 
@@ -137,6 +137,6 @@ class EstimateSelectivityTest extends CypherFunSuite with LogicalPlanningTestSup
     shouldHaveSelectivity( .75 )
   }
 
-  def createCardinalityModel(stats: GraphStatistics, semanticTable: SemanticTable): QueryGraphCardinalityModel =
+  def createCardinalityModel(stats: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable): QueryGraphCardinalityModel =
     AssumeDependenceQueryGraphCardinalityModel(stats, producePredicates, groupPredicates(estimateSelectivity(stats, semanticTable)), combinePredicates.assumeDependence)
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/AllNodesLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/AllNodesLeafPlannerTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{QueryGraph, LogicalPlanningTestSupport}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.allNodesLeafPlanner
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Candidates
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Cardinality, Candidates}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.LogicalPlanProducer._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.PatternExpression
 
@@ -37,7 +37,7 @@ class AllNodesLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     implicit val planContext = newMockedPlanContext
     implicit val context = newMockedLogicalPlanningContext(
       planContext = planContext,
-      metrics = newMockedMetricsFactory.newMetrics(hardcodedStatistics, newMockedSemanticTable))
+      metrics = newMockedMetricsFactory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable))
 
     // when
     val resultPlans = allNodesLeafPlanner(queryGraph)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/IdSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/IdSeekLeafPlannerTest.scala
@@ -60,7 +60,7 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
     })
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), newMockedSemanticTable)
     )
     when(context.semanticTable.isNode(identifier)).thenReturn(true)
 
@@ -100,7 +100,7 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
     })
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), newMockedSemanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
 
@@ -137,7 +137,7 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
     })
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), newMockedSemanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
 
@@ -180,7 +180,7 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
     })
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, semanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), semanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
 
@@ -227,7 +227,7 @@ class IdSeekLeafPlannerTest extends CypherFunSuite  with LogicalPlanningTestSupp
     })
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, semanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), semanticTable)
     )
     when(context.semanticTable.isRelationship(rIdent)).thenReturn(true)
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/LabelScanLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/LabelScanLeafPlannerTest.scala
@@ -56,7 +56,7 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     implicit val context = newMockedLogicalPlanningContext(
       semanticTable = semanticTable,
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), newMockedSemanticTable)
     )
 
     // when
@@ -87,7 +87,7 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     implicit val context = newMockedLogicalPlanningContext(
       semanticTable = semanticTable,
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(statistics, semanticTable)
+      metrics = factory.newMetrics(statistics, Cardinality(1), semanticTable)
     )
 
     // when

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/CartesianProductTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/CartesianProductTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.HardcodedGraphStatistics
 import org.neo4j.cypher.internal.compiler.v2_2.ast.PatternExpression
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{CartesianProduct, LogicalPlan}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.LogicalPlanProducer._
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Candidates, Cost, PlanTable}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Cardinality, Candidates, Cost, PlanTable}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport, QueryGraph}
 
 class CartesianProductTest extends CypherFunSuite with LogicalPlanningTestSupport {
@@ -61,7 +61,7 @@ class CartesianProductTest extends CypherFunSuite with LogicalPlanningTestSuppor
     when(factory.newCostModel(any())).thenReturn(cost.andThen(Cost.apply))
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(HardcodedGraphStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(HardcodedGraphStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val table = PlanTable(plans.map(p => p.availableSymbols -> p).toMap)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/OuterHashJoinTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/OuterHashJoinTest.scala
@@ -63,7 +63,7 @@ class OuterHashJoinTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
       strategy = newMockedStrategy(innerPlan),
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
     val left = newMockedLogicalPlanWithPatterns(Set(aNode))
     val plans = outerHashJoin(optionalQg, left)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -71,7 +71,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -104,7 +104,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -137,7 +137,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val bPlan = newMockedLogicalPlan("b")
@@ -172,7 +172,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -210,7 +210,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -257,7 +257,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -304,7 +304,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -351,7 +351,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -403,7 +403,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -455,7 +455,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
 
     val aPlan = newMockedLogicalPlan("a")

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/SolveOptionalMatchesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/SolveOptionalMatchesTest.scala
@@ -67,7 +67,7 @@ class SolveOptionalMatchesTest extends CypherFunSuite with LogicalPlanningTestSu
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
     val planTable = PlanTable(Map(Set(IdName("a")) -> lhs))
 
@@ -286,7 +286,7 @@ class SolveOptionalMatchesTest extends CypherFunSuite with LogicalPlanningTestSu
 
     implicit val context = newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
     val lhs = newMockedLogicalPlan("a")
     val planTable = PlanTable(Map(Set(IdName("a")) -> lhs))
@@ -314,7 +314,7 @@ class SolveOptionalMatchesTest extends CypherFunSuite with LogicalPlanningTestSu
     val factory = newMockedMetricsFactory
     newMockedLogicalPlanningContext(
       planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics, newMockedSemanticTable)
+      metrics = factory.newMetrics(hardcodedStatistics, Cardinality(1), newMockedSemanticTable)
     )
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
@@ -105,8 +105,9 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
     }
   }
 
-  private def customMetrics(qgcmCreator: (GraphStatistics, SemanticTable) => QueryGraphCardinalityModel) = new MetricsFactory {
-    def newQueryGraphCardinalityModel(statistics: GraphStatistics, semanticTable: SemanticTable) = qgcmCreator(statistics, semanticTable)
+  private def customMetrics(qgcmCreator: (GraphStatistics, Cardinality, SemanticTable) => QueryGraphCardinalityModel) = new MetricsFactory {
+    def newQueryGraphCardinalityModel(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable) =
+      qgcmCreator(statistics, inboundCardinality, semanticTable)
 
     def newCardinalityEstimator(queryGraphCardinalityModel: QueryGraphCardinalityModel) =
       SimpleMetricsFactory.newCardinalityEstimator(queryGraphCardinalityModel)
@@ -210,8 +211,8 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
 
     def newCandidateListCreator(): (Seq[LogicalPlan]) => CandidateList = plans => new LoggingCandidateList(plans)
 
-    def newQueryGraphCardinalityModel(statistics: GraphStatistics, semanticTable: SemanticTable) =
-      inner.newQueryGraphCardinalityModel(statistics, semanticTable)
+    def newQueryGraphCardinalityModel(statistics: GraphStatistics, inboundCardinality: Cardinality, semanticTable: SemanticTable) =
+      inner.newQueryGraphCardinalityModel(statistics, inboundCardinality, semanticTable)
   }
 
 }


### PR DESCRIPTION
When producing execution plans, a solution for recursive query building
is to stitch together by using Apply. A SingleRow doesn't actually produce
a single row when inside Apply. It is named SingleRow because that is
how many rows this operator will yield per open()/close() session, but the
total number of rows might be a value much higher. This commit changes
so the cardinality model returns the total number of rows, not just 1.
