### PR TITLE
Fixes deadlock issue with log appenders and rotator

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.kernel.impl.store.counts.CountsTracker.STORE_DESCRIPTOR;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/AbstractPhysicalTransactionAppender.java
@@ -81,7 +81,10 @@ abstract class AbstractPhysicalTransactionAppender implements TransactionAppende
         // log rotation, which will wait for all transactions closed or fail on kernel panic.
         try
         {
-            transactionLogWriter.append( transaction, transactionId );
+            synchronized ( channel )
+            {
+                transactionLogWriter.append( transaction, transactionId );
+            }
             long transactionChecksum = checksum( transaction.additionalHeader(), transaction.getMasterId(),
                     transaction.getAuthorId() );
             transactionMetadataCache.cacheTransactionMetadata( transactionId, logPosition, transaction.getMasterId(),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingPhysicalTransactionAppender.java
@@ -174,15 +174,15 @@ public class BatchingPhysicalTransactionAppender extends AbstractPhysicalTransac
     public void force() throws IOException
     {
         // Empty buffer into channel. We want to synchronize with appenders somehow so that they
-        // don't append while we're doing that. The natural way is to synchronize on logFile,
-        // which all other code around transaction appending does.
-        synchronized ( logFile )
+        // don't append while we're doing that. The way rotation is coordinated we can't synchronize
+        // on logFile because it would cause deadlocks. Synchronizing on channel assumes that appenders
+        // also synchronize on channel.
+        synchronized ( channel )
         {
             channel.emptyBufferIntoChannelAndClearIt();
         }
 
-        // Now force the channel
-        forceChannel();
+        channel.force();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotationControl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotationControl.java
@@ -24,20 +24,19 @@ import java.util.concurrent.locks.LockSupport;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.index.IndexingService;
-import org.neo4j.kernel.impl.store.NeoStore;
 
 public class LogRotationControl
 {
-    private final NeoStore neoStore;
+    private final TransactionIdStore transactionIdStore;
     private final IndexingService indexingService;
     private final LabelScanStore labelScanStore;
     private final Iterable<IndexImplementation> indexProviders;
 
-    public LogRotationControl( NeoStore neoStore, IndexingService indexingService,
+    public LogRotationControl( TransactionIdStore transactionIdStore, IndexingService indexingService,
             LabelScanStore labelScanStore,
             Iterable<IndexImplementation> indexProviders )
     {
-        this.neoStore = neoStore;
+        this.transactionIdStore = transactionIdStore;
         this.indexingService = indexingService;
         this.labelScanStore = labelScanStore;
         this.indexProviders = indexProviders;
@@ -45,7 +44,7 @@ public class LogRotationControl
 
     public void awaitAllTransactionsClosed()
     {
-        while ( !neoStore.closedTransactionIdIsOnParWithCommittedTransactionId() )
+        while ( !transactionIdStore.closedTransactionIdIsOnParWithCommittedTransactionId() )
         {
             LockSupport.parkNanos( 1_000_000 ); // 1 ms
         }
@@ -59,6 +58,6 @@ public class LogRotationControl
         {
             index.force();
         }
-        neoStore.flush();
+        transactionIdStore.flush();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -127,7 +127,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
     }
 
     @Override
-    public synchronized boolean rotationNeeded() throws IOException
+    public boolean rotationNeeded() throws IOException
     {
         /*
          * Whereas channel.size() should be fine, we're safer calling position() due to possibility
@@ -136,6 +136,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
         return (channel.position() >= rotateAtSize);
     }
 
+    @Override
     public synchronized void rotate() throws IOException
     {
         channel = rotate( channel );

--- a/community/kernel/src/test/java/org/neo4j/kernel/LogRotationDeadlockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/LogRotationDeadlockTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.index.IndexImplementation;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.DeadSimpleTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.BatchingPhysicalTransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.ControlledParkStrategy;
+import org.neo4j.kernel.impl.transaction.log.InMemoryLogChannel;
+import org.neo4j.kernel.impl.transaction.log.LogFile;
+import org.neo4j.kernel.impl.transaction.log.LogRotation;
+import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+import org.neo4j.kernel.impl.util.Counter;
+import org.neo4j.kernel.impl.util.IdOrderingQueue;
+import org.neo4j.test.Barrier;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
+import org.neo4j.test.OtherThreadRule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogRotationDeadlockTest
+{
+    /**
+     * Problem was that rotating thread that went to wait for all committed
+     * transactions to be closed held monitor that threads needed to grab between
+     * the point where transactions were committed and they were closed.
+     */
+    @Test
+    public void shouldNotDeadlockDuringRotation() throws Exception
+    {
+        // GIVEN
+        // controlled log rotation that will let loose a previously halted committer
+        TransactionIdStore txIdStore = new DeadSimpleTransactionIdStore();
+        LogFile logFile = mock( LogFile.class );
+        when( logFile.getWriter() ).thenReturn( new InMemoryLogChannel() );
+        final Barrier.Control inBetweenCommittedAndClosed = new Barrier.Control();
+        final ControlledParkStrategy controlledBatchedWritesParking = new ControlledParkStrategy();
+        LogRotationControl rotationControl = new LogRotationControl( txIdStore, mock( IndexingService.class ),
+                mock( LabelScanStore.class ), Iterables.<IndexImplementation,IndexImplementation>iterable() )
+        {
+            @Override
+            public void awaitAllTransactionsClosed()
+            {
+                controlledBatchedWritesParking.releaseIndefinitely();
+                inBetweenCommittedAndClosed.release();
+                super.awaitAllTransactionsClosed();
+            }
+        };
+        KernelHealth health = mock( KernelHealth.class );
+        LogRotationImpl rotation = new LogRotationImpl( mock( LogRotation.Monitor.class ), logFile,
+                rotationControl, health );
+
+        // controlled batching transaction appender that will halt a committer
+        TransactionAppender appender = new BatchingPhysicalTransactionAppender( logFile, rotation,
+                new TransactionMetadataCache( 10, 10 ), txIdStore, mock( IdOrderingQueue.class ),
+                Counter.ATOMIC_LONG, controlledBatchedWritesParking, health )
+        {
+            @Override
+            protected void forceAfterAppend( long ticket ) throws IOException
+            {
+                inBetweenCommittedAndClosed.reached();
+                super.forceAfterAppend( ticket );
+            }
+        };
+        controlledBatchedWritesParking.awaitIdle();
+
+        // commit process
+        LogicalTransactionStore txStore = mock( LogicalTransactionStore.class );
+        when( txStore.getAppender() ).thenReturn( appender );
+        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( txStore,
+                health, txIdStore, mock( TransactionRepresentationStoreApplier.class ),
+                TransactionApplicationMode.INTERNAL );
+
+        // WHEN
+        // trapping an appender in between having its transaction committed and closed
+        Future<Void> appendFuture = committer.execute( commitArbitraryTransaction( commitProcess ) );
+        inBetweenCommittedAndClosed.await();
+
+        // and another transaction appender comes in and wants to rotate the log,
+        // where the rotation resumes the first appender at the point where it starts awaiting
+        // committed transactions to be closed
+        when( logFile.rotationNeeded() ).thenReturn( true );
+        Future<Void> rotateFuture = rotator.execute( commitArbitraryTransaction( commitProcess ) );
+
+        // THEN
+        // first appender should be able to complete once we let it loose
+        appendFuture.get( 100, TimeUnit.SECONDS );
+        // and its completion should let the rotation be able to complete
+        rotateFuture.get( 100, TimeUnit.SECONDS );
+    }
+
+    private WorkerCommand<Void,Void> commitArbitraryTransaction( final TransactionCommitProcess commitProcess )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                commitProcess.commit( arbitraryTransaction(), new LockGroup() );
+                return null;
+            }
+        };
+    }
+
+    private TransactionRepresentation arbitraryTransaction()
+    {
+        TransactionRepresentation transaction = mock( TransactionRepresentation.class );
+        when( transaction.additionalHeader() ).thenReturn( new byte[0] );
+        return transaction;
+    }
+
+    public final @Rule OtherThreadRule<Void> committer = new OtherThreadRule<>( "COMMITTER" );
+    public final @Rule OtherThreadRule<Void> rotator = new OtherThreadRule<>( "ROTATOR" );
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ControlledParkStrategy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ControlledParkStrategy.java
@@ -22,12 +22,16 @@ package org.neo4j.kernel.impl.transaction.log;
 public class ControlledParkStrategy implements ParkStrategy
 {
     private volatile boolean idle;
+    private volatile boolean released;
 
     @Override
     public void park( Thread thread )
     {
-        idle = true;
-        await( false );
+        if ( !released )
+        {
+            idle = true;
+            await( false );
+        }
     }
 
     @Override
@@ -39,6 +43,12 @@ public class ControlledParkStrategy implements ParkStrategy
     public void awaitIdle()
     {
         await( true );
+    }
+
+    public void releaseIndefinitely()
+    {
+        released = true;
+        idle = false;
     }
 
     private void await( boolean idle )

--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadRule.java
@@ -33,17 +33,29 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class OtherThreadRule<STATE> implements TestRule
 {
+    private final String name;
     private final long timeout;
     private final TimeUnit unit;
     private volatile OtherThreadExecutor<STATE> executor;
 
     public OtherThreadRule()
     {
-        this( 10, SECONDS );
+        this( null );
+    }
+
+    public OtherThreadRule( String name )
+    {
+        this( name, 10, SECONDS );
     }
 
     public OtherThreadRule( long timeout, TimeUnit unit )
     {
+        this( null, timeout, unit );
+    }
+
+    public OtherThreadRule( String name, long timeout, TimeUnit unit )
+    {
+        this.name = name;
         this.timeout = timeout;
         this.unit = unit;
     }
@@ -98,7 +110,7 @@ public class OtherThreadRule<STATE> implements TestRule
             }
         };
     }
-    
+
     public OtherThreadExecutor<STATE> get()
     {
         return executor;
@@ -130,7 +142,10 @@ public class OtherThreadRule<STATE> implements TestRule
             @Override
             public void evaluate() throws Throwable
             {
-                executor = new OtherThreadExecutor<>( description.getDisplayName(), timeout, unit, initialState() );
+                String threadName = name != null
+                        ? name + "-" + description.getDisplayName()
+                        : description.getDisplayName();
+                executor = new OtherThreadExecutor<>( threadName, timeout, unit, initialState() );
                 try
                 {
                     base.evaluate();

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -21,14 +21,13 @@ package org.neo4j.server.rest.web;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
-
-import org.apache.commons.lang.StringUtils;
 
 import org.neo4j.cypher.CypherException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -53,9 +52,9 @@ public class CypherService
     private static final String PROFILE_PARAM = "profile";
     private final GraphDatabaseService database;
 
-    private CypherExecutor cypherExecutor;
-    private OutputFormat output;
-    private InputFormat input;
+    private final CypherExecutor cypherExecutor;
+    private final OutputFormat output;
+    private final InputFormat input;
 
     public CypherService( @Context CypherExecutor cypherExecutor, @Context InputFormat input,
                           @Context OutputFormat output, @Context GraphDatabaseService database )


### PR DESCRIPTION
Problem was that rotating thread that went to wait for all committed
transactions to be closed held monitor that threads needed to grab between
the point where transactions were committed and they were closed.

This commit provides a solution where appenders additionally grabs a
monitor on the log channel while appending, i.e. a smaller scope inside
the bigger logFile block. This log channel monitor is the one that the
batching appender also grabs when forcing. A slight performance
degradation has been observed though.