### PR TITLE
Use on-heap buffers for EFSA

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -1167,9 +1167,9 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
                     }
                 }
             }
-            return ByteBuffer.allocateDirect( (sizeIndex < SIZES.length) ? SIZES[sizeIndex]
-                                                                         : ((sizeIndex - SIZES.length + 1) *
-                                                                            SIZES[SIZES.length - 1]) );
+            return ByteBuffer.allocate( (sizeIndex < SIZES.length) ? SIZES[sizeIndex]
+                    : ((sizeIndex - SIZES.length + 1) *
+                    SIZES[SIZES.length - 1]) );
         }
 
         void free()
@@ -1260,6 +1260,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             ByteBuffer buf = allocate( sizeIndex );
             this.buf.position( 0 );
             buf.put( this.buf );
+            free();
             this.buf = buf;
             this.buf.position( oldPosition );
         }


### PR DESCRIPTION
The combination of direct ByteBuffers and SoftReferences doesn't work, as you'll OOM as the GC will never clear the SoftRefs. Putting the ByteBuffers on the heap makes it much more reliable.

Also pool the buffers that are unused as files grow.