### PR TITLE
More robust way of allocating memory in NumberArrayFactory

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/AvailableMemoryCalculator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/AvailableMemoryCalculator.java
@@ -39,19 +39,29 @@ public interface AvailableMemoryCalculator
         @Override
         public long availableOffHeapMemory()
         {
+            return osBean().getFreePhysicalMemorySize();
+        }
+
+        private com.sun.management.OperatingSystemMXBean osBean()
+        {
             com.sun.management.OperatingSystemMXBean bean =
                     (com.sun.management.OperatingSystemMXBean)
                     java.lang.management.ManagementFactory.getOperatingSystemMXBean();
-            long osMemory = bean.getTotalPhysicalMemorySize();
-            return osMemory-Runtime.getRuntime().maxMemory();
+            return bean;
         }
 
         @Override
         public long availableHeapMemory()
         {
+            Runtime runtime = runtime();
+            return runtime.maxMemory() - runtime.totalMemory();
+        }
+
+        private Runtime runtime()
+        {
             System.gc();
             Runtime runtime = Runtime.getRuntime();
-            return runtime.maxMemory() - runtime.totalMemory();
+            return runtime;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import java.util.Arrays;
+
+import org.neo4j.helpers.Exceptions;
+
 import static java.lang.String.format;
 
 import static org.neo4j.helpers.Format.bytes;
@@ -93,6 +97,12 @@ public interface NumberArrayFactory
         {
             return new HeapLongArray( safeCastLongToInt( length ), defaultValue );
         }
+
+        @Override
+        public String toString()
+        {
+            return "HEAP";
+        }
     };
 
     /**
@@ -111,6 +121,12 @@ public interface NumberArrayFactory
         {
             return new OffHeapLongArray( length, defaultValue );
         }
+
+        @Override
+        public String toString()
+        {
+            return "OFF_HEAP";
+        }
     };
 
     /**
@@ -120,70 +136,65 @@ public interface NumberArrayFactory
      */
     public static class Auto extends Adapter
     {
-        private final AvailableMemoryCalculator calculator;
-        private final long margin;
+        private final NumberArrayFactory[] candidates;
 
-        public Auto( AvailableMemoryCalculator calculator, long margin )
+        public Auto( NumberArrayFactory... candidates )
         {
-            this.calculator = calculator;
-            this.margin = margin;
+            this.candidates = candidates;
         }
 
         @Override
         public LongArray newLongArray( long length, long defaultValue )
         {
-            return mostAppropriateFactory( length, 8 ).newLongArray( length, defaultValue );
+            OutOfMemoryError error = null;
+            for ( NumberArrayFactory candidate : candidates )
+            {
+                try
+                {
+                    return candidate.newLongArray( length, defaultValue );
+                }
+                catch ( OutOfMemoryError e )
+                {   // Allright let's try the next one
+                    error = e;
+                }
+            }
+            throw error( length, 8, error );
         }
 
         @Override
         public IntArray newIntArray( long length, int defaultValue )
         {
-            return mostAppropriateFactory( length, 4 ).newIntArray( length, defaultValue );
-        }
-
-        private NumberArrayFactory mostAppropriateFactory( long length, int i )
-        {
-            long bytesRequired = length * 8;
-
-            // Try to fit it outside heap
-            long freeOffHeap = calculator.availableOffHeapMemory() - margin;
-            if ( bytesRequired < freeOffHeap )
-            {
-                return OFF_HEAP;
-            }
-
-            // Otherwise, try to fit it in heap
-            long freeHeap = calculator.availableHeapMemory() - margin;
-            if ( bytesRequired < Integer.MAX_VALUE && bytesRequired < freeHeap )
+            OutOfMemoryError error = null;
+            for ( NumberArrayFactory candidate : candidates )
             {
                 try
                 {
-                    return HEAP;
+                    return candidate.newIntArray( length, defaultValue );
                 }
                 catch ( OutOfMemoryError e )
-                {   // It seems there wasn't room after all...
+                {   // Allright let's try the next one
+                    error = e;
                 }
             }
+            throw error( length, 4, error );
+        }
 
-            // If there's room for it, off-heap and on-heap collectively, then allocate a dynamic
-            // array (which can have parts on- and parts off-heap).
-            if ( bytesRequired < (freeHeap + freeOffHeap) )
-            {
-                // There is! (at the moment at least). OK, so for the sake of conformity return a factory
-                // that creates dynamic arrays even when requesting static arrays. Just because we can.
-                return CHUNKED_STATIC;
-            }
-
-            throw new IllegalArgumentException( format( "Neither enough free heap (%d), nor off-heap (%d) space " +
-                    "for allocating %s", freeHeap, freeOffHeap, bytes( bytesRequired ) ) );
+        private OutOfMemoryError error( long length, int itemSize, OutOfMemoryError error )
+        {
+            throw Exceptions.withMessage( error, format( "%s: Not enough memory available for allocating %s, tried %s",
+                    error.getMessage(), bytes( length*itemSize ), Arrays.toString( candidates ) ) );
         }
     }
 
     /**
-     * Used as part of the fallback strategy for {@link Auto}.
+     * Used as part of the fallback strategy for {@link Auto}. Tries to split up fixed-size arrays
+     * ({@link #newLongArray(long, long)} and {@link #newIntArray(long, int)} into smaller chunks where
+     * some can live on heap and some off heap.
      */
-    public static final NumberArrayFactory CHUNKED_STATIC = new Adapter()
+    public static final NumberArrayFactory CHUNKED_FIXED_SIZE = new Adapter()
     {
+        private final NumberArrayFactory delegate = new Auto( OFF_HEAP, HEAP );
+
         @Override
         public LongArray newLongArray( long length, long defaultValue )
         {
@@ -204,19 +215,24 @@ public interface NumberArrayFactory
         @Override
         public IntArray newDynamicIntArray( long chunkSize, int defaultValue )
         {
-            return new DynamicIntArray( AUTO, chunkSize, defaultValue );
+            return new DynamicIntArray( delegate, chunkSize, defaultValue );
         }
 
         @Override
         public LongArray newDynamicLongArray( long chunkSize, long defaultValue )
         {
-            return new DynamicLongArray( AUTO, chunkSize, defaultValue );
+            return new DynamicLongArray( delegate, chunkSize, defaultValue );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CHUNKED_FIXED_SIZE";
         }
     };
 
     /**
      * {@link Auto} factory which uses JVM stats for gathering information about available memory.
      */
-    public static final NumberArrayFactory AUTO = new Auto(
-            AvailableMemoryCalculator.RUNTIME, 300*1024*1024 );
+    public static final NumberArrayFactory AUTO = new Auto( OFF_HEAP, HEAP, CHUNKED_FIXED_SIZE );
 }


### PR DESCRIPTION
also, the AvailableMemoryCalculator#RUNTIME uses the correct OS bean
method for figuring out how much free memory there's available.