### PR TITLE
Move naming of pattern elements in pattern relationships to Planning

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/Pattern.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/Pattern.scala
@@ -193,11 +193,16 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
 }
 
 sealed abstract class PatternElement extends ASTNode with ASTParticle {
+  def identifier: Option[Identifier]
   def declareIdentifiers(ctx: SemanticContext): SemanticCheck
   def semanticCheck(ctx: SemanticContext): SemanticCheck
 }
 
-case class RelationshipChain(element: PatternElement, relationship: RelationshipPattern, rightNode: NodePattern)(val position: InputPosition) extends PatternElement {
+case class RelationshipChain(element: PatternElement, relationship: RelationshipPattern, rightNode: NodePattern)(val position: InputPosition)
+  extends PatternElement {
+
+  def identifier: Option[Identifier] = relationship.identifier
+
   def declareIdentifiers(ctx: SemanticContext): SemanticCheck =
     element.declareIdentifiers(ctx) chain
     relationship.declareIdentifiers(ctx) chain

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/namePatternElements.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/namePatternElements.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
+import org.neo4j.cypher.internal.compiler.v2_2.helpers.UnNamedNameGenerator
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.PatternExpressionPatternElementNamer
+
+case object nameAllPatternElements extends Rewriter {
+
+  override def apply(in: AnyRef): AnyRef = bottomUp(namingRewriter).apply(in)
+
+  val namingRewriter: Rewriter = bottomUp(Rewriter.lift {
+    case pattern: NodePattern if !pattern.identifier.isDefined =>
+      val syntheticName = UnNamedNameGenerator.name(pattern.position.offset + 1)
+      pattern.copy(identifier = Some(Identifier(syntheticName)(pattern.position)))(pattern.position)
+
+    case pattern: RelationshipPattern if !pattern.identifier.isDefined  =>
+      val syntheticName = UnNamedNameGenerator.name(pattern.position.offset + 1)
+      pattern.copy(identifier = Some(Identifier(syntheticName)(pattern.position)))(pattern.position)
+  })
+}
+
+case object namePatternPredicatePatternElements extends Rewriter {
+
+  override def apply(in: AnyRef): AnyRef = bottomUp(instance).apply(in)
+
+  val instance: Rewriter = Rewriter.lift {
+    case expr: PatternExpression =>
+      val (rewrittenExpr, _) = PatternExpressionPatternElementNamer(expr)
+      rewrittenExpr
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
@@ -100,8 +100,7 @@ object Planner {
       nameUpdatingClauses,
       projectNamedPaths,
       projectFreshSortExpressions,
-      inlineProjections,
-      namePatternPredicates
+      inlineProjections
     )
 
     statement.endoRewrite(rewriter)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/SemanticTable.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/SemanticTable.scala
@@ -33,14 +33,22 @@ class SemanticTable(
     val resolvedLabelIds: mutable.Map[String, LabelId] = new mutable.HashMap[String, LabelId],
     val resolvedPropertyKeyNames: mutable.Map[String, PropertyKeyId] = new mutable.HashMap[String, PropertyKeyId],
     val resolvedRelTypeNames: mutable.Map[String, RelTypeId] = new mutable.HashMap[String, RelTypeId]
-  ) {
+  ) extends Cloneable {
 
   def isNode(expr: Identifier) = types(expr).specified == symbols.CTNode.invariant
 
   def isRelationship(expr: Identifier) = types(expr).specified == symbols.CTRelationship.invariant
 
+  def addNode(expr: Identifier) =
+    copy(types = types.updated(expr, ExpressionTypeInfo(symbols.CTNode.invariant, None)))
+
+  def addRelationship(expr: Identifier) =
+    copy(types = types.updated(expr, ExpressionTypeInfo(symbols.CTRelationship.invariant, None)))
+
   def replaceKeys(replacements: (Identifier, Identifier)*): SemanticTable =
     copy(types = types.replaceKeys(replacements: _*))
+
+  override def clone() = copy()
 
   def copy(
     types: ASTAnnotationMap[Expression, ExpressionTypeInfo] = types,
@@ -48,5 +56,5 @@ class SemanticTable(
     resolvedPropertyKeyNames: mutable.Map[String, PropertyKeyId] = resolvedPropertyKeyNames,
     resolvedRelTypeNames: mutable.Map[String, RelTypeId] = resolvedRelTypeNames
   ) =
-    new SemanticTable(types, resolvedLabelIds, resolvedPropertyKeyNames, resolvedRelTypeNames)
+    new SemanticTable(types, resolvedLabelIds.clone(), resolvedPropertyKeyNames.clone(), resolvedRelTypeNames.clone())
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamer.scala
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
+import org.neo4j.cypher.internal.compiler.v2_2.helpers.UnNamedNameGenerator
+
+object PatternExpressionPatternElementNamer {
+
+  def apply(expr: PatternExpression): (PatternExpression, Map[PatternElement, Identifier]) = {
+    val unnamedMap = nameUnnamedPatternElements(expr)
+    val namedPattern = expr.pattern.endoRewrite(namePatternElementsFromMap(unnamedMap))
+    val namedExpr = expr.copy(pattern = namedPattern)
+    (namedExpr, unnamedMap)
+  }
+
+  private def nameUnnamedPatternElements(expr: PatternExpression): Map[PatternElement, Identifier] = {
+    val unnamedElements = findPatternElements(expr.pattern).filter(_.identifier.isEmpty)
+    val unnamedMap: Map[PatternElement, Identifier] = unnamedElements.map {
+      case elem: NodePattern =>
+        elem -> Identifier(UnNamedNameGenerator.name(elem.position.offset + 1))(elem.position)
+      case elem@RelationshipChain(_, relPattern, _) =>
+        elem -> Identifier(UnNamedNameGenerator.name(relPattern.position.offset + 1))(relPattern.position)
+    }.toMap
+    unnamedMap
+  }
+
+  private case object findPatternElements {
+    def apply(astNode: ASTNode): Set[PatternElement] = astNode.treeFold(Set.empty[PatternElement]) {
+      case patternElement: PatternElement =>
+        (acc, children) => children(acc + patternElement)
+
+      case patternExpr: PatternExpression =>
+        (acc, _) => acc
+    }
+  }
+
+  private case class namePatternElementsFromMap(map: Map[PatternElement, Identifier]) extends Rewriter {
+    def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
+
+    private val instance: Rewriter = Rewriter.lift {
+      case pattern: NodePattern if map.contains(pattern) =>
+        pattern.copy(identifier = Some(map(pattern)))(pattern.position)
+      case pattern: RelationshipChain if map.contains(pattern) =>
+        val rel = pattern.relationship
+        pattern.copy(relationship = rel.copy(identifier = Some(map(pattern)))(rel.position))(pattern.position)
+    }
+  }
+}
+

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphSolvingContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphSolvingContext.scala
@@ -35,8 +35,15 @@ case class LogicalPlanningContext(planContext: PlanContext,
     copy(cardinalityInput = newInput)
   }
 
-  def forExpressionPlanning =
-    copy(cardinalityInput = cardinalityInput.copy(inboundCardinality = Cardinality(1)))
+  def forExpressionPlanning(nodes: Iterable[Identifier], rels: Iterable[Identifier]) = {
+    val tableWithNodes = nodes.foldLeft(semanticTable) { case (table, node) => table.addNode(node) }
+    val tableWithRels = rels.foldLeft(tableWithNodes) { case (table, rel) => table.addRelationship(rel) }
+
+    copy(
+      cardinalityInput = cardinalityInput.copy(inboundCardinality = Cardinality(1)),
+      semanticTable = tableWithRels
+    )
+  }
 
   def statistics = planContext.statistics
   def cost = metrics.cost

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NameMatchPatternElementTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NameMatchPatternElementTest.scala
@@ -42,14 +42,6 @@ class NameMatchPatternElementTest extends CypherFunSuite {
     assert(result === expected)
   }
 
-  test("name all pattern predicates in a query") {
-    val original = parser.parse("MATCH (n)-[:Foo]->(m) WHERE (n)-[:Bar]->(m) RETURN n")
-    val expected = parser.parse("MATCH (n)-[:Foo]->(m) WHERE (n)-[`  UNNAMED32`:Bar]->(m) RETURN n")
-
-    val result = original.rewrite(namePatternPredicates)
-    assert(result === expected)
-  }
-
   test("rename unnamed varlength paths") {
     val original = parser.parse("MATCH (n)-[:Foo*]->(m) RETURN n")
     val expected = parser.parse("MATCH (n)-[`  UNNAMED10`:Foo*]->(m) RETURN n")

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/SemanticTableTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/SemanticTableTest.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{Identifier, AstConstructionTestSupport}
+
+class SemanticTableTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  override implicit def ident(name: String): Identifier = Identifier(name)(pos)
+
+  test("can add nodes to a SemanticTable") {
+    val table = SemanticTable().addNode("x")
+
+    table.isNode("x") should be(true)
+    table.isRelationship("x") should be(false)
+  }
+
+  test("can add rels to a SemanticTable") {
+    val table = SemanticTable().addRelationship("r")
+
+    table.isRelationship("r") should be(true)
+    table.isNode("r") should be(false)
+  }
+
+  test("doesn't share mutable references after being copied") {
+    val table1 = SemanticTable()
+    val table2 = table1.copy()
+
+    (table1.resolvedLabelIds eq table2.resolvedLabelIds) should be(false)
+    (table1.resolvedPropertyKeyNames eq table2.resolvedPropertyKeyNames) should be(false)
+    (table1.resolvedRelTypeNames eq table2.resolvedRelTypeNames) should be(false)
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.Direction
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{PlannerQuery, LogicalPlanningTestSupport2}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_2.{InputPosition, ast}
+import org.neo4j.cypher.internal.compiler.v2_2.{InputPosition}
 
 class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
@@ -89,7 +89,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
                   )
                 )
       ), _) =>
-        val predicate: ast.Expression = ast.Equals(ast.Identifier("a1")_, ast.Identifier("a1$$$_")_)_
+        val predicate: Expression = Equals(Identifier("a1")_, Identifier("a1$$$_")_)_
         predicates should equal(Seq(predicate))
     }
   }
@@ -110,10 +110,10 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       ), _) =>
         args should equal(Set(IdName("r"), IdName("a1")))
 
-        val predicate1: ast.Expression = ast.Equals(ast.Identifier("a2")_, ast.Identifier("a2$$$_")_)_
+        val predicate1: Expression = Equals(Identifier("a2")_, Identifier("a2$$$_")_)_
         predicates1 should equal(Seq(predicate1))
 
-        val predicate2: ast.Expression = ast.Equals(ast.Identifier("a1")_, ast.Identifier("a2")_)_
+        val predicate2: Expression = Equals(Identifier("a1")_, Identifier("a2")_)_
         predicates2 should equal(Seq(predicate2))
     }
   }
@@ -132,7 +132,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
           )
         )
       ), _) =>
-        val predicate: ast.Expression = ast.Equals(ast.Identifier("a2")_, ast.Identifier("a2$$$_")_)_
+        val predicate: Expression = Equals(Identifier("a2")_, Identifier("a2$$$_")_)_
         predicates should equal(Seq(predicate))
     }
   }
@@ -144,8 +144,8 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
         OptionalExpand(
           OptionalExpand(
             AllNodesScan(IdName("a"), Set.empty)(PlannerQuery.empty),
-            IdName("a"), Direction.OUTGOING, List(ast.RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(PlannerQuery.empty),
-          IdName("a"), Direction.OUTGOING, List(ast.RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(PlannerQuery.empty),
+            IdName("a"), Direction.OUTGOING, List(RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(PlannerQuery.empty),
+          IdName("a"), Direction.OUTGOING, List(RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(PlannerQuery.empty),
         Map("a" -> ident("a"), "x1" -> ident("x1"), "x2" -> ident("x2"))
       )(PlannerQuery.empty)
     )

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamerTest.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
+import org.neo4j.cypher.internal.compiler.v2_2.planner.LogicalPlanningTestSupport2
+
+class PatternExpressionPatternElementNamerTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+
+  test("should not touch anything if everything is named") {
+    val original = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (a)-[r]->(b)")
+    val (actual, map) = PatternExpressionPatternElementNamer(original)
+    val expected = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (a)-[r]->(b)")
+
+    actual should equal(expected)
+    map should be(empty)
+  }
+
+  test("should name nodes") {
+    val original = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN ()-[r]->(b)")
+    val (actual, map) = PatternExpressionPatternElementNamer(original)
+    val expected = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (`  UNNAMED50`)-[r]->(b)")
+
+    actual should equal(expected)
+    processMap(map) should equal(Map(49 -> "  UNNAMED50"))
+  }
+
+  test("should name relationships") {
+    val original = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (a)-[]->(b)")
+    val (actual, map) = PatternExpressionPatternElementNamer(original)
+    val expected = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (a)-[`  UNNAMED53`]->(b)")
+
+    actual should equal(expected)
+    processMap(map) should equal(Map(52 -> "  UNNAMED53"))
+  }
+
+  private def processMap(map: Map[PatternElement, Identifier]) = {
+    map.collect {
+      case (pattern: NodePattern, ident) => pattern.position.offset -> ident.name
+      case (pattern: RelationshipChain, ident) => pattern.relationship.position.offset -> ident.name
+    }.toMap
+  }
+
+  private def parsePatternExpression(query: String): PatternExpression = {
+    parser.parse(query) match {
+      case Query(_, SingleQuery(clauses)) =>
+        val ret = clauses.last.asInstanceOf[Return]
+        val patExpr = ret.returnItems.items.head.expression.asInstanceOf[PatternExpression]
+        patExpr
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryPlanningStrategyTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryPlanningStrategyTest.scala
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.InputPosition
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics.QueryGraphCardinalityInput
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport2, QueryGraph, SemanticTable}
+
+class QueryPlanningStrategyTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+
+  test("names unnamed patterns when planning pattern expressions") {
+    // given
+    implicit val context = LogicalPlanningContext(null, null, SemanticTable(), mock[QueryGraphSolver], QueryGraphCardinalityInput.empty)
+    val patExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN ()-[]->(b)")
+
+    // when
+    val (_, namedExpr) = QueryPlanningStrategy.planPatternExpression(Set.empty, patExpr)
+
+    // then
+    val expectedExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (`  UNNAMED50`)-[`  UNNAMED52`]->(b)")
+
+    expectedExpr should equal(namedExpr)
+  }
+
+  test("build correct semantic table when planning pattern expressions") {
+
+    // then
+    val solver = new QueryGraphSolver {
+      override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
+        val table = context.semanticTable
+        table.isNode(Identifier("  UNNAMED50")(InputPosition(49, 1, 50))) should be(true)
+        table.isRelationship(Identifier("  UNNAMED52")(InputPosition(51, 1, 52))) should be(true)
+        null
+      }
+    }
+
+    // given
+    implicit val context = LogicalPlanningContext(null, null, SemanticTable(), solver, QueryGraphCardinalityInput.empty)
+    val patExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN ()-[]->(b)")
+
+    // when
+    QueryPlanningStrategy.planPatternExpression(Set.empty, patExpr)
+  }
+
+  private def parsePatternExpression(query: String): PatternExpression = {
+    parser.parse(query) match {
+      case Query(_, SingleQuery(clauses)) =>
+        val ret = clauses.last.asInstanceOf[Return]
+        val patExpr = ret.returnItems.items.head.expression.asInstanceOf[PatternExpression]
+        patExpr
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityData.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityData.scala
@@ -186,6 +186,14 @@ trait ABCDCardinalityData {
 
     def forQuery(testUnit: CardinalityTestHelper#TestUnit) =
       testUnit.
+        withNodeName("a").
+        withNodeName("b").
+        withNodeName("c").
+        withNodeName("d").
+        withRelationshipName("r1").
+        withRelationshipName("r2").
+        withRelationshipName("r3").
+        withRelationshipName("r4").
         withGraphNodes(N).
         withLabel('A, A).
         withLabel('B, B).

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityTestHelper.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityTestHelper.scala
@@ -49,10 +49,16 @@ trait CardinalityTestHelper extends QueryGraphProducer {
                       knownIndexSelectivity: Map[(String, String), Double] = Map.empty,
                       knownProperties: Set[String] = Set.empty,
                       knownRelationshipCardinality: Map[(String, String, String), Double] = Map.empty,
+                      knownNodeNames: Set[String] = Set.empty,
+                      knownRelNames: Set[String] = Set.empty,
                       queryGraphArgumentIds: Set[IdName] = Set.empty,
                       inboundCardinality: Cardinality = Cardinality(1)) {
 
     self =>
+
+    def withNodeName(nodeName: String) = copy(knownNodeNames = knownNodeNames + nodeName)
+
+    def withRelationshipName(relName: String) = copy(knownRelNames = knownRelNames + relName)
 
     def withInboundCardinality(d: Double) = copy(inboundCardinality = Cardinality(d))
 
@@ -170,9 +176,13 @@ trait CardinalityTestHelper extends QueryGraphProducer {
         }
       }
 
-      val semanticTable: SemanticTable = new SemanticTable() {
-        override def isRelationship(expr: Identifier): Boolean = true
+      val semanticTable: SemanticTable = {
+        val empty = SemanticTable()
+        val withNodes = knownNodeNames.foldLeft(empty) { case (table, node) => table.addNode(Identifier(node)(pos)) }
+        val withNodesAndRels = knownRelNames.foldLeft(withNodes) { case (table, rel) => table.addRelationship(Identifier(rel)(pos)) }
+        withNodesAndRels
       }
+
       fill(semanticTable.resolvedLabelIds, labelIds, LabelId.apply)
       fill(semanticTable.resolvedPropertyKeyNames, propertyIds, PropertyKeyId.apply)
       fill(semanticTable.resolvedRelTypeNames, relTypeIds, RelTypeId.apply)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
@@ -189,14 +189,14 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
       "MATCH (a:A) WHERE id(a) IN [1,2,3]"
         -> A * (3.0 / N),
 
-      "MATCH (a:A)-[:T1]->(b:B)-[:T2]->(c:C)"
+      "MATCH (a:A)-[r1:T1]->(b:B)-[r2:T2]->(c:C)"
         -> N * N * N * Asel * A_T1_B_sel * Bsel * B_T2_C_sel * Csel,
 
-      "MATCH (a:A)-[:T1]->(b:B)-[:T1]->(c:C)"
+      "MATCH (a:A)-[r1:T1]->(b:B)-[r2:T1]->(c:C)"
         -> N * N * N * Asel * A_T1_B_sel * Bsel * B_T1_C_sel * Csel *
         DEFAULT_REL_UNIQUENESS_SELECTIVITY,
 
-      "MATCH (:A)-[:T1]->(:A)-[:T1]->(:B)-[:T1]->(:B)"
+      "MATCH (:A)-[r1:T1]->(:A)-[r2:T1]->(:B)-[r3:T1]->(:B)"
         -> A * A * B * B * A_T1_A_sel * A_T1_B_sel * B_T1_B_sel *
         Math.pow(DEFAULT_REL_UNIQUENESS_SELECTIVITY, 3), // Once per rel-uniqueness predicate
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher
 import org.json4s.JsonAST._
 import org.json4s.native.JsonMethods
 import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v2_2.parser.{CypherParser, ParserMonitor}
 import org.neo4j.cypher.internal.compiler.v2_2.planner._
@@ -53,7 +54,7 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
   def buildCompiler(metricsFactoryInput: MetricsFactory = SimpleMetricsFactory)(graph: GraphDatabaseService) = {
     val kernelMonitors = new KernelMonitors()
     val monitors = new Monitors(kernelMonitors)
-    val parser = new CypherParser(monitors.newMonitor[ParserMonitor[ast.Statement]](monitorTag))
+    val parser = new CypherParser(monitors.newMonitor[ParserMonitor[Statement]](monitorTag))
     val checker = new SemanticChecker(monitors.newMonitor[SemanticCheckMonitor](monitorTag))
     val rewriter = new ASTRewriter(monitors.newMonitor[AstRewritingMonitor](monitorTag))
     val planBuilderMonitor = monitors.newMonitor[NewLogicalPlanSuccessRateMonitor](monitorTag)


### PR DESCRIPTION
This commit achieves the following invariants:

o In Planner, every identifier is covered by semantic table.
o All pattern elements are named in Planner, except if inside a PatternExpression
