### PR TITLE
fixes #3795

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/neo4j-arbiter-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/neo4j-arbiter-service
@@ -13,7 +13,7 @@
 
 # Author: Julian Simpson <julian.simpson@neotechnology.com>
 #
-# Copyright (c) 2002-2014 "Neo Technology,"
+# Copyright (c) 2002-2015 "Neo Technology,"
 
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
@@ -37,7 +37,7 @@ DESC="Neo4j Arbiter Service"
 NAME=neo4j-arbiter
 DAEMON=/var/lib/$NAME/bin/$NAME
 DAEMON_ARGS="start"
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=/var/lib/${NAME}/data/neo4j-arbiter.pid
 SCRIPTNAME=/etc/init.d/arbiter-service
 
 # Exit if the package is not installed
@@ -63,8 +63,6 @@ do_start()
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
-	# Copy the Neo4j PID to the sytem's PID store
-	cp /var/lib/${NAME}/data/neo4j-arbiter.pid $PIDFILE
 }
 
 do_stop()
@@ -103,7 +101,7 @@ case "$1" in
 	esac
 	;;
   status)
-       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       status_of_proc -p $PIDFILE "$DAEMON" "$NAME" && exit 0 || exit $?
        ;;
   restart|force-reload)
 	log_daemon_msg "Restarting $DESC" "$NAME"
@@ -118,7 +116,7 @@ case "$1" in
 		esac
 		;;
 	  *)
-	  	# Failed to stop
+		# Failed to stop
 		log_end_msg 1
 		;;
 	esac

--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
@@ -13,7 +13,7 @@
 
 # Author: Julian Simpson <julian.simpson@neotechnology.com>
 #
-# Copyright (c) 2002-2014 "Neo Technology,"
+# Copyright (c) 2002-2015 "Neo Technology,"
 
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
@@ -37,7 +37,7 @@ DESC="Neo4j Graph Database"
 NAME=neo4j
 DAEMON=/var/lib/$NAME/bin/$NAME
 DAEMON_ARGS="start"
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=/var/lib/${NAME}/data/neo4j-service.pid
 SCRIPTNAME=/etc/init.d/$NAME-service
 
 # Exit if the package is not installed
@@ -63,8 +63,6 @@ do_start()
 	start-stop-daemon --chuid ${NEO_USER} --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
-	# Copy the Neo4j PID to the sytem's PID store
-	cp /var/lib/${NAME}/data/neo4j-service.pid $PIDFILE
 }
 
 do_stop()
@@ -106,7 +104,7 @@ case "$1" in
 	esac
 	;;
   status)
-       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       status_of_proc -p $PIDFILE "$DAEMON" "$NAME" && exit 0 || exit $?
        ;;
   restart|force-reload)
 	log_daemon_msg "Restarting $DESC" "$NAME"
@@ -131,4 +129,5 @@ case "$1" in
 	exit 3
 	;;
 esac
-exit 0
+
+:


### PR DESCRIPTION
Bug reproduction procedure for `neo4j`
1. Install Neo4J on a debian-based distribution (mine was ubuntu trusty)
2. Start the service : `service neo4j-service start`
3. Check it is actually up : `service neo4j-service status`
4. Remove copied pid file : `rm /var/run/neo4j.pid`
5. Check service status again : `service neo4j-service status`

Similar procedure can be applied for `neo4j-arbiter`.