### PR TITLE
Make the page cache eviction thread immune to OutOfMemoryErrors

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePage.java
@@ -26,7 +26,7 @@ package org.neo4j.io.pagecache.impl.muninn;
  */
 final class FreePage
 {
-    final MuninnPage page;
+    MuninnPage page;
     int count;
     FreePage next;
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -148,7 +148,6 @@ abstract class MuninnPageCursor implements PageCursor
             // check before page.fault(), because that would otherwise reopen
             // the file channel.
             assertPagedFileStillMapped();
-            page.initBuffer();
             page.fault( swapper, filePageId, faultEvent );
         }
         catch ( Throwable throwable )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/DefaultPageCacheMonitor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/DefaultPageCacheMonitor.java
@@ -263,7 +263,7 @@ public class DefaultPageCacheMonitor implements PageCacheMonitor
         }
         catch ( Throwable throwable )
         {
-            throw new AssertionError( "Unexpected MethodHandle error", throwable );
+            return NULL_PIN_EVENT;
         }
     }
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/EvictionEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/EvictionEvent.java
@@ -40,6 +40,12 @@ public interface EvictionEvent extends AutoCloseablePageCacheMonitorEvent
 
     /**
      * Eviction implies an opportunity to flush.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public FlushEventOpportunity flushEventOpportunity();
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/EvictionRunEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/EvictionRunEvent.java
@@ -28,6 +28,12 @@ public interface EvictionRunEvent extends AutoCloseablePageCacheMonitorEvent
 {
     /**
      * An eviction is started as part of this eviction run.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public EvictionEvent beginEviction();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/FlushEventOpportunity.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/FlushEventOpportunity.java
@@ -30,6 +30,12 @@ public interface FlushEventOpportunity
 {
     /**
      * Begin flushing the given page.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public FlushEvent beginFlush( long filePageId, int cachePageId, PageSwapper swapper );
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/MajorFlushEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/MajorFlushEvent.java
@@ -26,6 +26,12 @@ public interface MajorFlushEvent extends AutoCloseablePageCacheMonitorEvent
 {
     /**
      * Mass-flushing obviously imply flushing opportunities.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public FlushEventOpportunity flushEventOpportunity();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheMonitor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheMonitor.java
@@ -301,25 +301,49 @@ public interface PageCacheMonitor
 
     /**
      * A background eviction has begun. Called from the background eviction thread.
-     * 
+     * <p>
      * This call will be paired with a following PageCacheMonitor#endPageEviction call.
-     *
+     * <p>
      * The method returns an EvictionRunEvent to represent the event of this eviction run.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      **/
     public EvictionRunEvent beginPageEvictions( int pageCountToEvict );
 
     /**
      * A page is to be pinned.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public PinEvent beginPin( boolean exclusiveLock, long filePageId, PageSwapper swapper );
 
     /**
      * A PagedFile wants to flush all its bound pages.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public MajorFlushEvent beginFileFlush( PageSwapper swapper );
 
     /**
      * The PageCache wants to flush all its bound pages.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public MajorFlushEvent beginCacheFlush();
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PinEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PinEvent.java
@@ -31,6 +31,12 @@ public interface PinEvent
 
     /**
      * The page we want to pin is not in memory, so being a page fault to load it in.
+     * <p>
+     * Implementers note: This method is not allowed to throw anything ever,
+     * not even OutOfMemoryError. Furthermore, it must always return a non-null
+     * value. So if the implementation cannot return an event object specific
+     * to its implementation, then it MUST return the relevant null-object
+     * constant from the PageCacheMonitor interface.
      */
     public PageFaultEvent beginPageFault();
 

--- a/community/io/src/test/java/org/neo4j/io/fs/StoreFileChannelTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/StoreFileChannelTest.java
@@ -19,12 +19,17 @@
  */
 package org.neo4j.io.fs;
 
+import org.junit.Test;
+
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-import org.junit.Test;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class StoreFileChannelTest
 {
@@ -32,8 +37,8 @@ public class StoreFileChannelTest
     public void shouldHandlePartialWrites() throws Exception
     {
         // Given
-        FileChannel mockChannel = mock(FileChannel.class);
-        when(mockChannel.write( any(ByteBuffer.class), anyLong() )).thenReturn( 4 );
+        FileChannel mockChannel = mock( FileChannel.class );
+        when(mockChannel.write( any( ByteBuffer.class ), anyLong() ) ).thenReturn( 4 );
 
         ByteBuffer buffer = ByteBuffer.wrap( "Hello, world!".getBytes( "UTF-8" ) );
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -646,7 +646,7 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
         channel.close();
     }
 
-    @Test( timeout = 1000 )
+    @Test( timeout = 10000 )
     public void flushingDuringPagedFileCloseMustRetryUntilItSucceeds() throws IOException
     {
         FileSystemAbstraction fs = new DelegatingFileSystemAbstraction( this.fs )
@@ -661,7 +661,7 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
                     @Override
                     public void writeAll( ByteBuffer src, long position ) throws IOException
                     {
-                        if ( writeCount++ < 10 )
+                        if ( writeCount++ < 5 )
                         {
                             throw new IOException( "This is a benign exception that we expect to be thrown " +
                                                    "during a flush of a PagedFile." );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
@@ -19,10 +19,13 @@
  */
 package org.neo4j.io.pagecache;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,17 +34,15 @@ import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith( Parameterized.class )
 public abstract class PageSwappingTest


### PR DESCRIPTION
These changes are fairly subtle, but they should allow the eviction thread so survive all possible OutOfMemoryErrors. OOMEs can be thrown from every spot where we, or anyone really, allocate an object. And they can also be thrown from UnsafeUtil.malloc.

These changes have been made by carefully analysing the code line by line. There are no tests ensuring that the property of OOME resilience is upheld in the future, so we have to be careful with our maintenance. The reason for the lack of testing is simply that I couldn't think of any way to test this in any way that is even remotely comprehensible.

I recommend a well-aged Islay whisky, a stress-free environment and plenty of time, when reviewing these changes.