### PR TITLE
Remove configuration change restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ out
 .java-version
 community/server/data
 enterprise/server-enterprise/data
+advanced/server-advanced/data
+advanced/server-advanced/neo4j-home
+community/neo4j-harness/data
+community/server-plugin-test/neo4j-home
+enterprise/server-enterprise/neo4j-home
+integrationtests/data

--- a/community/jmx/src/main/java/org/neo4j/jmx/JmxUtils.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/JmxUtils.java
@@ -20,13 +20,9 @@
 package org.neo4j.jmx;
 
 import java.lang.management.ManagementFactory;
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.management.ReflectionException;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.jmx.impl.JmxKernelExtension;
@@ -67,19 +63,7 @@ public class JmxUtils
         {
             return (T) mbeanServer.getAttribute( objectName, attribute );
         }
-        catch ( MBeanException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( AttributeNotFoundException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InstanceNotFoundException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( ReflectionException e )
+        catch ( Exception e )
         {
             throw new RuntimeException( e );
         }
@@ -92,15 +76,7 @@ public class JmxUtils
         {
             return (T) mbeanServer.invoke( objectName, attribute, params, signatur );
         }
-        catch ( MBeanException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InstanceNotFoundException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( ReflectionException e )
+        catch ( Exception e )
         {
             throw new RuntimeException( e );
         }

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxKernelExtension.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/JmxKernelExtension.java
@@ -56,7 +56,7 @@ public class JmxKernelExtension implements Lifecycle
         support = ManagementSupport.load();
         url = support.getJMXServiceURL( kernelData );
         mbs = support.getMBeanServer();
-        beans = new LinkedList<Neo4jMBean>();
+        beans = new LinkedList<>();
         try
         {
             Neo4jMBean bean = new KernelBean( kernelData, support );

--- a/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
@@ -19,22 +19,22 @@
  */
 package org.neo4j.jmx;
 
-import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
-import static org.junit.Assert.assertEquals;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.util.Hashtable;
-
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.jmx.impl.JmxKernelExtension;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static org.junit.Assert.assertEquals;
 
 public class DescriptionTest
 {
@@ -87,9 +87,8 @@ public class DescriptionTest
         Kernel kernel = ((GraphDatabaseAPI) graphdb).getDependencyResolver().resolveDependency( JmxKernelExtension
                 .class ).getSingleManagementBean( Kernel.class );
         ObjectName query = kernel.getMBeanQuery();
-        Hashtable<String, String> properties = new Hashtable<String, String>( query.getKeyPropertyList() );
+        Hashtable<String, String> properties = new Hashtable<>( query.getKeyPropertyList() );
         properties.put( "name", Kernel.NAME );
-        MBeanInfo beanInfo = getPlatformMBeanServer().getMBeanInfo( new ObjectName( query.getDomain(), properties ) );
-        return beanInfo;
+        return getPlatformMBeanServer().getMBeanInfo( new ObjectName( query.getDomain(), properties ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -19,20 +19,42 @@
  */
 package org.neo4j.graphdb.factory;
 
-import org.neo4j.graphdb.config.Setting;
-import org.neo4j.helpers.Service;
-import org.neo4j.helpers.Settings;
-import org.neo4j.kernel.configuration.*;
-import org.neo4j.kernel.impl.api.store.CacheLayer;
-import org.neo4j.kernel.impl.cache.CacheProvider;
-import org.neo4j.kernel.impl.cache.MonitorGc;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.neo4j.helpers.Settings.*;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.helpers.Service;
+import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.ConfigurationMigrator;
+import org.neo4j.kernel.configuration.GraphDatabaseConfigurationMigrator;
+import org.neo4j.kernel.configuration.Internal;
+import org.neo4j.kernel.configuration.Migrator;
+import org.neo4j.kernel.configuration.Obsoleted;
+import org.neo4j.kernel.configuration.Title;
+import org.neo4j.kernel.impl.api.store.CacheLayer;
+import org.neo4j.kernel.impl.cache.CacheProvider;
+import org.neo4j.kernel.impl.cache.MonitorGc;
+
+import static org.neo4j.helpers.Settings.ANY;
+import static org.neo4j.helpers.Settings.BOOLEAN;
+import static org.neo4j.helpers.Settings.BYTES;
+import static org.neo4j.helpers.Settings.DURATION;
 import static org.neo4j.helpers.Settings.DirectMemoryUsage.directMemoryUsage;
+import static org.neo4j.helpers.Settings.FALSE;
+import static org.neo4j.helpers.Settings.INTEGER;
+import static org.neo4j.helpers.Settings.NO_DEFAULT;
+import static org.neo4j.helpers.Settings.PATH;
+import static org.neo4j.helpers.Settings.STRING;
+import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.helpers.Settings.basePath;
+import static org.neo4j.helpers.Settings.illegalValueMessage;
+import static org.neo4j.helpers.Settings.matches;
+import static org.neo4j.helpers.Settings.max;
+import static org.neo4j.helpers.Settings.min;
+import static org.neo4j.helpers.Settings.options;
+import static org.neo4j.helpers.Settings.port;
+import static org.neo4j.helpers.Settings.setting;
 
 /**
  * Settings for Neo4j. Use this with {@link GraphDatabaseBuilder}.
@@ -89,6 +111,12 @@ public abstract class GraphDatabaseSettings
     @Description("The directory where the database files are located.")
     public static final Setting<File> store_dir = setting("store_dir", PATH, NO_DEFAULT );
 
+    @Description( "The maximum amount of time to wait for the database to become available, when " +
+                  "starting a new transaction." )
+    @Internal
+    public static final Setting<Long> transaction_start_timeout =
+            setting( "transaction_start_timeout", DURATION, "1s" );
+
     @Description("The base name for the Neo4j Store files, either an absolute path or relative to the store_dir " +
             "setting. This should generally not be changed.")
     @Internal
@@ -120,7 +148,8 @@ public abstract class GraphDatabaseSettings
     @Description("Controls the auto indexing feature for relationships. Setting it to `false` shuts it down, " +
             "while `true` enables it by default for properties "
             + "listed in the relationship_keys_indexable setting.")
-    public static final Setting<Boolean> relationship_auto_indexing = setting("relationship_auto_indexing",BOOLEAN, FALSE );
+    public static final Setting<Boolean> relationship_auto_indexing =
+            setting("relationship_auto_indexing", BOOLEAN, FALSE );
 
     @Description("A list of property names (comma separated) that will be indexed by default. This applies to " +
             "_relationships_ only." )

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/AnnotationBasedConfigurationMigrator.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 public class AnnotationBasedConfigurationMigrator implements ConfigurationMigrator {
 
-    private ArrayList<ConfigurationMigrator> migrators = new ArrayList<ConfigurationMigrator>();
+    private ArrayList<ConfigurationMigrator> migrators = new ArrayList<>();
     private AnnotatedFieldHarvester fieldHarvester = new AnnotatedFieldHarvester();
     
     public AnnotationBasedConfigurationMigrator(

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationChange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationChange.java
@@ -20,9 +20,9 @@
 package org.neo4j.kernel.configuration;
 
 /**
-* TODO
+* Represents a change to the database configuration.
 */
-public class ConfigurationChange
+public final class ConfigurationChange
 {
     private String name;
     private String oldValue;
@@ -54,5 +54,34 @@ public class ConfigurationChange
     public String toString()
     {
         return name+":"+oldValue+"->"+newValue;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( !(o instanceof ConfigurationChange) )
+        {
+            return false;
+        }
+
+        ConfigurationChange that = (ConfigurationChange) o;
+
+        return name.equals( that.name ) &&
+               !(newValue != null ? !newValue.equals( that.newValue ) : that.newValue != null) &&
+               !(oldValue != null ? !oldValue.equals( that.oldValue ) : that.oldValue != null);
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = name.hashCode();
+        result = 31 * result + (oldValue != null ? oldValue.hashCode() : 0);
+        result = 31 * result + (newValue != null ? newValue.hashCode() : 0);
+        return result;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/RestartOnChange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/RestartOnChange.java
@@ -19,17 +19,8 @@
  */
 package org.neo4j.kernel.configuration;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-
-import org.neo4j.graphdb.config.Setting;
-import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Predicate;
-import org.neo4j.helpers.Predicates;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-
-import static org.neo4j.helpers.Predicates.or;
-import static org.neo4j.helpers.collection.Iterables.map;
 
 /**
  * When a specified change happens, restart the given LifeSupport instance.
@@ -42,26 +33,6 @@ public class RestartOnChange
 {
     private final Predicate<String> restartSpecification;
     private final Lifecycle life;
-
-    public RestartOnChange( Class<?> settingsClass, Lifecycle life )
-    {
-        this( or( map( new Function<Field, Predicate<String>>()
-        {
-            @Override
-            public Predicate<String> apply( Field method )
-            {
-                try
-                {
-                    Setting setting = (Setting) method.get( null );
-                    return Predicates.in( setting.name() );
-                }
-                catch ( IllegalAccessException e )
-                {
-                    return Predicates.not( Predicates.<String>TRUE() );
-                }
-            }
-        }, Arrays.asList( settingsClass.getFields() ) ) ), life );
-    }
 
     public RestartOnChange( final String configurationNamePrefix, Lifecycle life )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfigConcurrency.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfigConcurrency.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.configuration;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-
-import org.junit.Test;
 
 public class TestConfigConcurrency
 {
@@ -82,8 +82,8 @@ public class TestConfigConcurrency
         // Given
         Config config = new Config();
 
-        List<Thread> threads = new ArrayList<Thread>(  );
-        List<ConfigHammer> hammers = new ArrayList<ConfigHammer>(  );
+        List<Thread> threads = new ArrayList<>(  );
+        List<ConfigHammer> hammers = new ArrayList<>(  );
 
         // When
         int numThreads = 10;
@@ -106,8 +106,4 @@ public class TestConfigConcurrency
             if(hammer.failure != null)
                 throw hammer.failure;
     }
-
-
-
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -124,7 +124,6 @@ public class ManyPropertyKeysIT
             store.updateRecord( record );
         }
         neoStore.close();
-        pageCache.close();
 
         return database();
     }

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigWrappingConfiguration.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigWrappingConfiguration.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.server.configuration;
 
+import org.apache.commons.configuration.AbstractConfiguration;
+
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.configuration.AbstractConfiguration;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.Pair;
@@ -46,28 +46,14 @@ public class ConfigWrappingConfiguration extends AbstractConfiguration
     @Override
     public boolean isEmpty()
     {
-        if( config == null )
-        {
-            return true;
-        }
-        else
-        {
-            // always return not empty as some properties have default values
-            return false;
-        }
+        // non-null config is always non-empty as some properties have default values
+        return config == null;
     }
 
     @Override
     public boolean containsKey( String key )
     {
-        if( getProperty( key ) != null )
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return getProperty( key ) != null;
     }
 
     @Override
@@ -88,12 +74,12 @@ public class ConfigWrappingConfiguration extends AbstractConfiguration
     public Iterator<String> getKeys()
     {
         // get all the properties keys
-        final Set<String> staticKeys = this.getRegistedSettings().keySet();
+        Set<String> staticKeys = getRegisteredSettings().keySet();
         // only keep the properties which have been assigned default values or user-defined values
-        final Set<String> notNullKeys = new HashSet();
-        for ( final String key : staticKeys )
+        Set<String> notNullKeys = new HashSet<>();
+        for ( String key : staticKeys )
         {
-            if ( this.containsKey( key ) )
+            if ( containsKey( key ) )
             {
                 notNullKeys.add( key );
             }
@@ -109,10 +95,10 @@ public class ConfigWrappingConfiguration extends AbstractConfiguration
 
     private Setting<?> getSettingForKey( String key )
     {
-        return this.getRegistedSettings().get( key );
+        return getRegisteredSettings().get( key );
     }
 
-    private Map<String, Setting<?>> getRegistedSettings()
+    private Map<String, Setting<?>> getRegisteredSettings()
     {
         Iterable<Class<?>> settingsClasses = config.getSettingsClasses();
         AnnotatedFieldHarvester fieldHarvester = new AnnotatedFieldHarvester();


### PR DESCRIPTION
This feature was completely broken, and no tests were concerned with its well-being.
If you asked the ConfigurationBean to apply a new configuration, the server would attempt a partial restart and fail half-way through, locking up the whole database until the process as a whole was restarted.
It's a high-complexity, low-value feature, that was easy to forget about, and the partial restarts were hard to reason about, and I've never heard of anyone using it.
If you were using it, the new way of applying new configurations is to just restart the whole database.
If there are no active transactions running that we need to wait for, then the turn-around time for a clean restart is pretty short anyway.

This commit also fixes a bug in the deprecated `Config.setProperty()` method that, if used, would delete all properties instead of adding the given one.
Furthermore, the ConfigurationBean will not refuse writes to the attributes that it has always claimed were read-only. Which is all of them.
A new internal configuration has also been added, called `transaction_start_timeout`, which controls how long we will wait for the database to become available when starting a new transaction.
