### PR TITLE
Fix SVG graph rendering in IE 9

### DIFF
--- a/community/browser/lib/visualization/components/layout.coffee
+++ b/community/browser/lib/visualization/components/layout.coffee
@@ -30,7 +30,7 @@ neo.layout = do ->
         maxStepsPerTick = 100
         maxAnimationFramesPerSecond = 60
         maxComputeTime = 1000 / maxAnimationFramesPerSecond
-        now = if window.performance
+        now = if window.performance and window.performance.now
           () ->
             window.performance.now()
         else

--- a/community/browser/lib/visualization/components/visualization.coffee
+++ b/community/browser/lib/visualization/components/visualization.coffee
@@ -96,7 +96,7 @@ neo.viz = (el, measureSize, graph, layout, style) ->
 
   currentStats = newStatsBucket()
 
-  now = if window.performance
+  now = if window.performance and window.performance.now
     () ->
       window.performance.now()
   else


### PR DESCRIPTION
- IE 9 has something called window.performance but not
  the method now on that object.
