### PR TITLE
Refactor: Push schema index/constraint conflict messages into the exceptions to align with SPI.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyIndexedException.java
@@ -25,19 +25,36 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 
 public class AlreadyIndexedException extends SchemaKernelException
 {
-    private static final String MESSAGE = "Already indexed %s.";
+    private static final String NO_CONTEXT_FORMAT = "Already indexed %s.";
+
+    private static final String INDEX_CONTEXT_FORMAT = "There already exists an index for label '%s' on property '%s'.";
+    private static final String CONSTRAINT_CONTEXT_FORMAT = "There already exists an index for label '%s' on property '%s'. " +
+                                                             "A constraint cannot be created until the index has been dropped.";
 
     private final IndexDescriptor descriptor;
+    private final OperationContext context;
 
-    public AlreadyIndexedException( IndexDescriptor descriptor )
+    public AlreadyIndexedException( IndexDescriptor descriptor, OperationContext context )
     {
-        super( Status.Schema.IndexAlreadyExists, String.format( MESSAGE, descriptor ) );
+        super( Status.Schema.IndexAlreadyExists, String.format( NO_CONTEXT_FORMAT, descriptor ) );
+
         this.descriptor = descriptor;
+        this.context = context;
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return String.format( String.format( MESSAGE, descriptor.userDescription( tokenNameLookup ) ) );
+        switch ( context )
+        {
+            case INDEX_CREATION:
+                return messageWithLabelAndPropertyName( tokenNameLookup, INDEX_CONTEXT_FORMAT,
+                        descriptor.getLabelId(), descriptor.getPropertyKeyId() );
+            case CONSTRAINT_CREATION:
+                return messageWithLabelAndPropertyName( tokenNameLookup, CONSTRAINT_CONTEXT_FORMAT,
+                        descriptor.getLabelId(), descriptor.getPropertyKeyId() );
+            default:
+                return String.format( NO_CONTEXT_FORMAT, descriptor );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 
@@ -28,6 +29,12 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public abstract class SchemaKernelException extends KernelException
 {
+    public enum OperationContext
+    {
+        INDEX_CREATION,
+        CONSTRAINT_CREATION
+    }
+
     protected SchemaKernelException( Status statusCode, Throwable cause, String message, Object... parameters )
     {
         super( statusCode, cause, message, parameters );
@@ -41,5 +48,21 @@ public abstract class SchemaKernelException extends KernelException
     public SchemaKernelException( Status statusCode, String message )
     {
         super( statusCode, message );
+    }
+
+    String messageWithLabelAndPropertyName( TokenNameLookup tokenNameLookup, String formatString, int labelId, int propertyKeyId )
+    {
+        if( tokenNameLookup != null )
+        {
+            return String.format( formatString,
+                    tokenNameLookup.labelGetName( labelId ),
+                    tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+        }
+        else
+        {
+            return String.format( formatString,
+                    "label[" + labelId + "]",
+                    "key[" + propertyKeyId+ "]" );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -366,14 +366,12 @@ public class SchemaImpl implements Schema
                 catch ( AlreadyIndexedException e )
                 {
                     throw new ConstraintViolationException(
-                            format( "There already exists an index for label '%s' on property '%s'.",
-                                    label.name(), propertyKey ), e );
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( AlreadyConstrainedException e )
                 {
-                    throw new ConstraintViolationException( format(
-                            "Label '%s' and property '%s' have a unique constraint defined on them, so an index is " +
-                            "already created that matches this.", label.name(), propertyKey ), e );
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( AddIndexFailureException e )
                 {
@@ -434,9 +432,8 @@ public class SchemaImpl implements Schema
                 }
                 catch ( AlreadyConstrainedException e )
                 {
-                    throw new ConstraintViolationException( format(
-                            "Label '%s' and property '%s' have a unique constraint defined on them.",
-                            label.name(), propertyKey ), e );
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( CreateConstraintFailureException e )
                 {
@@ -446,9 +443,7 @@ public class SchemaImpl implements Schema
                 catch ( AlreadyIndexedException e )
                 {
                     throw new ConstraintViolationException(
-                            format( "There already exists an index for label '%s' on property '%s'. " +
-                                    "A constraint cannot be created until the index has been dropped.",
-                                    label.name(), propertyKey ), e );
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( IllegalTokenNameException e )
                 {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -463,7 +463,7 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertEquals( "Label 'MY_LABEL' and property 'my_property_key' have a unique constraint defined on them.",
+            assertEquals( "Label 'MY_LABEL' and property 'my_property_key' already have a unique constraint defined on them.",
                           e.getMessage() );
         }
     }


### PR DESCRIPTION
Proper messages for these exceptions can only be created within the context of the operation
and below the SPI level so that such users (Cypher) enjoy increased friendliness.
