### PR TITLE
Planner handling fixes

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/ConservativeQueryAcceptorTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/ConservativeQueryAcceptorTest.scala
@@ -156,6 +156,22 @@ class ConservativeQueryAcceptorTest extends CypherFunSuite with LogicalPlanningT
     shouldAccept(qg1)
   }
 
+  test("should accept long paths") {
+    // MATCH a-[:T1]->b-[:T2]->c-[:T3]->d-[:T4]->e
+    val qg1 = QueryGraph(
+      patternNodes = Set("foo", "bar", "baz", "qux", "quux"),
+      patternRelationships =
+        Set(
+          PatternRelationship("r3", nodes = ("baz", "qux"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
+          PatternRelationship("r4", nodes = ("qux", "quux"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
+          PatternRelationship("r1", nodes = ("foo", "bar"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
+          PatternRelationship("r2", nodes = ("bar", "baz"), Direction.OUTGOING, Seq.empty, SimplePatternLength)
+        )
+    )
+
+    shouldAccept(qg1)
+  }
+
   private def shouldAccept(qg: QueryGraph) {
     val query = UnionQuery(Seq(PlannerQuery(graph = qg)), false)
     conservativeQueryAcceptor(query) should be(true)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -113,7 +113,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
 
   @throws(classOf[SyntaxException])
   private def parsePreParsedQuery(preParsedQuery: PreParsedQuery): ParsedQuery =
-    parsedQueries.getOrElseUpdate(preParsedQuery.statementWithVersion, compiler.parseQuery(preParsedQuery))
+    parsedQueries.getOrElseUpdate(preParsedQuery.statementWithVersionAndPlanner, compiler.parseQuery(preParsedQuery))
 
   @throws(classOf[SyntaxException])
   private def preParseQuery(queryText: String): PreParsedQuery =
@@ -125,7 +125,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
 
     val preParsedQuery = preParseQuery(queryText)
     val executionMode = preParsedQuery.executionMode
-    val cacheKey = preParsedQuery.statementWithVersion
+    val cacheKey = preParsedQuery.statementWithVersionAndPlanner
 
     var n = 0
     while (n < ExecutionEngine.PLAN_BUILDING_TRIES) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -38,9 +38,8 @@ object CypherCompiler {
 }
 
 case class PreParsedQuery(statement: String, version: CypherVersion, executionMode: ExecutionMode, planner: PlannerName) {
-  val statementWithVersion = s"CYPHER ${version.name} $statement"
+  val statementWithVersionAndPlanner = s"CYPHER ${version.name} PLANNER ${planner.name} $statement"
 }
-
 
 class CypherCompiler(graph: GraphDatabaseService,
                      kernelAPI: KernelAPI,
@@ -75,7 +74,7 @@ class CypherCompiler(graph: GraphDatabaseService,
 
   @throws(classOf[SyntaxException])
   def parseQuery(preParsedQuery: PreParsedQuery): ParsedQuery = {
-    val exeuctionMode = preParsedQuery.executionMode
+    val executionMode = preParsedQuery.executionMode
     val version = preParsedQuery.version
     val planner = preParsedQuery.planner
     val statementAsText = preParsedQuery.statement

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
@@ -66,9 +66,9 @@ class QueryCachingTest extends CypherFunSuite with GraphDatabaseTestSupport with
         val actual = cacheListener.trace
         val expected = List(
           s"cacheFlushDetected",
-          s"cacheMiss: CYPHER 2.2 $query",
-          s"cacheHit: CYPHER 2.2 $query",
-          s"cacheHit: CYPHER 2.2 $query")
+          s"cacheMiss: CYPHER 2.2 PLANNER CONSERVATIVE $query",
+          s"cacheHit: CYPHER 2.2 PLANNER CONSERVATIVE $query",
+          s"cacheHit: CYPHER 2.2 PLANNER CONSERVATIVE $query")
 
         actual should equal(expected)
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -69,6 +69,21 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
       .shouldHavePlannerName(Rule)
   }
 
+  test("should be able to switch between RULE and COST") {
+    given("match n return n")
+      .withCypherVersion(CypherVersion.v2_2)
+      .withPlannerName(Rule)
+      .shouldHaveCypherVersion(CypherVersion.v2_2)
+      .shouldHavePlannerName(Rule)
+
+    given("match n return n")
+      .withCypherVersion(CypherVersion.v2_2)
+      .withPlannerName(Cost)
+      .shouldHaveCypherVersion(CypherVersion.v2_2)
+      .shouldHavePlannerName(Cost)
+
+  }
+
   test("should use cost if we really ask for it in 2.2") {
     given("match n return n")
       .withCypherVersion(CypherVersion.v2_2)

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -1157,6 +1157,12 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
+    public void shouldBeAbleToForceCostPlannerInShell() throws Exception
+    {
+        executeCommand( "PROFILE PLANNER COST MATCH (n)-[:T*]-(n) RETURN n;", "Planner COST");
+    }
+
+    @Test
     public void shouldAllowCombiningPlannerAndProfile() throws Exception
     {
         executeCommand( "PLANNER RULE PROFILE MATCH (n) RETURN n;", "Planner RULE");

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -1157,8 +1157,9 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void shouldBeAbleToForceCostPlannerInShell() throws Exception
+    public void shouldBeAbleToSwitchBetweenPlanners() throws Exception
     {
+        executeCommand( "PROFILE PLANNER RULE MATCH (n)-[:T*]-(n) RETURN n;", "Planner RULE");
         executeCommand( "PROFILE PLANNER COST MATCH (n)-[:T*]-(n) RETURN n;", "Planner COST");
     }
 


### PR DESCRIPTION
Fixed two bugs with planner handling
- ConservativeQueryAcceptor was wrongly classifying single chained paths as cycles
- The planner name was not part of the cache key, lead cache hits when should have been misses
