### PR TITLE
Statistics divergence for query planned before any data has been created

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
@@ -159,6 +159,8 @@ case class Selectivity(factor: Double) extends Ordered[Selectivity] {
 }
 
 object Selectivity {
+  def of( value: Double ): Option[Selectivity] = if ( value.isInfinite || value.isNaN ) None else Some(value)
+
   val ZERO = Selectivity(0.0d)
   val ONE = Selectivity(1.0d)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
@@ -59,8 +59,14 @@ case class GraphStatisticsSnapshot(map: Map[StatisticsKey, Double] = Map.empty) 
       .map(_.map(_._2).product)
       .kahanSum
 
-    val cosine = dotProduct / (vectorLength(map) * vectorLength(snapshot.map))
-    val divergence = Math.acos(cosine) * 2 / Math.PI
+    // the dot product between _any_ vector with a "zero vector" is always 0, so
+    // if the dot product is 0 we call it diverged unless both vectors are equal
+    if (dotProduct == 0) {
+      return map != snapshot.map
+    }
+    // otherwise we compute the angular difference between the two vectors, and compare to the given threshold
+    val cosine = dotProduct / (vectorLength(map) * vectorLength(snapshot.map)) // range: [0, pi/2]
+    val divergence = Math.acos(cosine) * 2 / Math.PI // range: [0, 1]
     divergence >= minThreshold
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundGraphStatistics.scala
@@ -39,7 +39,7 @@ class TransactionBoundGraphStatistics(statement: KernelStatement) extends GraphS
       val frequencyOfNodesWithSameValue = 1.0 / indexEntrySelectivity
       val indexSelectivity = frequencyOfNodesWithSameValue / labeledNodes
 
-      Some(Selectivity(indexSelectivity))
+      Selectivity.of(indexSelectivity)
     }
     catch {
       case e: IndexNotFoundKernelException => None

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cypher.internal.compiler.v2_2.CypherCacheHitMonitor;
+import org.neo4j.cypher.internal.compiler.v2_2.PreparedQuery;
+import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.Result;
+import org.neo4j.helpers.Pair;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static java.util.Collections.singletonMap;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+public class QueryInvalidationIT
+{
+    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldRePlanAfterDataChanges() throws Exception
+    {
+        // GIVEN
+        Random random = ThreadLocalRandom.current();
+        int USERS = 1000, CONNECTIONS = 10000;
+        Monitor monitor = new Monitor();
+        db.resolveDependency( Monitors.class ).addMonitorListener( monitor );
+        // - setup schema -
+        db.execute( "CREATE INDEX ON :User(userId)" );
+        // - execute the query without the existence data -
+        distantFriend( random, USERS );
+
+        long replanTime = System.currentTimeMillis() + 1_100;
+
+        // - create data -
+        for ( long userId = 0; userId < USERS; userId++ )
+        {
+            db.execute( "CREATE (newUser:User {userId: {userId}})", singletonMap( "userId", (Object) userId ) );
+        }
+        Map<String, Object> params = new HashMap<>();
+        for ( int i = 0; i < CONNECTIONS; i++ )
+        {
+            long user1 = random.nextInt( USERS );
+            long user2;
+            do
+            {
+                user2 = random.nextInt( USERS );
+            } while ( user1 == user2 );
+            params.put( "user1", user1 );
+            params.put( "user2", user2 );
+            db.execute( "MATCH (user1:User { userId: {user1} }), (user2:User { userId: {user2} }) " +
+                        "CREATE UNIQUE user1 -[:FRIEND]- user2", params );
+        }
+
+        // - after the query TTL has expired -
+        while ( System.currentTimeMillis() < replanTime )
+        {
+            Thread.sleep( 100 );
+        }
+
+        // WHEN
+        monitor.reset();
+        // - execute the query again -
+        distantFriend( random, USERS );
+
+        // THEN
+        assertEquals( "Query should have been replanned.", 1, monitor.discards );
+    }
+
+    private Pair<Long, ExecutionPlanDescription> distantFriend( Random random, int USERS )
+    {
+        Result result = db
+                .execute( "MATCH (user:User { userId: {userId} } ) -[:FRIEND]- () -[:FRIEND]- (distantFriend) " +
+                          "RETURN COUNT(distinct distantFriend)",
+                          singletonMap( "userId", (Object) (long) random.nextInt( USERS ) ) );
+        return Pair.of( (Long) single( single( result ).values() ), result.getExecutionPlanDescription() );
+    }
+
+    private static class Monitor implements CypherCacheHitMonitor<PreparedQuery>
+    {
+        int hits, misses, discards;
+
+        @Override
+        public synchronized void cacheHit( PreparedQuery key )
+        {
+            hits++;
+        }
+
+        @Override
+        public synchronized void cacheMiss( PreparedQuery key )
+        {
+            misses++;
+        }
+
+        @Override
+        public synchronized void cacheDiscard( PreparedQuery key )
+        {
+            discards++;
+        }
+
+        public void reset()
+        {
+            hits = misses = discards = 0;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -19,14 +19,17 @@
  */
 package org.neo4j.test;
 
-import org.junit.rules.ExternalResource;
-
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
+
+import org.junit.rules.ExternalResource;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -93,6 +96,16 @@ public abstract class DatabaseRule extends ExternalResource
             }
             return result;
         }
+    }
+
+    public Result execute( String query ) throws QueryExecutionException
+    {
+        return database.execute( query );
+    }
+
+    public Result execute( String query, Map<String, Object> parameters ) throws QueryExecutionException
+    {
+        return database.execute( query, parameters );
     }
 
     public Transaction beginTx()


### PR DESCRIPTION
If there is no data in the graph matching the basic components of a query the statistics will be exceptionally poor for the planning. It is important to ensure that such queries be re-planned as soon as possible.
The previous logic would produce numbers (Infinity and NaN) that made divergence computation impossible, and even in the cases where it would be possible to compute divergence, a statistics vector with all zeros (which would be the case if the graph contains no data) would never be considered diverged, regardless of how much the data changed.
This change set ensures that no impossible statistics are ever produced, and introduces a special case for all-zero statistics vectors, falling back equality comparison between the vectors in this case.
