### PR TITLE
Added ability to trigger index sampling from shell.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.Function;
+import org.neo4j.function.Function;
 import org.neo4j.helpers.Predicate;
 
 /**

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.shell.Output;
 import org.neo4j.shell.Response;
@@ -115,6 +116,11 @@ public class GraphDatabaseShellServer extends AbstractAppServer
             TopLevelTransaction tx = threadToStatementContextBridge.getTopLevelTransactionBoundToThisThread( false );
             clients.put( clientId, tx );
         }
+    }
+
+    public Statement getStatement()
+    {
+        return getThreadToStatementContextBridge().instance();
     }
 
     private ThreadToStatementContextBridge getThreadToStatementContextBridge()

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -894,6 +894,192 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
+    public void failSampleWhenNoOptionGiven() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("Invalid usage of sample"));
+        }
+    }
+
+    @Test
+    public void canSampleAllIndexes() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        executeCommand( "schema sample -a");
+    }
+
+    @Test
+    public void canForceSampleIndexes() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        executeCommand( "schema sample -a -f");
+    }
+
+    @Test
+    public void canSampleSpecificIndex() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        executeCommand( "schema sample -l Person -p name");
+    }
+
+    @Test
+    public void failSamplingWhenProvidingBadLabel() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample -l People -p name");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("No label associated with 'People' was found"));
+        }
+    }
+
+    @Test
+    public void failSamplingWhenProvidingBadProperty() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample -l Person -p namn");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("No property associated with 'namn' was found"));
+        }
+    }
+
+    @Test
+    public void failSamplingWhenProvidingOnlyLabel() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample -l Person");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("Provide both the property and the label, or run with -a to sample all indexes"));
+        }
+    }
+
+    @Test
+    public void failSamplingWhenProvidingOnlyProperty() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index = db.schema().indexFor( label ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample -p name");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("Provide both the property and the label, or run with -a to sample all indexes"));
+        }
+    }
+
+    @Test
+    public void failSamplingWhenProvidingMultipleLabels() throws Exception
+    {
+        // GIVEN
+        Label label = label( "Person" );
+        Label otherLabel = label( "Dog" );
+        String property = "name";
+        beginTx();
+        IndexDefinition index1 = db.schema().indexFor( label ).on( property ).create();
+        IndexDefinition index2 = db.schema().indexFor( otherLabel ).on( property ).create();
+        finishTx();
+        waitForIndex( db, index1 );
+        waitForIndex( db, index2 );
+
+        // WHEN / THEN
+        try
+        {
+            executeCommand( "schema sample -p name -l [Person,Dog]");
+            fail("This should fail");
+        }
+        catch ( ShellException e )
+        {
+            assertThat(e.getMessage(), containsString("Only one label must be provided"));
+        }
+    }
+
+    @Test
     public void committingFailedTransactionShouldProperlyFinishTheTransaction() throws Exception
     {
         // GIVEN a transaction with a created constraint in it


### PR DESCRIPTION
Usage:
`schema sample -a`
will sample all indexes.
`schema sample -l Person -p name`
will sample the index on index the for label 'Person' on property 'name' (if existing)
`schema sample -a -f`
will force a sample of all indexes.
