### PR TITLE
Fix shortestPath behavior

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
@@ -91,7 +91,7 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
     checkContext(ctx) then
     checkContainsSingle then
     checkKnownEnds then
-    checkNoMinimalLength then
+    checkMinimalLength then
     element.semanticCheck(ctx)
 
   private def checkContext(ctx: SemanticContext): SemanticCheck = ctx match {
@@ -122,16 +122,14 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
       None
   }
 
-  private def checkNoMinimalLength: SemanticCheck = element match {
+  private def checkMinimalLength: SemanticCheck = element match {
     case RelationshipChain(_, rel, _) =>
       rel.length match {
-        case Some(Some(Range(Some(_), _))) =>
-          Some(SemanticError(s"$name(...) does not support a minimal length", position, element.position))
-        case _                             =>
-          None
+        case Some(Some(Range(Some(min), _))) if (min.value < 0 || min.value > 1) =>
+          Some(SemanticError(s"$name(...) does not support a minimal length different from 0 or 1", position, element.position))
+        case _ => None
       }
-    case _                            =>
-      None
+    case _ => None
   }
 }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/convert/PatternConverters.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/convert/PatternConverters.scala
@@ -123,11 +123,12 @@ object PatternConverters {
           throw new ThisShouldNotHappenError("Chris", "This should be caught during semantic checking")
       }
       val reltypes = rel.types.map(_.name)
-      val maxDepth = rel.length match {
-        case Some(Some(ast.Range(None, Some(i)))) => Some(i.value.toInt)
-        case _                                => None
+      val (allowZeroLength, maxDepth) = rel.length match {
+        case Some(Some(ast.Range(lower, Some(i)))) => (lower.exists(_.value == 0L), Some(i.value.toInt))
+        case None                                 => (false, Some(1))//non-varlength case
+        case _                                    => (false, None)
       }
-      Seq(commands.ShortestPath(pathName, leftName, rightName, reltypes, rel.direction, maxDepth, part.single, None))
+      Seq(commands.ShortestPath(pathName, leftName, rightName, reltypes, rel.direction, allowZeroLength, maxDepth, part.single, None))
     }
 
     def asLegacyNamedPath(pathName: String) = None

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/Pattern.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/Pattern.scala
@@ -50,7 +50,7 @@ object RelationshipPattern {
   def unapply(x: Any): Option[(RelationshipPattern, SingleNode, SingleNode)] = x match {
     case pattern@RelatedTo(left, right, _, _, _, _)                   => Some((pattern, left, right))
     case pattern@VarLengthRelatedTo(_, left, right, _, _, _, _, _, _) => Some((pattern, left, right))
-    case pattern@ShortestPath(_, left, right, _, _, _, _, _)          => Some((pattern, left, right))
+    case pattern@ShortestPath(_, left, right, _, _, _, _, _, _)          => Some((pattern, left, right))
     case _                                                            => None
   }
 }
@@ -200,6 +200,7 @@ case class ShortestPath(pathName: String,
                         right: SingleNode,
                         relTypes: Seq[String],
                         dir: Direction,
+                        allowZeroLength: Boolean,
                         maxDepth: Option[Int],
                         single: Boolean,
                         relIterator: Option[String])
@@ -225,7 +226,7 @@ case class ShortestPath(pathName: String,
   lazy val possibleStartPoints: Seq[(String, NodeType)] = left.possibleStartPoints ++ right.possibleStartPoints
 
   def rewrite(f: Expression => Expression) =
-    new ShortestPath(pathName, left.rewrite(f), right.rewrite(f), relTypes, dir, maxDepth, single, relIterator)
+    new ShortestPath(pathName, left.rewrite(f), right.rewrite(f), relTypes, dir, allowZeroLength, maxDepth, single, relIterator)
 
   def rels = Seq()
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/commands/expressions/ShortestPathExpression.scala
@@ -68,9 +68,9 @@ case class ShortestPathExpression(ast: ShortestPath) extends Expression with Pat
   }
 
   val shortestPathStrategy = if (ast.single)
-    new SingleShortestPathStrategy(expander, ast.maxDepth.getOrElse(15))
+    new SingleShortestPathStrategy(expander, ast.allowZeroLength, ast.maxDepth.getOrElse(15))
   else
-    new AllShortestPathsStrategy(expander, ast.maxDepth.getOrElse(15))
+    new AllShortestPathsStrategy(expander, ast.allowZeroLength, ast.maxDepth.getOrElse(15))
 
   def calculateType(symbols: SymbolTable) =  shortestPathStrategy.typ
 
@@ -82,20 +82,26 @@ trait ShortestPathStrategy {
   def typ: CypherType
 }
 
-class SingleShortestPathStrategy(expander: Expander, depth: Int) extends ShortestPathStrategy {
+class SingleShortestPathStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int) extends ShortestPathStrategy {
   private val finder = GraphAlgoFactory.shortestPath(expander, depth)
 
-  def findResult(start: Node, end: Node): Path = finder.findSinglePath(start, end)
+  def findResult(start: Node, end: Node): Path = {
+    val result = finder.findSinglePath(start, end)
+    if (!allowZeroLength && result != null && result.length() == 0)
+      null
+    else
+      result
+  }
 
   def typ = CTPath
 }
 
-class AllShortestPathsStrategy(expander: Expander, depth: Int) extends ShortestPathStrategy {
+class AllShortestPathsStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int) extends ShortestPathStrategy {
   private val finder = GraphAlgoFactory.shortestPath(expander, depth)
 
   def findResult(start: Node, end: Node): Stream[Path] = {
     finder.findAllPaths(start, end).asScala.toStream
-  }
+  }.filter { p => allowZeroLength || p.length() > 0 }
 
   def typ = CTCollection(CTPath)
 }

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/MatchPattern.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/MatchPattern.scala
@@ -38,7 +38,7 @@ object MatchPattern {
       val theThings: Seq[TUPLE] = patterns.map {
         case SingleNode(n, _, _)                               => Seq(n) -> Seq()
         case RelatedTo(from, to, r, _, _, _)                   => tuple(Some(r), from.name, to.name)
-        case ShortestPath(_, from, to, _, _, _, _, _)          => tuple(None, from.name, to.name)
+        case ShortestPath(_, from, to, _, _, _, _, _, _)          => tuple(None, from.name, to.name)
         case VarLengthRelatedTo(_, from, to, _, _, _, _, _, _) => tuple(None, from.name, to.name)
       }
 

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilder.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilder.scala
@@ -46,7 +46,7 @@ class DisconnectedShortestPathEndPointsBuilder extends PlanBuilder {
 
   private def unsolvedEndPoints(plan: ExecutionPlanInProgress): Set[String] = {
     val shortestPathEndPoints: Set[String] = plan.query.patterns.collect {
-      case Unsolved(ShortestPath(_, start, end, _, _, _, _, _)) => Seq(start.name, end.name)
+      case Unsolved(ShortestPath(_, start, end, _, _, _, _, _, _)) => Seq(start.name, end.name)
     }.flatten.toSet
 
     shortestPathEndPoints.filter {

--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/StartPointChoosingBuilder.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/StartPointChoosingBuilder.scala
@@ -75,7 +75,7 @@ class StartPointChoosingBuilder extends PlanBuilder {
 
     def findStartItemFor(pattern: MatchPattern): Iterable[RatedStartItem] = {
       val shortestPathPoints: Set[IdentifierName] = plan.query.patterns.collect {
-        case Unsolved(ShortestPath(_, start, end, _, _, _, _, _)) => Seq(start.name, end.name)
+        case Unsolved(ShortestPath(_, start, end, _, _, _, _, _, _)) => Seq(start.name, end.name)
       }.flatten.toSet
 
       val startPoints: Set[RatedStartItem] =

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/DisconnectedShortestPathEndPointsBuilderTest.scala
@@ -34,7 +34,7 @@ class DisconnectedShortestPathEndPointsBuilderTest extends BuilderTest with Mock
   val identifier = "n"
   val otherIdentifier = "p"
   val shortestPath = ShortestPath("p",
-    SingleNode(identifier), SingleNode(otherIdentifier), Seq.empty, Direction.OUTGOING, None, single = true, None)
+    SingleNode(identifier), SingleNode(otherIdentifier), Seq.empty, Direction.OUTGOING, false, None, single = true, None)
 
   @Test
   def should_add_nodes_for_shortest_path() {

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/MatchBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/MatchBuilderTest.scala
@@ -104,7 +104,7 @@ class MatchBuilderTest extends BuilderTest {
   def should_not_accept_patterns_with_only_shortest_path() {
     val inQ = PartiallySolvedQuery().
       copy(start = Seq(Solved(NodeById("a", 0)), Solved(NodeById("b", 0))),
-      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, None, single = true, None))))
+      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, None, single = true, None))))
 
     val inP = createPipe(nodes = Seq("l"))
 
@@ -115,7 +115,7 @@ class MatchBuilderTest extends BuilderTest {
   def should_accept_non_optional_parts_of_the_query_first() {
     val inQ = PartiallySolvedQuery().
       copy(start = Seq(Solved(NodeById("a", 0)), Solved(NodeById("b", 0))),
-      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, None, single = true, None))))
+      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, None, single = true, None))))
 
     val inP = createPipe(nodes = Seq("l"))
 

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/PredicateRewriterTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/PredicateRewriterTest.scala
@@ -99,7 +99,7 @@ object PredicateRewriterTest {
 
   val predicateForLabelA = HasLabel(Identifier("a"), label)
   val predicateForLabelB = HasLabel(Identifier("b"), label)
-  val shortestPathNoLabels = ShortestPath("p", bareA, bareB, Seq.empty, Direction.OUTGOING, None, single = false, None)
+  val shortestPathNoLabels = ShortestPath("p", bareA, bareB, Seq.empty, Direction.OUTGOING, false, None, single = false, None)
 
   val prop = UnresolvedProperty("foo")
 

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/ShortestPathBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/ShortestPathBuilderTest.scala
@@ -43,12 +43,12 @@ class ShortestPathBuilderTest extends BuilderTest {
   def should_accept_if_both_start_and_end_have_been_solved() {
     val q = PartiallySolvedQuery().
       copy(start = Seq(Solved(NodeById("a", 0)), Solved(NodeById("b", 0))),
-      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, None, single = true, None))))
+      patterns = Seq(Unsolved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, None, single = true, None))))
 
     val p = createPipe(nodes = Seq("a", "b"))
 
     val resultQ = assertAccepts(p, q).query
 
-    assert(resultQ.patterns == Seq(Solved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, None, single = true, None))))
+    assert(resultQ.patterns == Seq(Solved(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, None, single = true, None))))
   }
 }

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/StartPointChoosingBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/StartPointChoosingBuilderTest.scala
@@ -440,7 +440,7 @@ class StartPointChoosingBuilderTest extends BuilderTest with MockitoSugar {
         Equals(Property(Identifier(otherIdentifier), propertyKey), expression2)),
 
       patterns = Seq(
-        ShortestPath("p", SingleNode(identifier), SingleNode(otherIdentifier), Nil, Direction.OUTGOING, None, single = true, None))
+        ShortestPath("p", SingleNode(identifier), SingleNode(otherIdentifier), Nil, Direction.OUTGOING, false, None, single = true, None))
     )
 
     when(context.getIndexRule(label, property)).thenReturn(None)

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/prepare/KeyTokenResolverTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/executionplan/builders/prepare/KeyTokenResolverTest.scala
@@ -99,11 +99,11 @@ class KeyTokenResolverTest extends BuilderTest with MockitoSugar {
   @Test
   def should_resolve_label_keytoken_on_shortest_path_length_pattern() {
     val q = Query.
-      matches(ShortestPath("p", SingleNode("a", Seq(unresolvedFoo)), SingleNode("b", Seq(unresolvedBar)), Seq.empty, Direction.OUTGOING, None, single = false, relIterator = None)).
+      matches(ShortestPath("p", SingleNode("a", Seq(unresolvedFoo)), SingleNode("b", Seq(unresolvedBar)), Seq.empty, Direction.OUTGOING, false, None, single = false, relIterator = None)).
       returns()
 
     val result = assertAccepts(q)
-    assert(result.query.patterns === Seq(Unsolved(ShortestPath("p", SingleNode("a", Seq(resolvedFoo)), SingleNode("b", Seq(resolvedBar)), Seq.empty, Direction.OUTGOING, None, single = false, relIterator = None))))
+    assert(result.query.patterns === Seq(Unsolved(ShortestPath("p", SingleNode("a", Seq(resolvedFoo)), SingleNode("b", Seq(resolvedBar)), Seq.empty, Direction.OUTGOING, false, None, single = false, relIterator = None))))
   }
 
   @Test

--- a/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.0/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/parser/CypherParserTest.scala
@@ -1186,7 +1186,7 @@ class CypherParserTest extends CypherFunSuite {
       """start a=node(0), b=node(1) match p = shortestPath( a-[*..6]->b ) return p""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, Some(6), single = true, None)).
+        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, Some(6), single = true, None)).
         returns(ReturnItem(Identifier("p"), "p"))
     )
   }
@@ -1196,7 +1196,7 @@ class CypherParserTest extends CypherFunSuite {
       """start a=node(0), b=node(1) match p = shortestPath( a-[:KNOWS*..6]->b ) return p""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, Some(6), single = true, relIterator = None)).
+        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, false, Some(6), single = true, relIterator = None)).
         returns(ReturnItem(Identifier("p"), "p"))
     )
   }
@@ -1206,16 +1206,16 @@ class CypherParserTest extends CypherFunSuite {
       """start a=node(0), b=node(1) match p = allShortestPaths( a-[:KNOWS*..6]->b ) return p""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
-        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, Some(6), single = false, relIterator = None)).
+        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, false, Some(6), single = false, relIterator = None)).
         returns(ReturnItem(Identifier("p"), "p"))
     )
   }
 
   test("testShortestPathWithoutStart") {
     expectQuery(
-      """match p = shortestPath( a-[*..3]->b ) WHERE a.name = 'John' AND b.name = 'Sarah' return p""",
+      """match p = shortestPath( a-[*1..3]->b ) WHERE a.name = 'John' AND b.name = 'Sarah' return p""",
       Query.
-        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, Some(3), single = true, None)).
+        matches(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.OUTGOING, false, Some(3), single = true, None)).
         where(And(
         Equals(Property(Identifier("a"), PropertyKey("name")), Literal("John")),
         Equals(Property(Identifier("b"), PropertyKey("name")), Literal("Sarah"))))
@@ -1225,11 +1225,11 @@ class CypherParserTest extends CypherFunSuite {
 
   test("testShortestPathExpression") {
     expectQuery(
-      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*..3]->b) AS path""",
+      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..3]->b) AS path""",
       Query.
         start(NodeById("a", 0), NodeById("b", 1)).
         returns(ReturnItem(ShortestPathExpression(
-        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, Some(3), single = true, relIterator = None)),
+        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), Direction.OUTGOING, true, Some(3), single = true, relIterator = None)),
         "path", true)))
   }
 
@@ -2186,7 +2186,7 @@ class CypherParserTest extends CypherFunSuite {
          return *""",
       Query.
         start(NodeById("a", 1),NodeById("x", 2,3)).
-        matches(ShortestPath("p", SingleNode("a"), SingleNode("x"), Seq(), Direction.OUTGOING, None, single = true, relIterator = None)).
+        matches(ShortestPath("p", SingleNode("a"), SingleNode("x"), Seq(), Direction.OUTGOING, false, None, single = true, relIterator = None)).
         makeOptional().
         returns(AllIdentifiers())
     )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -400,6 +400,62 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     }
   }
 
+  test("finds a single path for paths of length one") {
+    /*
+       a-b-c
+     */
+    val nodeA = createLabeledNode("A")
+    val nodeB = createLabeledNode("B")
+    val nodeC = createLabeledNode("C")
+    relate(nodeA, nodeB)
+    relate(nodeB, nodeC)
+
+    val result = execute("match p = shortestpath((a:A)-[r*..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    result should equal(Set(List(nodeA, nodeB)))
+  }
+
+  test("if asked for also return paths of length 0") {
+    /*
+       a-b-c
+     */
+    val nodeA = createLabeledNode("A")
+    val nodeB = createLabeledNode("B")
+    val nodeC = createLabeledNode("C")
+    relate(nodeA, nodeB)
+    relate(nodeB, nodeC)
+
+    val result = execute("match p = shortestpath((a:A)-[r*0..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    result should equal(Set(List(nodeA), List(nodeA, nodeB)))
+  }
+
+  test("we can ask explicitly for paths of minimal length 1") {
+    /*
+       a-b-c
+     */
+    val nodeA = createLabeledNode("A")
+    val nodeB = createLabeledNode("B")
+    val nodeC = createLabeledNode("C")
+    relate(nodeA, nodeB)
+    relate(nodeB, nodeC)
+
+    val result = execute("match p = shortestpath((a:A)-[r*1..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    result should equal(Set(List(nodeA, nodeB)))
+  }
+
+  test("finds a single path for non-variable length paths") {
+    /*
+       a-b-c
+     */
+    val nodeA = createLabeledNode("A")
+    val nodeB = createLabeledNode("B")
+    val nodeC = createLabeledNode("C")
+    relate(nodeA, nodeB)
+    relate(nodeB, nodeC)
+
+    val result = execute("match p = shortestpath((a:A)-[r]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    result should equal(Set(List(nodeA, nodeB)))
+  }
+
   test("two bound nodes pointing to one") {
     val a = createNode("A")
     val b = createNode("B")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -148,14 +148,14 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineJUnitSuite {
     )
   }
 
-  @Test def shouldComplainIfShortestPathHasAMinimalLength() {
+  @Test def shouldComplainIfShortestPathHasAMinimalLengthOtherThanZeroOrOne() {
     test(
-      "start a=node(0), b=node(1) match p=shortestPath(a-[*1..2]->b) return p",
-      "shortestPath(...) does not support a minimal length (line 1, column 36)"
+      "start a=node(0), b=node(1) match p=shortestPath(a-[*2..3]->b) return p",
+      "shortestPath(...) does not support a minimal length different from 0 or 1 (line 1, column 36)"
     )
     test(
-      "start a=node(0), b=node(1) match p=allShortestPaths(a-[*1..2]->b) return p",
-      "allShortestPaths(...) does not support a minimal length (line 1, column 36)"
+      "start a=node(0), b=node(1) match p=allShortestPaths(a-[*2..3]->b) return p",
+      "allShortestPaths(...) does not support a minimal length different from 0 or 1 (line 1, column 36)"
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/AllShortestPathsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/AllShortestPathsPipeTest.scala
@@ -32,7 +32,7 @@ class AllShortestPathsPipeTest extends GraphDatabaseJUnitSuite {
   def runThroughPipeAndGetPath(a: Node, b: Node) = {
     val source = new FakePipe(List(Map("a" -> a, "b" -> b)), "a" -> CTNode, "b" -> CTNode)
 
-    val pipe = new ShortestPathPipe(source, ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.BOTH,
+    val pipe = new ShortestPathPipe(source, ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.BOTH, false,
       Some(15), single = false, relIterator = None))
     graph.inTx(pipe.createResults(QueryStateHelper.empty).toList.map(m => m("p").asInstanceOf[Path]))
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/PathExpressionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/PathExpressionTest.scala
@@ -46,6 +46,7 @@ class PathExpressionTest extends GraphDatabaseJUnitSuite {
       right = SingleNode("c"),
       relTypes = Seq(),
       dir = Direction.OUTGOING,
+      false,
       maxDepth = None,
       single = true,
       relIterator = None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/PipeLazynessTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/PipeLazynessTest.scala
@@ -178,7 +178,7 @@ object PipeLazynessTest extends MockitoSugar {
 
   private def shortestPathPipe = {
     val shortestPath = ShortestPath(pathName = "p", left = SingleNode("start"), right = SingleNode("end"), relTypes = Seq.empty,
-      dir = Direction.OUTGOING, maxDepth = None, single = true, relIterator = None)
+      dir = Direction.OUTGOING, false, maxDepth = None, single = true, relIterator = None)
     val iter = new LazyIterator[Map[String, Any]](10, (_) => Map("start" -> null, "end" -> null))
     val src = new FakePipe(iter, "start" -> CTNode, "end" -> CTNode)
     val pipe = new ShortestPathPipe(src, shortestPath)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/SingleShortestPathPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/SingleShortestPathPipeTest.scala
@@ -29,7 +29,7 @@ import collection.mutable.Map
 
 class SingleShortestPathPipeTest extends GraphDatabaseJUnitSuite {
 
-  val path = ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.BOTH, Some(15), single = true, relIterator = None)
+  val path = ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), Direction.BOTH, false, Some(15), single = true, relIterator = None)
 
   def runThroughPipeAndGetPath(a: Node, b: Node, path: ShortestPath): Path = {
     val source = new FakePipe(List(Map("a" -> a, "b" -> b)), "a"->CTNode, "b"->CTNode)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/SyntaxExceptionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_0/SyntaxExceptionTest.scala
@@ -97,10 +97,10 @@ class SyntaxExceptionTest extends ExecutionEngineJUnitSuite {
     )
   }
 
-  @Test def shortestPathCanNotHaveMinimumDepth() {
+  @Test def shortestPathCanNotHaveMinimumDepthDifferentFromZeroOrOne() {
     test(
       "start a=node(0), b=node(1) match p=shortestPath(a-[*2..3]->b) return p",
-      "shortestPath(...) does not support a minimal length (line 1, column 36)"
+      "shortestPath(...) does not support a minimal length different from 0 or 1 (line 1, column 36)"
     )
   }
 


### PR DESCRIPTION
- `shortestPath(a-[r*]->b)` is interpreted as `shortestPath(a-[r*1..]->b)`and not `shortestPath(a-[r*0..]->b)` as before
- minimal length of length zero or one is supported, i.e. `shortestPath(a-[r*0..5]->b)` or `shortestPath(a-[r*1..5]->b)`
- `shortestPath(a-[r]->b)` is interpreted as `shortestPath(a-[r*1..1]->b)`