### PR TITLE
Reflect selected node in legend.

### DIFF
--- a/community/browser/app/scripts/controllers/Legend.coffee
+++ b/community/browser/app/scripts/controllers/Legend.coffee
@@ -32,6 +32,24 @@ angular.module('neo4jApp')
     $scope.labelsContracted = yes
     $scope.typesContracted = yes
 
+    $scope.labelNotInSelection = (currentItem, label) ->
+      return false unless label
+      return false unless currentItem
+      return false unless currentItem.data.isNode
+      currentItem.data.labels.indexOf(label) < 0
+
+    $scope.relationshipNotInSelection = (currentItem, relationshipType) ->
+      return false unless relationshipType
+      return false unless currentItem
+      types = getRelationshipsTypesForNode currentItem
+      types.indexOf(relationshipType) < 0
+
+    getRelationshipsTypesForNode = (currentItem) ->
+      return [] unless currentItem
+      filtered = $scope.graph._relationships.filter( (item) ->
+        return item.source.id == currentItem.data.id or item.target.id == currentItem.data.id
+      )
+      filtered.map((item) -> return item.type)
 
     graphStats = (graph) ->
       resultLabels = {}

--- a/community/browser/app/styles/legend.styl
+++ b/community/browser/app/styles/legend.styl
@@ -8,6 +8,11 @@ legend-row-height = 32px
   background-color: #EEF1F8
   display: table-row
 
+  li.not-in-slection .label
+    box-shadow:inset 0px 0px 0px 1px #A5ABB6
+    background-color: #E5E5E7 !important
+    color: #A5ABB6 !important
+
   .row-toggle
     float: right
     display: block
@@ -91,3 +96,4 @@ legend-row-height = 32px
         margin-left: 12px
       &:hover .remove
           display: inline-block
+

--- a/community/browser/app/views/partials/legend.jade
+++ b/community/browser/app/views/partials/legend.jade
@@ -3,7 +3,7 @@
     .row-toggle(overflow-with-toggle='', ng-click="labelsContracted = !labelsContracted")
       .fa(ng-class="labelsContracted ? 'fa-caret-left' : 'fa-caret-down'")
     ul.list-unstyled.list-labels
-      li(ng-repeat='(label, node) in labels', ng-class="{active: currentItem == node}")
+      li(ng-repeat='(label, node) in labels', ng-class="{'not-in-slection': labelNotInSelection(currentItem, label)}")
         .contents(ng-click="onItemClick(node, 'label')")
           .label.label-node.class-name(ng-style='{"background-color": node.style.props.color, "color": node.style.props["text-color-internal"]}') {{label || '*'}}
             span.count ({{node.count}})
@@ -11,7 +11,7 @@
     .row-toggle(overflow-with-toggle='', ng-click="typesContracted = !typesContracted")
       .fa(ng-class="typesContracted ? 'fa-caret-left' : 'fa-caret-down'")
     ul.list-unstyled.list-relationships
-      li(ng-repeat='(type, rel) in types', ng-class="{active: currentItem == node}")
+      li(ng-repeat='(type, rel) in types', ng-class="{'not-in-slection': relationshipNotInSelection(currentItem, type)}")
         .contents(ng-click="onItemClick(rel, 'relationshipType')")
           .label.label-relationship.class-name(ng-style='{"background-color": rel.style.props.color, "color": rel.style.props["text-color-internal"]}') {{type || '*'}}
             span.count ({{rel.count}})

--- a/community/browser/app/views/template/inspector-rows.jade
+++ b/community/browser/app/views/template/inspector-rows.jade
@@ -1,7 +1,5 @@
 script(id="inspector/graphItem.html", type="text/ng-template")
   ul.list-inline
-    li(ng-if="item.isNode", ng-repeat="label in item.labels")
-      .label.label-node.class-name(ng-style='styleForLabel(label)', ng-bind="label")
     li(ng-if="!item.isNode")
       .label.label-node.class-name(ng-style='styleForItem(item)', ng-bind="item.type")
     li.empty(ng-if='item.propertyList.length == 0') No properties


### PR DESCRIPTION
- Reflect current node selection in labels.
- Reflect current node selection in relationships.
- Remove label from inspector when selecting a node.

![oskar4j 2014-12-02 at 12 54 28](https://cloud.githubusercontent.com/assets/570998/5262209/fb7da8ec-7a22-11e4-8ccd-24d9767de3fa.png)
![oskar4j 2014-12-02 at 12 54 36](https://cloud.githubusercontent.com/assets/570998/5262210/fbb0eef0-7a22-11e4-9ec3-15000af452b7.png)
![oskar4j 2014-12-02 at 12 54 44](https://cloud.githubusercontent.com/assets/570998/5262211/fbb12686-7a22-11e4-97f4-d513bf64b4b1.png)
