### PR TITLE
Hide the `mapped_memory_page_size` configuration.

### DIFF
--- a/community/embedded-examples/src/test/resources/neo4j.properties
+++ b/community/embedded-examples/src/test/resources/neo4j.properties
@@ -12,11 +12,6 @@
 # that less than 2GB of memory is free when it starts.
 #mapped_memory_total_size=50%
 
-# Size of the pages, in bytes, that we'll use for mapping the store files into
-# memory. Don't change this without carefully measuring the performance
-# implications.
-#mapped_memory_page_size=8192
-
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 

--- a/community/kernel/src/docs/ops/cache.asciidoc
+++ b/community/kernel/src/docs/ops/cache.asciidoc
@@ -54,9 +54,6 @@ IMPORTANT: Note that the block sizes can only be configured at store creation ti
   (or greater byte-like units, such as `100M` for 100 mega-bytes, or `4G` for 4 giga-bytes)
   or a percentage of the available amount of memory. |
   The amount of memory to use for mapping the store files, either in bytes or as a percentage of available memory. This will be clipped at the amount of free memory observed when the database starts, and automatically be rounded down to the nearest whole page. For example, if `500MB` is configured, but only 450MB of memory is free when the database starts, then the database will map at most 450MB. If `50%` is configured, and the system has a capacity of 4GB, then at most 2GB of memory will be mapped, unless the database observes that less than 2GB of memory is free when it starts.
-| mapped_memory_page_size | The number of bytes per page. Preferably a power-of-two that is close to the native sector size or page size of the durable medium. |
-  The size of the pages, in bytes, that the database will use for mapping the store files into memory.
-  Don't change this without carefully measuring the performance implications.
 | string_block_size .2+^.^| The number of bytes per block. |
   Specifies the block size for storing strings.
   This parameter is only honored when the store is created, otherwise it is ignored.

--- a/community/kernel/src/docs/ops/io-examples.asciidoc
+++ b/community/kernel/src/docs/ops/io-examples.asciidoc
@@ -18,7 +18,7 @@ If memory belonging to the Neo4j process gets swapped out, it can lead to consid
 
 The amount of memory available to the page cache can be configured in two ways; both using the `mapped_memory_total_size` setting.
 You can either directly specify the number of bytes available to the page cache, e.g. `150M` og `4G`, or you can specify a percentage of the available memory, which is what the default setting of `50%` means.
-In either case, the amount of memory reserved for the page cache is capped at the amount of free memory as measured when the database starts, and then rounded down to a multiple of the `mapped_memory_page_size`.
+In either case, the amount of memory reserved for the page cache is capped at the amount of free memory as measured when the database starts.
 
 For optimal performance, you will want to have as much of your data fit in the page cache as possible.
 You can sum up the size of all the `neostore.*` files in your store file directory, to figure out how big a page cache you need to fit all your data.

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
@@ -12,11 +12,6 @@
 # that less than 2GB of memory is free when it starts.
 #mapped_memory_total_size=50%
 
-# Size of the pages, in bytes, that we'll use for mapping the store files into
-# memory. Don't change this without carefully measuring the performance
-# implications.
-#mapped_memory_page_size=8192
-
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -12,11 +12,6 @@
 # that less than 2GB of memory is free when it starts.
 #mapped_memory_total_size=50%
 
-# Size of the pages, in bytes, that we'll use for mapping the store files into
-# memory. Don't change this without carefully measuring the performance
-# implications.
-#mapped_memory_page_size=8192
-
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -12,11 +12,6 @@
 # that less than 2GB of memory is free when it starts.
 #mapped_memory_total_size=50%
 
-# Size of the pages, in bytes, that we'll use for mapping the store files into
-# memory. Don't change this without carefully measuring the performance
-# implications.
-#mapped_memory_page_size=8192
-
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -12,11 +12,6 @@
 # that less than 2GB of memory is free when it starts.
 #mapped_memory_total_size=50%
 
-# Size of the pages, in bytes, that we'll use for mapping the store files into
-# memory. Don't change this without carefully measuring the performance
-# implications.
-#mapped_memory_page_size=8192
-
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 


### PR DESCRIPTION
I don't think there's any need to put this in front of users.
It's a high-level expert setting and really should only be experimented with by us.
