### PR TITLE
Fix a bug in the counts store which prevents recovery to happen

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -177,7 +177,7 @@ public class StoreFactory
                 newNodeStore(),
                 newSchemaStore(),
                 newRelationshipGroupStore(),
-                newCountsStore( txId ),
+                newCountsStore(),
                 versionMismatchHandler, monitors );
     }
 
@@ -205,7 +205,7 @@ public class StoreFactory
             try ( NodeStore nodeStore = newNodeStore();
                   RelationshipStore relationshipStore = newRelationshipStore();
                   CountsTracker tracker = new CountsTracker(
-                          stringLogger, fileSystemAbstraction, pageCache, storeFileBase, BASE_TX_ID ) )
+                          stringLogger, fileSystemAbstraction, pageCache, storeFileBase ) )
             {
                 CountsComputer.computeCounts( nodeStore, relationshipStore ).
                         accept( new CountsAccessor.Initializer( tracker ) );
@@ -381,9 +381,9 @@ public class StoreFactory
                 fileSystemAbstraction, stringLogger, dynamicLabelStore, versionMismatchHandler, monitors );
     }
 
-    private CountsTracker newCountsStore( long txId )
+    private CountsTracker newCountsStore()
     {
-        return new CountsTracker( stringLogger, fileSystemAbstraction, pageCache, storeFileName( COUNTS_STORE ), txId );
+        return new CountsTracker( stringLogger, fileSystemAbstraction, pageCache, storeFileName( COUNTS_STORE ) );
     }
 
     public NeoStore createNeoStore()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -63,22 +63,12 @@ public class CountsTracker implements CountsVisitor.Visitable, AutoCloseable, Co
     private final StringLogger logger;
     private volatile CountsTrackerState state;
 
-    public CountsTracker( StringLogger logger, FileSystemAbstraction fs, PageCache pageCache,
-                          File storeFileBase, long neoStoreTxId )
+    public CountsTracker( StringLogger logger, FileSystemAbstraction fs, PageCache pageCache, File storeFileBase )
     {
         this.logger = logger;
         this.alphaFile = storeFile( storeFileBase, ALPHA );
         this.betaFile = storeFile( storeFileBase, BETA );
         CountsStore store = openStore( logger, fs, pageCache, this.alphaFile, this.betaFile );
-        if ( store.lastTxId() < neoStoreTxId )
-        {
-            IOException exOnClose = safelyCloseTheStore( store );
-            throw new UnderlyingStorageException(
-                    "Counts store seems to be out of date (last count store txid is " + store.lastTxId() + " but " +
-                    "database wide last txid is " + neoStoreTxId + "). Please shut down the database and manually " +
-                    "delete the counts store files: " + alphaFile + " and " + betaFile + " to have the database " +
-                    "recreate them on next startup", exOnClose );
-        }
         this.state = new ConcurrentCountsTrackerState( store );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -95,7 +95,6 @@ import static org.neo4j.kernel.impl.store.StoreFactory.buildTypeDescriptorAndVer
 import static org.neo4j.kernel.impl.storemigration.FileOperation.COPY;
 import static org.neo4j.kernel.impl.storemigration.FileOperation.DELETE;
 import static org.neo4j.kernel.impl.storemigration.FileOperation.MOVE;
-import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 import static org.neo4j.unsafe.impl.batchimport.WriterFactories.parallel;
 
@@ -257,7 +256,7 @@ public class StoreMigrator implements StoreMigrationParticipant
         try ( NodeStore nodeStore = storeFactory.newNodeStore();
               RelationshipStore relationshipStore = storeFactory.newRelationshipStore();
               CountsTracker tracker = new CountsTracker( logging.getMessagesLog( CountsTracker.class ),
-                      fileSystem, pageCache, storeFileBase, BASE_TX_ID ) )
+                      fileSystem, pageCache, storeFileBase ) )
         {
             CountsComputer.computeCounts( nodeStore, relationshipStore ).
                     accept( new CountsAccessor.Initializer( tracker ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -329,7 +329,7 @@ public class CountsComputerTest
     private void rebuildCounts( CountsRecordState countsState, long lastCommittedTransactionId ) throws IOException
     {
         CountsTracker tracker = new CountsTracker( StringLogger.DEV_NULL, fs, pageCache,
-                new File( dir, COUNTS_STORE_BASE ), BASE_TX_ID );
+                new File( dir, COUNTS_STORE_BASE ) );
         countsState.accept( new CountsAccessor.Initializer( tracker ) );
         tracker.rotate( lastCommittedTransactionId );
         tracker.close();

--- a/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package recovery;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.api.CountsVisitor;
+import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
+import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.counts.CountsTracker;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.ReflectionUtil;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.test.EphemeralFileSystemRule.shutdownDb;
+
+public class CountsStoreRecoveryTest
+{
+    @Test
+    public void shouldRecoverTheCountsStoreEvenWhenIfNeoStoreDoesNotNeedRecovery() throws Exception
+    {
+        // given
+        createNode( "A" );
+        rotateLog();
+        createNode( "B" );
+        flushNeoStoreOnly();
+
+        // when
+        crashAndRestart();
+
+        // then
+        final AtomicInteger number = new AtomicInteger( 0 );
+        counts().accept( new CountsVisitor.Adapter()
+        {
+            @Override
+            public void visitNodeCount( int labelId, long count )
+            {
+                number.incrementAndGet();
+                if ( labelId != -1 )
+                {
+                    assertEquals( 1, count );
+                }
+                else
+                {
+                    assertEquals( 2, count );
+                }
+            }
+        } );
+        assertEquals( 3, number.get() );
+    }
+
+    private void flushNeoStoreOnly() throws Exception
+    {
+        NeoStore neoStore = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( NeoStore.class );
+        PagedFile storeFile = ReflectionUtil.getPrivateField( neoStore, "storeFile", PagedFile.class );
+        storeFile.flush();
+    }
+
+    private CountsTracker counts()
+    {
+        return ((GraphDatabaseAPI) db).getDependencyResolver()
+                                      .resolveDependency( NeoStore.class )
+                                      .getCounts();
+    }
+
+    @SuppressWarnings( "deprecated" )
+    private void rotateLog() throws IOException
+    {
+        ((GraphDatabaseAPI) db).getDependencyResolver()
+                               .resolveDependency( NeoStoreDataSource.class )
+                               .getDependencyResolver()
+                               .resolveDependency( PhysicalLogFile.class )
+                               .forceRotate();
+    }
+
+    private void crashAndRestart()
+    {
+        FileSystemAbstraction uncleanFs = fsRule.snapshot( shutdownDb( db ) );
+        db = databaseFactory( uncleanFs, indexProvider ).newImpermanentDatabase();
+    }
+
+    private void createNode( String label )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( label ) );
+
+            tx.success();
+        }
+    }
+
+    @Rule
+    public final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private GraphDatabaseService db;
+    private InMemoryIndexProvider indexProvider = new InMemoryIndexProvider( 100 );
+
+    @Before
+    public void before()
+    {
+        db = databaseFactory( fsRule.get(), indexProvider ).newImpermanentDatabase();
+    }
+
+    private TestGraphDatabaseFactory databaseFactory( FileSystemAbstraction fs, InMemoryIndexProvider indexProvider )
+    {
+        return new TestGraphDatabaseFactory()
+                .setFileSystem( fs ).addKernelExtension( new InMemoryIndexProviderFactory( indexProvider ) );
+    }
+
+    @After
+    public void after()
+    {
+        db.shutdown();
+    }
+}


### PR DESCRIPTION
The CountsTracker code was checking that the txId stored in the Counts
Store is never smaller than the txId stored in the NeoStore.  This is
not always true. The wrong assumption here is that dispite the fact
that the code rotates the Counts Store before flushing the NeoStore
pages, it might happen that the PageCache decides to evict the
NeoStore pages (and hence flush them to disk) before the Counts Store
rotation. The fix is basically removing the check and trust recovery
to fix the stores.
