### PR TITLE
Plan projectEndPoints on top of arguments when creating leaf-plans

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
@@ -34,10 +34,11 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[PlanTable],
   import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.CandidateGenerator._
 
     val select = config.applySelections.asFunctionInContext
+    val projectAllEndpoints = config.projectAllEndpoints.asFunctionInContext
     val pickBest = config.pickBestCandidate.asFunctionInContext
 
     def generateLeafPlanTable(): PlanTable = {
-      val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
+      val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, projectAllEndpoints)
       val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(select(_, queryGraph)))
       val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
       val startTable: PlanTable = leafPlan.foldLeft(emptyPlanTable)(_ + _)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlanTableGenerator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlanTableGenerator.scala
@@ -26,8 +26,9 @@ case class LeafPlanTableGenerator(config: PlanningStrategyConfiguration) extends
   def apply(queryGraph: QueryGraph, leafPlan: Option[LogicalPlan])(implicit context: LogicalPlanningContext): PlanTable = {
     val select = config.applySelections.asFunctionInContext
     val pickBest = config.pickBestCandidate.asFunctionInContext
+    val projectAllEndpoints = config.projectAllEndpoints.asFunctionInContext
 
-    val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
+    val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, projectAllEndpoints)
     val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(select(_, queryGraph)))
     val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
     val startTable: PlanTable = leafPlan.foldLeft(context.strategy.emptyPlanTable)(_ + _)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PlanTable.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PlanTable.scala
@@ -72,6 +72,8 @@ object GreedyPlanTable {
         new GreedyPlanTable(oldPlansNotCoveredByNewPlan + (newPlan.solved.lastQueryGraph -> newPlan))
       }
     }
+
+    override def toString(): String = s"PlanTable:\n${m.toString()}"
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PlanningStrategyConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/PlanningStrategyConfiguration.scala
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps._
 
 case class PlanningStrategyConfiguration(
   leafPlanners: LeafPlannerList,
   applySelections: PlanTransformer[QueryGraph],
+  projectAllEndpoints: PlanTransformer[QueryGraph],
   pickBestCandidate: CandidateSelector
 )
 
@@ -32,6 +33,7 @@ object PlanningStrategyConfiguration {
   val default = PlanningStrategyConfiguration(
     pickBestCandidate = pickBestPlan,
     applySelections = selectPatternPredicates(selectCovered),
+    projectAllEndpoints = projectEndpoints.all,
     leafPlanners = LeafPlannerList(
       argumentLeafPlanner,
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/argumentLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/argumentLeafPlanner.scala
@@ -25,8 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{LeafPlanner, Log
 
 object argumentLeafPlanner extends LeafPlanner {
   def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext) = {
-    val givenNodeIds = qg.argumentIds intersect qg.patternNodes
-    if (givenNodeIds.isEmpty)
+    val ids = qg.patternNodes ++ qg.patternRelationships.map(_.name).toSet
+    if ((qg.argumentIds intersect ids).isEmpty)
       Seq.empty
     else
       Seq(planQueryArgumentRow(qg))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/pickBestPlan.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/pickBestPlan.scala
@@ -34,13 +34,15 @@ object pickBestPlan extends CandidateSelector {
       val sortedPlans = plans.sortBy(comparePlans)
 
       if (sortedPlans.size > 1) {
-        println("Get best of:")
+        println("- Get best of:")
         for (plan <- sortedPlans) {
-          println("* " + plan.toString + s"\n${costs(plan, context.cardinalityInput)}\n")
+          println(s"\t* ${plan.toString}")
+          println(s"\t\t${costs(plan, context.cardinalityInput)}")
         }
 
-        println("Best is:")
-        println(sortedPlans.head.toString)
+        println("- Best is:")
+        println(s"\t${sortedPlans.head.toString}")
+        println()
       }
 
       sortedPlans.headOption

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/selectCovered.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/selectCovered.scala
@@ -19,11 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{LogicalPlanningContext, PlanTransformer}
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.LogicalPlanProducer._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
-import org.neo4j.cypher.internal.compiler.v2_2.ast.PatternExpression
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.LogicalPlanProducer._
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{LogicalPlanningContext, PlanTransformer}
 
 object selectCovered extends PlanTransformer[QueryGraph] {
   def apply(plan: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -22,8 +22,8 @@ package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{Limit, _}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.rewriter.unnestOptional
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{Limit, _}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport2, PlannerQuery}
 import org.neo4j.graphdb.Direction
 
@@ -98,21 +98,17 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
       Selection(
-      predicates1,
+      predicates,
       ProjectEndpoints(
-      Selection(predicates2, AllNodesScan(IdName("a2"), args)),
-      IdName("r"), IdName("b2"), IdName("a2$$$_"), true, SimplePatternLength
+      Argument(args),
+      IdName("r"), IdName("b2"), IdName("a2"), true, SimplePatternLength
       )
       )
       )
       ), _) =>
         args should equal(Set(IdName("r"), IdName("a1")))
-
-        val predicate1: Expression = Equals(Identifier("a2")_, Identifier("a2$$$_")_)_
-        predicates1 should equal(Seq(predicate1))
-
-        val predicate2: Expression = Equals(Identifier("a1")_, Identifier("a2")_)_
-        predicates2 should equal(Seq(predicate2))
+        val predicate: Expression = Equals(Identifier("a1")_, Identifier("a2")_)_
+        predicates should equal(Seq(predicate))
     }
   }
 
@@ -121,17 +117,13 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       case Projection(Apply(
       Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
-      Selection(
-      predicates,
       ProjectEndpoints(
-      AllNodesScan(IdName("a2"), args),
-      IdName("r"), IdName("a2$$$_"), IdName("b2"), true, SimplePatternLength
-      )
+      Argument(args),
+      IdName("r"), IdName("a2"), IdName("b2"), true, SimplePatternLength
       )
       )
       ), _) =>
-        val predicate: Expression = Equals(Identifier("a2")_, Identifier("a2$$$_")_)_
-        predicates should equal(Seq(predicate))
+        args should equal(Set(IdName("r")))
     }
   }
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/WithPlanningIntegrationTest.scala
@@ -71,7 +71,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     val plan = planFor("MATCH (a)-[r]->(b) WITH r LIMIT 1 MATCH (u)-[r]->(v) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Selection(List(Equals(Identifier(u),Identifier(u$$$_))),Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(AllNodesScan(IdName(u),Set(IdName(r))),IdName(r),IdName(u$$$_),IdName(v),true,SimplePatternLength))),Map(r -> Identifier(r)))")
+      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),IdName(v),true,SimplePatternLength)),Map(r -> Identifier(r)))")
   }
 
   test("should build plans that project endpoints of re-matched reversed directed relationship arguments") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeNodeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeNodeAcceptanceTest.scala
@@ -503,7 +503,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
       """MATCH (src:LeftLabel), (dst:RightLabel)
         |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
         |ON CREATE SET r.p3 = 42;""".stripMargin)
-    println(result.executionPlanDescription())
+
     result.executionPlanDescription().toString should not include "Eager"
   }
 }


### PR DESCRIPTION
This change will make sure that, when having relationship arguments,
we generate leaf-plans that projects all the end points of the
relationships passed in input (if applicable).  In this way we avoid
to use dumb plans that would scan again all nodes and filter.