### PR TITLE
Makes :TYPE header in import input optional

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DataException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/DataException.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
-public class HeaderException extends InputException
+public class DataException extends InputException
 {
-    public HeaderException( String message )
+    public DataException( String message )
     {
         super( message );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -457,7 +457,8 @@ public class DataFactories
     {
         protected DefaultRelationshipFileHeaderParser( HeaderCharSeekerFactory headerCharSeekerFactory )
         {
-            super( headerCharSeekerFactory, Type.START_ID, Type.END_ID, Type.TYPE );
+            // Don't have TYPE as mandatory since a decorator could provide that
+            super( headerCharSeekerFactory, Type.START_ID, Type.END_ID );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
@@ -26,6 +26,7 @@ import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.csv.reader.Mark;
 import org.neo4j.function.Function;
 import org.neo4j.helpers.collection.PrefetchingResourceIterator;
+import org.neo4j.unsafe.impl.batchimport.input.DataException;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.unsafe.impl.batchimport.input.UnexpectedEndOfInputException;
@@ -117,7 +118,9 @@ abstract class InputEntityDeserializer<ENTITY extends InputEntity> extends Prefe
                 data.seek( mark, delimiter );
             }
 
-            return decorator.apply( entity );
+            entity = decorator.apply( entity );
+            validate( entity );
+            return entity;
         }
         catch ( IOException e )
         {
@@ -127,6 +130,14 @@ abstract class InputEntityDeserializer<ENTITY extends InputEntity> extends Prefe
         {
             propertiesCursor = 0;
         }
+    }
+
+    /**
+     * Called after the entity has been fully populated.
+     * @throws DataException on validation error.
+     */
+    protected void validate( ENTITY entity )
+    {   // No default validation
     }
 
     protected void addProperty( Header.Entry entry, Object value )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserializer.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.function.Function;
 import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.unsafe.impl.batchimport.input.DataException;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
@@ -72,5 +73,14 @@ class InputRelationshipDeserializer extends InputEntityDeserializer<InputRelatio
     {
         return new InputRelationship( idSequence.nextId(), properties, null,
                 startNodeGroup, startNode, endNodeGroup, endNode, type, null );
+    }
+
+    @Override
+    protected void validate( InputRelationship entity )
+    {
+        if ( !entity.hasTypeId() && entity.type() == null )
+        {
+            throw new DataException( entity + " is missing " + Type.TYPE + " field" );
+        }
     }
 }


### PR DESCRIPTION
which is OK if a relationship decorator that provides the relationship
type instead is supplied. For the import tool it may look something like:

  `--nodes mynodes.csv --relationships:MY_TYPE myrels.csv`

where the header of myrels.csv may look something like:

  `:START_ID,:END_ID`

i.e. no `:TYPE` in there.