### PR TITLE
Shell: use a sane timeout for index to come up.

### DIFF
--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -108,7 +108,7 @@ public class Schema extends TransactionProvidingApp
             {
                 out.println( String.format( "Awaiting :%s ON %s %s", index.getLabel().name(),
                         toList( index.getPropertyKeys() ), IndexState.ONLINE ) );
-                schema.awaitIndexOnline( index, 10000, TimeUnit.DAYS );
+                schema.awaitIndexOnline( index, 10, TimeUnit.SECONDS );
             }
         }
     }


### PR DESCRIPTION
Assuming 10k was meant to mean milliseconds.

Are 10s enough for larger graphs, or should this rather be 30s or maybe 90s?
