### PR TITLE
Let jetty decide when to flush send buffer.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/batch/BatchOperations.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.server.rest.batch;
 
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonToken;
+import org.codehaus.jackson.map.ObjectMapper;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -27,18 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.neo4j.server.rest.web.InternalJettyServletRequest;
 import org.neo4j.server.rest.web.InternalJettyServletResponse;
 import org.neo4j.server.web.WebServer;
@@ -49,7 +49,7 @@ public abstract class BatchOperations
     protected static final String METHOD_KEY = "method";
     protected static final String BODY_KEY = "body";
     protected static final String TO_KEY = "to";
-    protected static final JsonFactory jsonFactory = new JsonFactory();
+    protected static final JsonFactory jsonFactory = new JsonFactory().disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     protected final WebServer webServer;
     protected final ObjectMapper mapper;
 

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.server.rest.repr.formats;
 
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.impl.Utf8Generator;
+import org.codehaus.jackson.io.IOContext;
+import org.codehaus.jackson.map.ObjectMapper;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -27,13 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.WebApplicationException;
-
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.impl.Utf8Generator;
-import org.codehaus.jackson.io.IOContext;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.server.rest.domain.JsonHelper;
@@ -61,7 +60,6 @@ public class StreamingJsonFormat extends RepresentationFormat implements Streami
     private JsonFactory createJsonFactory()
     {
         final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.getSerializationConfig().disable( SerializationConfig.Feature.FLUSH_AFTER_WRITE_VALUE );
         JsonFactory factory = new JsonFactory( objectMapper )
         {
             @Override
@@ -77,7 +75,7 @@ public class StreamingJsonFormat extends RepresentationFormat implements Streami
                 return gen;
             }
         };
-        factory.enable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
+        factory.disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
         return factory;
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -26,9 +29,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
 
 import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.cypher.javacompat.QueryStatistics;
@@ -249,7 +249,8 @@ public class ExecutionResultSerializer
 
     private State currentState = State.EMPTY;
 
-    private static final JsonFactory JSON_FACTORY = new JsonFactory( new Neo4jJsonCodec() );
+    private static final JsonFactory JSON_FACTORY = new JsonFactory( new Neo4jJsonCodec() )
+            .disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     private final JsonGenerator out;
     private final URI baseUri;
     private final StringLogger log;

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/StatementDeserializer.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonToken;
+import org.codehaus.jackson.map.JsonMappingException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -27,11 +34,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
@@ -48,7 +50,8 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class StatementDeserializer extends PrefetchingIterator<Statement>
 {
-    private static final JsonFactory JSON_FACTORY = new JsonFactory().setCodec( new Neo4jJsonCodec() );
+    private static final JsonFactory JSON_FACTORY = new JsonFactory().setCodec( new Neo4jJsonCodec() )
+            .disable( JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM );
     private static final Map<String, Object> NO_PARAMETERS = unmodifiableMap( map() );
     private static final Iterator<Neo4jError> NO_ERRORS = emptyIterator();
 


### PR DESCRIPTION
The jackson serialization uses an intermediary buffer to build its output,
and by default forwards "flush" calls to the underlying (jetty-provided) buffer.
This causes jackson to flush the jetty buffer much more often than necessary.

With this change, jackson will flush its contents into the jetty buffer, but
leave the rest up to jetty.
