### PR TITLE
Revert "When a file is expanded, pool the previously used buffer."

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -1151,9 +1151,9 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
                     }
                 }
             }
-            return ByteBuffer.allocate( (sizeIndex < SIZES.length) ? SIZES[sizeIndex]
-                    : ((sizeIndex - SIZES.length + 1) *
-                    SIZES[SIZES.length - 1]) );
+            return ByteBuffer.allocateDirect( (sizeIndex < SIZES.length) ? SIZES[sizeIndex]
+                                                                         : ((sizeIndex - SIZES.length + 1) *
+                                                                            SIZES[SIZES.length - 1]) );
         }
 
         void free()
@@ -1244,7 +1244,6 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             ByteBuffer buf = allocate( sizeIndex );
             this.buf.position( 0 );
             buf.put( this.buf );
-            free();
             this.buf = buf;
             this.buf.position( oldPosition );
         }


### PR DESCRIPTION
This reverts commit 2a0056c5597d6c7611b52ab60e83a2b35a9a7048.

The change was causing various test to fail, e.g., `IndexStatisticsTest`.