### PR TITLE
Fix flaky tests by adding a custom matcher

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
@@ -103,6 +103,20 @@ object Cardinality {
 
   def max(l: Cardinality, r: Cardinality): Cardinality =
     Cardinality(Math.max(l.amount, r.amount))
+
+  object NumericCardinality extends Numeric[Cardinality] {
+    def toDouble(x: Cardinality): Double = x.amount
+    def toFloat(x: Cardinality): Float = x.amount.toFloat
+    def toInt(x: Cardinality): Int = x.amount.toInt
+    def toLong(x: Cardinality): Long = x.amount.toLong
+    def fromInt(x: Int): Cardinality = Cardinality(x)
+
+    def negate(x: Cardinality): Cardinality = Cardinality(-x.amount)
+    def plus(x: Cardinality, y: Cardinality): Cardinality = Cardinality(x.amount + y.amount)
+    def times(x: Cardinality, y: Cardinality): Cardinality = Cardinality(x.amount * y.amount)
+    def minus(x: Cardinality, y: Cardinality): Cardinality = Cardinality(x.amount - y.amount)
+    def compare(x: Cardinality, y: Cardinality): Int = x.compare(y)
+  }
 }
 
 case class CostPerRow(cost: Double) {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/triplet/SimpleTripletCardinalityEstimatorTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/triplet/SimpleTripletCardinalityEstimatorTest.scala
@@ -37,7 +37,8 @@ class SimpleTripletCardinalityEstimatorTest
   with CardinalityTestHelper
   with ForumPostsCardinalityData {
 
-  implicit val input = QueryGraphCardinalityInput.empty
+  private val TOLERANCE = 0.0001d
+  private implicit val input = QueryGraphCardinalityInput.empty
 
   test("(a)-[r]->(b)") {
     import ForumPosts._
@@ -49,9 +50,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a)-[r]->(b)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> R
-    ))
+    ), TOLERANCE)
   }
 
   test("(a)-[r]-(b)") {
@@ -64,9 +65,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a)-[r]-(b)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> 2 * R
-    ))
+    ), TOLERANCE)
   }
 
   test("(a:Forum)-[r:MEMBER_IN]->(b:Forum:Person)") {
@@ -79,9 +80,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a:Forum)-[r:MEMBER_IN]->(b:Forum:Person)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> degree(Forums_MEMBER_IN_Forums, Forums) * N
-    ))
+    ), TOLERANCE)
   }
 
   test("(a:Person)-[r:KNOWS]->(b:Person)") {
@@ -94,9 +95,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a:Person)-[r:KNOWS]->(b:Person)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> degree(Persons_KNOWS_Persons, Persons)
-    ))
+    ), TOLERANCE)
   }
 
   test("(a:Person)-[r:KNOWS]->(b:Person:Clown)") {
@@ -107,9 +108,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a:Person)-[r:KNOWS]->(b:Person:Clown)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> 0.0d
-    ))
+    ), TOLERANCE)
   }
 
   test("(a:Person)-[r:XXX]->(b:Person)") {
@@ -120,9 +121,9 @@ class SimpleTripletCardinalityEstimatorTest
 
     val estimates = ForumPosts.asTriplets("(a:Person)-[r:XXX]->(b:Person)", nodeCardinalities)
 
-    estimates should equal(cardinalitiesMap(
+    estimates should equalWithTolerance(cardinalitiesMap(
       "r" -> 0.0d
-    ))
+    ), TOLERANCE)
   }
 
   implicit class RichCardinalityData(cardinalityData: CardinalityData) {


### PR DESCRIPTION
- when checking maps of Cardinalities we need to make sure we have a
  internally a tolerance when comparing doubles
