### PR TITLE
Removed the unnecessary rewriting to IN predicates. 

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/rewriteEqualityToInCollection.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/rewriteEqualityToInCollection.scala
@@ -37,6 +37,14 @@ case object rewriteEqualityToInCollection extends Rewriter {
     case e@Equals(a:FunctionInvocation, b:FunctionInvocation)
       if a.function == Some(functions.Id) && b.function == Some(functions.Id) => e
 
+    // id(a) = b.prop is also not rewritten to IN predicates as they cannot be optimized later on
+    case e@Equals(a:FunctionInvocation, b:Property)
+      if a.function == Some(functions.Id) => e
+
+    // a.prop = id(b) is also not rewritten to IN predicates as they cannot be optimized later on
+    case e@Equals(a:Property, b:FunctionInvocation)
+      if b.function == Some(functions.Id) => e
+
     // id(a) = value => id(a) IN [value]
     case predicate@Equals(func@FunctionInvocation(_, _, IndexedSeq(idExpr)), idValueExpr)
       if func.function == Some(functions.Id) =>

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteEqualityToInCollectionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteEqualityToInCollectionTest.scala
@@ -62,9 +62,11 @@ class RewriteEqualityToInCollectionTest extends CypherFunSuite with AstRewriting
   }
 
   test("MATCH a,b WHERE id(a) = b.prop (dependencies on the RHS)") {
-    shouldRewrite(
-      "MATCH a,b WHERE b.prop = id(a)",
-      "MATCH a,b WHERE b.prop IN [id(a)]")
+    shouldNotRewrite("MATCH a,b WHERE id(a) = b.prop")
+  }
+
+  test("MATCH a,b WHERE a.prop = id(b) (dependencies on the RHS)") {
+    shouldNotRewrite("MATCH a,b WHERE a.prop = id(b)")
   }
 
   test("MATCH a,b WHERE a.prop = b.prop (dependencies on the RHS)") {


### PR DESCRIPTION
It does not make sense to rewrite certain equality predicates; these are now ensured to not be rewritten.