### PR TITLE
Assigns default memory size for relationship group store

### DIFF
--- a/community/embedded-examples/src/test/resources/neo4j.properties
+++ b/community/embedded-examples/src/test/resources/neo4j.properties
@@ -1,6 +1,7 @@
 # Default values for the low-level graph engine
 neostore.nodestore.db.mapped_memory=25M
 neostore.relationshipstore.db.mapped_memory=50M
+neostore.relationshipgroupstore.db.mapped_memory=10M
 neostore.propertystore.db.mapped_memory=90M
 neostore.propertystore.db.strings.mapped_memory=130M
 neostore.propertystore.db.arrays.mapped_memory=130M

--- a/community/kernel/src/docs/ops/cache.asciidoc
+++ b/community/kernel/src/docs/ops/cache.asciidoc
@@ -60,6 +60,8 @@ IMPORTANT: Note that the block sizes can only be configured at store creation ti
   The maximum amount of memory to use for the file buffer cache of the node storage file.
 | neostore.relationshipstore.db.mapped_memory           |
   The maximum amount of memory to use for the file buffer cache of the relationship store file.
+| neostore.relationshipgroupstore.db.mapped_memory      |
+  The maximum amount of memory to use for the file buffer cache of the relationship group store file.
 | neostore.propertystore.db.index.keys.mapped_memory    |
   The maximum amount of memory to use for the file buffer cache of the something-something file.
 | neostore.propertystore.db.index.mapped_memory         |

--- a/community/kernel/src/docs/ops/io-examples.asciidoc
+++ b/community/kernel/src/docs/ops/io-examples.asciidoc
@@ -39,6 +39,7 @@ This is how the default memory mapping configuration looks:
 ----
 neostore.nodestore.db.mapped_memory=25M
 neostore.relationshipstore.db.mapped_memory=50M
+neostore.relationshipgroupstore.db.mapped_memory=10M
 neostore.propertystore.db.mapped_memory=90M
 neostore.propertystore.db.strings.mapped_memory=130M
 neostore.propertystore.db.arrays.mapped_memory=130M
@@ -66,6 +67,7 @@ An example configuration on the example machine focusing on traversal speed woul
 ----
 neostore.nodestore.db.mapped_memory=15M
 neostore.relationshipstore.db.mapped_memory=285M
+neostore.relationshipgroupstore.db.mapped_memory=10M
 neostore.propertystore.db.mapped_memory=100M
 neostore.propertystore.db.strings.mapped_memory=100M
 neostore.propertystore.db.arrays.mapped_memory=0M
@@ -82,6 +84,7 @@ The configuration should suit the data set you are about to inject using BatchIn
 ----
 neostore.nodestore.db.mapped_memory=90M
 neostore.relationshipstore.db.mapped_memory=3G
+neostore.relationshipgroupstore.db.mapped_memory=10M
 neostore.propertystore.db.mapped_memory=50M
 neostore.propertystore.db.strings.mapped_memory=100M
 neostore.propertystore.db.arrays.mapped_memory=0M

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -212,6 +212,9 @@ public abstract class GraphDatabaseSettings
     @Description("The size to allocate for memory mapping the relationship store.")
     public static final Setting<Long> relationshipstore_mapped_memory_size = setting("neostore.relationshipstore.db.mapped_memory", BYTES, "100M" );
 
+    @Description("The size to allocate for memory mapping the relationship group store.")
+    public static final Setting<Long> relationshipgroupstore_mapped_memory_size = setting( "neostore.relationshipgroupstore.db.mapped_memory", BYTES, "10M" );
+
 
     @Description("How many relationships to read at a time during iteration")
     public static final Setting<Integer> relationship_grab_size = setting("relationship_grab_size", INTEGER, "100", min( 1 ));

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/StoreAccess.java
@@ -266,6 +266,7 @@ public class StoreAccess
         params.put( GraphDatabaseSettings.strings_mapped_memory_size.name(), "130M" );
         params.put( GraphDatabaseSettings.arrays_mapped_memory_size.name(), "130M" );
         params.put( GraphDatabaseSettings.relationshipstore_mapped_memory_size.name(), "100M" );
+        params.put( GraphDatabaseSettings.relationshipgroupstore_mapped_memory_size.name(), "10M" );
         // if on windows, default no memory mapping
         if ( osIsWindows() )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -287,6 +287,7 @@ public class BatchInserterImpl implements BatchInserter
         params.put( "neostore.propertystore.db.strings.mapped_memory", "130M" );
         params.put( "neostore.propertystore.db.arrays.mapped_memory", "130M" );
         params.put( "neostore.relationshipstore.db.mapped_memory", "50M" );
+        params.put( "neostore.relationshipgroupstore.db.mapped_memory", "10M" );
         return params;
     }
 

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -111,6 +111,7 @@ public class BatchInsertDocTest
         {
             fw.append( "neostore.nodestore.db.mapped_memory=90M\n"
                        + "neostore.relationshipstore.db.mapped_memory=3G\n"
+                       + "neostore.relationshipgroupstore.db.mapped_memory=10M\n"
                        + "neostore.propertystore.db.mapped_memory=50M\n"
                        + "neostore.propertystore.db.strings.mapped_memory=100M\n"
                        + "neostore.propertystore.db.arrays.mapped_memory=0M" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/AutoConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/AutoConfiguratorTest.java
@@ -68,6 +68,7 @@ public class AutoConfiguratorTest
         ConsoleLogger logger = Mockito.mock( ConsoleLogger.class );
         mockFileSize( fs, "nodestore.db", 200 * GiB );
         mockFileSize( fs, "relationshipstore.db", 200 * GiB );
+        mockFileSize( fs, "relationshipgroupstore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db.strings", 200 * GiB );
         mockFileSize( fs, "propertystore.db.arrays", 200 * GiB );
@@ -90,6 +91,7 @@ public class AutoConfiguratorTest
         FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
         mockFileSize( fs, "nodestore.db", 200 * GiB );
         mockFileSize( fs, "relationshipstore.db", 200 * GiB );
+        mockFileSize( fs, "relationshipgroupstore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db.strings", 200 * GiB );
         mockFileSize( fs, "propertystore.db.arrays", 200 * GiB );
@@ -107,7 +109,8 @@ public class AutoConfiguratorTest
         // then
         assertMappedMemory( configuration, "75000M", "relationshipstore.db" );
         assertMappedMemory( configuration, " 5000M", "nodestore.db" );
-        assertMappedMemory( configuration, "15000M", "propertystore.db" );
+        assertMappedMemory( configuration, "    2M", "relationshipgroupstore.db" );
+        assertMappedMemory( configuration, "14998M", "propertystore.db" );
         assertMappedMemory( configuration, " 3750M", "propertystore.db.strings" );
         assertMappedMemory( configuration, " 1250M", "propertystore.db.arrays" );
     }
@@ -119,6 +122,7 @@ public class AutoConfiguratorTest
         FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
         mockFileSize( fs, "nodestore.db", 200 * GiB );
         mockFileSize( fs, "relationshipstore.db", 200 * GiB );
+        mockFileSize( fs, "relationshipgroupstore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db", 200 * GiB );
         mockFileSize( fs, "propertystore.db.strings", 200 * GiB );
         mockFileSize( fs, "propertystore.db.arrays", 200 * GiB );
@@ -133,7 +137,8 @@ public class AutoConfiguratorTest
         // then
         assertMappedMemory( configuration, "75000M", "relationshipstore.db" );
         assertMappedMemory( configuration, " 5000M", "nodestore.db" );
-        assertMappedMemory( configuration, "15000M", "propertystore.db" );
+        assertMappedMemory( configuration, "    2M", "relationshipgroupstore.db" );
+        assertMappedMemory( configuration, "14998M", "propertystore.db" );
         assertMappedMemory( configuration, " 3750M", "propertystore.db.strings" );
         assertMappedMemory( configuration, " 1250M", "propertystore.db.arrays" );
     }
@@ -145,6 +150,7 @@ public class AutoConfiguratorTest
         FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
         mockFileSize( fs, "nodestore.db", 0 );
         mockFileSize( fs, "relationshipstore.db", 0 );
+        mockFileSize( fs, "relationshipgroupstore.db", 0 );
         mockFileSize( fs, "propertystore.db", 0 );
         mockFileSize( fs, "propertystore.db.strings", 0 );
         mockFileSize( fs, "propertystore.db.arrays", 0 );
@@ -160,11 +166,12 @@ public class AutoConfiguratorTest
         Map<String, String> configuration = autoConf.configure();
 
         // then
-        assertMappedMemory( configuration, "15000M", "relationshipstore.db" );
-        assertMappedMemory( configuration, " 3400M", "nodestore.db" );
-        assertMappedMemory( configuration, "12240M", "propertystore.db" );
-        assertMappedMemory( configuration, "10404M", "propertystore.db.strings" );
-        assertMappedMemory( configuration, "11791M", "propertystore.db.arrays" );
+        assertMappedMemory( configuration, "12500M", "relationshipstore.db" );
+        assertMappedMemory( configuration, " 2916M", "nodestore.db" );
+        assertMappedMemory( configuration, "    1M", "relationshipgroupstore.db" );
+        assertMappedMemory( configuration, "10572M", "propertystore.db" );
+        assertMappedMemory( configuration, " 9251M", "propertystore.db.strings" );
+        assertMappedMemory( configuration, "10793M", "propertystore.db.arrays" );
     }
 
     @Test
@@ -174,6 +181,7 @@ public class AutoConfiguratorTest
         FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
         mockFileSize( fs, "nodestore.db", 0 );
         mockFileSize( fs, "relationshipstore.db", 0 );
+        mockFileSize( fs, "relationshipgroupstore.db", 0 );
         mockFileSize( fs, "propertystore.db", 0 );
         mockFileSize( fs, "propertystore.db.strings", 0 );
         mockFileSize( fs, "propertystore.db.arrays", 0 );
@@ -186,11 +194,12 @@ public class AutoConfiguratorTest
         Map<String, String> configuration = autoConf.configure();
 
         // then
-        assertMappedMemory( configuration, "15000M", "relationshipstore.db" );
-        assertMappedMemory( configuration, " 3400M", "nodestore.db" );
-        assertMappedMemory( configuration, "12240M", "propertystore.db" );
-        assertMappedMemory( configuration, "10404M", "propertystore.db.strings" );
-        assertMappedMemory( configuration, "11791M", "propertystore.db.arrays" );
+        assertMappedMemory( configuration, "12500M", "relationshipstore.db" );
+        assertMappedMemory( configuration, " 2916M", "nodestore.db" );
+        assertMappedMemory( configuration, "    1M", "relationshipgroupstore.db" );
+        assertMappedMemory( configuration, "10572M", "propertystore.db" );
+        assertMappedMemory( configuration, " 9251M", "propertystore.db.strings" );
+        assertMappedMemory( configuration, "10793M", "propertystore.db.arrays" );
     }
 
     @Test
@@ -200,6 +209,7 @@ public class AutoConfiguratorTest
         FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
         mockFileSize( fs, "nodestore.db", 0 );
         mockFileSize( fs, "relationshipstore.db", 0 );
+        mockFileSize( fs, "relationshipgroupstore.db", 0 );
         mockFileSize( fs, "propertystore.db", 0 );
         mockFileSize( fs, "propertystore.db.strings", 0 );
         mockFileSize( fs, "propertystore.db.arrays", 0 );
@@ -213,6 +223,7 @@ public class AutoConfiguratorTest
         // then
         verify( mock ).log( startsWith( "WARNING!" ) );
         assertMappedMemory( configuration, "0M", "relationshipstore.db" );
+        assertMappedMemory( configuration, "0M", "relationshipgroupstore.db" );
         assertMappedMemory( configuration, "0M", "nodestore.db" );
         assertMappedMemory( configuration, "0M", "propertystore.db" );
         assertMappedMemory( configuration, "0M", "propertystore.db.strings" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ProveFiveBillionIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ProveFiveBillionIT.java
@@ -50,6 +50,7 @@ public class ProveFiveBillionIT
         BatchInserter inserter = BatchInserters.inserter( PATH/*, stringMap(
                 "neostore.nodestore.db.mapped_memory", "300M",
                 "neostore.relationshipstore.db.mapped_memory", "800M",
+                "neostore.relationshipgroupstore.db.mapped_memory", "10M",
                 "neostore.propertystore.db.mapped_memory", "100M",
                 "neostore.propertystore.db.strings.mapped_memory", "100M" ) */);
         

--- a/community/server/src/test/java/org/neo4j/server/DatabaseTuningDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/DatabaseTuningDocIT.java
@@ -51,6 +51,7 @@ public class DatabaseTuningDocIT extends ExclusiveServerTestBase
 
         assertTrue( propertyAndValuePresentIn( "neostore.nodestore.db.mapped_memory", "25M", params ) );
         assertTrue( propertyAndValuePresentIn( "neostore.relationshipstore.db.mapped_memory", "50M", params ) );
+        assertTrue( propertyAndValuePresentIn( "neostore.relationshipgroupstore.db.mapped_memory", "10M", params ) );
         assertTrue( propertyAndValuePresentIn( "neostore.propertystore.db.mapped_memory", "90M", params ) );
         assertTrue( propertyAndValuePresentIn( "neostore.propertystore.db.strings.mapped_memory", "130M", params ) );
         assertTrue( propertyAndValuePresentIn( "neostore.propertystore.db.arrays.mapped_memory", "130M", params ) );

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfiguratorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfiguratorTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.neo4j.kernel.AutoConfigurator;
 import org.neo4j.server.ServerTestUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -93,7 +94,7 @@ public class ConfiguratorTest
 
         Map<String, String> databaseTuningProperties = configurator.getDatabaseTuningProperties();
         assertNotNull( databaseTuningProperties );
-        assertEquals( 6, databaseTuningProperties.size() );
+        assertEquals( 1 + AutoConfigurator.NUMBER_OF_STORES_FOR_MEMORY_MAPPING, databaseTuningProperties.size() );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/configuration/DatabaseTuningPropertyFileBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/DatabaseTuningPropertyFileBuilder.java
@@ -47,6 +47,7 @@ public class DatabaseTuningPropertyFileBuilder
         File temporaryConfigFile = new File( parentDirectory, "neo4j.properties" );
         Map<String, String> properties = MapUtil.stringMap(
                 "neostore.relationshipstore.db.mapped_memory", "50M",
+                "neostore.relationshipgroupstore.db.mapped_memory", "10M",
                 "neostore.propertystore.db.mapped_memory", "90M",
                 "neostore.propertystore.db.strings.mapped_memory", "130M",
                 "neostore.propertystore.db.arrays.mapped_memory", "150M" );

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -232,6 +232,7 @@ public class CommunityServerBuilder
             Map<String, String> properties = MapUtil.stringMap(
                     "neostore.nodestore.db.mapped_memory", "25M",
                     "neostore.relationshipstore.db.mapped_memory", "50M",
+                    "neostore.relationshipgroupstore.db.mapped_memory", "10M",
                     "neostore.propertystore.db.mapped_memory", "90M",
                     "neostore.propertystore.db.strings.mapped_memory", "130M",
                     "neostore.propertystore.db.arrays.mapped_memory", "130M" );

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/windowpool/MemoryMappingConfiguration.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/windowpool/MemoryMappingConfiguration.java
@@ -37,6 +37,7 @@ public class MemoryMappingConfiguration
         config.put( "neostore.propertystore.db.strings.mapped_memory", mega( 130 * memoryUnit ) );
         config.put( "neostore.propertystore.db.arrays.mapped_memory", mega( 130 * memoryUnit ) );
         config.put( "neostore.relationshipstore.db.mapped_memory", mega( 100 * memoryUnit ) );
+        config.put( "neostore.relationshipgroupstore.db.mapped_memory", mega( 10 * memoryUnit ) );
     }
 
     private static String mega( long bytes )

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
@@ -2,6 +2,7 @@
 
 #neostore.nodestore.db.mapped_memory=25M
 #neostore.relationshipstore.db.mapped_memory=50M
+#neostore.relationshipgroupstore.db.mapped_memory=10M
 #neostore.propertystore.db.mapped_memory=90M
 #neostore.propertystore.db.strings.mapped_memory=130M
 #neostore.propertystore.db.arrays.mapped_memory=130M

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -1,6 +1,7 @@
 # Default values for the low-level graph engine
 #neostore.nodestore.db.mapped_memory=25M
 #neostore.relationshipstore.db.mapped_memory=50M
+#neostore.relationshipgroupstore.db.mapped_memory=10M
 #neostore.propertystore.db.mapped_memory=90M
 #neostore.propertystore.db.strings.mapped_memory=130M
 #neostore.propertystore.db.arrays.mapped_memory=130M

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -1,6 +1,7 @@
 # Default values for the low-level graph engine
 #neostore.nodestore.db.mapped_memory=25M
 #neostore.relationshipstore.db.mapped_memory=50M
+#neostore.relationshipgroupstore.db.mapped_memory=10M
 #neostore.propertystore.db.mapped_memory=90M
 #neostore.propertystore.db.strings.mapped_memory=130M
 #neostore.propertystore.db.arrays.mapped_memory=130M

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -1,6 +1,7 @@
 # Default values for the low-level graph engine
 #neostore.nodestore.db.mapped_memory=25M
 #neostore.relationshipstore.db.mapped_memory=50M
+#neostore.relationshipgroupstore.db.mapped_memory=10M
 #neostore.propertystore.db.mapped_memory=90M
 #neostore.propertystore.db.strings.mapped_memory=130M
 #neostore.propertystore.db.arrays.mapped_memory=130M


### PR DESCRIPTION
The default size is 10M (or 0.03% size of nodestore if the size is allocated by AutoConfig)
Adds the default memory size in docs and property files
