### PR TITLE
utils shell script contains hard coded paths for log

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
@@ -324,11 +324,11 @@ removeservice() {
 # in place.
 checkandrepairenv() {
     # Create data/log if missing, change owner if created.
-    if [ ! -d "$NEO4J_HOME"/data/log ]; then
-      echo "${NEO4J_HOME}/data/log was missing, recreating..."
-      mkdir "$NEO4J_HOME"/data/log
+    if [ ! -d "$NEO4J_LOG" ]; then
+      echo "${NEO4J_LOG}" was missing, recreating..."
+      mkdir "$NEO4J_LOG}"
       if [ $UID == 0 ] ; then
-        chown $NEO4J_USER "$NEO4J_HOME"/data/log
+        chown $NEO4J_USER "$NEO4J_LOG"
       fi
     fi
 }


### PR DESCRIPTION
When I change my NEO4J_INSTANCE environment variable my log is no longer under NEO4J_HOME. Using this hard coded paths is wrong. This should point to NEO4J_LOG variable, to honor my customizations.
