### PR TITLE
Remove multi-threaded CC, fix duplicated errors in multi-pass CC

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
@@ -54,7 +54,7 @@ public class ConsistencyCheckSettings
             "checking the native stores, so it may be useful to turn off this check for very large databases.")
     public static final Setting<Boolean> consistency_check_indexes = setting( "consistency_check_indexes", BOOLEAN, TRUE );
 
-    @Description("Window pool implementation to be used when running consistency check")
+    @Description("Execution order of store cross-checks to be used when running consistency check")
     public static final Setting<TaskExecutionOrder> consistency_check_execution_order =
             setting( "consistency_check_execution_order", options( TaskExecutionOrder.class ), TaskExecutionOrder.MULTI_PASS.name() );
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -41,8 +41,10 @@ import org.neo4j.kernel.impl.store.record.IndexRule;
 import static java.lang.String.format;
 
 import static org.neo4j.consistency.checking.full.MultiPassStore.ARRAYS;
+import static org.neo4j.consistency.checking.full.MultiPassStore.LABELS;
 import static org.neo4j.consistency.checking.full.MultiPassStore.NODES;
 import static org.neo4j.consistency.checking.full.MultiPassStore.PROPERTIES;
+import static org.neo4j.consistency.checking.full.MultiPassStore.PROPERTY_KEYS;
 import static org.neo4j.consistency.checking.full.MultiPassStore.RELATIONSHIPS;
 import static org.neo4j.consistency.checking.full.MultiPassStore.RELATIONSHIP_GROUPS;
 import static org.neo4j.consistency.checking.full.MultiPassStore.STRINGS;
@@ -69,13 +71,13 @@ public class ConsistencyCheckTasks
         List<StoppableRunnable> tasks = new ArrayList<>();
 
         tasks.add( create( nativeStores.getNodeStore(),
-                multiPass.processors( PROPERTIES, RELATIONSHIPS ) ) );
+                multiPass.processors( LABELS, PROPERTIES, RELATIONSHIPS, RELATIONSHIP_GROUPS ) ) );
 
         tasks.add( create( nativeStores.getRelationshipStore(),
                 multiPass.processors(  NODES, PROPERTIES, RELATIONSHIPS  ) ) );
 
         tasks.add( create( nativeStores.getPropertyStore(),
-                multiPass.processors(  PROPERTIES, STRINGS, ARRAYS  ) ) );
+                multiPass.processors(  PROPERTIES, STRINGS, ARRAYS, PROPERTY_KEYS ) ) );
 
         tasks.add( create( nativeStores.getStringStore(), multiPass.processors( STRINGS ) ) );
 
@@ -148,14 +150,14 @@ public class ConsistencyCheckTasks
         return tasks;
     }
 
-    <RECORD extends AbstractBaseRecord> StoreProcessorTask<RECORD> create( RecordStore<RECORD> input )
+    private <RECORD extends AbstractBaseRecord> StoreProcessorTask<RECORD> create( RecordStore<RECORD> input )
     {
         return new StoreProcessorTask<>(
                 input, progress, order, processor, processor );
     }
 
-    <RECORD extends AbstractBaseRecord> StoreProcessorTask<RECORD> create( RecordStore<RECORD> input,
-                                                                           StoreProcessor[] processors )
+    private <RECORD extends AbstractBaseRecord> StoreProcessorTask<RECORD> create( RecordStore<RECORD> input,
+            StoreProcessor[] processors )
     {
         return new StoreProcessorTask<>(
                 input, progress, order, processor, processors );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
 import static org.neo4j.kernel.impl.store.RecordStore.IN_USE;
+import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
 
 public class IterableStore<RECORD extends AbstractBaseRecord> implements BoundedIterable<RECORD>
 {
@@ -51,9 +52,6 @@ public class IterableStore<RECORD extends AbstractBaseRecord> implements Bounded
     @Override
     public Iterator<RECORD> iterator()
     {
-        RecordStore.Processor<RuntimeException> processor = new RecordStore.Processor<RuntimeException>()
-        {
-        };
-        return processor.scan( store, IN_USE ).iterator();
+        return scan( store, IN_USE ).iterator();
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MultiPassStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MultiPassStore.java
@@ -35,7 +35,7 @@ public enum MultiPassStore
     NODES
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getNodeStore();
                 }
@@ -43,7 +43,7 @@ public enum MultiPassStore
     RELATIONSHIPS
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getRelationshipStore();
                 }
@@ -51,15 +51,23 @@ public enum MultiPassStore
     PROPERTIES
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getPropertyStore();
+                }
+            },
+    PROPERTY_KEYS
+            {
+                @Override
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
+                {
+                    return storeAccess.getPropertyKeyTokenStore();
                 }
             },
     STRINGS
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getNodeStore();
                 }
@@ -67,15 +75,23 @@ public enum MultiPassStore
     ARRAYS
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getNodeStore();
+                }
+            },
+    LABELS
+            {
+                @Override
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
+                {
+                    return storeAccess.getLabelTokenStore();
                 }
             },
     RELATIONSHIP_GROUPS
             {
                 @Override
-                RecordStore getRecordStore( StoreAccess storeAccess )
+                RecordStore<?> getRecordStore( StoreAccess storeAccess )
                 {
                     return storeAccess.getRelationshipGroupStore();
                 }
@@ -87,10 +103,10 @@ public enum MultiPassStore
     }
 
     public List<DiffRecordAccess> multiPassFilters( long memoryPerPass, StoreAccess storeAccess,
-                                                    DiffRecordAccess recordAccess, MultiPassStore[] stores )
+            DiffRecordAccess recordAccess, MultiPassStore[] stores )
     {
-        ArrayList<DiffRecordAccess> filteringStores = new ArrayList<DiffRecordAccess>();
-        RecordStore recordStore = getRecordStore( storeAccess );
+        List<DiffRecordAccess> filteringStores = new ArrayList<>();
+        RecordStore<?> recordStore = getRecordStore( storeAccess );
         long recordsPerPass = memoryPerPass / recordStore.getRecordSize();
         long highId = recordStore.getHighId();
         for ( int iPass = 0; iPass * recordsPerPass <= highId; iPass++ )
@@ -101,7 +117,7 @@ public enum MultiPassStore
     }
 
 
-    abstract RecordStore getRecordStore( StoreAccess storeAccess );
+    abstract RecordStore<?> getRecordStore( StoreAccess storeAccess );
 
     static class Factory
     {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
@@ -120,7 +120,7 @@ class StoreProcessorTask<R extends AbstractBaseRecord> implements StoppableRunna
     @Override
     public void stopScanning()
     {
-        processors[0].stopScanning();
+        processors[0].stop();
     }
 
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/incremental/IncrementalDiffCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/incremental/IncrementalDiffCheck.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.util.StringLogger;
 
+import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
+
 public class IncrementalDiffCheck extends DiffCheck
 {
     public IncrementalDiffCheck( StringLogger logger )
@@ -55,7 +57,7 @@ public class IncrementalDiffCheck extends DiffCheck
         {
             if ( 0 == summary.getInconsistencyCountForRecordType( RecordType.SCHEMA ) )
             {
-                performFullCheckOfSchemaStore( diffs, reporter, processor );
+                performFullCheckOfSchemaStore( diffs, reporter );
             }
         }
 
@@ -63,16 +65,15 @@ public class IncrementalDiffCheck extends DiffCheck
     }
 
     @SuppressWarnings("unchecked")
-    private void performFullCheckOfSchemaStore( DiffStore diffs, ConsistencyReporter reporter,
-                                                StoreProcessor processor )
+    private void performFullCheckOfSchemaStore( DiffStore diffs, ConsistencyReporter reporter )
     {
         SchemaRecordCheck schemaChecker = new SchemaRecordCheck( new RuleReader( diffs.getSchemaStore() ) );
-        for ( DynamicRecord record : processor.scan( diffs.getSchemaStore() ) )
+        for ( DynamicRecord record : scan( diffs.getSchemaStore() ) )
         {
             reporter.forSchema( record, schemaChecker );
         }
         schemaChecker = schemaChecker.forObligationChecking();
-        for ( DynamicRecord record : processor.scan( diffs.getSchemaStore() ) )
+        for ( DynamicRecord record : scan( diffs.getSchemaStore() ) )
         {
             reporter.forSchema( record, schemaChecker );
         }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordStore.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
@@ -248,8 +249,8 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
         }
 
         @Override
-        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string,
-                                   @SuppressWarnings( "deprecation") IdType idType ) throws FAILURE
+        public void processString( RecordStore<DynamicRecord> store, DynamicRecord string, IdType idType )
+                throws FAILURE
         {
             processor.processString( (RecordStore<DynamicRecord>) diffStore, string, idType );
         }
@@ -287,7 +288,14 @@ public class DiffRecordStore<R extends AbstractBaseRecord> implements RecordStor
 
         @Override
         public void processLabelToken(RecordStore<LabelTokenRecord> store, LabelTokenRecord record) throws FAILURE {
-            processor.processLabelToken((RecordStore<LabelTokenRecord>) diffStore, record);
+            processor.processLabelToken( (RecordStore<LabelTokenRecord>) diffStore, record );
+        }
+
+        @Override
+        public void processRelationshipGroup( RecordStore<RelationshipGroupRecord> store,
+                RelationshipGroupRecord record ) throws FAILURE
+        {
+            processor.processRelationshipGroup( (RecordStore<RelationshipGroupRecord>) diffStore, record );
         }
     }
 }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/ExecutionOrderIntegrationTest.java
@@ -65,6 +65,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -132,8 +133,9 @@ public class ExecutionOrderIntegrationTest
         {
             if ( LOG_DUPLICATES )
             {
-                new Exception(String.format( "Duplicate checks with single pass: %s, duplicate checks with multiple passes: %s%n",
-                        singlePassChecks.duplicates, multiPassChecks.duplicates ) );
+                throw new Exception(
+                        format( "Duplicate checks with single pass: %s, duplicate checks with multiple passes: %s%n",
+                                singlePassChecks.duplicates, multiPassChecks.duplicates ) );
             }
         }
     }
@@ -153,7 +155,7 @@ public class ExecutionOrderIntegrationTest
         private final Map<String, Integer> duplicates = new HashMap<>();
 
         @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-        void log( PendingReferenceCheck check, InvocationOnMock invocation )
+        void log( PendingReferenceCheck<?> check, InvocationOnMock invocation )
         {
             Method method = invocation.getMethod();
             if ( Object.class == method.getDeclaringClass() && "finalize".equals( method.getName() ) )

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
@@ -42,7 +42,7 @@ public class StoreProcessorTest
     {
         // given
         StoreProcessor processor = new StoreProcessor( CheckDecorator.NONE, mock( ConsistencyReport.Reporter.class ) );
-        RecordStore recordStore = mock( RecordStore.class );
+        RecordStore<?> recordStore = mock( RecordStore.class );
         when( recordStore.getHighId() ).thenReturn( 3L );
         when( recordStore.forceGetRecord( any( Long.class ) ) ).thenReturn( new NodeRecord( 0, false, 0, 0 ) );
 
@@ -62,7 +62,7 @@ public class StoreProcessorTest
     {
         // given
         final StoreProcessor processor = new StoreProcessor( CheckDecorator.NONE, mock( ConsistencyReport.Reporter.class ) );
-        RecordStore recordStore = mock( RecordStore.class );
+        RecordStore<?> recordStore = mock( RecordStore.class );
         when( recordStore.getHighId() ).thenReturn( 4L );
         when( recordStore.forceGetRecord( 0L ) ).thenReturn( new NodeRecord( 0, false, 0, 0 ) );
         when( recordStore.forceGetRecord( 1L ) ).thenReturn( new NodeRecord( 0, false, 0, 0 ) );
@@ -71,7 +71,7 @@ public class StoreProcessorTest
             @Override
             public NodeRecord answer( InvocationOnMock invocation ) throws Throwable
             {
-                processor.stopScanning();
+                processor.stop();
                 return new NodeRecord( 0, false, 0, 0 );
             }
         } );

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/PropertyStats.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/PropertyStats.java
@@ -24,15 +24,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
 class PropertyStats extends RecordStore.Processor<RuntimeException>
 {
-    Map<Integer, Long> sizeHistogram = new TreeMap<Integer, Long>();
-    Map<PropertyType, Long> typeHistogram = new EnumMap<PropertyType, Long>( PropertyType.class );
+    private final Map<Integer,Long> sizeHistogram = new TreeMap<>();
+    private final Map<PropertyType,Long> typeHistogram = new EnumMap<>( PropertyType.class );
 
     @Override
     public void processProperty( RecordStore<PropertyRecord> store, PropertyRecord property )
@@ -45,7 +53,7 @@ class PropertyStats extends RecordStore.Processor<RuntimeException>
         }
     }
 
-    private <T> void update( Map<T, Long> histogram, T key )
+    private <T> void update( Map<T,Long> histogram, T key )
     {
         Long value = histogram.get( key );
         histogram.put( key, (value == null) ? 1 : (value + 1) );
@@ -55,16 +63,74 @@ class PropertyStats extends RecordStore.Processor<RuntimeException>
     public String toString()
     {
         StringBuilder builder = new StringBuilder( getClass().getSimpleName() ).append( "{\n" );
-        for ( Map.Entry<Integer, Long> entry : sizeHistogram.entrySet() )
+        for ( Map.Entry<Integer,Long> entry : sizeHistogram.entrySet() )
         {
             builder.append( '\t' ).append( entry.getKey() ).append( ": " ).append( entry.getValue() ).append(
                     '\n' );
         }
-        for ( Map.Entry<PropertyType, Long> entry : typeHistogram.entrySet() )
+        for ( Map.Entry<PropertyType,Long> entry : typeHistogram.entrySet() )
         {
             builder.append( '\t' ).append( entry.getKey() ).append( ": " ).append( entry.getValue() ).append(
                     '\n' );
         }
         return builder.append( '}' ).toString();
+    }
+
+    @Override
+    public void processSchema( RecordStore<DynamicRecord> store, DynamicRecord schema ) throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processNode( RecordStore<NodeRecord> store, NodeRecord node ) throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processRelationship( RecordStore<RelationshipRecord> store, RelationshipRecord rel )
+            throws RuntimeException
+    {
+    }
+
+
+    @Override
+    public void processString( RecordStore<DynamicRecord> store, DynamicRecord string, IdType idType )
+            throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processArray( RecordStore<DynamicRecord> store, DynamicRecord array ) throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processLabelArrayWithOwner( RecordStore<DynamicRecord> store, DynamicRecord labelArray )
+            throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processRelationshipTypeToken( RecordStore<RelationshipTypeTokenRecord> store,
+            RelationshipTypeTokenRecord record ) throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processPropertyKeyToken( RecordStore<PropertyKeyTokenRecord> store, PropertyKeyTokenRecord record )
+            throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processLabelToken( RecordStore<LabelTokenRecord> store, LabelTokenRecord record )
+            throws RuntimeException
+    {
+    }
+
+    @Override
+    public void processRelationshipGroup( RecordStore<RelationshipGroupRecord> store, RelationshipGroupRecord record )
+            throws RuntimeException
+    {
     }
 }


### PR DESCRIPTION
This PR:
- removes MULTI_THREADED option for consistency check as it slow and not used;
- fixes duplicated error messages in MULTI_PASS consistency check, which were caused by duplicated store cross-checks.
