### PR TITLE
Adds the keys() function to Cypher

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/Function.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/Function.scala
@@ -61,6 +61,7 @@ object Function {
     functions.Pi,
     functions.PercentileCont,
     functions.PercentileDisc,
+    functions.Keys,
     functions.Radians,
     functions.Rand,
     functions.Range,

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/KeysFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/KeysFunction.scala
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.commands.expressions
+
+import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
+import pipes.QueryState
+import symbols._
+import org.neo4j.cypher.internal.compiler.v2_2.spi.QueryContext
+import org.neo4j.graphdb.{Relationship, Node}
+
+case class KeysFunction(nodeOrRelationshipExpr: Expression) extends NullInNullOutExpression(nodeOrRelationshipExpr) {
+
+  override def compute(value: Any, m: ExecutionContext)(implicit state: QueryState) = value match {
+    case node: Node        =>
+                              val queryCtx: QueryContext = state.query
+                              queryCtx.getPropertiesForNode(node.getId).map { case (v) =>
+                                queryCtx.getPropertyKeyName(v.toInt)
+                              }.toList
+    case rel: Relationship =>
+                              val queryCtx: QueryContext = state.query
+                              queryCtx.getPropertiesForRelationship(rel.getId).map { case (v) =>
+                                queryCtx.getPropertyKeyName(v.toInt)
+                              }.toList
+    case x => throw new CypherTypeException("Expected `%s` to be a node or relationship, but it was ``".format(nodeOrRelationshipExpr, x.getClass.getSimpleName))
+  }
+
+  def rewrite(f: (Expression) => Expression) = f(KeysFunction(nodeOrRelationshipExpr.rewrite(f)))
+
+  def arguments = Seq(nodeOrRelationshipExpr)
+
+  def symbolTableDependencies = nodeOrRelationshipExpr.symbolTableDependencies
+
+  protected def calculateType(symbols: SymbolTable) = nodeOrRelationshipExpr match {
+    case node: Node => nodeOrRelationshipExpr.evaluateType(CTNode, symbols)
+    case rel : Relationship => nodeOrRelationshipExpr.evaluateType(CTRelationship, symbols)
+    case _ => CTCollection(CTString)
+  }
+
+  def localEffects(symbols: SymbolTable) = nodeOrRelationshipExpr match {
+    case i: Identifier => symbols.identifiers(i.entityName) match {
+      case _: NodeType         => Effects.READS_NODES
+      case _: RelationshipType => Effects.READS_RELATIONSHIPS
+      case _                   => Effects.NONE
+    }
+    case _ => Effects.NONE
+  }
+
+}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/functions/Keys.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/functions/Keys.scala
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.functions
+
+import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.ExpressionConverters
+import ExpressionConverters._
+import commands.{expressions => commandexpressions}
+import symbols._
+
+case object Keys extends Function with SimpleTypedFunction {
+  def name = "keys"
+
+  val signatures = Vector(
+    Signature(argumentTypes = Vector(CTNode), outputType = CTCollection(CTString)),
+    Signature(argumentTypes = Vector(CTRelationship), outputType = CTCollection(CTString))
+  )
+
+  def asCommandExpression(invocation: ast.FunctionInvocation) =
+    commandexpressions.KeysFunction(invocation.arguments(0).asCommandExpression)
+}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
@@ -61,6 +61,10 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
   def removeLabelsFromNode(node: Long, labelIds: Iterator[Int]): Int =
     singleDbHit(inner.removeLabelsFromNode(node, labelIds))
 
+  def getPropertiesForNode(node: Long): Iterator[Long] = singleDbHit(inner.getPropertiesForNode(node))
+
+  def getPropertiesForRelationship(relId: Long): Iterator[Long] = singleDbHit(inner.getPropertiesForRelationship(relId))
+
   def getPropertyKeyName(propertyKeyId: Int): String = singleDbHit(inner.getPropertyKeyName(propertyKeyId))
 
   def getOptPropertyKeyId(propertyKeyName: String): Option[Int] = singleDbHit(inner.getOptPropertyKeyId(propertyKeyName))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
@@ -57,6 +57,10 @@ trait QueryContext extends TokenContext {
 
   def removeLabelsFromNode(node: Long, labelIds: Iterator[Int]): Int
 
+  def getPropertiesForNode(node: Long): Iterator[Long]
+
+  def getPropertiesForRelationship(relId: Long): Iterator[Long]
+
   def getOrCreatePropertyKeyId(propertyKey: String): Int
 
   def addIndexRule(labelId: Int, propertyKeyId: Int): IdempotentResult[IndexDescriptor]

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/RepeatableReadQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/RepeatableReadQueryContext.scala
@@ -57,6 +57,18 @@ final class RepeatableReadQueryContext(inner: QueryContext, locker: Locker) exte
     locker.releaseAllLocks()
   }
 
+
+  override def getPropertiesForNode(node: Long): Iterator[Long] = {
+    lockNode(node)
+    inner.getPropertiesForNode(node)
+  }
+
+  override def getPropertiesForRelationship(relId: Long): Iterator[Long] = {
+    lockRelationship(relId)
+    inner.getPropertiesForRelationship(relId)
+  }
+
+
   class RepeatableReadOperations[T <: PropertyContainer](inner: Operations[T]) extends DelegatingOperations[T](inner) {
     override def getProperty(id: Long, propertyKeyId: Int) = {
       val obj = inner.getById(id)
@@ -85,6 +97,10 @@ final class RepeatableReadQueryContext(inner: QueryContext, locker: Locker) exte
 
   private def lockNode(id: Long) {
     locker.acquireLock(nodeOps.getByInnerId(id))
+  }
+
+  private def lockRelationship(id : Long) {
+    locker.acquireLock(relationshipOps.getByInnerId(id))
   }
 
   private def lockAll[T <: PropertyContainer](iter: Iterator[T]): Iterator[T] = iter.map {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/KeysFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/KeysFunctionTest.scala
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.commands.expressions
+
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryStateHelper
+import org.neo4j.cypher.internal.compiler.v2_2.spi.QueryContext
+import org.neo4j.graphdb.Node
+
+class KeysFunctionTest extends CypherFunSuite {
+
+  test("test Property Keys") {
+    // GIVEN
+    val node = mock[Node]
+    val queryContext = mock[QueryContext]
+
+    val ls = List(11,12,13)
+    val lsValues = List("theProp1","OtherProp","MoreProp")
+    when(queryContext.getPropertiesForNode(node.getId)).then(new Answer[Iterator[Long]]() {
+      def answer(invocation: InvocationOnMock): Iterator[Long] = ls.toIterator.map(_.toLong)
+    })
+
+    when(queryContext.getPropertyKeyName(11)).thenReturn(lsValues(0))
+    when(queryContext.getPropertyKeyName(12)).thenReturn(lsValues(1))
+    when(queryContext.getPropertyKeyName(13)).thenReturn(lsValues(2))
+
+    val state = QueryStateHelper.emptyWith(query = queryContext)
+    val ctx = ExecutionContext() += ("n" -> node)
+
+    // WHEN
+    val result = KeysFunction(Identifier("n"))(ctx)(state)
+
+    // THEN
+    result should equal(lsValues)
+  }
+
+  test("test without Property Keys ") {
+
+    // GIVEN
+    val expectedNull: Any = null
+    val node = mock[Node]
+    val queryContext = mock[QueryContext]
+
+    val ls = List()
+
+    when(queryContext.getPropertiesForNode(node.getId)).then(new Answer[Iterator[Long]]() {
+      def answer(invocation: InvocationOnMock): Iterator[Long] = ls.toIterator
+    })
+
+    val state = QueryStateHelper.emptyWith(query = queryContext)
+    val ctx = ExecutionContext() += ("n" -> node)
+
+    // WHEN
+    val result = KeysFunction(Identifier("n"))(ctx)(state)
+
+
+    // THEN
+    //result should equal(expectedNull)
+    result should equal(List())
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
@@ -65,6 +65,13 @@ class ExceptionTranslatingQueryContext(inner: QueryContext) extends DelegatingQu
   override def removeLabelsFromNode(node: Long, labelIds: Iterator[Int]): Int =
     translateException(super.removeLabelsFromNode(node, labelIds))
 
+  override def getPropertiesForNode(node: Long): Iterator[Long] =
+    translateException(super.getPropertiesForNode(node))
+
+  override def getPropertiesForRelationship(relId: Long): Iterator[Long] =
+    translateException(super.getPropertiesForRelationship(relId))
+
+
   override def getPropertyKeyName(propertyKeyId: Int): String =
     translateException(super.getPropertyKeyName(propertyKeyId))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -103,6 +103,13 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def getLabelsForNode(node: Long) =
     JavaConversionSupport.asScala(statement.readOperations().nodeGetLabels(node))
 
+  def getPropertiesForNode(node: Long) =
+    JavaConversionSupport.asScala(statement.readOperations().nodeGetAllPropertiesKeys(node))
+
+  def getPropertiesForRelationship(relId: Long) =
+    JavaConversionSupport.asScala(statement.readOperations().relationshipGetAllPropertiesKeys(relId))
+
+
   override def isLabelSetOnNode(label: Int, node: Long) =
     statement.readOperations().nodeHasLabel(node, label)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KeysAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KeysAcceptanceTest.scala
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import internal.helpers.CollectionSupport
+import org.scalatest.Assertions
+import org.neo4j.graphdb.{Relationship, Node}
+import org.scalautils.LegacyTripleEquals
+
+class KeysAcceptanceTest extends ExecutionEngineFunSuite  with QueryStatisticsTestSupport {
+
+  test("Using keys() function with NODE Not Empty result") {
+
+    val n = createNode(Map("name" -> "Andres", "surname" -> "Lopez"))
+
+    val result = execute("match (n) where id(n) = " + n.getId + " unwind (keys(n)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List("name","surname"))
+  }
+
+  test("Using keys() function with MULTIPLE_NODES Not-Empty result") {
+
+    val n1 = createNode(Map("name" -> "Andres", "surname" -> "Lopez"))
+    val n2 = createNode(Map("otherName" -> "Andres", "otherSurname" -> "Lopez"))
+
+    val result = execute("match (n) where id(n) = " + n1.getId + " or id(n) = " + n2.getId + " unwind (keys(n)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List("name","surname","otherName","otherSurname"))
+  }
+
+  test("Using keys() function with NODE Empty result") {
+
+    val n = createNode()
+
+    val result = execute("match (n) where id(n) = " + n.getId() + " unwind (keys(n)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List())
+  }
+
+
+  test("Using keys() function with NODE NULL result") {
+
+    val n = createNode()
+
+    val result = execute("optional match (n) where id(n) = " + n.getId() + " unwind (keys(n)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List())
+  }
+
+  test("Using keys() function with RELATIONSHIP Not-Empty result") {
+
+    val r = relate(createNode(), createNode(), "KNOWS", Map("level" -> "bad", "year" -> "2015"))
+
+    val result = execute("match ()-[r:KNOWS]-() where id(r) = " + r.getId + " unwind (keys(r)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List("level","year"))
+  }
+
+  test("Using keys() function with RELATIONSHIP Empty result") {
+
+    val r = relate(createNode(), createNode(), "KNOWS")
+
+    val result = execute("match ()-[r:KNOWS]-() where id(r) = " + r.getId + " unwind (keys(r)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList  should equal(List())
+  }
+
+
+  test("Using keys() function with RELATIONSHIP NULL result") {
+
+    val r = relate(createNode(), createNode(), "KNOWS")
+
+    val result = execute("optional match ()-[r:KNOWS]-() where id(r) = " + r.getId + " unwind (keys(r)) AS x return distinct(x) as theProps")
+
+    result.columnAs[String]("theProps").toList should equal(List())
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
@@ -106,6 +106,10 @@ class SnitchingQueryContext extends QueryContext {
 
   def getTransaction = ???
 
+  def getPropertiesForNode(node: Long) = ???
+
+  def getPropertiesForRelationship(relId: Long) = ???
+
   def getOrCreatePropertyKeyId(propertyKey: String) = ???
 
   def getOptPropertyKeyId(propertyKey: String): Option[Int] = ???

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -86,6 +86,8 @@ include::relationships.asciidoc[]
 
 include::labels.asciidoc[]
 
+include::keys.asciidoc[]
+
 include::extract.asciidoc[]
 
 include::filter.asciidoc[]

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -147,6 +147,22 @@ class FunctionsTest extends DocumentingTestBase {
     )
   }
 
+  @Test def keys() {
+    testThis(
+      title = "KEYS",
+      syntax = "KEYS(  property-container )",
+      arguments = List("property-container" -> "A node or a relationship."),
+      text = """Returns a collection of string representations for the properties names from a node or relationship.""",
+      queryText = """match (a) where a.name='Alice' return keys(a)""",
+      returns = """The name of the properties of `n` is returned by the query.""",
+      assertions = {
+        (p) =>
+          val iter: Iterable[String] = p.columnAs[Iterable[String]]("keys(a)").next()
+          assert(iter.toSet === Set("name", "age", "eyes"))
+      }
+    )
+  }
+
   @Test def extract() {
     testThis(
       title = "EXTRACT",

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
@@ -101,6 +101,10 @@ interface DataRead
      */
     PrimitiveIntIterator nodeGetLabels( long nodeId ) throws EntityNotFoundException;
 
+    PrimitiveLongIterator nodeGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException;
+
+    PrimitiveLongIterator relationshipGetAllPropertiesKeys( long relationshipId ) throws EntityNotFoundException;
+
     PrimitiveIntIterator nodeGetRelationshipTypes( long nodeId ) throws EntityNotFoundException;
 
     Property nodeGetProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -279,10 +279,24 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
+    public PrimitiveLongIterator nodeGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException
+    {
+        statement.assertOpen();
+        return dataRead().nodeGetPropertyKeys(statement, nodeId);
+    }
+
+    @Override
     public Iterator<DefinedProperty> nodeGetAllProperties( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         return dataRead().nodeGetAllProperties( statement, nodeId );
+    }
+
+    @Override
+    public PrimitiveLongIterator relationshipGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException
+    {
+        statement.assertOpen();
+        return dataRead().relationshipGetPropertyKeys(statement, nodeId);
     }
 
     @Override


### PR DESCRIPTION
...names from the properties of Node(s) or Relationship(s).

usage: *keys(n), where n=> node(s) result(s)*
example 1 : `MATCH (n) RETURN keys(n);`
example 2 : `MATCH (n) WITH keys(n) AS p UNWIND p AS x WITH DISTINCT x RETURN collect(x) AS SET;`