### PR TITLE
Fixed a bug where last committed tx id in backup store logs are wrongly set

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
@@ -495,7 +495,24 @@ public class ServerUtil
                 if ( visitedDataSources.add( tx.first() ) )
                 {
                     dataSource.setLastCommittedTxId( tx.second() - 1 );
+                    maintainLastCommittedTxIdInLog( dataSource );
                 }
+            }
+
+            private void maintainLastCommittedTxIdInLog( XaDataSource dataSource )
+            {
+                long version = dataSource.getCurrentLogVersion();
+                try
+                {
+                    dataSource.rotateLogicalLog();
+                }
+                catch ( IOException e )
+                {
+                    throw new RuntimeException(
+                            "Fails to update last committed tx id in logical log for XA data source "
+                                    + dataSource.getName(), e );
+                }
+                dataSource.deleteLogicalLog( version );
             }
 
             @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/OnlineBackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/OnlineBackupHaIT.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ha;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.backup.OnlineBackup;
+import org.neo4j.backup.OnlineBackupSettings;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.helpers.Settings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.test.ha.ClusterManager;
+import org.neo4j.test.ha.ClusterManager.ManagedCluster;
+import org.neo4j.test.ha.OnlineBackupClusterManager;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.backup.BackupEmbeddedIT.BACKUP_PATH;
+import static org.neo4j.backup.BackupEmbeddedIT.PATH;
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.test.ha.ClusterManager.fromXml;
+
+public class OnlineBackupHaIT
+{
+    private ClusterManager clusterManager;
+    private ManagedCluster cluster;
+
+    private boolean doneBackup = false;
+    private int nodeCount = 1;
+
+    private final CountDownLatch doneDataWriting = new CountDownLatch( 1 );
+    private final CountDownLatch startedDataWriting = new CountDownLatch( 10 );
+
+    private final static int BACKUP_PORT = 6363;
+
+    @Before
+    public void cleanUpFolder() throws IOException
+    {
+        FileUtils.deleteDirectory( PATH );
+        FileUtils.deleteDirectory( BACKUP_PATH );
+    }
+
+    private void startCluster() throws Throwable
+    {
+        clusterManager = new ClusterManager( fromXml( getClass().getResource( "/threeinstances.xml" ).toURI() ), PATH,
+                MapUtil.stringMap( OnlineBackupSettings.online_backup_enabled.name(), Settings.TRUE ) )
+        {
+            @Override
+            protected void config( GraphDatabaseBuilder builder, String clusterName, InstanceId serverId )
+            {
+                builder.setConfig( OnlineBackupSettings.online_backup_server,
+                        (":" + (BACKUP_PORT - 1 + serverId.toIntegerIndex())) );
+            }
+        };
+        clusterManager.start();
+        cluster = clusterManager.getDefaultCluster();
+    }
+
+    private void startClusterFromBackup() throws Throwable
+    {
+        clusterManager = new OnlineBackupClusterManager( fromXml( getClass().getResource( "/threeinstances.xml" )
+                .toURI() ), BACKUP_PATH, MapUtil.stringMap( OnlineBackupSettings.online_backup_enabled.name(),
+                        Settings.TRUE ) );
+        clusterManager.start();
+        cluster = clusterManager.getDefaultCluster();
+    }
+
+    private void stopCluster() throws Throwable
+    {
+        clusterManager.stop();
+        clusterManager.shutdown();
+    }
+
+    @Test
+    public void shouldRestartClusterWithOnlineBackupDb() throws Throwable
+    {
+        // Given
+        startCluster();
+        performOnlineBackupAndDataWritingConcurrently();
+        doneDataWriting.await();
+        stopCluster();
+
+        // When
+        startClusterFromBackup();
+
+        // Then
+        int nodeCountInBackupStore = getNodeCountInStore();
+        assertThat( nodeCount, greaterThanOrEqualTo( nodeCountInBackupStore ) );
+        assertThat( nodeCountInBackupStore, greaterThanOrEqualTo( 10 ) );
+        stopCluster();
+    }
+
+    private void performOnlineBackupAndDataWritingConcurrently()
+    {
+        new Thread( new Runnable()
+        {
+            private final GraphDatabaseService db = cluster.getMaster();
+            @Override
+            public void run()
+            {
+                while ( true )
+                {
+                    // keep on writing data until backup is done
+                    Transaction tx = db.beginTx();
+                    Node node = db.createNode();
+                    node.setProperty( "name", "node" + nodeCount );
+                    tx.success();
+                    tx.finish();
+
+                    nodeCount++;
+                    startedDataWriting.countDown();
+
+                    if ( doneBackup )
+                    {
+                        break;
+                    }
+                }
+                doneDataWriting.countDown();
+
+                System.out.println("***Done data writing***");
+            }
+        } ).start();
+
+        new Thread( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                // wait db to have some data first
+                try
+                {
+                    startedDataWriting.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    e.printStackTrace();
+                }
+
+                // perform backup
+                OnlineBackup backup = OnlineBackup.from( "127.0.0.1", BACKUP_PORT );
+                backup.backup( BACKUP_PATH.getPath() );
+                doneBackup = true;
+
+                System.out.println( "***Done backup***" );
+            }
+        } ).start();
+    }
+
+    private int getNodeCountInStore()
+    {
+        cluster.await( allSeesAllAsAvailable() );
+        HighlyAvailableGraphDatabase db = cluster.getMaster();
+        Transaction tx = db.beginTx();
+        Iterable<Node> nodes = db.getAllNodes();
+        tx.success();
+        tx.finish();
+        int count = 0;
+        for ( Node node : nodes )
+        {
+            count++;
+        }
+        return count;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/OnlineBackupClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/OnlineBackupClusterManager.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.ha;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.client.Clusters;
+import org.neo4j.cluster.client.Clusters.Cluster;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+
+public class OnlineBackupClusterManager extends ClusterManager
+{
+    private final String pathToBackupStore;
+
+    public OnlineBackupClusterManager( Provider clustersProvider, File root, Map<String,String> commonConfig )
+    {
+        super( clustersProvider, root, commonConfig );
+        pathToBackupStore = root.getAbsolutePath();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        Clusters clusters = clustersProvider.clusters();
+        life = new LifeSupport();
+        // Started so instances added here will be started immediately, and in case of exceptions they can be
+        // shutdown() or stop()ped properly
+        life.start();
+        for ( int i = 0; i < clusters.getClusters().size(); i++ )
+        {
+            Clusters.Cluster cluster = clusters.getClusters().get( i );
+            ManagedCluster managedCluster = new OnlineBackupManagedCluster( cluster ); // use a new manager
+            clusterMap.put( cluster.getName(), managedCluster );
+            life.add( managedCluster );
+        }
+    }
+
+    public class OnlineBackupManagedCluster extends ManagedCluster
+    {
+        OnlineBackupManagedCluster( Cluster spec ) throws URISyntaxException
+        {
+            super( spec );
+        }
+
+        @Override
+        protected void startMember( InstanceId serverId ) throws URISyntaxException
+        {
+            String to = new File( new File( pathToBackupStore ).getParent(), "instance" + serverId ).getPath();
+            try
+            {
+                // delete store if already exists
+                FileUtils.deleteDirectory( new File( to ) );
+                // copy store to another new path
+                copyStore( pathToBackupStore, to );
+            }
+            catch ( IOException e )
+            {
+                System.out.println( "Failed to copy the instance with the backup db: failed to copy db from "
+                        + pathToBackupStore + " to " + to );
+                e.printStackTrace();
+                System.exit( 1 );
+            }
+            // start the member with the copied store
+            startMember( serverId, to );
+        }
+
+        private void copyStore( String from, String to ) throws IOException
+        {
+            FileUtils.copyDirectory( new File( from ), new File( to ) );
+        }
+    }
+}


### PR DESCRIPTION
This bug results in slaves failing to start in ha from backup db.

The bug arises when performing online backup and data writing concurrently.
As there is a time span between the start and the end of the store copy,
if more tx are flushed into stores during this time span, the last committed
tx id recorded in stores becomes different from the tx id before store copy.
Finally we get logs with wrong headers.