### PR TITLE
Unifies header comments in the two main configuration files

### DIFF
--- a/packaging/standalone/document.properties
+++ b/packaging/standalone/document.properties
@@ -1,4 +1,6 @@
-server.fullname=Neo4j
+product.fullname=Neo4j Database
+kernel.fullname=Neo4j Kernel
+server.fullname=Neo4j Server
 server.shortname=neo4j
 shell.fullname=Neo4j Shell
 shell.shortname=neo4j-shell

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
@@ -1,10 +1,10 @@
 ################################################################
-# ${server.fullname} configuration
+# ${product.fullname} configuration
 #
 ################################################################
 
 #***************************************************************
-# Server configuration
+# ${server.fullname} configuration
 #***************************************************************
 
 # location of the database directory 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -1,3 +1,11 @@
+################################################################
+# ${product.fullname} configuration
+#
+################################################################
+
+#***************************************************************
+# ${kernel.fullname} configuration
+#***************************************************************
 
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
@@ -1,10 +1,10 @@
 ################################################################
-# ${server.fullname} configuration
+# ${product.fullname} configuration
 #
 ################################################################
 
 #***************************************************************
-# Server configuration
+# ${server.fullname} configuration
 #***************************************************************
 
 # location of the database directory 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -1,3 +1,11 @@
+################################################################
+# ${product.fullname} configuration
+#
+################################################################
+
+#***************************************************************
+# ${kernel.fullname} configuration
+#***************************************************************
 
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
@@ -1,10 +1,10 @@
 ################################################################
-# ${server.fullname} configuration
+# ${product.fullname} configuration
 #
 ################################################################
 
 #***************************************************************
-# Server configuration
+# ${server.fullname} configuration
 #***************************************************************
 
 # location of the database directory 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -1,3 +1,11 @@
+################################################################
+# ${product.fullname} configuration
+#
+################################################################
+
+#***************************************************************
+# ${kernel.fullname} configuration
+#***************************************************************
 
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true


### PR DESCRIPTION
The conf/neo4j.properties file was lacking a comment at the top
 which would make it similar to conf/neo4j-server.properties file.
 This change intoduces a similar comment to both files for all
 three packaging configurations and also makes the consistent by
 having a product name and a component name explicitly set in
 documents.properties file