### PR TITLE
Individual names for each element in pattern expressions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamer.scala
@@ -34,19 +34,18 @@ object PatternExpressionPatternElementNamer {
 
   private def nameUnnamedPatternElements(expr: PatternExpression): Map[PatternElement, Identifier] = {
     val unnamedElements = findPatternElements(expr.pattern).filter(_.identifier.isEmpty)
-    val unnamedMap: Map[PatternElement, Identifier] = unnamedElements.map {
+    IdentityMap(unnamedElements.map {
       case elem: NodePattern =>
         elem -> Identifier(UnNamedNameGenerator.name(elem.position.bumped()))(elem.position)
       case elem@RelationshipChain(_, relPattern, _) =>
         elem -> Identifier(UnNamedNameGenerator.name(relPattern.position.bumped()))(relPattern.position)
-    }.toMap
-    unnamedMap
+    }: _*)
   }
 
   private case object findPatternElements {
-    def apply(astNode: ASTNode): Set[PatternElement] = astNode.treeFold(Set.empty[PatternElement]) {
+    def apply(astNode: ASTNode): Seq[PatternElement] = astNode.treeFold(Seq.empty[PatternElement]) {
       case patternElement: PatternElement =>
-        (acc, children) => children(acc + patternElement)
+        (acc, children) => children(acc :+ patternElement)
 
       case patternExpr: PatternExpression =>
         (acc, _) => acc

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PatternExpressionPatternElementNamerTest.scala
@@ -52,6 +52,24 @@ class PatternExpressionPatternElementNamerTest extends CypherFunSuite with Logic
     processMap(map) should equal(Map(52 -> "  UNNAMED53"))
   }
 
+  test("should rename multiple nodes") {
+    val original = parsePatternExpression("WITH {r} AS r LIMIT 1 RETURN ()-[r]->()")
+    val (actual, map) = PatternExpressionPatternElementNamer(original)
+    val expected = parsePatternExpression("WITH {r} AS r LIMIT 1 RETURN (`  UNNAMED30`)-[r]->(`  UNNAMED38`)")
+
+    actual should equal(expected)
+    processMap(map) should equal(Map(29 -> "  UNNAMED30", 37 -> "  UNNAMED38"))
+  }
+
+  test("should rename multiple relationships") {
+    val original = parsePatternExpression("WITH {a} AS a, {b} AS b, {c} AS c LIMIT 1 RETURN (a)-[]-(b)-[]-(c)")
+    val (actual, map) = PatternExpressionPatternElementNamer(original)
+    val expected = parsePatternExpression("WITH {a} AS a, {b} AS b, {c} AS c LIMIT 1 RETURN (a)-[`  UNNAMED53`]-(b)-[`  UNNAMED60`]-(c)")
+
+    actual should equal(expected)
+    processMap(map) should equal(Map(52 -> "  UNNAMED53", 59 -> "  UNNAMED60"))
+  }
+
   private def processMap(map: Map[PatternElement, Identifier]) = {
     map.collect {
       case (pattern: NodePattern, ident) => pattern.position.offset -> ident.name


### PR DESCRIPTION
PatternExpressionPatternElementNamer was giving the same name for each unnamed
element in long chains such as `()-[:R]-()-...` which caused non-sensical responses
for some queries.