### PR TITLE
Fix: Store copy decorator printing negative sizes.

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -230,11 +230,11 @@ public class StoreCopyClient
             private int totalFiles;
 
             @Override
-            public int write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
+            public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
                               boolean hasData ) throws IOException
             {
                 console.log( "Copying " + path );
-                int written = actual.write( path, data, temporaryBuffer, hasData );
+                long written = actual.write( path, data, temporaryBuffer, hasData );
                 console.log( "Copied  " + path + " " + bytes( written ) );
                 totalFiles++;
                 return written;

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
@@ -29,7 +29,7 @@ public interface StoreWriter extends Closeable
     // "hasData" is an effect of the block format not supporting a zero length block
     // whereas a neostore file may actually be 0 bytes we'll have to keep track
     // of that special case.
-    int write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer, boolean hasData )
+    long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer, boolean hasData )
             throws IOException;
 
     @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -36,7 +36,7 @@ public class ToFileStoreWriter implements StoreWriter
     }
 
     @Override
-    public int write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
+    public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
             boolean hasData ) throws IOException
     {
         try
@@ -47,7 +47,7 @@ public class ToFileStoreWriter implements StoreWriter
             file.getParentFile().mkdirs();
             try ( RandomAccessFile randomAccessFile = new RandomAccessFile( file, "rw" ) )
             {
-                int totalWritten = 0;
+                long totalWritten = 0;
                 if ( hasData )
                 {
                     FileChannel channel = randomAccessFile.getChannel();

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
@@ -42,7 +42,7 @@ public class ToNetworkStoreWriter implements StoreWriter
     }
 
     @Override
-    public int write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
+    public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
             boolean hasData ) throws IOException
     {
         char[] chars = path.toCharArray();
@@ -51,7 +51,7 @@ public class ToNetworkStoreWriter implements StoreWriter
         targetBuffer.writeByte( hasData ? 1 : 0 );
         // TODO Make use of temporaryBuffer?
         BlockLogBuffer buffer = new BlockLogBuffer( targetBuffer, bufferMonitor );
-        int totalWritten = 2 + chars.length*2 + 1;
+        long totalWritten = 2 + chars.length*2 + 1;
         if ( hasData )
         {
             totalWritten += buffer.write( data );


### PR DESCRIPTION
The implementation kept the totalWritten in an int instead of a long.
This had no functional impact, since only the decorator ever used
the number.