### PR TITLE
Send committed but not applied transaction logs when backing up.

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -70,7 +70,7 @@ public class StoreCopyServer
     {
         try
         {
-            long transactionIdWhenStartingCopy = transactionIdStore.getLastCommittedTransactionId();
+            long lastAppliedTransaction = transactionIdStore.getLastClosedTransactionId();
             logRotationControl.forceEverything();
             ByteBuffer temporaryBuffer = ByteBuffer.allocateDirect( 1024 * 1024 );
 
@@ -88,7 +88,7 @@ public class StoreCopyServer
                 }
             }
 
-            return anonymous( transactionIdWhenStartingCopy );
+            return anonymous( lastAppliedTransaction );
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
Previously the last committed transaction(s) might not have been sent, and
since the store copy could be newer i.e. containing partial updates, those
transaction logs are required for the idempotent command (re-)application
to repair the store to a consistent state.

The symptom was inconsistencies as reported by the consistency checker.