### PR TITLE
Do not leak transactions when executing a query in explain mode

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -87,7 +87,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
         } else
           QueryType.READ_ONLY
       if (planType == ExplainMode) {
-        new ExplainExecutionResult(columns, pipeInfo.pipe.planDescription, queryType)
+        new ExplainExecutionResult(taskCloser, columns, pipeInfo.pipe.planDescription, queryType)
       } else {
         val results = pipeInfo.pipe.createResults(state)
         val resultIterator = buildResultIterator(results, pipeInfo.updating)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResultTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResultTest.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2
+
+import org.mockito.Mockito
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription
+import org.neo4j.graphdb.QueryExecutionType.QueryType
+
+class ExplainExecutionResultTest extends CypherFunSuite {
+
+  private val closer = mock[TaskCloser]
+  private val result =
+    new ExplainExecutionResult(closer, List.empty, mock[InternalPlanDescription], QueryType.READ_ONLY)
+
+  test("should call taskCloser close on close") {
+    result.close()
+
+    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+  }
+
+  test("should call taskCloser close on close from java wrapper") {
+    result.javaIterator.close()
+
+    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+  }
+
+  test("should call taskCloser close on close from java columns wrapper") {
+    result.javaColumnAs("something").close()
+
+    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+  }
+
+  override protected def beforeEach() { Mockito.reset(closer) }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/GraphIcing.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/GraphIcing.scala
@@ -19,14 +19,16 @@
  */
 package org.neo4j.cypher.internal.helpers
 
-import org.neo4j.graphdb.{Transaction, DynamicLabel, Node}
-import org.neo4j.graphdb.DynamicLabel._
-import org.neo4j.kernel.GraphDatabaseAPI
-import collection.JavaConverters._
 import java.util.concurrent.TimeUnit
+
+import org.neo4j.graphdb.DynamicLabel._
+import org.neo4j.graphdb.{DynamicLabel, Node, Transaction}
+import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
-import org.neo4j.kernel.impl.transaction.{TransactionCounters, TransactionMonitor}
+import org.neo4j.kernel.impl.transaction.TransactionCounters
+
+import scala.collection.JavaConverters._
 
 trait GraphIcing {
 
@@ -45,13 +47,13 @@ trait GraphIcing {
       indexDefs.map(_.getPropertyKeys.asScala.toList)
     }
 
-    def createConstraint(label:String, property: String) {
+    def createConstraint(label:String, property: String) = {
       inTx {
         graph.schema().constraintFor(DynamicLabel.label(label)).assertPropertyIsUnique(property).create()
       }
     }
 
-    def createIndex(label: String, property: String) {
+    def createIndex(label: String, property: String) = {
       val indexDef = inTx {
         graph.schema().indexFor(DynamicLabel.label(label)).on(property).create()
       }
@@ -59,6 +61,8 @@ trait GraphIcing {
       inTx {
         graph.schema().awaitIndexOnline(indexDef, 10, TimeUnit.SECONDS)
       }
+
+      indexDef
     }
 
     def statement: Statement = txBridge.instance()


### PR DESCRIPTION
The problem was that when executing a query in explain mode the empty
result produced would never close the underlying transaction on close
like the other non-empty results.  Now this has been fixed by properly
closing the transaction when closing the result resource.