### PR TITLE
Added checks used in AST rewriting

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
@@ -25,6 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.spi.MapToPublicExceptions
 abstract class CypherException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
   def this() = this(null, null)
 
+  def this(message: String) = this(message, null)
+
   def this(cause: Throwable) = this(null, cause)
 
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T
@@ -62,15 +64,15 @@ class InvalidArgumentException(message: String, cause: Throwable = null) extends
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidArgumentException(message, cause)
 }
 
-class PatternException(message: String) extends CypherException {
+class PatternException(message: String) extends CypherException(message) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.patternException(message)
 }
 
-class InternalException(message: String, inner: Exception = null) extends CypherException(inner) {
+class InternalException(message: String, inner: Exception = null) extends CypherException(message, inner) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.internalException(message)
 }
 
-class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable) extends CypherException {
+class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable) extends CypherException(cause) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.nodeStillHasRelationshipsException(nodeId, cause)
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/Ref.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/Ref.scala
@@ -23,16 +23,16 @@ object Ref {
   def apply[T <: AnyRef](v: T) = new Ref[T](v)
 }
 
-final class Ref[T <: AnyRef](val v: T) {
-  if (v == null)
+final class Ref[T <: AnyRef](val value: T) {
+  if (value == null)
     throw new InternalException("Attempt to instantiate Ref(null)")
 
-  override def toString = s"Ref($v)"
+  override def toString = s"Ref($value)"
 
-  override def hashCode = java.lang.System.identityHashCode(v)
+  override def hashCode = java.lang.System.identityHashCode(value)
 
   override def equals(that: Any) = that match {
-    case other: Ref[_] => v eq other.v
+    case other: Ref[_] => value eq other.value
     case _             => false
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/Identifier.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/Identifier.scala
@@ -47,6 +47,10 @@ case class Identifier(name: String)(val position: InputPosition) extends Express
 
   def ensureDefined() =
     (_: SemanticState).ensureIdentifierDefined(this)
+
+  def copyId = copy()(position)
+
+  def bumpId = copy()(position.copy(offset = position.offset + 1)) // TODO: HACKISHHHH
 }
 
 object Identifier {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ReturnItem.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ReturnItem.scala
@@ -60,7 +60,7 @@ sealed trait ReturnItem extends ASTNode with ASTPhrase with SemanticCheckable {
 
 case class UnaliasedReturnItem(expression: Expression, inputText: String)(val position: InputPosition) extends ReturnItem {
   val alias = expression match {
-    case i: Identifier => Some(Identifier(i.name)(i.position.copy(offset = i.position.offset + 1)))
+    case i: Identifier => Some(i.bumpId)
     case _ => None
   }
   val name = alias.map(_.name) getOrElse { inputText.trim }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/collectNodesOfType.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/collectNodesOfType.scala
@@ -20,14 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_2.ast.conditions
 
 import org.neo4j.cypher.internal.compiler.v2_2.ast.ASTNode
-import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.Condition
 
 import scala.reflect.ClassTag
 
-case class containsNoNodesOfType[T <: ASTNode](implicit tag: ClassTag[T]) extends Condition {
-  def apply(that: Any): Seq[String] = collectNodesOfType[T].apply(that).map {
-    node => s"Expected none but found ${node.getClass.getSimpleName} at position ${node.position}"
+case class collectNodesOfType[T <: ASTNode](implicit tag: ClassTag[T]) extends (Any => Seq[T]) {
+  import org.neo4j.cypher.internal.compiler.v2_2.Foldable._
+  def apply(that: Any): Seq[T] = that.fold(Seq.empty[T]) {
+    case node: ASTNode if node.getClass == tag.runtimeClass =>
+      (acc) => acc :+ node.asInstanceOf[T]
   }
-
-  override def name() = s"$productPrefix[${tag.runtimeClass.getSimpleName}]"
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/containsNamedPathOnlyForShortestPath.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/containsNamedPathOnlyForShortestPath.scala
@@ -19,15 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v2_2.ast.ASTNode
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{NamedPatternPart, ShortestPaths}
 import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.Condition
 
-import scala.reflect.ClassTag
+case object containsNamedPathOnlyForShortestPath extends Condition {
+  private val matcher = containsNoMatchingNodes({
+    case namedPart@NamedPatternPart(_, part) if !part.isInstanceOf[ShortestPaths] =>
+      namedPart.toString
+  })
 
-case class containsNoNodesOfType[T <: ASTNode](implicit tag: ClassTag[T]) extends Condition {
-  def apply(that: Any): Seq[String] = collectNodesOfType[T].apply(that).map {
-    node => s"Expected none but found ${node.getClass.getSimpleName} at position ${node.position}"
-  }
+  def apply(that: Any) = matcher(that)
 
-  override def name() = s"$productPrefix[${tag.runtimeClass.getSimpleName}]"
+  override def name: String = productPrefix
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/containsNoReturnAll.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/containsNoReturnAll.scala
@@ -20,10 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_2.ast.conditions
 
 import org.neo4j.cypher.internal.compiler.v2_2.ast.ReturnItems
+import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.Condition
 
-case class containsNoReturnAll() extends (Any => Seq[String]) {
-  val matcher = containsNoMatchingNodes({
+case object containsNoReturnAll extends Condition {
+  private val matcher = containsNoMatchingNodes({
     case ri: ReturnItems if ri.includeExisting => "ReturnItems(includeExisting = true, ...)"
   })
   def apply(that: Any) = matcher(that)
+
+  override def name: String = productPrefix
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/Namespacer.scala
@@ -74,7 +74,7 @@ case class Namespacer(renamings: IdentifierRenamings) {
   })
 
   val tableRewriter = (semanticTable: SemanticTable) => {
-    val replacements = renamings.toSeq.collect { case (old, newIdentifier) => old.v -> newIdentifier }
+    val replacements = renamings.toSeq.collect { case (old, newIdentifier) => old.value -> newIdentifier }
     val newSemanticTable = semanticTable.replaceKeys(replacements: _*)
     newSemanticTable
   }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/addUniquenessPredicates.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/addUniquenessPredicates.scala
@@ -70,7 +70,7 @@ case object addUniquenessPredicates extends Rewriter {
     val predicates: Seq[Expression] = for {
       x <- uniqueRels
       y <- uniqueRels if x.name < y.name && !x.isAlwaysDifferentFrom(y)
-    } yield NotEquals(x.identifier, y.identifier)(pos)
+    } yield Not(Equals(x.identifier.copyId, y.identifier.copyId)(pos))(pos)
 
     predicates.reduceOption(And(_, _)(pos))
   }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/expandStar.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/expandStar.scala
@@ -48,7 +48,7 @@ case class expandStar(state: SemanticState) extends Rewriter {
     val expandedItems = symbolNames.toSeq.sorted.map { id =>
       val idPos = scope.symbolTable(id).definition.position
       val expr = Identifier(id)(idPos)
-      val alias = Identifier(id)(idPos.copy(offset = idPos.offset + 1)) //TODO: THIS IS A HORRIBLE HACK
+      val alias = expr.copyId
       AliasedReturnItem(expr, alias)(clausePos)
     }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
@@ -19,10 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
-import org.neo4j.cypher.internal.compiler.v2_2.{bottomUp, AggregatingFunction, Rewriter}
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
-import org.neo4j.cypher.internal.compiler.v2_2.ast.CountStar
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.AggregationNameGenerator
+import org.neo4j.cypher.internal.compiler.v2_2.{Rewriter, bottomUp}
 import org.neo4j.cypher.internal.helpers.Converge.iterateUntilConverged
 
 /**
@@ -74,7 +73,7 @@ case object isolateAggregation extends Rewriter {
           }
 
           val withReturnItems: Seq[ReturnItem] = expressionsToGoToWith.map {
-            case id: Identifier => AliasedReturnItem(id, id)(id.position)
+            case id: Identifier => AliasedReturnItem(id.copyId, id.copyId)(id.position)
             case e              => AliasedReturnItem(e, Identifier(AggregationNameGenerator.name(e.position.offset))(e.position))(e.position)
           }
           val pos = c.position
@@ -90,7 +89,7 @@ case object isolateAggregation extends Rewriter {
 
             case e: Expression =>
               withReturnItems.collectFirst {
-                case AliasedReturnItem(expression, identifier) if e == expression => identifier
+                case AliasedReturnItem(expression, identifier) if e == expression => identifier.copyId
               }.getOrElse(e)
           }))
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/normalizeReturnClauses.scala
@@ -56,7 +56,7 @@ case object normalizeReturnClauses extends Rewriter {
       )
 
     case clause @ Return(distinct, ri, orderBy, skip, limit) =>
-      var rewrites = Map[Expression, Expression]()
+      var rewrites = Map[Expression, Identifier]()
 
       val (aliasProjection, finalProjection) = ri.items.map {
         i =>
@@ -72,11 +72,11 @@ case object normalizeReturnClauses extends Rewriter {
           rewrites = rewrites + (returnColumn -> newIdentifier)
           rewrites = rewrites + (i.expression -> newIdentifier)
 
-          (AliasedReturnItem(i.expression, newIdentifier)(i.position), AliasedReturnItem(newIdentifier, returnColumn)(i.position))
+          (AliasedReturnItem(i.expression, newIdentifier)(i.position), AliasedReturnItem(newIdentifier.copyId, returnColumn)(i.position))
       }.unzip
 
       val newOrderBy = orderBy.endoRewrite(bottomUp(Rewriter.lift {
-        case exp: Expression if rewrites.contains(exp) => rewrites(exp)
+        case exp: Expression if rewrites.contains(exp) => rewrites(exp).copyId
       }))
 
       Seq(

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectFreshSortExpressions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectFreshSortExpressions.scala
@@ -20,8 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
-import org.neo4j.cypher.internal.compiler.v2_2.helpers.FreshIdNameGenerator
-import org.neo4j.cypher.internal.compiler.v2_2.{Rewriter, bottomUp, topDown}
+import org.neo4j.cypher.internal.compiler.v2_2.{Rewriter, bottomUp}
 
 /**
  * This rewriter ensures that WITH clauses containing a ORDER BY or WHERE are split, such that the ORDER BY or WHERE does not

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectNamedPaths.scala
@@ -32,8 +32,8 @@ case object projectNamedPaths extends Rewriter {
     Rewriter.lift {
       case NamedPatternPart(identifier, part) if paths.contains(identifier) =>
         part
-      case identifier: Identifier if !blacklist.contains(identifier) =>
-        paths.getOrElse(identifier, identifier)
+      case identifier: Identifier if !blacklist.contains(identifier) && paths.contains(identifier) =>
+        paths(identifier).endoRewrite(Rewriter.lift { case identifier: Identifier => identifier.copyId })
     }
 
   private def collectNamedPaths(input: AnyRef): Map[Identifier, PathExpression] = {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/Planner.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.planner
 
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
+import org.neo4j.cypher.internal.compiler.v2_2.ast.conditions.containsNamedPathOnlyForShortestPath
 import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters._
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{PipeBuilder, PipeInfo}
@@ -96,13 +97,13 @@ object Planner {
   def rewriteStatement(namespacer: Namespacer, statement: Statement): Statement = {
     val rewriter = RewriterStepSequencer.newDefault("Planner")(
       ApplyRewriter("namespaceIdentifiers", namespacer.astRewriter),
-
       rewriteEqualityToInCollection,
       splitInCollectionsToIsolateConstants,
       CNFNormalizer,
       collapseInCollectionsContainingConstants,
-      nameUpdatingClauses,
+      nameUpdatingClauses /* this is actually needed as a precondition for projectedNamedPaths even though we do not handle updates in Ronja */,
       projectNamedPaths,
+      enableCondition(containsNamedPathOnlyForShortestPath),
       projectFreshSortExpressions,
       inlineProjections
     )

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/tracing/rewriters/RewriterStep.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/tracing/rewriters/RewriterStep.scala
@@ -25,10 +25,10 @@ object RewriterStep {
    type Named[T] = Product with T
 
    implicit def namedProductRewriter(p: Named[Rewriter]) = ApplyRewriter(p.productPrefix, p)
-   implicit def productRewriterCondition(p: Named[Any => Seq[String]]) = RewriterCondition(p.productPrefix, p)
+   implicit def productRewriterCondition(p: Condition) = RewriterCondition(p.name, p)
 
-   def enableCondition(p: Named[Any => Seq[String]]) = EnableRewriterCondition(p)
-   def disableCondition(p: Named[Any => Seq[String]]) = DisableRewriterCondition(p)
+   def enableCondition(p: Condition) = EnableRewriterCondition(p)
+   def disableCondition(p: Condition) = DisableRewriterCondition(p)
  }
 
 sealed trait RewriterStep
@@ -36,3 +36,7 @@ final case class ApplyRewriter(name: String, rewriter: Rewriter) extends Rewrite
 final case class EnableRewriterCondition(cond: RewriterCondition) extends RewriterStep
 final case class DisableRewriterCondition(cond: RewriterCondition) extends RewriterStep
 case object EmptyRewriterStep extends RewriterStep
+
+trait Condition extends (Any => Seq[String]) {
+   def name: String
+}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/tracing/rewriters/RewriterTaskProcessor.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/tracing/rewriters/RewriterTaskProcessor.scala
@@ -44,11 +44,12 @@ trait RewriterTaskProcessor extends (RewriterTask => Rewriter) {
   private def buildMessage(sequenceName: String, optName: Option[String], failures: Seq[RewriterConditionFailure]) = {
     val name = optName.map(name => s"step '$name'").getOrElse("start of rewriting")
     val builder = new StringBuilder
-    builder ++= s"Error during '$sequenceName' rewriting after $name. The following conditions where violated: "
+    builder ++= s"Error during '$sequenceName' rewriting after $name. The following conditions where violated: \n"
     for (failure <- failures) {
       val name = failure.name
       for (problem <- failure.problems)
-        builder ++= s"Condition '$name' violated. $problem"
+        builder ++= s"Condition '$name' violated. $problem\n"
+
     }
     builder.toString()
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/CollectNodesOfTypeTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/CollectNodesOfTypeTest.scala
@@ -19,15 +19,24 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v2_2.ast.ASTNode
-import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
 
-import scala.reflect.ClassTag
+class CollectNodesOfTypeTest extends CypherFunSuite with AstConstructionTestSupport{
 
-case class containsNoNodesOfType[T <: ASTNode](implicit tag: ClassTag[T]) extends Condition {
-  def apply(that: Any): Seq[String] = collectNodesOfType[T].apply(that).map {
-    node => s"Expected none but found ${node.getClass.getSimpleName} at position ${node.position}"
-  }
+    private val collector: (Any => Seq[Identifier]) = collectNodesOfType[Identifier]()
 
-  override def name() = s"$productPrefix[${tag.runtimeClass.getSimpleName}]"
+    test("collect all identifiers") {
+      val idA = ident("a")
+      val idB = ident("b")
+      val ast: ASTNode = Match(optional = false, Pattern(Seq(EveryPath(NodePattern(Some(idA), Seq(), Some(idB), naked = true)_)))_, Seq(), None)_
+
+      collector(ast) should equal(Seq(idA, idB))
+    }
+
+    test("collect no identifiers") {
+      val ast: ASTNode = Match(optional = false, Pattern(Seq(EveryPath(NodePattern(None, Seq(), None, naked = true)_)))_, Seq(), None)_
+
+      collector(ast) shouldBe empty
+    }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/ContainsNamedPathOnlyForShortestPathTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/conditions/ContainsNamedPathOnlyForShortestPathTest.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.ast.conditions
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.ast._
+
+class ContainsNamedPathOnlyForShortestPathTest extends CypherFunSuite with AstConstructionTestSupport {
+  private val condition: (Any => Seq[String]) = containsNamedPathOnlyForShortestPath
+
+  test("happy when we have no named paths") {
+    val ast = Query(None, SingleQuery(Seq(
+      Match(optional = false, Pattern(Seq(EveryPath(NodePattern(Some(ident("n")), Seq.empty, None, naked = false)(pos))))(pos), Seq.empty, None)(pos),
+      Return(distinct = false, ReturnItems(includeExisting = false, Seq(AliasedReturnItem(ident("n"), ident("n"))(pos)))(pos), None, None, None)(pos)
+    ))(pos))(pos)
+
+    condition(ast) shouldBe empty
+  }
+
+  test("unhappy when we have a named path") {
+    val namedPattern: NamedPatternPart = NamedPatternPart(ident("p"), EveryPath(NodePattern(Some(ident("n")), Seq.empty, None, naked = false)(pos)))(pos)
+    val ast = Query(None, SingleQuery(Seq(
+      Match(optional = false, Pattern(Seq(namedPattern))(pos), Seq.empty, None)(pos),
+      Return(distinct = false, ReturnItems(includeExisting = false, Seq(AliasedReturnItem(ident("n"), ident("n"))(pos)))(pos), None, None, None)(pos)
+    ))(pos))(pos)
+
+    condition(ast) should equal(Seq(s"Expected none but found $namedPattern at position $pos"))
+  }
+
+  test("should allow named path for shortest path") {
+    val ast = Query(None, SingleQuery(Seq(
+      Match(optional = false, Pattern(Seq(NamedPatternPart(ident("p"), ShortestPaths(NodePattern(Some(ident("n")), Seq.empty, None, naked = false)(pos), single = true)(pos))(pos)))(pos), Seq.empty, None)(pos),
+      Return(distinct = false, ReturnItems(includeExisting = false, Seq(AliasedReturnItem(ident("n"), ident("n"))(pos)))(pos), None, None, None)(pos)
+    ))(pos))(pos)
+
+    condition(ast) shouldBe empty
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.plannerQuery.StatementConverters._
-import org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters.{namePatternPredicatePatternElements, nameAllPatternElements, normalizeReturnClauses, normalizeWithClauses}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters.{namePatternPredicatePatternElements, normalizeReturnClauses, normalizeWithClauses}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport, _}
 import org.neo4j.graphdb.Direction
@@ -212,7 +212,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), Direction.OUTGOING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), Direction.OUTGOING, Seq.empty, SimplePatternLength)))
     query.graph.patternNodes should equal(Set(IdName("a"), IdName("b"), IdName("c")))
-    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), NotEquals(Identifier("r")_, Identifier("r2")_)_)
+    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), Not(Equals(Identifier("r")_, Identifier("r2")_)_)_)
     query.graph.selections.predicates should equal(Set(predicate))
     query.horizon should equal(RegularQueryProjection(Map(
       "a" -> Identifier("a")_,
@@ -227,7 +227,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), Direction.OUTGOING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("a")), Direction.OUTGOING, Seq.empty, SimplePatternLength)))
     query.graph.patternNodes should equal(Set(IdName("a"), IdName("b")))
-    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), NotEquals(Identifier("r")_, Identifier("r2")_)_)
+    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), Not(Equals(Identifier("r")_, Identifier("r2")_)_)_)
     query.graph.selections.predicates should equal(Set(predicate))
     query.horizon should equal(RegularQueryProjection(Map(
       "a" -> Identifier("a")_,
@@ -241,7 +241,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), Direction.INCOMING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), Direction.BOTH, Seq.empty, SimplePatternLength)))
     query.graph.patternNodes should equal(Set(IdName("a"), IdName("b"), IdName("c")))
-    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), NotEquals(Identifier("r")_, Identifier("r2")_)_)
+    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), Not(Equals(Identifier("r")_, Identifier("r2")_)_)_)
     query.graph.selections.predicates should equal(Set(predicate))
     query.horizon should equal(RegularQueryProjection(Map(
       "a" -> Identifier("a")_,
@@ -255,7 +255,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), Direction.INCOMING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), Direction.BOTH, Seq.empty, SimplePatternLength)))
     query.graph.patternNodes should equal(Set(IdName("a"), IdName("b"), IdName("c")))
-    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), NotEquals(Identifier("r")_, Identifier("r2")_)_)
+    val predicate: Predicate = Predicate(Set(IdName("r"), IdName("r2")), Not(Equals(Identifier("r")_, Identifier("r2")_)_)_)
     query.graph.selections.predicates should equal(Set(predicate))
     query.horizon should equal(RegularQueryProjection(Map(
       "a" -> Identifier("a")_,
@@ -885,7 +885,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     val result = query.toString
 
     val expectation =
-      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r1),(IdName(  origin@7),IdName(c)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength), PatternRelationship(IdName(r2),(IdName(c),IdName(  candidate@60)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength)),Set(IdName(  origin@7), IdName(c), IdName(  candidate@60)),Set(),Selections(Set(Predicate(Set(IdName(r1), IdName(r2)),NotEquals(Identifier(r1),Identifier(r2))), Predicate(Set(IdName(  origin@7), IdName(  candidate@60)),Not(PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(Some(Identifier(  origin@7)),List(),None,false),RelationshipPattern(Some(Identifier(  UNNAMED143)),false,List(RelTypeName(KNOWS)),None,None,BOTH),NodePattern(Some(Identifier(  candidate@60)),List(),None,false)))))), Predicate(Set(IdName(r1), IdName(r2)),Equals(FunctionInvocation(FunctionName(type),false,Vector(Identifier(r1))),FunctionInvocation(FunctionName(type),false,Vector(Identifier(r2))))), Predicate(Set(IdName(  origin@7)),In(Property(Identifier(  origin@7),PropertyKeyName(name)),Collection(List(StringLiteral(Clark Kent))))))),List(),Set(),Set()),AggregatingQueryProjection(Map(  FRESHID178 -> Property(Identifier(  origin@7),PropertyKeyName(name)),   FRESHID204 -> Property(Identifier(  candidate@60),PropertyKeyName(name))),Map(  FRESHID223 -> FunctionInvocation(FunctionName(SUM),false,Vector(FunctionInvocation(FunctionName(ROUND),false,Vector(Add(Property(Identifier(r2),PropertyKeyName(weight)),Multiply(FunctionInvocation(FunctionName(COALESCE),false,Vector(Property(Identifier(r2),PropertyKeyName(activity)), SignedDecimalIntegerLiteral(0))),SignedDecimalIntegerLiteral(2)))))))),QueryShuffle(List(),None,None)),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID204), IdName(  FRESHID223), IdName(  FRESHID178)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(  FRESHID178 -> Identifier(  FRESHID178),   FRESHID204 -> Identifier(  FRESHID204),   FRESHID223 -> Identifier(  FRESHID223)),QueryShuffle(List(DescSortItem(Identifier(  FRESHID223))),None,Some(UnsignedDecimalIntegerLiteral(10)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(origin -> Identifier(  FRESHID178), candidate -> Identifier(  FRESHID204), boost -> Identifier(  FRESHID223)),QueryShuffle(List(),None,None)),None)))))""".stripMargin
+      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r1),(IdName(  origin@7),IdName(c)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength), PatternRelationship(IdName(r2),(IdName(c),IdName(  candidate@60)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength)),Set(IdName(  origin@7), IdName(c), IdName(  candidate@60)),Set(),Selections(Set(Predicate(Set(IdName(r1), IdName(r2)),Not(Equals(Identifier(r1),Identifier(r2)))), Predicate(Set(IdName(  origin@7), IdName(  candidate@60)),Not(PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(Some(Identifier(  origin@7)),List(),None,false),RelationshipPattern(Some(Identifier(  UNNAMED143)),false,List(RelTypeName(KNOWS)),None,None,BOTH),NodePattern(Some(Identifier(  candidate@60)),List(),None,false)))))), Predicate(Set(IdName(r1), IdName(r2)),Equals(FunctionInvocation(FunctionName(type),false,Vector(Identifier(r1))),FunctionInvocation(FunctionName(type),false,Vector(Identifier(r2))))), Predicate(Set(IdName(  origin@7)),In(Property(Identifier(  origin@7),PropertyKeyName(name)),Collection(List(StringLiteral(Clark Kent))))))),List(),Set(),Set()),AggregatingQueryProjection(Map(  FRESHID178 -> Property(Identifier(  origin@7),PropertyKeyName(name)),   FRESHID204 -> Property(Identifier(  candidate@60),PropertyKeyName(name))),Map(  FRESHID223 -> FunctionInvocation(FunctionName(SUM),false,Vector(FunctionInvocation(FunctionName(ROUND),false,Vector(Add(Property(Identifier(r2),PropertyKeyName(weight)),Multiply(FunctionInvocation(FunctionName(COALESCE),false,Vector(Property(Identifier(r2),PropertyKeyName(activity)), SignedDecimalIntegerLiteral(0))),SignedDecimalIntegerLiteral(2)))))))),QueryShuffle(List(),None,None)),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID204), IdName(  FRESHID223), IdName(  FRESHID178)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(  FRESHID178 -> Identifier(  FRESHID178),   FRESHID204 -> Identifier(  FRESHID204),   FRESHID223 -> Identifier(  FRESHID223)),QueryShuffle(List(DescSortItem(Identifier(  FRESHID223))),None,Some(UnsignedDecimalIntegerLiteral(10)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(origin -> Identifier(  FRESHID178), candidate -> Identifier(  FRESHID204), boost -> Identifier(  FRESHID223)),QueryShuffle(List(),None,None)),None)))))""".stripMargin
 
     result should equal(expectation)
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/AddUniquenessPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/AddUniquenessPredicatesTest.scala
@@ -34,15 +34,15 @@ class AddUniquenessPredicatesTest extends CypherFunSuite with RewriteTest {
   test("uniqueness check is done between relationships") {
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2]->(c) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2]->(c) WHERE not(r1 = r2) RETURN *")
 
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2]->(c)-[r3]->(d) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2]->(c)-[r3]->(d) WHERE r2 <> r3 AND r1 <> r3 AND r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2]->(c)-[r3]->(d) WHERE not(r2 = r3) AND not(r1 = r3) AND not(r1 = r2) RETURN *")
 
     assertRewrite(
       "MATCH (a)-[r1]->(b), (b)-[r2]->(c), (c)-[r3]->(d) RETURN *",
-      "MATCH (a)-[r1]->(b), (b)-[r2]->(c), (c)-[r3]->(d) WHERE r1 <> r2 AND r1 <> r3 AND r2 <> r3 RETURN *")
+      "MATCH (a)-[r1]->(b), (b)-[r2]->(c), (c)-[r3]->(d) WHERE not(r1 = r2) AND not(r1 = r3) AND not(r2 = r3) RETURN *")
   }
 
   test("no uniqueness check between relationships of different type") {
@@ -52,15 +52,15 @@ class AddUniquenessPredicatesTest extends CypherFunSuite with RewriteTest {
 
     assertRewrite(
       "MATCH (a)-[r1:X]->(b)-[r2:X|Y]->(c) RETURN *",
-      "MATCH (a)-[r1:X]->(b)-[r2:X|Y]->(c) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1:X]->(b)-[r2:X|Y]->(c) WHERE not(r1 = r2) RETURN *")
 
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2:X]->(c) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2:X]->(c) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2:X]->(c) WHERE not(r1 = r2) RETURN *")
 
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2]->(c) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2]->(c) WHERE not(r1 = r2) RETURN *")
   }
 
   test("ignores shortestPath relationships for uniqueness") {
@@ -70,7 +70,7 @@ class AddUniquenessPredicatesTest extends CypherFunSuite with RewriteTest {
 
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2]->c, shortestPath((a)-[r]->(b)) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2]->c, shortestPath((a)-[r]->(b)) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2]->c, shortestPath((a)-[r]->(b)) WHERE not(r1 = r2) RETURN *")
   }
 
   test("ignores allShortestPaths relationships for uniqueness") {
@@ -80,7 +80,7 @@ class AddUniquenessPredicatesTest extends CypherFunSuite with RewriteTest {
 
     assertRewrite(
       "MATCH (a)-[r1]->(b)-[r2]->c, allShortestPaths((a)-[r]->(b)) RETURN *",
-      "MATCH (a)-[r1]->(b)-[r2]->c, allShortestPaths((a)-[r]->(b)) WHERE r1 <> r2 RETURN *")
+      "MATCH (a)-[r1]->(b)-[r2]->c, allShortestPaths((a)-[r]->(b)) WHERE not(r1 = r2) RETURN *")
   }
 
   val rewriterUnderTest: Rewriter = addUniquenessPredicates

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/CollapseInCollectionsContainingConstantsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/CollapseInCollectionsContainingConstantsTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.planner.AstRewritingTestSupport
-import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 
 class CollapseInCollectionsContainingConstantsTest extends CypherFunSuite with AstRewritingTestSupport {
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NamespacerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NamespacerTest.scala
@@ -22,7 +22,6 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.{ASTAnnotationMap, Identifier, Statement}
-import org.neo4j.cypher.internal.compiler.v2_2.helpers.StatementHelper
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.StatementHelper._
 import org.neo4j.cypher.internal.compiler.v2_2.parser.ParserFixture.parser
 import org.neo4j.cypher.internal.compiler.v2_2.planner.SemanticTable

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectFreshSortExpressionsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectFreshSortExpressionsTest.scala
@@ -126,6 +126,20 @@ class ProjectFreshSortExpressionsTest extends CypherFunSuite with RewriteTest {
       """.stripMargin)
   }
 
+  test("handle RETURN * ORDERBY property") {
+    assertRewrite(
+      """MATCH n
+        |RETURN * ORDER BY n.prop
+      """.stripMargin,
+      """MATCH n
+        |WITH n AS n
+        |WITH n AS n, n.prop AS `  FRESHID28`
+        |WITH n AS n, `  FRESHID28` AS `  FRESHID28` ORDER BY `  FRESHID28`
+        |WITH n AS n
+        |RETURN n AS n
+      """.stripMargin)
+  }
+
   protected override def assertRewrite(originalQuery: String, expectedQuery: String) {
     val original = ast(originalQuery)
     val expected = ast(expectedQuery)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/ExpandPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/ExpandPlanningIntegrationTest.scala
@@ -88,7 +88,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
 
     } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").plan should equal(
     Projection(
-      Selection(Seq(NotEquals(Identifier("r1")_,Identifier("r2")_) _),
+      Selection(Seq(Not(Equals(Identifier("r1")_,Identifier("r2")_)_)_),
         Expand(
           Expand(
             AllNodesScan(IdName("b"),Set.empty)(PlannerQuery.empty),

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -20,10 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_2.ast.{Identifier, NotEquals}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{Equals, Identifier, Not}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v2_2.planner.{PlannerQuery, LogicalPlanningTestSupport2}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport2, PlannerQuery}
 import org.neo4j.graphdb.Direction
 
 class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
@@ -87,7 +87,7 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
       Projection(
         FindShortestPaths(
         Selection(
-          Seq(NotEquals(Identifier("r1") _, Identifier("r2") _) _),
+          Seq(Not(Equals(Identifier("r1")_, Identifier("r2")_)_)_),
           NodeHashJoin(
             Set(IdName("b")),
             Expand(

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -20,10 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_2.ast.{NotEquals, Identifier}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{Equals, Identifier, Not}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v2_2.planner.{PlannerQuery, LogicalPlanningTestSupport2}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport2, PlannerQuery}
 import org.neo4j.graphdb.Direction
 
 class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
@@ -49,7 +49,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
 
     val expected = Projection(
       Selection(
-        Seq(NotEquals(Identifier("r1")_, Identifier("r2")_) _),
+        Seq(Not(Equals(Identifier("r1")_, Identifier("r2")_)_)_),
         NodeHashJoin(
           Set(IdName("b")),
           Expand(


### PR DESCRIPTION
Many different rewriters act on the AST. To assert that no
rewriter reverts something already done by a previous rewriter,
this commit adds checks to make sure that does not happen.

Assumptions checked by this commit:
* Reference equality - the current code assumes that each
AST object is only used once - in a few places, IdentityMap's are used.
To make sure that we do not break this assumption, this commit
adds a check so that the assumption is tested while rewriting is
happening.

* No unaliased return items
* No use of RETURN *
The compiler assumes all return expressions are explicitly listed
and have aliases.

* Contains no "a <> b"
The compiler uses "not(a = b)"

* Contains no named paths except for shortest path
Named paths in a query are turned into expressions.