### PR TITLE
Sets a threshold in ArrayCollection where array is recreated if surpassed

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -138,7 +138,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private final StoreReadLayer storeLayer;
     private final Clock clock;
     private final TransactionToRecordStateVisitor txStateToRecordStateVisitor = new TransactionToRecordStateVisitor();
-    private final Collection<Command> extractedCommands = new ArrayCollection<>( 20 );
+    private final Collection<Command> extractedCommands = new ArrayCollection<>( 32 );
     private TransactionState txState;
     private LegacyIndexTransactionState legacyIndexTransactionState;
     private TransactionType transactionType = TransactionType.ANY;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
@@ -35,12 +35,33 @@ import static java.lang.reflect.Array.newInstance;
  */
 public class ArrayCollection<T> implements Collection<T>
 {
+    private final int initialCapacity;
     private Object[] array;
     private int size;
+    private final int fastClearThreshold;
 
+    /**
+     * Sets fastClearThreshold == initialCapacity.
+     *
+     * @param initialCapacity initial capacity of the backing array.
+     */
     public ArrayCollection( int initialCapacity )
     {
-        array = new Object[initialCapacity];
+        this( initialCapacity, initialCapacity );
+    }
+
+    /**
+     * @param initialCapacity initial capacity of the backing array.
+     * @param fastClearThreshold if {@link #size()} is {@code <= fastClearThreshold} then the items in
+     * the backing array are still referenced by the backing array after a call to {@link #clear()} just
+     * the internal cursor is reset, otherwise a new backing array of capacity {@code initialCapacity} is
+     * created to take its place.
+     */
+    public ArrayCollection( int initialCapacity, int fastClearThreshold )
+    {
+        this.initialCapacity = initialCapacity;
+        this.fastClearThreshold = Math.min( fastClearThreshold, initialCapacity );
+        this.array = new Object[initialCapacity];
     }
 
     @Override
@@ -184,6 +205,10 @@ public class ArrayCollection<T> implements Collection<T>
     @Override
     public void clear()
     {
+        if ( size > fastClearThreshold )
+        {
+            array = new Object[initialCapacity];
+        }
         size = 0;
     }
 }


### PR DESCRIPTION
this to avoid big arrays with all its references still set. This is an
artofact of the very purpose of ArrayCollection, that clear() should be
as performant as possible.
