### PR TITLE
Make our interpretation of the `lsof` output more robust

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -144,7 +144,7 @@ detectrunning() {
   else
       ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
       ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F -Ts | grep '^\(p\|TST=LISTEN\)' | head -n 1)
       newpid=${newpid:1}
   fi
 }


### PR DESCRIPTION
Turns out the old grep filter would let 3 lines through where we only expected one. Now we filter only for the PID and the "TST=LISTEN" lines.