### PR TITLE
Rebuild counts store after recovery

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -91,7 +91,7 @@ public class ConsistencyCheckService
         StringLogger report = StringLogger.lazyLogger( reportFile );
 
 
-        try ( NeoStore neoStore = factory.newNeoStore( false, false ); )
+        try ( NeoStore neoStore = factory.newNeoStore( false ) )
         {
             neoStore.makeStoreOk();
             StoreAccess store = new StoreAccess( neoStore );

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/CloseableVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/CloseableVisitor.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.io.Closeable;
+
+public interface CloseableVisitor<E, FAILURE extends Exception> extends Visitor<E, FAILURE>, Closeable
+{
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.CacheInvalidationTransactionApplier;
 import org.neo4j.kernel.impl.transaction.command.HighIdTransactionApplier;
@@ -109,12 +110,15 @@ public class TransactionRepresentationStoreApplier
 
     private NeoCommandHandler getCountsStoreApplier( long transactionId, TransactionApplicationMode mode )
     {
-        if ( TransactionApplicationMode.RECOVERY == mode && !neoStore.getCounts().acceptTx( transactionId ) )
+        CountsTracker counts = neoStore.getCounts();
+        if ( TransactionApplicationMode.RECOVERY == mode && (counts == null || !counts.acceptTx( transactionId ) ) )
         {
             return NeoCommandHandler.EMPTY;
         }
 
-        assert neoStore.getCounts().acceptTx( transactionId );
-        return new CountsStoreApplier( neoStore.getCounts(), neoStore.getNodeStore() );
+        assert counts != null;
+        assert counts.acceptTx( transactionId );
+        return new CountsStoreApplier( counts, neoStore.getNodeStore() );
     }
+
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/StandalonePageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/StandalonePageCacheFactory.java
@@ -46,8 +46,7 @@ public final class StandalonePageCacheFactory
         // Not constructable.
     }
 
-    public static StandalonePageCache createPageCache(
-            FileSystemAbstraction fileSystem, String pageCacheName )
+    public static StandalonePageCache createPageCache( FileSystemAbstraction fileSystem, String pageCacheName )
     {
         return createPageCache( fileSystem, new Config(), pageCacheName );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -115,7 +115,7 @@ public class StoreAccess
     private StoreAccess( FileSystemAbstraction fileSystem, PageCache pageCache, String path, Config config, Monitors monitors )
     {
         this( new StoreFactory( config, new DefaultIdGeneratorFactory(), pageCache,
-                fileSystem, StringLogger.DEV_NULL, monitors ).newNeoStore( false, false ) );
+                fileSystem, StringLogger.DEV_NULL, monitors ).newNeoStore( false ) );
         this.closeable = true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -352,17 +352,4 @@ public class CountsTracker implements CountsVisitor.Visitable, AutoCloseable, Co
     {
         return new File( base.getParentFile(), base.getName() + version );
     }
-
-    private IOException safelyCloseTheStore( CountsStore store )
-    {
-        try
-        {
-            store.close();
-            return null;
-        }
-        catch ( IOException ex )
-        {
-            return ex;
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -29,7 +29,7 @@ package org.neo4j.kernel.impl.transaction.log;
  * <ol>
  *   <li>{@link #nextCommittingTransactionId()} is called and an id is returned to a committer.
  *   At this point that id isn't visible from any getter.</li>
- *   <li>{@link #transactionCommitted(long)} is called with this id after the fact that the transaction
+ *   <li>{@link #transactionCommitted(long, long)} is called with this id after the fact that the transaction
  *   has been committed, i.e. written forcefully to a log. After this call the id may be visible from
  *   {@link #getLastCommittedTransactionId()} if all ids before it have also been committed.</li>
  *   <li>{@link #transactionClosed(long)} is called with this id again, this time after all changes the
@@ -46,7 +46,7 @@ public interface TransactionIdStore
     /**
      * @return the next transaction id for a committing transaction. The transaction id is incremented
      * with each call. Ids returned from this method will not be visible from {@link #getLastCommittedTransactionId()}
-     * until handed to {@link #transactionCommitted(long)}.
+     * until handed to {@link #transactionCommitted(long, long)}.
      */
     long nextCommittingTransactionId();
 
@@ -60,7 +60,7 @@ public interface TransactionIdStore
     void transactionCommitted( long transactionId, long checksum );
 
     /**
-     * @return highest seen gap-free {@link #transactionCommitted(long) committed transaction id}.
+     * @return highest seen gap-free {@link #transactionCommitted(long, long) committed transaction id}.
      */
     long getLastCommittedTransactionId();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecoveryVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecoveryVisitor.java
@@ -19,10 +19,9 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import java.io.Closeable;
 import java.io.IOException;
 
-import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.helpers.collection.CloseableVisitor;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.locking.LockGroup;
@@ -30,7 +29,7 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 
-public class RecoveryVisitor implements Visitor<CommittedTransactionRepresentation,IOException>, Closeable
+public class RecoveryVisitor implements CloseableVisitor<CommittedTransactionRepresentation,IOException>
 {
     public interface Monitor
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
@@ -82,7 +82,7 @@ public class RsdrMain
 
         File storepath = new File( args[0] );
         StoreFactory factory = openStore( storepath );
-        NeoStore neoStore = factory.newNeoStore( false, false );
+        NeoStore neoStore = factory.newNeoStore( false );
         interact( neoStore );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -255,7 +255,7 @@ public class BatchInserterImpl implements BatchInserter
         }
         msgLog.logMessage( Thread.currentThread() + " Starting BatchInserter(" + this + ")" );
         life.start();
-        neoStore = sf.newNeoStore( true, false );
+        neoStore = sf.newNeoStore( true );
         if ( !neoStore.isStoreOk() )
         {
             throw new IllegalStateException( storeDir + " store is not cleanly shutdown." );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
@@ -127,7 +127,7 @@ public class BatchingNeoStore implements AutoCloseable
     {
         StoreFactory storeFactory = new StoreFactory( neo4jConfig, new BatchingIdGeneratorFactory(),
                 pageCache, fileSystem, logger, monitors );
-        return storeFactory.newNeoStore( true, false );
+        return storeFactory.newNeoStore( true );
     }
 
     public NodeStore getNodeStore()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -112,7 +112,7 @@ public class ManyPropertyKeysIT
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreFactory storeFactory = new StoreFactory( fs, storeDir, pageCache, StringLogger.DEV_NULL, new Monitors() );
-        NeoStore neoStore = storeFactory.newNeoStore( true, false );
+        NeoStore neoStore = storeFactory.newNeoStore( true );
         PropertyKeyTokenStore store = neoStore.getPropertyKeyTokenStore();
         for ( int i = 0; i < propertyKeyCount; i++ )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -83,7 +83,7 @@ public class IdGeneratorRebuildFailureEmulationTest
         NeoStore neostore = null;
         try
         {
-            neostore = factory.newNeoStore( false, false );
+            neostore = factory.newNeoStore( false );
             // emulate a failure during rebuild:
             emulateFailureOnRebuildOf( neostore );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
@@ -74,7 +74,7 @@ public abstract class RecordStoreConsistentReadTest<R extends AbstractBaseRecord
         File storeDir = new File( "stores" );
         StringLogger logger = StringLogger.DEV_NULL;
         StoreFactory factory = new StoreFactory( fs, storeDir, pageCache, logger, new Monitors() );
-        NeoStore neoStore = factory.newNeoStore( true, false );
+        NeoStore neoStore = factory.newNeoStore( true );
         S store = initialiseStore( neoStore );
 
         CommonAbstractStore commonAbstractStore = (CommonAbstractStore) store;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
@@ -142,18 +142,18 @@ public class RelationshipGroupStoreTest
     {
         int expectedThreshold = customThreshold != null ? customThreshold : defaultThreshold;
         StoreFactory factory = factory( customThreshold );
-        NeoStore neoStore = factory.newNeoStore( true, false );
+        NeoStore neoStore = factory.newNeoStore( true );
         assertEquals( expectedThreshold, neoStore.getDenseNodeThreshold() );
         neoStore.close();
 
         // Next time we open it it should be the same
-        neoStore = factory.newNeoStore( false, false );
+        neoStore = factory.newNeoStore( false );
         assertEquals( expectedThreshold, neoStore.getDenseNodeThreshold() );
         neoStore.close();
 
         // Even if we open with a different config setting it should just ignore it
         factory = factory( 999999 );
-        neoStore = factory.newNeoStore( false, false );
+        neoStore = factory.newNeoStore( false );
         assertEquals( expectedThreshold, neoStore.getDenseNodeThreshold() );
         neoStore.close();
     }
@@ -320,7 +320,7 @@ public class RelationshipGroupStoreTest
         pageCache = pageCacheRule.withInconsistentReads( pageCache, nextReadIsInconsistent );
         StoreFactory factory = factory( null, pageCache );
 
-        try ( NeoStore neoStore = factory.newNeoStore( true, false ) )
+        try ( NeoStore neoStore = factory.newNeoStore( true ) )
         {
             RelationshipGroupStore relationshipGroupStore = neoStore.getRelationshipGroupStore();
             RelationshipGroupRecord record = new RelationshipGroupRecord( 1, 2, 3, 4, 5, 6, true );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreVersionTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashMap;
-
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
@@ -44,7 +44,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.StoreFactory.configForStoreDir;
 
@@ -60,7 +59,7 @@ public class StoreVersionTest
                 fs.get(),
                 StringLogger.DEV_NULL,
                 monitors );
-        NeoStore neoStore = sf.newNeoStore( true, false );
+        NeoStore neoStore = sf.newNeoStore( true );
 
         CommonAbstractStore[] stores = {
                 neoStore.getNodeStore(),
@@ -118,7 +117,7 @@ public class StoreVersionTest
                 fs.get(),
                 StringLogger.DEV_NULL,
                 monitors );
-        NeoStore neoStore = sf.newNeoStore( true, false );
+        NeoStore neoStore = sf.newNeoStore( true );
 
         // The first checks the instance method, the other the public one
         assertEquals( CommonAbstractStore.ALL_STORES_VERSION,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
@@ -193,7 +193,7 @@ public class TestGraphProperties
                 fs.get(),
                 StringLogger.DEV_NULL,
                 monitors );
-        NeoStore neoStore = storeFactory.newNeoStore( false, false );
+        NeoStore neoStore = storeFactory.newNeoStore( false );
         long prop = neoStore.getGraphNextProp();
         assertTrue( prop != 0 );
         neoStore.close();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -1227,7 +1227,7 @@ public class TestNeoStore
                 StringLogger.DEV_NULL,
                 monitors );
 
-        NeoStore neoStore = sf.newNeoStore( false, false );
+        NeoStore neoStore = sf.newNeoStore( false );
         assertEquals( 12, neoStore.getCurrentLogVersion() );
         neoStore.close();
     }
@@ -1247,7 +1247,7 @@ public class TestNeoStore
                 monitors );
 
         // when
-        NeoStore neoStore = sf.newNeoStore( true, false );
+        NeoStore neoStore = sf.newNeoStore( true );
 
         // then the default is 0
         assertEquals( 0l, neoStore.getLatestConstraintIntroducingTx() );
@@ -1261,7 +1261,7 @@ public class TestNeoStore
         // when
         neoStore.flush();
         neoStore.close();
-        neoStore = sf.newNeoStore( false, false );
+        neoStore = sf.newNeoStore( false );
 
         // then the value should have been stored
         assertEquals( 10l, neoStore.getLatestConstraintIntroducingTx() );
@@ -1275,10 +1275,10 @@ public class TestNeoStore
                 new StoreFactory( fs.get(), new File( "graph.db/neostore" ), pageCache, StringLogger.DEV_NULL,
                         new Monitors() );
 
-        NeoStore neoStore = factory.newNeoStore( true, false );
+        NeoStore neoStore = factory.newNeoStore( true );
         neoStore.close();
 
-        neoStore = factory.newNeoStore( false, false );
+        neoStore = factory.newNeoStore( false );
         long lastCommittedTransactionId = neoStore.getLastCommittedTransactionId();
         neoStore.close();
 
@@ -1292,7 +1292,7 @@ public class TestNeoStore
         File neoStoreDir = new File( "/tmp/graph.db/neostore" ).getAbsoluteFile();
         StoreFactory factory =
                 new StoreFactory( fileSystem, neoStoreDir, pageCache, StringLogger.DEV_NULL, new Monitors() );
-        NeoStore neoStore = factory.newNeoStore( true, false );
+        NeoStore neoStore = factory.newNeoStore( true );
         neoStore.setCreationTime( 3 );
         neoStore.setRandomNumber( 4 );
         neoStore.setCurrentLogVersion( 5 );
@@ -1320,7 +1320,7 @@ public class TestNeoStore
         NeoStore.setRecord( fileSystem, file, Position.UPGRADE_TRANSACTION_CHECKSUM, 11 );
         NeoStore.setRecord( fileSystem, file, Position.UPGRADE_TIME, 12 );
 
-        neoStore = factory.newNeoStore( false, false );
+        neoStore = factory.newNeoStore( false );
         assertEquals( 3, neoStore.getCreationTime() );
         assertEquals( 4, neoStore.getRandomNumber() );
         assertEquals( 5, neoStore.getCurrentLogVersion() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorTest.java
@@ -75,7 +75,7 @@ public class StoreMigratorTest
         // THEN starting the new store should be successful
         StoreFactory storeFactory = new StoreFactory( fs.get(), storeDirectory, pageCache,
                 logging.getMessagesLog( getClass() ), new Monitors() );
-        storeFactory.newNeoStore( false, false ).close();
+        storeFactory.newNeoStore( false ).close();
     }
 
     @Rule

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogicalTransactionStoreTest.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import org.neo4j.helpers.collection.CloseableVisitor;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
@@ -64,7 +65,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.util.IdOrderingQueue.BYPASS;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
@@ -139,7 +139,7 @@ public class PhysicalLogicalTransactionStoreTest
         final AtomicInteger recoveredTransactions = new AtomicInteger();
         final LogFileRecoverer recoverer = new LogFileRecoverer(
                 new LogEntryReaderFactory().versionable(),
-                new Visitor<CommittedTransactionRepresentation,IOException>()
+                new CloseableVisitor<CommittedTransactionRepresentation, IOException>()
                 {
                     @Override
                     public boolean visit( CommittedTransactionRepresentation committedTx ) throws IOException
@@ -153,6 +153,12 @@ public class PhysicalLogicalTransactionStoreTest
                         assertEquals( latestCommittedTxWhenStarted, transaction.getLatestCommittedTxWhenStarted() );
                         recoveredTransactions.incrementAndGet();
                         return false;
+                    }
+
+                    @Override
+                    public void close() throws IOException
+                    {
+                        // nothing to do
                     }
                 } );
         logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000, transactionIdStore, mock( LogVersionRepository.class ), monitor, positionCache ) );
@@ -233,7 +239,7 @@ public class PhysicalLogicalTransactionStoreTest
         final AtomicInteger recoveredTransactions = new AtomicInteger();
         final LogFileRecoverer recoverer = new LogFileRecoverer(
                 new LogEntryReaderFactory().versionable(),
-                new Visitor<CommittedTransactionRepresentation,IOException>()
+                new CloseableVisitor<CommittedTransactionRepresentation, IOException>()
                 {
                     @Override
                     public boolean visit( CommittedTransactionRepresentation committedTx ) throws IOException
@@ -247,6 +253,12 @@ public class PhysicalLogicalTransactionStoreTest
                         assertEquals( latestCommittedTxWhenStarted, transaction.getLatestCommittedTxWhenStarted() );
                         recoveredTransactions.incrementAndGet();
                         return false;
+                    }
+
+                    @Override
+                    public void close() throws IOException
+                    {
+                        // nothing to do
                     }
                 } );
         logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
@@ -117,7 +117,7 @@ public class ApplyRecoveredTransactionsTest
         Config config = configForStoreDir( new Config(), storeDir );
         StoreFactory storeFactory = new StoreFactory( config, new DefaultIdGeneratorFactory(),
                 pageCacheRule.getPageCache( fsr.get() ), fsr.get(), DEV_NULL, new Monitors() );
-        neoStore = storeFactory.newNeoStore( true, false );
+        neoStore = storeFactory.newNeoStore( true );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -133,7 +133,7 @@ public class TransactionRecordStateTest
         fsr.get().mkdirs( storeDir );
         StoreFactory storeFactory = new StoreFactory( fsr.get(), storeDir,
                 pageCacheRule.getPageCache( fsr.get() ), StringLogger.DEV_NULL, new Monitors() );
-        return cleanup.add( storeFactory.newNeoStore( true, false ) );
+        return cleanup.add( storeFactory.newNeoStore( true ) );
     }
 
     private TransactionRecordState nodeWithDynamicLabelRecord( NeoStore store,

--- a/community/neo4j/src/test/java/upgrade/StoreMigratorFrom19IT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreMigratorFrom19IT.java
@@ -104,7 +104,7 @@ public class StoreMigratorFrom19IT
             database.shutdown();
         }
 
-        try ( NeoStore neoStore = storeFactory.newNeoStore( true, false ) )
+        try ( NeoStore neoStore = storeFactory.newNeoStore( true ) )
         {
             verifyNeoStore( neoStore );
         }

--- a/community/neo4j/src/test/java/upgrade/StoreMigratorFrom20IT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreMigratorFrom20IT.java
@@ -19,13 +19,13 @@
  */
 package upgrade;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -53,14 +53,12 @@ import org.neo4j.test.ha.ClusterManager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.kernel.impl.store.CommonAbstractStore.ALL_STORES_VERSION;
 import static org.neo4j.kernel.impl.store.NeoStore.versionLongToString;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.find20FormatStoreDirectory;
 import static org.neo4j.kernel.impl.storemigration.UpgradeConfiguration.ALLOW_UPGRADE;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
-
 import static upgrade.StoreMigratorTestUtil.buildClusterWithMasterDirIn;
 
 public class StoreMigratorFrom20IT
@@ -91,7 +89,7 @@ public class StoreMigratorFrom20IT
             database.shutdown();
         }
 
-        try ( NeoStore neoStore = storeFactory.newNeoStore( true, false ) )
+        try ( NeoStore neoStore = storeFactory.newNeoStore( true ) )
         {
             verifyNeoStore( neoStore );
         }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -19,19 +19,19 @@
  */
 package upgrade;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -60,7 +60,6 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -77,7 +76,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.kernel.impl.store.CommonAbstractStore.ALL_STORES_VERSION;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allStoreFilesHaveVersion;
@@ -286,7 +284,7 @@ public class StoreUpgraderTest
 
         // Then
         NeoStore neoStore = new StoreFactory( fileSystem, dbDirectory, pageCache,
-                StringLogger.DEV_NULL, mock( Monitors.class ) ).newNeoStore( false, false );
+                StringLogger.DEV_NULL, mock( Monitors.class ) ).newNeoStore( false );
 
         assertThat( neoStore.getUpgradeTransaction(), equalTo( neoStore.getLastCommittedTransaction() ) );
         assertThat( neoStore.getUpgradeTime(), not( equalTo( NeoStore.FIELD_NOT_INITIALIZED ) ) );

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/ccheck/ConsistencyPerformanceCheck.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/ccheck/ConsistencyPerformanceCheck.java
@@ -156,7 +156,7 @@ public class ConsistencyPerformanceCheck
                 logger,
                 monitors );
 
-        NeoStore neoStore = factory.newNeoStore( true, false );
+        NeoStore neoStore = factory.newNeoStore( true );
 
         SchemaIndexProvider indexes = new LuceneSchemaIndexProvider( DirectoryFactory.PERSISTENT, tuningConfiguration );
         return new DirectStoreAccess( new StoreAccess( neoStore ),
@@ -173,5 +173,4 @@ public class ConsistencyPerformanceCheck
 
         return new Config( passedOnConfiguration, GraphDatabaseSettings.class );
     }
-
 }


### PR DESCRIPTION
The counts store was rebuilt when creating the stores which might be
problematic since the stores might be in an inconsistent state at that
stage.  This has been changed by delaying the rebuilding of counts
after recovery.