### PR TITLE
Rename the `mapped_memory_total_size` setting to `dbms.pagecache.memory`

### DIFF
--- a/community/browser/app/content/guides/sysinfo.jade
+++ b/community/browser/app/content/guides/sysinfo.jade
@@ -13,7 +13,7 @@ article.help
           dt Store location:
           dd {{kernel.StoreDirectory}}
           dt Memory:
-          dd {{kernel.mapped_memory_total_size}}
+          dd {{kernel.pagecache_memory}}
       .col-sm-4
         h2 Commands
           span something something

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -61,7 +61,7 @@ public class FullCheck
         this.checkLabelScanStore = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_label_scan_store );
         this.checkIndexes = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_indexes );
         this.order = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_execution_order );
-        this.totalMappedMemory = tuningConfiguration.get( GraphDatabaseSettings.mapped_memory_total_size );
+        this.totalMappedMemory = tuningConfiguration.get( GraphDatabaseSettings.pagecache_memory );
         this.samplingConfig = new IndexSamplingConfig( tuningConfiguration );
         this.progressFactory = progressFactory;
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -41,7 +41,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   var nodes: List[Node] = null
 
   def databaseConfig(): Map[String,String] =
-    Map(GraphDatabaseSettings.mapped_memory_total_size.name -> "8M")
+    Map(GraphDatabaseSettings.pagecache_memory.name -> "8M")
 
   override protected def initTest() {
     super.initTest()

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
@@ -67,7 +67,7 @@ public class Neo4jBasicDocTest
         // START SNIPPET: startDbWithConfig
         GraphDatabaseService db = new TestGraphDatabaseFactory()
             .newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.mapped_memory_total_size, "512M" )
+            .setConfig( GraphDatabaseSettings.pagecache_memory, "512M" )
             .setConfig( GraphDatabaseSettings.string_block_size, "60" )
             .setConfig( GraphDatabaseSettings.array_block_size, "300" )
             .newGraphDatabase();

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/StartWithConfigurationDocTest.java
@@ -49,7 +49,7 @@ public class StartWithConfigurationDocTest
         // START SNIPPET: startDbWithMapConfig
         GraphDatabaseService graphDb = new GraphDatabaseFactory()
             .newEmbeddedDatabaseBuilder( storeDir )
-            .setConfig( GraphDatabaseSettings.mapped_memory_total_size, "512M" )
+            .setConfig( GraphDatabaseSettings.pagecache_memory, "512M" )
             .setConfig( GraphDatabaseSettings.string_block_size, "60" )
             .setConfig( GraphDatabaseSettings.array_block_size, "300" )
             .newGraphDatabase();

--- a/community/embedded-examples/src/test/resources/neo4j.properties
+++ b/community/embedded-examples/src/test/resources/neo4j.properties
@@ -10,7 +10,7 @@
 # map at most 450MB. If "50%" is configured, and the system has a capacity of
 # 4GB, then at most 2GB of memory will be mapped, unless the database observes
 # that less than 2GB of memory is free when it starts.
-#mapped_memory_total_size=50%
+#dbms.pagecache.memory=50%
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/community/kernel/src/docs/ops/cache.asciidoc
+++ b/community/kernel/src/docs/ops/cache.asciidoc
@@ -49,7 +49,7 @@ IMPORTANT: Note that the block sizes can only be configured at store creation ti
 [options="header",cols="<35m,<30,<35"]
 |========================================================
 | Parameter                 | Possible values   | Effect
-| mapped_memory_total_size  |
+| dbms.pagecache.memory     |
   The maximum amount of memory to use for the file buffer cache, either in bytes
   (or greater byte-like units, such as `100M` for 100 mega-bytes, or `4G` for 4 giga-bytes)
   or a percentage of the available amount of memory. |

--- a/community/kernel/src/docs/ops/io-examples.asciidoc
+++ b/community/kernel/src/docs/ops/io-examples.asciidoc
@@ -16,7 +16,7 @@ Other processes may thus not use more than what is available after the configure
 Make sure that your system is configured such that it will never need to swap.
 If memory belonging to the Neo4j process gets swapped out, it can lead to considerable performance degradation.
 
-The amount of memory available to the page cache can be configured in two ways; both using the `mapped_memory_total_size` setting.
+The amount of memory available to the page cache can be configured in two ways; both using the `dbms.pagecache.memory` setting.
 You can either directly specify the number of bytes available to the page cache, e.g. `150M` og `4G`, or you can specify a percentage of the available memory, which is what the default setting of `50%` means.
 In either case, the amount of memory reserved for the page cache is capped at the amount of free memory as measured when the database starts.
 
@@ -36,7 +36,7 @@ The important thing is that the page cache has enough memory to work with, that 
 
 [source]
 ----
-mapped_memory_total_size=4G
+dbms.pagecache.memory=4G
 ----
 
 The configuration above will more or less fit the entire graph in memory.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -209,80 +209,88 @@ public abstract class GraphDatabaseSettings
 
     @Description("Target size for pages of mapped memory.")
     @Internal
-    public static final Setting<Long> mapped_memory_page_size = setting("mapped_memory_page_size", BYTES, "8192" );
+    public static final Setting<Long> mapped_memory_page_size = setting( "dbms.pagecache.pagesize", BYTES, "8192" );
 
-    @Description("The amount of memory to use for mapping the store files, either in bytes or" +
+    @Description( "The amount of memory to use for mapping the store files, either in bytes or" +
             " as a percentage of available memory. This will be clipped at the amount of" +
             " free memory observed when the database starts, and automatically be rounded" +
             " down to the nearest whole page. For example, if `500MB` is configured, but" +
             " only 450MB of memory is free when the database starts, then the database will" +
             " map at most 450MB. If `50%` is configured, and the system has a capacity of" +
             " 4GB, then at most 2GB of memory will be mapped, unless the database observes" +
-            " that less than 2GB of memory is free when it starts.")
-    public static final Setting<Long> mapped_memory_total_size = setting("mapped_memory_total_size", directMemoryUsage(), "50%" );
+            " that less than 2GB of memory is free when it starts." )
+    public static final Setting<Long> pagecache_memory = setting( "dbms.pagecache.memory", directMemoryUsage(), "50%" );
 
+    @Deprecated
+    @Obsoleted( "This is no longer used" )
     @Description( "Log memory mapping statistics regularly." )
-    public static final Setting<Boolean> log_mapped_memory_stats = setting("log_mapped_memory_stats", BOOLEAN, FALSE );
+    public static final Setting<Boolean> log_mapped_memory_stats = setting( "log_mapped_memory_stats", BOOLEAN, FALSE );
 
+    @Deprecated
+    @Obsoleted( "This is no longer used" )
     @Description( "The file where memory mapping statistics will be recorded." )
-    public static final Setting<File> log_mapped_memory_stats_filename = setting("log_mapped_memory_stats_filename", PATH, "mapped_memory_stats.log", basePath(store_dir) );
+    public static final Setting<File> log_mapped_memory_stats_filename = setting( "log_mapped_memory_stats_filename",
+            PATH, "mapped_memory_stats.log", basePath(store_dir) );
 
-    @Description("The number of records to be loaded between regular logging of memory mapping statistics.")
+    @Deprecated
+    @Obsoleted( "This is no longer used" )
+    @Description( "The number of records to be loaded between regular logging of memory mapping statistics." )
     public static final Setting<Integer> log_mapped_memory_stats_interval = setting("log_mapped_memory_stats_interval", INTEGER, "1000000");
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
-    @Description("The size to allocate for memory mapping the node store.")
-    public static final Setting<Long> nodestore_mapped_memory_size = setting("neostore.nodestore.db.mapped_memory", BYTES, NO_DEFAULT );
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
+    @Description( "The size to allocate for memory mapping the node store.")
+    public static final Setting<Long> nodestore_mapped_memory_size = setting( "neostore.nodestore.db.mapped_memory",
+            BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Description("The size to allocate for memory mapping the property value store.")
     public static final Setting<Long> nodestore_propertystore_mapped_memory_size = setting("neostore.propertystore.db.mapped_memory", BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Description("The size to allocate for memory mapping the store for property key indexes.")
     public static final Setting<Long> nodestore_propertystore_index_mapped_memory_size = setting("neostore.propertystore.db.index.mapped_memory", BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Deprecated
     @Description("The size to allocate for memory mapping the store for property key strings.")
     public static final Setting<Long> nodestore_propertystore_index_keys_mapped_memory_size = setting("neostore.propertystore.db.index.keys.mapped_memory", BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Description("The size to allocate for memory mapping the string property store.")
     public static final Setting<Long> strings_mapped_memory_size = setting("neostore.propertystore.db.strings.mapped_memory", BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Description("The size to allocate for memory mapping the array property store.")
     public static final Setting<Long> arrays_mapped_memory_size = setting("neostore.propertystore.db.arrays.mapped_memory", BYTES, NO_DEFAULT );
 
     /**
-     * @deprecated Replaced by the mapped_memory_total_size setting.
+     * @deprecated Replaced by the pagecache_memory setting.
      */
     @Deprecated
-    @Obsoleted( "Replaced by the mapped_memory_total_size setting." )
+    @Obsoleted( "Replaced by the dbms.pagecache.memory setting." )
     @Description("The size to allocate for memory mapping the relationship store.")
     public static final Setting<Long> relationshipstore_mapped_memory_size = setting("neostore.relationshipstore.db.mapped_memory", BYTES, NO_DEFAULT );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -31,7 +31,7 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
 {
 
     private static final String KEEP_LOGICAL_LOGS = "keep_logical_logs";
-    private static final String MAPPED_MEMORY_TOTAL_SIZE = "mapped_memory_total_size";
+    private static final String PAGECACHE_MEMORY = "dbms.pagecache.memory";
 
     {
         add( new SpecificPropertyMigration( "enable_online_backup",
@@ -161,7 +161,7 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
 
         add( new SpecificPropertyMigration("neostore.nodestore.db.mapped_memory",
                 "The neostore.*.db.mapped_memory settings have been replaced by the single '" +
-                        MAPPED_MEMORY_TOTAL_SIZE + "'. The sum of the old configuration will be used as the" +
+                PAGECACHE_MEMORY + "'. The sum of the old configuration will be used as the" +
                 " value for the new setting.")
         {
             private final String[] oldKeys = new String[]{
@@ -176,7 +176,7 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
             @Override
             public boolean appliesTo( Map<String, String> rawConfiguration )
             {
-                if(rawConfiguration.containsKey( MAPPED_MEMORY_TOTAL_SIZE ))
+                if(rawConfiguration.containsKey( PAGECACHE_MEMORY ))
                 {
                     return false;
                 }
@@ -205,7 +205,7 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
 
                 if(total > 0)
                 {
-                    rawConfiguration.put( MAPPED_MEMORY_TOTAL_SIZE, Long.toString( total ) );
+                    rawConfiguration.put( PAGECACHE_MEMORY, Long.toString( total ) );
                 }
             }
         });

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_page_size;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_total_size;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 
 public class LifecycledPageCache extends LifecycleAdapter implements PageCache
 {
@@ -72,7 +72,7 @@ public class LifecycledPageCache extends LifecycleAdapter implements PageCache
 
     private static int calculateMaxPages( Config config )
     {
-        long availableMemory = config.get( mapped_memory_total_size );
+        long availableMemory = config.get( pagecache_memory );
         long pageSize = config.get( mapped_memory_page_size );
         long pageCount = availableMemory / pageSize;
         return (int) Math.min( Integer.MAX_VALUE, pageCount );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/StandalonePageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/StandalonePageCacheFactory.java
@@ -62,7 +62,7 @@ public final class StandalonePageCacheFactory
         SingleFilePageSwapperFactory swapperFactory = new SingleFilePageSwapperFactory( fileSystem );
 
         Config baseConfig = new Config( MapUtil.stringMap(
-                GraphDatabaseSettings.mapped_memory_total_size.name(), "8M" ) );
+                GraphDatabaseSettings.pagecache_memory.name(), "8M" ) );
         Config finalConfig = baseConfig.with( config.getParams() );
         LifecycledPageCache delegate = life.add(
                 new LifecycledPageCache( swapperFactory, scheduler, finalConfig, PageCacheMonitor.NULL ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -258,7 +258,7 @@ public class StoreAccess
     private static Map<String, String> defaultParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put( GraphDatabaseSettings.mapped_memory_total_size.name(), "50%" );
+        params.put( GraphDatabaseSettings.pagecache_memory.name(), "50%" );
         params.put( GraphDatabaseSettings.rebuild_idgenerators_fast.name(), Settings.TRUE );
         return params;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
@@ -90,7 +90,7 @@ public class RsdrMain
     {
         Config config = new Config( MapUtil.stringMap(
                 GraphDatabaseSettings.read_only.name(), "true",
-                GraphDatabaseSettings.mapped_memory_total_size.name(), "64M",
+                GraphDatabaseSettings.pagecache_memory.name(), "64M",
                 GraphDatabaseSettings.neo_store.name(), storepath.getAbsolutePath() + File.separator + NeoStore.DEFAULT_NAME ) );
         IdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory();
         Neo4jJobScheduler jobScheduler = new Neo4jJobScheduler();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -292,7 +292,7 @@ public class BatchInserterImpl implements BatchInserter
     private Map<String, String> getDefaultParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put( GraphDatabaseSettings.mapped_memory_total_size.name(), "1%" );
+        params.put( GraphDatabaseSettings.pagecache_memory.name(), "1%" );
         return params;
     }
 

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -19,16 +19,16 @@
  */
 package examples;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicLabel;
@@ -38,10 +38,10 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 
@@ -93,7 +93,7 @@ public class BatchInsertDocTest
     {
         // START SNIPPET: configuredInsert
         Map<String, String> config = new HashMap<>();
-        config.put( "mapped_memory_total_size", "90M" );
+        config.put( "dbms.pagecache.memory", "90M" );
         BatchInserter inserter = BatchInserters.inserter(
                 new File("target/batchinserter-example-config").getAbsolutePath(), fileSystem, config );
         // Insert data here ... and then shut down:
@@ -106,7 +106,7 @@ public class BatchInsertDocTest
     {
         try ( Writer fw = fileSystem.openAsWriter( new File( "target/batchinsert-config" ).getAbsoluteFile(), "utf-8", false ) )
         {
-            fw.append( "mapped_memory_total_size=3G" );
+            fw.append( "dbms.pagecache.memory=3G" );
         }
 
         // START SNIPPET: configFileInsert

--- a/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
@@ -53,7 +53,7 @@ public class DiagnosticsLoggingTest
     {
         HashMap<String,String> settings = new HashMap<>();
         settings.put( GraphDatabaseSettings.dump_configuration.name(), "true" );
-        settings.put( GraphDatabaseSettings.mapped_memory_total_size.name(), "8M" );
+        settings.put( GraphDatabaseSettings.pagecache_memory.name(), "8M" );
         FakeDatabase db = new FakeDatabase( settings );
         FakeLogger logger = db.getLogger();
         String messages = logger.getMessages();

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.kernel.configuration;
 
+import org.junit.Test;
+
 import java.util.Map;
 
-import org.junit.Test;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.impl.util.TestLogger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_total_size;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.TestLogger.LogCall.warn;
 
@@ -106,9 +107,9 @@ public class TestGraphDatabaseConfigurationMigrator
                 "neostore.relationshipstore.db.mapped_memory", "0" );
 
         // When & Then
-        assertThat( migrator.apply( oldConfig, log ).get( mapped_memory_total_size.name() ),
+        assertThat( migrator.apply( oldConfig, log ).get( pagecache_memory.name() ),
             equalTo( "1074790416" ) );
 
-        log.assertAtLeastOnce( warn( "The neostore.*.db.mapped_memory settings have been replaced by the single 'mapped_memory_total_size'. The sum of the old configuration will be used as the value for the new setting." ) );
+        log.assertAtLeastOnce( warn( "The neostore.*.db.mapped_memory settings have been replaced by the single 'dbms.pagecache.memory'. The sum of the old configuration will be used as the value for the new setting." ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigJumpingStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigJumpingStoreIT.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicRelationshipType;
@@ -41,8 +41,7 @@ import org.neo4j.kernel.InternalAbstractGraphDatabase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_total_size;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.helpers.collection.IteratorUtil.firstOrNull;
 import static org.neo4j.helpers.collection.IteratorUtil.lastOrNull;
@@ -91,8 +90,7 @@ public class BigJumpingStoreIT
 
     private Map<String, String> config()
     {
-        return stringMap(
-                mapped_memory_total_size.name(), "10M");
+        return stringMap( pagecache_memory.name(), "10M" );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCacheTest.java
@@ -34,7 +34,7 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_page_size;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_total_size;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class LifecycledPageCacheTest
@@ -49,7 +49,7 @@ public class LifecycledPageCacheTest
         Config config = new Config();
         config.applyChanges( stringMap(
                 mapped_memory_page_size.name(), "4096",
-                mapped_memory_total_size.name(), Integer.toString(4096 * 16) ) );
+                pagecache_memory.name(), Integer.toString( 4096 * 16 ) ) );
 
         // When
         LifeSupport life = new LifeSupport();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
@@ -19,17 +19,15 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.StoreVersionMismatchHandler;
 import org.neo4j.kernel.impl.store.CommonAbstractStore.Configuration;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -41,8 +39,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_total_size;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.Settings.osIsWindows;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -61,7 +58,7 @@ public class TestGrowingFileMemoryMapping
 
         File storeDir = TargetDirectory.forTest( getClass() ).makeGraphDbDir();
         Config config = new Config( stringMap(
-                mapped_memory_total_size.name(), mmapSize( NUMBER_OF_RECORDS, NodeStore.RECORD_SIZE ),
+                pagecache_memory.name(), mmapSize( NUMBER_OF_RECORDS, NodeStore.RECORD_SIZE ),
                 Configuration.store_dir.name(), storeDir.getPath() ), NodeStore.Configuration.class );
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory();
         Monitors monitors = new Monitors();

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.test;
 
+import org.junit.rules.ExternalResource;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-
-import org.junit.rules.ExternalResource;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -178,7 +178,7 @@ public abstract class DatabaseRule extends ExternalResource
         // Override to configure the database
 
         // Adjusted defaults for testing
-        builder.setConfig( GraphDatabaseSettings.mapped_memory_total_size, "20M" );
+        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "20M" );
     }
 
     public GraphDatabaseService getGraphDatabaseService()

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -57,7 +57,7 @@ public class PageCacheRule extends ExternalResource
     public PageCache getPageCache( FileSystemAbstraction fs )
     {
         Map<String,String> settings = new HashMap<>();
-        settings.put( GraphDatabaseSettings.mapped_memory_total_size.name(), "8M" );
+        settings.put( GraphDatabaseSettings.pagecache_memory.name(), "8M" );
         return getPageCache( fs, new Config( settings ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInserterImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInserterImplTest.java
@@ -46,7 +46,7 @@ public class BatchInserterImplTest
     public void testHonorsPassedInParams() throws Exception
     {
         int mappedMemoryTotalSize = createInserterAndGetMemoryMappingConfig( stringMap(
-                GraphDatabaseSettings.mapped_memory_total_size.name(), "16K",
+                GraphDatabaseSettings.pagecache_memory.name(), "16K",
                 GraphDatabaseSettings.mapped_memory_page_size.name(), "1K" ) );
         assertThat( "memory mapped config is active", mappedMemoryTotalSize, is( 16 * 1024 ) );
     }

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/ccheck/ConsistencyPerformanceCheck.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/ccheck/ConsistencyPerformanceCheck.java
@@ -28,9 +28,9 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.index.lucene.LuceneLabelScanStoreBuilder;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
 import org.neo4j.io.pagecache.PageSwapperFactory;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.api.direct.DirectStoreAccess;
@@ -56,7 +56,6 @@ import static org.neo4j.perftest.enterprise.util.DirectlyCorrelatedParameter.par
 import static org.neo4j.perftest.enterprise.util.DirectlyCorrelatedParameter.passOn;
 import static org.neo4j.perftest.enterprise.util.Setting.booleanSetting;
 import static org.neo4j.perftest.enterprise.util.Setting.enumSetting;
-import static org.neo4j.perftest.enterprise.util.Setting.integerSetting;
 import static org.neo4j.perftest.enterprise.util.Setting.stringSetting;
 
 public class ConsistencyPerformanceCheck
@@ -67,15 +66,9 @@ public class ConsistencyPerformanceCheck
     static final Setting<TaskExecutionOrder> execution_order =
             enumSetting( "execution_order", TaskExecutionOrder.SINGLE_THREADED );
     static final Setting<Boolean> wait_before_check = booleanSetting( "wait_before_check", false );
-    static final Setting<String> mapped_memory_total_size =
-            stringSetting( "mapped_memory_total_size", "2G" );
-    static final Setting<String> mapped_memory_page_size = stringSetting( "mapped_memory_page_size", "4k" );
-    static final Setting<Boolean> log_mapped_memory_stats =
-            booleanSetting( "log_mapped_memory_stats", true );
-    static final Setting<String> log_mapped_memory_stats_filename =
-            stringSetting( "log_mapped_memory_stats_filename", "mapped_memory_stats.log" );
-    static final Setting<Long> log_mapped_memory_stats_interval =
-            integerSetting( "log_mapped_memory_stats_interval", 1000000 );
+    static final Setting<String> pagecache_memory =
+            stringSetting( "dbms.pagecache.memory", "2G" );
+    static final Setting<String> mapped_memory_page_size = stringSetting( "dbms.pagecache.pagesize", "4k" );
     private static LifecycledPageCache pageCache;
     private static Neo4jJobScheduler jobScheduler;
     private static FileSystemAbstraction fileSystem;
@@ -174,12 +167,9 @@ public class ConsistencyPerformanceCheck
     {
         Map<String, String> passedOnConfiguration = passOn( configuration,
                 param( GraphDatabaseSettings.store_dir, DataGenerator.store_dir ),
-                param( GraphDatabaseSettings.mapped_memory_total_size, mapped_memory_total_size ),
+                param( GraphDatabaseSettings.pagecache_memory, pagecache_memory ),
                 param( GraphDatabaseSettings.mapped_memory_page_size, mapped_memory_page_size ),
-                param( ConsistencyCheckSettings.consistency_check_execution_order, execution_order ),
-                param( GraphDatabaseSettings.log_mapped_memory_stats, log_mapped_memory_stats ),
-                param( GraphDatabaseSettings.log_mapped_memory_stats_filename, log_mapped_memory_stats_filename ),
-                param( GraphDatabaseSettings.log_mapped_memory_stats_interval, log_mapped_memory_stats_interval ) );
+                param( ConsistencyCheckSettings.consistency_check_execution_order, execution_order ) );
 
         return new Config( passedOnConfiguration, GraphDatabaseSettings.class );
     }

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
@@ -76,8 +76,8 @@ public class DataGenerator
     static final Setting<List<PropertySpec>> relationship_properties = listSetting(
             adaptSetting( Setting.stringSetting( "relationship_properties" ), PropertySpec.PARSER ),
             Collections.<PropertySpec>emptyList() );
-    private static final Setting<String> mapped_memory_total_size =
-            stringSetting( "mapped_memory_total_size", "2G" );
+    private static final Setting<String> pagecache_memory =
+            stringSetting( "dbms.pagecache.memory", "2G" );
 
     public static final Random RANDOM = new Random();
     private final boolean reportProgress;
@@ -232,8 +232,8 @@ public class DataGenerator
     {
         Map<String, String> config = new HashMap<>();
         config.put( "dump_configuration", "true" );
-        config.put( GraphDatabaseSettings.mapped_memory_total_size.name(),
-                configuration.get( mapped_memory_total_size ) );
+        config.put( GraphDatabaseSettings.pagecache_memory.name(),
+                configuration.get( pagecache_memory ) );
         return config;
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -19,31 +19,23 @@
  */
 package org.neo4j.test.ha;
 
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.test.TargetDirectory;
+
 import static org.neo4j.cluster.ClusterSettings.default_timeout;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-
-import org.junit.rules.ExternalResource;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
-import org.neo4j.kernel.impl.util.DumpLogicalLog;
-import org.neo4j.test.TargetDirectory;
-
 public class ClusterRule extends ExternalResource
 {
-
-    public static void main( String[] args ) throws IOException
-    {
-        DumpLogicalLog.main( new String[]{"/Users/chris/workspaces/neo4j/neo4j-2" +
-                ".2/enterprise/ha/target/test-data/org.neo4j.kernel.api" +
-                ".SchemaIndexHaIT/e9d355b22fea23deb9f278434cb5abaf/neo4j.ha/server3"} );
-    }
     private final Class<?> testClass;
 
     private ClusterManager clusterManager;

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
@@ -10,7 +10,7 @@
 # map at most 450MB. If "50%" is configured, and the system has a capacity of
 # 4GB, then at most 2GB of memory will be mapped, unless the database observes
 # that less than 2GB of memory is free when it starts.
-#mapped_memory_total_size=50%
+#dbms.pagecache.memory=50%
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -10,7 +10,7 @@
 # map at most 450MB. If "50%" is configured, and the system has a capacity of
 # 4GB, then at most 2GB of memory will be mapped, unless the database observes
 # that less than 2GB of memory is free when it starts.
-#mapped_memory_total_size=50%
+#dbms.pagecache.memory=50%
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -10,7 +10,7 @@
 # map at most 450MB. If "50%" is configured, and the system has a capacity of
 # 4GB, then at most 2GB of memory will be mapped, unless the database observes
 # that less than 2GB of memory is free when it starts.
-#mapped_memory_total_size=50%
+#dbms.pagecache.memory=50%
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -10,7 +10,7 @@
 # map at most 450MB. If "50%" is configured, and the system has a capacity of
 # 4GB, then at most 2GB of memory will be mapped, unless the database observes
 # that less than 2GB of memory is free when it starts.
-#mapped_memory_total_size=50%
+#dbms.pagecache.memory=50%
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0


### PR DESCRIPTION
The internal setting for the cache page size has similarly been renamed.
Also some small cleanup of the memory mapping stats logging settings, which are not used anymore.