### PR TITLE
Missing commons-logging for Neo4j-Desktop is back

### DIFF
--- a/advanced/server-advanced/LICENSES.txt
+++ b/advanced/server-advanced/LICENSES.txt
@@ -8,6 +8,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/advanced/server-advanced/NOTICE.txt
+++ b/advanced/server-advanced/NOTICE.txt
@@ -31,6 +31,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/advanced/server-advanced/pom.xml
+++ b/advanced/server-advanced/pom.xml
@@ -158,12 +158,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-shell</artifactId>
       <version>${project.version}</version>

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -9,6 +9,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -32,6 +32,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/community/server-api/LICENSES.txt
+++ b/community/server-api/LICENSES.txt
@@ -7,6 +7,7 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/server-api/NOTICE.txt
+++ b/community/server-api/NOTICE.txt
@@ -30,6 +30,7 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
 
 Common Development and Distribution License Version 1.1
   jsr311-api

--- a/community/server-examples/LICENSES.txt
+++ b/community/server-examples/LICENSES.txt
@@ -7,6 +7,7 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Lucene Core
   opencsv

--- a/community/server-examples/NOTICE.txt
+++ b/community/server-examples/NOTICE.txt
@@ -30,6 +30,7 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Lucene Core
   opencsv

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -9,6 +9,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -32,6 +32,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -247,13 +247,6 @@
     </dependency>
 
     <!-- Test dependencies -->
-
-     <dependency>
-       <groupId>commons-logging</groupId>
-       <artifactId>commons-logging</artifactId>
-       <scope>test</scope>
-     </dependency>
-
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
@@ -59,7 +59,7 @@ public interface ConfigurationBuilder
         public ConfiguratorWrappingConfigurationBuilder ( Configurator configurator )
         {
             // copy the server properties to create server config
-            Map<String, String> serverProperties = new HashMap();
+            Map<String, String> serverProperties = new HashMap<>();
             Configuration oldConfiguration = configurator.configuration();
             Iterator<String> keys = oldConfiguration.getKeys();
             while( keys.hasNext() )
@@ -137,5 +137,5 @@ public interface ConfigurationBuilder
             return builder.configuration().get( ServerSettings.third_party_packages );
         }
 
-    };
+    }
 }

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -8,6 +8,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -31,6 +31,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson

--- a/enterprise/server-enterprise/pom.xml
+++ b/enterprise/server-enterprise/pom.xml
@@ -163,12 +163,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-shell</artifactId>
       <version>${project.version}</version>

--- a/manual/javadocs/LICENSES.txt
+++ b/manual/javadocs/LICENSES.txt
@@ -7,6 +7,7 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/manual/javadocs/NOTICE.txt
+++ b/manual/javadocs/NOTICE.txt
@@ -30,4 +30,5 @@ Apache Software License, Version 2.0
   Commons BeanUtils
   Commons Digester
   Commons Lang
+  Commons Logging
 

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -10,6 +10,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -33,6 +33,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -40,8 +40,6 @@ public class DesktopConfigurator implements ConfigurationBuilder
     private final Map<String, String> map = new HashMap<>();
     private final Installation installation;
 
-    private ConfigurationBuilder propertyFileConfig;
-
     public DesktopConfigurator( Installation installation )
     {
         this.installation = installation;
@@ -50,10 +48,10 @@ public class DesktopConfigurator implements ConfigurationBuilder
 
     public void refresh()
     {
-        Map<String,String> newMap = new HashMap( map );
+        Map<String,String> newMap = new HashMap<>( map );
 
         // re-read server properties, then add to config
-        propertyFileConfig = new PropertyFileConfigurator( installation.getServerConfigurationsFile() );
+        ConfigurationBuilder propertyFileConfig = new PropertyFileConfigurator( installation.getServerConfigurationsFile() );
         newMap.putAll( propertyFileConfig.configuration().getParams() );
 
         this.compositeConfig.applyChanges( newMap );

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
@@ -10,6 +10,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
@@ -33,6 +33,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -10,6 +10,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -33,6 +33,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -10,6 +10,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -33,6 +33,7 @@ Apache Software License, Version 2.0
   Commons Digester
   Commons IO
   Commons Lang
+  Commons Logging
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   ExplorerCanvas

--- a/pom.xml
+++ b/pom.xml
@@ -516,18 +516,6 @@ public class ComponentVersion extends Version
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>1.3</version>


### PR DESCRIPTION
Neo4j desktop requires commons-logging at runtime.
This PR removes explicit declaration of commons-logging with scope test, now it will be brought to classpath as transitive dependency of commons-configuration.
