### PR TITLE
Fixed handling of flags in Args

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Args.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Args.java
@@ -328,6 +328,16 @@ public class Args
         return arg.startsWith( "-" ) && arg.length() > 1;
     }
 
+    private boolean isFlag( String arg )
+    {
+        return ArrayUtil.contains( flags, arg );
+    }
+
+    private static boolean isBoolean( String value )
+    {
+        return (value != null) && ("true".equalsIgnoreCase( value ) || "false".equalsIgnoreCase( value ));
+    }
+
     private static String stripOption( String arg )
     {
         while ( !arg.isEmpty() && arg.charAt( 0 ) == '-' )
@@ -355,9 +365,19 @@ public class Args
                         put( optionParser, key, value );
                     }
                 }
-                else if ( ArrayUtil.contains( flags, arg ) )
+                else if ( isFlag( arg ) )
                 {
-                    put( optionParser, arg, "true" );
+                    int nextIndex = i + 1;
+                    String value = nextIndex < args.length ? args[nextIndex] : null;
+                    if ( isBoolean( value ) )
+                    {
+                        i = nextIndex;
+                        put( optionParser, arg, Boolean.valueOf( value ).toString() );
+                    }
+                    else
+                    {
+                        put( optionParser, arg, null );
+                    }
                 }
                 else
                 {

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestArgs.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestArgs.java
@@ -252,8 +252,8 @@ public class TestArgs
 
         // Then
         assertEquals( Collections.<String>emptyList(), orphans );
-        assertTrue( args.getBoolean( "foo", false, false ) );
-        assertTrue( args.getBoolean( "bar", false, false ) );
+        assertTrue( args.getBoolean( "foo", false, true ) );
+        assertTrue( args.getBoolean( "bar", false, true ) );
     }
 
     @Test
@@ -268,7 +268,7 @@ public class TestArgs
         // Then
         assertEquals( Arrays.<String>asList() , orphans );
         assertFalse( args.getBoolean( "foo", false, false ) );
-        assertTrue( args.getBoolean( "bar", false, false ) );
+        assertTrue( args.getBoolean( "bar", false, true ) );
     }
 
     @Test
@@ -287,9 +287,44 @@ public class TestArgs
         assertEquals( 120, args.getNumber( "size", 0 ).intValue() );
         assertEquals( "ShereKhan", args.get( "name" ) );
 
-        assertTrue( args.getBoolean( "big", false, false ) );
+        assertTrue( args.getBoolean( "big", false, true ) );
         assertTrue( args.getBoolean( "soft", false, false ) );
         assertFalse( args.getBoolean( "saysMeow", true, true ) );
+    }
+
+    @Test
+    public void shouldHandleFlagSpecifiedAsLastArgument()
+    {
+        // Given
+        Args args = Args.withFlags( "flag1", "flag2" ).parse(
+                "-key=Foo", "-flag1", "false", "-value", "Bar", "-flag2", "false" );
+
+        // When
+        List<String> orphans = args.orphans();
+
+        // Then
+        assertTrue( "Orphan args expected to be empty, but were: " + orphans, orphans.isEmpty() );
+        assertEquals( "Foo", args.get( "key" ) );
+        assertEquals( "Bar", args.get( "value" ) );
+        assertFalse( "flag1", args.getBoolean( "flag1", true ) );
+        assertFalse( "flag1", args.getBoolean( "flag2", true ) );
+    }
+
+    @Test
+    public void shouldRecognizeFlagsOfAnyForm()
+    {
+        // Given
+        Args args = Args.withFlags( "flag1", "flag2", "flag3" ).parse(
+                "-key1=Foo", "-flag1", "-key1", "Bar", "-flag2=true", "-key3=Baz", "-flag3", "true" );
+
+        // When
+        List<String> orphans = args.orphans();
+
+        // Then
+        assertTrue( "Orphan args expected to be empty, but were: " + orphans, orphans.isEmpty() );
+        assertTrue( args.getBoolean( "flag1", false, true ) );
+        assertTrue( args.getBoolean( "flag2", false, false ) );
+        assertTrue( args.getBoolean( "flag3", false, false ) );
     }
 
     @Test

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolCmdArgumentsAcceptanceTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolCmdArgumentsAcceptanceTest.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.PrintStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+/**
+ * This test builds all valid combinations/permutations of args for {@link org.neo4j.backup.BackupTool} and asserts
+ * that it can handle those.
+ * It tests legacy and modern sets of args in all possible forms: (-option, --option, -option value, -option=value).
+ * Legacy is (-from, -to, -verify) and modern is (-host, -port, -to, -verify).
+ */
+
+@RunWith( Parameterized.class )
+public class BackupToolCmdArgumentsAcceptanceTest
+{
+    private static final String HOST = "localhost";
+    private static final int PORT = 9090;
+    private static final String PATH = "/var/backup/neo4j/";
+
+    @Parameter( 0 )
+    public String argsAsString;
+    @Parameter( 1 )
+    public boolean expectedVerifyStoreValue;
+
+    @Parameters( name = "args=({0})" )
+    public static Iterable<Object[]> data()
+    {
+        return Iterables.concat(
+                allCombinations(
+                        stringMap(
+                                "host", HOST,
+                                "port", String.valueOf( PORT ),
+                                "to", PATH
+                        )
+                ),
+                allCombinations(
+                        stringMap(
+                                "from", HOST + ":" + PORT,
+                                "to", PATH
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void shouldInvokeBackupServiceWhenArgsAreValid() throws Exception
+    {
+        // Given
+        String[] args = argsAsString.split( " " );
+
+        BackupService backupService = mock( BackupService.class );
+        PrintStream printStream = mock( PrintStream.class );
+        BackupTool backupTool = new BackupTool( backupService, printStream );
+
+        // When
+        backupTool.run( args );
+
+        // Then
+        verify( backupService ).doIncrementalBackupOrFallbackToFull(
+                eq( HOST ),
+                eq( PORT ),
+                eq( PATH ),
+                eq( expectedVerifyStoreValue ),
+                any( Config.class ),
+                eq( BackupClient.BIG_READ_TIMEOUT )
+        );
+    }
+
+    private static List<String> allFlagValues( String name, boolean value )
+    {
+        return value ?
+               asList(
+                       "-" + name,
+                       "--" + name,
+                       "-" + name + "=true",
+                       "--" + name + "=true",
+                       "-" + name + " true",
+                       "--" + name + " true" )
+                     :
+               asList(
+                       "-" + name + "=false",
+                       "--" + name + "=false",
+                       "-" + name + " false",
+                       "--" + name + " false" );
+    }
+
+    private static Iterable<Object[]> allCombinations( Map<String,String> optionsMap )
+    {
+        return Iterables.concat( allCombinations( optionsMap, true ), allCombinations( optionsMap, false ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static List<Object[]> allCombinations( Map<String,String> optionsMap, boolean verifyStore )
+    {
+        List<Object[]> result = new ArrayList<>();
+
+        List<List<String>> optionCombinations = gatherAllOptionCombinations( optionsMap );
+        List<String> verifyFlagValues = allFlagValues( "verify", verifyStore );
+
+        for ( List<String> options : optionCombinations )
+        {
+            for ( String flag : verifyFlagValues )
+            {
+                List<String> args = join( options, flag );
+                List<List<String>> argsPermutations = permutations( args );
+                for ( List<String> permutation : argsPermutations )
+                {
+                    StringBuilder sb = new StringBuilder();
+                    for ( String arg : permutation )
+                    {
+                        sb.append( sb.length() > 0 ? " " : "" ).append( arg );
+                    }
+                    String argsJoinedAsString = sb.toString();
+                    result.add( new Object[]{argsJoinedAsString, verifyStore} );
+                }
+            }
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static List<List<String>> gatherAllOptionCombinations( Map<String,String> optionsMap )
+    {
+        List<List<String>> result = new ArrayList<>();
+
+        Deque<String> stack = new ArrayDeque<>();
+        Map.Entry<String,String>[] entries = optionsMap.entrySet().toArray( new Map.Entry[optionsMap.size()] );
+        gatherAllOptionCombinations( entries, 0, stack, result );
+
+        return result;
+    }
+
+    private static void gatherAllOptionCombinations( Map.Entry<String,String>[] entries, int current,
+            Deque<String> stack, List<List<String>> result )
+    {
+        if ( current == entries.length )
+        {
+            result.add( new ArrayList<>( stack ) );
+        }
+        else
+        {
+            Map.Entry<String,String> entry = entries[current];
+            int next = current + 1;
+
+            for ( String arg : possibleArgs( entry.getKey(), entry.getValue() ) )
+            {
+                stack.push( arg );
+                gatherAllOptionCombinations( entries, next, stack, result );
+                stack.pop();
+            }
+        }
+    }
+
+    private static List<String> possibleArgs( String key, String value )
+    {
+        return (value == null) ? asList( "-" + key, "--" + key )
+                               : asList(
+                                       "-" + key + "=" + value,
+                                       "--" + key + "=" + value,
+                                       "-" + key + " " + value,
+                                       "--" + key + " " + value );
+    }
+
+    private static List<List<String>> permutations( List<String> list )
+    {
+        List<List<String>> result = new ArrayList<>();
+        permutations( result, new ArrayList<String>(), list );
+        return result;
+    }
+
+    private static void permutations( List<List<String>> result, List<String> prefix, List<String> list )
+    {
+        if ( list.isEmpty() )
+        {
+            result.add( prefix );
+        }
+        else
+        {
+            for ( int i = 0; i < list.size(); i++ )
+            {
+                permutations(
+                        result,
+                        join( prefix, list.get( i ) ),
+                        join( list.subList( 0, i ), list.subList( i + 1, list.size() ) ) );
+            }
+        }
+    }
+
+    private static List<String> join( List<String> list, String element )
+    {
+        List<String> result = new ArrayList<>( list );
+        result.add( element );
+        return result;
+    }
+
+    private static List<String> join( List<String> list1, List<String> list2 )
+    {
+        List<String> result = new ArrayList<>( list1.size() + list2.size() );
+        result.addAll( list1 );
+        result.addAll( list2 );
+        return result;
+    }
+}

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
@@ -295,4 +295,25 @@ public class BackupToolTest
 
         verifyZeroInteractions( service, systemOut );
     }
+
+    @Test
+    public void shouldRespectVerifyFlagWithLegacyArguments() throws BackupTool.ToolFailureException
+    {
+        // Given
+        String host = "localhost";
+        String targetDir = "/var/backup/neo4j/";
+        String[] args = {"-from", host, "-to", targetDir, "-verify", "false"};
+        BackupService service = mock( BackupService.class );
+        PrintStream systemOut = mock( PrintStream.class );
+
+        // When
+        new BackupTool( service, systemOut ).run( args );
+
+        // Then
+        verify( service ).doIncrementalBackupOrFallbackToFull( eq( host ), eq( BackupServer.DEFAULT_PORT ),
+                eq( targetDir ), eq( false ), any( Config.class ), eq( BackupClient.BIG_READ_TIMEOUT ) );
+        verify( systemOut ).println(
+                "Performing backup from '" + new HostnamePort( host, BackupServer.DEFAULT_PORT ) + "'" );
+        verify( systemOut ).println( "Done" );
+    }
 }


### PR DESCRIPTION
Currently after parsing `-option1=value -flag1 false -option2=value -flag2 false` both `false` would be recognised as orphan arguments.
This happens because parser does not consume any values after flags.
So `-flag=true` results in `flag-->true`, `-flag=false` results in `flag-->false`, `-flag` results in `flag-->true` and `-flag false` results in `flag-->true` & orphan `false`.

This PR fixes parsing and makes Args compatible with previous versions (<= 2.1).
When value that follows flag could be consumed as boolean it is consumed, otherwise it is treated as orphan.
PR also adds some tests for `BackupTool`.