### PR TITLE
Correctly responds to inactive update puller

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerClient.java
@@ -54,7 +54,8 @@ public class UpdatePullerClient extends LifecycleAdapter
             return;
         }
 
-        updatePuller.await( UpdatePuller.NEXT_TICKET );
+        updatePuller.await( UpdatePuller.NEXT_TICKET,
+                false /*we're OK with the update puller becoming inactive while we await the condition*/ );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfiller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfiller.java
@@ -61,11 +61,6 @@ public class UpdatePullingTransactionObligationFulfiller extends LifecycleAdapte
     @Override
     public void fulfill( final long toTxId ) throws InterruptedException
     {
-        if ( !updatePuller.isActive() )
-        {
-            throw new IllegalStateException( "Update puller not active " + updatePuller );
-        }
-
         updatePuller.await( new Condition()
         {
             @Override
@@ -78,7 +73,7 @@ public class UpdatePullingTransactionObligationFulfiller extends LifecycleAdapte
                  */
                 return transactionIdStore.getLastClosedTransactionId() >= toTxId;
             }
-        } );
+        }, true /*We strictly need the update puller to be and remain active while we wait*/ );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -422,7 +422,7 @@ public class SwitchToSlave
         // Unpause the update puller, because we know that we are a slave that just started communication with master.
         UpdatePuller updatePuller = resolver.resolveDependency( UpdatePuller.class );
         updatePuller.unpause();
-        updatePuller.await( UpdatePuller.NEXT_TICKET );
+        updatePuller.await( UpdatePuller.NEXT_TICKET, true );
 
         console.log( "Now caught up with master" );
         monitor.catchupCompleted();


### PR DESCRIPTION
There are different use cases for the update puller. Some cases are OK
with observing the puller becoming inactive while awaiting the condition,
others aren't. This different existed already, but only as a check before
the call and inside await an exception was thrown when this happened. This
commit moves the difference in handling an inactive puller into await
where the caller can decide how to handle it.
