### PR TITLE
Reduce the space overhead of MuninnPage objects

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePageWaiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FreePageWaiter.java
@@ -39,12 +39,12 @@ final class FreePageWaiter
     // A special poison-pill value that is used to tell FreePageWaiters that they should
     // stop waiting and that there is no free page for them, because the page cache is
     // shutting down.
-    private static final MuninnPage interruptSignal = new MuninnPage( 0, -1, null );
+    private static final MuninnPage interruptSignal = new MuninnPage( 0, null );
 
     // Like the interruptSignal above, this is used to tell the FreePageWaiters that they
     // should stop waiting, but this time the reason is that the eviction thread has
     // encountered an exception, which must be bubbled out.
-    private static final MuninnPage exceptionSignal = new MuninnPage( 0, -2, null );
+    private static final MuninnPage exceptionSignal = new MuninnPage( 0, null );
 
     FreePageWaiter next;
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MemoryReleaser.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MemoryReleaser.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.io.pagecache.impl.muninn;
 
-final class MemoryReleaser
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class MemoryReleaser extends AtomicInteger
 {
     private final long[] rawPointers;
 
@@ -41,8 +43,9 @@ final class MemoryReleaser
         super.finalize();
     }
 
-    public void registerPointer( int cachePageId, long pointer )
+    public void registerPointer( long pointer )
     {
-        rawPointers[cachePageId] = pointer;
+        int index = getAndIncrement();
+        rawPointers[index] = pointer;
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -169,6 +169,7 @@ public class MuninnPageCache implements RunnablePageCache
             PageCacheMonitor monitor )
     {
         verifyHacks();
+        verifyCachePageSizeIsPowerOfTwo( cachePageSize );
 
         this.swapperFactory = swapperFactory;
         this.cachePageSize = cachePageSize;
@@ -179,11 +180,11 @@ public class MuninnPageCache implements RunnablePageCache
 
         MemoryReleaser memoryReleaser = new MemoryReleaser( maxPages );
         Object pageList = null;
-        int cachePageId = maxPages;
-        while ( cachePageId --> 0 )
+        int pageIndex = maxPages;
+        while ( pageIndex --> 0 )
         {
-            MuninnPage page = new MuninnPage( cachePageSize, cachePageId, memoryReleaser );
-            pages[cachePageId] = page;
+            MuninnPage page = new MuninnPage( cachePageSize, memoryReleaser );
+            pages[pageIndex] = page;
 
             if ( pageList == null )
             {
@@ -207,12 +208,22 @@ public class MuninnPageCache implements RunnablePageCache
         UnsafeUtil.putObjectVolatile( this, freelistOffset, pageList );
     }
 
-    static void verifyHacks()
+    private static void verifyHacks()
     {
         // Make sure that we have access to theUnsafe.
         if ( !UnsafeUtil.hasUnsafe() )
         {
             throw new AssertionError( "MuninnPageCache requires access to sun.misc.Unsafe" );
+        }
+    }
+
+    private static void verifyCachePageSizeIsPowerOfTwo( int cachePageSize )
+    {
+        int exponent = 31 - Integer.numberOfLeadingZeros( cachePageSize );
+        if ( 1 << exponent != cachePageSize )
+        {
+            throw new IllegalArgumentException(
+                    "Cache page size must be a power of two, but was " + cachePageSize );
         }
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -92,11 +92,11 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
     protected final File file = new File( "a" );
 
     protected int recordSize = 9;
-    protected int recordCount = 1060;
     protected int maxPages = 20;
-    protected int pageCachePageSize = 20;
-    protected int filePageSize = 18;
-    protected int recordsPerFilePage = filePageSize / recordSize;
+    protected int pageCachePageSize = 32;
+    protected int recordsPerFilePage = pageCachePageSize / recordSize;
+    protected int recordCount = 25 * maxPages * recordsPerFilePage;
+    protected int filePageSize = recordsPerFilePage * recordSize;
     protected ByteBuffer bufA = ByteBuffer.allocate( recordSize );
 
     protected EphemeralFileSystemAbstraction fs;
@@ -199,6 +199,7 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
             generateRecordForId( recordId, expectedPageContents.slice() );
             do
             {
+                cursor.setOffset( recordSize * i );
                 cursor.getBytes( record );
             } while ( cursor.shouldRetry() );
             actualPageContents.position( recordSize * i );
@@ -311,6 +312,12 @@ public abstract class PageCacheTest<T extends RunnablePageCache>
     {
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheMonitor.NULL );
         assertThat( pageCache.pageSize(), is( pageCachePageSize ) );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void cachePageSizeMustBePowerOfTwo() throws IOException
+    {
+        getPageCache( fs, maxPages, 31, PageCacheMonitor.NULL );
     }
 
     @Test( timeout = 1000 )

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageSwappingTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageSwappingTest.java
@@ -35,7 +35,7 @@ public class MuninnPageSwappingTest extends PageSwappingTest
     protected Page createPage( int cachePageSize )
     {
         MemoryReleaser memoryReleaser = new MemoryReleaser( 1 );
-        MuninnPage page = new MuninnPage( cachePageSize, 0, memoryReleaser );
+        MuninnPage page = new MuninnPage( cachePageSize, memoryReleaser );
         long stamp = page.writeLock();
         try
         {

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -13,6 +13,7 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+wrapper.java.additional=-XX:hashCode=5
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
 # Also make sure to update the jmx.access and jmx.password files with appropriate permission roles and passwords,

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -13,6 +13,7 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+wrapper.java.additional=-XX:hashCode=5
 
 # Uncomment the following lines to enable garbage collection logging
 #wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -13,6 +13,7 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 wrapper.java.additional=-XX:+UseConcMarkSweepGC
 wrapper.java.additional=-XX:+CMSClassUnloadingEnabled
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+wrapper.java.additional=-XX:hashCode=5
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
 # Also make sure to update the jmx.access and jmx.password files with appropriate permission roles and passwords,


### PR DESCRIPTION
These changes reduce the overhead of the Muninn page cache by about 10% in runtime images where oops are 4 bytes, by reducing the instance size of MuninnPage objects from 72 bytes to 64 bytes, with a 2 byte allignment gap.
As part of these changes, MuninnPage objects no longer know their index into the MuninnPageCache.pages array.
This means that the cachePageIds reported through the PageCacheMonitor APIs are now based in the identityHashCode of the MuninnPage objects.
To ensure that the identityHashCodes have a very high chance of being unique amongst the objects, I have changed the default hashCode implementation by setting -XX:hashCode=5 on the JVM.
This implementation of hashCode (used for both System.identityHashCode and Object.hashCode) uses a per-thread XorShift RNG, seeded from a JVM-global racy Park-Miller RNG.
The default is otherwise to use the JVM-global Park-Miller RNG in an unsynchronised way, which can lead to multiple objects getting the same hashCodes via race.
With the changed -XX:hashCode setting, this race only exist on thread initialization, wherein it can lead to threads producing the same sequences of hashCodes.
This is not a problem in our case, because all the MuninnPage instances are allocated by the same thread, and they have been made to initialise their identityHashCode on allocation.
As such, we should not see two MuninnPage instances in a cache with the same hashCode, as long as there are fewer than 2^31 pages in the cache.
See `get_next_hashcode` in `synchronizer.cpp` in the OpenJDK hotspot source code for more information on the various hashCode implementation variants.

Another important change is that the cachePageSizes are now required to be a power of two.
A number of tests had to be updated to live up to this requirement.

The performance impact of the extra work on page bounds checking appear to be within error on the measurements I've done.
There is a slight performance during startup, because the construction of MuninnPage instances now incur the extra overhead of computing the identityHashCode, which itself includes a LOCK:CMPXCHG instruction for installing the computed has into the object header.
There is also a slight performance overhead added to the MemoryReleaser, as it now has to use an AtomicInteger to thread-safely find an array slot to install a given native pointer into.
These overheads only exist when the cache is new and still warming up, so I don't think it's a problem.
The PageCacheTests are only slowed down by a second or two.