### PR TITLE
Revert "Change neo4j-community packaging from jar to pom."

### DIFF
--- a/community/neo4j-community/pom.xml
+++ b/community/neo4j-community/pom.xml
@@ -13,7 +13,7 @@
   <version>2.2-SNAPSHOT</version>
 
   <name>Neo4j - Community</name>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
   <description>A meta package containing the most used Neo4j Community libraries. Intended use: as a Maven dependency.</description>
 


### PR DESCRIPTION
Reverts neo4j/neo4j#3709 since this change seems to have broken the RC build.
