### PR TITLE
Fix parsing of empty fields when skipping eol chars

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -90,6 +90,7 @@ public class BufferedCharSeeker implements CharSeeker
         int endOffset = 1;
         int skippedChars = 0;
         int quoteDepth = 0;
+        boolean isQuoted = false;
         while ( !eof )
         {
             ch = nextChar( skippedChars );
@@ -111,8 +112,7 @@ public class BufferedCharSeeker implements CharSeeker
                     {
                         if ( ch == untilOneOfChars[i] )
                         {   // We found a delimiter, set marker and return true
-                            mark.set( lineNumber, seekStartPos, bufferPos - endOffset - skippedChars, ch,
-                                    endOffset + skippedChars > 1 );
+                            mark.set( lineNumber, seekStartPos, bufferPos - endOffset - skippedChars, ch, isQuoted );
                             return true;
                         }
                     }
@@ -120,6 +120,7 @@ public class BufferedCharSeeker implements CharSeeker
             }
             else
             {   // In quoted mode, i.e. within quotes
+                isQuoted = true;
                 if ( ch == quoteChar )
                 {   // Found a quote within a quote, peek at next char
                     int nextCh = peekChar();
@@ -158,8 +159,7 @@ public class BufferedCharSeeker implements CharSeeker
 
         // We found the last value of the line or stream
         skippedChars += skipEolChars();
-        mark.set( lineNumber, seekStartPos, bufferPos - endOffset - skippedChars, END_OF_LINE_CHARACTER,
-                endOffset + skippedChars > 1 );
+        mark.set( lineNumber, seekStartPos, bufferPos - endOffset - skippedChars, END_OF_LINE_CHARACTER, isQuoted );
         lineNumber++;
         lineStartPos = bufferPos;
         return true;
@@ -207,7 +207,7 @@ public class BufferedCharSeeker implements CharSeeker
     {
         long from = mark.startPosition();
         long to = mark.position();
-        return extractor.extract( buffer, (int)(from), (int)(to-from), mark.hasSkippedChars() );
+        return extractor.extract( buffer, (int)(from), (int)(to-from), mark.isQuoted() );
     }
 
     private int skipEolChars() throws IOException

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Mark.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Mark.java
@@ -34,22 +34,21 @@ public class Mark
     private long startPosition;
     private long position;
     private int character;
-    private boolean skippedChars;
+    private boolean quoted;
 
     /**
      * @param startPosition
      * @param position
      * @param character use {@code -1} to denote that the matching character was an end-of-line or end-of-file
-     * @param skippedChars whether or not the original data had some characters that were skipped, f.ex
-     * quotation or escaped characters.
+     * @param quoted whether or not the original data was quoted.
      */
-    void set( int lineNumber, long startPosition, long position, int character, boolean skippedChars )
+    void set( int lineNumber, long startPosition, long position, int character, boolean quoted )
     {
         this.lineNumber = lineNumber;
         this.startPosition = startPosition;
         this.position = position;
         this.character = character;
-        this.skippedChars = skippedChars;
+        this.quoted = quoted;
     }
 
     public int character()
@@ -68,9 +67,9 @@ public class Mark
         return lineNumber;
     }
 
-    public boolean hasSkippedChars()
+    public boolean isQuoted()
     {
-        return skippedChars;
+        return quoted;
     }
 
     long position()
@@ -94,6 +93,6 @@ public class Mark
     @Override
     public String toString()
     {
-        return format( "Mark[line:%d, from:%d, to:%d, skipped:%b]", lineNumber, startPosition, position, skippedChars );
+        return format( "Mark[line:%d, from:%d, to:%d, qutoed:%b]", lineNumber, startPosition, position, quoted);
     }
 }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -274,6 +274,20 @@ public class BufferedCharSeekerTest
         assertFalse( seeker.seek( mark, COMMA ) );
     }
 
+    @Test
+    public void shouldExtractNullForEmptyFieldWhenWeSkipEOLChars() throws Exception
+    {
+        // GIVEN
+        seeker = new BufferedCharSeeker( wrap( new StringReader( "\"\",\r\n" ) ), 100 );
+
+        // WHEN
+        assertNextValue( seeker, mark, COMMA, "" );
+        assertNextValueNotExtracted( seeker, mark, COMMA );
+
+        // THEN
+        assertFalse( seeker.seek( mark, COMMA ) );
+    }
+
     private void assertNextValue( CharSeeker seeker, Mark mark, int[] delimiter, String expectedValue )
             throws IOException
     {


### PR DESCRIPTION
The problem was caused by the fact that we were considering eol
skipped chars as equal as quotes causing to wrongly produce
empty-strings instead of null when parsing unquoted-empty-fields
followed by '\r\n' ('\r' would be the skipped eol char).