### PR TITLE
Adds test for correct behaviour of tx store when log files are missing

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
@@ -79,12 +79,11 @@ public class LabelRecoveryTest
         database = new TestGraphDatabaseFactory().setFileSystem( snapshot ).newImpermanentDatabase();
 
         // THEN
-        try ( Transaction tx = database.beginTx() )
+        try ( Transaction ignored = database.beginTx() )
         {
             node = database.getNodeById( node.getId() );
             for ( Label label : labels )
             {
-                System.out.println(label.name());
                 assertTrue( node.hasLabel( label ) );
             }
         }


### PR DESCRIPTION
A missing log file can lead to a FileNotFoundException but such an event
 should not be visible to users of the TransactionStore in any way other
 than a missing transaction. A test is added that ensures that even if a
 log file goes missing, extracting transactions that were present in it
 does not result in a FileNotFoundException but in a
 NoSuchTransactionException instead. Since that was already the case,
 just untested, no runtime code changes were necessary.
Removes unnecessary console prints from LabelRecoveryTest and renames
 a try-with-resource variable which was unused, to remove a warning.