### PR TITLE
Rename counts store files

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsStoreTest.java
@@ -288,8 +288,8 @@ public class CountsStoreTest
     public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     @Rule
     public PageCacheRule pageCacheRule = new PageCacheRule();
-    private final File alpha = new File( "alpha" );
-    private final File beta = new File( "beta" );
+    private final File alpha = new File( "a" );
+    private final File beta = new File( "b" );
     private final int lastCommittedTxId = 42;
     private FileSystemAbstraction fs;
     private PageCache pageCache;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexImplementation;
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
@@ -59,8 +58,8 @@ public class NeoStoreFileListingTest
             "messages.log",
             "neostore",
             "neostore.id",
-            "neostore.counts.db.alpha",
-            "neostore.counts.db.beta",
+            "neostore.counts.db.a",
+            "neostore.counts.db.b",
             "neostore.labeltokenstore.db",
             "neostore.labeltokenstore.db.id",
             "neostore.labeltokenstore.db.names",
@@ -121,8 +120,8 @@ public class NeoStoreFileListingTest
         assertThat( asSetOfPaths( result ), equalTo( asSet(
                 "neostore.labeltokenstore.db",
                 "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.alpha",
-                "neostore.counts.db.beta",
+                "neostore.counts.db.a",
+                "neostore.counts.db.b",
                 "neostore.nodestore.db",
                 "neostore.nodestore.db.labels",
                 "neostore.propertystore.db",
@@ -154,8 +153,8 @@ public class NeoStoreFileListingTest
         assertThat( pathSet, equalTo( asSet(
                 "neostore.labeltokenstore.db",
                 "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.alpha",
-                "neostore.counts.db.beta",
+                "neostore.counts.db.a",
+                "neostore.counts.db.b",
                 "neostore.nodestore.db",
                 "neostore.nodestore.db.labels",
                 "neostore.propertystore.db",
@@ -187,8 +186,8 @@ public class NeoStoreFileListingTest
         assertThat( pathSet, equalTo( asSet(
                 "neostore.labeltokenstore.db",
                 "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.alpha",
-                "neostore.counts.db.beta",
+                "neostore.counts.db.a",
+                "neostore.counts.db.b",
                 "neostore.nodestore.db",
                 "neostore.nodestore.db.labels",
                 "neostore.propertystore.db",
@@ -223,8 +222,8 @@ public class NeoStoreFileListingTest
                 "schema/index/their.index",
                 "neostore.labeltokenstore.db",
                 "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.alpha",
-                "neostore.counts.db.beta",
+                "neostore.counts.db.a",
+                "neostore.counts.db.b",
                 "neostore.nodestore.db",
                 "neostore.nodestore.db.labels",
                 "neostore.propertystore.db",


### PR DESCRIPTION
'neostore.counts.db.{alpha,beta}' -> 'neostore.counts.db.{a,b}'
- improved error and log messages by referring to file names when speaking about a specific counts store file
