### PR TITLE
JSON Serialization Performance

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/mocking/Properties.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mocking/Properties.java
@@ -22,6 +22,8 @@ package org.neo4j.test.mocking;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -41,7 +43,7 @@ public class Properties implements Answer<Object>, Iterable<String>
         return new Properties( properties );
     }
 
-    private final Map<String, Object> properties = new HashMap<>();
+    private final SortedMap<String, Object> properties = new TreeMap<>();
 
     private Properties( Property[] properties )
     {

--- a/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
@@ -48,7 +48,7 @@ public abstract class BatchOperations
     protected static final String METHOD_KEY = "method";
     protected static final String BODY_KEY = "body";
     protected static final String TO_KEY = "to";
-    protected static final JsonFactory jsonFactory = new JsonFactory();
+    protected static final JsonFactory jsonFactory = new JsonFactory().disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     protected final WebServer webServer;
     protected final ObjectMapper mapper;
 

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
@@ -77,7 +77,7 @@ public class StreamingJsonFormat extends RepresentationFormat implements Streami
                 return gen;
             }
         };
-        factory.enable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
+        factory.disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
         return factory;
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -248,7 +248,7 @@ public class ExecutionResultSerializer
 
     private State currentState = State.EMPTY;
 
-    private static final JsonFactory JSON_FACTORY = new JsonFactory( new Neo4jJsonCodec() );
+    private static final JsonFactory JSON_FACTORY = new JsonFactory( new Neo4jJsonCodec() ).disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     private final JsonGenerator out;
     private final URI baseUri;
     private final StringLogger log;

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -27,12 +27,18 @@ import java.util.Set;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 
+import org.codehaus.jackson.map.SerializationConfig;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PropertyContainer;
 
 public class Neo4jJsonCodec extends ObjectMapper
 {
 
+    public Neo4jJsonCodec()
+    {
+        getSerializationConfig().without( SerializationConfig.Feature.FLUSH_AFTER_WRITE_VALUE );
+    }
+    
     @Override
     public void writeValue( JsonGenerator out, Object value ) throws IOException
     {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
@@ -27,10 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import org.codehaus.jackson.*;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -48,7 +45,7 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class StatementDeserializer extends PrefetchingIterator<Statement>
 {
-    private static final JsonFactory JSON_FACTORY = new JsonFactory().setCodec( new Neo4jJsonCodec() );
+    private static final JsonFactory JSON_FACTORY = new JsonFactory().setCodec( new Neo4jJsonCodec() ).disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     private static final Map<String, Object> NO_PARAMETERS = unmodifiableMap( map() );
     private static final Iterator<Neo4jError> NO_ERRORS = emptyIterator();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
@@ -67,6 +67,7 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
     private static final String PAGED_TRAVERSE_LINK_REL = "paged_traverse";
     private static final int SHORT_LIST_LENGTH = 33;
     private static final int LONG_LIST_LENGTH = 444;
+    private static final int VERY_LONG_LIST_LENGTH = LONG_LIST_LENGTH*2;
 
     @ClassRule
     public static TemporaryFolder staticFolder = new TemporaryFolder();
@@ -415,10 +416,10 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
     public void shouldHaveTransportEncodingChunkedOnResponseHeader()
     {
         // given
-        theStartNode = createLinkedList( SHORT_LIST_LENGTH, server.getDatabase() );
+        theStartNode = createLinkedList( VERY_LONG_LIST_LENGTH, server.getDatabase() );
 
         // when
-        JaxRsResponse response = createStreamingPagedTraverserWithTimeoutInMinutesAndPageSize( 60, 1 );
+        JaxRsResponse response = createStreamingPagedTraverserWithTimeoutInMinutesAndPageSize( 60, 1000 );
 
         // then
         assertEquals( 201, response.getStatus() );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -23,12 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
@@ -293,7 +288,7 @@ public class ExecutionResultSerializerTest
         // then
         String result = output.toString( "UTF-8" );
         assertEquals( "{\"results\":[{\"columns\":[\"node\"]," +
-                      "\"data\":[{\"row\":[{\"d\":[1,0,1,2],\"e\":[\"a\",\"b\",\"ääö\"],\"b\":true,\"c\":[1,0,1,2],\"a\":12}]}]}]," +
+                      "\"data\":[{\"row\":[{\"a\":12,\"b\":true,\"c\":[1,0,1,2],\"d\":[1,0,1,2],\"e\":[\"a\",\"b\",\"ääö\"]}]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -308,11 +303,11 @@ public class ExecutionResultSerializerTest
         Node b = node( 2, properties( property( "bar", false ) ) );
         Relationship r = relationship( 1, properties( property( "baz", "quux" ) ), a, "FRAZZLE", b );
         ExecutionResult executionResult = mockExecutionResult( map(
-                "nested", map(
+                "nested", new TreeMap<>( map(
                 "node", a,
                 "edge", r,
                 "path", path( a, link(r, b) )
-        ) ) );
+        ) ) ) );
 
         // when
         serializer.statementResult( executionResult, false );
@@ -321,7 +316,7 @@ public class ExecutionResultSerializerTest
         // then
         String result = output.toString( "UTF-8" );
         assertEquals( "{\"results\":[{\"columns\":[\"nested\"]," +
-                      "\"data\":[{\"row\":[{\"node\":{\"foo\":12},\"edge\":{\"baz\":\"quux\"},\"path\":[{\"foo\":12},{\"baz\":\"quux\"},{\"bar\":false}]}]}]}]," +
+                      "\"data\":[{\"row\":[{\"edge\":{\"baz\":\"quux\"},\"node\":{\"foo\":12},\"path\":[{\"foo\":12},{\"baz\":\"quux\"},{\"bar\":false}]}]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -573,7 +568,7 @@ public class ExecutionResultSerializerTest
     @SafeVarargs
     private static ExecutionResult mockExecutionResult( Map<String, Object>... rows )
     {
-        Set<String> keys = new HashSet<>();
+        Set<String> keys = new TreeSet<>();
         for ( Map<String, Object> row : rows )
         {
             keys.addAll( row.keySet() );


### PR DESCRIPTION
Don't flush when the Jackson UTF8 buffer is full but when the http stream flushes
Fix flaky tests, that rely on HasMap order (Java7 vs. Java8)
