### PR TITLE
Fixed issue with prematurely exhausted iterator.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/UniquenessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/UniquenessFactory.java
@@ -37,4 +37,13 @@ public interface UniquenessFactory
      * @return a new {@link UniquenessFilter} of the type that this factory creates.
      */
     UniquenessFilter create( Object optionalParameter );
+
+    /**
+     * Specifies if the {@link UniquenessFilter} must handle start branches eagerly. Depending on the
+     * level of {@link org.neo4j.kernel.Uniqueness} it is not always necessary to eagerly exhaust start
+     * branches which can speed up the execution of the traversal.
+     *
+     * @return <tt>true</tt> if eager start branches must be used, otherwise <tt>false</tt>.
+     */
+    boolean eagerStartBranches();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/Uniqueness.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Uniqueness.java
@@ -39,6 +39,11 @@ public enum Uniqueness implements UniquenessFactory
             acceptNull( optionalParameter );
             return new GloballyUnique( PrimitiveTypeFetcher.NODE );
         }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
+        }
     },
     /**
      * For each returned node there's a unique path from the start node to it.
@@ -49,6 +54,11 @@ public enum Uniqueness implements UniquenessFactory
         {
             acceptNull( optionalParameter );
             return new PathUnique( PrimitiveTypeFetcher.NODE );
+        }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
         }
     },
     /**
@@ -68,17 +78,26 @@ public enum Uniqueness implements UniquenessFactory
             acceptIntegerOrNull( optionalParameter );
             return new RecentlyUnique( PrimitiveTypeFetcher.NODE, optionalParameter );
         }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
+        }
     },
     /**
      * Entities on the same level are guaranteed to be unique.
      */
     NODE_LEVEL
     {
-        @Override
         public UniquenessFilter create( Object optionalParameter )
         {
             acceptNull( optionalParameter );
             return new LevelUnique( PrimitiveTypeFetcher.NODE );
+        }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
         }
     },
 
@@ -92,6 +111,11 @@ public enum Uniqueness implements UniquenessFactory
             acceptNull( optionalParameter );
             return new GloballyUnique( PrimitiveTypeFetcher.RELATIONSHIP );
         }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
+        }
     },
     /**
      * For each returned node there's a (relationship wise) unique path from the
@@ -104,6 +128,11 @@ public enum Uniqueness implements UniquenessFactory
             acceptNull( optionalParameter );
             return new PathUnique( PrimitiveTypeFetcher.RELATIONSHIP );
         }
+
+        public boolean eagerStartBranches()
+        {
+            return false;
+        }
     },
     /**
      * Same as for {@link Uniqueness#NODE_RECENT}, but for relationships.
@@ -115,17 +144,26 @@ public enum Uniqueness implements UniquenessFactory
             acceptIntegerOrNull( optionalParameter );
             return new RecentlyUnique( PrimitiveTypeFetcher.RELATIONSHIP, optionalParameter );
         }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
+        }
     },
     /**
      * Entities on the same level are guaranteed to be unique.
      */
     RELATIONSHIP_LEVEL
     {
-        @Override
         public UniquenessFilter create( Object optionalParameter )
         {
             acceptNull( optionalParameter );
             return new LevelUnique( PrimitiveTypeFetcher.RELATIONSHIP );
+        }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
         }
     },
     
@@ -140,6 +178,11 @@ public enum Uniqueness implements UniquenessFactory
         {
             acceptNull( optionalParameter );
             return instance;
+        }
+
+        public boolean eagerStartBranches()
+        {
+            return true;
         }
     };
     

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
@@ -79,9 +79,9 @@ class BidirectionalTraverserIterator extends AbstractTraverserIterator
         // Solved this way for now, to have it return the start side to begin with.
         this.selector = alwaysOutgoingSide();
         BranchSelector startSelector = start.branchOrdering.create(
-                new AsOneStartBranch( this, startNodes, start.initialState ), start.expander );
+                new AsOneStartBranch( this, startNodes, start.initialState, start.uniqueness ), start.expander );
         BranchSelector endSelector = end.branchOrdering.create(
-                new AsOneStartBranch( this, endNodes, end.initialState ), end.expander );
+                new AsOneStartBranch( this, endNodes, end.initialState, start.uniqueness ), end.expander );
 
         this.selector = description.sideSelector.create( startSelector, endSelector, description.maxDepth );
         this.collisionDetector = description.collisionPolicy.create( description.collisionEvaluator );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserImpl.java
@@ -39,7 +39,7 @@ class TraverserImpl extends AbstractTraverser
     {
         TraverserIterator iterator = new TraverserIterator( description.uniqueness.create( description.uniquenessParameter ),
                 description.expander, description.branchOrdering, description.evaluator,
-                startNodes, description.initialState );
+                startNodes, description.initialState, description.uniqueness);
         return description.sorting != null ? new SortingTraverserIterator( this, iterator ) : iterator;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraverserIterator.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.InitialBranchState;
 import org.neo4j.graphdb.traversal.PathEvaluator;
 import org.neo4j.graphdb.traversal.TraversalBranch;
+import org.neo4j.graphdb.traversal.UniquenessFactory;
 import org.neo4j.graphdb.traversal.UniquenessFilter;
 
 class TraverserIterator extends AbstractTraverserIterator
@@ -38,13 +39,13 @@ class TraverserIterator extends AbstractTraverserIterator
     private final UniquenessFilter uniqueness;
     
     TraverserIterator( UniquenessFilter uniqueness, PathExpander expander, BranchOrderingPolicy order,
-            PathEvaluator evaluator, Iterable<Node> startNodes, InitialBranchState initialState )
+                       PathEvaluator evaluator, Iterable<Node> startNodes, InitialBranchState initialState, UniquenessFactory uniquenessFactory )
     {
         this.uniqueness = uniqueness;
         this.evaluator = evaluator;
-        this.selector = order.create( new AsOneStartBranch( this, startNodes, initialState ), expander );
+        this.selector = order.create( new AsOneStartBranch( this, startNodes, initialState, uniquenessFactory ), expander );
     }
-    
+
     protected BranchSelector selector()
     {
         return selector;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AsOneStartBranchTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.traversal;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.traversal.InitialBranchState;
+import org.neo4j.graphdb.traversal.TraversalContext;
+import org.neo4j.kernel.Uniqueness;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AsOneStartBranchTest
+{
+    @Test
+    public void donNotExhaustIteratorWhenUsingRelationshipPath()
+    {
+        // Given
+        Iterable<Node> nodeIterable = mock( Iterable.class );
+        Iterator<Node> nodeIterator = mock( Iterator.class );
+        when(nodeIterable.iterator()).thenReturn( nodeIterator );
+        when( nodeIterator.hasNext() ).thenReturn( true );
+
+        // When
+        new AsOneStartBranch( mock( TraversalContext.class ), nodeIterable, mock( InitialBranchState.class ), Uniqueness.RELATIONSHIP_PATH );
+
+        // Then
+        verify( nodeIterator, never() ).next();
+    }
+
+}


### PR DESCRIPTION
By exhausting the iterator on initialization, some queries lead to a lot
of unnecessary dbhits, e.g.

```
profile MATCH (n:topic)-[r]->(m:topic) return n,r,m limit 1;

+------------------+------+----------+-------------+----------------------+
|         Operator | Rows |   DbHits | Identifiers |                Other |
+------------------+------+----------+-------------+----------------------+
|            Slice |    1 |        0 |             |         {  AUTOINT0} |
|           Filter |    1 |        1 |             | hasLabel(m:topic(0)) |
| TraversalMatcher |    1 | 11292978 |             |              m, r, m |
+------------------+------+----------+-------------+----------------------+

Total database accesses: 11292979
```

should ideally only touch a small portion of the graph but ends up touching something like
50% instead. This fix I believe fix this.
