### PR TITLE
Cope better when asking import-tool to import empty files

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
@@ -20,6 +20,7 @@
 package org.neo4j.csv.reader;
 
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -155,6 +156,10 @@ public class Readables
             try ( DataInputStream in = new DataInputStream( new FileInputStream( file ) ) )
             {
                 return in.readInt();
+            }
+            catch ( EOFException e )
+            {
+                return -1;
             }
         }
     };

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -52,6 +52,7 @@ public class ThreadAheadReadable extends Thread implements CharReadable, Closeab
         this.readAheadArray = new char[bufferSize];
         this.readAheadBuffer = CharBuffer.wrap( readAheadArray );
         this.readAheadBuffer.position( bufferSize );
+        setDaemon( true );
         start();
     }
 

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -117,7 +117,8 @@ public class ImportTool
                          + "input files are treated.\n"
                          + IdType.STRING + ": arbitrary strings for identifying nodes.\n"
                          + IdType.INTEGER + ": arbitrary integer values for identifying nodes.\n"
-                         + IdType.ACTUAL + ": (advanced) actual node ids." );
+                         + IdType.ACTUAL + ": (advanced) actual node ids." ),
+        STACKTRACE( "stacktrace", "", "Enable printing of stack traces when something goes wrong with the import.");
 
         private final String key;
         private final String usage;
@@ -168,6 +169,7 @@ public class ImportTool
         File storeDir;
         // The input groups
         Collection<Option<File[]>> nodesFiles, relationshipsFiles;
+        boolean enableStacktrace;
         try
         {
             storeDir =
@@ -181,6 +183,7 @@ public class ImportTool
                     args.interpretOptionsWithMetadata( Options.RELATIONSHIP_DATA.key(),
                             Converters.<File[]> mandatory(), Converters.toFiles( MULTI_FILE_DELIMITER ),
                             Validators.FILES_EXISTS, Validators.<File> atLeast( 1 ) );
+            enableStacktrace = args.getBoolean( Options.STACKTRACE.key(), Boolean.FALSE, Boolean.TRUE );
         }
         catch ( IllegalArgumentException e )
         {
@@ -209,9 +212,9 @@ public class ImportTool
             importer.doImport( input );
             success = true;
         }
-        catch ( IOException e )
+        catch ( Exception e )
         {
-            throw andPrintError( "Import error", e, true );
+            throw andPrintError( "Import error", e, enableStacktrace );
         }
         finally
         {
@@ -227,6 +230,10 @@ public class ImportTool
                 catch ( IOException e )
                 {
                     System.err.println( "Unable to delete store files after an aborted import " + e );
+                    if ( enableStacktrace )
+                    {
+                        e.printStackTrace();
+                    }
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -108,8 +108,16 @@ public abstract class AbstractStep<T> implements Step<T>
 
     protected void issuePanic( Throwable cause )
     {
+        issuePanic( cause, true );
+    }
+
+    protected void issuePanic( Throwable cause, boolean rethrow )
+    {
         control.panic( cause );
-        throw Exceptions.launderedException( cause );
+        if ( rethrow )
+        {
+            throw Exceptions.launderedException( cause );
+        }
     }
 
     protected long await( PrimitiveLongPredicate predicate, long value )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -56,7 +56,7 @@ public abstract class ProducerStep<T> extends AbstractStep<Void>
                 }
                 catch ( Throwable e )
                 {
-                    issuePanic( e );
+                    issuePanic( e, false );
                 }
             }
         }.start();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
@@ -47,9 +47,11 @@ public class StageExecution implements StageControl
 
     public boolean stillExecuting()
     {
-        if ( panicCause != null )
+        Throwable panic = panicCause;
+        if ( panic != null )
         {
-            throw new RuntimeException( "Panic", panicCause );
+            String message = panic.getMessage();
+            throw new RuntimeException( message == null? "Panic" : message, panic );
         }
 
         for ( Step<?> step : pipeline )


### PR DESCRIPTION
- ImportTool now no longer prints a big stack trace (by default) when asked to import empty files.
- Add a new --stacktrace command line option that can enable printing of stack
  traces for those who want to debug things.
- The Thread created by the ThreadReadaheadReadable has been made daemon so it
  no longer prevents a shut down of the importer process.
- Panics in the import pipeline now preserve exception messages when wrapping
  causes.
