### PR TITLE
Let's not add DurationLogger to the public API

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index.sampling;
 
-import org.neo4j.helpers.logging.DurationLogger;
+import org.neo4j.kernel.impl.util.DurationLogger;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexReader;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DurationLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DurationLogger.java
@@ -17,9 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.helpers.logging;
-
-import org.neo4j.kernel.impl.util.StringLogger;
+package org.neo4j.kernel.impl.util;
 
 import static java.lang.String.format;
 


### PR DESCRIPTION
The org.neo4j.helpers package has enough random stuff in it as it stands.

Don't you agree, @davidegrohmann ?