### PR TITLE
Building correct paths for undirected relationships patterns.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/commands/ExpressionConverters.scala
@@ -395,14 +395,20 @@ object ExpressionConverters {
         case SingleRelationshipPathStep(Identifier(rel), Direction.INCOMING, next) =>
           singleIncomingRelationshipProjector(rel, project(next))
 
-        case SingleRelationshipPathStep(Identifier(rel), _, next) =>
+        case SingleRelationshipPathStep(Identifier(rel), Direction.OUTGOING, next) =>
           singleOutgoingRelationshipProjector(rel, project(next))
+
+        case SingleRelationshipPathStep(Identifier(rel), Direction.BOTH, next) =>
+          singleUndirectedRelationshipProjector(rel, project(next))
 
         case MultiRelationshipPathStep(Identifier(rel), Direction.INCOMING, next) =>
           multiIncomingRelationshipProjector(rel, project(next))
 
-        case MultiRelationshipPathStep(Identifier(rel), _, next) =>
+        case MultiRelationshipPathStep(Identifier(rel), Direction.OUTGOING, next) =>
           multiOutgoingRelationshipProjector(rel, project(next))
+
+        case MultiRelationshipPathStep(Identifier(rel), Direction.BOTH, next) =>
+          multiUndirectedRelationshipProjector(rel, project(next))
 
         case NilPathStep =>
           nilProjector

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/ProjectedPath.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/ProjectedPath.scala
@@ -47,6 +47,11 @@ object ProjectedPath {
       tailProjector(ctx, builder.addOutgoingRelationship(ctx(rel).asInstanceOf[Relationship]))
   }
 
+  case class singleUndirectedRelationshipProjector(rel: String, tailProjector: Projector) extends Projector {
+    def apply(ctx: ExecutionContext, builder: PathValueBuilder) =
+      tailProjector(ctx, builder.addUndirectedRelationship(ctx(rel).asInstanceOf[Relationship]))
+  }
+
   case class multiIncomingRelationshipProjector(rel: String, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, builder: PathValueBuilder) =
       tailProjector(ctx, builder.addIncomingRelationships(ctx(rel).asInstanceOf[Iterable[Relationship]]))
@@ -55,6 +60,11 @@ object ProjectedPath {
   case class multiOutgoingRelationshipProjector(rel: String, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, builder: PathValueBuilder) =
       tailProjector(ctx, builder.addOutgoingRelationships(ctx(rel).asInstanceOf[Iterable[Relationship]]))
+  }
+
+  case class multiUndirectedRelationshipProjector(rel: String, tailProjector: Projector) extends Projector {
+    def apply(ctx: ExecutionContext, builder: PathValueBuilder) =
+      tailProjector(ctx, builder.addUndirectedRelationships(ctx(rel).asInstanceOf[Iterable[Relationship]]))
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/PathValueBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/PathValueBuilderTest.scala
@@ -59,6 +59,24 @@ class PathValueBuilderTest extends CypherFunSuite {
     builder.result() should equal(new PathImpl(node2, rel1, node1))
   }
 
+  test("p = (a)-[r:X]-(b)") {
+    val builder = new PathValueBuilder
+
+    builder.addNode(node1)
+      .addUndirectedRelationship(rel1)
+
+    builder.result() should equal(new PathImpl(node1, rel1, node2))
+  }
+
+  test("p = (b)-[r:X]-(a)") {
+    val builder = new PathValueBuilder
+
+    builder.addNode(node2)
+      .addUndirectedRelationship(rel1)
+
+    builder.result() should equal(new PathImpl(node2, rel1, node1))
+  }
+
   test("p = <empty> should throw") {
     val builder = new PathValueBuilder
 
@@ -99,6 +117,24 @@ class PathValueBuilderTest extends CypherFunSuite {
 
     builder.addNode(node1)
       .addIncomingRelationships(null)
+
+    builder.result() should equal(null)
+  }
+
+  test("p = (b)-[r:X*]-(a)") {
+    val builder = new PathValueBuilder
+
+    builder.addNode(node3)
+      .addUndirectedRelationships(Iterable(rel2, rel1))
+
+    builder.result() should equal(new PathImpl(node3, rel2, node2, rel1, node1))
+  }
+
+  test("p = (b)-[r:X*]-(a) when rels is null") {
+    val builder = new PathValueBuilder
+
+    builder.addNode(node1)
+      .addUndirectedRelationships(null)
 
     builder.result() should equal(null)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1778,4 +1778,21 @@ return b
     //THEN
     result.toList should equal (List(Map("host" -> host), Map("host" -> null)))
   }
+
+  test("Undirected paths should be properly handled") {
+    //GIVEN
+    val node1 = createLabeledNode("Movie")
+    val node2 = createNode()
+    val rel = relate(node2, node1)
+
+    val query =
+      """profile match p = (n:Movie)--(m) return p limit 1""".stripMargin
+
+    graph.inTx {
+      val res = executeWithNewPlanner(query).toList
+      val path = res.head("p").asInstanceOf[Path]
+      path.startNode should equal(node1)
+      path.endNode should equal(node2)
+    }
+  }
 }


### PR DESCRIPTION
PathValueBuilder must keep track of direction for undirected paths.