### PR TITLE
Improve error message on server startup fail. 

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -458,8 +458,7 @@ public abstract class AbstractNeoServer implements NeoServer
         catch ( RuntimeException e )
         {
             //noinspection deprecation
-            log.error( format( "Failed to start Neo Server on port [%d], reason [%s]",
-                    getWebServerPort(), e.getMessage() ) );
+            log.error( format( "Failed to start Neo4j HTTP Connector, reason [%s]", e.getMessage() ) );
             throw e;
         }
     }


### PR DESCRIPTION
It used to contain the primary port number, but that became super confusing when there were bind exceptions on *other* ports, causing messages like 'Failed to start on port 7474, because [Bind exception]' when the bind exception was caused by failing to bind to the https port, 7473.