### PR TITLE
Update fingerprint if plan is still valid

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprint.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.executionplan
+
+import org.neo4j.cypher.internal.compiler.v2_2.spi.{GraphStatistics, GraphStatisticsSnapshot}
+import org.neo4j.helpers.Clock
+
+case class PlanFingerprint(creationTimeMillis: Long, txId: Long, snapshot: GraphStatisticsSnapshot)
+
+case class PlanFingerprintReference(clock: Clock, ttl: Long, statsDivergenceThreshold : Double,
+                                    var fingerprint: Option[PlanFingerprint])
+{
+  def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = {
+    fingerprint.fold(false) { f =>
+      lazy val currentTimeMillis = clock.currentTimeMillis()
+      lazy val currentTxId = lastTxId()
+
+      check(f.creationTimeMillis + ttl <= currentTimeMillis, {}) &&
+      check(currentTxId != f.txId, { fingerprint = Some(f.copy(creationTimeMillis = currentTimeMillis)) }) &&
+      check(f.snapshot.diverges(f.snapshot.recompute(statistics), statsDivergenceThreshold),
+            { fingerprint = Some(f.copy(creationTimeMillis = currentTimeMillis, txId = currentTxId)) })
+    }
+  }
+
+  private def check(test: => Boolean, ifFalse: => Unit ) = if (test) { true } else { ifFalse ; false }
+}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -19,8 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.execution
 
-import java.util.Date
-
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.OtherConverters._
@@ -216,18 +214,6 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
       result.withEstimatedCardinality(cardinality.amount.toLong)
     }
 
-    def buildExpression(expr: ast.Expression): CommandExpression = {
-      val rewrittenExpr = expr.endoRewrite(buildPipeExpressions)
-
-      rewrittenExpr.asCommandExpression.rewrite(resolver.resolveExpressions(_, planContext))
-    }
-
-    def buildPredicate(expr: ast.Expression): CommandPredicate = {
-      val rewrittenExpr: Expression = expr.endoRewrite(buildPipeExpressions)
-
-      rewrittenExpr.asCommandPredicate.rewrite(resolver.resolveExpressions(_, planContext)).asInstanceOf[CommandPredicate]
-    }
-
     object buildPipeExpressions extends Rewriter {
       val instance = Rewriter.lift {
         case ast.NestedPlanExpression(patternPlan, pattern) =>
@@ -239,6 +225,18 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
       }
 
       def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+    }
+
+    def buildExpression(expr: ast.Expression): CommandExpression = {
+      val rewrittenExpr = expr.endoRewrite(buildPipeExpressions)
+
+      rewrittenExpr.asCommandExpression.rewrite(resolver.resolveExpressions(_, planContext))
+    }
+
+    def buildPredicate(expr: ast.Expression): CommandPredicate = {
+      val rewrittenExpr: Expression = expr.endoRewrite(buildPipeExpressions)
+
+      rewrittenExpr.asCommandPredicate.rewrite(resolver.resolveExpressions(_, planContext)).asInstanceOf[CommandPredicate]
     }
 
     val topLevelPipe = buildPipe(plan, QueryGraphCardinalityInput.empty)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
@@ -30,8 +30,7 @@ case class CardinalityByLabelsAndRelationshipType(lhs: Option[LabelId], relType:
 case class IndexSelectivity(labelId: LabelId, propertyKeyId: PropertyKeyId) extends StatisticsKey
 
 case class MutableGraphStatisticsSnapshot(map: mutable.Map[StatisticsKey, Double] = mutable.Map.empty) {
-  def freeze: GraphStatisticsSnapshot =
-    GraphStatisticsSnapshot(map.toMap)
+  def freeze: GraphStatisticsSnapshot = GraphStatisticsSnapshot(map.toMap)
 }
 
 case class GraphStatisticsSnapshot(map: Map[StatisticsKey, Double] = Map.empty) {
@@ -60,9 +59,9 @@ case class GraphStatisticsSnapshot(map: Map[StatisticsKey, Double] = Map.empty) 
       .map(_.map(_._2).product)
       .kahanSum
 
-    val cosa = dotProduct / (vectorLength(map) * vectorLength(snapshot.map))
-    val divergence = Math.acos(cosa) * 2 / Math.PI
-    divergence > minThreshold
+    val cosine = dotProduct / (vectorLength(map) * vectorLength(snapshot.map))
+    val divergence = Math.acos(cosine) * 2 / Math.PI
+    divergence >= minThreshold
   }
 
   implicit class RichDoubleIterable(xs: Iterable[Double]) {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprintReferenceTest.scala
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.executionplan
+
+import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
+
+import org.mockito.Mockito.when
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.LabelId
+import org.neo4j.cypher.internal.compiler.v2_2.spi.{GraphStatistics, GraphStatisticsSnapshot, NodesWithLabelCardinality}
+import org.neo4j.helpers.FakeClock
+
+class PlanFingerprintReferenceTest extends CypherFunSuite {
+
+  test("should be stale if all properties are out of date") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.0
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    clock.forward(2, SECONDS)
+
+    val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
+
+    stale should be(true)
+  }
+
+  test("should not be stale if stats are not diverged over the threshold") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.5
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    clock.forward(2, SECONDS)
+
+    val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
+
+    stale should be(false)
+  }
+
+  test("should not be stale if txId didn't change") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.0
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    clock.forward(2, SECONDS)
+
+    val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(17), stats)
+
+    stale should be(false)
+  }
+
+  test("should not be stale if life time has not expired") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.0
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    clock.forward(500, MILLISECONDS)
+
+    val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
+
+    stale should be(false)
+  }
+
+  test("should update the timestamp if the life time is expired but transaction has not changed") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.0
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
+
+    clock.forward(2, SECONDS)
+    reference.isStale(->(17), stats) should be(false)
+
+    clock.forward(500, MILLISECONDS)
+    reference.isStale(->(23), stats) should be(false)
+  }
+
+  test("should update the timestamp and the txId if the life time is expired the txId is old but stats has not changed over the threshold") {
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val ttl = 1000l
+    val threshold = 0.1
+    val clock = new FakeClock
+    val stats = mock[GraphStatistics]
+    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+
+    val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
+
+    clock.forward(2, SECONDS)
+    reference.isStale(->(23), stats) should be(false)
+
+    clock.forward(2, SECONDS)
+    reference.isStale(->(23), stats) should be(false)
+  }
+
+  implicit def liftToOption[T](item: T): Option[T] = Option(item)
+  def ->[T](item: T): () => T = () => item
+  def label(i: Int): LabelId = LabelId(i)
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -113,7 +113,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
             parsedQuery.plan(kernelStatement)
           })
         }.flatMap { case (plan, params) =>
-          if ( !touched && plan.isStale(lastTxId, kernelStatement)) {
+          if (!touched && plan.isStale(lastTxId, kernelStatement)) {
             cacheAccessor.remove(cache)(queryText)
             None
           } else {


### PR DESCRIPTION
We have three guards in place for replanning:
1. How much time has passed since the query was planned?
2. How many transactions have been committed since the query was planned?
3. How much has the statistics changed since the query was planned?

These guards are ordered the way they are since it is assumed that the later guards are more expensive than the former guards. Going to the store for the current transaction ID is more expensive than looking at the current time, and going to the store for several statistical values is more expensive than just getting a single transaction id.

This has a problem in that after a guard has first failed, it will continue to fail even if the later guards still keep the query alive. Say that the database is very read heavy, so after the default query TTL of 1 second has passed, guard (1) will always say that the query needs to be re-planned. This means that we will always go to disk to read the transaction ID, making each execution of the query more expensive.

This PR solves this by updating the guards that say "replan" if a later guard says not to replan. I.e. we should update the timestamp for a query if we find that we have not seen that many transactions.
