### PR TITLE
Fix inconsistent counts

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreApplier.java
@@ -37,6 +37,7 @@ import static org.neo4j.collection.primitive.Primitive.longSet;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.emptyIterator;
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
+import static org.neo4j.kernel.impl.store.NodeLabelsField.fieldPointsToDynamicRecordOfLabels;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 
 public class CountsStoreApplier extends NeoCommandHandler.Adapter
@@ -111,7 +112,8 @@ public class CountsStoreApplier extends NeoCommandHandler.Adapter
         { // node deleted
             nodesDelta--;
         }
-        if ( before.getLabelField() != after.getLabelField() )
+        if ( before.getLabelField() != after.getLabelField() ||
+             fieldPointsToDynamicRecordOfLabels( before.getLabelField() ) )
         {
             long[] labelsBefore = labels( before );
             long[] labelsAfter = labels( after );
@@ -152,9 +154,8 @@ public class CountsStoreApplier extends NeoCommandHandler.Adapter
     @Override
     public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
     {
-        long delta = command.delta();
         countsAccessor.incrementRelationshipCount(
-                command.startLabelId(), command.typeId(), command.endLabelId(), delta );
+                command.startLabelId(), command.typeId(), command.endLabelId(), command.delta() );
         return false;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -72,6 +72,7 @@ public class StoreFactory
     public static final String RELATIONSHIP_GROUP_STORE_NAME = ".relationshipgroupstore.db";
     public static final String COUNTS_STORE = ".counts.db";
     private final Config config;
+    @SuppressWarnings( "deprecation" )
     private final IdGeneratorFactory idGeneratorFactory;
     private final FileSystemAbstraction fileSystemAbstraction;
     private final StringLogger stringLogger;
@@ -80,6 +81,7 @@ public class StoreFactory
     private final Monitors monitors;
     private final PageCache pageCache;
 
+    @SuppressWarnings( "deprecation" )
     public StoreFactory( FileSystemAbstraction fileSystem, File storeDir, PageCache pageCache, StringLogger logger,
                          Monitors monitors )
     {
@@ -88,15 +90,16 @@ public class StoreFactory
                 logger, monitors, StoreVersionMismatchHandler.THROW_EXCEPTION );
     }
 
-    public StoreFactory( Config config, IdGeneratorFactory idGeneratorFactory, PageCache pageCache,
-                         FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger, Monitors monitors )
+    public StoreFactory( Config config, @SuppressWarnings( "deprecation" ) IdGeneratorFactory idGeneratorFactory,
+                         PageCache pageCache, FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger,
+                         Monitors monitors )
     {
         this( config, idGeneratorFactory, pageCache, fileSystemAbstraction, stringLogger,
                 monitors, StoreVersionMismatchHandler.THROW_EXCEPTION );
     }
 
-    public StoreFactory( Config config, IdGeneratorFactory idGeneratorFactory, PageCache pageCache,
-                         FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger,
+    public StoreFactory( Config config, @SuppressWarnings( "deprecation" ) IdGeneratorFactory idGeneratorFactory,
+                         PageCache pageCache, FileSystemAbstraction fileSystemAbstraction, StringLogger stringLogger,
                          Monitors monitors, StoreVersionMismatchHandler versionMismatchHandler )
     {
         this.config = config;
@@ -194,8 +197,8 @@ public class StoreFactory
 
             try ( NodeStore nodeStore = newNodeStore();
                   RelationshipStore relationshipStore = newRelationshipStore();
-                  CountsTracker tracker =
-                          new CountsTracker( fileSystemAbstraction, pageCache, storeFileBase, BASE_TX_ID ) )
+                  CountsTracker tracker = new CountsTracker(
+                          stringLogger, fileSystemAbstraction, pageCache, storeFileBase, BASE_TX_ID ) )
             {
                 CountsComputer.computeCounts( nodeStore, relationshipStore ).
                         accept( new CountsAccessor.Initializer( tracker ) );
@@ -231,13 +234,15 @@ public class StoreFactory
         return newSchemaStore( storeFileName( SCHEMA_STORE_NAME ) );
     }
 
+    @SuppressWarnings( "deprecation" )
     public SchemaStore newSchemaStore( File baseFile )
     {
         return new SchemaStore( baseFile, config, IdType.SCHEMA,
                 idGeneratorFactory, pageCache, fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
     }
 
-    public DynamicStringStore newDynamicStringStore( File fileName, IdType nameIdType )
+    public DynamicStringStore newDynamicStringStore( File fileName,
+                                                     @SuppressWarnings( "deprecation" ) IdType nameIdType )
     {
         return new DynamicStringStore( fileName, config, nameIdType, idGeneratorFactory, pageCache,
                 fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
@@ -254,6 +259,7 @@ public class StoreFactory
         return newRelationshipTypeTokenStore( new File( baseFile + NAMES_PART ), baseFile );
     }
 
+    @SuppressWarnings( "deprecation" )
     private RelationshipTypeTokenStore newRelationshipTypeTokenStore( File relationshipTypeTokenNamesStore,
                                                                       File relationshipTypeTokenStore )
     {
@@ -278,6 +284,7 @@ public class StoreFactory
                 new File( baseFile.getPath() + INDEX_PART ) );
     }
 
+    @SuppressWarnings( "deprecation" )
     private PropertyStore newPropertyStore( File propertyStringStore, File propertyArrayStore, File propertyStore,
                                             File propertyKeysStore )
     {
@@ -300,6 +307,7 @@ public class StoreFactory
         return newPropertyKeyTokenStore( new File( baseFile.getPath() + KEYS_PART ), baseFile );
     }
 
+    @SuppressWarnings( "deprecation" )
     private PropertyKeyTokenStore newPropertyKeyTokenStore( File propertyKeyTokenNamesStore,
                                                             File propertyKeyTokenStore )
     {
@@ -323,6 +331,7 @@ public class StoreFactory
 
     private LabelTokenStore newLabelTokenStore( File labelTokenNamesStore, File labelTokenStore )
     {
+        @SuppressWarnings( "deprecation" )
         DynamicStringStore nameStore = newDynamicStringStore( labelTokenNamesStore, IdType.LABEL_TOKEN_NAME );
         return new LabelTokenStore( labelTokenStore, config, idGeneratorFactory,
                 pageCache, fileSystemAbstraction, stringLogger, nameStore, versionMismatchHandler, monitors );
@@ -339,7 +348,7 @@ public class StoreFactory
                 idGeneratorFactory, pageCache, fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
     }
 
-    public DynamicArrayStore newDynamicArrayStore( File fileName, IdType idType )
+    public DynamicArrayStore newDynamicArrayStore( File fileName, @SuppressWarnings( "deprecation" ) IdType idType )
     {
         return new DynamicArrayStore( fileName, config, idType, idGeneratorFactory, pageCache,
                 fileSystemAbstraction, stringLogger, versionMismatchHandler, monitors );
@@ -355,6 +364,7 @@ public class StoreFactory
         return newNodeStore( new File( baseFile.getPath() + LABELS_PART ), baseFile );
     }
 
+    @SuppressWarnings( "deprecation" )
     private NodeStore newNodeStore( File labelStore, File nodeStore )
     {
         DynamicArrayStore dynamicLabelStore = new DynamicArrayStore( labelStore,
@@ -366,7 +376,7 @@ public class StoreFactory
 
     private CountsTracker newCountsStore( long txId )
     {
-        return new CountsTracker( fileSystemAbstraction, pageCache, storeFileName( COUNTS_STORE ), txId );
+        return new CountsTracker( stringLogger, fileSystemAbstraction, pageCache, storeFileName( COUNTS_STORE ), txId );
     }
 
     public NeoStore createNeoStore()
@@ -437,6 +447,7 @@ public class StoreFactory
         ) );
     }
 
+    @SuppressWarnings( "deprecation" )
     private void createNodeLabelsStore()
     {
         int labelStoreBlockSize = config.get( Configuration.label_block_size );
@@ -460,6 +471,7 @@ public class StoreFactory
      * filename is <CODE>null</CODE> or the file already exists an
      * <CODE>IOException</CODE> is thrown.
      */
+    @SuppressWarnings( "deprecation" )
     public void createPropertyStore()
     {
         createEmptyStore( storeFileName( PROPERTY_STORE_NAME ),
@@ -478,6 +490,7 @@ public class StoreFactory
      * If filename is <CODE>null</CODE> or the file already exists an
      * <CODE>IOException</CODE> is thrown.
      */
+    @SuppressWarnings( "deprecation" )
     private void createRelationshipTypeStore()
     {
         createEmptyStore( storeFileName( RELATIONSHIP_TYPE_TOKEN_STORE_NAME ),
@@ -488,6 +501,7 @@ public class StoreFactory
         store.close();
     }
 
+    @SuppressWarnings( "deprecation" )
     private void createLabelTokenStore()
     {
         createEmptyStore( storeFileName( LABEL_TOKEN_STORE_NAME ),
@@ -498,11 +512,13 @@ public class StoreFactory
         store.close();
     }
 
-    public void createDynamicStringStore( File fileName, int blockSize, IdType idType )
+    public void createDynamicStringStore( File fileName, int blockSize,
+                                          @SuppressWarnings( "deprecation" ) IdType idType )
     {
         createEmptyDynamicStore( fileName, blockSize, DynamicStringStore.VERSION, idType );
     }
 
+    @SuppressWarnings( "deprecation" )
     public void createPropertyKeyTokenStore()
     {
         createEmptyStore( storeFileName( PROPERTY_KEY_TOKEN_STORE_NAME ),
@@ -511,11 +527,13 @@ public class StoreFactory
                 TokenStore.NAME_STORE_BLOCK_SIZE, IdType.PROPERTY_KEY_TOKEN_NAME );
     }
 
+    @SuppressWarnings( "deprecation" )
     public void createDynamicArrayStore( File fileName, int blockSize )
     {
         createEmptyDynamicStore( fileName, blockSize, DynamicArrayStore.VERSION, IdType.ARRAY_BLOCK );
     }
 
+    @SuppressWarnings( "deprecation" )
     public void createSchemaStore()
     {
         createEmptyDynamicStore( storeFileName( SCHEMA_STORE_NAME ), SchemaStore.BLOCK_SIZE,
@@ -545,7 +563,8 @@ public class StoreFactory
      * @param typeAndVersionDescriptor The type and version descriptor that identifies this store
      */
     public void createEmptyDynamicStore( File fileName, int baseBlockSize,
-                                         String typeAndVersionDescriptor, IdType idType )
+                                         String typeAndVersionDescriptor,
+                                         @SuppressWarnings( "deprecation" ) IdType idType )
     {
         int blockSize = baseBlockSize;
         // sanity checks
@@ -597,6 +616,7 @@ public class StoreFactory
         idGenerator.close();
     }
 
+    @SuppressWarnings( "deprecation" )
     public void createRelationshipGroupStore( int denseNodeThreshold )
     {
         ByteBuffer firstRecord = ByteBuffer.allocate( RelationshipGroupStore.RECORD_SIZE ).putInt( denseNodeThreshold );
@@ -613,7 +633,7 @@ public class StoreFactory
     }
 
     private void createEmptyStore( File fileName, String typeAndVersionDescriptor, ByteBuffer firstRecordData,
-                                   IdType idType )
+                                   @SuppressWarnings( "deprecation" ) IdType idType )
     {
         // sanity checks
         if ( fileName == null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ConcurrentCountsTrackerState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/ConcurrentCountsTrackerState.java
@@ -60,7 +60,7 @@ class ConcurrentCountsTrackerState implements CountsTrackerState
     @Override
     public String toString()
     {
-        return String.format( "ConcurrentTrackerState[store=%s - %s]", store, super.toString() );
+        return String.format( "ConcurrentTrackerState[store=%s - %s]", store, changes.toString() );
     }
 
     public boolean hasChanges()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -261,7 +261,8 @@ public class StoreMigrator implements StoreMigrationParticipant
                 new StoreFactory( fileSystem, storeDir, pageCache, DEV_NULL, new Monitors() );
         try ( NodeStore nodeStore = storeFactory.newNodeStore();
               RelationshipStore relationshipStore = storeFactory.newRelationshipStore();
-              CountsTracker tracker = new CountsTracker( fileSystem, pageCache, storeFileBase, BASE_TX_ID ) )
+              CountsTracker tracker = new CountsTracker( logging.getMessagesLog( CountsTracker.class ),
+                      fileSystem, pageCache, storeFileBase, BASE_TX_ID ) )
         {
             CountsComputer.computeCounts( nodeStore, relationshipStore ).
                     accept( new CountsAccessor.Initializer( tracker ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2.java
@@ -163,11 +163,6 @@ public class PhysicalLogNeoCommandReaderV2 implements CommandReader
             command = new Command.CountsCommand();
             break;
         }
-        case NeoCommandType.NONE:
-        {
-            command = null;
-            break;
-        }
         default:
         {
             LogPositionMarker position = new LogPositionMarker();
@@ -175,7 +170,7 @@ public class PhysicalLogNeoCommandReaderV2 implements CommandReader
             throw new IOException( "Unknown command type[" + commandType + "] near " + position.newPosition() );
         }
         }
-        if ( command != null && command.handle( reader ) )
+        if ( command.handle( reader ) )
         {
             return null;
         }
@@ -260,7 +255,7 @@ public class PhysicalLogNeoCommandReaderV2 implements CommandReader
             }
             else
             {
-                record = new RelationshipRecord( id, -1, -1, -1 );
+                record = new RelationshipRecord( id, -1, -1, channel.getInt() );
                 record.setInUse( false );
             }
             if ( bitFlag( flags, Record.CREATED_IN_TX ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
@@ -93,6 +93,10 @@ public class CommandWriter implements NeoCommandHandler
                    .putLong( record.getNextProp() )
                    .put( (byte) ((record.isFirstInFirstChain() ? 1 : 0) | (record.isFirstInSecondChain() ? 2 : 0)) );
         }
+        else
+        {
+            channel.putInt( record.getType() );
+        }
         return false;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.store.CountsComputer;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.register.Register;
 import org.neo4j.register.Registers;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -61,6 +62,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateAnEmptyCountsStoreFromAnEmptyDatabase() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.newGraphDatabase();
         final CountsRecordState countsState = CountsComputer.computeCounts( db );
         long lastCommittedTransactionId = getLastTxId( db );
@@ -81,6 +83,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateACountsStoreWhenThereAreNodesInTheDB() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
@@ -113,6 +116,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateACountsStoreWhenThereAreUnusedNodeRecordsInTheDB() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
@@ -146,6 +150,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateACountsStoreWhenThereAreUnusedRelationshipRecordsInTheDB() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
@@ -183,6 +188,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateACountsStoreWhenThereAreNodesAndRelationshipsInTheDB() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
@@ -226,6 +232,7 @@ public class CountsComputerTest
     @Test
     public void shouldCreateACountStoreWhenDBContainsDenseNodes() throws IOException
     {
+        @SuppressWarnings( "deprecation" )
         final GraphDatabaseAPI db = (GraphDatabaseAPI) dbBuilder.
                 setConfig( GraphDatabaseSettings.dense_node_threshold, "2" ).newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
@@ -306,7 +313,7 @@ public class CountsComputerTest
         return new File( dir, COUNTS_STORE_BASE + CountsTracker.BETA );
     }
 
-    private long getLastTxId( GraphDatabaseAPI db )
+    private long getLastTxId( @SuppressWarnings( "deprecation" ) GraphDatabaseAPI db )
     {
         return db.getDependencyResolver().resolveDependency( NeoStore.class )
                 .getLastCommittedTransactionId();
@@ -322,7 +329,8 @@ public class CountsComputerTest
 
     private void rebuildCounts( CountsRecordState countsState, long lastCommittedTransactionId ) throws IOException
     {
-        CountsTracker tracker = new CountsTracker( fs, pageCache, new File( dir, COUNTS_STORE_BASE ), BASE_TX_ID );
+        CountsTracker tracker = new CountsTracker( StringLogger.DEV_NULL, fs, pageCache,
+                new File( dir, COUNTS_STORE_BASE ), BASE_TX_ID );
         countsState.accept( new CountsAccessor.Initializer( tracker ) );
         tracker.rotate( lastCommittedTransactionId );
         tracker.close();


### PR DESCRIPTION
Counts were becoming inconsistent when deleting a node and its relationships in the same transaction. This is fixed by inspecting the (pre-state) labels and relationships of the node that is being deleted when building the counts from the transaction state.

Counts also became inconsistent during recovery, since commands in the log did not contain information about the relationship type for deleted relationships. We need this information in order to be able to consistently update the counts, since we cannot trust what is in the store during recovery. This is fixed by adding type information to removed relationship commands in the log.

Recovery of the counts store also has a problem in that the counts store did not have a marking to signal that it is inconsistent, since it was updated in place. To mark the store as inconsistent / incomplete the file is truncated before writing of the store is started.
Reading of a truncated file will show up as an IOException in openVerifiedCountsStore(), this is handled in the same way as the previous internal-consistency-check (which is still in place, and complements this new additional check) of making sure that the number of expected data entries written in the header matches the actual number of data entries in the store.
The truncation is required since we would otherwise not be able to recognize a partial write of the store where the new number of records is the same as the old number of records.
