### PR TITLE
Prevents Jetty from logging to stdout (and messing with console.log formatting)

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestLogger.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestLogger.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -67,7 +68,7 @@ public class TestLogger extends StringLogger
         private LogCall( Level level, String message, Throwable cause, boolean flush )
         {
             this.level = level;
-            this.message = message;
+            this.message = message == null ? "" : message;
             this.cause = cause;
             this.flush = flush;
         }
@@ -354,6 +355,12 @@ public class TestLogger extends StringLogger
         {
             logCall.accept( visitor );
         }
+    }
+
+    /** Dump this whole log into a print stream */
+    public void dump( PrintStream out )
+    {
+        out.print( serialize( logCalls.iterator() ) );
     }
 
     private Predicate<LogCall> hasLevel( final Level level )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestLogging.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestLogging.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,5 +99,21 @@ public class TestLogging implements Logging
     public void visitConsoleLog( Class loggingClass, Visitor<TestLogger.LogCall,RuntimeException> logVisitor )
     {
         visitLog( consoleLoggers.get( loggingClass ), logVisitor );
+    }
+
+    /** Dump everything logged to every file to a printstream */
+    public void dump( PrintStream out )
+    {
+        for ( Map.Entry<Class,TestLogger> entry : messageLoggers.entrySet() )
+        {
+            out.println("== MessagesLog, " + entry.getKey() + " ==");
+            entry.getValue().dump(out);
+        }
+
+        for ( Map.Entry<Class,TestLogger> entry : consoleLoggers.entrySet() )
+        {
+            out.println("== ConsoleLog, " + entry.getKey() + " ==");
+            entry.getValue().dump(out);
+         }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -460,6 +460,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
             setUpTimeoutFilter();
 
+            webServer.init();
             webServer.start();
 
             log.log( "Server started on: " + baseUri() );

--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -71,17 +71,20 @@ public class CommunityNeoServer extends AbstractNeoServer
      * Should use the new constructor with {@link ConfigurationBuilder}
      */
     @Deprecated
-    public CommunityNeoServer( Configurator configurator, Database.Factory dbFactory, InternalAbstractGraphDatabase.Dependencies dependencies)
+    public CommunityNeoServer( Configurator configurator, Database.Factory dbFactory, InternalAbstractGraphDatabase
+            .Dependencies dependencies )
     {
         super( configurator, dbFactory, dependencies );
     }
 
-    public CommunityNeoServer( ConfigurationBuilder configurator, InternalAbstractGraphDatabase.Dependencies dependencies )
+    public CommunityNeoServer( ConfigurationBuilder configurator, InternalAbstractGraphDatabase.Dependencies
+            dependencies )
     {
         this( configurator, lifecycleManagingDatabase( EMBEDDED ), dependencies );
     }
 
-    public CommunityNeoServer( ConfigurationBuilder configurator, Database.Factory dbFactory, InternalAbstractGraphDatabase.Dependencies dependencies)
+    public CommunityNeoServer( ConfigurationBuilder configurator, Database.Factory dbFactory,
+                               InternalAbstractGraphDatabase.Dependencies dependencies )
     {
         super( configurator, dbFactory, dependencies );
     }
@@ -90,22 +93,22 @@ public class CommunityNeoServer extends AbstractNeoServer
     protected PreFlightTasks createPreflightTasks()
     {
         Logging logging = dependencies.logging();
-		return new PreFlightTasks( logging,
-				// TODO: Move the config check into bootstrapper
-				//new EnsureNeo4jPropertiesExist(configurator.configuration()),
-				new EnsurePreparedForHttpLogging(configurator.configuration()),
-				new PerformUpgradeIfNecessary(getConfig(),
-						configurator.getDatabaseTuningProperties(), logging, StoreUpgrader.NO_MONITOR),
-				new PerformRecoveryIfNecessary(getConfig(),
-						configurator.getDatabaseTuningProperties(), System.out, logging));
-	}
+        return new PreFlightTasks( logging,
+                // TODO: Move the config check into bootstrapper
+                //new EnsureNeo4jPropertiesExist(configurator.configuration()),
+                new EnsurePreparedForHttpLogging( configurator.configuration() ),
+                new PerformUpgradeIfNecessary( getConfig(),
+                        configurator.getDatabaseTuningProperties(), logging, StoreUpgrader.NO_MONITOR ),
+                new PerformRecoveryIfNecessary( getConfig(),
+                        configurator.getDatabaseTuningProperties(), System.out, logging ) );
+    }
 
     @Override
     protected Iterable<ServerModule> createServerModules()
     {
         Logging logging = dependencies.logging();
         return Arrays.asList(
-                new DBMSModule(webServer, security, configurator.configuration() ),
+                new DBMSModule( webServer, security, configurator.configuration() ),
                 new RESTApiModule( webServer, database, configurator.configuration(), logging ),
                 new ManagementApiModule( webServer, configurator.configuration() ),
                 new ThirdPartyJAXRSModule( webServer, configurator.configuration(), logging, this ),
@@ -117,8 +120,8 @@ public class CommunityNeoServer extends AbstractNeoServer
     @Override
     protected WebServer createWebServer()
     {
-		return new Jetty9WebServer( dependencies.logging());
-	}
+        return new Jetty9WebServer( dependencies.logging() );
+    }
 
     @Override
     public Iterable<AdvertisableService> getServices()

--- a/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.InternalAbstractGraphDatabase.Dependencies;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 
@@ -65,7 +66,7 @@ public class LifecycleManagingDatabase implements Database
     private final Config dbConfig;
     private final GraphFactory dbFactory;
     private final Dependencies dependencies;
-    private final ConsoleLogger log;
+    private final StringLogger log;
 
     private boolean isRunning = false;
     private GraphDatabaseAPI graph;
@@ -75,7 +76,7 @@ public class LifecycleManagingDatabase implements Database
         this.dbConfig = dbConfig;
         this.dbFactory = dbFactory;
         this.dependencies = dependencies;
-        this.log = dependencies.logging().getConsoleLog( getClass() );
+        this.log = dependencies.logging().getMessagesLog( getClass() );
     }
 
     @Override
@@ -109,7 +110,7 @@ public class LifecycleManagingDatabase implements Database
         {
             this.graph = dbFactory.newGraphDatabase( getLocation(), dbConfig.getParams(), dependencies );
             isRunning = true;
-            log.log( "Successfully started database" );
+            log.info( "Successfully started database" );
         }
         catch ( Exception e )
         {
@@ -128,12 +129,12 @@ public class LifecycleManagingDatabase implements Database
                 graph.shutdown();
                 isRunning = false;
                 graph = null;
-                log.log( "Successfully stopped database" );
+                log.info( "Successfully stopped database" );
             }
         }
         catch ( Exception e )
         {
-            log.error( "Database did not stop cleanly. Reason [%s]", e.getMessage() );
+            log.error( String.format("Database did not stop cleanly. Reason [%s]", e.getMessage() ) );
             throw e;
         }
     }

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.server.database.InjectableProvider;
+import org.neo4j.server.logging.JettyLoggerAdapter;
 import org.neo4j.server.plugins.Injectable;
 import org.neo4j.server.security.ssl.KeyStoreInformation;
 import org.neo4j.server.security.ssl.SslSocketConnectorFactory;
@@ -124,11 +125,14 @@ public class Jetty9WebServer implements WebServer
     private final SslSocketConnectorFactory sslSocketFactory = new SslSocketConnectorFactory();
     private final HttpConnectorFactory connectorFactory = new HttpConnectorFactory();
     private File requestLoggingConfiguration;
+
+    private final Logging logging;
     private final ConsoleLogger console;
     private final StringLogger log;
 
     public Jetty9WebServer( Logging logging )
     {
+        this.logging = logging;
         this.console = logging.getConsoleLog( getClass() );
         this.log = logging.getMessagesLog( getClass() );
     }
@@ -136,6 +140,8 @@ public class Jetty9WebServer implements WebServer
     @Override
     public void init()
     {
+        JettyLoggerAdapter.setGlobalLogging( logging );
+        System.setProperty( "org.eclipse.jetty.util.log.class", JettyLoggerAdapter.class.getName() );
     }
 
     @Override

--- a/community/server/src/test/java/org/neo4j/server/logging/LoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/logging/LoggingIT.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.logging;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.util.TestLogging;
+import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.helpers.CommunityServerBuilder;
+import org.neo4j.server.web.WebServer;
+import org.neo4j.test.server.ExclusiveServerTestBase;
+
+import static org.eclipse.jetty.server.Server.getVersion;
+import static org.neo4j.kernel.impl.util.TestLogger.LogCall.info;
+
+public class LoggingIT extends ExclusiveServerTestBase
+{
+    private CommunityNeoServer server;
+
+    @Test
+    public void shouldNotLogToStandardOutByDefault() throws Throwable
+    {
+        // Given
+        // The mute assertion should not fail, meaning nothing has logged to stdout/stderr
+        mute.withSilenceAssertion();
+
+        TestLogging logging = new TestLogging();
+        server = CommunityServerBuilder.server( logging ).build();
+
+        // When
+        server.start();
+        server.stop();
+        server = null;
+    }
+
+    @Test
+    public void jettyOutputShouldBeInOurLog() throws Exception
+    {
+        // Given
+        TestLogging logging = new TestLogging();
+        server = CommunityServerBuilder.server( logging ).build();
+
+        // When
+        server.start();
+        server.stop();
+        server = null;
+
+        // Then
+        logging.getMessagesLog( WebServer.class ).assertAtLeastOnce(
+                // This is a terrible thing to assert on, but it was the only log message I could see from
+                // jetty that is stable across runs. The point here is to ensure jetty does forward its log messages
+                // to Neo logging.
+                info( "jetty-"+getVersion() )
+        );
+    }
+
+    @After
+    public void cleanup()
+    {
+        if( server != null )
+        {
+            server.stop();
+        }
+    }
+}


### PR DESCRIPTION
Jetty9WebServer now sets things up so that when Jetty starts it uses
 an adapter for logging which will output to StringLogger instead
 of System.out
AbstractNeoServer properly calls init() before start() on WebServer
Adds new assertion in Mute to verify no output has reached stdout

This is a modification of https://github.com/neo4j/neo4j/pull/3520 to
 make it work with 2.2