### PR TITLE
Remove the use of reachability fences

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -45,7 +45,6 @@ final class MuninnReadPageCursor extends MuninnPageCursor
             {
                 p.unlockRead( lockStamp );
             }
-            UnsafeUtil.retainReference( p );
         }
         lockStamp = 0;
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
@@ -36,7 +36,6 @@ final class MuninnWritePageCursor extends MuninnPageCursor
             pinEvent.done();
             assert page.isWriteLocked(): "page pinned for writing was not write locked: " + page;
             page.unlockWrite( lockStamp );
-            UnsafeUtil.retainReference( page );
             page = null;
         }
         lockStamp = 0;


### PR DESCRIPTION
We don't need them because the use of the native pointer is contained within the critical section of the pin, as represented by the StampedLock. This locking similarly constrains the life-time of the page objects.
In essence, use of the native pointer cannot move above taking the lock, nor bellow its release, and since the MuninnPage objects are themselves StampedLocks, their life-times is guaranteed to extend at least as far as their last lock release.
