### PR TITLE
Existance of node/rel is checked before deletion

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataWrite.java
@@ -29,12 +29,12 @@ interface DataWrite
 {
     long nodeCreate();
 
-    void nodeDelete( long nodeId );
+    void nodeDelete( long nodeId ) throws EntityNotFoundException;
 
     long relationshipCreate( int relationshipTypeId, long startNodeId, long endNodeId )
             throws RelationshipTypeIdNotFoundKernelException, EntityNotFoundException;
 
-    void relationshipDelete( long relationshipId );
+    void relationshipDelete( long relationshipId ) throws EntityNotFoundException;
 
     /**
      * Labels a node with the label corresponding to the given label id.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -142,7 +142,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations
     // Simply delegate the rest of the invocations
 
     @Override
-    public void nodeDelete( KernelStatement state, long nodeId )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         entityWriteOperations.nodeDelete( state, nodeId );
     }
@@ -154,7 +154,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations
     }
 
     @Override
-    public void relationshipDelete( KernelStatement state, long relationshipId )
+    public void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         entityWriteOperations.relationshipDelete( state, relationshipId );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -195,7 +195,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void nodeDelete( KernelStatement state, long nodeId )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         state.locks().acquireExclusive( ResourceTypes.NODE, nodeId );
         entityWriteDelegate.nodeDelete( state, nodeId );
@@ -225,7 +225,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void relationshipDelete( KernelStatement state, long relationshipId )
+    public void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         state.locks().acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
         entityWriteDelegate.relationshipDelete( state, relationshipId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -507,7 +507,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void nodeDelete( long nodeId )
+    public void nodeDelete( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         dataWrite().nodeDelete( statement, nodeId );
@@ -522,7 +522,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void relationshipDelete( long relationshipId )
+    public void relationshipDelete( long relationshipId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         dataWrite().relationshipDelete( statement, relationshipId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
@@ -33,9 +33,9 @@ public interface EntityWriteOperations
 
     long nodeCreate( KernelStatement statement );
 
-    void nodeDelete( KernelStatement state, long nodeId );
+    void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException;
 
-    void relationshipDelete( KernelStatement state, long relationshipId );
+    void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException;
 
     /**
      * Labels a node with the label corresponding to the given label id.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -150,16 +150,7 @@ public class CacheLayer implements StoreReadLayer
     @Override
     public boolean nodeExists( long nodeId )
     {
-        // Write a proper implementation later
-        try
-        {
-            persistenceCache.getNode( nodeId );
-            return true;
-        }
-        catch ( EntityNotFoundException e )
-        {
-            return false;
-        }
+        return persistenceCache.nodeExists( nodeId );
     }
 
     @Override
@@ -270,6 +261,12 @@ public class CacheLayer implements StoreReadLayer
     public Iterator<DefinedProperty> nodeGetAllProperties( long nodeId ) throws EntityNotFoundException
     {
         return persistenceCache.nodeGetProperties( nodeId, nodePropertyLoader );
+    }
+
+    @Override
+    public boolean relationshipExists( long relationshipId )
+    {
+        return persistenceCache.relationshipExists( relationshipId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
@@ -109,6 +109,11 @@ public class PersistenceCache
         return node;
     }
 
+    public boolean nodeExists( long nodeId )
+    {
+        return nodeCache.get( nodeId ) != null;
+    }
+
     public RelationshipImpl getRelationship( long relationshipId ) throws EntityNotFoundException
     {
         RelationshipImpl relationship = relationshipCache.get( relationshipId );
@@ -117,6 +122,11 @@ public class PersistenceCache
             throw new EntityNotFoundException( EntityType.RELATIONSHIP, relationshipId );
         }
         return relationship;
+    }
+
+    public boolean relationshipExists( long relationshipId )
+    {
+        return relationshipCache.get( relationshipId ) != null;
     }
 
     public void apply( Collection<NodeLabelUpdate> updates )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -84,6 +84,8 @@ public interface StoreReadLayer
 
     Iterator<DefinedProperty> nodeGetAllProperties( long nodeId ) throws EntityNotFoundException;
 
+    boolean relationshipExists( long relationshipId );
+
     PrimitiveLongIterator relationshipGetPropertyKeys( long relationshipId )
                     throws EntityNotFoundException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -126,6 +126,11 @@ public class NodeProxy implements Node
         {
             throw new ReadOnlyDbException();
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new IllegalStateException( "Unable to delete Node[" + nodeId +
+                                             "] since it has already been deleted." );
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -91,6 +91,11 @@ public class RelationshipProxy implements Relationship
         {
             throw new ReadOnlyDbException();
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new IllegalStateException( "Unable to delete relationship[" +
+                                             relId + "] since it is already deleted." );
+        }
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -122,7 +123,7 @@ public class LockingStatementOperationsTest
     }
 
     @Test
-    public void shouldAcquireEntityWriteLockBeforeDeletingNode()
+    public void shouldAcquireEntityWriteLockBeforeDeletingNode() throws EntityNotFoundException
     {
         // WHEN
         lockingOps.nodeDelete( state, 123 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -345,6 +345,7 @@ public class IndexQueryTransactionStateTest
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
         when( store.constraintsGetForLabel( labelId ) ).thenReturn( Collections.<UniquenessConstraint>emptyIterator() );
+        when( store.nodeExists( anyLong() ) ).thenReturn( true );
         when( store.indexesGetForLabelAndPropertyKey( labelId, propertyKeyId ) )
                 .thenReturn( new IndexDescriptor( labelId, propertyKeyId ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -39,9 +39,9 @@ import org.neo4j.kernel.impl.MyRelTypes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
@@ -936,5 +936,70 @@ public class TestRelationship extends AbstractNeo4jTestCase
 
         // THEN
         assertEquals( two, one );
+    }
+
+    @Test( expected = NotFoundException.class )
+    public void deletionOfSameRelationshipTwiceInOneTransactionShouldNotRollbackIt()
+    {
+        // Given
+        GraphDatabaseService db = getGraphDb();
+
+        // transaction is opened by test
+        Node node1 = db.createNode();
+        Node node2 = db.createNode();
+        Relationship relationship = node1.createRelationshipTo( node2, TEST );
+        commit();
+
+        // When
+        Exception exceptionThrownBySecondDelete = null;
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            relationship.delete();
+            try
+            {
+                relationship.delete();
+            }
+            catch ( IllegalStateException e )
+            {
+                exceptionThrownBySecondDelete = e;
+            }
+            tx.success();
+        }
+
+        // Then
+        assertNotNull( exceptionThrownBySecondDelete );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.getRelationshipById( relationship.getId() ); // should throw NotFoundException
+            tx.success();
+        }
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void deletionOfAlreadyDeletedRelationshipShouldThrow()
+    {
+        // Given
+        GraphDatabaseService db = getGraphDb();
+
+        // transaction is opened by test
+        Node node1 = db.createNode();
+        Node node2 = db.createNode();
+        Relationship relationship = node1.createRelationshipTo( node2, TEST );
+        commit();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            relationship.delete();
+            tx.success();
+        }
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            relationship.delete(); // should throw IllegalStateException as this relationship is already deleted
+            tx.success();
+        }
     }
 }


### PR DESCRIPTION
When node/relationship is deleted twice in the same transaction, than second delete call throws IllegalStateException (which is ok) and whole transaction is marked as rollback-only (which is too harsh).
This PR adds node/relationship existence check before deletion. This check examines transaction state and falls back to asking disk layer if entity exists.
