### PR TITLE
Ability to control maximum number of processors used during import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -42,7 +42,7 @@ public interface Configuration
     int fileChannelBufferSize();
 
     /**
-     * Number of batches that a stage can queue up before awaiting the downstream stage to catch up.
+     * Number of batches that a step can queue up before awaiting the downstream step to catch up.
      */
     int workAheadSize();
 
@@ -55,18 +55,26 @@ public interface Configuration
      * Max number of I/O threads doing file write operations. Optimal value for this setting is heavily
      * dependent on hard drive. A spinning disk is most likely best off with 1, where an SSD may see
      * better performance with a handful of threads writing to it simultaneously.
-     * This value eats into the cake of {@link #maxNumberOfThreads()}. The total number of threads
-     * used by the importer at any given time is {@link #maxNumberOfThreads()}, out of those
+     * This value eats into the cake of {@link #maxNumberOfProcessors()}. The total number of threads
+     * used by the importer at any given time is {@link #maxNumberOfProcessors()}, out of those
      * a maximum number of I/O threads can be used.
+     *   "Processor" in the context of the batch importer is different from "thread" since when discovering
+     * how many processors are fully in use there's a calculation where one thread takes up 0 < fraction <= 1
+     * of a processor.
      */
-    int maxNumberOfIoThreads();
+    int maxNumberOfIoProcessors();
 
     /**
-     * Max number of threads simultaneously used in total by importer at any given time.
-     * This will have to includes {@link #maxNumberOfIoThreads()}. Defaults to the value provided
-     * by the {@link Runtime#availableProcessors() jvm}.
+     * Rough max number of processors (CPU cores) simultaneously used in total by importer at any given time.
+     * This value should be set including {@link #maxNumberOfIoProcessors()} in mind.
+     * Defaults to the value provided by the {@link Runtime#availableProcessors() jvm}. There's a discrete
+     * number of threads that needs to be used just to get the very basics of the import working,
+     * so for that reason there's no lower bound to this value.
+     *   "Processor" in the context of the batch importer is different from "thread" since when discovering
+     * how many processors are fully in use there's a calculation where one thread takes up 0 < fraction <= 1
+     * of a processor.
      */
-    int maxNumberOfThreads();
+    int maxNumberOfProcessors();
 
     /**
      * For statistics the average processing time is based on total processing time divided by
@@ -115,13 +123,13 @@ public interface Configuration
         }
 
         @Override
-        public int maxNumberOfIoThreads()
+        public int maxNumberOfIoProcessors()
         {
             return max( 2, Runtime.getRuntime().availableProcessors()/3 );
         }
 
         @Override
-        public int maxNumberOfThreads()
+        public int maxNumberOfProcessors()
         {
             return Runtime.getRuntime().availableProcessors();
         }
@@ -176,15 +184,15 @@ public interface Configuration
         }
 
         @Override
-        public int maxNumberOfIoThreads()
+        public int maxNumberOfIoProcessors()
         {
-            return defaults.maxNumberOfIoThreads();
+            return defaults.maxNumberOfIoProcessors();
         }
 
         @Override
-        public int maxNumberOfThreads()
+        public int maxNumberOfProcessors()
         {
-            return defaults.maxNumberOfThreads();
+            return defaults.maxNumberOfProcessors();
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -98,7 +98,7 @@ public class ParallelBatchImporter implements BatchImporter
         this.highTokenIds = highTokenIds;
         this.logger = logging.getMessagesLog( getClass() );
         this.executionPoller = new ExecutionSupervisor( Clock.SYSTEM_CLOCK, new MultiExecutionMonitor(
-                executionMonitor, new DynamicProcessorAssigner( config, config.maxNumberOfThreads() ) ) );
+                executionMonitor, new DynamicProcessorAssigner( config, config.maxNumberOfProcessors() ) ) );
         this.monitors = new Monitors();
         this.writeMonitor = new IoMonitor();
         this.writerFactory = writerFactory.apply( config );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriterFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriterFactories.java
@@ -37,7 +37,7 @@ public class WriterFactories
             @Override
             public WriterFactory apply( Configuration configuration )
             {
-                return new IoQueue( 1, configuration.maxNumberOfIoThreads(),
+                return new IoQueue( 1, configuration.maxNumberOfIoProcessors(),
                         configuration.workAheadSize()*10, SYNCHRONOUS );
             }
         };

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -43,13 +43,13 @@ public class DynamicTaskExecutor implements TaskExecutor
     private volatile boolean shutDown;
     private volatile Throwable shutDownCause;
 
-    public DynamicTaskExecutor( int initialThreadCount, int maxQueueSize, ParkStrategy parkStrategy,
+    public DynamicTaskExecutor( int initialProcessorCount, int maxQueueSize, ParkStrategy parkStrategy,
             String processorThreadNamePrefix )
     {
         this.parkStrategy = parkStrategy;
         this.processorThreadNamePrefix = processorThreadNamePrefix;
         this.queue = new ArrayBlockingQueue<>( maxQueueSize );
-        setNumberOfProcessors( initialThreadCount );
+        setNumberOfProcessors( initialProcessorCount );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
@@ -43,7 +43,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * removes processors from those steps.</li>
  * <li>Also manages I/O threads, see {@link IoQueue}, in this aspect proxied by {@link EntityStoreUpdaterStep}.
  * <li>At all times keeps the total number of processors assigned to steps to a total of less than or equal to
- * {@link Configuration#maxNumberOfThreads()}.</li>
+ * {@link Configuration#maxNumberOfProcessors()}.</li>
  * </ul>
  */
 public class DynamicProcessorAssigner extends AbstractExecutionMonitor

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueue.java
@@ -36,19 +36,19 @@ public class IoQueue implements WriterFactory
     private final TaskExecutor executor;
     private final JobMonitor jobMonitor = new JobMonitor();
     private final WriterFactory delegateFactory;
-    private final int maxThreads;
+    private final int maxProcessors;
 
-    public IoQueue( int initialThreads, int maxThreads, int queueSize, WriterFactory delegateFactory )
+    public IoQueue( int initialProcessorCount, int maxProcessors, int queueSize, WriterFactory delegateFactory )
     {
-        this( new DynamicTaskExecutor( initialThreads, queueSize,
-                DynamicTaskExecutor.DEFAULT_PARK_STRATEGY, "IoQueue I/O thread" ), maxThreads, delegateFactory );
+        this( new DynamicTaskExecutor( initialProcessorCount, queueSize,
+                DynamicTaskExecutor.DEFAULT_PARK_STRATEGY, "IoQueue I/O thread" ), maxProcessors, delegateFactory );
     }
 
-    IoQueue( TaskExecutor executor, int maxIoThreads, WriterFactory delegateFactory )
+    IoQueue( TaskExecutor executor, int maxProcessors, WriterFactory delegateFactory )
     {
         this.executor = executor;
         this.delegateFactory = delegateFactory;
-        this.maxThreads = maxIoThreads;
+        this.maxProcessors = maxProcessors;
     }
 
     @Override
@@ -96,7 +96,7 @@ public class IoQueue implements WriterFactory
     @Override
     public boolean incrementNumberOfProcessors()
     {
-        if ( executor.numberOfProcessors() >= maxThreads )
+        if ( executor.numberOfProcessors() >= maxProcessors )
         {
             return false;
         }


### PR DESCRIPTION
also made terminology and doc around processor vs. thread in the context
of the importer more clear and consistent.
