### PR TITLE
Better output for compare expressions in plan descriptions.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/ComparablePredicate.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/ComparablePredicate.scala
@@ -20,10 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v2_2.commands
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import expressions.{Identifier, Literal, Expression}
-import pipes.QueryState
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Expression, Identifier, Literal}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryState
 import org.neo4j.cypher.internal.helpers.IsCollection
-import org.neo4j.graphdb.{Relationship, Node}
+import org.neo4j.graphdb.{Node, Relationship}
 
 abstract sealed class ComparablePredicate(left: Expression, right: Expression) extends Predicate with Comparer {
   def compare(comparisonResult: Int): Boolean
@@ -75,7 +75,7 @@ case class Equals(a: Expression, b: Expression) extends Predicate with Comparer 
   private def incomparable(lhs: Any, rhs: Any)(implicit state: QueryState): Nothing =
     throw new IncomparableValuesException(textWithType(lhs), textWithType(rhs))
 
-  override def toString = a.toString() + " == " + b.toString()
+  override def toString = s"$a == $b"
 
   def containsIsNull = (a, b) match {
     case (Identifier(_), Literal(null)) => true

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -26,9 +26,10 @@ import org.neo4j.graphdb.Direction
 object PlanDescriptionArgumentSerializer {
   def serialize(arg: Argument): String = {
     val SEPARATOR = ", "
+    val UNNAMED_PATTERN = """  (UNNAMED|FRESHID|AGGREGATION)(\d+)""".r
     arg match {
       case ColumnsLeft(columns) => s"keep columns ${columns.mkString(SEPARATOR)}"
-      case LegacyExpression(expr) => expr.toString
+      case LegacyExpression(expr) => UNNAMED_PATTERN.replaceAllIn(expr.toString, m => s"anon[${m group 2}]")
       case UpdateActionName(action) => action
       case LegacyIndex(index) => index
       case Index(label, property) => s":$label($property)"

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
@@ -20,6 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Identifier
+import org.neo4j.cypher.internal.compiler.v2_2.commands.{Equals, GreaterThanOrEqual, Not}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.graphdb.Direction
@@ -181,6 +183,23 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite {
         |+----------+---------------+------+--------+-------------+-------------------------------------------------+
         ||     NAME |             1 |   42 |     33 |           n | (source)-[through:SOME|:OTHER|:THING]->(target) |
         |+----------+---------------+------+--------+-------------+-------------------------------------------------+
+        |""".stripMargin)
+  }
+
+  test("show nicer output instead of unnamed identifiers in equals expression") {
+    val arguments = Seq(
+      Rows(42),
+      DbHits(33),
+      LegacyExpression(Not(Equals(Identifier("  UNNAMED123"), Identifier("  UNNAMED321")))))
+
+    val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
+    val p = renderDetails(plan)
+    renderDetails(plan) should equal(
+      """+----------+---------------+------+--------+-------------+-----------------------------+
+        || Operator | EstimatedRows | Rows | DbHits | Identifiers |                       Other |
+        |+----------+---------------+------+--------+-------------+-----------------------------+
+        ||     NAME |             1 |   42 |     33 |           n | NOT(anon[123] == anon[321]) |
+        |+----------+---------------+------+--------+-------------+-----------------------------+
         |""".stripMargin)
   }
 }


### PR DESCRIPTION
When using unnamed identifiers instead of just removing all unnamed identifiers
leading to outputs like `NOT( == )`, we now output `NOT(anon[22] == anon[42])`.
