### PR TITLE
Fixes a race allowing transactions to be rotate away before applied

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -27,8 +27,6 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 
-import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.checksum;
-
 public class TransactionRepresentationCommitProcess implements TransactionCommitProcess
 {
     private final LogicalTransactionStore logicalTransactionStore;
@@ -56,8 +54,6 @@ public class TransactionRepresentationCommitProcess implements TransactionCommit
         // apply changes to the store
         try
         {
-            transactionIdStore.transactionCommitted( transactionId,
-                    checksum( transaction.additionalHeader(), transaction.getMasterId(), transaction.getAuthorId() ) );
             storeApplier.apply( transaction, locks, transactionId, mode );
         }
         // TODO catch different types of exceptions here, some which are OK

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.when;
 
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.checksum;
 
 public class TransactionRepresentationCommitProcessTest
 {
@@ -112,8 +111,7 @@ public class TransactionRepresentationCommitProcessTest
         }
 
         // THEN
-        verify( transactionIdStore, times( 1 ) ).transactionCommitted( txId,
-                checksum( transaction.additionalHeader(), transaction.getMasterId(), transaction.getAuthorId() ) );
+        // we can't verify transactionCommitted since that's part of the TransactionAppender, which we have mocked
         verify( transactionIdStore, times( 1 ) ).transactionClosed( txId );
         verifyNoMoreInteractions( transactionIdStore );
     }

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
@@ -107,7 +107,7 @@ public class TransactionCommittingResponseUnpackerTest
         unpacker.unpackResponse( response, stoppingTxHandler );
 
         // Then
-        verify( txIdStore, times( 1 ) ).transactionCommitted( committingTransactionId, 0 );
+        // we can't verify transactionCommitted since that's part of the TransactionAppender, which we have mocked
         verify( txIdStore, times( 1 ) ).transactionClosed( committingTransactionId );
         verify( appender, times( 1 ) ).append( any( TransactionRepresentation.class ), anyLong() );
         verify( appender, times( 1 ) ).force();

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -145,7 +145,7 @@ public class MasterClientTest
 
         // Then
         verify( txAppender, times( TX_LOG_COUNT ) ).append( any( TransactionRepresentation.class ), anyLong() );
-        verify( txIdStore, times( TX_LOG_COUNT ) ).transactionCommitted( anyLong(), anyLong() );
+        // we can't verify transactionCommitted since that's part of the TransactionAppender, which we have mocked
         verify( txApplier, times( TX_LOG_COUNT ) )
                 .apply( any( TransactionRepresentation.class ), any( LockGroup.class ), anyLong(),
                         any( TransactionApplicationMode.class ) );


### PR DESCRIPTION
The problem was that there was a window after appending the transaction to
the log and before marking that transaction as committed where a log
rotation could come in and rotate the log. The rotator would not wait for
the transaction(s) that had just been appended, and potentially also
forced since it hadn't even been marked as committed yet.
So a crash right after or at least before the changes of such
transactions would have been applied and fully forced to the store would
be lost since the transaction describing those changes would not be
recovered.
