### PR TITLE
Improve messages.log output on transaction log rotation, and verify that rotation does not obstruct read transactions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogRotationMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/LogRotationMonitor.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.xaframework;
+
+// TODO 2.2 delete this and put the method in PhysicalLogFile.Monitor.
+public interface LogRotationMonitor
+{
+    /**
+     * Notified when a log is being rotated.
+     * @param currentVersion The current log version that is being rotated out.
+     */
+    void rotatingLog( long currentVersion );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -148,6 +148,7 @@ public class XaLogicalLog implements LogLoader
     private final LogEntry.Done doneEntry = new LogEntry.Done(-1);
 
     private final KernelHealth kernelHealth;
+    private final LogRotationMonitor logRotationMonitor;
 
     public XaLogicalLog( File fileName, XaResourceManager xaRm, XaCommandReaderFactory commandReaderFactory,
                          XaCommandWriterFactory commandWriterFactory,
@@ -208,6 +209,7 @@ public class XaLogicalLog implements LogLoader
                     logWriterSPI, logEntryWriter ) ) );
 
         translatingEntryConsumer = new TranslatingEntryConsumer( transactionTranslator );
+        logRotationMonitor = monitors.newMonitor( LogRotationMonitor.class, "logicallog" );
     }
 
     synchronized void open() throws IOException
@@ -1167,6 +1169,8 @@ public class XaLogicalLog implements LogLoader
         File currentLogFile = logFiles.getLog1FileName();
         char newActiveLog = LOG2;
         final long currentVersion = xaTf.getCurrentVersion();
+
+        logRotationMonitor.rotatingLog( currentVersion );
 
         rotationMessage( currentVersion, "Log rotation initiated. Starting store flush..." );
         xaTf.flushAll();

--- a/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
+++ b/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package synchronization;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.transaction.xaframework.LogRotationMonitor;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.TargetDirectory;
+
+public class TestStartTransactionDuringLogRotation
+{
+    @Rule
+    public TargetDirectory.TestDirectory storeDir = TargetDirectory.testDirForTest(
+            TestStartTransactionDuringLogRotation.class );
+
+    private GraphDatabaseAPI db;
+    private ExecutorService executor;
+    private CountDownLatch startLogRotationLatch;
+    private CountDownLatch completeLogRotationLatch;
+    private AtomicBoolean writerStopped;
+    private Monitors monitors;
+    private LogRotationMonitor rotationListener;
+    private Future<?> writerTaskFuture;
+    private Label label;
+
+    @Before
+    public void setUp() throws InterruptedException
+    {
+        GraphDatabaseFactory factory = new GraphDatabaseFactory();
+        GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( storeDir.absolutePath() );
+        builder.setConfig( GraphDatabaseSettings.logical_log_rotation_threshold.name(), "1M" );
+        db = (GraphDatabaseAPI) builder.newGraphDatabase();
+        executor = Executors.newCachedThreadPool();
+        startLogRotationLatch = new CountDownLatch( 1 );
+        completeLogRotationLatch = new CountDownLatch( 1 );
+        writerStopped = new AtomicBoolean();
+        monitors = db.getDependencyResolver().resolveDependency( Monitors.class );
+        // TODO 2.2 change this to PhysicalLogFile.Monitor and add the rotatingLog method to that
+        rotationListener = new LogRotationMonitor()
+        {
+            @Override
+            public void rotatingLog( long currentVersion )
+            {
+                startLogRotationLatch.countDown();
+                try
+                {
+                    completeLogRotationLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+        };
+
+        monitors.addMonitorListener( rotationListener, "logicallog" );
+        label = DynamicLabel.label( "Label" );
+
+        Runnable writerTask = new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                while ( !writerStopped.get() )
+                {
+                    try ( Transaction tx = db.beginTx() )
+                    {
+                        Node node = db.createNode( label );
+                        node.setProperty( "a", 1 );
+                        tx.success();
+                    }
+                }
+            }
+        };
+
+        writerTaskFuture = executor.submit( writerTask );
+
+        // Waiting for the writer task to start a log rotation
+        startLogRotationLatch.await();
+
+        // Then we should be able to start a transaction, though perhaps not be able to finish it.
+        // This is what the individual test methods will be doing.
+        // The test passes when transaction.close completes within the test timeout, that is, it didn't deadlock.
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        writerStopped.set( true );
+        writerTaskFuture.get( 1, TimeUnit.SECONDS );
+        db.shutdown();
+        executor.shutdown();
+    }
+
+    @Test( timeout = 10000 )
+    public void logRotationMustNotObstructStartingReadTransaction() throws InterruptedException
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.getNodeById( 0 );
+            tx.success();
+            completeLogRotationLatch.countDown();
+        }
+    }
+
+    @Ignore( "This is not supported until 2.2" )
+    @Test( timeout = 10000 )
+    public void logRotationMustNotObstructStartingWriteTransaction() throws InterruptedException
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+            completeLogRotationLatch.countDown();
+        }
+    }
+
+    // One might be tempted to create a similar test for schema change transactions, e.g.
+    // ones that do something like `db.schema().indexFor( label ).on( "a" ).create();`.
+    // However, those will always fail because they will try to grab the schema write lock,
+    // which they will never be able to get, because the transaction we have stuck in log
+    // rotation will already be holding the schema read lock.
+}


### PR DESCRIPTION
One particularly notable improvement, is that we can now see roughly how long store flushing takes.

This PR also verifies that read transactions can start during log rotation. A similar test is added for write transactions, but it is ignored because it won't pass until 2.2.

Some TODOs are added that describe the changes that one have to make to this PR, when merging it into 2.2.