### PR TITLE
Use SB.appendCodePoint() in UTF-16 literal parsing

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
@@ -67,6 +67,14 @@ class CypherParserTest extends CypherFunSuite {
         returns(ReturnItem(Literal("a\tp\'a\"b"), "\'a\\tp\\\'a\\\"b\'")))
   }
 
+  test("should return string literal containing UTF-16 escape sequence") {
+    expectQuery(
+      "start s = node(1) return \"a\\uE12345\" AS x",
+      Query.
+        start(NodeById("s", 1)).
+        returns(ReturnItem(Literal("a" + "\uE123" + "45"), "x")))
+  }
+
   test("allTheNodes") {
     expectQuery(
       "start s = NODE(*) return s",


### PR DESCRIPTION
Rather than casting an integer to a char, use `StringBuilder.appendCodePoint(codepoint)`, as described here: http://www.oracle.com/us/technologies/java/supplementary-142654.html