### PR TITLE
Fix collision on item properties and node-id / rel type in GraSS.

### DIFF
--- a/community/browser/app/scripts/controllers/Inspector.coffee
+++ b/community/browser/app/scripts/controllers/Inspector.coffee
@@ -99,11 +99,11 @@ angular.module('neo4jApp.controllers')
         item.style = graphStyle.changeForSelector(item.style.selector, size)
 
       $scope.selectCaption = (item, caption) ->
-        item.style = graphStyle.changeForSelector(item.style.selector, { caption: '{' + caption + '}'})
+        item.style = graphStyle.changeForSelector(item.style.selector, { caption: caption})
 
       $scope.isSelectedCaption = (item, caption) ->
         grassProps = graphStyle.findRule(item.style.selector).props
-        grassProps.caption is "{#{caption}}" or (!grassProps.caption and caption is "id")
+        grassProps.caption is "#{caption}" or (!grassProps.caption and caption in ["<id>", "<type>"])
 
       $scope.selectScheme = (item, scheme) ->
         item.style = graphStyle.changeForSelector(item.style.selector, angular.copy(scheme))

--- a/community/browser/app/scripts/services/GraphGeometry.coffee
+++ b/community/browser/app/scripts/services/GraphGeometry.coffee
@@ -34,7 +34,7 @@ angular.module('neo4jApp.services')
       formatNodeCaptions = (nodes) ->
         for node in nodes
           template = GraphStyle.forNode(node).get("caption")
-          captionText = GraphStyle.interpolate(template, node.id, node.propertyMap)
+          captionText = GraphStyle.interpolate(template, node)
           words = captionText.split(" ")
           lines = []
           for i in [0..words.length - 1]

--- a/community/browser/app/scripts/services/GraphStyle.coffee
+++ b/community/browser/app/scripts/services/GraphStyle.coffee
@@ -166,7 +166,7 @@ angular.module('neo4jApp.services')
         rule = @findRule(selector)
 
         if not rule?
-          rule = new StyleRule(selector, angular.extend({color: provider.defaultStyle.relationship.color}, @getDefaultRelationshipCaption()))
+          rule = new StyleRule(selector, angular.extend(provider.defaultStyle.relationship, @getDefaultRelationshipCaption()))
           @rules.push(rule)
           @persist()
         if not rule.props.caption?
@@ -188,12 +188,12 @@ angular.module('neo4jApp.services')
           @persist()
 
       getDefaultCaption: (item) ->
-        return {caption: '{id}'} if not item or not item.propertyList?.length > 0
+        return {caption: '<id>'} if not item or not item.propertyList?.length > 0
         default_caption = {caption: "{#{item.propertyList?[0].key}}"}
         default_caption
 
       getDefaultRelationshipCaption: (item) ->
-        return {caption: '{type}'} 
+        return {caption: '<type>'} 
 
       #
       # Methods for getting and modifying rules
@@ -328,17 +328,21 @@ angular.module('neo4jApp.services')
       defaultSizes: -> provider.defaultSizes
       defaultArrayWidths: -> provider.defaultArrayWidths
       defaultColors: -> angular.copy(provider.defaultColors)
-      interpolate: (str, fallback, properties) ->
-        # Supplant
-        # http://javascript.crockford.com/remedial.html
-        str.replace(
+      interpolate: (str, item) ->
+        str.replace( #Caption from user set properties as {property} 
           /\{([^{}]*)\}/g,
           (a, b) ->
-            r = properties[b] or fallback
+            r = item.propertyMap[b]
             if typeof r is 'object'
               r = r.join(', ')
-            return if (typeof r is 'string' or typeof r is 'number') then r else a
+            return if (typeof r is 'string' or typeof r is 'number') then r else ''
+        ).replace( #<id> and <type> from item properties
+          /^<(id|type)>$/,
+          (a,b) ->
+            r = item[b]
+            return if (typeof r is 'string' or typeof r is 'number') then r else ''
         )
+
 
     @$get = ['localStorageService', (localStorageService) ->
       new GraphStyle(localStorageService)

--- a/community/browser/app/views/template/inspector-rows.jade
+++ b/community/browser/app/views/template/inspector-rows.jade
@@ -31,13 +31,13 @@ script(id="inspector/label.html", type="text/ng-template")
       ul.list-inline
         li Caption:
         li
-          a.attribute(ng-click='selectCaption(item, "id")'
-            ng-class="{selected: isSelectedCaption(item, 'id')}") id
+          a.attribute(ng-click='selectCaption(item, "<id>")'
+            ng-class="{selected: isSelectedCaption(item, '<id>')}") &lt;id&gt;
         li(ng-repeat='property in item.attrs')
           a.attribute(
-            ng-click='selectCaption(item, property)'
+            ng-click='selectCaption(item, "{" + property + "}")'
             ng-bind="property"
-            ng-class="{selected: isSelectedCaption(item, property)}")
+            ng-class="{selected: isSelectedCaption(item, '{' + property + '}')}")
 
 script(id="inspector/relationshipType.html", type="text/ng-template")
   ul.list-inline
@@ -61,10 +61,10 @@ script(id="inspector/relationshipType.html", type="text/ng-template")
       ul.list-inline
         li Caption:
         li
-          a.attribute(ng-click='selectCaption(item, "type")'
-            ng-class="{selected: isSelectedCaption(item, 'type')}") type
+          a.attribute(ng-click='selectCaption(item, "<type>")'
+            ng-class="{selected: isSelectedCaption(item, '<type>')}") &lt;type&gt;
         li(ng-repeat='property in item.attrs')
           a.attribute(
-            ng-click='selectCaption(item, property)'
+            ng-click='selectCaption(item, "{" + property + "}")'
             ng-bind="property"
-            ng-class="{selected: isSelectedCaption(item, property)}")
+            ng-class="{selected: isSelectedCaption(item, '{' + property + '}')}")

--- a/community/browser/lib/visualization/components/graphGeometry.coffee
+++ b/community/browser/lib/visualization/components/graphGeometry.coffee
@@ -18,7 +18,7 @@ class NeoD3Geometry
 
   fitCaptionIntoCircle = (node, style) ->
     template = style.forNode(node).get("caption")
-    captionText = style.interpolate(template, node.id, node.propertyMap)
+    captionText = style.interpolate(template, node)
     fontFamily = 'sans-serif'
     fontSize = parseFloat(style.forNode(node).get('font-size'))
     lineHeight = fontSize
@@ -71,7 +71,7 @@ class NeoD3Geometry
   formatRelationshipCaptions: (relationships) ->
     for relationship in relationships
       template = @style.forRelationship(relationship).get("caption")
-      relationship.caption = @style.interpolate(template, relationship.type, relationship.propertyMap)
+      relationship.caption = @style.interpolate(template, relationship)
 
   setNodeRadii: (nodes) ->
     for node in nodes


### PR DESCRIPTION
- Change so database autoset node-id and relationship type
  are referenced as &lt;id&gt; and &lt;type&gt; while user set properties
  still are referenced as {propName} for caption in style / grass.

Fixes #3660 
#### To try it out

Run this in 2.2-M01 vs. this branch.
Run cypher: `CREATE (n:Hero {id:'SUPERMAN', firstname:"Clark"})-[r:HAS_POWER {type:"PHYSICAL"}]->(m:Power {name:"Flying"}) RETURN *`

Get them: `MATCH (n) WHERE n:Power OR n:Hero RETURN n`

Click on label names and relationship types in legend to set the style in the inspector at the bottom of the frame to see what you can do now.

![oskar4j 2014-12-15 at 20 16 03](https://cloud.githubusercontent.com/assets/570998/5442182/51163a02-8497-11e4-8ae3-9e7bf8d243d0.png)  
Here you can't get the relationship TYPE to be the caption.

![oskar4j 2014-12-15 at 20 16 21](https://cloud.githubusercontent.com/assets/570998/5442183/513e8994-8497-11e4-8eee-65fde62a9a59.png)  
Here you can.  
The same goes for node-id:s.

In GraSS file you reference them like this.
![oskar4j 2014-12-16 at 09 27 01](https://cloud.githubusercontent.com/assets/570998/5450432/ca9e9e00-8505-11e4-9f10-572cc8c7f6a9.png)
