### PR TITLE
Refactor: Push schema index/constraint conflict messages into the exceptions to align with SPI.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/AlreadyConstrainedException.java
@@ -27,18 +27,40 @@ import static java.lang.String.format;
 
 public class AlreadyConstrainedException extends SchemaKernelException
 {
-    private final UniquenessConstraint constraint;
-    private final static String message = "Already constrained %s.";
+    private final static String NO_CONTEXT_FORMAT = "Already constrained %s.";
 
-    public AlreadyConstrainedException( UniquenessConstraint constraint )
+    private static final String CONSTRAINT_CONTEXT_FORMAT = "Label '%s' and property '%s' already have a unique constraint defined on them.";
+    private static final String INDEX_CONTEXT_FORMAT = "Label '%s' and property '%s' have a unique constraint defined on them, so an index is " +
+                                                       "already created that matches this.";
+
+    private final UniquenessConstraint constraint;
+    private final OperationContext context;
+
+    public AlreadyConstrainedException( UniquenessConstraint constraint, OperationContext context )
     {
-        super( Status.Schema.ConstraintAlreadyExists, format( message, constraint ) );
+        super( Status.Schema.ConstraintAlreadyExists, constructUserMessage( context, null, constraint ) );
         this.constraint = constraint;
+        this.context = context;
+    }
+
+    private static String constructUserMessage( OperationContext context, TokenNameLookup tokenNameLookup, UniquenessConstraint constraint )
+    {
+        switch ( context )
+        {
+            case INDEX_CREATION:
+                return messageWithLabelAndPropertyName( tokenNameLookup, INDEX_CONTEXT_FORMAT,
+                        constraint.label(), constraint.propertyKeyId() );
+            case CONSTRAINT_CREATION:
+                return messageWithLabelAndPropertyName( tokenNameLookup, CONSTRAINT_CONTEXT_FORMAT,
+                        constraint.label(), constraint.propertyKeyId() );
+            default:
+                return format( NO_CONTEXT_FORMAT, constraint );
+        }
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return format( message, constraint.userDescription( tokenNameLookup ) );
+        return constructUserMessage( context, tokenNameLookup, constraint );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaKernelException.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 
@@ -28,6 +29,12 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public abstract class SchemaKernelException extends KernelException
 {
+    public enum OperationContext
+    {
+        INDEX_CREATION,
+        CONSTRAINT_CREATION
+    }
+
     protected SchemaKernelException( Status statusCode, Throwable cause, String message, Object... parameters )
     {
         super( statusCode, cause, message, parameters );
@@ -43,4 +50,19 @@ public abstract class SchemaKernelException extends KernelException
         super( statusCode, message );
     }
 
+    protected static String messageWithLabelAndPropertyName( TokenNameLookup tokenNameLookup, String formatString, int labelId, int propertyKeyId )
+    {
+        if( tokenNameLookup != null )
+        {
+            return String.format( formatString,
+                    tokenNameLookup.labelGetName( labelId ),
+                    tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+        }
+        else
+        {
+            return String.format( formatString,
+                    "label[" + labelId + "]",
+                    "key[" + propertyKeyId+ "]" );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBelongsToConstraintException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchIndexException;
+import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException.OperationContext;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.impl.api.operations.KeyWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
@@ -86,7 +87,7 @@ public class DataIntegrityValidatingStatementOperations implements
     public IndexDescriptor indexCreate( KernelStatement state, int labelId, int propertyKey )
             throws AddIndexFailureException, AlreadyIndexedException, AlreadyConstrainedException
     {
-        checkIndexExistence( state, labelId, propertyKey );
+        checkIndexExistence( state, OperationContext.INDEX_CREATION, labelId, propertyKey );
         return schemaWriteDelegate.indexCreate( state, labelId, propertyKey );
     }
 
@@ -120,11 +121,11 @@ public class DataIntegrityValidatingStatementOperations implements
                 state, labelId, propertyKey );
         if ( constraints.hasNext() )
         {
-            throw new AlreadyConstrainedException( constraints.next() );
+            throw new AlreadyConstrainedException( constraints.next(), OperationContext.CONSTRAINT_CREATION );
         }
 
         // It is not allowed to create uniqueness constraints on indexed label/property pairs
-        checkIndexExistence( state, labelId, propertyKey );
+        checkIndexExistence( state, OperationContext.CONSTRAINT_CREATION, labelId, propertyKey );
 
         return schemaWriteDelegate.uniquenessConstraintCreate( state, labelId, propertyKey );
     }
@@ -144,14 +145,14 @@ public class DataIntegrityValidatingStatementOperations implements
         schemaWriteDelegate.constraintDrop( state, constraint );
     }
 
-    private void checkIndexExistence( KernelStatement state, int labelId, int propertyKey )
+    private void checkIndexExistence( KernelStatement state, OperationContext context, int labelId, int propertyKey )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
         for ( IndexDescriptor descriptor : loop( schemaReadDelegate.indexesGetForLabel( state, labelId ) ) )
         {
             if ( descriptor.getPropertyKeyId() == propertyKey )
             {
-                throw new AlreadyIndexedException( descriptor );
+                throw new AlreadyIndexedException( descriptor, context );
             }
         }
         for ( IndexDescriptor descriptor : loop( schemaReadDelegate.uniqueIndexesGetForLabel( state, labelId ) ) )
@@ -159,7 +160,7 @@ public class DataIntegrityValidatingStatementOperations implements
             if ( descriptor.getPropertyKeyId() == propertyKey )
             {
                 throw new AlreadyConstrainedException(
-                        new UniquenessConstraint( descriptor.getLabelId(), descriptor.getPropertyKeyId() ) );
+                        new UniquenessConstraint( descriptor.getLabelId(), descriptor.getPropertyKeyId() ), context );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -370,14 +370,12 @@ public class SchemaImpl implements Schema
                 catch ( AlreadyIndexedException e )
                 {
                     throw new ConstraintViolationException(
-                            format( "There already exists an index for label '%s' on property '%s'.",
-                                    label.name(), propertyKey ), e );
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( AlreadyConstrainedException e )
                 {
-                    throw new ConstraintViolationException( format(
-                            "Label '%s' and property '%s' have a unique constraint defined on them, so an index is " +
-                            "already created that matches this.", label.name(), propertyKey ), e );
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( AddIndexFailureException e )
                 {
@@ -446,9 +444,8 @@ public class SchemaImpl implements Schema
                 }
                 catch ( AlreadyConstrainedException e )
                 {
-                    throw new ConstraintViolationException( format(
-                            "Label '%s' and property '%s' have a unique constraint defined on them.",
-                            label.name(), propertyKey ), e );
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( CreateConstraintFailureException e )
                 {
@@ -458,9 +455,7 @@ public class SchemaImpl implements Schema
                 catch ( AlreadyIndexedException e )
                 {
                     throw new ConstraintViolationException(
-                            format( "There already exists an index for label '%s' on property '%s'. " +
-                                    "A constraint cannot be created until the index has been dropped.",
-                                    label.name(), propertyKey ), e );
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
                 }
                 catch ( IllegalTokenNameException e )
                 {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -467,7 +467,7 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertEquals( "Label 'MY_LABEL' and property 'my_property_key' have a unique constraint defined on them.",
+            assertEquals( "Label 'MY_LABEL' and property 'my_property_key' already have a unique constraint defined on them.",
                           e.getMessage() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -184,8 +184,8 @@ public class IndexIT extends KernelIntegrationTest
         // then
         catch ( SchemaKernelException e )
         {
-            assertEquals( "Already constrained CONSTRAINT ON ( n:label[5] ) " +
-                          "ASSERT n.property[8] IS UNIQUE.", e.getMessage() );
+            assertEquals( "Label 'label[5]' and property 'key[8]' have a unique constraint defined on " +
+                          "them, so an index is already created that matches this.", e.getMessage() );
         }
     }
 


### PR DESCRIPTION
Proper messages for these exceptions can only be created within the context of the operation
and below the SPI level so that such users (Cypher) enjoy increased friendliness.
