### PR TITLE
Throw an exception if shortest path relationships are constrained by literal properties

### DIFF
--- a/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
+++ b/community/cypher/cypher-compiler-2.0/src/main/scala/org/neo4j/cypher/internal/compiler/v2_0/ast/Pattern.scala
@@ -104,8 +104,10 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
   }
 
   private def checkContainsSingle: SemanticCheck = element match {
-    case RelationshipChain(l: NodePattern, _, r: NodePattern) =>
-      None
+    case RelationshipChain(_: NodePattern, r, _: NodePattern) =>
+      r.properties.map { props =>
+        SemanticError(s"$name(...) contains properties $props. This is currently not supported.", position, element.position)
+      }
     case _                                                    =>
       SemanticError(s"$name(...) requires a pattern containing a single relationship", position, element.position)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -406,6 +406,20 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineJUnitSuite {
     )
   }
 
+  @Test def shouldRejectPropertiesOnShortestPathRelationships() {
+    test(
+      "MATCH (a), (b), shortestPath( (a)-[r* {x: 1}]->(b) ) RETURN *",
+      "shortestPath(...) contains properties MapExpression(List((Identifier(x),SignedDecimalIntegerLiteral(1)))). This is currently not supported. (line 1, column 17)"
+    )
+  }
+
+  @Test def shouldRejectPropertiesOnAllShortestPathsRelationships() {
+    test(
+      "MATCH (a), (b), allShortestPaths( (a)-[r* {x: 1}]->(b) ) RETURN *",
+      "allShortestPaths(...) contains properties MapExpression(List((Identifier(x),SignedDecimalIntegerLiteral(1)))). This is currently not supported. (line 1, column 17)"
+    )
+  }
+
   def test(query: String, message: String) {
     try {
       val result = execute(query)


### PR DESCRIPTION
o This is not supported for now but we will implement it in the future