### PR TITLE
Cypher operators may not end in plus or minus

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
@@ -29,6 +29,7 @@ import org.parboiled.support.IndexRange
 trait Base extends Parser {
 
   def OpChar = rule("an operator char") { anyOf("|^&<>=?!:+-*/%~") }
+  def OpCharTail = rule("an operator char") { anyOf("|^&<>=?!:*/%~") }
 
   def DecimalInteger = rule { (optional("-") ~ UnsignedDecimalInteger).memoMismatches }
   def UnsignedDecimalInteger = rule { (group(("1" - "9") ~ optional(DigitString)) | "0").memoMismatches }
@@ -93,7 +94,7 @@ trait Base extends Parser {
       (acc, s) => acc ~ WS ~ word(s)
     })
   }
-  def operator(string: String) = group(string ~ !OpChar)
+  def operator(string: String) = group(string ~ !OpCharTail)
 
   def push[R](f: InputPosition => R): Rule1[R] = pushFromContext(ctx => f(ContextPosition(ctx)))
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Expressions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Expressions.scala
@@ -152,7 +152,7 @@ trait Expressions extends Parser
 
   private def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {
     operator(".") ~~ (
-        (group(PropertyKeyName ~~ group(anyOf("?!") ~ !OpChar) ~> ((s:String) => s)) ~~>> (ast.LegacyProperty(_: ast.Expression, _, _)))
+        (group(PropertyKeyName ~~ group(anyOf("?!") ~ !OpCharTail) ~> ((s:String) => s)) ~~>> (ast.LegacyProperty(_: ast.Expression, _, _)))
       | (PropertyKeyName ~~>> (ast.Property(_: ast.Expression, _)))
     )
   }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Literals.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Literals.scala
@@ -47,7 +47,7 @@ trait Literals extends Parser
     rule("a rel type name") { SymbolicNameString ~~>> (ast.RelTypeName(_) ) }.memoMismatches
 
   def Operator: Rule1[ast.Identifier] = rule {
-    oneOrMore(OpChar) ~>>> (ast.Identifier(_: String)) ~ !OpChar
+    OpChar ~ zeroOrMore(OpCharTail) ~>>> (ast.Identifier(_: String)) ~ !OpCharTail
   }
 
   def MapLiteral: Rule1[ast.MapExpression] = rule {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
@@ -335,13 +335,16 @@ class CypherParserTest extends CypherFunSuite {
 
   test("shouldHandleNegativeLiteralsAsExpected") {
     expectQuery(
-      "start a = NODE(1) where -35 = a.age AND a.age > -1.2 return a",
+      "start a = NODE(1) where -35 = a.age AND (a.age > -1.2 AND a.weight=-50) return a",
       Query.
         start(NodeById("a", 1)).
         where(And(
-        Equals(Literal(-35), Property(Identifier("a"), PropertyKey("age"))),
-        GreaterThan(Property(Identifier("a"), PropertyKey("age")), Literal(-1.2)))
-      ).
+          Equals(Literal(-35), Property(Identifier("a"), PropertyKey("age"))),
+          And(
+            GreaterThan(Property(Identifier("a"), PropertyKey("age")), Literal(-1.2)),
+            Equals(Property(Identifier("a"), PropertyKey("weight")), Literal(-50))
+          )
+        )).
         returns(ReturnItem(Identifier("a"), "a")))
   }
 
@@ -2969,9 +2972,10 @@ class CypherParserTest extends CypherFunSuite {
 
   test("test unary plus minus") {
     expectQuery(
-      "MATCH n RETURN -n.prop, +n.foo, 1 + -n.bar",
+      "MATCH n WHERE n.prop=+2 RETURN -n.prop, +n.foo, 1 + -n.bar",
       Query.
         matches(SingleNode("n")).
+        where(Equals(Property(Identifier("n"), PropertyKey("prop")), Literal(2))).
         returns(ReturnItem(Subtract(Literal(0), Property(Identifier("n"), PropertyKey("prop"))), "-n.prop"),
         ReturnItem(Property(Identifier("n"), PropertyKey("foo")), "+n.foo"),
         ReturnItem(Add(Literal(1), Subtract(Literal(0), Property(Identifier("n"), PropertyKey("bar")))), "1 + -n.bar"))


### PR DESCRIPTION
Given no operator is likely to ever end in plus (`+`) or minus (`-`), change the parser to allow it immediately following an operator. This allows for expressions like `SET n.prop=-1`.
