### PR TITLE
Don't prematurely delete the temp store dir when we receive a cancellation request during store copy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyMonitor.java
@@ -21,7 +21,8 @@ package org.neo4j.kernel.monitoring;
 
 import java.io.File;
 
-public interface BackupMonitor {
+public interface StoreCopyMonitor
+{
 
     void startCopyingFiles();
 
@@ -29,19 +30,28 @@ public interface BackupMonitor {
 
     void finishedRotatingLogicalLogs();
 
-    void streamedFile( File storefile );
+    void streamedFile( File file );
 
-    void streamingFile( File storefile );
+    void streamingFile( File file );
 
-    public static final BackupMonitor NONE = new BackupMonitor()
+    void recoveredStore();
+
+    public static final StoreCopyMonitor NONE = new Adaptor();
+
+    class Adaptor implements StoreCopyMonitor
     {
         @Override
-        public void streamingFile( File storefile )
+        public void streamingFile( File file )
         {   // Do nothing
         }
 
         @Override
-        public void streamedFile( File storefile )
+        public void recoveredStore()
+        {   // Do nothing
+        }
+
+        @Override
+        public void streamedFile( File file )
         {   // Do nothing
         }
 
@@ -59,5 +69,5 @@ public interface BackupMonitor {
         public void finishedCopyingStoreFiles()
         {   // Do nothing
         }
-    };
+    }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -31,12 +31,12 @@ import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.nioneo.store.StoreId;
 import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.kernel.monitoring.BackupMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 class BackupImpl implements TheBackupInterface
 {
-    private final BackupMonitor backupMonitor;
+    private final StoreCopyMonitor storeCopyMonitor;
 
     public interface SPI
     {
@@ -58,18 +58,18 @@ class BackupImpl implements TheBackupInterface
         this.spi = spi;
         this.xaDataSourceManager = xaDataSourceManager;
         this.kpeg = kpeg;
-        this.backupMonitor = monitors.newMonitor( BackupMonitor.class, getClass() );
+        this.storeCopyMonitor = monitors.newMonitor( StoreCopyMonitor.class, getClass() );
     }
 
     @Override
     public Response<Void> fullBackup( StoreWriter writer )
     {
-        backupMonitor.startCopyingFiles();
+        storeCopyMonitor.startCopyingFiles();
         RequestContext context = ServerUtil.rotateLogsAndStreamStoreFiles( spi.getStoreDir(),
                 xaDataSourceManager,
-                kpeg, logger, false, writer, new DefaultFileSystemAbstraction(), backupMonitor );
+                kpeg, logger, false, writer, new DefaultFileSystemAbstraction(), storeCopyMonitor );
         writer.done();
-        backupMonitor.finishedCopyingStoreFiles();
+        storeCopyMonitor.finishedCopyingStoreFiles();
         return packResponse( context );
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 
 class BackupService
 {
@@ -126,7 +127,7 @@ class BackupService
         try
         {
             RemoteStoreCopier storeCopier = new RemoteStoreCopier( tuningConfiguration, loadKernelExtensions(),
-                    new ConsoleLogger( StringLogger.SYSTEM ), new DefaultFileSystemAbstraction() );
+                    new ConsoleLogger( StringLogger.SYSTEM ), new DefaultFileSystemAbstraction(), new Monitors());
             storeCopier.copyStore( new RemoteStoreCopier.StoreCopyRequester()
             {
                 private BackupClient client;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -57,7 +57,7 @@ import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.LogIoUtils;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.kernel.monitoring.BackupMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.Mute;
@@ -400,37 +400,19 @@ public class BackupServiceIT
         Config config = new Config( defaultBackupPortHostParams() );
 
         Monitors monitors = new Monitors();
-        monitors.addMonitorListener( new BackupMonitor()
+        monitors.addMonitorListener( new StoreCopyMonitor.Adaptor()
         {
             @Override
-            public void startCopyingFiles()
-            {
-
-            }
-
-            @Override
-            public void finishedCopyingStoreFiles()
-            {
-
-            }
-
-            @Override
-            public void finishedRotatingLogicalLogs()
-            {
-
-            }
-
-            @Override
-            public void streamedFile( File storefile )
+            public void streamedFile( File file )
             {
                 if ( neitherStoreHasBeenStreamed() )
                 {
-                    if ( storefile.getAbsolutePath().contains( NODE_STORE ) )
+                    if ( file.getAbsolutePath().contains( NODE_STORE ) )
                     {
                         storesThatHaveBeenStreamed.add( NODE_STORE );
                         firstStoreFinishedStreaming.countDown();
                     }
-                    else if ( storefile.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
+                    else if ( file.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
                     {
                         storesThatHaveBeenStreamed.add(RELATIONSHIP_STORE);
                         firstStoreFinishedStreaming.countDown();
@@ -444,9 +426,9 @@ public class BackupServiceIT
             }
 
             @Override
-            public void streamingFile( File storefile )
+            public void streamingFile( File file )
             {
-                if ( storefile.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
+                if ( file.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
                 {
                     if ( streamedFirst( NODE_STORE ) )
                     {
@@ -460,7 +442,7 @@ public class BackupServiceIT
                         }
                     }
                 }
-                else if ( storefile.getAbsolutePath().contains( NODE_STORE ) )
+                else if ( file.getAbsolutePath().contains( NODE_STORE ) )
                 {
                     if ( streamedFirst( RELATIONSHIP_STORE ) )
                     {

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerUtilTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerUtilTest.java
@@ -52,7 +52,7 @@ import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.impl.transaction.xaframework.XaLogicalLog;
 import org.neo4j.kernel.impl.transaction.xaframework.XaResourceManager;
 import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.kernel.monitoring.BackupMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -103,7 +103,7 @@ public class ServerUtilTest
 
         // when
         ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
-                StringLogger.DEV_NULL, false, storeWriter, fs, BackupMonitor.NONE );
+                StringLogger.DEV_NULL, false, storeWriter, fs, StoreCopyMonitor.NONE );
 
         // then
         verify( storeWriter ).write( eq( "neostore.nodestore.db" ), any( ReadableByteChannel.class ),
@@ -147,7 +147,7 @@ public class ServerUtilTest
 
         // when
         ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
-                StringLogger.DEV_NULL, true, storeWriter, fs, BackupMonitor.NONE );
+                StringLogger.DEV_NULL, true, storeWriter, fs, StoreCopyMonitor.NONE );
 
         // then
         verify( storeWriter ).write( eq( "nioneo_logical.log.v0" ), any( ReadableByteChannel.class ),
@@ -187,7 +187,7 @@ public class ServerUtilTest
 
         // when
         ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager, kernelPanicEventGenerator,
-                StringLogger.DEV_NULL, true, storeWriter, fs, BackupMonitor.NONE );
+                StringLogger.DEV_NULL, true, storeWriter, fs, StoreCopyMonitor.NONE );
 
         // then
         verify( storeWriter ).write( eq( "neostore.nodestore.db" ), any( ReadableByteChannel.class ),
@@ -231,7 +231,7 @@ public class ServerUtilTest
         {
             ServerUtil.rotateLogsAndStreamStoreFiles( testDirectory.absolutePath(), dsManager,
                     kernelPanicEventGenerator,
-                    StringLogger.DEV_NULL, true, storeWriter, fs, BackupMonitor.NONE );
+                    StringLogger.DEV_NULL, true, storeWriter, fs, StoreCopyMonitor.NONE );
             fail( "should have thrown exception" );
         }
         catch ( ServerFailureException e )

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ThirdPartyDSStoreCopyIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ThirdPartyDSStoreCopyIT.java
@@ -55,7 +55,7 @@ import org.neo4j.kernel.impl.util.ResourceIterators;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
-import org.neo4j.kernel.monitoring.BackupMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.TargetDirectory;
 
@@ -97,7 +97,8 @@ public class ThirdPartyDSStoreCopyIT
         final String copyDir = new File(testDir.directory(), "copy").getAbsolutePath();
         final String originalDir = new File(testDir.directory(), "original").getAbsolutePath();
         Config config = new Config( MapUtil.stringMap( store_dir.name(), copyDir ) );
-        RemoteStoreCopier copier = new RemoteStoreCopier( config, loadKernelExtensions(), new ConsoleLogger( StringLogger.DEV_NULL ), fs );
+        RemoteStoreCopier copier = new RemoteStoreCopier( config, loadKernelExtensions(), new ConsoleLogger(
+                StringLogger.DEV_NULL ), fs, new Monitors() );
 
         // When
         copier.copyStore( new RemoteStoreCopier.StoreCopyRequester()
@@ -116,7 +117,7 @@ public class ThirdPartyDSStoreCopyIT
                             dsManager,
                             original.getDependencyResolver().resolveDependency( KernelPanicEventGenerator.class ),
                             StringLogger.SYSTEM, false, writer, fs,
-                            original.getDependencyResolver().resolveDependency( Monitors.class ).newMonitor( BackupMonitor.class ) );
+                            original.getDependencyResolver().resolveDependency( Monitors.class ).newMonitor( StoreCopyMonitor.class ) );
 
                     return ServerUtil.packResponse( original.storeId(), dsManager, ctx, null, ServerUtil.ALL );
                 } finally

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -56,7 +56,7 @@ import org.neo4j.kernel.impl.transaction.XaDataSourceManager;
 import org.neo4j.kernel.impl.transaction.xaframework.TxIdGenerator;
 import org.neo4j.kernel.impl.transaction.xaframework.XaDataSource;
 import org.neo4j.kernel.logging.Logging;
-import org.neo4j.kernel.monitoring.BackupMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 class DefaultMasterImplSPI implements MasterImpl.SPI
@@ -210,7 +210,7 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
                 true,
                 writer,
                 new DefaultFileSystemAbstraction(),
-                monitors.newMonitor( BackupMonitor.class, getClass() ) );
+                monitors.newMonitor( StoreCopyMonitor.class, getClass() ) );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -93,6 +93,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.StoreCopyMonitor;
 
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.getServerId;
 import static org.neo4j.kernel.impl.nioneo.store.NeoStore.isStorePresent;
@@ -379,7 +380,8 @@ public class SwitchToSlave
             // This will move the copied db to the graphdb location
             console.log( "Copying store from master" );
             new RemoteStoreCopier( config, kernelExtensions, console,
-                    fs ).copyStore( new RemoteStoreCopier.StoreCopyRequester()
+                    fs, monitors ).copyStore( new RemoteStoreCopier
+                    .StoreCopyRequester()
 
             {
                 @Override


### PR DESCRIPTION
* Hopefully fixes RequestContextFactory.newRequestContext NPE - were
  able to reproduce the exception by forcing a cancellation after recovery
  of tempDb after store copy.
* Repurpose the BackupMonitor to be a StoreCopierMonitor that we can use
  to track how far we've got with store copying in backup & slave store
  copy
* Add tests to simulate the various places where store copy can be
  cancelled and assert the expect behaviour