### PR TITLE
Fixed the bug where messages.log on windows is missing

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
@@ -22,20 +22,19 @@ package org.neo4j.kernel.logging;
 import java.io.File;
 import java.net.URL;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
-import org.slf4j.Logger;
-import org.slf4j.Marker;
-
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Visitor;
-import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.RestartOnChange;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
 
 /**
  * Logging service that uses Logback as backend.
@@ -62,7 +61,7 @@ public class LogbackService
         this.loggerContext = loggerContext;
 
         // We do the initialization in the constructor, because some services will use logging during creation phase, before init.
-        final File storeDir = config.get( InternalAbstractGraphDatabase.Configuration.store_dir );
+        final File storeDir = config.get( GraphDatabaseSettings.store_dir );
 
         if ( storeDir != null )
         {
@@ -83,7 +82,9 @@ public class LogbackService
                     configurator.setContext( loggerContext );
 
                     if (config.getParams().containsKey( "ha.server_id" ))
+                    {
                         loggerContext.putProperty( "host", config.getParams().get( "ha.server_id" ) );
+                    }
 
                     loggerContext.putProperty( "neo_store", storeDir.getPath() );
                     loggerContext.putProperty( "remote_logging_enabled", config.get( GraphDatabaseSettings
@@ -98,7 +99,9 @@ public class LogbackService
                         URL resource = getClass().getClassLoader().getResource( logbackConfigurationFilename );
 
                         if (resource == null)
+                        {
                             throw new IllegalStateException( String.format("Could not find %s configuration", logbackConfigurationFilename ));
+                        }
 
                         configurator.doConfigure( resource );
                     }

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -46,6 +46,20 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j.app</groupId>
+      <artifactId>neo4j-server</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -91,6 +105,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+            <!--This line is needed to prevent maven shade plugin from getting stuck in infinite loop when building dependency reduced POM https://jira.codehaus.org/browse/MSHADE-148-->
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.neo4j.desktop.Neo4jDesktop</mainClass>

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 
 import org.neo4j.desktop.config.Installation;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.PropertyFileConfigurator;
 import org.neo4j.server.configuration.ThirdPartyJaxRsPackage;
@@ -70,14 +72,19 @@ public class DesktopConfigurator implements Configurator
     @Override
     public Map<String, String> getDatabaseTuningProperties()
     {
+        Map<String,String> databaseProperties = null;
         try
         {
-            return load( getDatabaseConfigurationFile() );
+            databaseProperties = new HashMap<>( load( getDatabaseConfigurationFile() ) );
         }
         catch ( IOException e )
         {
-            return stringMap();
+            databaseProperties = stringMap();
         }
+
+        String storeDir = getDatabaseDirectory();
+        databaseProperties.put( GraphDatabaseSettings.store_dir.name(), storeDir );
+        return databaseProperties;
     }
 
     @Override

--- a/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
+++ b/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.desktop.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.desktop.config.Installation;
+import org.neo4j.desktop.ui.DesktopModel;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.server.ServerTestUtils.writePropertiesToFile;
+
+public class DatabaseActionsTest
+{
+    @Rule
+    public final TargetDirectory.TestDirectory baseDir = TargetDirectory.forTest( getClass() ).testDirectory();
+
+    private File storeDir;
+    private File serverConfigFile;
+    private File dbConfigFile;
+
+    @Test
+    public void shouldCreateMessagesLogInDbDirWithClassicLog() throws Exception
+    {
+        // Given
+        Installation installation = mock( Installation.class );
+        when( installation.getDatabaseDirectory() ).thenReturn( storeDir );
+        when( installation.getServerConfigurationsFile() ).thenReturn( serverConfigFile );
+
+        DesktopModel model = new DesktopModel( installation );
+        DatabaseActions databaseActions = new DatabaseActions( model );
+
+        try
+        {
+            // when
+            databaseActions.start();
+
+            // Then
+            File logFile = new File( storeDir, "messages.log" );
+            assertTrue( logFile.exists() );
+        }
+        finally
+        {
+            // After
+            databaseActions.stop(); // do not need to wait for the server to finish all its start procedure
+        }
+    }
+
+    @Before
+    public void createFiles() throws IOException
+    {
+        storeDir = new File( baseDir.directory(), "store_dir" );
+        serverConfigFile = new File( storeDir, "neo4j-server.properties" );
+        dbConfigFile = new File( storeDir, "neo4j.properties" );
+        storeDir.mkdirs();
+
+        Map<String,String> properties = MapUtil.stringMap( GraphDatabaseSettings.store_dir.name(),
+                storeDir.getAbsolutePath());
+        writePropertiesToFile( properties, serverConfigFile );
+
+        dbConfigFile.createNewFile();
+    }
+}

--- a/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DesktopConfiguratorTest.java
+++ b/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DesktopConfiguratorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.desktop.runtime;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.desktop.config.Installation;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DesktopConfiguratorTest
+{
+    private File emptyServerConfigFile;
+
+    @Before
+    public void setUp() throws Throwable
+    {
+        emptyServerConfigFile = File.createTempFile( "emptyFile", "tmp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        emptyServerConfigFile.delete();
+    }
+
+    @Test
+    public void dbPropertiesShouldContainStoreDirProperty() throws Exception
+    {
+        // Given
+        Installation installation = mock( Installation.class );
+        when( installation.getServerConfigurationsFile() ).thenReturn( emptyServerConfigFile );
+        DesktopConfigurator config = new DesktopConfigurator( installation );
+
+        File storeDir = new File( "graph.db" ); // will not create any file
+
+        // When
+        config.setDatabaseDirectory( storeDir );
+
+        // Then
+        assertEquals( storeDir.getAbsolutePath(), config.getDatabaseDirectory() );
+
+        String pathToStoreDir = config.getDatabaseTuningProperties().get( GraphDatabaseSettings.store_dir.name() );
+        assertEquals( storeDir.getAbsolutePath(), pathToStoreDir );
+    }
+}


### PR DESCRIPTION
The cause of the bug is that the path where messages.log is supposed to be saved is not specified and as a result the creation of the log file is skipped in LogbackService.