### PR TITLE
Fixed issue with prematurely exhausted iterator.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AsOneStartBranch.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AsOneStartBranch.java
@@ -19,10 +19,8 @@
  */
 package org.neo4j.kernel.impl.traversal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PathExpander;
@@ -61,10 +59,7 @@ class AsOneStartBranch implements TraversalBranch
     
     private Iterator<TraversalBranch> toBranches( Iterable<Node> nodes )
     {
-        List<TraversalBranch> result = new ArrayList<TraversalBranch>();
-        for ( Node node : nodes )
-            result.add( new StartNodeTraversalBranch( context, this, node, initialState ) );
-        return result.iterator();
+        return new TraversalBranchIterator( nodes.iterator() );
     }
 
     @Override
@@ -177,5 +172,34 @@ class AsOneStartBranch implements TraversalBranch
     public Object state()
     {
         throw new UnsupportedOperationException();
+    }
+
+    private class TraversalBranchIterator implements Iterator<TraversalBranch>
+    {
+        private final Iterator<Node> nodeIterator;
+
+        public TraversalBranchIterator( Iterator<Node> nodeIterator )
+        {
+            this.nodeIterator = nodeIterator;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return nodeIterator.hasNext();
+        }
+
+        @Override
+        public TraversalBranch next()
+        {
+            return new StartNodeTraversalBranch( context, AsOneStartBranch.this, nodeIterator.next(),
+                    initialState );
+        }
+
+        @Override
+        public void remove()
+        {
+            nodeIterator.remove();
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.traversal;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.traversal.InitialBranchState;
+import org.neo4j.graphdb.traversal.TraversalContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AsOneStartBranchTest
+{
+    @Test
+    public void donNotExhaustIteratorOnInitialization()
+    {
+        // Given
+        Iterable<Node> nodeIterable = mock( Iterable.class );
+        Iterator<Node> nodeIterator = mock( Iterator.class );
+        when(nodeIterable.iterator()).thenReturn( nodeIterator );
+        when( nodeIterator.hasNext() ).thenReturn( true );
+
+        // When
+        new AsOneStartBranch( mock( TraversalContext.class ), nodeIterable, mock( InitialBranchState.class ) );
+
+        // Then
+        verify( nodeIterator, never() ).next();
+    }
+
+}


### PR DESCRIPTION
By exhausting the iterator on initialization, some queries lead to a lot
of unnecessary dbhits, e.g.

```
profile MATCH (n:topic)-[r]->(m:topic) return n,r,m limit 1;

+------------------+------+----------+-------------+----------------------+
|         Operator | Rows |   DbHits | Identifiers |                Other |
+------------------+------+----------+-------------+----------------------+
|            Slice |    1 |        0 |             |         {  AUTOINT0} |
|           Filter |    1 |        1 |             | hasLabel(m:topic(0)) |
| TraversalMatcher |    1 | 11292978 |             |              m, r, m |
+------------------+------+----------+-------------+----------------------+

Total database accesses: 11292979
```

should ideally only touch a small portion of the graph but ends up touching something like
50% instead. This fix I believe fix this.
