### PR TITLE
Remove the MaxDirectMemory setting from wrapper.conf

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -1,3 +1,7 @@
+#********************************************************************
+# Property file references
+#********************************************************************
+
 wrapper.java.additional=-Dorg.neo4j.server.properties=conf/neo4j-server.properties
 wrapper.java.additional=-Djava.util.logging.config.file=conf/logging.properties
 wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
@@ -8,7 +12,6 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
-wrapper.java.additional=-XX:MaxDirectMemorySize=2G
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -1,3 +1,7 @@
+#********************************************************************
+# Property file references
+#********************************************************************
+
 wrapper.java.additional=-Dorg.neo4j.server.properties=conf/neo4j-server.properties
 wrapper.java.additional=-Djava.util.logging.config.file=conf/logging.properties
 wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
@@ -8,7 +12,6 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
-wrapper.java.additional=-XX:MaxDirectMemorySize=2G
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 
 # Uncomment the following lines to enable garbage collection logging

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -1,3 +1,7 @@
+#********************************************************************
+# Property file references
+#********************************************************************
+
 wrapper.java.additional=-Dorg.neo4j.server.properties=conf/neo4j-server.properties
 wrapper.java.additional=-Djava.util.logging.config.file=conf/logging.properties
 wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
@@ -8,7 +12,6 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
-wrapper.java.additional=-XX:MaxDirectMemorySize=2G
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.


### PR DESCRIPTION
It was added as part of implementing the StandardPageCache, which has since been removed.
Also added a headline to the system property group.
