### PR TITLE
Considers all deleted relationships when patching chain positions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -120,5 +120,4 @@ public class TransactionRepresentationStoreApplier
         assert counts.acceptTx( transactionId );
         return new CountsStoreApplier( counts, neoStore.getNodeStore() );
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
@@ -51,14 +51,12 @@ import org.neo4j.kernel.impl.core.RelationshipImpl;
 import org.neo4j.kernel.impl.core.RelationshipLoader;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.transaction.command.RelationshipHoles;
 import org.neo4j.kernel.impl.util.RelIdArray;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 import org.neo4j.kernel.impl.util.RelIdArrayWithLoops;
 
 import static org.neo4j.kernel.impl.api.store.CacheUpdateListener.NO_UPDATES;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.BOTH;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.INCOMING;
-import static org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper.OUTGOING;
 
 /**
  * This is a cache for the {@link KernelAPI}. Currently it piggy-backs on NodeImpl/RelationshipImpl
@@ -492,23 +490,12 @@ public class PersistenceCache
         labelTokenHolder.addToken( token );
     }
 
-    public void patchDeletedRelationshipNodes( long relId, int type, long firstNodeId, long firstNodeNextRelId,
-            long secondNodeId, long secondNodeNextRelId )
-    {
-        boolean loop = firstNodeId == secondNodeId;
-        invalidateNode( firstNodeId, loop ? BOTH : OUTGOING, type, relId, firstNodeNextRelId );
-        if ( !loop )
-        {
-            invalidateNode( secondNodeId, INCOMING, type, relId, secondNodeNextRelId );
-        }
-    }
-
-    private void invalidateNode( long nodeId, DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
+    public void patchDeletedRelationshipNodes( long nodeId, RelationshipHoles holes )
     {
         NodeImpl node = nodeCache.getIfCached( nodeId );
         if ( node != null )
         {
-            node.updateRelationshipChainPosition( direction, type, relIdDeleted, nextRelId );
+            node.updateRelationshipChainPosition( holes );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.impl.api.store.SchemaCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
+import org.neo4j.kernel.impl.transaction.command.RelationshipHoles;
 
 public class BridgingCacheAccess implements CacheAccessBackDoor
 {
@@ -114,11 +115,9 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     }
 
     @Override
-    public void patchDeletedRelationshipNodes( long relId, int type, long firstNodeId, long firstNodeNextRelId,
-            long secondNodeId, long secondNodeNextRelId )
+    public void patchDeletedRelationshipNodes( long nodeId, RelationshipHoles holes )
     {
-        persistenceCache.patchDeletedRelationshipNodes( relId, type, firstNodeId, firstNodeNextRelId, secondNodeId,
-                secondNodeNextRelId );
+        persistenceCache.patchDeletedRelationshipNodes( nodeId, holes );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
+import org.neo4j.kernel.impl.transaction.command.RelationshipHoles;
 
 public interface CacheAccessBackDoor
 {
@@ -64,6 +65,5 @@ public interface CacheAccessBackDoor
      * @param secondNodeId The relId of the second node
      * @param secondNodeNextRelId The next relationship relId of the second node in its relationship chain
      */
-    void patchDeletedRelationshipNodes( long relId, int type,
-            long firstNodeId, long firstNodeNextRelId, long secondNodeId, long secondNodeNextRelId );
+    void patchDeletedRelationshipNodes( long nodeId, RelationshipHoles holes );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
+import org.neo4j.function.primitive.PrimitiveLongPredicate;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 
@@ -57,12 +59,15 @@ public class SingleChainPosition implements RelationshipLoadingPosition
     }
 
     @Override
-    public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
+    public boolean atPosition( PrimitiveLongPredicate predicate )
     {
-        if ( position == relIdDeleted )
-        {
-            position = nextRelId;
-        }
+        return predicate.accept( position );
+    }
+
+    @Override
+    public void patchPosition( long nodeId, FunctionFromPrimitiveLongLongToPrimitiveLong<RuntimeException> next )
+    {
+        position = next.apply( nodeId, position );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/RelationshipHoles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/RelationshipHoles.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.command;
+
+import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.collection.primitive.PrimitiveLongVisitor;
+import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
+import org.neo4j.function.primitive.PrimitiveLongPredicate;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.neo4j.collection.primitive.Primitive.longObjectMap;
+import static org.neo4j.collection.primitive.Primitive.longSet;
+import static org.neo4j.kernel.impl.transaction.state.RelationshipChainLoader.followRelationshipChain;
+
+/**
+ * Keeps track of deleted relationships in a transaction and can detect and navigate past holes of deleted
+ * relationships via their next pointers, such that a relationship that is in use after a hole can be retrieved.
+ */
+public class RelationshipHoles implements
+        PrimitiveLongPredicate, FunctionFromPrimitiveLongLongToPrimitiveLong<RuntimeException>
+{
+    private final PrimitiveLongSet nodes = longSet( 8 );
+    private final PrimitiveLongObjectMap<RelationshipRecord> relationships = longObjectMap( 32 );
+
+    /**
+     * Keeps track of the given relationship and makes use of it later in {@link #accept(long)}
+     * and {@link #apply(long, long)}
+     *
+     * @param deletedRelationship relationship that has been deleted in this transaction.
+     */
+    public void deleted( RelationshipRecord deletedRelationship )
+    {
+        nodes.add( deletedRelationship.getFirstNode() );
+        nodes.add( deletedRelationship.getSecondNode() );
+        relationships.put( deletedRelationship.getId(), deletedRelationship );
+    }
+
+    /**
+     * @return whether or not relationship by id {@code relationshipId} has been deleted in this transaction.
+     */
+    @Override
+    public boolean accept( long relationshipId )
+    {
+        return relationships.containsKey( relationshipId );
+    }
+
+    /**
+     * @return the next-most {@link RelationshipRecord#inUse() inUse} relationship given the deleted relationship
+     * with id {@code deletedRelationshipId}.
+     */
+    @Override
+    public long apply( long nodeId, long deletedRelationshipId ) throws RuntimeException
+    {
+        long relationshipId = deletedRelationshipId;
+        while ( true )
+        {
+            RelationshipRecord relationship = relationships.get( relationshipId );
+            if ( relationship == null )
+            {
+                return relationshipId;
+            }
+            relationshipId = followRelationshipChain( nodeId, relationship );
+        }
+    }
+
+    public void apply( final CacheAccessBackDoor cacheAccess )
+    {
+        nodes.visitKeys( new PrimitiveLongVisitor<RuntimeException>()
+        {
+            @Override
+            public boolean visited( long nodeId )
+            {
+                cacheAccess.patchDeletedRelationshipNodes( nodeId, RelationshipHoles.this );
+                return false;
+            }
+        } );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotation.java
@@ -21,8 +21,6 @@ package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.util.StringLogger;
-
 /**
  * Used to check if a log rotation is needed, and also to execute a log rotation.
  *

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipChainLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipChainLoader.java
@@ -123,25 +123,27 @@ public class RelationshipChainLoader
             {
                 i--;
             }
-            long next = 0;
-            if ( firstNode == nodeId )
-            {
-                next = relRecord.getFirstNextRel();
-            }
-            else if ( secondNode == nodeId )
-            {
-                next = relRecord.getSecondNextRel();
-            }
-            else
-            {
-                throw new InvalidRecordException( "While loading relationships for Node[" + nodeId +
-                        "] a Relationship[" + relRecord.getId() + "] was encountered that had startNode: " + firstNode +
-                        " and endNode: " + secondNode + ", i.e. which had neither start nor end node as the node we're " +
-                        "loading relationships for" );
-            }
+            long next = followRelationshipChain( nodeId, relRecord );
             position = loadPosition.nextPosition( next, direction, types );
         }
         return Pair.of( result, loadPosition );
+    }
+
+    public static long followRelationshipChain( long nodeId, RelationshipRecord relRecord )
+    {
+        if ( relRecord.getFirstNode() == nodeId )
+        {
+            return relRecord.getFirstNextRel();
+        }
+        else if ( relRecord.getSecondNode() == nodeId )
+        {
+            return relRecord.getSecondNextRel();
+        }
+
+        throw new InvalidRecordException( "While loading relationships for Node[" + nodeId +
+                "] a Relationship[" + relRecord.getId() + "] was encountered that had startNode: " +
+                relRecord.getFirstNode() + " and endNode: " + relRecord.getSecondNode() +
+                ", i.e. which had neither start nor end node as the node we're loading relationships for" );
     }
 
     public int getRelationshipCount( long id, int type, DirectionWrapper direction )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/RelationshipChainPositionPoisoningTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/cache/RelationshipChainPositionPoisoningTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.cache;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.RepeatRule;
+import org.neo4j.test.RepeatRule.Repeat;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+
+public class RelationshipChainPositionPoisoningTest
+{
+    /**
+     * Problem previously relied on order that items were iterated over a VersionedHashMap,
+     * which for ids 0-9 will be ordered, although not so for higher ids. That's why this test
+     * is repeated, so that all orderings are tested.
+     */
+    @Repeat( times = 10 )
+    @Test
+    public void shouldPatchNodeCacheWithCorrectRelationshipAfterTwoDeleted() throws Exception
+    {
+        // GIVEN a relationship chain like 4->3->2->1->0
+        Node node = createNode();
+        Relationship[] rels = new Relationship[5];
+        for ( int i = 0; i < rels.length; i++ )
+        {
+            rels[i] = createRelationship( node );
+        }
+        db.clearCache();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            // and GIVEN relationship chain position is at 2 (see chain layout above).
+            // This will be the case since grab size is 2.
+            node.getRelationships().iterator().next();
+
+            // WHEN
+            // deleting relationships 2 and 1
+            rels[2].delete();
+            rels[1].delete();
+            tx.success();
+        }
+
+        // THEN continuing loading relationships should see the last one (0) as well.
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( 3, count( node.getRelationships() ) );
+        }
+    }
+
+    private Relationship createRelationship( Node node )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = node.createRelationshipTo( db.createNode(), MyRelTypes.TEST );
+            tx.success();
+            return relationship;
+        }
+    }
+
+    private Node createNode()
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            tx.success();
+            return node;
+        }
+    }
+
+    public final @Rule RepeatRule repeater = new RepeatRule();
+    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( GraphDatabaseSettings.cache_type, StrongCacheProvider.NAME );
+            builder.setConfig( GraphDatabaseSettings.relationship_grab_size, "2" );
+        }
+    };
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -37,6 +37,8 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
+import org.neo4j.function.primitive.PrimitiveLongPredicate;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -506,9 +508,15 @@ public class TestNeoStore
         }
 
         @Override
-        public void compareAndAdvance( DirectionWrapper direction, int type, long relIdDeleted, long nextRelId )
+        public boolean atPosition( PrimitiveLongPredicate predicate )
         {
-            actual.compareAndAdvance( direction, type, relIdDeleted, nextRelId );
+            return actual.atPosition( predicate );
+        }
+
+        @Override
+        public void patchPosition( long nodeId, FunctionFromPrimitiveLongLongToPrimitiveLong<RuntimeException> next )
+        {
+            actual.patchPosition( nodeId, next );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/RelationshipHolesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/RelationshipHolesTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.command;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RelationshipHolesTest
+{
+    @Test
+    public void shouldFindEdgeOfHole() throws Exception
+    {
+        // GIVEN
+        // 10->20->4->15->3
+        RelationshipHoles holes = new RelationshipHoles();
+        long node = 0;
+
+        // WHEN
+        // delete 4 and 15
+        holes.deleted( relationship( 4, node, 15 ) );
+        holes.deleted( relationship( 15, node, 3 ) );
+
+        // THEN
+        assertTrue( holes.accept( 4 ) );
+        assertTrue( holes.accept( 15 ) );
+        assertFalse( holes.accept( 20 ) );
+
+        assertEquals( 3L, holes.apply( node, 4 ) );
+        assertEquals( 3L, holes.apply( node, 15 ) );
+        assertEquals( 20L, holes.apply( node, 20 ) );
+    }
+
+    private RelationshipRecord relationship( long id, long node, long next )
+    {
+        return new RelationshipRecord( id, false, node, IGNORE, 0, IGNORE, next, IGNORE, IGNORE, false, false );
+    }
+
+    private static final int IGNORE = -99;
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/function/primitive/FunctionFromPrimitiveLongLongToPrimitiveLong.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/function/primitive/FunctionFromPrimitiveLongLongToPrimitiveLong.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.function.primitive;
+
+public interface FunctionFromPrimitiveLongLongToPrimitiveLong<EXCEPTION extends Exception>
+{
+    long apply( long first, long other ) throws EXCEPTION;
+}

--- a/community/server/src/test/java/org/neo4j/server/security/auth/SecurityCentralTest.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/SecurityCentralTest.java
@@ -20,12 +20,13 @@
 package org.neo4j.server.security.auth;
 
 import org.junit.Test;
+
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.server.security.auth.exception.IllegalTokenException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class SecurityCentralTest
 {


### PR DESCRIPTION
Previously when multiple consecutive relationships in a chain got deleted
the current chain positions for cached nodes (NodeImpl) got patched to go
the next relationship in that chain. Problem was that the chain
positions got patched by looking at each deleted relationship individually
and so depending on the order the relationships existed in the chain, the
chain positions might have gotten patched to another deleted relationship.

This commit collects deleted relationships and patches each chain position
knowing all deleted relationships and so these "holes" can be detected and
the next relationship after the hole selected.