### PR TITLE
Ignores empty property values from CSV input

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -192,10 +192,20 @@ public class BufferedCharSeeker implements CharSeeker
     @Override
     public <EXTRACTOR extends Extractor<?>> EXTRACTOR extract( Mark mark, EXTRACTOR extractor )
     {
+        if ( !tryExtract( mark, extractor ) )
+        {
+            throw new IllegalStateException( extractor + " didn't extract value for " + mark +
+                    ". For values which are optional please use tryExtract method instead" );
+        }
+        return extractor;
+    }
+
+    @Override
+    public boolean tryExtract( Mark mark, Extractor<?> extractor )
+    {
         long from = mark.startPosition();
         long to = mark.position();
-        extractor.extract( buffer, (int)(from), (int)(to-from) );
-        return extractor;
+        return extractor.extract( buffer, (int)(from), (int)(to-from) );
     }
 
     private int skipEolChars() throws IOException

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
@@ -69,8 +69,19 @@ public interface CharSeeker extends Closeable
      * @param extractor {@link Extractor} capable of extracting the value.
      * @return the supplied {@link Extractor}, which after the call carries the extracted value itself,
      * where either {@link Extractor#value()} or a more specific accessor method can be called to access the value.
+     * @throws IllegalStateException if the {@link Extractor#extract(char[], int, int) extraction}
+     * returns {@code false}.
      */
     <EXTRACTOR extends Extractor<?>> EXTRACTOR extract( Mark mark, EXTRACTOR extractor );
+
+    /**
+     * Extracts the value specified by the {@link Mark}, previously populated by a call to {@link #seek(Mark, int[])}.
+     * @param mark the {@link Mark} specifying which part of a bigger piece of data contains the found value.
+     * @param extractor {@link Extractor} capable of extracting the value.
+     * @return {@code true} if a value was extracted, otherwise {@code false}. Probably the only reason for
+     * returning {@code false} would be if the data to extract was empty.
+     */
+    boolean tryExtract( Mark mark, Extractor<?> extractor );
 
     public static final CharSeeker EMPTY = new CharSeeker()
     {
@@ -81,9 +92,15 @@ public interface CharSeeker extends Closeable
         }
 
         @Override
-        public <EXTRACTOR extends Extractor<?>> EXTRACTOR extract( Mark mark, EXTRACTOR extractor )
+        public <EXTRACTOR extends org.neo4j.csv.reader.Extractor<?>> EXTRACTOR extract( Mark mark, EXTRACTOR extractor )
         {
             throw new IllegalStateException( "Nothing to extract" );
+        }
+
+        @Override
+        public boolean tryExtract( Mark mark, Extractor<?> extractor )
+        {
+            return false;
         }
 
         @Override

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
@@ -34,8 +34,18 @@ package org.neo4j.csv.reader;
  */
 public interface Extractor<T>
 {
-    void extract( char[] data, int offset, int length );
+    /**
+     * Extracts value of type {@code T} from the given character data.
+     * @param data characters in a buffer.
+     * @param offset offset into the buffer where the value starts.
+     * @param length number of characters from the offset to extract.
+     * @return {@code true} if a value was extracted, otherwise {@code false}.
+     */
+    boolean extract( char[] data, int offset, int length );
 
+    /**
+     * @return the most recently extracted value.
+     */
     T value();
 
     /**

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -243,7 +243,30 @@ public class Extractors
         }
     }
 
-    private static class StringExtractor extends AbstractExtractor<String>
+    private static abstract class AbstractSingleValueExtractor<T> extends AbstractExtractor<T>
+    {
+        AbstractSingleValueExtractor( String toString )
+        {
+            super( toString );
+        }
+
+        @Override
+        public final boolean extract( char[] data, int offset, int length )
+        {
+            if ( length == 0 )
+            {
+                clear();
+                return false;
+            }
+            return extract0( data, offset, length );
+        }
+
+        protected abstract void clear();
+
+        protected abstract boolean extract0( char[] data, int offset, int length );
+    }
+
+    private static class StringExtractor extends AbstractSingleValueExtractor<String>
     {
         private String value;
 
@@ -253,9 +276,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
         {
-            value = length > 0 ? new String( data, offset, length ) : null;
+            value = null;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
+        {
+            value = new String( data, offset, length );
+            return true;
         }
 
         @Override
@@ -265,7 +295,7 @@ public class Extractors
         }
     }
 
-    public static class LongExtractor extends AbstractExtractor<Long>
+    public static class LongExtractor extends AbstractSingleValueExtractor<Long>
     {
         private long value;
 
@@ -275,9 +305,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             value = extractLong( data, offset, length );
+            return true;
         }
 
         @Override
@@ -296,7 +333,7 @@ public class Extractors
         }
     }
 
-    public static class IntExtractor extends AbstractExtractor<Integer>
+    public static class IntExtractor extends AbstractSingleValueExtractor<Integer>
     {
         private int value;
 
@@ -306,9 +343,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             value = safeCastLongToInt( extractLong( data, offset, length ) );
+            return true;
         }
 
         @Override
@@ -327,7 +371,7 @@ public class Extractors
         }
     }
 
-    public static class ShortExtractor extends AbstractExtractor<Short>
+    public static class ShortExtractor extends AbstractSingleValueExtractor<Short>
     {
         private short value;
 
@@ -337,9 +381,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             value = safeCastLongToShort( extractLong( data, offset, length ) );
+            return true;
         }
 
         @Override
@@ -358,7 +409,7 @@ public class Extractors
         }
     }
 
-    public static class ByteExtractor extends AbstractExtractor<Byte>
+    public static class ByteExtractor extends AbstractSingleValueExtractor<Byte>
     {
         private byte value;
 
@@ -368,9 +419,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             value = safeCastLongToByte( extractLong( data, offset, length ) );
+            return true;
         }
 
         @Override
@@ -396,7 +454,7 @@ public class Extractors
         Boolean.TRUE.toString().getChars( 0, BOOLEAN_MATCH.length, BOOLEAN_MATCH, 0 );
     }
 
-    public static class BooleanExtractor extends AbstractExtractor<Boolean>
+    public static class BooleanExtractor extends AbstractSingleValueExtractor<Boolean>
     {
         private boolean value;
 
@@ -406,9 +464,16 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = false;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             value = extractBoolean( data, offset, length );
+            return true;
         }
 
         @Override
@@ -423,7 +488,7 @@ public class Extractors
         }
     }
 
-    public static class CharExtractor extends AbstractExtractor<Character>
+    public static class CharExtractor extends AbstractSingleValueExtractor<Character>
     {
         private char value;
 
@@ -433,13 +498,20 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
         {
-            if ( length != 1 )
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
+        {
+            if ( length > 1 )
             {
                 throw new IllegalStateException( "Was told to extract a character, but length:" + length );
             }
             value = data[offset];
+            return true;
         }
 
         @Override
@@ -454,7 +526,7 @@ public class Extractors
         }
     }
 
-    public static class FloatExtractor extends AbstractExtractor<Float>
+    public static class FloatExtractor extends AbstractSingleValueExtractor<Float>
     {
         private float value;
 
@@ -464,10 +536,17 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             // TODO Figure out a way to do this conversion without round tripping to String
             value = Float.parseFloat( String.valueOf( data, offset, length ) );
+            return true;
         }
 
         @Override
@@ -482,7 +561,7 @@ public class Extractors
         }
     }
 
-    public static class DoubleExtractor extends AbstractExtractor<Double>
+    public static class DoubleExtractor extends AbstractSingleValueExtractor<Double>
     {
         private double value;
 
@@ -492,10 +571,17 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void clear()
+        {
+            value = 0;
+        }
+
+        @Override
+        protected boolean extract0( char[] data, int offset, int length )
         {
             // TODO Figure out a way to do this conversion without round tripping to String
             value = Double.parseDouble( String.valueOf( data, offset, length ) );
+            return true;
         }
 
         @Override
@@ -526,6 +612,15 @@ public class Extractors
         {
             return value;
         }
+
+        @Override
+        public boolean extract( char[] data, int offset, int length )
+        {
+            extract0( data, offset, length );
+            return true;
+        }
+
+        protected abstract void extract0( char[] data, int offset, int length );
 
         protected int charsToNextDelimiter( char[] data, int offset, int length )
         {
@@ -575,7 +670,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new String[numberOfValues] : EMPTY;
@@ -598,7 +693,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new byte[numberOfValues] : EMPTY;
@@ -621,7 +716,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new short[numberOfValues] : EMPTY;
@@ -644,7 +739,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new int[numberOfValues] : EMPTY;
@@ -667,7 +762,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new long[numberOfValues] : EMPTY;
@@ -690,7 +785,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new float[numberOfValues] : EMPTY;
@@ -714,7 +809,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new double[numberOfValues] : EMPTY;
@@ -738,7 +833,7 @@ public class Extractors
         }
 
         @Override
-        public void extract( char[] data, int offset, int length )
+        protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
             value = numberOfValues > 0 ? new boolean[numberOfValues] : EMPTY;

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -245,13 +245,13 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "one" );
         assertNextValue( seeker, mark, COMMA, "two" );
         assertNextValue( seeker, mark, COMMA, "three" );
-        assertNextValue( seeker, mark, COMMA, null );
+        assertNextValueNotExtracted( seeker, mark, COMMA );
         assertTrue( mark.isEndOfLine() );
 
         assertNextValue( seeker, mark, COMMA, "uno" );
         assertNextValue( seeker, mark, COMMA, "dos" );
         assertNextValue( seeker, mark, COMMA, "tres" );
-        assertNextValue( seeker, mark, COMMA, null );
+        assertNextValueNotExtracted( seeker, mark, COMMA );
         assertTrue( mark.isEndOfLine() );
 
         // THEN
@@ -263,6 +263,12 @@ public class BufferedCharSeekerTest
     {
         assertTrue( seeker.seek( mark, delimiter ) );
         assertEquals( expectedValue, seeker.extract( mark, extractors.string() ).value() );
+    }
+
+    private void assertNextValueNotExtracted( CharSeeker seeker, Mark mark, int[] delimiter ) throws IOException
+    {
+        assertTrue( seeker.seek( mark, delimiter ) );
+        assertFalse( seeker.tryExtract( mark, extractors.string() ) );
     }
 
     @Test

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -298,7 +298,8 @@ public class DataFactories
                 List<Header.Entry> columns = new ArrayList<>();
                 for ( int i = 0; !mark.isEndOfLine() && headerSeeker.seek( mark, delimiter ); i++ )
                 {
-                    String entryString = headerSeeker.extract( mark, extractors.string() ).value();
+                    String entryString = headerSeeker.tryExtract( mark, extractors.string() )
+                            ? extractors.string().value() : null;
                     int typeIndex = entryString != null ? entryString.lastIndexOf( ':' ) : -1;
                     String name;
                     String typeSpec;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
@@ -79,7 +79,8 @@ abstract class InputEntityDeserializer<ENTITY extends InputEntity> extends Prefe
 
                 // Extract it, type according to our header
                 Header.Entry entry = entries[i];
-                Object value = data.extract( mark, entry.extractor() ).value();
+                Object value = data.tryExtract( mark, entry.extractor() )
+                        ? entry.extractor().value() : null;
                 boolean handled = true;
                 switch ( entry.type() )
                 {
@@ -130,9 +131,13 @@ abstract class InputEntityDeserializer<ENTITY extends InputEntity> extends Prefe
 
     protected void addProperty( Header.Entry entry, Object value )
     {
-        ensurePropertiesArrayCapacity( propertiesCursor+2 );
-        properties[propertiesCursor++] = entry.name();
-        properties[propertiesCursor++] = value;
+        if ( value != null )
+        {
+            ensurePropertiesArrayCapacity( propertiesCursor+2 );
+            properties[propertiesCursor++] = entry.name();
+            properties[propertiesCursor++] = value;
+        }
+        // else it's fine because no value was specified
     }
 
     private Object[] properties()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserializer.java
@@ -55,7 +55,7 @@ class InputNodeDeserializer extends InputEntityDeserializer<InputNode>
         switch ( entry.type() )
         {
         case ID:
-            if ( entry.name() != null && value != null && idsAreExternal )
+            if ( entry.name() != null && idsAreExternal )
             {
                 addProperty( entry, value );
             }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -360,6 +360,48 @@ public class CsvInputTest
         }
     }
 
+    @Test
+    public void shouldIgnoreEmptyPropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory<InputNode> data = data(
+                ":ID,name,extra\n" +
+                "0,Mattias,\n" +            // here we leave out "extra" property
+                "1,Johan,Additional\n" );
+        Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL, COMMAS );
+
+        // WHEN
+        try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNode( nodes.next(), 0L, new Object[] {"name", "Mattias"}, labels() );
+            assertNode( nodes.next(), 1L, new Object[] {"name", "Johan", "extra", "Additional"}, labels() );
+            assertFalse( nodes.hasNext() );
+        }
+    }
+
+    @Test
+    public void shouldIgnoreEmptyIntPropertyValues() throws Exception
+    {
+        // GIVEN
+        DataFactory<InputNode> data = data(
+                ":ID,name,extra:int\n" +
+                "0,Mattias,\n" +            // here we leave out "extra" property
+                "1,Johan,10\n" );
+        Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
+        Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL, COMMAS );
+
+        // WHEN
+        try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
+        {
+            // THEN
+            assertNode( nodes.next(), 0L, new Object[] {"name", "Mattias"}, labels() );
+            assertNode( nodes.next(), 1L, new Object[] {"name", "Johan", "extra", 10}, labels() );
+            assertFalse( nodes.hasNext() );
+        }
+    }
+
     private <ENTITY extends InputEntity> DataFactory<ENTITY> given( final CharSeeker data )
     {
         return new DataFactory<ENTITY>()


### PR DESCRIPTION
by adding an additional CharSeeker#tryExtract returning whether or not a
value was extracted. Extractor#extract was changed to return whether or
not a values extracted for this occasion as well. The existing
CharSeeker#extract method throws exception if no value was extracted.
  Therefore skipping of empty values is consistent, whereas previously
non-primitive extractors could return null which was the only tell whether
or not a value was extracted.
