### PR TITLE
Identify periodic commits and send request to auto committing API endpoint.

### DIFF
--- a/community/browser/app/index.jade
+++ b/community/browser/app/index.jade
@@ -166,4 +166,5 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     script(src='scripts/services/History.js')
     script(src='scripts/controllers/GenerateTokenCtrl.js')
     script(src='scripts/directives/serverTopic.js')
+    script(src='scripts/services/CypherParser.js')
     //endbuild

--- a/community/browser/app/scripts/init/commandInterpreters.coffee
+++ b/community/browser/app/scripts/init/commandInterpreters.coffee
@@ -352,7 +352,7 @@ angular.module('neo4jApp')
         pattern = new RegExp("^[^#{cmdchar}]")
         input.match(pattern)
       templateUrl: 'views/frame-cypher.html'
-      exec: ['Cypher', 'CypherGraphModel', (Cypher, CypherGraphModel) ->
+      exec: ['Cypher', 'CypherGraphModel', 'CypherParser', (Cypher, CypherGraphModel, CypherParser) ->
         # Return the function that handles the input
         (input, q) ->
           current_transaction = Cypher.transaction()
@@ -371,7 +371,7 @@ angular.module('neo4jApp')
             )
 
           #Periodic commits cannot be sent to an open transaction.
-          if /^\s*USING\sPERIODIC\sCOMMIT/i.test(input)
+          if CypherParser.isPeriodicCommit input
             commit_fn()
           #All other queries should be sent through an open transaction
           #so they can be canceled.

--- a/community/browser/app/scripts/init/commandInterpreters.coffee
+++ b/community/browser/app/scripts/init/commandInterpreters.coffee
@@ -356,25 +356,34 @@ angular.module('neo4jApp')
         # Return the function that handles the input
         (input, q) ->
           current_transaction = Cypher.transaction()
+          commit_fn = () ->
+            current_transaction.commit(input).then(
+              (response) ->
+                if response.size > Settings.maxRows
+                  response.displayedSize = Settings.maxRows
+                q.resolve(
+                  table: response
+                  graph: extractGraphModel(response, CypherGraphModel)
+                )
+              ,
+              (r) ->
+                q.reject(r)
+            )
 
-          r = current_transaction.begin().then(
-            (begin_response) ->
-              current_transaction.commit(input).then(
-                (response) ->
-                  if response.size > Settings.maxRows
-                    response.displayedSize = Settings.maxRows
-                  q.resolve(
-                    table: response
-                    graph: extractGraphModel(response, CypherGraphModel)
-                  )
-                ,
-                (r) ->
-                  q.reject(r)
-              )
-            ,
-            (r) -> 
-              q.reject(r)
-          )
+          #Periodic commits cannot be sent to an open transaction.
+          if /^\s*USING\sPERIODIC\sCOMMIT/i.test(input)
+            commit_fn()
+          #All other queries should be sent through an open transaction
+          #so they can be canceled.
+          else
+            r = current_transaction.begin().then(
+              (begin_response) ->
+                commit_fn()
+              ,
+              (r) -> 
+                q.reject(r)
+            )
+            
           q.promise.transaction = current_transaction
           q.promise
       ]

--- a/community/browser/app/scripts/services/CypherParser.coffee
+++ b/community/browser/app/scripts/services/CypherParser.coffee
@@ -1,0 +1,34 @@
+###!
+Copyright (c) 2002-2014 "Neo Technology,"
+Network Engine for Objects in Lund AB [http://neotechnology.com]
+
+This file is part of Neo4j.
+
+Neo4j is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+'use strict';
+
+angular.module('neo4jApp.services')
+  .service 'CypherParser', [
+     'Utils'
+     (Utils) ->
+        class CypherParser
+          isPeriodicCommit: (input)->
+            pattern = /^\s*USING\sPERIODIC\sCOMMIT/i
+            clean_input = Utils.stripComments input
+            pattern.test clean_input
+
+        new CypherParser()
+  ]

--- a/community/browser/test/spec/services/CypherParser.coffee
+++ b/community/browser/test/spec/services/CypherParser.coffee
@@ -1,0 +1,30 @@
+'use strict'
+
+describe 'Service: CypherParser', () ->
+
+  # load the service's module
+  beforeEach module 'neo4jApp.services'
+
+  # instantiate service
+  CypherParser = {}
+  beforeEach inject (_CypherParser_) ->
+    CypherParser = _CypherParser_
+
+  it 'should find these queries to be periodic commits', ->
+    shouldMatchPeriodicCommit = [
+      "Using Periodic Commit"
+      "Using Periodic Commit\n"
+      " Using Periodic Commit 200"
+      "//This is a comment\nUSING PERIODIC COMMIT"
+    ]
+    for query in shouldMatchPeriodicCommit
+      expect(CypherParser.isPeriodicCommit(query)).toBe(true)
+
+  it 'should find these queries NOT to be periodic commits', ->
+    shouldNotMatchPeriodicCommit = [
+          "MATCH (r:Person) WHERE "
+          "//Comment\nMATCH (r:Person) WHERE "
+          'MATCH (r:Person {title: "USING PERIODIC COMMIT"}) '
+        ]
+    for query in shouldNotMatchPeriodicCommit
+      expect(CypherParser.isPeriodicCommit(query)).toBe(false)


### PR DESCRIPTION
All cypher queries are sent through an open transaction as it is now, but periodic commits cannot be sent that way.  
