### PR TITLE
Uses garbage free read-method on Reader for CSV reading

### DIFF
--- a/advanced/management/src/main/java/org/neo4j/management/IndexSamplingManager.java
+++ b/advanced/management/src/main/java/org/neo4j/management/IndexSamplingManager.java
@@ -21,9 +21,6 @@ package org.neo4j.management;
 
 import org.neo4j.jmx.Description;
 import org.neo4j.jmx.ManagementInterface;
-import org.neo4j.kernel.info.LockInfo;
-
-import java.util.List;
 
 @ManagementInterface( name = IndexSamplingManager.NAME )
 @Description( "Handle index sampling." )

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.CharBuffer;
+
+/**
+ * A {@link Readable}, but focused on {@code char[]} instead of {@link CharBuffer}, with the main reaon
+ * that {@link Reader#read(CharBuffer)} creates a new {@code char[]} as big as the data it's about to read
+ * every call. However {@link Reader#read(char[], int, int)} doesn't, and so leaves no garbage.
+ *
+ * The fact that this is a separate interface means that {@link Readable} instances need to be wrapped,
+ * but that's fine since the buffer size should be reasonably big such that {@link #read(char[], int, int)}
+ * isn't called too often. Therefore the wrapping overhead should not be noticeable at all.
+ *
+ * Also took the opportunity to let {@link CharReadable} extends {@link Closeable}, something that
+ * {@link Readable} doesn't.
+ */
+public interface CharReadable extends Closeable
+{
+    /**
+     * Reads characters into a portion of an array. This method will block until some input is available,
+     * an I/O error occurs, or the end of the stream is reached.
+     *
+     * @param buffer {@code char[]} buffer to read the data into.
+     * @param offset offset at which to start storing characters in {@code buffer}.
+     * @param length maximum number of characters to read.
+     * @return the number of characters read, or -1 if the end of the stream has been reached.
+     * @throws IOException if an I/O error occurs.
+     */
+    int read( char[] buffer, int offset, int length ) throws IOException;
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
@@ -34,7 +34,7 @@ public class CharSeekers
     /**
      * Instantiates a {@link BufferedCharSeeker} with optional {@link ThreadAheadReadable read-ahead} capability.
      *
-     * @param reader the {@link Readable} which is the source of data, f.ex. a {@link FileReader}.
+     * @param reader the {@link CharReadable} which is the source of data, f.ex. a {@link FileReader}.
      * @param bufferSize buffer size of the seeker and, if enabled, the read-ahead thread.
      * @param readAhead whether or not to start a {@link ThreadAheadReadable read-ahead thread}
      * which strives towards always keeping one buffer worth of data read and available from I/O when it's
@@ -42,7 +42,7 @@ public class CharSeekers
      * @param quotationCharacter character to interpret quotation character.
      * @return a {@link CharSeeker} with optional {@link ThreadAheadReadable read-ahead} capability.
      */
-    public static CharSeeker charSeeker( Readable reader, int bufferSize, boolean readAhead, char quotationCharacter )
+    public static CharSeeker charSeeker( CharReadable reader, int bufferSize, boolean readAhead, char quotationCharacter )
     {
         if ( readAhead )
         {   // Thread that always has one buffer read ahead
@@ -60,7 +60,7 @@ public class CharSeekers
      * @return {@link CharSeeker} reading and parsing data from {@code file}.
      * @throws FileNotFoundException if the specified {@code file} doesn't exist.
      */
-    public static CharSeeker charSeeker( Readable reader, char quotationCharacter ) throws FileNotFoundException
+    public static CharSeeker charSeeker( CharReadable reader, char quotationCharacter ) throws FileNotFoundException
     {
         return charSeeker( reader, DEFAULT_BUFFER_SIZE, true, quotationCharacter );
     }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -25,28 +25,32 @@ import java.nio.CharBuffer;
 import java.util.concurrent.locks.LockSupport;
 
 import static java.lang.Math.min;
+import static java.lang.System.arraycopy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * Like an ordinary {@link Readable}, it's just that the reading happens in a separate thread, so when
+ * Like an ordinary {@link CharReadable}, it's just that the reading happens in a separate thread, so when
  * a consumer wants to {@link #read(CharBuffer)} more data it's already available, merely a memcopy away.
  */
-public class ThreadAheadReadable extends Thread implements Readable, Closeable
+public class ThreadAheadReadable extends Thread implements CharReadable, Closeable
 {
     private static final long PARK_TIME = MILLISECONDS.toNanos( 100 );
 
-    private final Readable actual;
+    private final CharReadable actual;
     private final Thread owner;
+    private final char[] readAheadArray;
     private final CharBuffer readAheadBuffer;
     private volatile boolean hasReadAhead;
     private volatile boolean closed;
+    private volatile boolean eof;
     private volatile IOException ioException;
 
-    private ThreadAheadReadable( Readable actual, int bufferSize  )
+    private ThreadAheadReadable( CharReadable actual, int bufferSize  )
     {
         this.actual = actual;
         this.owner = Thread.currentThread();
-        this.readAheadBuffer = CharBuffer.allocate( bufferSize );
+        this.readAheadArray = new char[bufferSize];
+        this.readAheadBuffer = CharBuffer.wrap( readAheadArray );
         this.readAheadBuffer.position( bufferSize );
         start();
     }
@@ -56,7 +60,7 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
      * waits for this thread to have fully read the next buffer.
      */
     @Override
-    public int read( CharBuffer target ) throws IOException
+    public int read( char[] buffer, int offset, int length ) throws IOException
     {
         // are we still healthy and all that?
         assertHealthy();
@@ -68,31 +72,27 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
             assertHealthy();
         }
 
-        // copy data from the read ahead buffer into the target buffer
-        int available = readAheadBuffer.limit();
-        int bytesToCopy;
-        try
+        if ( eof )
         {
-            bytesToCopy = min( available, target.remaining() );
-            readAheadBuffer.limit( bytesToCopy );
-            target.put( readAheadBuffer );
-        }
-        finally
-        {
-            readAheadBuffer.limit( available );
+            return -1;
         }
 
-        // Wake up the reader... there's stuff to do, data to read
+        // copy data from the read ahead buffer into the target buffer
+        int bytesToCopy = min( readAheadBuffer.remaining(), length );
+        arraycopy( readAheadArray, readAheadBuffer.position(), buffer, offset, bytesToCopy );
+        readAheadBuffer.position( readAheadBuffer.position() + bytesToCopy );
+
+        // wake up the reader... there's stuff to do, data to read
         hasReadAhead = false;
         LockSupport.unpark( this );
-        return bytesToCopy;
+        return bytesToCopy == 0 ? -1 : bytesToCopy;
     }
 
     private void assertHealthy() throws IOException
     {
         if ( ioException != null )
         {
-            throw new IOException( "IOException occured in read-ahead thread", ioException );
+            throw new IOException( "Error occured in read-ahead thread", ioException );
         }
     }
 
@@ -115,10 +115,7 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
         }
         finally
         {
-            if ( actual instanceof Closeable )
-            {
-                ((Closeable) actual).close();
-            }
+            actual.close();
         }
     }
 
@@ -127,7 +124,7 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
     {
         while ( !closed )
         {
-            if ( hasReadAhead )
+            if ( hasReadAhead || eof )
             {   // We have already read ahead, sleep a little
                 parkAWhile();
             }
@@ -136,8 +133,14 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
                 try
                 {
                     readAheadBuffer.compact();
-                    actual.read( readAheadBuffer );
-                    readAheadBuffer.flip();
+                    int read = actual.read( readAheadArray, readAheadBuffer.position(), readAheadBuffer.remaining() );
+                    if ( read == -1 )
+                    {
+                        eof = true;
+                        read = 0;
+                    }
+                    readAheadBuffer.limit( readAheadBuffer.position() + read );
+                    readAheadBuffer.position( 0 );
                     hasReadAhead = true;
                     LockSupport.unpark( owner );
                 }
@@ -146,11 +149,16 @@ public class ThreadAheadReadable extends Thread implements Readable, Closeable
                     ioException = e;
                     closed = true;
                 }
+                catch ( Throwable e )
+                {
+                    ioException = new IOException( e );
+                    closed = true;
+                }
             }
         }
     }
 
-    public static Readable threadAhead( Readable actual, int bufferSize )
+    public static CharReadable threadAhead( CharReadable actual, int bufferSize )
     {
         return new ThreadAheadReadable( actual, bufferSize );
     }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -34,13 +34,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.neo4j.csv.reader.Readables.wrap;
+
 public class BufferedCharSeekerTest
 {
     @Test
     public void shouldFindCertainCharacter() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader( "abcdefg\thijklmnop\tqrstuvxyz" ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader( "abcdefg\thijklmnop\tqrstuvxyz" ) ) );
 
         // WHEN/THEN
         // first value
@@ -69,9 +71,9 @@ public class BufferedCharSeekerTest
     public void shouldReadMultipleLines() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
                 "1\t2\t3\n" +
-                "4\t5\t6\n" ) );
+                "4\t5\t6\n" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -108,8 +110,8 @@ public class BufferedCharSeekerTest
     public void shouldSeekThroughAdditionalBufferRead() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
-                                                  "1234,5678,9012,3456" ), 12 );
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
+                                                  "1234,5678,9012,3456" ) ), 12 );
         // bufferSIze 12 should have seeker read more here     ^
 
         // WHEN/THEN
@@ -128,10 +130,10 @@ public class BufferedCharSeekerTest
     public void shouldHandleWindowsEndOfLineCharacters() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
                 "here,comes,Windows\r\n" +
                 "and,it,has\r" +
-                "other,line,endings" ), 100 );
+                "other,line,endings" ) ), 100 );
 
         // WHEN/THEN
         assertEquals( "here", seeker.seek( mark, COMMA ) ? seeker.extract( mark, extractors.string() ).value() : "" );
@@ -155,7 +157,7 @@ public class BufferedCharSeekerTest
         int cols = 3, rows = 3;
         char delimiter = '\t';
         String[][] data = randomWeirdValues( cols, rows, delimiter, '\n', '\r' );
-        seeker = new BufferedCharSeeker( new StringReader( join( data, delimiter ) ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader( join( data, delimiter ) ) ) );
 
         // WHEN/THEN
         for ( int row = 0; row < rows; row++ )
@@ -174,7 +176,7 @@ public class BufferedCharSeekerTest
     public void shouldHandleEmptyValues() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader( "1,,3,4" ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader( "1,,3,4" ) ) );
 
         // WHEN
         assertTrue( seeker.seek( mark, COMMA ) );
@@ -193,8 +195,8 @@ public class BufferedCharSeekerTest
     public void shouldNotLetEolCharSkippingMessUpPositionsInMark() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader( "12,34,56\n789,901,23" ), 9 );
-        //      reading this char will cause new chunk read          ^
+        seeker = new BufferedCharSeeker( wrap( new StringReader( "12,34,56\n789,901,23" ) ), 9 );
+        //      reading this char will cause new chunk read                ^
 
         // WHEN
         assertTrue( seeker.seek( mark, COMMA ) );
@@ -218,7 +220,7 @@ public class BufferedCharSeekerTest
     public void shouldSeeEofEvenIfBufferAlignsWithEnd() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader( "123,56" ), 6 );
+        seeker = new BufferedCharSeeker( wrap( new StringReader( "123,56" ) ), 6 );
 
         // WHEN
         assertTrue( seeker.seek( mark, COMMA ) );
@@ -235,9 +237,9 @@ public class BufferedCharSeekerTest
     public void shouldSkipEmptyLastValue() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
                 "one,two,three,\n" +
-                "uno,dos,tres," ), 100 );
+                "uno,dos,tres," ) ), 100 );
 
         // WHEN
         assertNextValue( seeker, mark, COMMA, "one" );
@@ -267,8 +269,8 @@ public class BufferedCharSeekerTest
     public void shouldContinueThroughCompletelyEmptyLines() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
-                "one,two,three\n\n\nfour,five,six" ), 200 );
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
+                "one,two,three\n\n\nfour,five,six" ) ), 200 );
 
         // WHEN/THEN
         assertArrayEquals( new String[] {"one", "two", "three"}, nextLineOfAllStrings( seeker, mark ) );
@@ -302,8 +304,8 @@ public class BufferedCharSeekerTest
     public void shouldReadQuotes() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
-                "value one\t\"value two\"\tvalue three" ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
+                "value one\t\"value two\"\tvalue three" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -320,8 +322,8 @@ public class BufferedCharSeekerTest
     public void shouldReadQuotedValuesWithDelimiterInside() throws Exception
     {
         // GIVEN
-        seeker =  new BufferedCharSeeker( new StringReader(
-                "value one\t\"value\ttwo\"\tvalue three" ) );
+        seeker =  new BufferedCharSeeker( wrap( new StringReader(
+                "value one\t\"value\ttwo\"\tvalue three" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -338,8 +340,8 @@ public class BufferedCharSeekerTest
     public void shouldReadQuotedValuesWithNewLinesInside() throws Exception
     {
         // GIVEN
-        seeker =  new BufferedCharSeeker( new StringReader(
-                "value one\t\"value\ntwo\"\tvalue three" ) );
+        seeker =  new BufferedCharSeeker( wrap( new StringReader(
+                "value one\t\"value\ntwo\"\tvalue three" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -356,8 +358,8 @@ public class BufferedCharSeekerTest
     public void shouldHandleDoubleQuotes() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
-                "\"value \"\"one\"\"\"\t\"\"\"value\"\" two\"\t\"va\"\"lue\"\" three\"" ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
+                "\"value \"\"one\"\"\"\t\"\"\"value\"\" two\"\t\"va\"\"lue\"\" three\"" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -374,8 +376,8 @@ public class BufferedCharSeekerTest
     public void shouldHandleSlashEncodedQuotes() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
-                "\"value \\\"one\\\"\"\t\"\\\"value\\\" two\"\t\"va\\\"lue\\\" three\"" ) );
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
+                "\"value \\\"one\\\"\"\t\"\\\"value\\\" two\"\t\"va\\\"lue\\\" three\"" ) ) );
 
         // WHEN/THEN
         assertTrue( seeker.seek( mark, TAB ) );
@@ -392,9 +394,9 @@ public class BufferedCharSeekerTest
     public void shouldRecognizeStrayQuoteCharacters() throws Exception
     {
         // GIVEN
-        seeker = new BufferedCharSeeker( new StringReader(
+        seeker = new BufferedCharSeeker( wrap( new StringReader(
                 "one,two\",th\"ree\n" +
-                "four,five,s\"ix" ) );
+                "four,five,s\"ix" ) ) );
 
         // THEN
         assertNextValue( seeker, mark, COMMA, "one" );

--- a/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
@@ -41,7 +41,7 @@ public class MultiReadableTest
                 {"where this", "is the second line"},
                 {"and here comes", "the third line"}
         };
-        RawIterator<Readable,IOException> readers = readerIteratorFromStrings( data, null );
+        RawIterator<CharReadable,IOException> readers = readerIteratorFromStrings( data, null );
         CharSeeker seeker = CharSeekers.charSeeker( new MultiReadable( readers ), 200, true, '"' );
 
         // WHEN/THEN
@@ -63,7 +63,7 @@ public class MultiReadableTest
         };
 
         // WHEN
-        RawIterator<Readable,IOException> readers = readerIteratorFromStrings( data, '\n' );
+        RawIterator<CharReadable,IOException> readers = readerIteratorFromStrings( data, '\n' );
         CharSeeker seeker = CharSeekers.charSeeker( Readables.multipleSources( readers ), 200, true, '"' );
 
         // WHEN/THEN
@@ -85,10 +85,10 @@ public class MultiReadableTest
         assertTrue( mark.isEndOfLine() );
     }
 
-    private RawIterator<Readable,IOException> readerIteratorFromStrings(
+    private RawIterator<CharReadable,IOException> readerIteratorFromStrings(
             final String[][] data, final Character lineEnding )
     {
-        return new RawIterator<Readable,IOException>()
+        return new RawIterator<CharReadable,IOException>()
         {
             private int cursor;
 
@@ -99,9 +99,9 @@ public class MultiReadableTest
             }
 
             @Override
-            public Readable next()
+            public CharReadable next()
             {
-                return new StringReader( join( data[cursor++] ) );
+                return Readables.wrap( new StringReader( join( data[cursor++] ) ) );
             }
 
             private String join( String[] strings )

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.CharBuffer;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -48,9 +47,9 @@ public class ReadablesTest
         File compressed = compressWithZip( text );
 
         // WHEN
-        Readable readable = Readables.file( compressed );
+        CharReadable readable = Readables.file( compressed );
         char[] readText = new char[text.toCharArray().length];
-        readable.read( CharBuffer.wrap( readText ) );
+        readable.read( readText, 0, readText.length );
 
         // THEN
         assertArrayEquals( text.toCharArray(), readText );
@@ -64,9 +63,9 @@ public class ReadablesTest
         File compressed = compressWithGZip( text );
 
         // WHEN
-        Readable readable = Readables.file( compressed );
+        CharReadable readable = Readables.file( compressed );
         char[] readText = new char[text.toCharArray().length];
-        readable.read( CharBuffer.wrap( readText ) );
+        readable.read( readText, 0, readText.length );
 
         // THEN
         assertArrayEquals( text.toCharArray(), readText );
@@ -80,9 +79,9 @@ public class ReadablesTest
         File plainText = write( text );
 
         // WHEN
-        Readable readable = Readables.file( plainText );
+        CharReadable readable = Readables.file( plainText );
         char[] readText = new char[text.toCharArray().length];
-        readable.read( CharBuffer.wrap( readText ) );
+        readable.read( readText, 0, readText.length );
 
         // THEN
         assertArrayEquals( text.toCharArray(), readText );
@@ -96,9 +95,9 @@ public class ReadablesTest
         File compressed = compressWithZip( text, ".nothing", ".DS_Store", "__MACOSX/", "__MACOSX/file" );
 
         // WHEN
-        Readable readable = Readables.file( compressed );
+        CharReadable readable = Readables.file( compressed );
         char[] readText = new char[text.toCharArray().length];
-        readable.read( CharBuffer.wrap( readText ) );
+        readable.read( readText, 0, readText.length );
 
         // THEN
         assertArrayEquals( text.toCharArray(), readText );
@@ -112,7 +111,7 @@ public class ReadablesTest
         File compressed = compressWithZip( text, ".nothing", ".DS_Store", "somewhere/something" );
 
         // WHEN
-        Readable readable;
+        CharReadable readable;
         try
         {
             readable = Readables.file( compressed );

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.spi
 import java.io._
 import java.net.{CookieHandler, CookieManager, CookiePolicy, URL}
 
-import org.neo4j.csv.reader.{Extractors, CharSeekers, Mark}
+import org.neo4j.csv.reader.{Extractors, CharSeekers, Mark, Readables}
 import org.neo4j.cypher.internal.compiler.v2_2.{LoadExternalResourceException, TaskCloser}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.ExternalResource
 
@@ -39,7 +39,7 @@ class CSVResources(cleaner: TaskCloser) extends ExternalResource {
 
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
     val inputStream = openStream(url)
-    val reader = new InputStreamReader(inputStream, "UTF-8")
+    val reader = Readables.wrap(new InputStreamReader(inputStream, "UTF-8"))
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
     val seeker = CharSeekers.charSeeker(reader, CSVResources.DEFAULT_BUFFER_SIZE, true, CSVResources.DEFAULT_QUOTE_CHAR)
     val extractors = new Extractors(delimiter)

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.csv.reader.Extractor;
 import org.neo4j.csv.reader.Extractors;
@@ -132,7 +133,7 @@ public class DataFactories
      * @return {@link DataFactory} that returns a {@link CharSeeker} over the supplied {@code readable}
      */
     public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
-                                                                         final Factory<Readable> readable )
+                                                                         final Factory<CharReadable> readable )
     {
         return new DataFactory<ENTITY>()
         {
@@ -175,7 +176,7 @@ public class DataFactories
      * from a {@link Readable} containing that data.
      * @param reader {@link Readable} containing header data.
      */
-    public static Header.Factory defaultFormatNodeFileHeader( Readable reader )
+    public static Header.Factory defaultFormatNodeFileHeader( CharReadable reader )
     {
         return new DefaultNodeFileHeaderParser( new HeaderFromSeparateReaderFactory( reader ) );
     }
@@ -197,7 +198,7 @@ public class DataFactories
      * from a {@link Readable} containing that data.
      * @param reader {@link Readable} containing header data.
      */
-    public static Header.Factory defaultFormatRelationshipFileHeader( Readable reader )
+    public static Header.Factory defaultFormatRelationshipFileHeader( CharReadable reader )
     {
         return new DefaultRelationshipFileHeaderParser( new HeaderFromSeparateReaderFactory( reader ) );
     }
@@ -257,9 +258,9 @@ public class DataFactories
 
     private static class HeaderFromSeparateReaderFactory extends SeparateHeaderReaderFactory
     {
-        private final Readable readable;
+        private final CharReadable readable;
 
-        HeaderFromSeparateReaderFactory( Readable readable )
+        HeaderFromSeparateReaderFactory( CharReadable readable )
         {
             this.readable = readable;
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.helpers.ArrayUtil.union;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
@@ -349,7 +350,7 @@ public class CsvInputTest
 
     private CharSeeker charSeeker( String data )
     {
-        return new BufferedCharSeeker( new StringReader( data ) );
+        return new BufferedCharSeeker( wrap( new StringReader( data ) ) );
     }
 
     @SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -24,6 +24,7 @@ import java.io.StringReader;
 import org.junit.Test;
 
 import org.neo4j.csv.reader.BufferedCharSeeker;
+import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.csv.reader.Extractor;
 import org.neo4j.csv.reader.Extractors;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import static org.neo4j.csv.reader.Readables.multipleSources;
+import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.helpers.collection.IteratorUtil.array;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.TABS;
@@ -52,8 +54,8 @@ public class DataFactoriesTest
     public void shouldParseDefaultNodeFileHeaderCorrectly() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "ID:ID,label-one:label,also-labels:LABEL,name,age:long" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader(
+                "ID:ID,label-one:label,also-labels:LABEL,name,age:long" ) ) );
         IdType idType = IdType.STRING;
         Extractors extractors = new Extractors( ',' );
 
@@ -74,8 +76,8 @@ public class DataFactoriesTest
     public void shouldParseDefaultRelationshipFileHeaderCorrectly() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                ":START_ID\t:END_ID\ttype:TYPE\tdate:long\tmore:long[]" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader(
+                ":START_ID\t:END_ID\ttype:TYPE\tdate:long\tmore:long[]" ) ) );
         IdType idType = IdType.ACTUAL;
         Extractors extractors = new Extractors( '\t' );
 
@@ -96,8 +98,7 @@ public class DataFactoriesTest
     public void shouldHaveEmptyHeadersBeInterpretedAsIgnored() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "one:id\ttwo\t\tdate:long" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader( "one:id\ttwo\t\tdate:long" ) ) );
         IdType idType = IdType.ACTUAL;
         Extractors extractors = new Extractors( '\t' );
 
@@ -117,8 +118,7 @@ public class DataFactoriesTest
     public void shouldFailForDuplicatePropertyHeaderEntries() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "one:id\tname\tname:long" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader( "one:id\tname\tname:long" ) ) );
         IdType idType = IdType.ACTUAL;
         Extractors extractors = new Extractors( '\t' );
 
@@ -140,8 +140,7 @@ public class DataFactoriesTest
     public void shouldFailForDuplicateIdHeaderEntries() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "one:id\ttwo:id" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader( "one:id\ttwo:id" ) ) );
         IdType idType = IdType.ACTUAL;
         Extractors extractors = new Extractors( '\t' );
 
@@ -163,8 +162,7 @@ public class DataFactoriesTest
     public void shouldFailForMissingIdHeaderEntry() throws Exception
     {
         // GIVEN
-        CharSeeker seeker = new BufferedCharSeeker( new StringReader(
-                "one\ttwo" ) );
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader( "one\ttwo" ) ) );
 
         // WHEN
         try
@@ -185,7 +183,7 @@ public class DataFactoriesTest
         // GIVEN
         CharSeeker dataSeeker = mock( CharSeeker.class );
         Header.Factory headerFactory =
-                defaultFormatNodeFileHeader( new StringReader( "id:ID\tname:String\tbirth_date:long" ) );
+                defaultFormatNodeFileHeader( wrap( new StringReader( "id:ID\tname:String\tbirth_date:long" ) ) );
         Extractors extractors = new Extractors( ';' );
 
         // WHEN
@@ -204,12 +202,12 @@ public class DataFactoriesTest
     public void shouldParseHeaderFromFirstLineOfFirstInputFile() throws Exception
     {
         // GIVEN
-        final Readable firstSource = new StringReader( "id:ID\tname:String\tbirth_date:long" );
-        final Readable secondSource = new StringReader( "0\tThe node\t123456789" );
-        DataFactory<InputNode> dataFactory = data( Functions.<InputNode>identity(), new Factory<Readable>()
+        final CharReadable firstSource = wrap( new StringReader( "id:ID\tname:String\tbirth_date:long" ) );
+        final CharReadable secondSource = wrap( new StringReader( "0\tThe node\t123456789" ) );
+        DataFactory<InputNode> dataFactory = data( Functions.<InputNode>identity(), new Factory<CharReadable>()
         {
             @Override
-            public Readable newInstance()
+            public CharReadable newInstance()
             {
                 return multipleSources( firstSource, secondSource );
             }


### PR DESCRIPTION
i.e. the method accepting a char[]. The read-method accepting a CharBuffer
is implemented wastefully in Reader, and should therefore be avoided. This
means that a new interface has been introduced, of which javadoc explains
the situation as well.
