### PR TITLE
Pessimistic synchronization when patching chain positions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DenseNodeChainPosition.java
@@ -28,7 +28,6 @@ import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveIntObjectVisitor;
 import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
-import org.neo4j.function.primitive.PrimitiveLongPredicate;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
@@ -141,14 +140,6 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
     }
 
     @Override
-    public boolean atPosition( final PrimitiveLongPredicate predicate )
-    {
-        AnyPositionVisitor visitor = new AnyPositionVisitor( predicate );
-        positions.visitEntries( visitor );
-        return visitor.hit;
-    }
-
-    @Override
     public void patchPosition( final long nodeId, final FunctionFromPrimitiveLongLongToPrimitiveLong<RuntimeException> next )
     {
         positions.visitEntries( new PrimitiveIntObjectVisitor<RelationshipLoadingPosition,RuntimeException>()
@@ -174,28 +165,6 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
         StringBuilder builder = new StringBuilder( getClass().getSimpleName() + ":" );
         builder.append( format( "%n  positions: %s", positions ) );
         return builder.toString();
-    }
-
-    private static final class AnyPositionVisitor implements
-            PrimitiveIntObjectVisitor<RelationshipLoadingPosition,RuntimeException>
-    {
-        private final PrimitiveLongPredicate predicate;
-        private boolean hit;
-
-        private AnyPositionVisitor( PrimitiveLongPredicate predicate )
-        {
-            this.predicate = predicate;
-        }
-
-        @Override
-        public boolean visited( int key, RelationshipLoadingPosition value )
-        {
-            if ( value.atPosition( predicate ) )
-            {
-                hit = true;
-            }
-            return false;
-        }
     }
 
     private static class TypePosition implements RelationshipLoadingPosition
@@ -287,19 +256,6 @@ public class DenseNodeChainPosition implements RelationshipLoadingPosition
                 return directions.get( direction ).hasMore( direction, types ) ||
                         directions.get( DirectionWrapper.BOTH ).hasMore( direction, types );
             }
-        }
-
-        @Override
-        public boolean atPosition( PrimitiveLongPredicate predicate )
-        {
-            for ( RelationshipLoadingPosition position : directions.values() )
-            {
-                if ( position.atPosition( predicate ) )
-                {
-                    return true;
-                }
-            }
-            return false;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeImpl.java
@@ -696,16 +696,16 @@ public class NodeImpl extends ArrayBasedPrimitive
 
     public void updateRelationshipChainPosition( RelationshipHoles holes )
     {
-        if ( relChainPosition != null )
+        // If the position is EMPTY, i.e. it has reached the end there's no point in patching it
+        // However even if it's null, i.e. it hasn't even yet been initialized we must check under
+        // synchronization since a concurrent loader might initialize it simultaneously.
+        if ( relChainPosition != RelationshipLoadingPosition.EMPTY )
         {
-            if ( relChainPosition.atPosition( holes ) )
+            synchronized ( this )
             {
-                synchronized ( this )
+                if ( relChainPosition != null )
                 {
-                    if ( relChainPosition.atPosition( holes ) )
-                    {
-                        relChainPosition.patchPosition( getId(), holes );
-                    }
+                    relChainPosition.patchPosition( getId(), holes );
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipLoadingPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipLoadingPosition.java
@@ -86,17 +86,6 @@ public interface RelationshipLoadingPosition extends CloneableInPublic
     boolean atPosition( DirectionWrapper direction, int type, long position );
 
     /**
-     * Checks whether or not the chain is at a position such that the supplied {@code predicate} returns
-     * {@code true}.
-     *
-     * @param predicate {@link PrimitiveLongPredicate} capable of deciding whether or not a position
-     * (relationship id) is affected.
-     * @return {@code true} if the chain is at a position such that the supplied {@code predicate}
-     * {@code true}.
-     */
-    boolean atPosition( PrimitiveLongPredicate predicate );
-
-    /**
      * Used when relationships gets deleted in the middle of traversing their chain(s). Should only be called if
      * {@link #atPosition(PrimitiveLongPredicate)} returns {@code true}. Current positions can here be
      * moved to the next in use relationship if the current position happens to point to a deleted relationship.
@@ -133,12 +122,6 @@ public interface RelationshipLoadingPosition extends CloneableInPublic
 
         @Override
         public boolean atPosition( DirectionWrapper direction, int type, long position )
-        {
-            return false;
-        }
-
-        @Override
-        public boolean atPosition( PrimitiveLongPredicate predicate )
         {
             return false;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/SingleChainPosition.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.core;
 
 import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
-import org.neo4j.function.primitive.PrimitiveLongPredicate;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 
@@ -56,12 +55,6 @@ public class SingleChainPosition implements RelationshipLoadingPosition
     public boolean atPosition( DirectionWrapper direction, int type, long position )
     {
         return this.position == position;
-    }
-
-    @Override
-    public boolean atPosition( PrimitiveLongPredicate predicate )
-    {
-        return predicate.accept( position );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,15 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.function.primitive.FunctionFromPrimitiveLongLongToPrimitiveLong;
-import org.neo4j.function.primitive.PrimitiveLongPredicate;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -505,12 +504,6 @@ public class TestNeoStore
         public boolean atPosition( DirectionWrapper direction, int type, long position )
         {
             return actual.atPosition( direction, type, position );
-        }
-
-        @Override
-        public boolean atPosition( PrimitiveLongPredicate predicate )
-        {
-            return actual.atPosition( predicate );
         }
 
         @Override


### PR DESCRIPTION
for patching cached nodes (NodeImpl) when relationships have been deleted.
The scenario can be outlined below:

````
Given node N with chain position
4-->3-->2-->1-->0
        ^

T1 starts loading (getMoreRelationships() under synchronization)
4-->3-->2-->1-->0
        ^

T2 simultaneously commits tx which deletes 1
4-->3-->2-->1-->0
          ^

T1 tries to load 1, fails and remains here
before returning
4-->3-->2-->1-->0
            ^

T2 checks-and-patches the chain position, skips since chain position
   not at deleted rel
4-->3-->2-->1-->0
            ^

T1 returns its loaded rels (only rel 2) and chain position 1.
The chain position in that node is now forever broken.
````

Previously there was no guard against this scenario. The patching of
relationship chains for nodes with deleted relationships used to be
preceded by a double-checked locking where the check was whether or not
any chain was currently at a deleted relationship. The above scenario
shows that that kind of optimistic locking doesn't work, and so this
commit instead always pessimistically grabs the NodeImpl monitor before
checking whether or not any chain position should be patched. This way the
coordination with concurrent loaders work as intended.

As a side note one could argue that it's unnecessary to, in order to
update a NodeImpl about deleted relationship changes we affected NodeImpl
instances needs to be locked one more time in addition to synchronization
entialed by "normal" relationship/property cache updates. An effort to try
to get this chain position updating into another "normal" update block
could be benefitial.