### PR TITLE
Adds ability to specify disjoint id groups in import tool

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Map.Entry;
 
 import org.neo4j.function.Function;
+import org.neo4j.function.Function2;
 import org.neo4j.function.Functions;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Args.Option;
@@ -71,15 +72,6 @@ import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultF
  */
 public class ImportTool
 {
-    private static final Function<String,IdType> TO_ID_TYPE = new Function<String,IdType>()
-    {
-        @Override
-        public IdType apply( String from )
-        {
-            return IdType.valueOf( from.toUpperCase() );
-        }
-    };
-
     enum Options
     {
         STORE_DIR( "into", "<store-dir>", "Database directory to import into. " + "Must not contain existing database." ),
@@ -142,9 +134,14 @@ public class ImportTool
             return key;
         }
 
+        String argument()
+        {
+            return "--" + key();
+        }
+
         void printUsage( PrintStream out )
         {
-            out.println( "--" + key + " " + usage );
+            out.println( argument() + " " + usage );
             for ( String line : Args.splitLongLine( description.replace( "`", "" ), 80 ) )
             {
                 out.println( "\t" + line );
@@ -155,7 +152,7 @@ public class ImportTool
         {
             String filteredDescription = description.replace( availableProcessorsHint(), "" );
             String usageString = (usage.length() > 0) ? " " + usage : "";
-            return "*--" + key + usageString + "*::\n" + filteredDescription + "\n\n";
+            return "*" + argument() + usageString + "*::\n" + filteredDescription + "\n\n";
         }
 
         private static String availableProcessorsHint()
@@ -167,7 +164,7 @@ public class ImportTool
     /**
      * Delimiter used between files in an input group.
      */
-    static final String MULTI_FILE_DELIMITER = " ";
+    static final String MULTI_FILE_DELIMITER = ",";
 
     public static void main( String[] incomingArguments )
     {
@@ -180,33 +177,20 @@ public class ImportTool
 
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         File storeDir;
-        // The input groups
         Collection<Option<File[]>> nodesFiles, relationshipsFiles;
         boolean enableStacktrace;
         Number processors = null;
         Input input = null;
         try
         {
-            storeDir =
-                    args.interpretOption( Options.STORE_DIR.key(), Converters.<File> mandatory(), Converters.toFile(),
-                            Validators.DIRECTORY_IS_WRITABLE, Validators.CONTAINS_NO_EXISTING_DATABASE );
-            nodesFiles =
-                    args.interpretOptionsWithMetadata( Options.NODE_DATA.key(), Converters.<File[]> mandatory(),
-                            Converters.toFiles( MULTI_FILE_DELIMITER ), Validators.FILES_EXISTS,
-                            Validators.<File> atLeast( 1 ) );
-            relationshipsFiles =
-                    args.interpretOptionsWithMetadata( Options.RELATIONSHIP_DATA.key(),
-                            Converters.<File[]> optional(), Converters.toFiles( MULTI_FILE_DELIMITER ),
-                            Validators.FILES_EXISTS, Validators.<File> atLeast( 1 ) );
+            storeDir = args.interpretOption( Options.STORE_DIR.key(), Converters.<File>mandatory(),
+                    Converters.toFile(), Validators.DIRECTORY_IS_WRITABLE, Validators.CONTAINS_NO_EXISTING_DATABASE );
+            nodesFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.NODE_DATA.key() );
+            relationshipsFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.RELATIONSHIP_DATA.key() );
             enableStacktrace = args.getBoolean( Options.STACKTRACE.key(), Boolean.FALSE, Boolean.TRUE );
             processors = args.getNumber( Options.PROCESSORS.key(), null );
-            input = new CsvInput(
-                    nodeData( nodesFiles ),
-                    defaultFormatNodeFileHeader(),
-                    relationshipData( relationshipsFiles ),
-                    defaultFormatRelationshipFileHeader(),
-                    args.interpretOption( Options.ID_TYPE.key(), withDefault( IdType.STRING ), TO_ID_TYPE ),
-                    csvConfiguration( args ) );
+            IdType idType = args.interpretOption( Options.ID_TYPE.key(), withDefault( IdType.STRING ), TO_ID_TYPE );
+            input = input( nodesFiles, relationshipsFiles, INPUT_FILES_EXTRACTOR, idType, csvConfiguration( args ) );
         }
         catch ( IllegalArgumentException e )
         {
@@ -252,6 +236,19 @@ public class ImportTool
                 }
             }
         }
+    }
+
+    private static Input input( Collection<Option<File[]>> nodesFiles, Collection<Option<File[]>> relationshipsFiles,
+            Function2<Args,String,Collection<Option<File[]>>> inputFilesExtractor,
+            IdType idType, Configuration configuration )
+    {
+        Iterable<DataFactory<InputNode>> nodeData = nodeData( nodesFiles );
+        Iterable<DataFactory<InputRelationship>> relationshipData = relationshipData( relationshipsFiles );
+
+        return new CsvInput(
+                nodeData, defaultFormatNodeFileHeader(),
+                relationshipData, defaultFormatRelationshipFileHeader(),
+                idType, configuration );
     }
 
     private static org.neo4j.unsafe.impl.batchimport.Configuration importConfiguration( final Number processors )
@@ -307,17 +304,17 @@ public class ImportTool
         };
     }
 
-    private static Iterable<DataFactory<InputNode>> nodeData( Collection<Option<File[]>> files )
+    private static Iterable<DataFactory<InputNode>> nodeData( Collection<Option<File[]>> nodesFiles )
     {
-        return new IterableWrapper<DataFactory<InputNode>,Option<File[]>>( files )
+        return new IterableWrapper<DataFactory<InputNode>,Option<File[]>>( nodesFiles )
         {
             @Override
-            protected DataFactory<InputNode> underlyingObjectToObject( Option<File[]> group )
+            protected DataFactory<InputNode> underlyingObjectToObject( Option<File[]> input )
             {
-                Function<InputNode,InputNode> decorator = group.metadata() != null
-                        ? additiveLabels( group.metadata().split( ":" ) )
+                Function<InputNode,InputNode> decorator = input.metadata() != null
+                        ? additiveLabels( input.metadata().split( ":" ) )
                         : Functions.<InputNode>identity();
-                return data( decorator, group.value() );
+                return data( decorator, input.value() );
             }
         };
     }
@@ -401,6 +398,15 @@ public class ImportTool
         };
     }
 
+    private static final Function<String,IdType> TO_ID_TYPE = new Function<String,IdType>()
+    {
+        @Override
+        public IdType apply( String from )
+        {
+            return IdType.valueOf( from.toUpperCase() );
+        }
+    };
+
     private static final Function<String,Character> DELIMITER_CONVERTER = new Function<String,Character>()
     {
         private final Function<String,Character> fallback = Converters.toCharacter();
@@ -413,6 +419,18 @@ public class ImportTool
                 return '\t';
             }
             return fallback.apply( value );
+        }
+    };
+
+    private static final Function2<Args,String,Collection<Option<File[]>>> INPUT_FILES_EXTRACTOR =
+            new Function2<Args,String,Collection<Option<File[]>>>()
+    {
+        @Override
+        public Collection<Option<File[]>> apply( Args args, String key )
+        {
+            return args.interpretOptionsWithMetadata( key, Converters.<File[]>optional(),
+                    Converters.toFiles( MULTI_FILE_DELIMITER ), Validators.FILES_EXISTS,
+                    Validators.<File>atLeast( 1 ) );
         }
     };
 }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGenerator.java
@@ -212,16 +212,16 @@ public class CsvDataGenerator
         Configuration config = Configuration.COMMAS;
         Extractors extractors = new Extractors( config.arrayDelimiter() );
         Header nodeHeader = new Header( new Entry[] {
-                new Entry( null, Type.ID, extractors.string() ),
-                new Entry( "name", Type.PROPERTY, extractors.string() ),
-                new Entry( "age", Type.PROPERTY, extractors.int_() ),
-                new Entry( "something", Type.PROPERTY, extractors.string() ),
-                new Entry( null, Type.LABEL, extractors.stringArray() ),
+                new Entry( null, Type.ID, null, extractors.string() ),
+                new Entry( "name", Type.PROPERTY, null, extractors.string() ),
+                new Entry( "age", Type.PROPERTY, null, extractors.int_() ),
+                new Entry( "something", Type.PROPERTY, null, extractors.string() ),
+                new Entry( null, Type.LABEL, null, extractors.stringArray() ),
         } );
         Header relationshipHeader = new Header( new Entry[] {
-                new Entry( null, Type.START_ID, extractors.string() ),
-                new Entry( null, Type.END_ID, extractors.string() ),
-                new Entry( null, Type.TYPE, extractors.string() )
+                new Entry( null, Type.START_ID, null, extractors.string() ),
+                new Entry( null, Type.END_ID, null, extractors.string() ),
+                new Entry( null, Type.TYPE, null, extractors.string() )
         } );
 
         ProgressListener progress = textual( System.out ).singlePart( "Generating", nodeCount + relationshipCount );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -238,7 +238,7 @@ public class ImportToolDocIT
     {
         try (PrintStream out = new PrintStream( file( "man", "options.adoc" ) ))
         {
-            for ( Options option : ImportTool.Options.values() )
+            for ( Options option : Options.values() )
             {
                 out.print( option.manPageEntry() );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validators.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Validators.java
@@ -35,10 +35,19 @@ public class Validators
         {
             for ( File file : files )
             {
-                if ( !file.exists() )
-                {
-                    throw new IllegalArgumentException( file + " doesn't exist" );
-                }
+                FILE_EXISTS.validate( file );
+            }
+        }
+    };
+
+    public static final Validator<File> FILE_EXISTS = new Validator<File>()
+    {
+        @Override
+        public void validate( File file )
+        {
+            if ( !file.exists() )
+            {
+                throw new IllegalArgumentException( "'" + file + "' doesn't exist" );
             }
         }
     };

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipPreparationStep.java
@@ -49,8 +49,8 @@ public class RelationshipPreparationStep extends ExecutorServiceStep<List<InputR
         int index = 0;
         for ( InputRelationship batchRelationship : batch )
         {
-            ids[index++] = idMapper.get( batchRelationship.startNode(), batchRelationship.startNodeGroups() );
-            ids[index++] = idMapper.get( batchRelationship.endNode(), batchRelationship.endNodeGroups() );
+            ids[index++] = idMapper.get( batchRelationship.startNode(), batchRelationship.startNodeGroup() );
+            ids[index++] = idMapper.get( batchRelationship.endNode(), batchRelationship.endNodeGroup() );
         }
         return Pair.of( batch, ids );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
-import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
@@ -33,8 +32,6 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
  */
 public interface IdMapper
 {
-    public static final PrimitiveIntPredicate ANY_GROUP = PrimitiveIntCollections.alwaysTrue();
-
     /**
      * Maps an {@code inputId} to an actual node id.
      * @param inputId an id of an unknown type, coming from input.
@@ -72,11 +69,10 @@ public interface IdMapper
      * @link #put(Object, long) being put}
      *
      * @param inputId the input id to get the actual node id for.
-     * @param inGroup a {@link PrimitiveIntPredicate} helping out with resolving collisions stemming from
-     * multiple equal input ids.
+     * @param group {@link Group} the given {@code inputId} must exist in, i.e. have been put with.
      * @return the actual node id previously specified by {@link #put(Object, long)}, or {@code -1} if not found.
      */
-    long get( Object inputId, PrimitiveIntPredicate inGroup );
+    long get( Object inputId, Group group );
 
     /**
      * Gathers statistics about memory usage in this object.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
-import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
@@ -55,7 +54,7 @@ public class IdMappers
         }
 
         @Override
-        public long get( Object inputId, PrimitiveIntPredicate inGroup )
+        public long get( Object inputId, Group group )
         {
             return ((Long)inputId).longValue();
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -111,10 +111,10 @@ public class EncodingIdMapper implements IdMapper
     }
 
     @Override
-    public long get( Object inputId, PrimitiveIntPredicate inGroup )
+    public long get( Object inputId, Group group )
     {
         assert readyForUse;
-        return binarySearch( inputId, inGroup );
+        return binarySearch( inputId, group );
     }
 
     @Override
@@ -125,7 +125,8 @@ public class EncodingIdMapper implements IdMapper
         boolean newGroup = groupId >= idGroups.size();
         if ( newGroup )
         {
-            assert groupId == idGroups.size();
+            assert groupId == idGroups.size() :
+                "Nodes for any specific group must be added in sequence before adding nodes for any other group";
             endPreviousGroup();
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IdGroup.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IdGroup.java
@@ -29,7 +29,7 @@ class IdGroup
     private final Group group;
     private final int groupId;
     private final long lowDataIndex; // inclusive
-    private long highDataIndex; // inclusive
+    private long highDataIndex = -1; // inclusive
 
     IdGroup( Group group, long lowDataIndex )
     {
@@ -48,12 +48,12 @@ class IdGroup
         return index >= lowDataIndex && index <= highDataIndex;
     }
 
-    public int id()
+    int id()
     {
         return groupId;
     }
 
-    public long translate( long dataIndex )
+    long translate( long dataIndex )
     {
         return dataIndex - lowDataIndex;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
@@ -19,15 +19,18 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
+import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 
 /**
  * Group of {@link InputEntity inputs}. Used primarily in {@link IdMapper} for supporting multiple
  * id groups within the same index.
  */
-public interface Group
+public interface Group extends PrimitiveIntPredicate
 {
     int id();
+
+    String name();
 
     public static class Adapter implements Group
     {
@@ -47,11 +50,54 @@ public interface Group
         }
 
         @Override
+        public String name()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean accept( int value )
+        {
+            return value == id;
+        }
+
+        @Override
         public String toString()
         {
             return name;
         }
+
+        @Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + id;
+            return result;
+        }
+
+        @Override
+        public boolean equals( Object obj )
+        {
+            if ( this == obj )
+                return true;
+            if ( obj == null )
+                return false;
+            if ( getClass() != obj.getClass() )
+                return false;
+            Adapter other = (Adapter) obj;
+            if ( id != other.id )
+                return false;
+            return true;
+        }
     }
 
-    public static final Group GLOBAL = new Adapter( 0, "global" );
+    public static final Group GLOBAL = new Adapter( 0, "global" )
+    {
+        @Override
+        public boolean accept( int value )
+        {
+            return true;
+        }
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mapping from name to {@link Group}. Assigns proper {@link Group#id() ids} to created groups.
+ */
+public class Groups
+{
+    private final Map<String,Group> groups = new HashMap<>();
+    private int nextId = 0;
+    private Boolean globalMode;
+
+    /**
+     * @param name group name or {@code null} for the {@link Group#GLOBAL global group}.
+     * @return {@link Group} for the given name. If the group doesn't already exist it will be created
+     * with a new id. If {@code name} is {@code null} then the {@link Group#GLOBAL global group} is returned.
+     * This method also prevents mixing global and non-global groups, i.e. if first call is {@code null},
+     * then consecutive calls have to specify {@code null} name as well. The same holds true for non-null values.
+     */
+    public Group getOrCreate( String name )
+    {
+        boolean global = name == null;
+        if ( globalMode == null )
+        {
+            globalMode = global;
+        }
+        else
+        {
+            if ( global != globalMode.booleanValue() )
+            {
+                throw new IllegalStateException( "Mixing specified and unspecified group belongings " +
+                        "in a single import isn't supported" );
+            }
+        }
+
+        if ( global )
+        {
+            return Group.GLOBAL;
+        }
+
+        Group group = groups.get( name );
+        if ( group == null )
+        {
+            groups.put( name, group = new Group.Adapter( nextId++, name ) );
+        }
+        return group;
+    }
+
+    /**
+     * @param name group name or {@code null} for the {@link Group#GLOBAL global group}.
+     * @return an already created {@link Group} or {@link Group#GLOBAL}.
+     */
+    public Group get( String name )
+    {
+        if ( name == null )
+        {
+            return Group.GLOBAL;
+        }
+
+        Group group = groups.get( name );
+        if ( group == null )
+        {
+            throw new IllegalArgumentException( "Unknown group '" + name + "'" );
+        }
+        return group;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
@@ -21,11 +21,10 @@ package org.neo4j.unsafe.impl.batchimport.input;
 
 import java.util.Collection;
 
-import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.Pair;
 
-import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper.ANY_GROUP;
+import static org.neo4j.unsafe.impl.batchimport.input.Group.GLOBAL;
 
 /**
  * Represents a relationship from an input source, for example a .csv file.
@@ -37,27 +36,27 @@ public class InputRelationship extends InputEntity
     private final Object endNode;
     private String type;
     private final Integer typeId;
-    private final PrimitiveIntPredicate startNodeGroups;
-    private final PrimitiveIntPredicate endNodeGroups;
+    private final Group startNodeGroup;
+    private final Group endNodeGroup;
 
     public InputRelationship( long id,
             Object[] properties, Long firstPropertyId, Object startNode, Object endNode,
             String type, Integer typeId )
     {
-        this( id, properties, firstPropertyId, ANY_GROUP, startNode, ANY_GROUP, endNode, type, typeId );
+        this( id, properties, firstPropertyId, GLOBAL, startNode, GLOBAL, endNode, type, typeId );
     }
 
     public InputRelationship( long id,
             Object[] properties, Long firstPropertyId,
-            PrimitiveIntPredicate startNodeGroups, Object startNode,
-            PrimitiveIntPredicate endNodeGroups, Object endNode,
+            Group startNodeGroups, Object startNode,
+            Group endNodeGroups, Object endNode,
             String type, Integer typeId )
     {
         super( properties, firstPropertyId );
         this.id = id;
-        this.startNodeGroups = startNodeGroups;
+        this.startNodeGroup = startNodeGroups;
         this.startNode = startNode;
-        this.endNodeGroups = endNodeGroups;
+        this.endNodeGroup = endNodeGroups;
         this.endNode = endNode;
         this.type = type;
         this.typeId = typeId;
@@ -68,9 +67,9 @@ public class InputRelationship extends InputEntity
         return id;
     }
 
-    public PrimitiveIntPredicate startNodeGroups()
+    public Group startNodeGroup()
     {
-        return startNodeGroups;
+        return startNodeGroup;
     }
 
     public Object startNode()
@@ -78,9 +77,9 @@ public class InputRelationship extends InputEntity
         return startNode;
     }
 
-    public PrimitiveIntPredicate endNodeGroups()
+    public Group endNodeGroup()
     {
-        return endNodeGroups;
+        return endNodeGroup;
     }
 
     public Object endNode()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
@@ -48,6 +49,7 @@ public class CsvInput implements Input
     private final Configuration config;
     private final int[] delimiter;
     private final BatchingIdSequence relationshipIds = new BatchingIdSequence();
+    private final Groups groups = new Groups();
 
     /**
      * @param nodeDataFactory multiple {@link DataFactory} instances providing data, each {@link DataFactory}
@@ -104,14 +106,14 @@ public class CsvInput implements Input
             public ResourceIterator<InputNode> iterator()
             {
                 return new InputGroupsDeserializer<InputNode>( nodeDataFactory.iterator(),
-                                                               nodeHeaderFactory, config, idType )
+                        nodeHeaderFactory, config, idType )
                 {
                     @Override
                     protected ResourceIterator<InputNode> entityDeserializer( CharSeeker dataStream, Header dataHeader,
-                                                                              Function<InputNode,InputNode> decorator )
+                            Function<InputNode,InputNode> decorator )
                     {
                         return new InputNodeDeserializer( dataHeader, dataStream, delimiter, decorator,
-                                idType.idsAreExternal() );
+                                idType.idsAreExternal(), groups );
                     }
                 };
             }
@@ -128,14 +130,14 @@ public class CsvInput implements Input
             {
                 relationshipIds.reset();
                 return new InputGroupsDeserializer<InputRelationship>( relationshipDataFactory.iterator(),
-                                                                       relationshipHeaderFactory, config, idType )
+                        relationshipHeaderFactory, config, idType )
                 {
                     @Override
                     protected ResourceIterator<InputRelationship> entityDeserializer( CharSeeker dataStream,
                               Header dataHeader, Function<InputRelationship,InputRelationship> decorator )
                     {
                         return new InputRelationshipDeserializer( dataHeader, dataStream, delimiter,
-                                relationshipIds, decorator );
+                                relationshipIds, decorator, groups );
                     }
                 };
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -56,7 +56,7 @@ public class DataFactories
      * @return {@link DataFactory} that returns a {@link CharSeeker} over the supplied {@code file}.
      */
     public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
-                                                                         final File file )
+            final File file )
     {
         return new DataFactory<ENTITY>()
         {
@@ -96,7 +96,7 @@ public class DataFactories
      * @return {@link DataFactory} that returns a {@link CharSeeker} over all the supplied {@code files}.
      */
     public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
-                                                                         final File... files )
+            final File... files )
     {
         if ( files.length == 0 )
         {
@@ -133,7 +133,7 @@ public class DataFactories
      * @return {@link DataFactory} that returns a {@link CharSeeker} over the supplied {@code readable}
      */
     public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
-                                                                         final Factory<CharReadable> readable )
+            final Factory<CharReadable> readable )
     {
         return new DataFactory<ENTITY>()
         {
@@ -300,27 +300,15 @@ public class DataFactories
                 {
                     String entryString = headerSeeker.tryExtract( mark, extractors.string() )
                             ? extractors.string().value() : null;
-                    int typeIndex = entryString != null ? entryString.lastIndexOf( ':' ) : -1;
-                    String name;
-                    String typeSpec;
-                    if ( typeIndex != -1 )
-                    {   // Specific type given
-                        name = typeIndex > 0 ? entryString.substring( 0, typeIndex ) : null;
-                        typeSpec = entryString.substring( typeIndex+1 );
-                    }
-                    else
-                    {
-                        name = entryString;
-                        typeSpec = null;
-                    }
+                    HeaderEntrySpec spec = new HeaderEntrySpec( entryString );
 
-                    if ( name == null && typeSpec == null )
+                    if ( spec.name == null && spec.type == null )
                     {
-                        columns.add( new Header.Entry( null, Type.IGNORE, null ) );
+                        columns.add( new Header.Entry( null, Type.IGNORE, null, null ) );
                     }
                     else
                     {
-                        columns.add( entry( i, name, typeSpec, extractors, idExtractor ) );
+                        columns.add( entry( i, spec.name, spec.type, spec.groupName, extractors, idExtractor ) );
                     }
                 }
                 Entry[] entries = columns.toArray( new Header.Entry[columns.size()] );
@@ -365,6 +353,9 @@ public class DataFactories
                     }
                     singletonEntries.put( entry.type(), entry );
                     break;
+                default:
+                    // No need to validate other headers
+                    break;
                 }
             }
 
@@ -381,8 +372,45 @@ public class DataFactories
          * @param idExtractor we supply the id extractor explicitly because it's a configuration,
          * or at least input-global concern and not a concern of this particular header.
          */
-        protected abstract Header.Entry entry( int index, String name, String typeSpec, Extractors extractors,
-                Extractor<?> idExtractor );
+        protected abstract Header.Entry entry( int index, String name, String typeSpec, String groupName,
+                Extractors extractors, Extractor<?> idExtractor );
+    }
+
+    private static class HeaderEntrySpec
+    {
+        private final String name;
+        private final String type;
+        private final String groupName;
+
+        HeaderEntrySpec( String rawHeaderField )
+        {
+            String name = rawHeaderField;
+            String type = null;
+            String groupName = null;
+
+            int typeIndex;
+            if ( rawHeaderField != null && (typeIndex = rawHeaderField.lastIndexOf( ':' )) != -1 )
+            {   // Specific type given
+                name = typeIndex > 0 ? rawHeaderField.substring( 0, typeIndex ) : null;
+                type = rawHeaderField.substring( typeIndex+1 );
+                int groupNameStartIndex = type.indexOf( '(' );
+                if ( groupNameStartIndex != -1 )
+                {   // Specific group given also
+                    if ( !type.endsWith( ")" ) )
+                    {
+                        throw new IllegalArgumentException( "Group specification in '" + rawHeaderField +
+                                "' is invalid, format expected to be 'name:TYPE(group)' " +
+                                "where TYPE and (group) are optional" );
+                    }
+                    groupName = type.substring( groupNameStartIndex+1, type.length()-1 );
+                    type = type.substring( 0, groupNameStartIndex );
+                }
+            }
+
+            this.name = name;
+            this.type = type;
+            this.groupName = groupName;
+        }
     }
 
     private static class DefaultNodeFileHeaderParser extends AbstractDefaultFileHeaderParser
@@ -393,7 +421,7 @@ public class DataFactories
         }
 
         @Override
-        protected Header.Entry entry( int index, String name, String typeSpec, Extractors extractors,
+        protected Header.Entry entry( int index, String name, String typeSpec, String groupName, Extractors extractors,
                 Extractor<?> idExtractor )
         {
             // For nodes it's simply ID,LABEL,PROPERTY. typeSpec can be either ID,LABEL or a type of property,
@@ -421,7 +449,7 @@ public class DataFactories
                 extractor = extractors.valueOf( typeSpec );
             }
 
-            return new Header.Entry( name, type, extractor );
+            return new Header.Entry( name, type, groupName, extractor );
         }
     }
 
@@ -433,7 +461,7 @@ public class DataFactories
         }
 
         @Override
-        protected Header.Entry entry( int index, String name, String typeSpec, Extractors extractors,
+        protected Header.Entry entry( int index, String name, String typeSpec, String groupName, Extractors extractors,
                 Extractor<?> idExtractor )
         {
             Type type = null;
@@ -464,7 +492,7 @@ public class DataFactories
                 extractor = extractors.valueOf( typeSpec );
             }
 
-            return new Header.Entry( name, type, extractor );
+            return new Header.Entry( name, type, groupName, extractor );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
@@ -53,16 +53,35 @@ public class Header
         return entries;
     }
 
+    public Entry entry( Type type )
+    {
+        Entry result = null;
+        for ( Entry entry : entries )
+        {
+            if ( entry.type() == type )
+            {
+                if ( result != null )
+                {
+                    throw new IllegalStateException( "Multiple header entries of type " + type );
+                }
+                result = entry;
+            }
+        }
+        return result;
+    }
+
     public static class Entry
     {
         private final String name;
         private final Type type;
+        private final String groupName;
         private final Extractor<?> extractor;
 
-        public Entry( String name, Type type, Extractor<?> extractor )
+        public Entry( String name, Type type, String groupName, Extractor<?> extractor )
         {
             this.name = name;
             this.type = type;
+            this.groupName = groupName;
             this.extractor = extractor;
         }
 
@@ -82,6 +101,11 @@ public class Header
             return type;
         }
 
+        public String groupName()
+        {
+            return groupName;
+        }
+
         public String name()
         {
             return name;
@@ -92,8 +116,15 @@ public class Header
         {
             final int prime = 31;
             int result = 1;
-            result = prime * result + name.hashCode();
+            if ( name != null )
+            {
+                result = prime * result + name.hashCode();
+            }
             result = prime * result + type.hashCode();
+            if ( groupName != null )
+            {
+                result = prime * result + groupName.hashCode();
+            }
             result = prime * result + extractor.hashCode();
             return result;
         }
@@ -110,7 +141,8 @@ public class Header
                 return false;
             }
             Entry other = (Entry) obj;
-            return nullSafeEquals( name, other.name ) && type == other.type && extractorEquals( extractor, other.extractor );
+            return nullSafeEquals( name, other.name ) && type == other.type &&
+                    nullSafeEquals( groupName, other.groupName ) && extractorEquals( extractor, other.extractor );
         }
 
         private boolean nullSafeEquals( Object o1, Object o2 )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -39,7 +39,7 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
     private final Header.Factory headerFactory;
     private final Configuration config;
     private final IdType idType;
-    private ResourceIterator<ENTITY> currentGroup;
+    private ResourceIterator<ENTITY> currentInput;
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
                              Configuration config, IdType idType )
@@ -58,26 +58,25 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
         // Open the data stream. It's closed by the batch importer when execution is done.
         Data<ENTITY> data = dataFactory.create( config );
         CharSeeker dataStream = data.stream();
-        Function<ENTITY,ENTITY> decorator = data.decorator();
 
         // Read the header, given the data stream. This allows the header factory to be able to
         // parse the header from the data stream directly. Or it can decide to grab the header
         // from somewhere else, it's up to that factory.
         Header dataHeader = headerFactory.create( dataStream, config, idType );
 
-        return currentGroup = entityDeserializer( dataStream, dataHeader, decorator );
+        return currentInput = entityDeserializer( dataStream, dataHeader, data.decorator() );
     }
 
     private void closeCurrent()
     {
-        if ( currentGroup != null )
+        if ( currentInput != null )
         {
-            currentGroup.close();
+            currentInput.close();
         }
     }
 
     protected abstract ResourceIterator<ENTITY> entityDeserializer( CharSeeker dataStream, Header dataHeader,
-                                                                    Function<ENTITY,ENTITY> decorator  );
+            Function<ENTITY,ENTITY> decorator );
 
     @Override
     public void close()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
@@ -22,6 +22,8 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.function.Function;
 import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.unsafe.impl.batchimport.input.Group;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
 /**
@@ -33,16 +35,19 @@ class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelatio
     private final IdSequence idSequence;
 
     // Additional data
-    private long id;
     private String type;
     private Object startNode;
     private Object endNode;
+    private final Group startNodeGroup;
+    private final Group endNodeGroup;
 
     InputRelationshipDeserializer( Header header, CharSeeker data, int[] delimiter, IdSequence idSequence,
-            Function<InputRelationship,InputRelationship> decorator )
+            Function<InputRelationship,InputRelationship> decorator, Groups groups )
     {
         super( header, data, delimiter, decorator );
         this.idSequence = idSequence;
+        this.startNodeGroup = groups.getOrCreate( header.entry( Type.START_ID ).groupName() );
+        this.endNodeGroup = groups.getOrCreate( header.entry( Type.END_ID ).groupName() );
     }
 
     @Override
@@ -65,6 +70,7 @@ class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelatio
     @Override
     protected InputRelationship convertToInputEntity( Object[] properties )
     {
-        return new InputRelationship( idSequence.nextId(), properties, null, startNode, endNode, type, null );
+        return new InputRelationship( idSequence.nextId(), properties, null,
+                startNodeGroup, startNode, endNodeGroup, endNode, type, null );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannelTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.Random;
 
 import org.junit.Rule;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -224,8 +224,35 @@ public class DataFactoriesTest
         seeker.close();
     }
 
+    @Test
+    public void shouldParseGroupName() throws Exception
+    {
+     // GIVEN
+        CharSeeker seeker = new BufferedCharSeeker( wrap( new StringReader(
+                ":START_ID(GroupOne)\t:END_ID(GroupTwo)\ttype:TYPE\tdate:long\tmore:long[]" ) ) );
+        IdType idType = IdType.ACTUAL;
+        Extractors extractors = new Extractors( '\t' );
+
+        // WHEN
+        Header header = DataFactories.defaultFormatRelationshipFileHeader().create( seeker, TABS, idType );
+
+        // THEN
+        assertArrayEquals( array(
+                entry( null, Type.START_ID, "GroupOne", idType.extractor( extractors ) ),
+                entry( null, Type.END_ID, "GroupTwo", idType.extractor( extractors ) ),
+                entry( "type", Type.TYPE, extractors.string() ),
+                entry( "date", Type.PROPERTY, extractors.long_() ),
+                entry( "more", Type.PROPERTY, extractors.longArray() ) ), header.entries() );
+        seeker.close();
+    }
+
     private Header.Entry entry( String name, Type type, Extractor<?> extractor )
     {
-        return new Header.Entry( name, type, extractor );
+        return entry( name, type, null, extractor );
+    }
+
+    private Header.Entry entry( String name, Type type, String groupName, Extractor<?> extractor )
+    {
+        return new Header.Entry( name, type, groupName, extractor );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
@@ -49,8 +49,6 @@ import org.neo4j.shell.ShellClient;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.ShellLobby;
 import org.neo4j.shell.ShellSettings;
-import org.neo4j.test.RepeatRule;
-import org.neo4j.test.RepeatRule.Repeat;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.ha.ClusterManager;
 


### PR DESCRIPTION
using the input headers, group belonging is specified with an added
parentheses containing the name of the group, like :ID(MyGroup) and
similar. Likewise relationships can specify, for start/end ids,
individually from which group to look up those ids.

This commit also changes delimiter between multiple files from space to
comma since space was broken, disallowing files with spaces.