### PR TITLE
Make PageCache.flush take read-locks

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -342,14 +342,14 @@ public class MuninnPageCache implements RunnablePageCache
             for ( int i = 0; i < pages.length; i++ )
             {
                 MuninnPage page = pages[i];
-                long stamp = page.writeLock();
+                long stamp = page.readLock();
                 try
                 {
                     page.flush( cacheFlush.flushEventOpportunity() );
                 }
                 finally
                 {
-                    page.unlockWrite( stamp );
+                    page.unlockRead( stamp );
                 }
             }
         }


### PR DESCRIPTION
It used to take write-locks, but this brings it in line with PagedFile.flush, which already only takes read-locks.
Pessimistic read-locks are good enough, because the `dirty` flag is only ever set to `true` under a write lock.