### PR TITLE
Cluster test made less flaky

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -26,9 +26,7 @@ import static org.neo4j.helpers.NamedThreadFactory.named;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -85,7 +83,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
     private final int maxUnusedChannels;
     private final StoreId storeId;
     private ResourceReleaser resourcePoolReleaser;
-    private final List<ComExceptionHandler> comExceptionHandlers;
+    private ComExceptionHandler comExceptionHandler;
 
     private final RequestMonitor requestMonitor;
 
@@ -104,7 +102,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         this.readTimeout = readTimeout;
         // ResourcePool no longer controls max concurrent channels. Use this value for the pool size
         this.maxUnusedChannels = maxConcurrentChannels;
-        this.comExceptionHandlers = new ArrayList<ComExceptionHandler>( 2 );
+        this.comExceptionHandler = ComExceptionHandler.NO_OP;
         this.address = new InetSocketAddress( hostNameOrIp, port );
         this.protocol = new Protocol( chunkSize, applicationProtocolVersion, getInternalProtocolVersion() );
 
@@ -189,7 +187,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         bootstrap.releaseExternalResources();
         bossExecutor.shutdownNow();
         workerExecutor.shutdownNow();
-        comExceptionHandlers.clear();
+        comExceptionHandler = ComExceptionHandler.NO_OP;
         msgLog.logMessage( toString() + " shutdown", true );
     }
 
@@ -249,10 +247,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         {
             failure = e;
             success = false;
-            for ( ComExceptionHandler handler : comExceptionHandlers )
-            {
-                handler.handle( e );
-            }
+            comExceptionHandler.handle( e );
             throw e;
         }
         catch ( Throwable e )
@@ -335,9 +330,9 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         return pipeline;
     }
 
-    public void addComExceptionHandler( ComExceptionHandler handler )
+    public void setComExceptionHandler( ComExceptionHandler handler )
     {
-        comExceptionHandlers.add( handler );
+        comExceptionHandler = (handler == null) ? ComExceptionHandler.NO_OP : handler;
     }
 
     protected byte getInternalProtocolVersion()

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -406,7 +406,7 @@ public class TestCommunication
 
         life.add( builder.server( communication ) );
         MadeUpClient client = life.add( builder.client() );
-        client.addComExceptionHandler( handler );
+        client.setComExceptionHandler( handler );
 
         life.start();
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -85,6 +85,8 @@ import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.DefaultSlaveFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.Slaves;
+import org.neo4j.kernel.ha.com.slave.InvalidEpochExceptionHandler;
+import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.ha.lock.LockManagerModeSwitcher;
 import org.neo4j.kernel.ha.management.ClusterDatabaseInfoProvider;
@@ -486,12 +488,33 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
     {
         idGeneratorFactory = new HaIdGeneratorFactory( masterDelegateInvocationHandler, logging,
                 requestContextFactory );
-        highAvailabilityModeSwitcher =
-                new HighAvailabilityModeSwitcher( new SwitchToSlave(logging.getConsoleLog( HighAvailabilityModeSwitcher.class ), config, getDependencyResolver(), (HaIdGeneratorFactory) idGeneratorFactory,
-                        logging, masterDelegateInvocationHandler, clusterMemberAvailability, requestContextFactory, clusterClient ),
-                        new SwitchToMaster( logging, msgLog, this,
-                        (HaIdGeneratorFactory) idGeneratorFactory, config, getDependencyResolver(), masterDelegateInvocationHandler, clusterMemberAvailability ),
-                        clusterClient, clusterMemberAvailability, logging.getMessagesLog( HighAvailabilityModeSwitcher.class ));
+
+        InvalidEpochExceptionHandler invalidEpochHandler = new InvalidEpochExceptionHandler()
+        {
+            @Override
+            public void handle()
+            {
+                highAvailabilityModeSwitcher.forceElections();
+            }
+        };
+
+        MasterClientResolver masterClientResolver = new MasterClientResolver( logging, invalidEpochHandler,
+                config.get( HaSettings.read_timeout ).intValue(),
+                config.get( HaSettings.lock_read_timeout ).intValue(),
+                config.get( HaSettings.max_concurrent_channels_per_slave ),
+                config.get( HaSettings.com_chunk_size ).intValue() );
+
+        SwitchToSlave switchToSlave = new SwitchToSlave( logging.getConsoleLog( HighAvailabilityModeSwitcher.class ),
+                config, getDependencyResolver(), (HaIdGeneratorFactory) idGeneratorFactory, logging,
+                masterDelegateInvocationHandler, clusterMemberAvailability, requestContextFactory,
+                masterClientResolver );
+
+        SwitchToMaster switchToMaster = new SwitchToMaster( logging, msgLog, this,
+                (HaIdGeneratorFactory) idGeneratorFactory, config, getDependencyResolver(),
+                masterDelegateInvocationHandler, clusterMemberAvailability );
+
+        highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher( switchToSlave, switchToMaster, clusterClient,
+                clusterMemberAvailability, logging.getMessagesLog( HighAvailabilityModeSwitcher.class ) );
 
         clusterClient.addBindingListener( highAvailabilityModeSwitcher );
         memberStateMachine.addHighAvailabilityMemberListener( highAvailabilityModeSwitcher );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -105,14 +105,12 @@ public class SwitchToSlave
     private final DelegateInvocationHandler<Master> masterDelegateHandler;
     private final ClusterMemberAvailability clusterMemberAvailability;
     private final RequestContextFactory requestContextFactory;
-    private final ClusterClient clusterClient;
-
-    private MasterClientResolver masterClientResolver;
+    private final MasterClientResolver masterClientResolver;
 
     public SwitchToSlave( ConsoleLogger console, Config config, DependencyResolver resolver, HaIdGeneratorFactory
             idGeneratorFactory, Logging logging, DelegateInvocationHandler<Master> masterDelegateHandler,
-            ClusterMemberAvailability clusterMemberAvailability, RequestContextFactory
-            requestContextFactory, ClusterClient clusterClient )
+            ClusterMemberAvailability clusterMemberAvailability, RequestContextFactory requestContextFactory,
+            MasterClientResolver masterClientResolver )
     {
         this.console = console;
         this.config = config;
@@ -123,7 +121,7 @@ public class SwitchToSlave
         this.requestContextFactory = requestContextFactory;
         this.msgLog = logging.getMessagesLog( getClass() );
         this.masterDelegateHandler = masterDelegateHandler;
-        this.clusterClient = clusterClient;
+        this.masterClientResolver = masterClientResolver;
     }
 
     /**
@@ -145,13 +143,6 @@ public class SwitchToSlave
                 masterUri );
 
         assert masterUri != null; // since we are here it must already have been set from outside
-
-        this.masterClientResolver = new MasterClientResolver( logging, clusterClient, clusterMemberAvailability, msgLog,
-                config.get( HaSettings.read_timeout ).intValue(),
-                config.get( HaSettings.lock_read_timeout ).intValue(),
-                config.get( HaSettings.max_concurrent_channels_per_slave ).intValue(),
-                config.get( HaSettings.com_chunk_size ).intValue()  );
-
 
         HaXaDataSourceManager xaDataSourceManager = resolver.resolveDependency(
                 HaXaDataSourceManager.class );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/InvalidEpochExceptionHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/InvalidEpochExceptionHandler.java
@@ -17,17 +17,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.com;
+package org.neo4j.kernel.ha.com.slave;
 
-public interface ComExceptionHandler
+public interface InvalidEpochExceptionHandler
 {
-    static ComExceptionHandler NO_OP = new ComExceptionHandler()
-    {
-        @Override
-        public void handle( ComException exception )
-        {
-        }
-    };
-
-    void handle( ComException exception );
+    void handle();
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -93,5 +93,5 @@ public interface MasterClient extends Master
     public Response<Void> copyTransactions( RequestContext context, final String ds, final long startTxId,
             final long endTxId );
 
-    public void addComExceptionHandler( ComExceptionHandler handler );
+    public void setComExceptionHandler( ComExceptionHandler handler );
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -118,18 +118,19 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
 
         // whole cluster looks fine, but slaves have stale value of the epoch
         cluster.await( allSeesAllAsAvailable() );
+        HighlyAvailableGraphDatabase newMaster = cluster.getMaster();
+        HighlyAvailableGraphDatabase newSlave1 = cluster.getAnySlave();
+        HighlyAvailableGraphDatabase newSlave2 = cluster.getAnySlave( newSlave1 );
 
-        // attempt to perform tx on slave1 throws InvalidEpochException, election is triggered
-        assertHasInvalidEpoch( slave1 );
-        // tx on slave2 might fail with InvalidEpochException or might succeed because election was triggered by slave1
-        safeCreateNodeOn( slave2 );
+        // attempt to perform transactions on both slaves throws, election is triggered
+        attemptTransactions( newSlave1, newSlave2 );
 
-        // THEN: InvalidEpochException handled and election triggered, cluster feels good and able to serve transactions
+        // THEN: done with election, cluster feels good and able to serve transactions
         cluster.await( allSeesAllAsAvailable() );
 
-        assertNotNull( createNodeOn( master ) );
-        assertNotNull( createNodeOn( slave1 ) );
-        assertNotNull( createNodeOn( slave2 ) );
+        assertNotNull( createNodeOn( newMaster ) );
+        assertNotNull( createNodeOn( newSlave1 ) );
+        assertNotNull( createNodeOn( newSlave2 ) );
     }
 
     @Override
@@ -188,14 +189,17 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
         return node;
     }
 
-    private static void safeCreateNodeOn( HighlyAvailableGraphDatabase db )
+    private static void attemptTransactions( HighlyAvailableGraphDatabase... dbs )
     {
-        try
+        for ( HighlyAvailableGraphDatabase db : dbs )
         {
-            createNodeOn( db );
-        }
-        catch ( Exception ignored )
-        {
+            try
+            {
+                createNodeOn( db );
+            }
+            catch ( Exception ignored )
+            {
+            }
         }
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -27,16 +27,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.doAnswer;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState.PENDING;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState.TO_SLAVE;
 
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockito.InOrder;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.cluster.protocol.election.Election;
@@ -230,5 +236,101 @@ public class HighAvailabilityModeSwitcherTest
         verifyZeroInteractions( switchToSlave );
             // And an error must be logged
         verify( msgLog, times( 1 ) ).error( anyString() );
+    }
+
+    @Test
+    public void shouldPerformForcedElections()
+    {
+        // Given
+        ClusterMemberAvailability memberAvailability = mock( ClusterMemberAvailability.class );
+        Election election = mock( Election.class );
+
+        HighAvailabilityModeSwitcher modeSwitcher = new HighAvailabilityModeSwitcher( mock( SwitchToSlave.class ),
+                mock( SwitchToMaster.class ), election, memberAvailability, StringLogger.DEV_NULL );
+
+        // When
+        modeSwitcher.forceElections();
+
+        // Then
+        InOrder inOrder = inOrder( memberAvailability, election );
+        inOrder.verify( memberAvailability ).memberIsUnavailable( HighAvailabilityModeSwitcher.SLAVE );
+        inOrder.verify( election ).performRoleElections();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldPerformForcedElectionsOnlyOnce()
+    {
+        // Given: HAMS
+        ClusterMemberAvailability memberAvailability = mock( ClusterMemberAvailability.class );
+        Election election = mock( Election.class );
+
+        HighAvailabilityModeSwitcher modeSwitcher = new HighAvailabilityModeSwitcher( mock( SwitchToSlave.class ),
+                mock( SwitchToMaster.class ), election, memberAvailability, StringLogger.DEV_NULL );
+
+        // When: reelections are forced multiple times
+        modeSwitcher.forceElections();
+        modeSwitcher.forceElections();
+        modeSwitcher.forceElections();
+
+        // Then: instance sens out memberIsUnavailable and asks for elections and does this only once
+        InOrder inOrder = inOrder( memberAvailability, election );
+        inOrder.verify( memberAvailability ).memberIsUnavailable( HighAvailabilityModeSwitcher.SLAVE );
+        inOrder.verify( election ).performRoleElections();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldAllowForcedElectionsAfterModeSwitch() throws Throwable
+    {
+        // Given
+        SwitchToSlave switchToSlave = mock( SwitchToSlave.class );
+        when( switchToSlave.switchToSlave( any( LifeSupport.class ), any( URI.class ), any( URI.class ),
+                any( CancellationRequest.class ) ) ).thenReturn( URI.create( "http://localhost" ) );
+        ClusterMemberAvailability memberAvailability = mock( ClusterMemberAvailability.class );
+        Election election = mock( Election.class );
+
+        final CountDownLatch modeSwitchHappened = new CountDownLatch( 1 );
+
+        HighAvailabilityModeSwitcher modeSwitcher = new HighAvailabilityModeSwitcher( switchToSlave,
+                mock( SwitchToMaster.class ), election, memberAvailability, StringLogger.DEV_NULL )
+        {
+            @Override
+            ScheduledExecutorService createExecutor()
+            {
+                ScheduledExecutorService executor = mock( ScheduledExecutorService.class );
+
+                doAnswer( new Answer()
+                {
+                    @Override
+                    public Object answer( InvocationOnMock invocation ) throws Throwable
+                    {
+                        ((Runnable) invocation.getArguments()[0]).run();
+                        modeSwitchHappened.countDown();
+                        return mock( Future.class );
+                    }
+                } ).when( executor ).submit( any( Runnable.class ) );
+
+                return executor;
+            }
+        };
+
+        modeSwitcher.init();
+        modeSwitcher.start();
+
+        modeSwitcher.forceElections();
+        reset( memberAvailability, election );
+
+        // When
+        modeSwitcher.masterIsAvailable( new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 1 ),
+                URI.create( "http://localhost:9090?serverId=42" ) ) );
+        modeSwitchHappened.await();
+        modeSwitcher.forceElections();
+
+        // Then
+        InOrder inOrder = inOrder( memberAvailability, election );
+        inOrder.verify( memberAvailability ).memberIsUnavailable( HighAvailabilityModeSwitcher.SLAVE );
+        inOrder.verify( election ).performRoleElections();
+        inOrder.verifyNoMoreInteractions();
     }
 }


### PR DESCRIPTION
Test ClusterTopologyChangesIT turned out to be very flaky. This PR attempts to make it more robust.

Improved handling of IllegalEpochException:
  - HighAvailabilityModeSwitcher is now responsible for making the SLAVE --> PENDING switch
  - only one reelection might happen at the same time, no flood MemberIsUnavailable and concurrent elections