### PR TITLE
Support UTF-32 literals in Cypher using \Uxxxxxxxx

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Strings.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Strings.scala
@@ -42,11 +42,13 @@ trait Strings extends Base {
       | ch('n') ~ appendToStringBuilder('\n')
       | ch('r') ~ appendToStringBuilder('\r')
       | ch('t') ~ appendToStringBuilder('\t')
-      | Unicode ~~% withContext((code, ctx) => appendCodePointToStringBuilder(code)(ctx))
+      | UTF16 ~~% withContext((code, ctx) => appendCodePointToStringBuilder(code)(ctx))
+      | UTF32 ~~% withContext((code, ctx) => appendCodePointToStringBuilder(code)(ctx))
     )
   }
 
-  protected def Unicode = rule { ch('u') ~ group(HexDigit ~ HexDigit ~ HexDigit ~ HexDigit) ~> (java.lang.Integer.parseInt(_, 16)) }
+  protected def UTF16 = rule { ch('u') ~ group(HexDigit ~ HexDigit ~ HexDigit ~ HexDigit) ~> (java.lang.Integer.parseInt(_, 16)) }
+  protected def UTF32 = rule { ch('U') ~ group(HexDigit ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit) ~> (java.lang.Integer.parseInt(_, 16)) }
   private def HexDigit = rule { "0" - "9" | "a" - "f" | "A" - "F" }
 
   protected def appendToStringBuilder(c: Any): Context[Any] => Unit = ctx =>

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParserTest.scala
@@ -75,6 +75,14 @@ class CypherParserTest extends CypherFunSuite {
         returns(ReturnItem(Literal("a" + "\uE123" + "45"), "x")))
   }
 
+  test("should return string literal containing UTF-32 escape sequence") {
+    expectQuery(
+      "start s = node(1) return \"a\\U000292b145\" AS x",
+      Query.
+        start(NodeById("s", 1)).
+        returns(ReturnItem(Literal("a" + "\uD864\uDEB1" + "45"), "x")))
+  }
+
   test("allTheNodes") {
     expectQuery(
       "start s = NODE(*) return s",

--- a/community/cypher/docs/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -37,6 +37,8 @@ String literals can contain these escape sequences.
 |`\'`|Single quote
 |`\"`|Double quote
 |`\\`|Backslash
+|`\uxxxx`|Unicode UTF-16 code point (4 hex digits must follow the `\u`)
+|`\Uxxxxxxxx`|Unicode UTF-32 code point (8 hex digits must follow the `\U`)
 |===================
 
 include::../ql/syntax/index.asciidoc[]


### PR DESCRIPTION
For reference, the capital U literal form is also used in Python