### PR TITLE
Rely on recovery for index statistics not flushed to counts store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -136,7 +136,6 @@ public class IndexPopulationJob implements Runnable
                         storeView.replaceIndexCounts( descriptor, result.readFirst(), result.readSecond(),
                                 indexSize );
 
-                        storeView.flushIndexCounts();
                         populator.close( true );
                         updateableSchemaState.clear();
                         return null;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import java.io.IOException;
-
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -58,6 +56,4 @@ public interface IndexStoreView extends PropertyAccessor
     void replaceIndexCounts( IndexDescriptor descriptor, long uniqueElements, long maxUniqueElements, long indexSize );
 
     void incrementIndexUpdates( IndexDescriptor descriptor, long updatesDelta );
-
-    void flushIndexCounts() throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
@@ -55,9 +55,9 @@ public class IndexSamplingControllerFactory
         OnlineIndexSamplingJobFactory jobFactory =
                 new OnlineIndexSamplingJobFactory( storeView, tokenNameLookup, logging );
         Predicate<IndexDescriptor> samplingUpdatePredicate = createSamplingPredicate();
-        IndexSamplingJobQueue jobQueue = new IndexSamplingJobQueue( samplingUpdatePredicate );
+        IndexSamplingJobQueue<IndexDescriptor> jobQueue = new IndexSamplingJobQueue<>( samplingUpdatePredicate );
         IndexSamplingJobTracker jobTracker = new IndexSamplingJobTracker( config, scheduler );
-        Predicate<IndexDescriptor> indexRecoveryCondition = createIndexDescriptorPredicate( logging, tokenNameLookup );
+        Predicate<IndexDescriptor> indexRecoveryCondition = createIndexRecoveryCondition( logging, tokenNameLookup );
         return new IndexSamplingController(
                 config, jobFactory, jobQueue, jobTracker, snapshotProvider, scheduler, indexRecoveryCondition
         );
@@ -81,8 +81,8 @@ public class IndexSamplingControllerFactory
         };
     }
 
-    private Predicate<IndexDescriptor> createIndexDescriptorPredicate( final Logging logging,
-                                                                       final TokenNameLookup tokenNameLookup )
+    private Predicate<IndexDescriptor> createIndexRecoveryCondition( final Logging logging,
+                                                                     final TokenNameLookup tokenNameLookup )
     {
         return new Predicate<IndexDescriptor>()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
@@ -107,12 +107,6 @@ public class NeoStoreIndexStoreView implements IndexStoreView
     }
 
     @Override
-    public void flushIndexCounts() throws IOException
-    {
-        counts.rotate( txIdStore.getLastCommittedTransactionId() );
-    }
-
-    @Override
     public <FAILURE extends Exception> StoreScan<FAILURE> visitNodesWithPropertyAndLabel(
             IndexDescriptor descriptor, final Visitor<NodePropertyUpdate, FAILURE> visitor )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
@@ -19,19 +19,19 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -48,23 +48,21 @@ import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 @RunWith( Parameterized.class )
 public class TestRelationshipCount
 {
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "denseNodeThreshold={0}")
     public static Collection<Object[]> data()
     {
         Collection<Object[]> data = new ArrayList<>();
         int max = parseInt( GraphDatabaseSettings.dense_node_threshold.getDefaultValue() );
         for ( int i = 1; i < max; i++ )
         {
-            data.add( new Object[] { Integer.valueOf( i ) } );
+            data.add( new Object[] {i} );
         }
         return data;
     }


### PR DESCRIPTION
There was a race condition between committing transactions and flushing the counts store as part of taking an index online. This problem is related to the fact that an index comes online non-transactionally, so when that process tries to flush the counts store it would read the lastCommittedTransactionID from the store, but that transaction might not have been fully applied yet. We write the lastCommittedTransactionID after we have successfully written the transaction to the log, but before the transaction has been applied to the store files. With the counts rotated before the transaction commits, the committing transaction would encounter a counts store that already thinks the transaction in question has been committed, and thus reject it.

Since flushing the counts store when taking an index online is only an optimisation to avoid having to re-sample the index on recovery, it is safe to simply remove the flushing on the counts store and pay the cost of slightly longer recovery time instead.

The alternative we could come up with would be to distinguish between committed and applied transactions, and that seems like a much more complicated change, that wouldn't give much benefit. It is also possible that such a solution would have other unforeseen complications that we would have encountered, had we started down that route.

If we find later that we actually want to enforce flushing the counts store after an index comes online, the appropriate way to do that would seem to be to force a log rotation. That would work since it has the appropriate synchronizations in place.
