### PR TITLE
Semantic error when using re-using variable in variable length pattern

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -442,6 +442,13 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     )
   }
 
+  test("prevent broken use of variables declared in var-length pattern") {
+    executeAndEnsureError(
+      "MATCH a, b, (a)-[r* {x: r.y}]->(b) RETURN *",
+      "Cannot use identifier r as a relation property when declared as a variable length relationship (line 1, column 25 (offset: 24))"
+    )
+  }
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.StringHelper._
 


### PR DESCRIPTION
Queries like `MATCH a, b, (a)-[r* {x: r.y}]->(b)` where `r` is really
a collection is currently failing at runtime. This is currently an invalid
query and should fail during semantic checking.