### PR TITLE
Improves some messages concerning the state of store files

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
@@ -85,7 +85,7 @@ public class CountsStore extends SortedKeyValueStore<CountsKey, CopyableDoubleLo
                 {
                     if ( register.hasValues( 0, 0 ) )
                     {
-                        throw new UnderlyingStorageException( "Counts store contains corrupted values" );
+                        throw new UnderlyingStorageException( "Counts store contains unexpected value (0,0)" );
                     }
                     keys.increment( 1 );
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -74,7 +74,9 @@ public class CountsTracker implements CountsVisitor.Visitable, AutoCloseable, Co
         {
             IOException exOnClose = safelyCloseTheStore( store );
             throw new UnderlyingStorageException(
-                "Corrupted counts store. Please shut down the database and manually delete the counts store files " +
+                "Counts store seems to be out of date ( last count store txid is " + store.lastTxId() +
+                        " but database wide last txid is " + neoStoreTxId +
+                        " ). Please shut down the database and manually delete the counts store files " +
                 "to have the database recreate them on next startup", exOnClose );
         }
         this.state = new ConcurrentCountsTrackerState( store );
@@ -93,13 +95,13 @@ public class CountsTracker implements CountsVisitor.Visitable, AutoCloseable, Co
             if ( isAlphaCorrupted && isBetaCorrupted )
             {
                 throw new UnderlyingStorageException(
-                        "Both counts store files are corrupted. Please shut down the database and delete them " +
+                        "Neither of the two store files could be properly opened. Please shut down the database and delete them " +
                         "to have the database recreate the counts store on next startup" );
             }
 
             if ( isAlphaCorrupted )
             {
-                logger.debug( "CountsStore picked beta since alpha store file is corrupted " +
+                logger.debug( "CountsStore picked beta store file since alpha store file could not be opened " +
                               "(txId=" + betaStore.lastTxId() +
                               ", minorVersion=" + betaStore.minorVersion() + ")" );
                 return betaStore;
@@ -107,7 +109,7 @@ public class CountsTracker implements CountsVisitor.Visitable, AutoCloseable, Co
 
             if ( isBetaCorrupted )
             {
-                logger.debug( "CountsStore picked alpha store file since beta is corrupted " +
+                logger.debug( "CountsStore picked alpha store file since beta store file could not be opened " +
                               "(txId=" + alphaStore.lastTxId() +
                               ", minorVersion=" + alphaStore.minorVersion() + ")" );
                 return alphaStore;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsStoreTest.java
@@ -281,7 +281,7 @@ public class CountsStoreTest
         catch ( UnderlyingStorageException  ex )
         {
             // then
-            assertEquals( "Counts store contains corrupted values", ex.getMessage() );
+            assertEquals( "Counts store contains unexpected value (0,0)", ex.getMessage() );
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
@@ -104,7 +104,7 @@ public class LuceneLabelScanStore
             @Override
             public void corruptIndex( IOException corruptionException )
             {
-                logger.warn( "Corrupt lucene scan store index found. Preparing to rebuild.",
+                logger.warn( "Lucene scan store index could not be read. Preparing to rebuild.",
                         corruptionException );
             }
 
@@ -266,7 +266,7 @@ public class LuceneLabelScanStore
         {
             // The index was somehow corrupted, fail
             monitor.corruptIndex( e );
-            throw new IOException( "Label scan store is corrupted, and needs to be rebuilt. " +
+            throw new IOException( "Label scan store could not be read, and needs to be rebuilt. " +
                     "To trigger a rebuild, ensure the database is stopped, delete the files in '" +
                     directoryLocation.getAbsolutePath() + "', and then start the database again." );
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NodeRangeDocumentLabelScanStorageStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NodeRangeDocumentLabelScanStorageStrategy.java
@@ -107,7 +107,8 @@ public class NodeRangeDocumentLabelScanStorageStrategy implements LabelScanStora
             }
             else if ( topDocs.scoreDocs.length > 1 )
             {
-                throw new RuntimeException( "This label scan store is corrupted" );
+                throw new RuntimeException( "This label scan store seems to contain an incorrect number of entries ("
+                        + topDocs.scoreDocs.length + ")" );
             }
 
             int doc = topDocs.scoreDocs[0].doc;

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
@@ -91,7 +91,7 @@ public class LuceneLabelScanStoreChaosIT
             // THEN
             @SuppressWarnings( "unchecked" )
             Throwable ioe = peel( e, exceptionsOfType( RuntimeException.class ) );
-            assertThat( ioe.getMessage(), containsString( "Label scan store is corrupted" ) );
+            assertThat( ioe.getMessage(), containsString( "Label scan store could not be read" ) );
         }
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
@@ -306,7 +306,7 @@ public class LuceneLabelScanStoreTest
         {
             assertThat(e.getCause(), instanceOf( IOException.class ));
             assertThat(e.getCause().getMessage(), equalTo(
-                    "Label scan store is corrupted, and needs to be rebuilt. To trigger a rebuild, ensure the " +
+                    "Label scan store could not be read, and needs to be rebuilt. To trigger a rebuild, ensure the " +
                             "database is stopped, delete the files in '"+dir.getAbsolutePath()+"', and then start the " +
                             "database again." ));
         }


### PR DESCRIPTION
Some exception messages and debug logging statements were too generic
 and lacked information about the specific condition that could lead
 to the problem observed. This commit adds some information that can
 provide some insights that can be useful for debugging.
