### PR TITLE
Lock-free loading of relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -688,14 +688,14 @@ public abstract class InternalAbstractGraphDatabase
     {
         if ( readOnly )
         {
-            return new ReadOnlyNodeManager( logging, this, locks, txManager, persistenceManager,
+            return new ReadOnlyNodeManager( logging, this, txManager, persistenceManager,
                     persistenceSource, relationshipTypeTokenHolder, cacheType, propertyKeyTokenHolder, labelTokenHolder,
                     createNodeLookup(), createRelationshipLookups(), nodeCache, relCache, xaDataSourceManager,
                     statementContextProvider );
         }
 
         return new NodeManager(
-                logging, this, locks, txManager, persistenceManager,
+                logging, this, txManager, persistenceManager,
                 persistenceSource, relationshipTypeTokenHolder, cacheType, propertyKeyTokenHolder, labelTokenHolder,
                 createNodeLookup(), createRelationshipLookups(), nodeCache, relCache, xaDataSourceManager,
                 statementContextProvider );
@@ -707,7 +707,7 @@ public abstract class InternalAbstractGraphDatabase
     {
         if ( readOnly )
         {
-            return new ReadOnlyNodeManager( logging, this, locks, txManager, persistenceManager,
+            return new ReadOnlyNodeManager( logging, this, txManager, persistenceManager,
                     persistenceSource, relationshipTypeTokenHolder, cacheType, propertyKeyTokenHolder, labelTokenHolder, createNodeLookup(),
                     createRelationshipLookups(), nodeCache, relCache, xaDataSourceManager, statementContextProvider )
             {
@@ -756,7 +756,7 @@ public abstract class InternalAbstractGraphDatabase
             };
         }
 
-        return new NodeManager( logging, this, locks, txManager, persistenceManager,
+        return new NodeManager( logging, this, txManager, persistenceManager,
                 persistenceSource, relationshipTypeTokenHolder, cacheType, propertyKeyTokenHolder, labelTokenHolder, createNodeLookup(),
                 createRelationshipLookups(), nodeCache, relCache, xaDataSourceManager, statementContextProvider )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -118,11 +118,12 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     }
 
     @Override
-    public void patchDeletedRelationshipNodes( long relId, long firstNodeId, long firstNodeNextRelId,
+    public void patchDeletedRelationshipNodes( long relId, int type,
+            long firstNodeId, long firstNodeNextRelId,
             long secondNodeId, long secondNodeNextRelId )
     {
-        nodeManager.patchDeletedRelationshipNodes( relId, firstNodeId, firstNodeNextRelId, secondNodeId,
-                secondNodeNextRelId );
+        nodeManager.patchDeletedRelationshipNodes( relId, type,
+                firstNodeId, firstNodeNextRelId, secondNodeId, secondNodeNextRelId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -58,11 +58,13 @@ public interface CacheAccessBackDoor
      * {@link #removeRelationshipFromCache(long)} for that purpose before calling this method.
      *
      * @param relId The relId of the relationship deleted
+     * @param type type of the deleted relationship
      * @param firstNodeId The relId of the first node
      * @param firstNodeNextRelId The next relationship relId of the first node in its relationship chain
      * @param secondNodeId The relId of the second node
      * @param secondNodeNextRelId The next relationship relId of the second node in its relationship chain
      */
-    void patchDeletedRelationshipNodes( long relId, long firstNodeId, long firstNodeNextRelId, long secondNodeId,
-                                      long secondNodeNextRelId );
+    void patchDeletedRelationshipNodes( long relId, int type,
+            long firstNodeId, long firstNodeNextRelId,
+            long secondNodeId, long secondNodeNextRelId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
@@ -20,11 +20,13 @@
 package org.neo4j.kernel.impl.core;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
+import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
+import org.neo4j.collection.primitive.PrimitiveIntObjectVisitor;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
@@ -33,38 +35,41 @@ import static java.lang.String.format;
 
 public class DenseNodeChainPosition implements RelationshipLoadingPosition
 {
-    private final Map<Integer, RelationshipLoadingPosition> positions = new HashMap<>();
-    private final Map<Integer, RelationshipGroupRecord> groups;
+    private final PrimitiveIntObjectMap<RelationshipLoadingPosition> positions = Primitive.intObjectMap();
     private final int[] types;
     private RelationshipLoadingPosition currentPosition;
 
     public DenseNodeChainPosition( Map<Integer, RelationshipGroupRecord> groups )
     {
-        this.types = PrimitiveIntCollections.asArray( groups.keySet().iterator() );
-        this.groups = groups;
+        this.types = PrimitiveIntCollections.asArray( groups.keySet() );
+
+        // Instantiate all positions eagerly so that we get a fixed point in time where
+        // all positions where initialized. This is required for relationship addition filtering
+        // during committing relationship changes to a NodeImpl.
+        for ( Entry<Integer,RelationshipGroupRecord> entry : groups.entrySet() )
+        {
+            this.positions.put( entry.getKey(), new TypePosition( entry.getValue() ) );
+        }
     }
 
-    private DenseNodeChainPosition( DenseNodeChainPosition copyFrom )
+    private DenseNodeChainPosition( final DenseNodeChainPosition copyFrom )
     {
         // Deep-copy of positions
-        for ( Entry<Integer, RelationshipLoadingPosition> entry : copyFrom.positions.entrySet() )
+        copyFrom.positions.visitEntries( new PrimitiveIntObjectVisitor<RelationshipLoadingPosition>()
         {
-            RelationshipLoadingPosition position = entry.getValue().clone();
-            this.positions.put( entry.getKey(), position );
-            if ( entry.getValue() == copyFrom.currentPosition )
+            @Override
+            public void visited( int type, RelationshipLoadingPosition originalPosition )
             {
-                this.currentPosition = position;
+                RelationshipLoadingPosition position = originalPosition.clone();
+                positions.put( type, position );
+                if ( originalPosition == copyFrom.currentPosition )
+                {
+                    currentPosition = position;
+                }
             }
-        }
+        } );
 
-        this.groups = new HashMap<>( copyFrom.groups );
-        this.types = copyFrom.types.clone();
-    }
-
-    @Override
-    public void updateFirst( long first )
-    {
-        // TODO here we need relationship groups for any new
+        this.types = copyFrom.types;
     }
 
     @Override
@@ -91,9 +96,7 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         RelationshipLoadingPosition position = positions.get( type );
         if ( position == null )
         {
-            RelationshipGroupRecord record = groups.get( type );
-            position = record != null ? new TypePosition( record ) : RelationshipLoadingPosition.EMPTY;
-            positions.put( type, position );
+            return RelationshipLoadingPosition.EMPTY;
         }
         return position;
     }
@@ -128,12 +131,16 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     }
 
     @Override
-    public void compareAndAdvance( long relIdDeleted, long nextRelId )
+    public boolean atPosition( DirectionWrapper direction, int type, long position )
     {
-        for ( RelationshipLoadingPosition typePosition : positions.values() )
-        {
-            typePosition.compareAndAdvance( relIdDeleted, nextRelId );
-        }
+        RelationshipLoadingPosition typePosition = positions.get( type );
+        return typePosition != null ? typePosition.atPosition( direction, type, position ) : false;
+    }
+
+    @Override
+    public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
+    {
+        getTypePosition( type ).compareAndAdvance( direction, type, relIdDeleted, nextRelId );
     }
 
     @Override
@@ -146,7 +153,6 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     public String toString()
     {
         StringBuilder builder = new StringBuilder( getClass().getSimpleName() + ":" );
-        builder.append( format( "%n  groups: %s", groups ) );
         builder.append( format( "%n  positions: %s", positions ) );
         return builder.toString();
     }
@@ -159,9 +165,11 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
 
         TypePosition( RelationshipGroupRecord record )
         {
-            for ( DirectionWrapper dir : DirectionWrapper.values() )
+            for ( DirectionWrapper direction : DirectionWrapper.values() )
             {
-                directions.put( dir, new SingleChainPosition( dir.getNextRel( record ) ) );
+                long firstRel = direction.getNextRel( record );
+                directions.put( direction, firstRel != Record.NO_NEXT_RELATIONSHIP.intValue()
+                        ? new SingleChainPosition( firstRel ) : RelationshipLoadingPosition.EMPTY );
             }
         }
 
@@ -179,9 +187,9 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         }
 
         @Override
-        public void updateFirst( long first )
+        public boolean atPosition( DirectionWrapper direction, int type, long position )
         {
-            throw new UnsupportedOperationException();
+            return directions.get( direction ).atPosition( direction, type, position );
         }
 
         @Override
@@ -241,12 +249,9 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         }
 
         @Override
-        public void compareAndAdvance( long relIdDeleted, long nextRelId )
+        public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
         {
-            for ( RelationshipLoadingPosition position : directions.values() )
-            {
-                position.compareAndAdvance( relIdDeleted, nextRelId );
-            }
+            directions.get( direction ).compareAndAdvance( direction, type, relIdDeleted, nextRelId );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeImpl.java
@@ -22,7 +22,10 @@ package org.neo4j.kernel.impl.core;
 import java.util.Iterator;
 
 import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.util.RelIdArray;
+import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+import org.neo4j.kernel.impl.util.RelationshipFilter;
 
 public class DenseNodeImpl extends NodeImpl
 {
@@ -36,13 +39,13 @@ public class DenseNodeImpl extends NodeImpl
     {
         return getDegree( nm, type, Direction.BOTH );
     }
-    
+
     @Override
     public int getDegree( NodeManager nm, Direction direction )
     {
         return nm.getRelationshipCount( this, -1, RelIdArray.wrap( direction ) );
     }
-    
+
     @Override
     public int getDegree( NodeManager nm, int type, Direction direction )
     {
@@ -53,5 +56,55 @@ public class DenseNodeImpl extends NodeImpl
     public Iterator<Integer> getRelationshipTypes( NodeManager nm )
     {
         return hasMoreRelationshipsToLoad() ? nm.getRelationshipTypes( this ) : super.getRelationshipTypes( nm );
+    }
+
+    @Override
+    protected boolean isDense()
+    {
+        return true;
+    }
+
+    @Override
+    protected RelationshipFilter filterForAddingRelationships( final FirstRelationshipIds firstRelationshipIdsToCommit,
+            final RelationshipLoadingPosition relChainPosition )
+    {
+        // Filtering for dense nodes is different from that of sparse nodes in that on-disk and cached
+        // are split up the same way. So here we don't need to collect all first ids that sparse nodes will
+        // have to do, instead we can check the specific chain each time.
+        return new RelationshipFilter()
+        {
+            @Override
+            public boolean accept( int type, DirectionWrapper direction, long firstCachedId )
+            {
+                long firstIdToCommit = firstRelationshipIdsToCommit.firstIdOf( type, direction );
+                assert firstIdToCommit != Record.NO_NEXT_RELATIONSHIP.intValue() :
+                        "About to add relationships of " + type + " " + direction +
+                        " to node " + getId() + ", but apparently the tx state says that no such relationships " +
+                        "are to be added " + firstRelationshipIdsToCommit;
+
+                return  firstCachedId == Record.NO_NEXT_RELATIONSHIP.intValue()
+
+                        // This condition guards for the case where, for a particular relationship chain, there
+                        // are no cached relationships yet. This might be because there have been no relationships
+                        // loaded or if there simply are no relationships in that chain. For the former,
+                        // if the chain position is currently pointing to the same id as we're about to commit
+                        // as first id for this chain, then we can tell that a READER has already seen this
+                        // change, and so we will not add these relationships.
+                        ? relationshipChainAtPosition( relChainPosition, direction, type, firstIdToCommit )
+
+                        // This condition guards for the case where, for a particular relationship chain, there
+                        // are one or more cached relationships, and the first relationship loaded and cached
+                        // for this chain is the same as the id we're about to commit as first id for this chain,
+                        // then we can tell that a READER has already seen this change, and so we will not add
+                        // these relationships.
+                        : firstCachedId != firstIdToCommit;
+            }
+
+            private boolean relationshipChainAtPosition( RelationshipLoadingPosition relChainPosition,
+                    DirectionWrapper direction, int type, long firstIdToCommit )
+            {
+                return relChainPosition != null && !relChainPosition.atPosition( direction, type, firstIdToCommit );
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/FirstRelationshipIds.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/FirstRelationshipIds.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+
+/**
+ * Able to provide information about which id is the first id, in a list of many.
+ */
+public interface FirstRelationshipIds
+{
+    /**
+     * @param type relationship type token id.
+     * @param direction direction of the relationship.
+     * @return first id for the given type and direction, or {@link Record#NO_NEXT_RELATIONSHIP} if none.
+     */
+    long firstIdOf( int type, DirectionWrapper direction );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NoTransactionState.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.core.WritableTransactionState.SetAndDirectionCounter;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.persistence.PersistenceManager.ResourceHolder;
 import org.neo4j.kernel.impl.transaction.RemoteTxHook;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
@@ -57,7 +58,12 @@ public class NoTransactionState implements TransactionState
     }
 
     @Override
-    public void setFirstIds( long nodeId, long firstRel, long firstProp )
+    public void setFirstIds( long nodeId, boolean dense, long firstRel, long firstProp )
+    {
+    }
+
+    @Override
+    public void addRelationshipGroupChange( long nodeId, RelationshipGroupRecord group )
     {
     }
 
@@ -74,7 +80,7 @@ public class NoTransactionState implements TransactionState
     }
 
     @Override
-    public void commitCows()
+    public void commitCows( CacheAccessBackDoor cacheAccess )
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.core;
 
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.binarySearch;
+
 import static org.neo4j.kernel.impl.cache.SizeOfs.REFERENCE_SIZE;
 import static org.neo4j.kernel.impl.cache.SizeOfs.sizeOfArray;
 import static org.neo4j.kernel.impl.cache.SizeOfs.withArrayOverheadIncludingReferences;
@@ -35,8 +36,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
@@ -48,10 +51,11 @@ import org.neo4j.kernel.impl.api.store.CacheLoader;
 import org.neo4j.kernel.impl.core.WritableTransactionState.CowEntityElement;
 import org.neo4j.kernel.impl.core.WritableTransactionState.PrimitiveElement;
 import org.neo4j.kernel.impl.core.WritableTransactionState.SetAndDirectionCounter;
-import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
+import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
+import org.neo4j.kernel.impl.util.RelationshipFilter;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.RelIdIterator;
 
@@ -61,6 +65,44 @@ import org.neo4j.kernel.impl.util.RelIdIterator;
  *
  * Responsibilities inside this class are slowly being moved over to {@link org.neo4j.kernel.impl.api.Kernel} and its
  * friends.
+ *
+ * As for the cache parts of this class the following can be said:
+ *
+ * The node cache is a combination of the node state itself together with state information regarding the
+ * completeness of what is cached. The cached state is kept for performance reasons and the uncached state
+ * information is necessary for completeness/correctness so that the missing parts can and will be fetched
+ * from the disk store on demand.
+ *
+ * The cached state for a node is carried in the NodeImpl class and apart from node specific state,
+ * it also carries some high-level properties of its related relationships, like relationship id, type and direction.
+ * This is carried in the associated RelIdArray{WithLoops} classes.
+ *
+ * The uncached state information is kept by a set of relationship chain loading positions.
+ * All other relationship metadata is carried in the relationship cache and not detailed here.
+ *
+ * Updating the node cache
+ * -----------------------
+ *
+ * The node cache should be updated when changes are performed. Avoiding updates can lead to two problems:
+ * <ul>
+ * <li>lesser performance</li>
+ * <li>incorrect state</li>
+ * </ul>
+ * The updates must cover the correctness both of the cached as well as the uncached state.
+ * Most of the complexities in node cache updating are due to relationship changes, since they are much more dynamic
+ * (can be added/removed) and also since only parts of the relationship state may be cached.
+ * Failure to update properly can lead to cache poisoning, such as missing or duplicate relationships, f.ex. due to:
+ * <ul>
+ * <li>not adding to cached state</li>
+ * <li>not updating uncached state information correctly</li>
+ * <li>mismatch between cached state and uncached state info</li>
+ * </ul>
+ *
+ * The node cache is updated when a:
+ * <ul>
+ * <li>transaction is committed, see {@link WritableTransactionState}</li>
+ * <li>reader loads relationships (as part of getRelationships)</li>
+ * </ul>
  */
 public class NodeImpl extends ArrayBasedPrimitive
 {
@@ -87,9 +129,6 @@ public class NodeImpl extends ArrayBasedPrimitive
     // newNode will only be true for NodeManager.createNode
     public NodeImpl( long id, boolean newNode )
     {
-        /* TODO firstRel/firstProp isn't used yet due to some unresolved issue with clearing
-         * of cache and keeping those first ids in the node instead of loading on demand.
-         */
         super( newNode );
         this.id = id;
         if ( newNode )
@@ -270,30 +309,27 @@ public class NodeImpl extends ArrayBasedPrimitive
             int[] types )
     {
         Triplet<ArrayMap<Integer, RelIdArray>, List<RelationshipImpl>, RelationshipLoadingPosition> rels = null;
-        try ( Lock ignored = nodeManager.lowLevelNodeReadLock( id ) )
+        synchronized ( this )
         {
-            synchronized ( this )
+            if ( relationships == null ||
+                 (relationships.length == 0 && relChainPosition.hasMore( direction, types )) )
             {
-                if ( relationships == null ||
-                     (relationships.length == 0 && relChainPosition.hasMore( direction, types )) )
+                try
                 {
-                    try
-                    {
-                        relChainPosition = nodeManager.getRelationshipChainPosition( this );
-                    }
-                    catch ( InvalidRecordException e )
-                    {
-                        throw new NotFoundException( asProxy( nodeManager ) +
-                                                     " concurrently deleted while loading its relationships?", e );
-                    }
-
-                    ArrayMap<Integer, RelIdArray> tmpRelMap = new ArrayMap<>();
-                    rels = getMoreRelationships( nodeManager, tmpRelMap, direction, types );
-                    this.relationships = toRelIdArray( tmpRelMap );
-                    this.relChainPosition = rels == null ? RelationshipLoadingPosition.EMPTY : rels.third();
-                    moreRelationshipsLoaded();
-                    updateSize( nodeManager );
+                    relChainPosition = nodeManager.getRelationshipChainPosition( this );
                 }
+                catch ( InvalidRecordException e )
+                {
+                    throw new NotFoundException( asProxy( nodeManager ) +
+                                                 " concurrently deleted while loading its relationships?", e );
+                }
+
+                ArrayMap<Integer, RelIdArray> tmpRelMap = new ArrayMap<>();
+                rels = getMoreRelationships( nodeManager, tmpRelMap, direction, types );
+                this.relationships = toRelIdArray( tmpRelMap );
+                this.relChainPosition = rels == null ? RelationshipLoadingPosition.EMPTY : rels.third();
+                moreRelationshipsLoaded();
+                updateSize( nodeManager );
             }
         }
         if ( rels != null && rels.second().size() > 0 )
@@ -433,43 +469,40 @@ public class NodeImpl extends ArrayBasedPrimitive
             return LoadStatus.NOTHING;
         }
         boolean more;
-        try ( Lock ignored = nodeManager.lowLevelNodeReadLock( id ) )
+        synchronized ( this )
         {
-            synchronized ( this )
+            if ( !hasMoreRelationshipsToLoad( direction, types ) )
             {
-                if ( !hasMoreRelationshipsToLoad( direction, types ) )
-                {
-                    return LoadStatus.NOTHING;
-                }
-                rels = loadMoreRelationshipsFromNodeManager( nodeManager, direction, types );
-                ArrayMap<Integer, RelIdArray> addMap = rels.first();
-                if ( addMap.size() == 0 )
-                {
-                    return LoadStatus.NOTHING;
-                }
-                for ( int type : addMap.keySet() )
-                {
-                    RelIdArray addRels = addMap.get( type );
-                    RelIdArray srcRels = getRelIdArray( type );
-                    if ( srcRels == null )
-                    {
-                        putRelIdArray( addRels );
-                    }
-                    else
-                    {
-                        RelIdArray newSrcRels = srcRels.addAll( addRels );
-                        // This can happen if srcRels gets upgraded to a RelIdArrayWithLoops
-                        if ( newSrcRels != srcRels )
-                        {
-                            putRelIdArray( newSrcRels );
-                        }
-                    }
-                }
-                relChainPosition = rels.third();
-                moreRelationshipsLoaded();
-                more = hasMoreRelationshipsToLoad( direction, types );
-                updateSize( nodeManager );
+                return LoadStatus.NOTHING;
             }
+            rels = loadMoreRelationshipsFromNodeManager( nodeManager, direction, types );
+            ArrayMap<Integer, RelIdArray> addMap = rels.first();
+            if ( addMap.size() == 0 )
+            {
+                return LoadStatus.NOTHING;
+            }
+            for ( int type : addMap.keySet() )
+            {
+                RelIdArray addRels = addMap.get( type );
+                RelIdArray srcRels = getRelIdArray( type );
+                if ( srcRels == null )
+                {
+                    putRelIdArray( addRels );
+                }
+                else
+                {
+                    RelIdArray newSrcRels = srcRels.addAll( addRels );
+                    // This can happen if srcRels gets upgraded to a RelIdArrayWithLoops
+                    if ( newSrcRels != srcRels )
+                    {
+                        putRelIdArray( newSrcRels );
+                    }
+                }
+            }
+            relChainPosition = rels.third();
+            moreRelationshipsLoaded();
+            more = hasMoreRelationshipsToLoad( direction, types );
+            updateSize( nodeManager );
         }
         nodeManager.putAllInRelCache( rels.second() );
         return more ? LoadStatus.LOADED_MORE : LoadStatus.LOADED_END;
@@ -525,50 +558,142 @@ public class NodeImpl extends ArrayBasedPrimitive
         relationships = array;
     }
 
-    protected void commitRelationshipMaps(
-            ArrayMap<Integer, RelIdArray> cowRelationshipAddMap,
-            ArrayMap<Integer, SetAndDirectionCounter> relationshipRemoveMap )
+    protected boolean isDense()
     {
+        return false;
+    }
+
+    /**
+     * @param dense {@code true} if this node, including the changes in this change set, should be dense,
+     * otherwise {@code false}.
+     * @return {@code true} if this node should be evicted, due to upgrade to dense node for example,
+     * otherwise {@code false}.
+     */
+    protected synchronized boolean commitRelationshipMaps(
+            ArrayMap<Integer, RelIdArray> cowRelationshipAddMap,
+            ArrayMap<Integer, SetAndDirectionCounter> relationshipRemoveMap,
+            FirstRelationshipIds firstRelationshipIds, boolean dense )
+    {
+        if ( dense != isDense() )
+        {
+            return true;
+        }
+
         if ( relationships == null )
         {
             // we will load full in some other tx
-            return;
+            return false;
         }
 
-        synchronized ( this )
+        if ( cowRelationshipAddMap != null )
         {
-            if ( cowRelationshipAddMap != null )
+            // Instantiate the filter which additions go through. Must be instantiated before we start
+            // adding any relationships as part of this change set.
+            RelationshipFilter filter = filterForAddingRelationships( firstRelationshipIds, relChainPosition );
+
+            for ( int type : cowRelationshipAddMap.keySet() )
             {
-                for ( int type : cowRelationshipAddMap.keySet() )
+                RelIdArray add = cowRelationshipAddMap.get( type );
+                SetAndDirectionCounter remove = null;
+                if ( relationshipRemoveMap != null )
                 {
-                    RelIdArray add = cowRelationshipAddMap.get( type );
-                    SetAndDirectionCounter remove = null;
-                    if ( relationshipRemoveMap != null )
-                    {
-                        remove = relationshipRemoveMap.get( type );
-                    }
-                    RelIdArray src = getRelIdArray( type );
-                    putRelIdArray( RelIdArray.from( src, add, remove != null ? remove.set : null ) );
+                    remove = relationshipRemoveMap.get( type );
                 }
+                RelIdArray src = getRelIdArray( type );
+                putRelIdArray( RelIdArray.from( src, add, remove != null ? remove.set : null, filter ) );
             }
-            if ( relationshipRemoveMap != null )
+        }
+        if ( relationshipRemoveMap != null )
+        {
+            for ( int type : relationshipRemoveMap.keySet() )
             {
-                for ( int type : relationshipRemoveMap.keySet() )
+                if ( cowRelationshipAddMap != null &&
+                        cowRelationshipAddMap.get( type ) != null )
                 {
-                    if ( cowRelationshipAddMap != null &&
-                            cowRelationshipAddMap.get( type ) != null )
-                    {
-                        continue;
-                    }
-                    RelIdArray src = getRelIdArray( type );
-                    if ( src != null )
-                    {
-                        SetAndDirectionCounter remove = relationshipRemoveMap.get( type );
-                        putRelIdArray( RelIdArray.from( src, null, remove != null ? remove.set : null ) );
-                    }
+                    continue;
+                }
+                RelIdArray src = getRelIdArray( type );
+                if ( src != null )
+                {
+                    SetAndDirectionCounter remove = relationshipRemoveMap.get( type );
+                    putRelIdArray( RelIdArray.from( src, null, remove != null ? remove.set : null ) );
                 }
             }
         }
+        return false;
+    }
+
+    /**
+     * Instantiates a filter which relationships that committers apply to this cached node must pass
+     * before being added. This filter is needed since there is no synchronization between committers and
+     * regular readers which loads relationships.
+     *
+     * Specifically this filter guards for the following scenario:
+     * <ol>
+     * <li>COMMITTER: updates records as part of commit, and completes that work.</li>
+     * <li>READER: comes in before COMMITTER applies its changes to cache and either loads the node fresh if it
+     * has been evicted, or starts loading relationships if no relationships have been loaded yet. It will then see
+     * the new changes made by COMMITTER. By the way, relationship chain additions are atomically visible,
+     * as a result of the order that records are committed. Also, for clarification, loading relationships
+     * implies also adding them to the relationship id cache on each node.</li>
+     * <li>COMMITTER: adds the created relationships to the cached nodes and no duplication detection is made,
+     * since that would be expensive and wouldn't scale.</li>
+     * <li>At this point the relationships that COMMITTER created now exists two times in the cache.</li>
+     * </ol>
+     *
+     * This all assumes that applying a commit means writing record changes to store first,
+     * and then updating the cache. Doing it the other way around would have solved some tricky races that
+     * we guard for here below, but fails in the face of random cache eviction.
+     *
+     * Solution presented here is to make the COMMITTER aware of this problem and let it have the ability to
+     * not add its created relationships to cache where any READER has already loaded the very same relationships.
+     * There's further documentation in each specific check within the implementation of this filter.
+     *
+     * @param firstRelationshipIdsToCommit object that is able to provide information about which relationship
+     * ids will be the first in each changed relationship chain, as part of this commit.
+     */
+    protected RelationshipFilter filterForAddingRelationships( final FirstRelationshipIds firstRelationshipIdsToCommit,
+            RelationshipLoadingPosition relChainPosition )
+    {
+        // Before we start to add any relationships as part of this commit, find and keep all first ids for every chain
+        final PrimitiveLongSet cachedFirstIds = gatherFirstIds();
+        return new RelationshipFilter()
+        {
+            @Override
+            public boolean accept( int type, DirectionWrapper direction, long firstCachedId )
+            {
+                long firstIdToCommit = firstRelationshipIdsToCommit.firstIdOf( type, direction );
+                assert firstIdToCommit != Record.NO_NEXT_RELATIONSHIP.intValue() :
+                        "About to add relationships of " + type + " " + direction +
+                        " to node " + getId() + ", but apparently the tx state says that no such relationships " +
+                        "are to be added " + firstRelationshipIdsToCommit;
+
+                // For sparse nodes there's a mismatch between how the relationship chain is laid out on disk
+                // and how it's represented in the cache. On disk all relationships sits in one long chain,
+                // but in cache relationships are split up by type and direction. The information about which
+                // relationship is the first in the chain is lost after relationships have been loaded, and
+                // we need to check all cached chains and if any of them has that id as its first one then
+                // we can tell that a READER has already loaded the relationship(s) we're about to commit.
+                return !cachedFirstIds.contains( firstIdToCommit );
+            }
+        };
+    }
+
+    protected PrimitiveLongSet gatherFirstIds()
+    {
+        PrimitiveLongSet result = Primitive.longSet( relationships.length * 3 );
+        for ( RelIdArray ids : relationships )
+        {
+            for ( DirectionWrapper direction : DirectionWrapper.values() )
+            {
+                long firstId = direction.firstId( ids );
+                if ( firstId != Record.NO_NEXT_RELATIONSHIP.intValue() )
+                {
+                    result.add( firstId );
+                }
+            }
+        }
+        return result;
     }
 
     RelationshipLoadingPosition getRelChainPosition()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ReadOnlyNodeManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ReadOnlyNodeManager.java
@@ -24,7 +24,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.cache.Cache;
 import org.neo4j.kernel.impl.cache.CacheProvider;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.persistence.EntityIdGenerator;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.transaction.AbstractTransactionManager;
@@ -34,7 +33,7 @@ import org.neo4j.kernel.logging.Logging;
 
 public class ReadOnlyNodeManager extends NodeManager
 {
-    public ReadOnlyNodeManager( Logging logging, GraphDatabaseService graphDb, LockService locks,
+    public ReadOnlyNodeManager( Logging logging, GraphDatabaseService graphDb,
                                 AbstractTransactionManager transactionManager, PersistenceManager persistenceManager,
                                 EntityIdGenerator idGenerator, RelationshipTypeTokenHolder relationshipTypeTokenHolder,
                                 CacheProvider cacheType, PropertyKeyTokenHolder propertyKeyTokenHolder,
@@ -44,7 +43,7 @@ public class ReadOnlyNodeManager extends NodeManager
                                 Cache<NodeImpl> nodeCache, Cache<RelationshipImpl> relCache, XaDataSourceManager xaDsm,
                                 ThreadToStatementContextBridge statementCtxProvider )
     {
-        super( logging, graphDb, locks, transactionManager, persistenceManager, idGenerator,
+        super( logging, graphDb, transactionManager, persistenceManager, idGenerator,
                 relationshipTypeTokenHolder, cacheType, propertyKeyTokenHolder, labelTokenHolder, nodeLookup, relationshipLookups,
                 nodeCache, relCache, xaDsm, statementCtxProvider );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipLoadingPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipLoadingPosition.java
@@ -23,40 +23,95 @@ import org.neo4j.helpers.CloneableInPublic;
 import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 
+/**
+ * Keeps track of the current load position(s) for loading relationships for a particular node.
+ * A {@link NodeImpl cached node} caches relationships as it loads them. Loading occurs in batches
+ * and so a node may not have loaded all its relationship at any given point in time. Since loading happens
+ * in batches, a batch will continue to load from where the previous batch ended. This state is exactly
+ * what instances of this type keeps track of. All its methods accepts direction and type since dense nodes
+ * have individual relationship chains per direction and type.
+ */
 public interface RelationshipLoadingPosition extends CloneableInPublic
 {
-    void updateFirst( long first );
-    
+    /**
+     * Returns the relationship id that a chain for the given direction and type(s) is at.
+     *
+     * @param direction relationship direction. If {@link DirectionWrapper#BOTH} is supplied then
+     * all directions are tried and first non-ended chain will be returned, otherwise the supplied direction
+     * and loops are considered.
+     * @param types a list of types to try. The first encountered chain that is not at its end will be used.
+     * @return position, i.e. relationship id to start loading from for the first encountered non-ended direction
+     * and first encountered non-ended type.
+     */
     long position( DirectionWrapper direction, int[] types );
-    
+
+    /**
+     * Goes to and returns the next relationship id in a chain for the given direction and type(s).
+     *
+     * @param relationship id to have this relationship chain position point to. In a multi-chain
+     * scenario a value of {@link Record#NO_NEXT_RELATIONSHIP} will trigger moving over to the next
+     * relationship chain matching the given {@code direction} and {@code types}.
+     * @param direction relationship direction. If {@link DirectionWrapper#BOTH} is supplied then
+     * all directions are tried and first non-ended chain will be returned, otherwise the supplied direction
+     * and loops are considered.
+     * @param types a list of types to try. The first encountered chain that is not at its end will be used.
+     * @return next position in the chain, i.e. next relationship id to load for the first encountered
+     * non-ended direction and first encountered non-ended type. For a single chain the returned value
+     * will always be the specified {@code position}, but in a multi-chain scenario the end of one chain
+     * will instead return the position of another chain.
+     */
     long nextPosition( long position, DirectionWrapper direction, int[] types );
-    
+
+    /**
+     * Checks whether or not there are any more relationships in a chain for the given direction and type(s).
+     *
+     * @param direction relationship direction. If {@link DirectionWrapper#BOTH} is supplied then
+     * all directions are tried and first non-ended chain will be returned, otherwise the supplied direction
+     * and loops are considered.
+     * @param types a list of types to try. The first encountered chain that is not at its end will be used.
+     * @return {@code true} if a non-ended chain for the given direction and type(s) was found.
+     */
     boolean hasMore( DirectionWrapper direction, int[] types );
 
-    void compareAndAdvance( long relIdDeleted, long nextRelId );
-    
+    /**
+     * Checks whether or not the chain for the given direction and type is currently at the given position.
+     *
+     * @param direction relationship direction. A value of {@link DirectionWrapper#BOTH} means the loop chain.
+     * @param type relationship type.
+     * @return {@code true} if the chain for the given direction and type is currently at the given position,
+     * otherwise {@code false}.
+     */
+    boolean atPosition( DirectionWrapper direction, int type, long position );
+
+    /**
+     * Used when a relationship has been deleted, so that if there's any chain that is currently at position
+     * {@code relIdDeleted}, then its position is moved to {@code nextRelId} instead so that loading is able
+     * to continue the next time that will happen.
+     *
+     * @param direction direction of the deleted relationship.
+     * @param type type of the deleted relationship.
+     * @param relIdDeleted relationship id that has been deleted.
+     * @param nextRelId relationship id to move the position to instead.
+     */
+    void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId );
+
     @Override
-    public RelationshipLoadingPosition clone();
-    
+    RelationshipLoadingPosition clone();
+
     public static final RelationshipLoadingPosition EMPTY = new RelationshipLoadingPosition()
     {
-        @Override
-        public void updateFirst( long first )
-        {
-        }
-        
         @Override
         public long position( DirectionWrapper direction, int[] types )
         {
             return Record.NO_NEXT_RELATIONSHIP.intValue();
         }
-        
+
         @Override
         public long nextPosition( long position, DirectionWrapper direction, int[] types )
         {
             return Record.NO_NEXT_RELATIONSHIP.intValue();
         }
-        
+
         @Override
         public boolean hasMore( DirectionWrapper direction, int[] types )
         {
@@ -64,15 +119,20 @@ public interface RelationshipLoadingPosition extends CloneableInPublic
         }
 
         @Override
-        public void compareAndAdvance( long relIdDeleted, long nextRelId )
+        public boolean atPosition( DirectionWrapper direction, int type, long position )
+        {
+            return false;
+        }
+
+        @Override
+        public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
         {
         }
-        
+
         @Override
         public RelationshipLoadingPosition clone()
         {
             return this;
         }
     };
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
@@ -32,13 +32,6 @@ public class SingleChainPosition implements RelationshipLoadingPosition
     }
 
     @Override
-    public void updateFirst( long first )
-    {
-        // TODO assert that it's the first position in the chain
-        this.position = first;
-    }
-
-    @Override
     public long position( DirectionWrapper direction, int[] types )
     {
         return this.position;
@@ -58,7 +51,13 @@ public class SingleChainPosition implements RelationshipLoadingPosition
     }
 
     @Override
-    public void compareAndAdvance( long relIdDeleted, long nextRelId )
+    public boolean atPosition( DirectionWrapper direction, int type, long position )
+    {
+        return this.position == position;
+    }
+
+    @Override
+    public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
     {
         if ( position == relIdDeleted )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TransactionState.java
@@ -25,6 +25,7 @@ import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.core.WritableTransactionState.SetAndDirectionCounter;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreTransaction;
 import org.neo4j.kernel.impl.persistence.PersistenceManager;
 import org.neo4j.kernel.impl.persistence.PersistenceManager.ResourceHolder;
@@ -56,11 +57,13 @@ public interface TransactionState
 
     SetAndDirectionCounter getOrCreateCowRelationshipRemoveMap( NodeImpl node, int type );
 
-    void setFirstIds( long nodeId, long firstRel, long firstProp );
+    void setFirstIds( long nodeId, boolean dense, long firstRel, long firstProp );
 
+    void addRelationshipGroupChange( long nodeId, RelationshipGroupRecord group );
+    
     void commit();
 
-    void commitCows();
+    void commitCows( CacheAccessBackDoor cacheAccess );
 
     void rollback();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/RelationshipCreator.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.nioneo.xa;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.neo4j.kernel.impl.nioneo.store.InvalidRecordException;
 import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.Record;
@@ -36,19 +33,12 @@ public class RelationshipCreator
     private final RelationshipLocker locker;
     private final int denseNodeThreshold;
 
-    private Collection<NodeRecord> upgradedDenseNodes;
-
     public RelationshipCreator( RelationshipLocker locker, RelationshipGroupGetter relGroupGetter,
             int denseNodeThreshold )
     {
         this.locker = locker;
         this.relGroupGetter = relGroupGetter;
         this.denseNodeThreshold = denseNodeThreshold;
-    }
-
-    public Collection<NodeRecord> getUpgradedDenseNodes()
-    {
-        return upgradedDenseNodes;
     }
 
     /**
@@ -207,11 +197,6 @@ public class RelationshipCreator
                 relRecord = relRecords.getOrLoad( relId, null ).forChangingLinkage();
             }
         }
-        if ( upgradedDenseNodes == null )
-        {
-            upgradedDenseNodes = new ArrayList<>();
-        }
-        upgradedDenseNodes.add( node );
     }
 
     private void connect( long nodeId, long firstRelId, RelationshipRecord rel,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/xa/command/Command.java
@@ -211,22 +211,21 @@ public abstract class Command extends XaCommand
         public void applyToCache( CacheAccessBackDoor cacheAccess )
         {
             cacheAccess.removeRelationshipFromCache( getKey() );
-            /*
-             * If isRecovered() then beforeUpdate is the correct one UNLESS this is the second time this command
-             * is executed, where it might have been actually written out to disk so the fields are already -1. So
-             * we still need to check.
-             * If !isRecovered() then beforeUpdate is the same as record, so we are still ok.
-             * We don't check for !inUse() though because that is implicit in the call of this method.
-             * The above is a hand waiving proof that the conditions that lead to the patchDeletedRelationshipNodes()
-             * in the if below are the same as in RelationshipCommand.execute() so it should be safe.
-             */
-            if ( beforeUpdate.getFirstNode() != -1 || beforeUpdate.getSecondNode() != -1 )
-            {
-                cacheAccess.patchDeletedRelationshipNodes( getKey(), beforeUpdate.getFirstNode(),
-                        beforeUpdate.getFirstNextRel(), beforeUpdate.getSecondNode(), beforeUpdate.getSecondNextRel() );
-            }
             if ( !record.inUse() )
             { // the relationship was deleted - invalidate the cached versions of the related nodes
+                /*
+                 * If isRecovered() then beforeUpdate is the correct one UNLESS this is the second time this command
+                 * is executed, where it might have been actually written out to disk so the fields are already -1. So
+                 * we still need to check.
+                 * If !isRecovered() then beforeUpdate is the same as record, so we are still ok.
+                 * The above is a hand waiving proof that the conditions that lead to the patchDeletedRelationshipNodes()
+                 * in the if below are the same as in RelationshipCommand.execute() so it should be safe.
+                 */
+                if ( beforeUpdate.getFirstNode() != -1 || beforeUpdate.getSecondNode() != -1 )
+                {
+                    cacheAccess.patchDeletedRelationshipNodes( getKey(), beforeUpdate.getType(), beforeUpdate.getFirstNode(),
+                            beforeUpdate.getFirstNextRel(), beforeUpdate.getSecondNode(), beforeUpdate.getSecondNextRel() );
+                }
                 if ( before != null )
                 { // reading from the log
                     cacheAccess.removeNodeFromCache( before.getFirstNode() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/RelationshipFilter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
+
+/**
+ * Able to filter relationship additions based on type, direction and which id is the first id of already
+ * existing ids.
+ */
+public interface RelationshipFilter
+{
+    /**
+     * @param type relationship type token id.
+     * @param direction direction of the relationship.
+     * @param firstCachedId first existing cached id, for comparison.
+     * @return whether or not adding relationships, given the information above, is accepted.
+     */
+    boolean accept( int type, DirectionWrapper direction, long firstCachedId );
+
+    public static final RelationshipFilter ACCEPT_ALL = new RelationshipFilter()
+    {
+        @Override
+        public boolean accept( int type, DirectionWrapper direction, long firstCachedId )
+        {
+            return true;
+        }
+    };
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/CacheRaceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/CacheRaceTest.java
@@ -20,44 +20,70 @@
 package org.neo4j.kernel.impl.cache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.locks.LockSupport;
 
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.core.NodeImpl;
 import org.neo4j.kernel.impl.core.RelationshipImpl;
+import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
+import org.neo4j.kernel.impl.nioneo.store.Record;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.nioneo.store.RelationshipRecord;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
 import org.neo4j.test.Barrier;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.NamedFunction;
+import org.neo4j.test.RepeatRule;
+import org.neo4j.test.RepeatRule.Repeat;
 import org.neo4j.test.ThreadingRule;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.Iterables.toList;
 
 public class CacheRaceTest
 {
     private final NodeCache nodeCache = new NodeCache();
+    private final long seed = currentTimeMillis();
+    private final Random random = new Random( seed );
+    public final @Rule RepeatRule repeater = new RepeatRule();
     public final @Rule DatabaseRule db = new ImpermanentDatabaseRule()
     {
         @Override
@@ -142,6 +168,299 @@ public class CacheRaceTest
         assertEquals( join( "\n\t", after ), before.size(), after.size() );
     }
 
+    @Repeat( times = 100 )
+    @Test
+    public void shouldNotCacheDuplicateRelationshipsStressTest() throws Exception
+    {
+        final GraphDatabaseAPI graphDb = db.getGraphDatabaseAPI();
+        final CountDownLatch prepareLatch = new CountDownLatch( 2 );
+        final CountDownLatch startSignal = new CountDownLatch( 1 );
+        final Node node = createNode( graphDb );
+        Relationship[] initialRels = createRelationships( graphDb, node, 1000, null );
+        db.clearCache();
+
+        ControlledThread reader = new ControlledThread( "Reader", prepareLatch, startSignal, seed+1 )
+        {
+            @Override
+            protected void perform()
+            {
+                try ( Transaction tx = graphDb.beginTx() )
+                {
+                    IteratorUtil.count( node.getRelationships() );
+                    tx.success();
+                }
+                catch ( NotFoundException e )
+                {
+                    // Expected, although perhaps not every single time?
+                }
+            }
+        };
+        ControlledThread evictor = new ControlledThread( "Evictor", prepareLatch, startSignal, seed+2 )
+        {
+            @Override
+            protected void perform()
+            {
+                db.clearCache();
+            }
+        };
+        prepareLatch.await();
+
+        Pair<Relationship[],Relationship[]> modification = modifyRelationships( graphDb, node, 100, startSignal );
+        Relationship[] additionalRels = modification.first();
+        Relationship[] removedRels = modification.other();
+
+        // Allow the other threads to speak freely about any error that may have occurred as well
+        reader.awaitCompletion();
+        evictor.awaitCompletion();
+
+        // Verify that no duplicates exist and that the number of relationships add up
+        Relationship[] rels = null;
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            try
+            {
+                rels = duplicateSafeCountRelationships( node );
+                if ( rels.length != initialRels.length + additionalRels.length - removedRels.length )
+                {
+                    throw new IllegalStateException( "Relationship count mismatch" );
+                }
+                tx.success();
+            }
+            catch ( IllegalStateException e )
+            {
+                fail( e.getMessage() + ":\n" +
+                        "  initial:    " + Arrays.toString( initialRels ) + "\n" +
+                        "  additional: " + Arrays.toString( additionalRels ) + "\n" +
+                        "  removed:    " + Arrays.toString( removedRels ) + "\n" +
+        (rels != null ? "  rels:       " + Arrays.toString( rels ) + "\n" : "") +
+        (rels != null ? "  missing:    " + Arrays.toString( missingRels( initialRels, additionalRels, removedRels, rels ) ) + "\n" : "") +
+                        "  on-disk:\n"   + onDiskChain( graphDb, node.getId() ) + "\n" +
+                        "  seed:       " + seed );
+            }
+        }
+    }
+
+    private Relationship[] missingRels( Relationship[] initialRels, Relationship[] additionalRels, Relationship[] removedRels,
+            Relationship[] rels )
+    {
+        Set<Relationship> set = new HashSet<>();
+        set.addAll( Arrays.asList( initialRels ) );
+        set.addAll( Arrays.asList( additionalRels ) );
+        set.removeAll( Arrays.asList( removedRels ) );
+        set.removeAll( Arrays.asList( rels ) );
+        return set.toArray( new Relationship[set.size()] );
+    }
+
+    private String onDiskChain( GraphDatabaseAPI graphDb, long nodeId )
+    {
+        StringBuilder builder = new StringBuilder();
+        NeoStore neoStore = graphDb.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate();
+        NodeRecord node = neoStore.getNodeStore().getRecord( nodeId );
+        if ( node.isDense() )
+        {
+            RelationshipGroupRecord group = neoStore.getRelationshipGroupStore().getRecord( node.getNextRel() );
+            do
+            {
+                builder.append( "group " + group );
+                builder.append( "out:\n" );
+                printRelChain( builder, neoStore, nodeId, group.getFirstOut() );
+                builder.append( "in:\n" );
+                printRelChain( builder, neoStore, nodeId, group.getFirstIn() );
+                builder.append( "loop:\n" );
+                printRelChain( builder, neoStore, nodeId, group.getFirstLoop() );
+                group = group.getNext() != -1 ? neoStore.getRelationshipGroupStore().getRecord( group.getNext() ) : null;
+            } while ( group != null );
+        }
+        else
+        {
+            printRelChain( builder, neoStore, nodeId, node.getNextRel() );
+        }
+        return builder.toString();
+    }
+
+    private void printRelChain( StringBuilder builder, NeoStore access, long nodeId, long firstRelId )
+    {
+        for ( long rel = firstRelId; rel != Record.NO_NEXT_RELATIONSHIP.intValue(); )
+        {
+            RelationshipRecord record = access.getRelationshipStore().getRecord( rel );
+            builder.append( rel + "\t" + record + "\n" );
+            if ( record.getFirstNode() == nodeId )
+            {
+                rel = record.getFirstNextRel();
+            }
+            else
+            {
+                rel = record.getSecondNextRel();
+            }
+        }
+    }
+
+    private Relationship[] duplicateSafeCountRelationships( final Node node )
+    {
+        Set<Relationship> relationships = new HashSet<>();
+        List<Relationship> result = new ArrayList<>();
+        for ( Relationship relationship : node.getRelationships() )
+        {
+            if ( !relationships.add( relationship ) )
+            {
+                throw new IllegalStateException( "Spotted duplication relationship " + relationship );
+            }
+            result.add( relationship );
+        }
+
+        return result.toArray( new Relationship[result.size()] );
+    }
+
+    private Node createNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            tx.success();
+            return node;
+        }
+    }
+
+    private Relationship[] createRelationships( GraphDatabaseAPI graphDb, Node node, int relsBound,
+            CountDownLatch startLatch )
+    {
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            Node other = graphDb.createNode();
+
+            int nbrRels = random.nextInt( relsBound );
+            Relationship[] result = new Relationship[nbrRels];
+            for ( int i = 0; i < nbrRels; i++ )
+            {
+                result[i] = createRandomRelationship( node, other );
+            }
+
+            tx.success();
+
+            if ( startLatch != null )
+            {
+                startLatch.countDown();
+            }
+
+            return result;
+        }
+    }
+
+    private Relationship createRandomRelationship( Node node, Node other )
+    {
+        int dir = random.nextInt( 3 );
+        RelationshipType type = withName( "TYPE_" + random.nextInt( 4 ) );
+        Relationship rel;
+        if ( dir == 0 )
+        {   // OUTGOING
+            rel = node.createRelationshipTo( other, type );
+        }
+        else if ( dir == 1 )
+        {   // INCOMING
+            rel = other.createRelationshipTo( node, type );
+        }
+        else
+        {   // LOOP
+            rel = node.createRelationshipTo( node, type );
+        }
+        return rel;
+    }
+
+    private Pair<Relationship[],Relationship[]> modifyRelationships( GraphDatabaseAPI graphDb, Node node,
+            int maxNumberOfChanges, CountDownLatch startLatch )
+    {
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            List<Relationship> createdRelationships = new ArrayList<>();
+            List<Relationship> deletedRelationships = new ArrayList<>();
+            Node other = graphDb.createNode();
+            int changes = random.nextInt( maxNumberOfChanges );
+            for ( int i = 0; i < changes; i++ )
+            {
+                if ( random.nextFloat() < 0.8f ) // 1/5 or so
+                {
+                    createdRelationships.add( createRandomRelationship( node, other ) );
+                }
+                else
+                {
+                    Relationship deletedRelationship = deleteRandomRelationship( node );
+                    if ( deletedRelationship != null )
+                    {
+                        deletedRelationships.add( deletedRelationship );
+                    }
+                }
+            }
+
+            tx.success();
+
+            if ( startLatch != null )
+            {
+                startLatch.countDown();
+            }
+
+            return Pair.of(
+                    createdRelationships.toArray( new Relationship[createdRelationships.size()] ),
+                    deletedRelationships.toArray( new Relationship[deletedRelationships.size()] ) );
+        }
+    }
+
+    private Relationship deleteRandomRelationship( Node node )
+    {
+        List<Relationship> rels = toList( node.getRelationships() );
+        if ( !rels.isEmpty() )
+        {
+            Relationship relationship = rels.get( random.nextInt( rels.size() ) );
+            relationship.delete();
+            return relationship;
+        }
+        return null;
+    }
+
+    private static abstract class ControlledThread extends Thread
+    {
+        private final Random random;
+        private final CountDownLatch prepareLatch;
+        private final CountDownLatch startSignal;
+        private volatile Exception error;
+
+        ControlledThread( String name, CountDownLatch prepareLatch, CountDownLatch startSignal, long seed )
+        {
+            super( name );
+            this.random = new Random( seed );
+            this.prepareLatch = prepareLatch;
+            this.startSignal = startSignal;
+            start();
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                prepareLatch.countDown();
+                startSignal.await();
+                LockSupport.parkNanos( random.nextInt( 20_000_000 ) );
+                perform();
+            }
+            catch ( Exception e )
+            {
+                error = e;
+                throw Exceptions.launderedException( e );
+            }
+        }
+
+        protected abstract void perform();
+
+        protected void awaitCompletion() throws Exception
+        {
+            join();
+            if ( error != null )
+            {
+                throw error;
+            }
+        }
+    }
+
     private Function<GraphDatabaseService, Node> createNode( final Barrier done )
     {
         return new NamedFunction<GraphDatabaseService, Node>( "create-node" )
@@ -184,7 +503,7 @@ public class CacheRaceTest
     {
         try ( Transaction tx = graphDb.beginTx() )
         {
-            List<String> relationships = new ArrayList<String>();
+            List<String> relationships = new ArrayList<>();
             for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
             {
                 for ( Relationship relationship : node.getRelationships() )
@@ -220,7 +539,7 @@ public class CacheRaceTest
 
     private static class NodeCache extends StrongReferenceCache<NodeImpl>
     {
-        private final Map<String/*thread name*/, Barrier> barriers = new ConcurrentHashMap<String, Barrier>();
+        private final Map<String/*thread name*/, Barrier> barriers = new ConcurrentHashMap<>();
 
         public NodeCache()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/TestNeoStore.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -467,12 +468,6 @@ public class TestNeoStore
         }
 
         @Override
-        public void updateFirst( long first )
-        {
-            actual.updateFirst( first );
-        }
-
-        @Override
         public long position( DirectionWrapper direction, int[] types )
         {
             return actual.position( direction, types );
@@ -491,15 +486,21 @@ public class TestNeoStore
         }
 
         @Override
-        public void compareAndAdvance( long relIdDeleted, long nextRelId )
+        public boolean atPosition( DirectionWrapper direction, int type, long position )
         {
-            actual.compareAndAdvance( relIdDeleted, nextRelId );
+            return actual.atPosition( direction, type, position );
+        }
+
+        @Override
+        public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
+        {
+            actual.compareAndAdvance( direction, type, relIdDeleted, nextRelId );
         }
 
         @Override
         public RelationshipLoadingPosition clone()
         {
-            return actual.clone();
+            return new MutableRelationshipLoadingPosition( actual.clone() );
         }
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntCollections.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.collection.primitive;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -634,22 +635,13 @@ public class PrimitiveIntCollections
         return array;
     }
 
-    public static int[] asArray( Iterator<Integer> iterator )
+    public static int[] asArray( Collection<Integer> values )
     {
-        int[] array = new int[8];
+        int[] array = new int[values.size()];
         int i = 0;
-        for ( ; iterator.hasNext(); i++ )
+        for ( int value : values )
         {
-            if ( i >= array.length )
-            {
-                array = copyOf( array, i << 1 );
-            }
-            array[i] = iterator.next();
-        }
-
-        if ( i < array.length )
-        {
-            array = copyOf( array, i );
+            array[i++] = value;
         }
         return array;
     }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PowerOfTwoQuantizedTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PowerOfTwoQuantizedTable.java
@@ -20,6 +20,7 @@
 package org.neo4j.collection.primitive.hopscotch;
 
 import static java.lang.Integer.highestOneBit;
+import static java.lang.Math.max;
 import static java.lang.String.format;
 
 /**
@@ -41,7 +42,7 @@ public abstract class PowerOfTwoQuantizedTable<VALUE> implements Table<VALUE>
         }
 
         this.h = h;
-        this.capacity = quantize( capacity );
+        this.capacity = quantize( max( capacity, 2 ) );
         this.tableMask = highestOneBit( this.capacity )-1;
     }
 

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.collection.primitive;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -30,6 +31,7 @@ import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import static java.util.Arrays.asList;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -314,6 +316,19 @@ public class PrimitiveIntCollectionsTest
         {   // Good
             assertThat( e.getMessage(), containsString( "More than one" ) );
         }
+    }
+
+    @Test
+    public void shouldConvertCollectionToPrimitiveArray() throws Exception
+    {
+        // GIVEN
+        Collection<Integer> values = asList( 1, 2, 3, 4, 5 );
+
+        // WHEN
+        int[] primitiveValues = PrimitiveIntCollections.asArray( values );
+
+        // THEN
+        assertArrayEquals( new int[] {1, 2, 3, 4, 5}, primitiveValues );
     }
 
     private static final class CountingPrimitiveIntIteratorResource implements PrimitiveIntIterator, AutoCloseable

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongSetTest.java
@@ -24,10 +24,10 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.collection.primitive.hopscotch.HopScotchHashingAlgorithm.Monitor;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -345,6 +345,16 @@ public class PrimitiveLongSetTest
         assertFalse( "1103190229303827372 should not exist before adding here", existedBefore );
         assertTrue( "1103190229303827372 should be reported as added here", added );
         assertTrue( "1103190229303827372 should exist", existsAfter );
+    }
+
+    @Test
+    public void shouldHandleEmptySet() throws Exception
+    {
+        // GIVEN
+        PrimitiveLongSet set = Primitive.longSet( 0 );
+
+        // THEN
+        assertFalse( set.contains( 564 ) );
     }
 
     private Monitor onlyAllowGrowing( final int growthsToAllow )

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -280,7 +280,7 @@ public class DefaultUdcInformationCollectorTest
             if ( type == NodeManager.class )
             {
                 //noinspection unchecked
-                return (T) new NodeManager( mock(Logging.class), null, null, null, null, new StubIdGenerator(), null, null, null, null,
+                return (T) new NodeManager( mock(Logging.class), null, null, null, new StubIdGenerator(), null, null, null, null,
                         null, null, null,
                         null, null, null );
             }


### PR DESCRIPTION
Removes node lock previously used during loading of relationships. This
lock would contend with committing transaction and produce latency issues.
The lock prevented cache poisoning issues introduced by race conditions
between committer and reader(s).

To achieve a lock-free solution some guards had to be added for various
corner cases. These are:
- Committers are now aware of ot he fact that, and parries for,
  concurrent readers loading and caching relationships committed by the
  committer, before the committer has put them into cache itself,
  producing duplicates when the committer would add them.
  (Issue comes from the fact that store is updated before cache).
- Committers uses knowledge about how relationships are stored on disk to
  be able to tell if any reader has loaded the relationships it has just
  written to the store, before updating the cache. This logic sits in a
  filter which is consulted before adding relationships to the cache.
- Nodes evicted from cache as part of being upgraded from sparse to dense
  now happens as part of updating the node instead of as a separate step
  during commit. This to also guard for concurrent readers.
- Simplification and reduction of code and logic of DenseNodeChainPosition
  where all individual chain positions are initialized eagerly, so that
  the filtering logic (as mentioned above) becomes simpler.
- Ordering of relationship-related records when applying transaction
  to store changed to: relationships, relationship groups, nodes so that
  additions to relationship chains are seen atomically by
  concurrent readers.
