### PR TITLE
Produce fewer exceptions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ResultIterator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ResultIterator.scala
@@ -57,13 +57,15 @@ class ClosingIterator(inner: Iterator[collection.Map[String, Any]],
   def wasMaterialized: Boolean = isEmpty
 
   def hasNext: Boolean = failIfThrows {
-    if (closer.isClosed) return false
-
-    val innerHasNext: Boolean = inner.hasNext
-    if (!innerHasNext) {
-      close(success = true)
+    if (!closer.isClosed) {
+      val innerHasNext: Boolean = inner.hasNext
+      if (!innerHasNext) {
+        close(success = true)
+      }
+      innerHasNext
+    } else {
+      false
     }
-    innerHasNext
   }
 
   def next(): Map[String, Any] = failIfThrows {

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CollectUserAgentFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CollectUserAgentFilter.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.server.rest.web;
 
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-
-import com.sun.jersey.spi.container.ContainerRequest;
-import com.sun.jersey.spi.container.ContainerRequestFilter;
 
 public class CollectUserAgentFilter implements ContainerRequestFilter
 {
@@ -65,7 +65,7 @@ public class CollectUserAgentFilter implements ContainerRequestFilter
         try
         {
             List<String> headers = request.getRequestHeader( "User-Agent" );
-            if ( ! headers.isEmpty() )
+            if ( headers != null && !headers.isEmpty() )
             {
                 userAgents.add( headers.get( 0 ).split( " " )[0] );
             }


### PR DESCRIPTION
This fixes two hot exception producers that popped up during performance testing.
This might slightly improve performance, but there's another benefit in that it removes two very noisy spots from the code, so we can get more interesting signal about rarer exceptions.

The CollectUserAgentFilter is only a problem during performance testing, where the load generators don't provide a User-Agent header.
Probably not an issue in production.

The ResultIterator was implemented in a way that required non-local control flow through lambdas.
This is implemented in Scala with trace-less exceptions.
Changing the logic around to no longer do an early return removes the need for this control-flow-by-exception.
