### PR TITLE
Recognizes stray quote characters and treats them as any other normal char

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -92,9 +92,9 @@ public class BufferedCharSeeker implements CharSeeker
         {
             ch = nextChar( skippedChars );
             if ( quoteDepth == 0 )
-            {   //In normal mode, i.e. not within quotes
-                if ( ch == quoteChar )
-                {   // We found a quote, skip it and switch modes
+            {   // In normal mode, i.e. not within quotes
+                if ( ch == quoteChar && seekStartPos == bufferPos - 1/* -1 since we just advanced one */ )
+                {   // We found a quote, which was the first of the value, skip it and switch mode
                     quoteDepth++;
                     seekStartPos++;
                     continue;

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -388,6 +388,26 @@ public class BufferedCharSeekerTest
         assertEquals( "va\"lue\" three", seeker.extract( mark, extractors.string() ).value() );
     }
 
+    @Test
+    public void shouldRecognizeStrayQuoteCharacters() throws Exception
+    {
+        // GIVEN
+        seeker = new BufferedCharSeeker( new StringReader(
+                "one,two\",th\"ree\n" +
+                "four,five,s\"ix" ) );
+
+        // THEN
+        assertNextValue( seeker, mark, COMMA, "one" );
+        assertNextValue( seeker, mark, COMMA, "two\"" );
+        assertNextValue( seeker, mark, COMMA, "th\"ree" );
+        assertTrue( mark.isEndOfLine() );
+        assertNextValue( seeker, mark, COMMA, "four" );
+        assertNextValue( seeker, mark, COMMA, "five" );
+        assertNextValue( seeker, mark, COMMA, "s\"ix" );
+        assertTrue( mark.isEndOfLine() );
+        assertFalse( seeker.seek( mark, COMMA ) );
+    }
+
     private String[][] randomWeirdValues( int cols, int rows, char... except )
     {
         String[][] data = new String[rows][cols];


### PR DESCRIPTION
A stray quote in a value, i.e. a quote character outside a quotation and
not the first one of a value, for example:

  `Blue 29.5" monitor`

Such quote characters are now recognized as just normal characters and
doesn't semantically change how the value is interpreted, and more
importantly doesn't affect interpreation of other values following.
