### PR TITLE
Return paths ending with / in root representation

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/discovery/DiscoveryService.java
@@ -53,8 +53,8 @@ public class DiscoveryService
     @Produces( MediaType.APPLICATION_JSON )
     public Response getDiscoveryDocument() throws URISyntaxException
     {
-        String webAdminManagementUri = configuration.get( ServerInternalSettings.management_api_path ).getPath();
-        String dataUri = configuration.get( ServerInternalSettings.rest_api_path ).getPath();
+        String webAdminManagementUri = configuration.get( ServerInternalSettings.management_api_path ).getPath() + "/";
+        String dataUri = configuration.get( ServerInternalSettings.rest_api_path ).getPath() + "/";
 
         return outputFormat.ok( new DiscoveryRepresentation( webAdminManagementUri, dataUri ) );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/discovery/DiscoveryServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/discovery/DiscoveryServiceTest.java
@@ -62,8 +62,8 @@ public class DiscoveryServiceTest
         assertThat( json, is( not( "\"\"" ) ) );
         assertThat( json, is( not( "null" ) ) );
 
-        assertThat( json, containsString( "\"management\" : \"" + baseUri + managementUri + "\"" ) );
-        assertThat( json, containsString( "\"data\" : \"" + baseUri + dataUri + "\"" ) );
+        assertThat( json, containsString( "\"management\" : \"" + baseUri + managementUri + "/\"" ) );
+        assertThat( json, containsString( "\"data\" : \"" + baseUri + dataUri + "/\"" ) );
 
     }
 
@@ -91,8 +91,8 @@ public class DiscoveryServiceTest
         assertThat( json, is( not( "\"\"" ) ) );
         assertThat( json, is( not( "null" ) ) );
 
-        assertThat( json, containsString( "\"management\" : \"" + managementUri + "\"" ) );
-        assertThat( json, containsString( "\"data\" : \"" + dataUri + "\"" ) );
+        assertThat( json, containsString( "\"management\" : \"" + managementUri + "/\"" ) );
+        assertThat( json, containsString( "\"data\" : \"" + dataUri + "/\"" ) );
 
     }
 


### PR DESCRIPTION
This avoids an unnecessary redirect, for drivers that (properly) follow hyperlinks.