### PR TITLE
Change neo4j-community packaging from jar to pom, change reference to use pom type.

### DIFF
--- a/community/neo4j-community/pom.xml
+++ b/community/neo4j-community/pom.xml
@@ -13,7 +13,7 @@
   <version>2.2-SNAPSHOT</version>
 
   <name>Neo4j - Community</name>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
   <description>A meta package containing the most used Neo4j Community libraries. Intended use: as a Maven dependency.</description>
 

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -152,6 +152,7 @@ the relevant Commercial Agreement.
           <groupId>org.neo4j</groupId>
           <artifactId>neo4j-community</artifactId>
           <version>${project.version}</version>
+          <type>pom</type>
         </dependency>
         <dependency>
           <groupId>org.neo4j</groupId>


### PR DESCRIPTION
This should fix the validation error from mvn central.
Also updates the reference in the `community-build` pom to use the `pom` artifact type, as it won't find the jar any more.
