### PR TITLE
Fixes leak of file mapping from count store on error during file open

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsStore.java
@@ -98,7 +98,7 @@ public class CountsStore extends SortedKeyValueStore<CountsKey, CopyableDoubleLo
 
             return countsStore;
         }
-        catch ( RuntimeException e )
+        catch ( Exception e )
         {
             pageCache.unmap( storeFile );
             throw e;


### PR DESCRIPTION
It is possible for the count store files to be perceived as
 unusable in case the header information or some key data is not
 consistent. While not a fatal error, this is communicated by
 throwing an IOException which is caught and the paged portion
 of the opened file will be unmapped. However, before this
 fix it was that IOException would be ignored by the responsible
 catch clause, leading to the leak of the file map and the
 inability of the database to shutdown since that file was
 mapped.
This patch fixes the issue by catching all possible Exceptions
 thrown during open and not only RuntimeExceptions as before.
