### PR TITLE
Detects opportunity of counting entities in parallel with other stages

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -81,6 +81,7 @@ import org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+import org.neo4j.unsafe.impl.batchimport.cache.AvailableMemoryCalculator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
@@ -345,7 +346,7 @@ public class StoreMigrator implements StoreMigrationParticipant
         BatchImporter importer = new ParallelBatchImporter( migrationDir.getAbsolutePath(), fileSystem,
                 new Configuration.OverrideFromConfig( config ), logging,
                 migrationBatchImporterMonitor( legacyStore, progressMonitor ),
-                parallel(), readAdditionalIds( storeDir, lastTxId, lastTxChecksum ) );
+                parallel(), readAdditionalIds( storeDir, lastTxId, lastTxChecksum ), AvailableMemoryCalculator.RUNTIME );
         Iterable<InputNode> nodes = legacyNodesAsInput( legacyStore );
         Iterable<InputRelationship> relationships = legacyRelationshipsAsInput( legacyStore );
         importer.doImport( Inputs.input( nodes, relationships, IdMappers.actual(), IdGenerators.fromInput() ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
@@ -64,11 +64,11 @@ public class EntityStoreUpdaterStep<RECORD extends PrimitiveRecord,INPUT extends
     private final BatchingPropertyRecordAccess propertyRecords = new BatchingPropertyRecordAccess();
     private final ReusableIteratorCostume<PropertyBlock> blockIterator = new ReusableIteratorCostume<>();
 
-    EntityStoreUpdaterStep( StageControl control, String name, Configuration config,
+    EntityStoreUpdaterStep( StageControl control, Configuration config,
             AbstractRecordStore<RECORD> entityStore,
             PropertyStore propertyStore, IoMonitor monitor, WriterFactory writerFactory )
     {
-        super( control, name, 1, config.movingAverageSize(), 1 ); // work-ahead doesn't matter, we're the last one
+        super( control, "WRITER", 1, config.movingAverageSize(), 1 ); // work-ahead doesn't matter, we're the last one
         this.entityStore = entityStore;
         this.propertyStore = propertyStore;
         this.writerFactory = writerFactory;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
@@ -25,22 +25,22 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
-import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
 
 /**
- * Calculates counts per label and puts data into {@link NodeLabelsCache} for use by {@link RelationshipCountsStep}.
+ * Calculates counts per label and puts data into {@link NodeLabelsCache} for use by {@link RelationshipCountsProcessor}.
  */
-public class NodeCountsStep extends NodeStoreProcessorStep
+public class NodeCountsProcessor implements StoreProcessor<NodeRecord>
 {
+    private final NodeStore nodeStore;
     private final long[] labelCounts;
     private final NodeLabelsCache cache;
     private final CountsTracker countsTracker;
     private final int anyLabel;
 
-    public NodeCountsStep( StageControl control, Configuration config, NodeStore nodeStore, NodeLabelsCache cache,
-            int highLabelId, CountsTracker countsTracker )
+    public NodeCountsProcessor( NodeStore nodeStore, NodeLabelsCache cache, int highLabelId,
+            CountsTracker countsTracker )
     {
-        super( control, "NODE COUNTS", config, nodeStore );
+        this.nodeStore = nodeStore;
         this.cache = cache;
         this.anyLabel = highLabelId;
         this.countsTracker = countsTracker;
@@ -49,7 +49,7 @@ public class NodeCountsStep extends NodeStoreProcessorStep
     }
 
     @Override
-    protected boolean process( NodeRecord node )
+    public boolean process( NodeRecord node )
     {
         long[] labels = NodeLabelsField.get( node, nodeStore );
         if ( labels.length > 0 )
@@ -67,7 +67,7 @@ public class NodeCountsStep extends NodeStoreProcessorStep
     }
 
     @Override
-    protected void done()
+    public void done()
     {
         for ( int i = 0; i < labelCounts.length; i++ )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStoreProcessorStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStoreProcessorStage.java
@@ -17,40 +17,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.cache;
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 
 /**
- * Abstraction over primitive arrays.
- *
- * @see NumberArrayFactory
+ * {@link Stage} that has just a single {@link NodeStoreProcessorStep} where a custom {@link StoreProcessor}
+ * is passed in.
  */
-public interface NumberArray extends MemoryStatsVisitor.Home, AutoCloseable
+public class NodeStoreProcessorStage extends Stage
 {
-    /**
-     * @return length of the array, i.e. the capacity.
-     */
-    long length();
-
-    /**
-     * @return number of indexes occupied, i.e. setting the same index multiple times doesn't increment size.
-     */
-    long size();
-
-    void swap( long fromIndex, long toIndex, int numberOfEntries );
-
-    /**
-     * Sets all values to a default value.
-     */
-    void clear();
-
-    /**
-     * @return highest set index or -1 if no set.
-     */
-    long highestSetIndex();
-
-    /**
-     * Releases any resources that GC won't release automatically.
-     */
-    @Override
-    public void close();
+    public NodeStoreProcessorStage( String name, Configuration config, NodeStore store,
+            StoreProcessor<NodeRecord> processor )
+    {
+        super( name, config );
+        add( new NodeStoreProcessorStep( control(), name, config, store, processor ) );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -31,9 +31,13 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.unsafe.impl.batchimport.cache.AvailableMemoryCalculator;
+import org.neo4j.unsafe.impl.batchimport.cache.GatheringMemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipLink;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipLinkImpl;
@@ -82,6 +86,7 @@ public class ParallelBatchImporter implements BatchImporter
     private final Monitors monitors;
     private final WriterFactory writerFactory;
     private final AdditionalInitialIds additionalInitialIds;
+    private final AvailableMemoryCalculator memoryCalculator;
 
     /**
      * Advanced usage of the parallel batch importer, for special and very specific cases. Please use
@@ -89,13 +94,14 @@ public class ParallelBatchImporter implements BatchImporter
      */
     public ParallelBatchImporter( String storeDir, FileSystemAbstraction fileSystem, Configuration config,
             Logging logging, ExecutionMonitor executionMonitor, Function<Configuration,WriterFactory> writerFactory,
-            AdditionalInitialIds additionalInitialIds )
+            AdditionalInitialIds additionalInitialIds, AvailableMemoryCalculator memoryCalculator )
     {
         this.storeDir = storeDir;
         this.fileSystem = fileSystem;
         this.config = config;
         this.logging = logging;
         this.additionalInitialIds = additionalInitialIds;
+        this.memoryCalculator = memoryCalculator;
         this.logger = logging.getMessagesLog( getClass() );
         this.executionPoller = new ExecutionSupervisor( Clock.SYSTEM_CLOCK, new MultiExecutionMonitor(
                 executionMonitor, new DynamicProcessorAssigner( config, config.maxNumberOfProcessors() ) ) );
@@ -107,7 +113,8 @@ public class ParallelBatchImporter implements BatchImporter
     public ParallelBatchImporter( String storeDir, Configuration config, Logging logging,
             ExecutionMonitor executionMonitor )
     {
-        this( storeDir, new DefaultFileSystemAbstraction(), config, logging, executionMonitor, parallel(), EMPTY );
+        this( storeDir, new DefaultFileSystemAbstraction(), config, logging, executionMonitor, parallel(), EMPTY,
+                AvailableMemoryCalculator.RUNTIME );
     }
 
     @Override
@@ -154,53 +161,64 @@ public class ParallelBatchImporter implements BatchImporter
             // Stage 3 -- relationships, properties
             final RelationshipStage relationshipStage =
                     new RelationshipStage( relationships, idMapper, neoStore, nodeRelationshipLink );
-
-            // execute stage 3
             executeStages( relationshipStage );
 
-            // Switch to reverse updating mode
+            // Switch to reverse updating mode and release references that are no longer used so they can be collected
             writerFactory.awaitEverythingWritten();
             neoStore.switchToUpdateMode();
-            // Release IdMapper references since they are no longer needed, and so can be collected
             idMapper = null;
             idGenerator = null;
 
-            // Stage 4 -- set node nextRel fields
-            final NodeFirstRelationshipStage nodeFirstRelationshipStage =
-                    new NodeFirstRelationshipStage( neoStore, nodeRelationshipLink );
-
-            // execute stage 4
-            executeStages( nodeFirstRelationshipStage );
-
-            nodeRelationshipLink.clearRelationships();
-
-            // Stage 5 -- link relationship chains together
-            final RelationshipLinkbackStage relationshipLinkbackStage =
-                    new RelationshipLinkbackStage( neoStore, nodeRelationshipLink );
-
-            // execute stage 5
-            executeStages( relationshipLinkbackStage );
-
-            // Counts stages. The reason we're doing this as separate stages is that they require
-            // as much, and different, memory as the node/relationship encoding stages
-            // TODO OK so opportunity here: if we spot that there's at least as much memory available
-            // as our current node --> relationship cache has allocated we can execute these count stages
-            // in parallel with the link-back stages, or rather piggy-back on that processing directly.
-
-            // Release this potentially really big piece of cached data
-            nodeRelationshipLink.close();
-            nodeRelationshipLink = null;
-
-            // Stage 6 -- count nodes per label and labels per node
+            // Remaining node processors
             nodeLabelsCache = new NodeLabelsCache( AUTO, neoStore.getLabelRepository().getHighId() );
-            final NodeCountsStage nodeCountsStage = new NodeCountsStage( neoStore, nodeLabelsCache );
-            executeStages( nodeCountsStage );
+            StoreProcessor<NodeRecord> nodeFirstRelationshipProcessor = new NodeFirstRelationshipProcessor(
+                    neoStore.getRelationshipGroupStore(), nodeRelationshipLink );
+            StoreProcessor<NodeRecord> nodeCountsProcessor = new NodeCountsProcessor( neoStore.getNodeStore(),
+                    nodeLabelsCache, neoStore.getLabelRepository().getHighId(), neoStore.getCountsStore() );
 
-            // Stage 7 -- count label-[type]->label
-            final RelationshipCountsStage relationshipCountsStage =
-                    new RelationshipCountsStage( neoStore, nodeLabelsCache );
-            executeStages( relationshipCountsStage );
+            // Remaining relationship processors
+            StoreProcessor<RelationshipRecord> relationshipLinkerProcessor =
+                    new RelationshipLinkbackProcessor( nodeRelationshipLink );
+            StoreProcessor<RelationshipRecord> relationshipCountsProcessor = new RelationshipCountsProcessor(
+                    nodeLabelsCache, neoStore.getLabelRepository().getHighId(),
+                    neoStore.getRelationshipTypeRepository().getHighId(), neoStore.getCountsStore() );
 
+            // Determine if we have enough available memory to be able to execute all remaining processors
+            // in parallel.
+            if ( enoughAvailableMemoryForRemainingProcessors( nodeRelationshipLink ) )
+            {
+                // Stages 4, 5, 6 and 7
+                executeStages( new NodeStoreProcessorStage( "Node --> Relationship + counts", config,
+                        neoStore.getNodeStore(), new StoreProcessor.Multiple<>(
+                                nodeFirstRelationshipProcessor, nodeCountsProcessor ) ) );
+                nodeRelationshipLink.clearRelationships();
+                executeStages( new RelationshipStoreProcessorStage( "Relationship --> Relationship + counts", config,
+                        neoStore.getRelationshipStore(), new StoreProcessor.Multiple<>(
+                                relationshipLinkerProcessor, relationshipCountsProcessor ) ) );
+            }
+            else
+            {
+                // Stage 4 -- set node nextRel fields
+                executeStages( new NodeStoreProcessorStage( "Node --> Relationship", config,
+                        neoStore.getNodeStore(), nodeFirstRelationshipProcessor ) );
+                // Stage 5 -- link relationship chains together
+                nodeRelationshipLink.clearRelationships();
+                executeStages( new RelationshipStoreProcessorStage( "Relationship --> Relationship", config,
+                        neoStore.getRelationshipStore(), relationshipLinkerProcessor ) );
+
+                // Release this potentially really big piece of cached data
+                nodeRelationshipLink.close();
+                nodeRelationshipLink = null;
+
+                // Stage 6 -- count nodes per label and labels per node
+                executeStages( new NodeStoreProcessorStage( "Node --> Relationship", config,
+                        neoStore.getNodeStore(), nodeCountsProcessor ) );
+                // Stage 7 -- count label-[type]->label
+                executeStages( new RelationshipStoreProcessorStage( "Relationship --> Relationship", config,
+                        neoStore.getRelationshipStore(), relationshipCountsProcessor ) );
+            }
+
+            // We're done, do some final logging about it
             long totalTimeMillis = currentTimeMillis() - startTime;
             executionPoller.done( totalTimeMillis );
             logger.info( "Import completed, took " + Format.duration( totalTimeMillis ) );
@@ -222,6 +240,15 @@ public class ParallelBatchImporter implements BatchImporter
                 nodeLabelsCache.close();
             }
         }
+    }
+
+    private boolean enoughAvailableMemoryForRemainingProcessors( NodeRelationshipLink nodeRelationshipLink )
+    {
+        GatheringMemoryStatsVisitor usedMemory = new GatheringMemoryStatsVisitor();
+        nodeRelationshipLink.visit( usedMemory );
+        long used = usedMemory.getHeapUsage() + usedMemory.getOffHeapUsage();
+        long available = memoryCalculator.availableHeapMemory() + memoryCalculator.availableOffHeapMemory();
+        return available > used * 2; // to be on the safe side
     }
 
     private synchronized void executeStages( Stage... stages )
@@ -258,7 +285,7 @@ public class ParallelBatchImporter implements BatchImporter
             add( new NodeEncoderStep( control(), config, idMapper, idGenerator,
                     neoStore.getLabelRepository(), nodeStore, idsOf( nodes ) ) );
             add( new PropertyEncoderStep<>( control(), config, 1, neoStore.getPropertyKeyRepository(), propertyStore ) );
-            add( new EntityStoreUpdaterStep<>( control(), "WRITER", config, nodeStore, propertyStore,
+            add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore,
                     writeMonitor, writerFactory ) );
         }
     }
@@ -292,49 +319,8 @@ public class ParallelBatchImporter implements BatchImporter
             add( new RelationshipEncoderStep( control(), config,
                     neoStore.getRelationshipTypeRepository(), relationshipStore, nodeRelationshipLink ) );
             add( new PropertyEncoderStep<>( control(), config, 1, neoStore.getPropertyKeyRepository(), propertyStore ) );
-            add( new EntityStoreUpdaterStep<>( control(), "WRITER", config,
+            add( new EntityStoreUpdaterStep<>( control(), config,
                     relationshipStore, propertyStore, writeMonitor, writerFactory ) );
-        }
-    }
-
-    public class NodeFirstRelationshipStage extends Stage
-    {
-        public NodeFirstRelationshipStage( BatchingNeoStore neoStore, NodeRelationshipLink nodeRelationshipLink )
-        {
-            super( "Node first rel", config );
-            add( new NodeFirstRelationshipStep( control(), config,
-                    neoStore.getNodeStore(), neoStore.getRelationshipGroupStore(), nodeRelationshipLink ) );
-        }
-    }
-
-    public class RelationshipLinkbackStage extends Stage
-    {
-        public RelationshipLinkbackStage( BatchingNeoStore neoStore, NodeRelationshipLink nodeRelationshipLink )
-        {
-            super( "Relationship back link", config );
-            add( new RelationshipLinkbackStep( control(), config,
-                    neoStore.getRelationshipStore(), nodeRelationshipLink ) );
-        }
-    }
-
-    public class NodeCountsStage extends Stage
-    {
-        public NodeCountsStage( BatchingNeoStore neoStore, NodeLabelsCache cache )
-        {
-            super( "Node counts", config );
-            add( new NodeCountsStep( control(), config, neoStore.getNodeStore(), cache,
-                    neoStore.getLabelRepository().getHighId(), neoStore.getCountsStore() ) );
-        }
-    }
-
-    public class RelationshipCountsStage extends Stage
-    {
-        public RelationshipCountsStage( BatchingNeoStore neoStore, NodeLabelsCache cache )
-        {
-            super( "Relationship counts", config );
-            add( new RelationshipCountsStep( control(), config, neoStore.getRelationshipStore(), cache,
-                    neoStore.getLabelRepository().getHighId(), neoStore.getRelationshipTypeRepository().getHighId(),
-                    neoStore.getCountsStore() ) );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -20,16 +20,14 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
-import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
 
 /**
  * Calculates counts as labelId --[type]--> labelId for relationships with the labels coming from its start/end nodes.
  */
-public class RelationshipCountsStep extends RelationshipStoreProcessorStep
+public class RelationshipCountsProcessor implements StoreProcessor<RelationshipRecord>
 {
     /** Don't support these counts at the moment so don't compute them */
     private static final boolean COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS = false;
@@ -41,10 +39,9 @@ public class RelationshipCountsStep extends RelationshipStoreProcessorStep
     private final int anyLabel;
     private final int anyRelationshipType;
 
-    protected RelationshipCountsStep( StageControl control, Configuration config, RelationshipStore relationshipStore,
-            NodeLabelsCache nodeLabelCache, int highLabelId, int highRelationshipTypeId, CountsTracker countsTracker )
+    protected RelationshipCountsProcessor( NodeLabelsCache nodeLabelCache,
+            int highLabelId, int highRelationshipTypeId, CountsTracker countsTracker )
     {
-        super( control, "RELATIONSHIP COUNTS", config, relationshipStore );
         this.nodeLabelCache = nodeLabelCache;
         this.countsTracker = countsTracker;
 
@@ -55,7 +52,7 @@ public class RelationshipCountsStep extends RelationshipStoreProcessorStep
     }
 
     @Override
-    protected boolean process( RelationshipRecord record )
+    public boolean process( RelationshipRecord record )
     {
         long startNode = record.getFirstNode();
         long endNode = record.getSecondNode();
@@ -104,7 +101,7 @@ public class RelationshipCountsStep extends RelationshipStoreProcessorStep
     }
 
     @Override
-    protected void done()
+    public void done()
     {
         for ( int startNodeLabelId = 0; startNodeLabelId < counts.length; startNodeLabelId++ )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackProcessor.java
@@ -20,28 +20,24 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.graphdb.Direction;
-import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipLink;
-import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
 
 /**
  * Links the {@code previous} fields in {@link RelationshipRecord relationship records}. This is done after
  * a forward pass where the {@code next} fields are linked.
  */
-public class RelationshipLinkbackStep extends RelationshipStoreProcessorStep
+public class RelationshipLinkbackProcessor implements StoreProcessor<RelationshipRecord>
 {
     private final NodeRelationshipLink nodeRelationshipLink;
 
-    public RelationshipLinkbackStep( StageControl control, Configuration config,
-            RelationshipStore relStore, NodeRelationshipLink nodeRelationshipLink )
+    public RelationshipLinkbackProcessor( NodeRelationshipLink nodeRelationshipLink )
     {
-        super( control, "LINKER", config, relStore );
         this.nodeRelationshipLink = nodeRelationshipLink;
     }
 
     @Override
-    protected boolean process( RelationshipRecord record )
+    public boolean process( RelationshipRecord record )
     {
         boolean isLoop = record.getFirstNode() == record.getSecondNode();
         if ( isLoop )
@@ -83,5 +79,10 @@ public class RelationshipLinkbackStep extends RelationshipStoreProcessorStep
             record.setSecondPrevRel( secondPrevRel );
         }
         return true;
+    }
+
+    @Override
+    public void done()
+    {   // Nothing to do here
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStoreProcessorStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStoreProcessorStage.java
@@ -17,40 +17,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.cache;
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 
 /**
- * Abstraction over primitive arrays.
- *
- * @see NumberArrayFactory
+ * {@link Stage} that has just a single {@link RelationshipStoreProcessorStep} where a custom {@link StoreProcessor}
+ * is passed in.
  */
-public interface NumberArray extends MemoryStatsVisitor.Home, AutoCloseable
+public class RelationshipStoreProcessorStage extends Stage
 {
-    /**
-     * @return length of the array, i.e. the capacity.
-     */
-    long length();
-
-    /**
-     * @return number of indexes occupied, i.e. setting the same index multiple times doesn't increment size.
-     */
-    long size();
-
-    void swap( long fromIndex, long toIndex, int numberOfEntries );
-
-    /**
-     * Sets all values to a default value.
-     */
-    void clear();
-
-    /**
-     * @return highest set index or -1 if no set.
-     */
-    long highestSetIndex();
-
-    /**
-     * Releases any resources that GC won't release automatically.
-     */
-    @Override
-    public void close();
+    public RelationshipStoreProcessorStage( String name, Configuration config,
+            RelationshipStore store, StoreProcessor<RelationshipRecord> processor )
+    {
+        super( name, config );
+        add( new RelationshipStoreProcessorStep( control(), name, config, store, processor ) );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoreProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoreProcessor.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+public interface StoreProcessor<T>
+{
+    /**
+     * Processes an item.
+     *
+     * @return {@code true} if the store should be updated as part of processing this item.
+     */
+    boolean process( T item );
+
+    void done();
+
+    public static class Multiple<T> implements StoreProcessor<T>
+    {
+        private final StoreProcessor<T>[] processors;
+
+        @SafeVarargs
+        public Multiple( StoreProcessor<T>... processors )
+        {
+            this.processors = processors;
+        }
+
+        @Override
+        public boolean process( T item )
+        {
+            boolean result = false;
+            for ( StoreProcessor<T> processor : processors )
+            {
+                result |= processor.process( item );
+            }
+            return result;
+        }
+
+        @Override
+        public void done()
+        {
+            for ( StoreProcessor<T> processor : processors )
+            {
+                processor.done();
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/AvailableMemoryCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/AvailableMemoryCalculator.java
@@ -53,5 +53,11 @@ public interface AvailableMemoryCalculator
             Runtime runtime = Runtime.getRuntime();
             return runtime.maxMemory() - runtime.totalMemory();
         }
+
+        @Override
+        public String toString()
+        {
+            return "Java runtime memory calculator";
+        }
     };
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
@@ -82,11 +82,11 @@ abstract class DynamicNumberArray<N extends NumberArray> implements NumberArray
     }
 
     @Override
-    public void visitMemoryStats( MemoryStatsVisitor visitor )
+    public void visit( MemoryStatsVisitor visitor )
     {
         for ( NumberArray chunk : chunks )
         {
-            chunk.visitMemoryStats( visitor );
+            chunk.visit( visitor );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
@@ -53,7 +53,7 @@ abstract class HeapNumberArray implements NumberArray
     }
 
     @Override
-    public void visitMemoryStats( MemoryStatsVisitor visitor )
+    public void visit( MemoryStatsVisitor visitor )
     {
         visitor.heapUsage( length() * itemSize ); // roughly
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
@@ -24,6 +24,11 @@ package org.neo4j.unsafe.impl.batchimport.cache;
  */
 public interface MemoryStatsVisitor
 {
+    interface Home
+    {
+        void visit( MemoryStatsVisitor visitor );
+    }
+
     void heapUsage( long bytes );
 
     void offHeapUsage( long bytes );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
@@ -29,7 +29,7 @@ import static org.neo4j.kernel.impl.util.Bits.bitsFromLongs;
  * Caches labels for each node. Tries to keep memory as 8b (a long) per node. If a particular node has many labels
  * it will spill over into two or more longs in a separate array.
  */
-public class NodeLabelsCache
+public class NodeLabelsCache implements MemoryStatsVisitor.Home
 {
     private final LongArray cache;
     private final LongArray spillOver;
@@ -136,10 +136,11 @@ public class NodeLabelsCache
         return target;
     }
 
-    public void visitMemoryStats( MemoryStatsVisitor visitor )
+    @Override
+    public void visit( MemoryStatsVisitor visitor )
     {
-        cache.visitMemoryStats( visitor );
-        spillOver.visitMemoryStats( visitor );
+        cache.visit( visitor );
+        spillOver.visit( visitor );
     }
 
     private void decode( Bits bits, int length, int[] target )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipLink.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipLink.java
@@ -25,7 +25,7 @@ import org.neo4j.graphdb.Direction;
  * Caches of parts of node store and relationship group store. A crucial part of batch import where
  * any random access must be covered by this cache. All I/O, both read and write must be sequential.
  */
-public interface NodeRelationshipLink
+public interface NodeRelationshipLink extends MemoryStatsVisitor.Home
 {
     // PHASE 1
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipLinkImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipLinkImpl.java
@@ -148,7 +148,7 @@ public class NodeRelationshipLinkImpl implements NodeRelationshipLink
         return IdFieldManipulator.getCount( field );
     }
 
-    private static class RelGroupCache implements AutoCloseable
+    private static class RelGroupCache implements AutoCloseable, MemoryStatsVisitor.Home
     {
         private static final int ENTRY_SIZE = 4;
 
@@ -334,6 +334,12 @@ public class NodeRelationshipLinkImpl implements NodeRelationshipLink
         {
             array.close();
         }
+
+        @Override
+        public void visit( MemoryStatsVisitor visitor )
+        {
+            array.visit( visitor );
+        }
     }
 
     @Override
@@ -347,5 +353,12 @@ public class NodeRelationshipLinkImpl implements NodeRelationshipLink
     {
         array.close();
         relGroupCache.close();
+    }
+
+    @Override
+    public void visit( MemoryStatsVisitor visitor )
+    {
+        array.visit( visitor );
+        relGroupCache.visit( visitor );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
@@ -76,7 +76,7 @@ abstract class OffHeapNumberArray implements NumberArray
     }
 
     @Override
-    public void visitMemoryStats( MemoryStatsVisitor visitor )
+    public void visit( MemoryStatsVisitor visitor )
     {
         visitor.offHeapUsage( length * stride );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -440,8 +440,8 @@ public class EncodingIdMapper implements IdMapper
     @Override
     public void visitMemoryStats( MemoryStatsVisitor visitor )
     {
-        dataCache.visitMemoryStats( visitor );
-        trackerCache.visitMemoryStats( visitor );
-        collisionCache.visitMemoryStats( visitor );
+        dataCache.visit( visitor );
+        trackerCache.visit( visitor );
+        collisionCache.visit( visitor );
     }
 }


### PR DESCRIPTION
To avoid going over the node and relationship stores twice after importing
its data. The deciding factor is whether or not there are enough memory
available to be able to populate state for counting entities while the
node -> relationship cache is still in use.