### PR TITLE
Made ClusterRule#startCluster to ignore the HA roles of ManagedCluster#arbiters when starting a cluster

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaLoggingIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaLoggingIT.java
@@ -23,7 +23,6 @@ import java.io.File;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -37,7 +36,6 @@ import static org.neo4j.test.ha.ClusterManager.clusterWithAdditionalClients;
 import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 import static org.neo4j.test.ha.ClusterManager.masterSeesMembers;
 
-@Ignore
 public class HaLoggingIT
 {
     @Rule

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -30,13 +30,14 @@ import org.junit.runners.model.Statement;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.ha.ClusterManager.Builder;
 
 import static org.neo4j.cluster.ClusterSettings.default_timeout;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
-import static org.neo4j.test.ha.ClusterManager.Builder;
-import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.test.ha.ClusterManager.allSeesAllAsJoined;
 import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
+import static org.neo4j.test.ha.ClusterManager.masterAvailable;
 
 public class ClusterRule extends ExternalResource
 {
@@ -89,7 +90,8 @@ public class ClusterRule extends ExternalResource
             throw new RuntimeException( throwable );
         }
         ClusterManager.ManagedCluster cluster = clusterManager.getDefaultCluster();
-        cluster.await( allSeesAllAsAvailable() );
+        cluster.await( masterAvailable() );
+        cluster.await( allSeesAllAsJoined() );
         return cluster;
     }
 


### PR DESCRIPTION
ManagedCluster#arbiters are in UNKNOWN status all the time to a cluster.
All the HA members that are declared to be not full HA members will be added in arbiters when they are created by ClusterManager.