### PR TITLE
Handle illegal epoch on slaves via state switch and new election

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -85,7 +85,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
     private final int maxUnusedChannels;
     private final StoreId storeId;
     private ResourceReleaser resourcePoolReleaser;
-    private final List<MismatchingVersionHandler> mismatchingVersionHandlers;
+    private final List<ComExceptionHandler> comExceptionHandlers;
 
     private final RequestMonitor requestMonitor;
 
@@ -104,7 +104,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         this.readTimeout = readTimeout;
         // ResourcePool no longer controls max concurrent channels. Use this value for the pool size
         this.maxUnusedChannels = maxConcurrentChannels;
-        this.mismatchingVersionHandlers = new ArrayList<MismatchingVersionHandler>( 2 );
+        this.comExceptionHandlers = new ArrayList<ComExceptionHandler>( 2 );
         this.address = new InetSocketAddress( hostNameOrIp, port );
         this.protocol = new Protocol( chunkSize, applicationProtocolVersion, getInternalProtocolVersion() );
 
@@ -189,7 +189,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         bootstrap.releaseExternalResources();
         bossExecutor.shutdownNow();
         workerExecutor.shutdownNow();
-        mismatchingVersionHandlers.clear();
+        comExceptionHandlers.clear();
         msgLog.logMessage( toString() + " shutdown", true );
     }
 
@@ -245,13 +245,13 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
 
             return response;
         }
-        catch ( IllegalProtocolVersionException e )
+        catch ( ComException e )
         {
             failure = e;
             success = false;
-            for ( MismatchingVersionHandler handler : mismatchingVersionHandlers )
+            for ( ComExceptionHandler handler : comExceptionHandlers )
             {
-                handler.versionMismatched( e.getExpected(), e.getReceived() );
+                handler.handle( e );
             }
             throw e;
         }
@@ -335,9 +335,9 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         return pipeline;
     }
 
-    public void addMismatchingVersionHandler( MismatchingVersionHandler toAdd )
+    public void addComExceptionHandler( ComExceptionHandler handler )
     {
-        mismatchingVersionHandlers.add( toAdd );
+        comExceptionHandlers.add( handler );
     }
 
     protected byte getInternalProtocolVersion()

--- a/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.com;
 
-public interface MismatchingVersionHandler
+public interface ComExceptionHandler
 {
-    public void versionMismatched( int expected, int received );
+    void handle( ComException exception );
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/IllegalProtocolVersionException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/IllegalProtocolVersionException.java
@@ -67,4 +67,10 @@ public class IllegalProtocolVersionException extends ComException
     {
         return received;
     }
+
+    @Override
+    public String toString()
+    {
+        return "IllegalProtocolVersionException{expected=" + expected + ", received=" + received + "}";
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -488,7 +488,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 requestContextFactory );
         highAvailabilityModeSwitcher =
                 new HighAvailabilityModeSwitcher( new SwitchToSlave(logging.getConsoleLog( HighAvailabilityModeSwitcher.class ), config, getDependencyResolver(), (HaIdGeneratorFactory) idGeneratorFactory,
-                        logging, masterDelegateInvocationHandler, clusterMemberAvailability, requestContextFactory),
+                        logging, masterDelegateInvocationHandler, clusterMemberAvailability, requestContextFactory, clusterClient ),
                         new SwitchToMaster( logging, msgLog, this,
                         (HaIdGeneratorFactory) idGeneratorFactory, config, getDependencyResolver(), masterDelegateInvocationHandler, clusterMemberAvailability ),
                         clusterClient, clusterMemberAvailability, logging.getMessagesLog( HighAvailabilityModeSwitcher.class ));

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
@@ -279,8 +279,10 @@ public enum HighAvailabilityMemberState
                     {
                         return TO_MASTER;
                     }
-                    // We need to go through slave switching process once again as
-                    // it is possible that we've missed elections and have stale epoch
+                    if ( masterId.equals( context.getElectedMasterId() ) )
+                    {
+                        return this;
+                    }
                     return PENDING;
                 }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -120,7 +120,7 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         return getClass().getSimpleName() + "[" + getCurrentState() + "]";
     }
 
-    private class StateMachineClusterEventListener extends ClusterMemberListener.Adapter
+    private class StateMachineClusterEventListener implements ClusterMemberListener
     {
         @Override
         public synchronized void coordinatorIsElected( InstanceId coordinatorId )
@@ -231,38 +231,22 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         }
 
         @Override
+        public void memberIsUnavailable( String role, InstanceId unavailableId )
+        {
+            if ( context.getMyId().equals( unavailableId ) &&
+                 HighAvailabilityModeSwitcher.SLAVE.equals( role ) &&
+                 state == HighAvailabilityMemberState.SLAVE )
+            {
+                changeStateToPending();
+            }
+        }
+
+        @Override
         public void memberIsFailed( InstanceId instanceId )
         {
-            if ( !isQuorum(getAliveCount(), getTotalCount()) )
+            if ( !isQuorum( getAliveCount(), getTotalCount() ) )
             {
-                try
-                {
-                    if(state.isAccessAllowed())
-                    {
-                        availabilityGuard.deny(HighAvailabilityMemberStateMachine.this);
-                    }
-
-                    final HighAvailabilityMemberChangeEvent event =
-                            new HighAvailabilityMemberChangeEvent(
-                                    state, HighAvailabilityMemberState.PENDING, null, null );
-                    state = HighAvailabilityMemberState.PENDING;
-                    Listeners.notifyListeners( memberListeners, new Listeners
-                            .Notification<HighAvailabilityMemberListener>()
-                    {
-                        @Override
-                        public void notify( HighAvailabilityMemberListener listener )
-                        {
-                            listener.instanceStops( event );
-                        }
-                    } );
-
-                    context.setAvailableHaMasterId( null );
-                    context.setElectedMasterId( null );
-                }
-                catch ( Throwable throwable )
-                {
-                    throw new RuntimeException( throwable );
-                }
+                changeStateToPending();
             }
         }
 
@@ -273,6 +257,31 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
             {
                 election.performRoleElections();
             }
+        }
+
+        private void changeStateToPending()
+        {
+            if ( state.isAccessAllowed() )
+            {
+                availabilityGuard.deny( HighAvailabilityMemberStateMachine.this );
+            }
+
+            final HighAvailabilityMemberChangeEvent event =
+                    new HighAvailabilityMemberChangeEvent( state, HighAvailabilityMemberState.PENDING, null, null );
+
+            state = HighAvailabilityMemberState.PENDING;
+
+            Listeners.notifyListeners( memberListeners, new Listeners.Notification<HighAvailabilityMemberListener>()
+            {
+                @Override
+                public void notify( HighAvailabilityMemberListener listener )
+                {
+                    listener.instanceStops( event );
+                }
+            } );
+
+            context.setAvailableHaMasterId( null );
+            context.setElectedMasterId( null );
         }
 
         private long getAliveCount()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/InvalidEpochException.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/InvalidEpochException.java
@@ -23,8 +23,19 @@ import org.neo4j.com.ComException;
 
 public class InvalidEpochException extends ComException
 {
+    private final long correctEpoch;
+    private final long invalidEpoch;
+
     public InvalidEpochException( long correctEpoch, long invalidEpoch )
     {
         super( "Invalid epoch " + invalidEpoch + ", correct epoch is " + correctEpoch );
+        this.correctEpoch = correctEpoch;
+        this.invalidEpoch = invalidEpoch;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "InvalidEpochException{correctEpoch=" + correctEpoch + ", invalidEpoch=" + invalidEpoch + "}";
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -19,15 +19,13 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import static org.neo4j.com.Protocol.readString;
-import static org.neo4j.com.Protocol.writeString;
+import org.jboss.netty.buffer.ChannelBuffer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.jboss.netty.buffer.ChannelBuffer;
+import org.neo4j.com.ComExceptionHandler;
 import org.neo4j.com.Deserializer;
-import org.neo4j.com.MismatchingVersionHandler;
 import org.neo4j.com.ObjectSerializer;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
@@ -36,6 +34,9 @@ import org.neo4j.com.TxExtractor;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.lock.LockResult;
 import org.neo4j.kernel.ha.lock.LockStatus;
+
+import static org.neo4j.com.Protocol.readString;
+import static org.neo4j.com.Protocol.writeString;
 
 public interface MasterClient extends Master
 {
@@ -92,5 +93,5 @@ public interface MasterClient extends Master
     public Response<Void> copyTransactions( RequestContext context, final String ds, final long startTxId,
             final long endTxId );
 
-    public void addMismatchingVersionHandler( MismatchingVersionHandler toAdd );
+    public void addComExceptionHandler( ComExceptionHandler handler );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
@@ -22,18 +22,31 @@ package org.neo4j.kernel.ha.com.slave;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.neo4j.com.MismatchingVersionHandler;
+import org.neo4j.cluster.client.ClusterClient;
+import org.neo4j.cluster.member.ClusterMemberAvailability;
+import org.neo4j.com.ComException;
+import org.neo4j.com.ComExceptionHandler;
+import org.neo4j.com.IllegalProtocolVersionException;
 import org.neo4j.kernel.ha.MasterClient196;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.com.master.InvalidEpochException;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
 
-public class MasterClientResolver implements MasterClientFactory, MismatchingVersionHandler
+public class MasterClientResolver implements MasterClientFactory
 {
     private volatile MasterClientFactory currentFactory;
     private volatile ProtocolVersionCombo currentVersion;
     private boolean downgradeForbidden = false;
+
+    private final Map<ProtocolVersionCombo,MasterClientFactory> protocolToFactoryMapping;
+    private final StringLogger log;
+
+    private final ClusterClient clusterClient;
+    private final ClusterMemberAvailability clusterMemberAvailability;
 
     @Override
     public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors, StoreId storeId, LifeSupport life )
@@ -42,16 +55,11 @@ public class MasterClientResolver implements MasterClientFactory, MismatchingVer
         {
             assignDefaultFactory();
         }
-        
-        MasterClient result = currentFactory.instantiate( hostNameOrIp, port, monitors, storeId, life );
-        result.addMismatchingVersionHandler( this );
-        return result;
-    }
 
-    @Override
-    public void versionMismatched( int expected, int received )
-    {
-        getFor( received, 2 );
+        MasterClient result = currentFactory.instantiate( hostNameOrIp, port, monitors, storeId, life );
+        result.addComExceptionHandler( new MismatchingProtocolVersionHandler() );
+        result.addComExceptionHandler( new InvalidEpochHandler() );
+        return result;
     }
 
     private static final class ProtocolVersionCombo implements Comparable<ProtocolVersionCombo>
@@ -97,11 +105,13 @@ public class MasterClientResolver implements MasterClientFactory, MismatchingVer
         static final ProtocolVersionCombo PC_196 = new ProtocolVersionCombo( 7, 2 );
     }
 
-    private final Map<ProtocolVersionCombo, MasterClientFactory> protocolToFactoryMapping;
-
-    public MasterClientResolver( Logging logging, int readTimeout, int lockReadTimeout, int channels,
-            int chunkSize )
+    public MasterClientResolver( Logging logging, ClusterClient clusterClient,
+            ClusterMemberAvailability clusterMemberAvailability, StringLogger msgLog,
+            int readTimeout, int lockReadTimeout, int channels, int chunkSize )
     {
+        this.log = msgLog;
+        this.clusterClient = clusterClient;
+        this.clusterMemberAvailability = clusterMemberAvailability;
         protocolToFactoryMapping = new HashMap<ProtocolVersionCombo, MasterClientFactory>();
         protocolToFactoryMapping.put( ProtocolVersionCombo.PC_18, new F18( logging, readTimeout, lockReadTimeout,
                 channels, chunkSize ) );
@@ -184,7 +194,37 @@ public class MasterClientResolver implements MasterClientFactory, MismatchingVer
                     readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize ) );
         }
     }
-    
+
+    private class MismatchingProtocolVersionHandler implements ComExceptionHandler
+    {
+        @Override
+        public void handle( ComException exception )
+        {
+            if ( exception instanceof IllegalProtocolVersionException )
+            {
+                log.info( "Handling " + exception + ", will pick new master client" );
+
+                IllegalProtocolVersionException illegalProtocolVersion = (IllegalProtocolVersionException) exception;
+                getFor( illegalProtocolVersion.getReceived(), 2 );
+            }
+        }
+    }
+
+    private class InvalidEpochHandler implements ComExceptionHandler
+    {
+        @Override
+        public void handle( ComException exception )
+        {
+            if ( exception instanceof InvalidEpochException )
+            {
+                log.info( "Handling " + exception + ", will go to PENDING and ask for election" );
+
+                clusterMemberAvailability.memberIsUnavailable( HighAvailabilityModeSwitcher.SLAVE );
+                clusterClient.performRoleElections();
+            }
+        }
+    }
+
     public void enableDowngradeBarrier()
     {
         downgradeForbidden = true;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateTest.java
@@ -277,9 +277,9 @@ public class HighAvailabilityMemberStateTest
         HighAvailabilityMemberState newStateCase2 = SLAVE.masterIsElected( context, new InstanceId( 3 ) );
         assertEquals( PENDING, newStateCase2 );
 
-        // CASE 3: It is the current master that got elected again - SLAVE should switch to PENDING
+        // CASE 3: It is the current master that got elected again - ignore
         HighAvailabilityMemberState newStateCase3 = SLAVE.masterIsElected( context, masterInstanceId );
-        assertEquals( PENDING, newStateCase3 );
+        assertEquals( SLAVE, newStateCase3 );
     }
 
     @Test


### PR DESCRIPTION
Currently slaves go to PENDING on every masterIsElected event. This introduces quite a lot of flakiness in cluster state.
This PR unifies handling of ComExceptions and adds special handler for IllegalEpochException, which will send instance to PENDING and ask for new elections.
SLAVE to PENDING switch is not performed if elected master is the same as previous one.