### PR TITLE
Reserved rel-type records are removed during IdGenerator rebuild

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/RelationshipTypeTokenStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.nioneo.store;
 
 import java.io.File;
+import java.nio.ByteBuffer;
 
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
@@ -75,8 +76,8 @@ public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeToken
     }
 
     @Override
-    protected boolean reserveIdsDuringRebuild()
+    protected boolean isRecordReserved( ByteBuffer recordData )
     {
-        return true;
+        return recordData.getInt( 1 ) == Record.RESERVED.intValue();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/TokenStore.java
@@ -146,7 +146,7 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
                 continue;
             }
             found++;
-            if ( record != null && record.getNameId() != Record.RESERVED.intValue() )
+            if ( record != null && record.inUse() && record.getNameId() != Record.RESERVED.intValue() )
             {
                 String name = getStringFor( record );
                 recordList.add( new Token( name, i ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/store/StoreHighIdInflationTest.java
@@ -19,12 +19,13 @@
  */
 package org.neo4j.kernel.impl.nioneo.store;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -35,9 +36,14 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.UTF8.encode;
 import static org.neo4j.kernel.impl.nioneo.store.CommonAbstractStore.buildTypeDescriptorAndVersion;
+import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.LABEL_TOKEN_STORE_NAME;
+import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.NODE_STORE_NAME;
+import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.PROPERTY_STRINGS_STORE_NAME;
+import static org.neo4j.kernel.impl.nioneo.store.StoreFactory.RELATIONSHIP_TYPE_TOKEN_STORE_NAME;
 
 public class StoreHighIdInflationTest
 {
@@ -47,17 +53,15 @@ public class StoreHighIdInflationTest
         // GIVEN
         FileSystemAbstraction fs = fsr.get();
         fs.mkdirs( new File( storeDir ) );
-        GraphDatabaseAPI db = (GraphDatabaseAPI)
-                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        GraphDatabaseAPI db = (GraphDatabaseAPI) newImpermanentDb();
         long highestCreatedNodeId = createACoupleOfNodes( db, 3 );
         long highestPropertyStringRecord = getHighestDynamicStringPropertyId( db );
         db.shutdown();
-        inflateStore( NodeStore.TYPE_DESCRIPTOR, NodeStore.RECORD_SIZE, ".nodestore.db" );
-        inflateStore( DynamicStringStore.TYPE_DESCRIPTOR, DynamicStringStore.BLOCK_HEADER_SIZE, ".nodestore.db" );
+        inflateStore( NodeStore.TYPE_DESCRIPTOR, NODE_STORE_NAME, megabyteWorthOfZeros() );
+        inflateStore( DynamicStringStore.TYPE_DESCRIPTOR, PROPERTY_STRINGS_STORE_NAME, megabyteWorthOfZeros() );
 
         // WHEN
-        db = (GraphDatabaseAPI)
-                new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        db = (GraphDatabaseAPI) newImpermanentDb();
         long nodeIdAfterInflation = createACoupleOfNodes( db, 1 );
         long stringPropertyIdAfterInflation = getHighestDynamicStringPropertyId( db );
         db.shutdown();
@@ -67,6 +71,69 @@ public class StoreHighIdInflationTest
         assertEquals( highestPropertyStringRecord+1, stringPropertyIdAfterInflation );
     }
 
+    @Test
+    public void shouldTrimInflatedTokenStoreDuringRecovery() throws IOException
+    {
+        // Given
+        int nodesWithUniqueLabels = 10;
+        int relsWithUniqueTypes = 5;
+        int labelTokenRecordSize;
+
+        FileSystemAbstraction fs = fsr.get();
+        fs.mkdirs( new File( storeDir ) );
+        GraphDatabaseService db = newImpermanentDb();
+        createLabeledNodesAndRels( nodesWithUniqueLabels, relsWithUniqueTypes, db );
+        labelTokenRecordSize = ((GraphDatabaseAPI) db).getDependencyResolver()
+                .resolveDependency( XaDataSourceManager.class ).getNeoStoreDataSource().getNeoStore()
+                .getLabelTokenStore().getRecordSize();
+        db.shutdown();
+
+        // When
+        inflateStore( LabelTokenStore.TYPE_DESCRIPTOR, LABEL_TOKEN_STORE_NAME, megabyteWorthOfZeros() );
+        newImpermanentDb().shutdown();
+
+        // Then
+        long fileSize = fs.getFileSize( new File( storeDir, NeoStore.DEFAULT_NAME + LABEL_TOKEN_STORE_NAME ) );
+        int trailerLength = trailerLength( LabelTokenStore.TYPE_DESCRIPTOR );
+        assertEquals( "Unexpected file size; trailerLength=" + trailerLength,
+                nodesWithUniqueLabels * labelTokenRecordSize, fileSize - trailerLength );
+    }
+
+    @Test
+    public void shouldMarkReservedRelationshipTypesAsNotInUse() throws IOException
+    {
+        // Given
+        int nodesWithUniqueLabels = 5;
+        int relsWithUniqueTypes = 10;
+        int reservedRelTypeRecordsCount = 100;
+        int relTypeTokenRecordSize;
+        String relTypeStoreFileName = NeoStore.DEFAULT_NAME + RELATIONSHIP_TYPE_TOKEN_STORE_NAME;
+
+        FileSystemAbstraction fs = fsr.get();
+        fs.mkdirs( new File( storeDir ) );
+        GraphDatabaseService db = newImpermanentDb();
+        createLabeledNodesAndRels( nodesWithUniqueLabels, relsWithUniqueTypes, db );
+        relTypeTokenRecordSize = relTypeTokenStore( db ).getRecordSize();
+        assertEquals( "Unexpected highest inUse id",
+                relsWithUniqueTypes - 1, relTypeTokenStore( db ).getHighestPossibleIdInUse() );
+        db.shutdown();
+
+        // When
+        inflateStore( RelationshipTypeTokenStore.TYPE_DESCRIPTOR, RELATIONSHIP_TYPE_TOKEN_STORE_NAME,
+                reservedRelTypeRecords( reservedRelTypeRecordsCount, relTypeTokenRecordSize ) );
+
+        int lastInUseRecordId = findLastInUseRecord( relTypeStoreFileName, relTypeTokenRecordSize, 0 );
+        assertEquals( reservedRelTypeRecordsCount + relsWithUniqueTypes, lastInUseRecordId );
+        newImpermanentDb().shutdown();
+
+        // Then
+        lastInUseRecordId = findLastInUseRecord( relTypeStoreFileName, relTypeTokenRecordSize,
+                trailerLength( RelationshipTypeTokenStore.TYPE_DESCRIPTOR ) );
+        assertEquals( "Unexpected number of inUse records", relsWithUniqueTypes, lastInUseRecordId );
+        assertEquals( "Unexpected highest inUse id",
+                relsWithUniqueTypes - 1, relTypeTokenStore( newImpermanentDb() ).getHighestPossibleIdInUse() );
+    }
+
     private long getHighestDynamicStringPropertyId( GraphDatabaseAPI db )
     {
         return db.getDependencyResolver().resolveDependency( XaDataSourceManager.class )
@@ -74,21 +141,22 @@ public class StoreHighIdInflationTest
                 .getStringStore().getHighestPossibleIdInUse();
     }
 
-    private void inflateStore( String trailerTypeDescriptor, int recordSize, String store ) throws IOException
+    private static RelationshipTypeTokenStore relTypeTokenStore( GraphDatabaseService db )
     {
-        int trailerLength = encode( buildTypeDescriptorAndVersion( trailerTypeDescriptor ) ).length;
+        return ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( XaDataSourceManager.class )
+                .getNeoStoreDataSource().getNeoStore().getRelationshipTypeStore();
+    }
+
+    private void inflateStore( String trailerTypeDescriptor, String store, ByteBuffer data ) throws IOException
+    {
+        int trailerLength = trailerLength( trailerTypeDescriptor );
         File neoStore = new File( storeDir, NeoStore.DEFAULT_NAME );
         File storeFile = new File( neoStore.getAbsolutePath() + store );
         FileSystemAbstraction fs = fsr.get();
-        StoreChannel channel = fs.open( storeFile, "rw" );
-        try
+        try ( StoreChannel channel = fs.open( storeFile, "rw" ) )
         {
             channel.position( channel.size() - trailerLength );
-            channel.write( megabyteWorthOfZeros() );
-        }
-        finally
-        {
-            channel.close();
+            channel.write( data );
         }
         fs.deleteFile( new File( storeFile, ".id" ) );
     }
@@ -104,26 +172,85 @@ public class StoreHighIdInflationTest
         return buffer;
     }
 
+    private ByteBuffer reservedRelTypeRecords( int count, int size )
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( count * size );
+        for ( int i = 0; i < count; i++ )
+        {
+            buffer.put( Record.IN_USE.byteValue() ).putInt( Record.RESERVED.intValue() );
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    private int findLastInUseRecord( String storeFile, int recordSize, int trailerLength ) throws IOException
+    {
+        try ( StoreChannel channel = fsr.get().open( new File( storeDir, storeFile ), "rw" ) )
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( recordSize );
+            long position = channel.size() - trailerLength - recordSize;
+            while ( position > 0 )
+            {
+                buffer.clear();
+                channel.read( buffer, position );
+                buffer.flip();
+                if ( buffer.get() == Record.IN_USE.byteValue() )
+                {
+                    return (int) (position / recordSize) + 1;
+                }
+                position -= recordSize;
+            }
+        }
+        throw new IllegalStateException( "No inUse records found" );
+    }
+
     private long createACoupleOfNodes( GraphDatabaseService db, int count )
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
             long last = 0;
             for ( int i = 0; i < count; i++ )
             {
                 Node node = db.createNode();
                 node.setProperty( "key", "A very very very loooooooooooooooooooooooooooooooooooooooooooooong string " +
-                        "that should spill over into a dynamic record" );
+                                         "that should spill over into a dynamic record" );
                 last = node.getId();
             }
             tx.success();
             return last;
         }
-        finally
+    }
+
+    private static void createLabeledNodesAndRels( int nodeCount, int relCount, GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
         {
-            tx.finish();
+            Node[] nodes = new Node[nodeCount];
+            for ( int i = 0; i < nodeCount; i++ )
+            {
+                nodes[i] = db.createNode( label( "LABEL" + i ) );
+            }
+
+            for ( int i = 0; i < relCount; i++ )
+            {
+                Node source = nodes[ThreadLocalRandom.current().nextInt( nodes.length )];
+                Node target = nodes[ThreadLocalRandom.current().nextInt( nodes.length )];
+                source.createRelationshipTo( target, withName( "REL" + i ) );
+            }
+            tx.success();
         }
+    }
+
+    private GraphDatabaseService newImpermanentDb()
+    {
+        return new TestGraphDatabaseFactory().setFileSystem( fsr.get() ).newImpermanentDatabase( storeDir );
+    }
+
+    private static int trailerLength( String typeDescriptor )
+    {
+        String trailer = buildTypeDescriptorAndVersion( typeDescriptor );
+        byte[] trailerBytes = encode( trailer );
+        return trailerBytes.length;
     }
 
     public final @Rule EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();


### PR DESCRIPTION
Now relationship type records, that are reachable for highId, are marked as inUse==true and nameId is set to special reserved value (-1). Such behaviour might be dangerous as it can lead to 'Id capacity exceeded' errors for inflated relationship type store files.
This PR makes IdGenerator mark all reserved records as inUse==false during rebuild, so such records can be reused.
