### PR TITLE
Explicitly call channel.force when writing lucene-store.db file

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
@@ -57,7 +57,7 @@ public class IndexProviderStore
         try
         {
             // Create it if it doesn't exist
-            if ( !fileSystem.fileExists( file ) )
+            if ( !fileSystem.fileExists( file ) || fileSystem.getFileSize( file ) == 0 )
                 create( file, fileSystem, expectedVersion );
             
             // Read all the records in the file
@@ -143,7 +143,7 @@ public class IndexProviderStore
     
     private void create( File file, FileSystemAbstraction fileSystem, long indexVersion ) throws IOException
     {
-        if ( fileSystem.fileExists( file ) )
+        if ( fileSystem.fileExists( file ) && fileSystem.getFileSize( file ) > 0 )
             throw new IllegalArgumentException( file + " already exist" );
         
         StoreChannel fileChannel = null;
@@ -166,9 +166,10 @@ public class IndexProviderStore
         buf.clear();
         buf.putLong( time ).putLong( identifier ).putLong( version ).putLong( lastCommittedTxId ).putLong( indexVersion );
         buf.flip();
-        channel.position( 0 );
 
-        int written = channel.write( buf );
+        int written = channel.write( buf, 0 );
+        channel.force( true );
+
         int expectedLength = RECORD_COUNT*RECORD_SIZE;
         if ( written != expectedLength )
             throw new RuntimeException( "Expected to write " + expectedLength + " bytes, but wrote " + written );


### PR DESCRIPTION
When writing metadata file for lucene store sequence of calls is:
```
channel = fs.open(...)
channel.write(buffer)
channel.close()
```
It could lead to content of the `buffer` being lost and not written to disk, as `channel.close` does not guarantee flush.

This PR adds `channel.force(true)` call and ability to write metadata file when empty one is present. Assumption is that empty lucene-store.db might appear when there is a crash right after `channel.write` call.