### PR TITLE
Allow kernel extensions to depend on other kernel extensions.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
@@ -50,6 +50,15 @@ public interface DependencyResolver
     <T> T resolveDependency( Class<T> type, SelectionStrategy selector ) throws IllegalArgumentException;
 
     /**
+     * Check if a dependency can be resolved by this resolver. This allows you to check for the existence of
+     * dependencies without treating their non-existence as exceptional.
+     * @param type the type of {@link Class} that the returned instance must implement.
+     * @param <T>
+     * @return true if at least one instance of the specified type exists
+     */
+    <T> boolean canResolve( Class<T> type );
+
+    /**
      * Responsible for making the choice between available candidates.
      */
     interface SelectionStrategy
@@ -91,6 +100,23 @@ public interface DependencyResolver
         public <T> T resolveDependency( Class<T> type ) throws IllegalArgumentException
         {
             return resolveDependency( type, FIRST );
+        }
+
+        @Override
+        public <T> boolean canResolve( Class<T> type )
+        {
+            try
+            {
+                // Flow control by exception by design, this was added after the resolveDependency method,
+                // and because this class is public API, to to avoid breaking client implementations (based on the
+                // assumption that they extend this public adapter), we provide this default implementation.
+                resolveDependency( type );
+                return true;
+            }
+            catch(IllegalArgumentException e)
+            {
+                return false;
+            }
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
@@ -25,4 +25,9 @@ public class UnsatisfiedDependencyException extends RuntimeException
     {
         super( cause );
     }
+
+    public UnsatisfiedDependencyException( String msg )
+    {
+        super(msg);
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.extension;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertNotNull;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+public class KernelExtensionsTest
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldHandleExtensionsThatDependOnEachOther() throws Throwable
+    {
+        // Given
+        LifeSupport life = new LifeSupport();
+        Dependencies dependencies = new Dependencies();
+        KernelExtensions extensions = life.add( new KernelExtensions(
+                asList(
+                    new DependsOnExtensionA.Factory(),
+                    new ExtensionA.Factory() ),
+                new Config(), dependencies, UnsatisfiedDependencyStrategies.fail() ));
+
+        // When
+        life.start();
+
+        // Then no exception should've been thrown
+        // And when
+        ExtensionA extA = extensions.resolveDependency( ExtensionA.class );
+        DependsOnExtensionA depsOnExtA = extensions.resolveDependency( DependsOnExtensionA.class );
+
+        // Then
+        assertNotNull( extA );
+        assertNotNull( depsOnExtA );
+
+        assertThat( depsOnExtA.extension, equalTo(extA) );
+    }
+
+    @Test
+    public void shouldDescribeMissingDependenciesWell() throws Throwable
+    {
+        // Given
+        LifeSupport life = new LifeSupport();
+        Dependencies dependencies = new Dependencies();
+        KernelExtensions extensions = life.add( new KernelExtensions(
+                asList(
+                    new DependsOnExtensionA.Factory(),
+                    new ExtensionB.Factory() ),
+                new Config(), dependencies, UnsatisfiedDependencyStrategies.fail() ));
+
+        // Expect
+        exception.expectCause( hasMessage( equalTo("Unable to instantiate Factory, " +
+                                           "unable to satisfy the following dependencies: [ExtensionA].") ) );
+
+        // When
+        life.start();
+    }
+
+    public static class ExtensionA extends LifecycleAdapter
+    {
+        public static class Factory extends KernelExtensionFactory<Factory.Dependencies>
+        {
+            public interface Dependencies
+            {
+
+            }
+
+            protected Factory()
+            {
+                super( "extension-a" );
+            }
+
+            @Override
+            public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
+            {
+                return new ExtensionA();
+            }
+
+        }
+    }
+
+    public static class ExtensionB extends LifecycleAdapter
+    {
+        public static class Factory extends KernelExtensionFactory<Factory.Dependencies>
+        {
+            public interface Dependencies
+            {
+
+            }
+
+            protected Factory()
+            {
+                super( "extension-b" );
+            }
+
+            @Override
+            public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
+            {
+                return new ExtensionB();
+            }
+
+        }
+    }
+
+    public static class DependsOnExtensionA extends LifecycleAdapter
+    {
+        public static class Factory extends KernelExtensionFactory<Factory.Dependencies>
+        {
+            public interface Dependencies
+            {
+                ExtensionA extension();
+            }
+
+            protected Factory()
+            {
+                super( "extension-b" );
+            }
+
+            @Override
+            public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
+            {
+                return new DependsOnExtensionA(dependencies.extension());
+            }
+
+        }
+
+        private final ExtensionA extension;
+
+        public DependsOnExtensionA( ExtensionA extension )
+        {
+            this.extension = extension;
+        }
+    }
+}


### PR DESCRIPTION
- Introduce a simple algorithm for deducing the required instantiation-order
  of kernel extensions by looping over factories over and over, instantiating each one we
  have all dependencies for, until none remain.

  Not super efficient, but since kernel extensions are relatively few and only
  instantiated once, at boot time, this shouldn't be an issue any time soon.

  This will allow us to move to a more modular approach over time, with major
  components declaring which components they require, and each properly
  implementing lifecycle.

  It does move further in a direction that risks obfuscating the dependency
  tree - but frankly the dependency tree is hard to follow anyway, and this way
  it will at least be explicitly expressed in the KernelExtensionFactory
  classes.

  This is desired, although not required, by Mjolnir, which wishes to consist
  of multiple services with clean interfaces between each other and other
  database services. Rather than introducing more manually written component
  wiring code, this solves it in a general way for services in the kernel.