### PR TITLE
Fixing the order that we write relationship/node records when properties are involved

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
@@ -25,31 +25,46 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
-public class PropertyStoreIT
+public class NeoStoresIT
 {
     public final
     @Rule
     EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
 
+    public final
+    @Rule
+    DatabaseRule db = new ImpermanentDatabaseRule() {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            super.configure( builder );
+            builder.setConfig(  GraphDatabaseSettings.dense_node_threshold, "1");
+        }
+    };
+
     private EphemeralFileSystemAbstraction fileSystem;
     private File storeDir;
 
-    public final
-    @Rule
-    DatabaseRule db = new ImpermanentDatabaseRule();
+    private static final DynamicRelationshipType FRIEND = DynamicRelationshipType.withName( "FRIEND" );
 
     private static final String LONG_STRING_VALUE =
             "ALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALALA"
@@ -133,7 +148,127 @@ public class PropertyStoreIT
             }
             catch ( NotFoundException e )
             {
-                // acceptable!
+                // This will catch nodes not found (expected) and also PropertyRecords not found (shouldn't happen
+                // but handled in shouldWriteOutThePropertyRecordBeforeReferencingItFromANodeRecord)
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination( 2000, TimeUnit.MILLISECONDS );
+    }
+
+    @Test
+    public void shouldWriteOutThePropertyRecordBeforeReferencingItFromANodeRecord()
+            throws IOException, ExecutionException, InterruptedException
+    {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+        final long[] latestNodeId = new long[1];
+
+        for ( int i = 0; i < 100_000; i++ )
+        {
+            executor.scheduleAtFixedRate( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try ( Transaction tx = db.beginTx() )
+                    {
+                        Node node = db.createNode();
+                        latestNodeId[0] = node.getId();
+                        node.setProperty( "largeProperty", LONG_STRING_VALUE );
+                        tx.success();
+                    }
+                }
+            }, 5, 25, TimeUnit.MILLISECONDS );
+        }
+
+        for ( int i = 0; i < 100_000; i++ )
+        {
+            try ( Transaction tx = db.getGraphDatabaseAPI().beginTx() )
+            {
+                Node node = db.getGraphDatabaseService().getNodeById( latestNodeId[0] );
+
+                for ( String propertyKey : node.getPropertyKeys() )
+                {
+                    node.getProperty( propertyKey );
+                }
+                tx.success();
+            }
+            catch ( NotFoundException e )
+            {
+                if ( Exceptions.contains( e, InvalidRecordException.class ) )
+                {
+                    throw e;
+                }
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination( 2000, TimeUnit.MILLISECONDS );
+    }
+
+    @Test
+    public void shouldWriteOutThePropertyRecordBeforeReferencingItFromARelationshipRecord()
+            throws IOException, ExecutionException, InterruptedException
+    {
+        final long node1Id;
+        final long node2Id;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node1 = db.createNode();
+            node1Id = node1.getId();
+
+            Node node2 = db.createNode();
+            node2Id = node2.getId();
+
+            tx.success();
+        }
+
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+        final long[] latestRelationshipId = new long[1];
+
+        for ( int i = 0; i < 100_000; i++ )
+        {
+            executor.scheduleAtFixedRate( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try ( Transaction tx = db.beginTx() )
+                    {
+                        Node node1 = db.getGraphDatabaseService().getNodeById( node1Id );
+                        Node node2 = db.getGraphDatabaseService().getNodeById( node2Id );
+
+                        Relationship rel = node1.createRelationshipTo( node2, FRIEND );
+                        latestRelationshipId[0] = rel.getId();
+                        rel.setProperty( "largeProperty", LONG_STRING_VALUE );
+
+                        tx.success();
+                    }
+                }
+            }, 5, 25, TimeUnit.MILLISECONDS );
+        }
+
+        for ( int i = 0; i < 100_000; i++ )
+        {
+            try ( Transaction tx = db.getGraphDatabaseAPI().beginTx() )
+            {
+                Relationship rel = db.getGraphDatabaseService().getRelationshipById( latestRelationshipId[0] );
+
+                for ( String propertyKey : rel.getPropertyKeys() )
+                {
+                    rel.getProperty( propertyKey );
+                }
+                tx.success();
+            }
+            catch ( NotFoundException e )
+            {
+                if ( Exceptions.contains( e, InvalidRecordException.class ) )
+                {
+                    throw e;
+                }
             }
         }
 


### PR DESCRIPTION
* Before this commit when a property is involved we write out the node/relationship first
  which leads to a race condition where you get a NotFoundException if you try to read
  all a node/rel's properties before they've actually been written.
* The ordering is controlled in TransactionRecordState#extractCommands but we didn't
  have the created flag set properly. This commit fixes that
* The actual exception is wrapped in two others so we have to unravel those to get to it.
  Hence why NeoStoresIT's catch block is a bit full on.
* Added tests to TransactionRecordStateTest to check the order of commands