### PR TITLE
Add some tests to verify that SchemaState is flushed when indexes come online

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -93,9 +93,9 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     }
 
     @Override
-    public void removeSchemaRuleFromCache( long id )
+    public void removeSchemaRuleFromCache( long schemaRuleId )
     {
-        schemaCache.removeSchemaRule( id );
+        schemaCache.removeSchemaRule( schemaRuleId );
         schemaState.clear();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -40,7 +40,7 @@ public interface CacheAccessBackDoor
 
     void addSchemaRule( SchemaRule schemaRule );
 
-    void removeSchemaRuleFromCache( long id );
+    void removeSchemaRuleFromCache( long schemaRuleId );
 
     void addRelationshipTypeToken( Token type );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/BridgingCacheAccessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/BridgingCacheAccessTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2002-2014 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.api.SchemaState;
+import org.neo4j.kernel.impl.api.store.PersistenceCache;
+import org.neo4j.kernel.impl.api.store.SchemaCache;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.core.NodeManager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BridgingCacheAccessTest
+{
+    private NodeManager nodeManager;
+    private SchemaCache schemaCache;
+    private SchemaState schemaState;
+    private PersistenceCache persistenceCache;
+    private CacheAccessBackDoor access;
+
+    @Before
+    public void setUp()
+    {
+        nodeManager = mock( NodeManager.class );
+        schemaCache = mock( SchemaCache.class );
+        schemaState = mock( SchemaState.class );
+        persistenceCache = mock( PersistenceCache.class );
+        access = new BridgingCacheAccess( nodeManager, schemaCache, schemaState, persistenceCache );
+    }
+
+    @Test
+    public void removingSchemaRuleMustClearSchemaState()
+    {
+        // when
+        access.removeSchemaRuleFromCache( 1 );
+
+        // then
+        verify( schemaState ).clear();
+    }
+}


### PR DESCRIPTION
The behaviour is already correct in this regard. This PR just adds assurance that we don't break this in the future.
