### PR TITLE
Add query logging.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/LRUCache.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/LRUCache.scala
@@ -55,7 +55,9 @@ class LRUCache[K, V](cacheSize: Int) extends ((K, => V) => V) {
 
   def put(key: K, value: V) = inner.put(key, value)
 
-  def remove(key: K) = inner.remove(key)
+  def +=(kv: (K, V)) = put(kv._1, kv._2)
+
+  def remove(key: K): Option[V] = Option(inner.remove(key))
 
   def containsKey(key: K) = inner.containsKey(key)
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/internal/ServerExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/internal/ServerExecutionEngine.java
@@ -23,10 +23,12 @@ import java.util.Map;
 
 import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+import org.neo4j.kernel.impl.query.QuerySession;
 import org.neo4j.kernel.impl.util.StringLogger;
 
 /**
@@ -44,19 +46,19 @@ public class ServerExecutionEngine extends ExecutionEngine implements QueryExecu
         super( database, logger );
     }
 
-    @Override
-    protected org.neo4j.cypher.ExecutionEngine createInnerEngine( GraphDatabaseService database, StringLogger logger )
+    protected
+    org.neo4j.cypher.ExecutionEngine createInnerEngine( GraphDatabaseService database, StringLogger logger )
     {
-        serverExecutionEngine = new org.neo4j.cypher.internal.ServerExecutionEngine( database, logger );
-        return serverExecutionEngine;
+        return serverExecutionEngine = new org.neo4j.cypher.internal.ServerExecutionEngine( database, logger );
     }
 
     @Override
-    public Result executeQuery( String query, Map<String, Object> parameters ) throws QueryExecutionKernelException
+    public Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession ) throws
+            QueryExecutionKernelException
     {
         try
         {
-            return execute( query, parameters );
+            return new ExecutionResult( serverExecutionEngine.execute( query, parameters, querySession ) );
         }
         catch ( CypherException e )
         {
@@ -71,11 +73,11 @@ public class ServerExecutionEngine extends ExecutionEngine implements QueryExecu
     }
 
     @Override
-    public Result profileQuery( String query, Map<String, Object> parameters ) throws QueryExecutionKernelException
+    public Result profileQuery( String query, Map<String, Object> parameters, QuerySession session ) throws QueryExecutionKernelException
     {
         try
         {
-            return profile( query, parameters );
+            return new ExecutionResult( serverExecutionEngine.profile( query, parameters, session ) );
         }
         catch ( CypherException e )
         {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -51,8 +51,8 @@ class CypherCompiler(graph: GraphDatabaseService,
 
   private val queryCacheSize: Int = getQueryCacheSize
   private val queryPlanTTL: Long = getQueryPlanTTL
-  private val compatibilityFor1_9 = CompatibilityFor1_9(graph, queryCacheSize)
-  private val compatibilityFor2_0 = CompatibilityFor2_0(graph, queryCacheSize)
+  private val compatibilityFor1_9 = CompatibilityFor1_9(graph, queryCacheSize, kernelMonitors)
+  private val compatibilityFor2_0 = CompatibilityFor2_0(graph, queryCacheSize, kernelMonitors)
   private val compatibilityFor2_1 = CompatibilityFor2_1(graph, queryCacheSize, kernelMonitors, kernelAPI)
   private val compatibilityFor2_2Rule =
     CompatibilityFor2_2Rule(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -23,11 +23,12 @@ import org.neo4j.cypher.ExtendedExecutionResult
 import org.neo4j.graphdb.Transaction
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
+import org.neo4j.kernel.impl.query.QuerySession
 
 final case class TransactionInfo(tx: Transaction, isTopLevelTx: Boolean, statement: Statement)
 
 trait ExecutionPlan {
-  def run(graph: GraphDatabaseAPI, txInfo: TransactionInfo, executionMode: ExecutionMode, params: Map[String, Any]): ExtendedExecutionResult
+  def run(graph: GraphDatabaseAPI, txInfo: TransactionInfo, executionMode: ExecutionMode, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult
 
   def isPeriodicCommit: Boolean
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreparedPlanExecution.scala
@@ -20,11 +20,12 @@
 package org.neo4j.cypher.internal
 
 import org.neo4j.kernel.GraphDatabaseAPI
+import org.neo4j.kernel.impl.query.QuerySession
 
 case class PreparedPlanExecution(plan: ExecutionPlan, executionMode: ExecutionMode, extractedParams: Map[String, Any]) {
-  def execute(graph: GraphDatabaseAPI, txInfo: TransactionInfo, params: Map[String, Any]) =
-    plan.run(graph, txInfo, executionMode, params ++ extractedParams)
+  def execute(graph: GraphDatabaseAPI, txInfo: TransactionInfo, params: Map[String, Any], session: QuerySession) =
+    plan.run(graph, txInfo, executionMode, params ++ extractedParams, session)
 
-  def profile(graph: GraphDatabaseAPI, txInfo: TransactionInfo, params: Map[String, Any]) =
-    plan.run(graph, txInfo, ProfileMode, params ++ extractedParams)
+  def profile(graph: GraphDatabaseAPI, txInfo: TransactionInfo, params: Map[String, Any], session: QuerySession) =
+    plan.run(graph, txInfo, ProfileMode, params ++ extractedParams, session)
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -37,7 +37,7 @@ object RewindableExecutionResult {
   }
 
   def apply(in: ExecutionResult): InternalExecutionResult = in match {
-    case ExecutionResultWrapperFor2_2(inner, _) => exceptionHandlerFor2_2.runSafely {apply(inner)}
+    case ExecutionResultWrapperFor2_2(inner, _) => exceptionHandlerFor2_2.runSafely(apply(inner))
 
     case _                                      => throw new InternalException("Can't get the internal execution result of an older compiler")
   }

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.kernel.GraphDatabaseAPI
+import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QueryEngineProvider}
+import org.neo4j.kernel.monitoring.Monitors
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.mockito.Mockito._
+
+class QueryExecutionMonitorTest extends CypherFunSuite {
+
+  test("monitor is not called if iterator not exhausted") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    engine.execute("RETURN 42", Map.empty[String, Any], session)
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, never()).endSuccess(session)
+  }
+
+  test("monitor is called when exhausted") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("RETURN 42", Map.empty[String, Any], session).javaIterator
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called directly when return is empty") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CREATE()", Map.empty[String, Any], session).javaIterator
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CREATE()")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor really not called until result is exhausted") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
+
+    //then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("nothing breaks when no monitor is there") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    engine.execute("RETURN 42", Map.empty[String, Any], session).toList
+  }
+
+  test("monitor is called when iterator closes") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("RETURN 42", Map.empty[String, Any], session).javaIterator.close()
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when next on empty iterator") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val iterator = engine.execute("RETURN 42", Map.empty[String, Any], session).javaIterator
+    iterator.next()
+    var throwable: Throwable = null
+    try {
+      iterator.next()
+      fail("we expect an exception here")
+    }
+    catch {
+      case e: Throwable => throwable = e
+    }
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).endFailure(session, throwable)
+  }
+
+  test("check so that profile triggers monitor") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.profile("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
+
+    //then
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("triggering monitor in 2.1") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.profile("CYPHER 2.1 RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
+
+    //then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN [1, 2, 3, 4, 5]")
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when iterator closes in 2.1") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 2.1 RETURN 42", Map.empty[String, Any], session).javaIterator.close()
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when next on empty iterator in 2.1") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val iterator = engine.execute("CYPHER 2.1 RETURN 42", Map.empty[String, Any], session).javaIterator
+    iterator.next()
+    var throwable: Throwable = null
+    try {
+      iterator.next()
+      fail("we expect an exception here")
+    }
+    catch {
+      case e: Throwable => throwable = e
+    }
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42")
+    verify(monitor, times(1)).endFailure(session, throwable)
+  }
+
+  test("monitor is called directly when return is empty in 2.1 ") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 2.1 CREATE()", Map.empty[String, Any], session).javaIterator
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 CREATE()")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("triggering monitor in 2.0") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.profile("CYPHER 2.0 RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
+
+    //then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN [1, 2, 3, 4, 5]")
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when iterator closes in 2.0") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 2.0 RETURN 42", Map.empty[String, Any], session).javaIterator.close()
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when next on empty iterator in 2.0") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val iterator = engine.execute("CYPHER 2.0 RETURN 42", Map.empty[String, Any], session).javaIterator
+    iterator.next()
+    var throwable: Throwable = null
+    try {
+      iterator.next()
+      fail("we expect an exception here")
+    }
+    catch {
+      case e: Throwable => throwable = e
+    }
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42")
+    verify(monitor, times(1)).endFailure(session, throwable)
+  }
+
+  test("monitor is called directly when return is empty in 2.0 ") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 2.0 CREATE()", Map.empty[String, Any], session).javaIterator
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 CREATE()")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("triggering monitor in 1.9") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.profile("CYPHER 1.9 CREATE() RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
+
+    //then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN [1, 2, 3, 4, 5]")
+    while (result.hasNext) {
+      verify(monitor, never).endSuccess(session)
+      result.next()
+    }
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when iterator closes in 1.9") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 1.9 CREATE() RETURN 42", Map.empty[String, Any], session).javaIterator.close()
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  test("monitor is called when next on empty iterator in 1.9") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val iterator = engine.execute("CYPHER 1.9 CREATE() RETURN 42", Map.empty[String, Any], session).javaIterator
+    iterator.next()
+    var throwable: Throwable = null
+    try {
+      iterator.next()
+      fail("we expect an exception here")
+    }
+    catch {
+      case e: Throwable => throwable = e
+    }
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42")
+    verify(monitor, times(1)).endFailure(session, throwable)
+  }
+
+  test("monitor is called directly when return is empty in 1.9 ") {
+    // given
+    val graph = new TestGraphDatabaseFactory().newImpermanentDatabase()
+    val monitor = mock[QueryExecutionMonitor]
+    monitors(graph).addMonitorListener(monitor)
+    val engine = new ExecutionEngine(graph)
+    val session = QueryEngineProvider.embeddedSession()
+
+    // when
+    val result = engine.execute("CYPHER 1.9 CREATE()", Map.empty[String, Any], session).javaIterator
+
+    // then
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE()")
+    verify(monitor, times(1)).endSuccess(session)
+  }
+
+  private def monitors(graph: GraphDatabaseService): Monitors = {
+    val graphAPI = graph.asInstanceOf[GraphDatabaseAPI]
+    graphAPI.getDependencyResolver.resolveDependency(classOf[org.neo4j.kernel.monitoring.Monitors])
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
@@ -37,6 +37,7 @@ import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseAPI
+import org.neo4j.kernel.impl.query.{QueryEngineProvider, QueryExecutionEngine}
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
 
 import scala.collection.mutable
@@ -97,6 +98,7 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
   }
 
   private def runQueryWith(query: String, compiler: CypherCompiler, db: GraphDatabaseAPI): (List[Map[String, Any]], InternalExecutionResult) = {
+    val session = QueryEngineProvider.embeddedSession()
     val (plan, parameters) = db.withTx {
       tx =>
         val planContext = new TransactionBoundPlanContext(db.statement, db) with RealStatistics

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher
 
 import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor2_2
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.InternalExecutionResult
+import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QuerySession, QueryEngineProvider}
 import org.scalatest.Assertions
 
 trait QueryStatisticsTestSupport {
@@ -32,6 +33,14 @@ trait QueryStatisticsTestSupport {
     }
 
     def apply(actual: InternalExecutionResult) {
+      implicit val monitor = new QueryExecutionMonitor {
+        override def startQueryExecution(session: QuerySession, query: String){}
+
+        override def endSuccess(session: QuerySession){}
+
+        override def endFailure(session: QuerySession, throwable: Throwable){}
+      }
+      implicit val session = QueryEngineProvider.embeddedSession
       val r = new ExecutionResultWrapperFor2_2(actual, CypherVersion.v2_2)
       apply(r.queryStatistics())
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -132,6 +132,6 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     graph.inTx { compiler.planQuery(query, planContext) }
 
     // then
-    logger.assertAtLeastOnce(LogCall.info(s"Discarded stale query from the query cache: $query"))
+    logger.assertExactly(LogCall.info(s"Discarded stale query from the query cache: $query"))
   }
 }

--- a/community/cypher/docs/graphgist/src/main/java/org/neo4j/doc/cypherdoc/BlockType.java
+++ b/community/cypher/docs/graphgist/src/main/java/org/neo4j/doc/cypherdoc/BlockType.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle;
@@ -225,7 +226,7 @@ enum BlockType
             try
             {
                 state.latestResult = new Result( fileQuery, state.engine.profileQuery(
-                        fileQuery, Collections.<String, Object>emptyMap() ) );
+                        fileQuery, Collections.<String, Object>emptyMap(), QueryEngineProvider.embeddedSession() ) );
             }
             catch ( QueryExecutionKernelException e )
             {

--- a/community/cypher/docs/graphgist/src/test/java/org/neo4j/doc/cypherdoc/BlockTest.java
+++ b/community/cypher/docs/graphgist/src/test/java/org/neo4j/doc/cypherdoc/BlockTest.java
@@ -34,6 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
+import org.neo4j.kernel.impl.query.QuerySession;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeFalse;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -232,8 +234,8 @@ public class BlockTest
         ArgumentCaptor<String> fileQuery = ArgumentCaptor.forClass( String.class );
         ArgumentCaptor<String> httpQuery = ArgumentCaptor.forClass( String.class );
 
-        when( engine.profileQuery( fileQuery.capture(), anyMapOf( String.class, Object.class ) ) ).
-                thenReturn( mock( org.neo4j.graphdb.Result.class ) );
+        when(engine.profileQuery(fileQuery.capture(), anyMapOf(String.class, Object.class), any(QuerySession.class))).
+                thenReturn(mock(org.neo4j.graphdb.Result.class));
 
         when( engine.prettify( httpQuery.capture() ) ).
                 thenReturn( "apa" );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -107,6 +107,8 @@ public abstract class GraphDatabaseSettings
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )
     public static Setting<Boolean> allow_file_urls = setting( "allow_file_urls", BOOLEAN, TRUE );
 
+
+
     // Store files
     @Description("The directory where the database files are located.")
     public static final Setting<File> store_dir = setting("store_dir", PATH, NO_DEFAULT );
@@ -329,6 +331,16 @@ public abstract class GraphDatabaseSettings
 
     @Description("Whether or not transactions are appended to the log in batches")
     public static final Setting<Boolean> batched_writes = setting( "batched_writes", BOOLEAN, Boolean.TRUE.toString() );
+
+    @Description( "Log executed queries that takes longer than the configured threshold." )
+    public static final Setting<Boolean> log_queries = setting("dbms.querylog.enabled", BOOLEAN, FALSE );
+
+    @Description( "The file where queries will be recorded." )
+    public static final Setting<File> log_queries_filename = setting("dbms.querylog.filename", PATH, "queries.log", basePath(store_dir) );
+
+    @Description("If the execution of query takes more time than this threshold, the query is logged - " +
+            "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
+    public static final Setting<Long> log_queries_threshold = setting("dbms.querylog.threshold", DURATION, "0s");
 
     private static String[] availableCaches()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -932,7 +932,7 @@ public abstract class InternalAbstractGraphDatabase
         availabilityGuard.checkAvailability( transactionStartTimeout, TransactionFailureException.class );
         try
         {
-            return queryExecutor.executeQuery( query, parameters );
+            return queryExecutor.executeQuery( query, parameters, QueryEngineProvider.embeddedSession() );
         }
         catch ( QueryExecutionKernelException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
@@ -28,7 +28,7 @@ enum NoQueryEngine implements QueryExecutionEngine
     INSTANCE;
 
     @Override
-    public Result executeQuery( String query, Map<String, Object> parameters )
+    public Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession )
     {
         throw noQueryEngine();
     }
@@ -40,7 +40,7 @@ enum NoQueryEngine implements QueryExecutionEngine
     }
 
     @Override
-    public Result profileQuery( String query, Map<String, Object> parameters )
+    public Result profileQuery( String query, Map<String, Object> parameter, QuerySession session )
     {
         throw noQueryEngine();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
@@ -56,4 +56,17 @@ public abstract class QueryEngineProvider extends Service
     {
         return NoQueryEngine.INSTANCE;
     }
+
+    public static QuerySession embeddedSession()
+    {
+        final Thread thread = Thread.currentThread();
+        return new QuerySession()
+        {
+            @Override
+            public String toString()
+            {
+                return String.format( "EmbeddedSession{thread=%s}", thread.getName() );
+            }
+        };
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
@@ -25,11 +25,12 @@ import org.neo4j.graphdb.Result;
 
 public interface QueryExecutionEngine
 {
-    Result executeQuery( String query, Map<String, Object> parameters ) throws QueryExecutionKernelException;
+    Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession ) throws QueryExecutionKernelException;
 
     boolean isPeriodicCommit( String query );
 
     String prettify( String query );
 
-    Result profileQuery( String query, Map<String, Object> parameters ) throws QueryExecutionKernelException;
+    Result profileQuery( String query, Map<String, Object> parameters, QuerySession querySession) throws QueryExecutionKernelException;
 }
+

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionMonitor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+/**
+ * The current (December 2014) usage of this interface expects the {@code end*} methods to be idempotent.
+ * That is, once either of them have been invoked with a particular session as parameter, invoking either
+ * of them with the same session parameter should do nothing.
+ */
+public interface QueryExecutionMonitor
+{
+    void startQueryExecution( QuerySession session, String query );
+
+    void endFailure( QuerySession session, Throwable failure );
+
+    void endSuccess( QuerySession session );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QuerySession.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QuerySession.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A unique QuerySession should be created and provided to
+ * {@link QueryExecutionEngine#executeQuery(String, java.util.Map, QuerySession)} for each cypher query.
+ * If queryLogging is enabled {@link org.neo4j.graphdb.factory.GraphDatabaseSettings#log_queries},
+ * the result of {@link #toString()} will be serialized in the log.
+ */
+public abstract class QuerySession
+{
+    private final Map<MetadataKey<?>, Object> metadata = new HashMap<>();
+
+    /**
+     * Defines what the output of this QuerySession should be.
+     *
+     * @return The output of this QuerySession.
+     */
+    @Override
+    public abstract String toString();
+
+    public final <ValueType> ValueType put( MetadataKey<ValueType> key, ValueType value )
+    {
+        return key.valueType.cast( metadata.put( key, value ) );
+    }
+
+    public final <ValueType> ValueType get( MetadataKey<ValueType> key )
+    {
+        return key.valueType.cast( metadata.get( key ) );
+    }
+
+    public final <ValueType> ValueType remove( MetadataKey<ValueType> key )
+    {
+        return key.valueType.cast( metadata.remove( key ) );
+    }
+
+    public static final class MetadataKey<ValueType>
+    {
+        private final Class<ValueType> valueType;
+        private final String name;
+
+        public MetadataKey( Class<ValueType> valueType, String name )
+        {
+            this.valueType = valueType;
+            this.name = name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "QuerySession.MetadataKey(%s:%s)", name, valueType.getName() );
+        }
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ConsoleService.java
@@ -67,7 +67,7 @@ public class ConsoleService implements AdvertisableService
     public ConsoleService( @Context Config config, @Context Database database, @Context HttpServletRequest req,
                            @Context OutputFormat output, @Context CypherExecutor cypherExecutor )
     {
-        this( new SessionFactoryImpl( req.getSession( true ), config.get( ServerSettings.management_console_engines ),
+        this( new SessionFactoryImpl( req, config.get( ServerSettings.management_console_engines ),
                 cypherExecutor ), database, database.getLogging(), output );
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSession.java
@@ -38,23 +38,29 @@
  */
 package org.neo4j.server.rest.management.console;
 
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
+
 import org.neo4j.cypher.SyntaxException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.database.CypherExecutor;
+import org.neo4j.server.rest.web.ServerQuerySession;
 import org.neo4j.server.webadmin.console.ScriptSession;
 
 public class CypherSession implements ScriptSession
 {
     private final CypherExecutor cypherExecutor;
     private final ConsoleLogger log;
+    private final HttpServletRequest request;
 
-    public CypherSession( CypherExecutor cypherExecutor, Logging logging )
+    public CypherSession( CypherExecutor cypherExecutor, Logging logging, HttpServletRequest request )
     {
         this.cypherExecutor = cypherExecutor;
         this.log = logging.getConsoleLog( getClass() );
+        this.request = request;
     }
 
     @Override
@@ -68,7 +74,7 @@ public class CypherSession implements ScriptSession
         String resultString;
         try
         {
-            Result result = cypherExecutor.getExecutionEngine().execute( script );
+            Result result = cypherExecutor.getExecutionEngine().executeQuery( script, Collections.<String, Object>emptyMap(), new ServerQuerySession( request ) );
             resultString = result.resultAsString();
         }
         catch ( SyntaxException error )

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/CypherSessionCreator.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.management.console;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.webadmin.console.ConsoleSessionCreator;
@@ -33,8 +35,8 @@ public class CypherSessionCreator implements ConsoleSessionCreator
     }
 
     @Override
-    public ScriptSession newSession( Database database, CypherExecutor cypherExecutor )
+    public ScriptSession newSession( Database database, CypherExecutor cypherExecutor, HttpServletRequest request )
     {
-        return new CypherSession( cypherExecutor, database.getLogging() );
+        return new CypherSession( cypherExecutor, database.getLogging(), request );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/SessionFactoryImpl.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/SessionFactoryImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.neo4j.helpers.collection.IteratorUtil;
@@ -41,10 +42,12 @@ public class SessionFactoryImpl implements ConsoleSessionFactory
     private final HttpSession httpSession;
     private final CypherExecutor cypherExecutor;
     private final Map<String, ConsoleSessionCreator> engineCreators = new HashMap<String, ConsoleSessionCreator>();
+    private final HttpServletRequest request;
 
-    public SessionFactoryImpl( HttpSession httpSession, List<String> supportedEngines, CypherExecutor cypherExecutor )
+    public SessionFactoryImpl( HttpServletRequest request, List<String> supportedEngines, CypherExecutor cypherExecutor )
     {
-        this.httpSession = httpSession;
+        this.request = request;
+        this.httpSession = request.getSession(true);
         this.cypherExecutor = cypherExecutor;
 
         enableEngines( supportedEngines );
@@ -73,7 +76,7 @@ public class SessionFactoryImpl implements ConsoleSessionFactory
         Object session = httpSession.getAttribute( key );
         if ( session == null )
         {
-            session = creator.newSession( database, cypherExecutor );
+            session = creator.newSession( database, cypherExecutor, request );
             httpSession.setAttribute( key, session );
         }
         return (ScriptSession) session;

--- a/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/console/ShellSessionCreator.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.rest.management.console;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.webadmin.console.ConsoleSessionCreator;
@@ -35,7 +37,7 @@ public class ShellSessionCreator implements ConsoleSessionCreator
     }
 
     @Override
-    public ScriptSession newSession( Database database, CypherExecutor cypherExecutor )
+    public ScriptSession newSession( Database database, CypherExecutor cypherExecutor, HttpServletRequest request )
     {
         return new ShellSession( database.getGraph() );
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.server.rest.transactional.error.TransactionLifecycleException;
+import org.neo4j.server.rest.web.QuerySessionProvider;
 import org.neo4j.server.rest.web.TransactionUriScheme;
 
 /**
@@ -67,7 +68,7 @@ public class TransactionFacade
 
     public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme ) throws TransactionLifecycleException
     {
-        return new TransactionHandle( kernel, engine, registry, uriScheme, log );
+        return new TransactionHandle( kernel, engine, registry, uriScheme, log, QuerySessionProvider.provider );
     }
 
     public TransactionHandle findTransactionHandle( long txId ) throws TransactionLifecycleException

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -21,11 +21,14 @@ package org.neo4j.server.rest.web;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.StringUtils;
 
 import org.neo4j.cypher.CypherException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -71,6 +74,7 @@ public class CypherService
     @POST
     @SuppressWarnings({"unchecked", "ParameterCanBeLocal"})
     public Response cypher(String body,
+                           @Context HttpServletRequest request,
                            @QueryParam( INCLUDE_STATS_PARAM ) boolean includeStats,
                            @QueryParam( INCLUDE_PLAN_PARAM ) boolean includePlan,
                            @QueryParam( PROFILE_PARAM ) boolean profile) throws BadInputException {
@@ -106,12 +110,12 @@ public class CypherService
             Result result;
             if ( profile )
             {
-                result = executionEngine.profileQuery( query, params );
+                result = executionEngine.profileQuery( query, params, new ServerQuerySession( request ) );
                 includePlan = true;
             }
             else
             {
-                result = executionEngine.executeQuery( query, params );
+                result = executionEngine.executeQuery( query, params, new ServerQuerySession( request ) );
                 includePlan = result.getQueryExecutionType().requestedExecutionPlanDescription();
             }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/web/QuerySessionProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/QuerySessionProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.neo4j.kernel.impl.query.QuerySession;
+
+public class QuerySessionProvider
+{
+    public QuerySession create(HttpServletRequest request) {
+        return new ServerQuerySession( request );
+    }
+
+    public static final QuerySessionProvider provider = new QuerySessionProvider();
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ServerQuerySession.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ServerQuerySession.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.neo4j.kernel.impl.query.QuerySession;
+
+public class ServerQuerySession extends QuerySession
+{
+    private final HttpServletRequest request;
+
+    public ServerQuerySession( HttpServletRequest request )
+    {
+        this.request = request;
+    }
+
+    @Override
+    public String toString()
+    {
+        return request != null ? String.format( "server-session\t%s\t%s", request.getRemoteAddr(),
+                request.getRequestURI() ) : "server-session";
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/webadmin/console/ConsoleSessionCreator.java
+++ b/community/server/src/main/java/org/neo4j/server/webadmin/console/ConsoleSessionCreator.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.webadmin.console;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.Database;
 
@@ -26,5 +28,5 @@ public interface ConsoleSessionCreator
 {
     String name();
 
-    ScriptSession newSession( Database database, CypherExecutor cypherExecutor );
+    ScriptSession newSession( Database database, CypherExecutor cypherExecutor, HttpServletRequest request );
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -30,6 +30,8 @@ import org.neo4j.server.rest.transactional.error.InvalidConcurrentTransactionAcc
 import org.neo4j.server.rest.web.TransactionUriScheme;
 import org.neo4j.test.DoubleLatch;
 
+import javax.servlet.http.HttpServletRequest;
+
 import static javax.xml.bind.DatatypeConverter.parseLong;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -68,7 +70,8 @@ public class ConcurrentTransactionAccessTest
             public void run()
             {
                 // start and block until finish
-                transactionHandle.execute( statements, mock( ExecutionResultSerializer.class ) );
+                transactionHandle.execute( statements, mock( ExecutionResultSerializer.class ), mock(
+                        HttpServletRequest.class ) );
             }
         } ).start();
 

--- a/community/server/src/test/java/org/neo4j/server/webadmin/console/CypherSessionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/webadmin/console/CypherSessionDocTest.java
@@ -41,6 +41,7 @@ package org.neo4j.server.webadmin.console;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.neo4j.helpers.Pair;
@@ -51,6 +52,8 @@ import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
 import org.neo4j.server.rest.management.console.CypherSession;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import javax.servlet.http.HttpServletRequest;
 
 public class CypherSessionDocTest
 {
@@ -63,7 +66,7 @@ public class CypherSessionDocTest
         executor.start();
         try
         {
-            CypherSession session = new CypherSession( executor, DevNullLoggingService.DEV_NULL );
+            CypherSession session = new CypherSession( executor, DevNullLoggingService.DEV_NULL, mock(HttpServletRequest.class));
             Pair<String, String> result = session.evaluate( "create (a) return a" );
             assertThat( result.first(), containsString( "Node[0]" ) );
         }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
@@ -20,7 +20,6 @@
 package org.neo4j.shell.kernel.apps.cypher;
 
 import java.rmi.RemoteException;
-import java.util.Map;
 
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.Service;
@@ -30,13 +29,14 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 import org.neo4j.shell.App;
+import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 
 @Service.Implementation(App.class)
 public class Using extends Start
 {
     @Override
-    protected Result getResult( String query, Map<String, Object> parameters )
+    protected Result getResult( String query, final Session session )
             throws ShellException, RemoteException, QueryExecutionKernelException
     {
         GraphDatabaseAPI graphDatabaseAPI = getServer().getDb();
@@ -50,7 +50,7 @@ public class Using extends Start
 
             try
             {
-                return super.getResult( query, parameters );
+                return super.getResult( query, session );
             }
             finally
             {
@@ -59,7 +59,7 @@ public class Using extends Start
         }
         else
         {
-            return super.getResult( query, parameters );
+            return super.getResult( query, session );
         }
     }
 }

--- a/enterprise/neo4j-enterprise/pom.xml
+++ b/enterprise/neo4j-enterprise/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-query-logging</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-com</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -28,6 +28,7 @@
   </scm>
 
   <modules>
+    <module>query-logging</module>
     <module>com</module>
     <module>cluster</module>
     <module>backup</module>

--- a/enterprise/query-logging/LICENSES.txt
+++ b/enterprise/query-logging/LICENSES.txt
@@ -1,0 +1,4 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+

--- a/enterprise/query-logging/NOTICE.txt
+++ b/enterprise/query-logging/NOTICE.txt
@@ -1,0 +1,27 @@
+Neo4j
+Copyright © 2002-2014 Network Engine for Objects in Lund AB (referred to
+in this notice as "Neo Technology")
+   [http://neotechnology.com]
+
+This product includes software ("Software") developed by Neo Technology.
+
+The copyright in the bundled Neo4j graph database (including the
+Software) is owned by Neo Technology. The Software developed and owned
+by Neo Technology is licensed under the GNU AFFERO GENERAL PUBLIC
+LICENSE Version 3 (http://www.fsf.org/licensing/licenses/agpl-3.0.html)
+("AGPL") to all third parties and that license, as required by the AGPL,
+is included in the LICENSE.txt file.
+
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the AGPL and you may use the
+software solely pursuant to the terms of the relevant Commercial
+Agreement.
+
+Full license texts are found in LICENSES.txt.
+
+Third-party licenses
+--------------------
+

--- a/enterprise/query-logging/pom.xml
+++ b/enterprise/query-logging/pom.xml
@@ -1,0 +1,102 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.neo4j</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.2-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+  <groupId>org.neo4j</groupId>
+  <artifactId>neo4j-query-logging</artifactId>
+  <version>2.2-SNAPSHOT</version>
+
+  <name>Neo4j - Query Logging</name>
+  <description>Extension for logging queries to a separate query log file</description>
+  <packaging>jar</packaging>
+  <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
+
+  <properties>
+    <bundle.namespace>org.neo4j.kernel.impl.query</bundle.namespace>
+    <short-name>query-logging</short-name>
+    <version-package>kernel.impl.query</version-package>
+    <docs-plugin.skip>false</docs-plugin.skip>
+  </properties>
+
+  <scm>
+    <url>https://github.com/neo4j/neo4j/tree/master/enterprise/query-logging</url>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>GNU Affero General Public License, Version 3</name>
+      <url>http://www.gnu.org/licenses/agpl-3.0-standalone.html</url>
+      <comments>The software ("Software") developed and owned by Network Engine for
+        Objects in Lund AB (referred to in this notice as "Neo Technology") is
+        licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3 to all
+        third parties and that license is included below.
+
+        However, if you have executed an End User Software License and Services
+        Agreement or an OEM Software License and Support Services Agreement, or
+        another commercial license agreement with Neo Technology or one of its
+        affiliates (each, a "Commercial Agreement"), the terms of the license in
+        such Commercial Agreement will supersede the GNU AFFERO GENERAL PUBLIC
+        LICENSE Version 3 and you may use the Software solely pursuant to the
+        terms of the relevant Commercial Agreement.
+      </comments>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-cypher</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-io</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.neo4j.function.Factory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Clock;
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.query.QuerySession.MetadataKey;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.Monitors;
+
+@Service.Implementation(KernelExtensionFactory.class)
+public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLoggerKernelExtension.Dependencies>
+{
+    public interface Dependencies
+    {
+        FileSystemAbstraction filesystem();
+
+        Config config();
+
+        Monitors monitoring();
+    }
+
+    public QueryLoggerKernelExtension()
+    {
+        super( "query-logging" );
+    }
+
+    @Override
+    public Lifecycle newKernelExtension( Dependencies the ) throws Throwable
+    {
+        if ( the.config().get( GraphDatabaseSettings.log_queries ) )
+        {
+            QueryLogger logger = new QueryLogger(
+                    Clock.SYSTEM_CLOCK,
+                    new LoggerFactory(
+                            the.filesystem(),
+                            the.config().get( GraphDatabaseSettings.log_queries_filename ) ),
+                    the.config().get( GraphDatabaseSettings.log_queries_threshold ) );
+            the.monitoring().addMonitorListener( logger );
+            return logger;
+        }
+        return null;
+    }
+
+    public static class QueryLogger extends LifecycleAdapter implements QueryExecutionMonitor
+    {
+        private static final MetadataKey<Long> START_TIME = new MetadataKey<>( Long.class, "start time" );
+        private static final MetadataKey<String> QUERY_STRING = new MetadataKey<>( String.class, "query string" );
+        private final Clock clock;
+        private final Factory<StringLogger> loggerFactory;
+        private final long thresholdMillis;
+        private StringLogger logger;
+
+        public QueryLogger( Clock clock, Factory<StringLogger> loggerFactory, long thresholdMillis )
+        {
+            this.clock = clock;
+            this.loggerFactory = loggerFactory;
+            this.thresholdMillis = thresholdMillis;
+        }
+
+        @Override
+        public void init()
+        {
+            logger = loggerFactory.newInstance();
+        }
+
+        @Override
+        public void shutdown()
+        {
+            logger.close();
+            logger = null;
+        }
+
+        @Override
+        public void startQueryExecution( QuerySession session, String query )
+        {
+            long startTime = clock.currentTimeMillis();
+            Object oldTime = session.put( START_TIME, startTime );
+            Object oldQuery = session.put( QUERY_STRING, query );
+            if ( oldTime != null || oldQuery != null )
+            {
+                logger.warn( String.format( "Concurrent queries for session %s: \"%s\" @ %s and \"%s\" @ %s",
+                        session, oldQuery, oldTime, query, startTime ) );
+            }
+        }
+
+        @Override
+        public void endFailure( QuerySession session, Throwable failure )
+        {
+            String query = session.remove( QUERY_STRING );
+            Long startTime = session.remove( START_TIME );
+            if ( startTime != null )
+            {
+                long time = clock.currentTimeMillis() - startTime;
+                logger.logMessage( String.format( "FAILURE %d ms: %s - %s", time, session,
+                        query == null ? "<unknown query>" : query ), failure );
+            }
+        }
+
+        @Override
+        public void endSuccess( QuerySession session )
+        {
+            String query = session.remove( QUERY_STRING );
+            Long startTime = session.remove( START_TIME );
+            if ( startTime != null )
+            {
+                long time = clock.currentTimeMillis() - startTime;
+                if ( time >= thresholdMillis )
+                {
+                    logger.logMessage( String.format( "SUCCESS %d ms: %s - %s", time, session,
+                            query == null ? "<unknown query>" : query ));
+                }
+            }
+        }
+    }
+
+    private static class LoggerFactory implements Factory<StringLogger>
+    {
+        private final FileSystemAbstraction filesystem;
+        private final File logfile;
+
+        public LoggerFactory( FileSystemAbstraction filesystem, File logfile )
+        {
+            this.filesystem = filesystem;
+            this.logfile = logfile;
+        }
+
+        @Override
+        public StringLogger newInstance()
+        {
+            return StringLogger.loggerDirectory( filesystem, logfile );
+        }
+    }
+}

--- a/enterprise/query-logging/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
+++ b/enterprise/query-logging/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
@@ -1,0 +1,1 @@
+org.neo4j.kernel.impl.query.QueryLoggerKernelExtension

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.mockito.InOrder;
+
+import org.neo4j.function.Factory;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.FakeClock;
+import org.neo4j.helpers.Settings;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.QueryLogger;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class QueryLoggerIT
+{
+    @Rule
+    public TestRule ruleOrder()
+    {
+        return RuleChain.outerRule( fs ).around( db );
+    }
+
+    private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    private final DatabaseRule db = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected GraphDatabaseFactory newFactory()
+        {
+            return ((TestGraphDatabaseFactory) super.newFactory()).setFileSystem( fs.get() );
+        }
+
+        @Override
+        protected GraphDatabaseBuilder newBuilder( GraphDatabaseFactory factory )
+        {
+            return super.newBuilder( factory )
+                    .setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE );
+        }
+    };
+
+    @Test
+    public void shouldLogQuerySlowerThanThreshold() throws Exception
+    {
+        String QUERY = "CREATE (n:Foo{bar:\"baz\"})";
+        db.getGraphDatabaseService().execute( QUERY );
+
+        db.shutdown();
+
+        File logfile = new File( "target/test-data/impermanent-db/queries.log/messages.log" );
+        List<String> logLines = new ArrayList<>();
+        try ( BufferedReader reader = new BufferedReader( fs.get().openAsReader( logfile, "UTF-8" ) ) )
+        {
+            for ( String line; (line = reader.readLine()) != null; )
+            {
+                logLines.add( line );
+            }
+        }
+
+        assertEquals( 1, logLines.size() );
+        assertThat( logLines.get( 0 ), Matchers.endsWith( String.format( " ms: %s - %s",
+                QueryEngineProvider.embeddedSession(), QUERY ) ) );
+    }
+}

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import org.neo4j.function.Factory;
+import org.neo4j.helpers.FakeClock;
+import org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.QueryLogger;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class QueryLoggerTest
+{
+    @Test
+    public void shouldLogQuerySlowerThanThreshold() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session = session( "{the session}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        queryLogger.init();
+
+        // when
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        clock.forward( 11, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session );
+
+        // then
+        verify( logger ).logMessage( "SUCCESS 11 ms: {the session} - MATCH (n) RETURN n" );
+    }
+
+    @Test
+    public void shouldNotLogQueryFasterThanThreshold() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session = session( "{the session}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        queryLogger.init();
+
+        // when
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        clock.forward( 9, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session );
+
+        // then
+        verifyZeroInteractions( logger );
+    }
+
+    @Test
+    public void shouldKeepTrackOfDifferentSessions() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session1 = session( "{session one}" );
+        QuerySession session2 = session( "{session two}" );
+        QuerySession session3 = session( "{session three}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        queryLogger.init();
+
+        // when
+        queryLogger.startQueryExecution( session1, "MATCH (a) RETURN a" );
+        clock.forward( 1, TimeUnit.MILLISECONDS );
+        queryLogger.startQueryExecution( session2, "MATCH (b) RETURN b" );
+        clock.forward( 1, TimeUnit.MILLISECONDS );
+        queryLogger.startQueryExecution( session3, "MATCH (c) RETURN c" );
+        clock.forward( 7, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session3 );
+        clock.forward( 7, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session2 );
+        clock.forward( 7, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session1 );
+
+        // then
+        InOrder order = inOrder( logger );
+        order.verify( logger ).logMessage( "SUCCESS 15 ms: {session two} - MATCH (b) RETURN b" );
+        order.verify( logger ).logMessage( "SUCCESS 23 ms: {session one} - MATCH (a) RETURN a" );
+        verifyNoMoreInteractions( logger );
+    }
+
+    @Test
+    public void shouldLogQueryOnFailureEvenIfFasterThanThreshold() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session = session( "{the session}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        queryLogger.init();
+        RuntimeException failure = new RuntimeException();
+
+        // when
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        clock.forward( 1, TimeUnit.MILLISECONDS );
+        queryLogger.endFailure( session, failure );
+
+        // then
+        verify( logger ).logMessage( "FAILURE 1 ms: {the session} - MATCH (n) RETURN n", failure );
+    }
+
+    private static QuerySession session( final String data )
+    {
+        return new QuerySession()
+        {
+            @Override
+            public String toString()
+            {
+                return data;
+            }
+        };
+    }
+
+    private static class LoggerFactory implements Factory<StringLogger>
+    {
+        private final StringLogger logger;
+
+        LoggerFactory( StringLogger logger )
+        {
+            this.logger = logger;
+        }
+
+        @Override
+        public StringLogger newInstance()
+        {
+            return logger;
+        }
+    }
+}


### PR DESCRIPTION
Three new options added
- dbms.querylog.enabled, if true log queries, defaults to false
- dbms.querylog.filename, the file where queries are logged, defaults to `queries.log`
- dbms.querylog.threshold, only log queries that run slower than threshold (in milliseconds)
  defaults to 0, i.e. log all queries.
