### PR TITLE
Clears cached tokens in TokenHolder before loading new ones

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -574,11 +574,11 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 }
                 neoStoreModule.neoStore().makeStoreOk();
 
-                propertyKeyTokenHolder.addTokens(
+                propertyKeyTokenHolder.setInitialTokens(
                         neoStoreModule.neoStore().getPropertyKeyTokenStore().getTokens( Integer.MAX_VALUE ) );
-                relationshipTypeTokens.addTokens(
+                relationshipTypeTokens.setInitialTokens(
                         neoStoreModule.neoStore().getRelationshipTypeTokenStore().getTokens( Integer.MAX_VALUE ) );
-                labelTokens.addTokens( neoStoreModule.neoStore().getLabelTokenStore().getTokens( Integer.MAX_VALUE ) );
+                labelTokens.setInitialTokens( neoStoreModule.neoStore().getLabelTokenStore().getTokens( Integer.MAX_VALUE ) );
 
                 if ( neoStore.getCounts() == null )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
@@ -57,8 +57,11 @@ public abstract class TokenHolder<TOKEN extends Token> extends LifecycleAdapter
         this.tokenCreator = tokenCreator;
     }
 
-    public void addTokens( Token... tokens ) throws NonUniqueTokenException
+    public void setInitialTokens( Token... tokens ) throws NonUniqueTokenException
     {
+        nameToId.clear();
+        idToToken.clear();
+
         Map<String,Integer> newNameToId = new HashMap<>();
         Map<Integer,TOKEN> newIdToToken = new HashMap<>();
 
@@ -180,13 +183,6 @@ public abstract class TokenHolder<TOKEN extends Token> extends LifecycleAdapter
     public Iterable<TOKEN> getAllTokens()
     {
         return idToToken.values();
-    }
-
-    @Override
-    public void stop()
-    {
-        nameToId.clear();
-        idToToken.clear();
     }
 
     protected abstract TOKEN newToken( String name, int id );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class TokenHolderTest
+{
+    @Test
+    public void shouldClearTokensAsPartOfInitialTokenLoading() throws Exception
+    {
+        // GIVEN
+        TokenCreator creator = mock( TokenCreator.class );
+        TokenHolder<Token> holder = new TokenHolder<Token>( creator )
+        {
+            @Override
+            protected Token newToken( String name, int id )
+            {
+                return new Token( name, id );
+            }
+        };
+        holder.setInitialTokens(
+                token( "one", 1 ),
+                token( "two", 2 ) );
+        assertTokens( holder.getAllTokens(),
+                token( "one", 1 ),
+                token( "two", 2 ) );
+
+        // WHEN
+        holder.setInitialTokens(
+                token( "two", 2 ),
+                token( "three", 3 ),
+                token( "four", 4 ) );
+
+        // THEN
+        assertTokens( holder.getAllTokens(),
+                token( "two", 2 ),
+                token( "three", 3 ),
+                token( "four", 4 ) );
+    }
+
+    private void assertTokens( Iterable<Token> allTokens, Token... expectedTokens )
+    {
+        Map<String,Token> existing = new HashMap<>();
+        for ( Token token : allTokens )
+        {
+            existing.put( token.name(), token );
+        }
+        Map<String,Token> expected = new HashMap<>();
+        for ( Token token : expectedTokens )
+        {
+            expected.put( token.name(), token );
+        }
+        assertEquals( expected, existing );
+    }
+
+    private Token token( String name, int id )
+    {
+        return new Token( name, id );
+    }
+}


### PR DESCRIPTION
instead of during stop since there's a window of opportunity for a
concurrent shutdown and a transaction racing so that the thread shutting
down makes it as far as clearing the token maps right before the
transaction thread tries to create a relationship of a certain type, sees
that it's not there and decides to create it. At this point the
transaction thread got past the availability guard right before it shut
down and at the point where it's at for the moment there are enough
components alive in the database to have the transaction complete.

The end result would be that there would now exist duplicate tokens with
the same name, but different ids, something that would be observed the
next startup.

This scenario is very hard to test for with making a brittle and
potentially flaky test.