### PR TITLE
Log rotation won't happen on kernel panic

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -812,13 +812,13 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
         final LogRotationControl logRotationControl = new LogRotationControl( neoStore, indexingService, labelScanStore,
                 indexProviders );
 
-        final LogRotation logRotation =
-                new LogRotationImpl( monitors.newMonitor( LogRotation.Monitor.class ), logFile, logRotationControl );
+        final LogRotation logRotation = new LogRotationImpl( monitors.newMonitor( LogRotation.Monitor.class ),
+                logFile, logRotationControl, kernelHealth );
 
         final LogicalTransactionStore logicalTransactionStore =
                 new PhysicalLogicalTransactionStore( logFile, logRotation,
                         transactionMetadataCache, neoStore, legacyIndexTransactionOrdering,
-                        config.get( GraphDatabaseSettings.batched_writes ) );
+                        kernelHealth, config.get( GraphDatabaseSettings.batched_writes ) );
 
         life.add( logFile );
         life.add( logicalTransactionStore );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStore.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.transaction.log;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache.TransactionMetadata;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
@@ -48,17 +49,19 @@ public class PhysicalLogicalTransactionStore extends LifecycleAdapter implements
     private final TransactionIdStore transactionIdStore;
     private final boolean batchedWrites;
     private final IdOrderingQueue legacyIndexTransactionOrdering;
+    private final KernelHealth kernelHealth;
 
     public PhysicalLogicalTransactionStore( LogFile logFile, LogRotation logRotation,
             TransactionMetadataCache transactionMetadataCache,
             TransactionIdStore transactionIdStore, IdOrderingQueue legacyIndexTransactionOrdering,
-            boolean batchedWrites )
+            KernelHealth kernelHealth, boolean batchedWrites )
     {
         this.logFile = logFile;
         this.logRotation = logRotation;
         this.transactionMetadataCache = transactionMetadataCache;
         this.transactionIdStore = transactionIdStore;
         this.legacyIndexTransactionOrdering = legacyIndexTransactionOrdering;
+        this.kernelHealth = kernelHealth;
         this.batchedWrites = batchedWrites;
     }
 
@@ -67,9 +70,9 @@ public class PhysicalLogicalTransactionStore extends LifecycleAdapter implements
     {
         this.appender = batchedWrites ?
                 new BatchingPhysicalTransactionAppender( logFile, logRotation, transactionMetadataCache, transactionIdStore,
-                        legacyIndexTransactionOrdering, ATOMIC_LONG, DEFAULT_WAIT_STRATEGY ) :
+                        legacyIndexTransactionOrdering, ATOMIC_LONG, DEFAULT_WAIT_STRATEGY, kernelHealth ) :
                 new PhysicalTransactionAppender( logFile, logRotation,
-                        transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering );
+                        transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering, kernelHealth );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionAppender.java
@@ -21,15 +21,17 @@ package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
 
 public class PhysicalTransactionAppender extends AbstractPhysicalTransactionAppender
 {
     public PhysicalTransactionAppender( LogFile logFile, LogRotation logRotation,
             TransactionMetadataCache transactionMetadataCache, TransactionIdStore transactionIdStore,
-            IdOrderingQueue legacyIndexTransactionOrdering )
+            IdOrderingQueue legacyIndexTransactionOrdering, KernelHealth kernelHealth )
     {
-        super( logFile, logRotation, transactionMetadataCache, transactionIdStore, legacyIndexTransactionOrdering );
+        super( logFile, logRotation, transactionMetadataCache, transactionIdStore,
+                legacyIndexTransactionOrdering, kernelHealth );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache.TransactionMetadata;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -39,7 +40,8 @@ public class ReadOnlyTransactionStore extends LifecycleAdapter implements Logica
     private final LifeSupport life = new LifeSupport();
     private final LogicalTransactionStore physicalStore;
 
-    public ReadOnlyTransactionStore( FileSystemAbstraction fs, File fromPath, Monitors monitors )
+    public ReadOnlyTransactionStore( FileSystemAbstraction fs, File fromPath, Monitors monitors,
+            KernelHealth kernelHealth )
     {
         PhysicalLogFiles logFiles = new PhysicalLogFiles( fromPath, fs );
         TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 10, 100 );
@@ -48,7 +50,8 @@ public class ReadOnlyTransactionStore extends LifecycleAdapter implements Logica
                 transactionIdStore, new ReadOnlyLogVersionRepository(fs, fromPath),
                 monitors.newMonitor( PhysicalLogFile.Monitor.class ), transactionMetadataCache));
 
-        physicalStore = life.add( new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION, transactionMetadataCache, transactionIdStore, BYPASS, false ) );
+        physicalStore = life.add( new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION,
+                transactionMetadataCache, transactionIdStore, BYPASS, kernelHealth, false ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionAppender.java
@@ -33,9 +33,16 @@ public interface TransactionAppender
      * Appends a transaction to a log, effectively committing it. After this method have returned the
      * returned transaction id should be visible in {@link TransactionIdStore#getLastCommittedTransactionId()}.
      *
+     * Any failure happening inside this method will automatically
+     * {@link TransactionIdStore#transactionClosed(long) close} the transaction if the execution got past
+     * {@link TransactionIdStore#transactionCommitted(long, long)}, so callers should not close transactions
+     * on exception thrown from this method. Although callers must make sure that successfully appended
+     * transactions exiting this method are {@link TransactionIdStore#transactionClosed(long)}.
+     *
      * @param transaction transaction representation to append.
      * @return transaction id the appended transaction got.
-     * @throws IOException if there was a problem appending the transaction.
+     * @throws IOException if there was a problem appending the transaction. See method javadoc body for
+     * how to handle exceptions in general thrown from this method.
      */
     long append( TransactionRepresentation transaction ) throws IOException;
 
@@ -43,6 +50,12 @@ public interface TransactionAppender
      * Appends a transaction to a log with an expected transaction id. The written data is not forced as
      * part of this method call, instead that is controlled manually by {@link #force()}. It's assumed
      * that only a single thread calls this method.
+     *
+     * Any failure happening inside this method will automatically
+     * {@link TransactionIdStore#transactionClosed(long) close} the transaction if the execution got past
+     * {@link TransactionIdStore#transactionCommitted(long, long)}, so callers should not close transactions
+     * on exception thrown from this method. Although callers must make sure that successfully appended
+     * transactions exiting this method are {@link TransactionIdStore#transactionClosed(long)}.
      *
      * @param transaction transaction representation to append.
      * @param transaction id the appended transaction is expected to have.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestStoreRecoverer.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/TestStoreRecoverer.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.store.record.NeoStoreUtil;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
@@ -113,7 +114,7 @@ public class TestStoreRecoverer
         try
         {
             TransactionAppender appender = new PhysicalTransactionAppender( logFile, LogRotation.NO_ROTATION, positionCache,
-                    transactionIdStore, null );
+                    transactionIdStore, null, mock( KernelHealth.class ) );
             appender.append( singleNodeTransaction() );
         }
         finally

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogicalTransactionStoreTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.Recovery;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
@@ -95,7 +96,7 @@ public class PhysicalLogicalTransactionStoreTest
         LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000,
                 transactionIdStore, mock( LogVersionRepository.class ), monitor, positionCache ) );
         life.add( new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION, positionCache,
-                transactionIdStore, BYPASS, true ) );
+                transactionIdStore, BYPASS, mock( KernelHealth.class ), true ) );
 
         try
         {
@@ -159,7 +160,7 @@ public class PhysicalLogicalTransactionStoreTest
 
         PhysicalLogicalTransactionStore store = new PhysicalLogicalTransactionStore( logFile,
                 LogRotation.NO_ROTATION, positionCache,
-                transactionIdStore, BYPASS, true );
+                transactionIdStore, BYPASS, mock( KernelHealth.class ), true );
         life.add( store );
         life.add(new Recovery(new Recovery.SPI()
         {
@@ -253,7 +254,7 @@ public class PhysicalLogicalTransactionStoreTest
                 positionCache ) );
 
         LogicalTransactionStore store = life.add( new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION,
-                positionCache, transactionIdStore, BYPASS, true ) );
+                positionCache, transactionIdStore, BYPASS, mock( KernelHealth.class ), true ) );
 
         // WHEN
         life.start();
@@ -282,7 +283,8 @@ public class PhysicalLogicalTransactionStoreTest
         TransactionMetadataCache cache = new TransactionMetadataCache( 10, 10 );
         TransactionIdStore txIdStore = mock( TransactionIdStore.class );
         LogicalTransactionStore txStore =
-                new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION, cache, txIdStore, BYPASS, false );
+                new PhysicalLogicalTransactionStore( logFile, LogRotation.NO_ROTATION, cache, txIdStore, BYPASS,
+                        mock( KernelHealth.class ), false );
 
         // WHEN
         try
@@ -302,7 +304,8 @@ public class PhysicalLogicalTransactionStoreTest
                                            long latestCommittedTxWhenStarted, long timeCommitted ) throws IOException
     {
         TransactionAppender appender = new PhysicalTransactionAppender(
-                logFile, LogRotation.NO_ROTATION, positionCache, transactionIdStore, BYPASS );
+                logFile, LogRotation.NO_ROTATION, positionCache, transactionIdStore, BYPASS,
+                mock( KernelHealth.class ) );
         PhysicalTransactionRepresentation transaction =
                 new PhysicalTransactionRepresentation( singleCreateNodeCommand() );
         transaction.setHeader( additionalHeader, masterId, authorId, timeStarted, latestCommittedTxWhenStarted,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppenderTest.java
@@ -27,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.function.Factory;
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.util.Counter;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.OtherThreadExecutor;
@@ -50,8 +51,9 @@ public class BatchingPhysicalTransactionAppenderTest
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         LimitedCounterFactory counters = new LimitedCounterFactory( highestValueBeforeWrappingAround, 0 );
         ControlledParkStrategy forceThreadControl = new ControlledParkStrategy();
-        BatchingPhysicalTransactionAppender appender = new BatchingPhysicalTransactionAppender( logFile, mock(LogRotation.class), cache,
-                transactionIdStore, BYPASS, counters, forceThreadControl );
+        BatchingPhysicalTransactionAppender appender = new BatchingPhysicalTransactionAppender( logFile,
+                mock( LogRotation.class ), cache, transactionIdStore, BYPASS, counters, forceThreadControl,
+                mock( KernelHealth.class ) );
         Counter appendCounter = counters.createdCounters.get( 0 );
         OtherThreadExecutor<Void> t2 = cleanup.add( new OtherThreadExecutor<Void>( "T2", null ) );
 
@@ -72,7 +74,7 @@ public class BatchingPhysicalTransactionAppenderTest
                 highestValueBeforeWrappingAround, highestValueBeforeWrappingAround );
         ControlledParkStrategy forceThreadControl = new ControlledParkStrategy();
         BatchingPhysicalTransactionAppender appender = new BatchingPhysicalTransactionAppender( logFile, mock(LogRotation.class), cache,
-                transactionIdStore, BYPASS, counters, forceThreadControl );
+                transactionIdStore, BYPASS, counters, forceThreadControl, mock( KernelHealth.class ) );
         Counter appendCounter = counters.createdCounters.get( 0 );
         OtherThreadExecutor<Void> t2 = cleanup.add( new OtherThreadExecutor<Void>( "T2", null ) );
 


### PR DESCRIPTION
Log rotation checks that the kernel is still healthy, while having the
logFile lock, before doing the rotation. This to be on the safe side in
the event of panic, ehere the next recovery will have a chance to repair
the damages if all transactions are still in the active log.

For this the TransactionAppender#append method decides on success or panic
while holding the logFile lock and therefore safely communicates this
state to any log rotation happening concurrently.
