### PR TITLE
Reduces unnecessarily thrown exceptions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -469,9 +469,9 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public void nodeVisitDegrees( long nodeId, DegreeVisitor visitor ) throws EntityNotFoundException
+    public boolean nodeVisitDegrees( long nodeId, DegreeVisitor visitor )
     {
-        persistenceCache.nodeVisitDegrees( nodeId, visitor );
+        return persistenceCache.nodeVisitDegrees( nodeId, visitor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -266,7 +266,7 @@ public class DiskLayer implements StoreReadLayer
     }
 
     @Override
-    public void nodeVisitDegrees( long nodeId, DegreeVisitor visitor ) throws EntityNotFoundException
+    public boolean nodeVisitDegrees( long nodeId, DegreeVisitor visitor )
     {
         throw new UnsupportedOperationException( "expected to be answered by cache" );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
@@ -461,9 +461,15 @@ public class PersistenceCache
         return getNode( nodeId ).getDegree( relationshipLoader, type, direction, NODE_CACHE_SIZE_LISTENER );
     }
 
-    public void nodeVisitDegrees( long nodeId, DegreeVisitor visitor ) throws EntityNotFoundException
+    public boolean nodeVisitDegrees( long nodeId, DegreeVisitor visitor )
     {
-        getNode( nodeId ).visitDegrees( relationshipLoader, visitor, NODE_CACHE_SIZE_LISTENER );
+        NodeImpl node = nodeCache.get( nodeId );
+        if ( node != null )
+        {
+            node.visitDegrees( relationshipLoader, visitor, NODE_CACHE_SIZE_LISTENER );
+            return true;
+        }
+        return false;
     }
 
     public PrimitiveIntIterator nodeGetRelationshipTypes( long nodeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -71,8 +71,7 @@ public interface StoreReadLayer
     int nodeGetDegree( long nodeId, Direction direction, int relType )
             throws EntityNotFoundException;
 
-    void nodeVisitDegrees( long nodeId, DegreeVisitor visitor )
-            throws EntityNotFoundException;
+    boolean nodeVisitDegrees( long nodeId, DegreeVisitor visitor );
 
     PrimitiveIntIterator nodeGetRelationshipTypes( long nodeId )
             throws EntityNotFoundException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
- when initially loading nodes and relationships, i.e. mostly checking
  that such exists. Previously went through a path throwing
  InvalidRecordException. Now uses method returning null or record.
- when visiting node degrees for state before commit, as part of
  committing nodes. Previously went through path throwing
  EntityNotFoundException. Now uses method returning boolean.
