### PR TITLE
Rare cluster join issue

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMessage;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.cluster.statemachine.State;
@@ -304,7 +305,8 @@ public enum ElectionState
                                     ClusterMessage.VersionedConfigurationStateChange configurationChangeState =
                                             context.newConfigurationStateChange();
                                     configurationChangeState.elected( data.getRole(), winner );
-                                    outgoing.offer( Message.internal( ProposerMessage.propose,
+
+                                    outgoing.offer( Message.internal( AtomicBroadcastMessage.broadcast,
                                             configurationChangeState ) );
                                 }
                                 else


### PR DESCRIPTION
Previously, joining node broadcasted 'propose' message after gathering votes. This could result in use of Paxos instance id, which was already used by rest of the cluster, while mentioned node was away. This might cause message retransmission, out of order delivery and as result node unavailability.
With this PR node sends atomic broadcast to coordinator and thus performs the whole conversation via coordinator, which is aware of a correct Paxos instance id.
