### PR TITLE
Respect the projected direction in variable length expansions.

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailBuilder.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailBuilder.scala
@@ -72,16 +72,16 @@ final class TrailBuilder(patterns: Seq[Pattern], boundPoints: Seq[String], predi
         done.add(start => SingleStepTrail(EndPoint(end), dir, rel.relName, rel.relTypes, start, relPred, nodePred, rel, orgNodePred ++ orgRelPred))
       }
 
-      def multiStep(rel: VarLengthRelatedTo, end: String, dir: Direction) =
-        done.add(start => VariableLengthStepTrail(EndPoint(end), dir, rel.relTypes, rel.minHops.getOrElse(1), rel.maxHops, rel.pathName, rel.relIterator, start, rel))
+      def multiStep(rel: VarLengthRelatedTo, end: String, dir: Direction, projectedDir: Direction) =
+        done.add(start => VariableLengthStepTrail(EndPoint(end), dir, projectedDir, rel.relTypes, rel.minHops.getOrElse(1), rel.maxHops, rel.pathName, rel.relIterator, start, rel))
 
       val patternsLeft = patternsToDo.filterNot(_ == p)
 
       val result: Trail = p match {
         case rel: RelatedTo if rel.left.name == done.end           => singleStep(rel, rel.right.name, rel.direction)
         case rel: RelatedTo if rel.right.name == done.end          => singleStep(rel, rel.left.name, rel.direction.reverse())
-        case rel: VarLengthRelatedTo if rel.right.name == done.end   => multiStep(rel, rel.left.name, rel.direction.reverse())
-        case rel: VarLengthRelatedTo if rel.left.name == done.end => multiStep(rel, rel.right.name, rel.direction)
+        case rel: VarLengthRelatedTo if rel.right.name == done.end   => multiStep(rel, rel.left.name, rel.direction.reverse(), rel.direction)
+        case rel: VarLengthRelatedTo if rel.left.name == done.end => multiStep(rel, rel.right.name, rel.direction, rel.direction)
         case _                                                     => throw new ThisShouldNotHappenError("Andres", "This pattern is not expected")
       }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/matching/VariableLengthStepTrail.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/pipes/matching/VariableLengthStepTrail.scala
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.{Relationship, Node, PropertyContainer, Direction}
 
 final case class VariableLengthStepTrail(next: Trail,
                                          dir: Direction,
+                                         projectedDir: Direction,
                                          typ: Seq[String],
                                          min: Int,
                                          max: Option[Int],
@@ -77,7 +78,8 @@ final case class VariableLengthStepTrail(next: Trail,
              idx <= max.getOrElse(idx) &&
              left.nonEmpty) {
 
-        val currentPath = curr :+ left.head
+        val currentPath = if (projectedDir == dir) curr :+ left.head
+                          else (curr :+ left.head).reverse
         map += (path -> PathImpl(currentPath: _*))
 
         relIterator.foreach {

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailBuilderTest.scala
@@ -151,7 +151,7 @@ class TrailBuilderTest extends Assertions {
     //(b)-[:A*]->(e)
 
     val boundPoint = EndPoint("e")
-    val first = VariableLengthStepTrail(boundPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val first = VariableLengthStepTrail(boundPoint, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val expectedTrail = Some(LongestTrail("b", None, first))
 
     val foundTrail = TrailBuilder.findLongestTrail(Seq(BtoE), Seq("b"), Nil)
@@ -162,7 +162,7 @@ class TrailBuilderTest extends Assertions {
     //(a)-[:A]->(b)-[:A*]->(e)
 
     val endPoint = EndPoint("e")
-    val last = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val last = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val first = SingleStepTrail(last, Direction.OUTGOING, "pr1", Seq("A"), "a", True(), True(), AtoB, Seq())
     val expected = Some(LongestTrail("a", None, first))
 
@@ -174,7 +174,7 @@ class TrailBuilderTest extends Assertions {
     //(b)-[:A*]->(e)-[:C*]->f
 
     val endPoint = EndPoint("e")
-    val trail = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val trail = VariableLengthStepTrail(endPoint, Direction.OUTGOING,Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val expected = Some(LongestTrail("b", None, trail))
 
     val foundTrail = TrailBuilder.findLongestTrail(Seq(BtoE, EtoF), Seq("b", "f"), Nil)
@@ -194,7 +194,7 @@ class TrailBuilderTest extends Assertions {
     */
 
     val endPoint = EndPoint("e")
-    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING,Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", True(), True(), AtoB, Seq())
 
     val expected = Some(LongestTrail("a", None, trail))
@@ -213,7 +213,7 @@ class TrailBuilderTest extends Assertions {
     */
 
     val endPoint = EndPoint("e")
-    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", True(), True(), AtoB, Seq())
 
     val expected = Some(LongestTrail("a", None, trail))
@@ -232,7 +232,7 @@ class TrailBuilderTest extends Assertions {
     */
 
     val endPoint = EndPoint("e")
-    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", True(), True(), AtoB, Seq())
 
     val expected = Some(LongestTrail("a", None, trail))
@@ -254,7 +254,7 @@ class TrailBuilderTest extends Assertions {
     */
 
     val endPoint = EndPoint("e")
-    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val second = VariableLengthStepTrail(endPoint, Direction.OUTGOING,Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
     val trail = SingleStepTrail(second, Direction.OUTGOING, "pr1", Seq("A"), "a", True(), True(), AtoB, Seq())
 
     val expected = Some(LongestTrail("a", None, trail))

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailToStepTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/TrailToStepTest.scala
@@ -158,7 +158,7 @@ class TrailToStepTest extends Assertions {
     val expected = varlengthStep(0, Seq(A), OUTGOING, 1, None, None)
 
     val boundPoint = EndPoint("e")
-    val trail = VariableLengthStepTrail(boundPoint, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
+    val trail = VariableLengthStepTrail(boundPoint, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, None, "p", None, "b", BtoE)
 
     val result = trail.toSteps(0).get
     assert(result.equals(expected))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1112,4 +1112,18 @@ RETURN x0.name""")
     result should equal (1)
   }
 
+  test("should return relationships by collecting them as a list - wrong way") {
+    val a = createNode()
+    val b = createNode()
+    val c = createLabeledNode("End")
+
+    val r1 = relate(a, b, "rel")
+    val r2 = relate(b, c, "rel")
+
+    val result = execute("match a-[r:rel*2..2]->(b:End) return r")
+
+    result.columnAs[List[Relationship]]("r").toList.head should equal(List(r1, r2))
+  }
+
+
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/TrailDecomposeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/TrailDecomposeTest.scala
@@ -128,7 +128,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
 
     val kernPath = Seq(nodeA, rel1, nodeB)
     val path =
-      VariableLengthStepTrail(EndPoint("b"), Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
+      VariableLengthStepTrail(EndPoint("b"), Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
 
     //Then
     assertInTx(path.decompose(kernPath).toList === List(Map("a" -> nodeA, "b" -> nodeB, "p" -> PathImpl(kernPath:_*))))
@@ -145,7 +145,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
 
     val kernPath = Seq(nodeA, rel0, nodeB)
     val path =
-      VariableLengthStepTrail(EndPoint("b"), Direction.OUTGOING, Seq("A"), 1, Some(2), "p", Some("r"), "a", null)
+      VariableLengthStepTrail(EndPoint("b"), Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", Some("r"), "a", null)
 
     //Then
     assertInTx(path.decompose(kernPath).toList === List(Map("a" -> nodeA, "b" -> nodeB, "p" -> PathImpl(kernPath:_*), "r"->Seq(rel0))))
@@ -166,7 +166,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
     val expectedPath = PathImpl(node1, rel2, node2)
 
     val point = EndPoint("b")
-    val lastStep = VariableLengthStepTrail(point, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
+    val lastStep = VariableLengthStepTrail(point, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
     val firstStep = SingleStepTrail(lastStep, Direction.OUTGOING, "r1", Seq("B"), "x", True(), True(), null, Seq())
 
     //Then
@@ -188,7 +188,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
     val expectedPath = PathImpl(node0, rel0, node1)
     val bound = EndPoint("x")
     val single = SingleStepTrail(bound, Direction.INCOMING, "r1", Seq("B"), "b", True(), True(), null, Seq())
-    val path = VariableLengthStepTrail(single, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
+    val path = VariableLengthStepTrail(single, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
 
     //Then
     assertInTx(path.decompose(kernPath).toList === List(Map("x" -> node2, "a" -> node0, "b" -> node1, "r1" -> rel1, "p" -> expectedPath)))
@@ -209,7 +209,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
     val expectedPath = input
 
     val bound = EndPoint("b")
-    val path = VariableLengthStepTrail(bound, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
+    val path = VariableLengthStepTrail(bound, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 1, Some(2), "p", None, "a", null)
 
     //Then
     assertInTx(path.decompose(input).toList === List(Map("a" -> node0, "b" -> node2, "p" -> PathImpl(expectedPath:_*))))
@@ -229,7 +229,7 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
 
     val bound = EndPoint("c")
     val single = SingleStepTrail(bound, Direction.INCOMING, "r", Seq("B"), "b", True(), True(), null, Seq())
-    val path = VariableLengthStepTrail(single, Direction.OUTGOING, Seq("A"), 0, Some(1), "p", None, "a", null)
+    val path = VariableLengthStepTrail(single, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 0, Some(1), "p", None, "a", null)
 
     //Then
     assertInTx(path.decompose(input).toList === List(Map("a" -> node0, "b" -> node0, "c" -> node1, "p" -> expectedPath, "r" -> rel0)))
@@ -254,8 +254,8 @@ class TrailDecomposeTest extends GraphDatabaseJUnitSuite {
     val input = Seq(node0, rel0, node1, rel1, node2, rel2, node3, rel3, node4)
 
     val bound = EndPoint("b")
-    val first = VariableLengthStepTrail(bound, Direction.OUTGOING, Seq("A"), 0, None, "p2", None, "x", null)
-    val second = VariableLengthStepTrail(first, Direction.OUTGOING, Seq("A"), 0, None, "p1", None, "a", null)
+    val first = VariableLengthStepTrail(bound, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 0, None, "p2", None, "x", null)
+    val second = VariableLengthStepTrail(first, Direction.OUTGOING, Direction.OUTGOING, Seq("A"), 0, None, "p1", None, "a", null)
 
     //Then
     assertInTx(second.decompose(input).toList === List(


### PR DESCRIPTION
For patterns of the type a-[r:rel*]->(b) we should always return the the found
relationships in the order going from a to b even though the actual expansion
was done from b to a.
