### PR TITLE
Early termination of hash joins when possible

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeHashJoinPipe.scala
@@ -34,7 +34,13 @@ case class NodeHashJoinPipe(nodeIdentifiers: Set[String], left: Pipe, right: Pip
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
 
+    if (input.isEmpty)
+      return Iterator.empty
+
     val table = buildProbeTable(input)
+
+    if (table.isEmpty)
+      return Iterator.empty
 
     val result = for {context: ExecutionContext <- right.createResults(state)
                       joinKey <- computeKey(context)}


### PR DESCRIPTION
If the LHS of the HashJoin is empty or the probe table that is built (in order to execute the hash join)
is empty, we terminate immediately; i.e. no further processing occurs
