### PR TITLE
Fixed issue with `CREATE UNIQUE` when using array parameters.

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/mutation/NamedExpectation.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/mutation/NamedExpectation.scala
@@ -91,7 +91,13 @@ case class NamedExpectation(name: String, e: Expression, properties: Map[String,
     val propsOk = expectations.properties.forall {
       case ("*", expression) =>
         getMapFromExpression(expression(ctx)(state)).forall {
-          case (k, value) => state.query.getOptPropertyKeyId(k).exists(ops.getProperty(id(x), _) == value)
+          case (k, value) => state.query.getOptPropertyKeyId(k).exists(key => {
+            val expectedValue = ops.getProperty(id(x), key)
+            (expectedValue, value) match {
+              case (IsCollection(l), IsCollection(r)) => l == r
+              case (l, r) => l == r
+            }
+          })
         }
 
       // case (k, _) if !ops.hasProperty(x, state.query.getOrCreatePropertyKeyId(k)) => false

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CreateUniqueAcceptanceTest.scala
@@ -42,6 +42,27 @@ class CreateUniqueAcceptanceTest
     }
   }
 
+  //zendesk issue 2038
+  @Test
+  def test_create_unique_with_array_properties_as_parameters() {
+    // given
+    createNode()
+    createNode()
+    val nodeProps1: Map[String, Any] = Map("foo"-> Array("Pontus"))
+    val nodeProps2: Map[String, Any] = Map("foo"-> Array("Pontus"))
+
+    // when
+    val query = "MATCH (s) WHERE id(s) = 0 CREATE UNIQUE s-[:REL]->(n:label {param}) RETURN n"
+    val res1 = execute(query,"param" -> nodeProps1)
+    val res2 = execute(query, "param" -> nodeProps2)
+
+    //then
+    assertStats(res1, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1, labelsAdded = 1)
+    assertStats(res2, nodesCreated = 0, relationshipsCreated = 0, propertiesSet = 0, labelsAdded = 0)
+  }
+
+
+
   @Test
   def create_new_node_with_labels_on_the_right() {
     val a = createNode()


### PR DESCRIPTION
Arrays were compared by reference instead of equality which lead
to the unique constraint to fail.
