### PR TITLE
Fixed two bugs in batch inserter related to label creation and search

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/DynamicNodeLabels.java
@@ -78,6 +78,12 @@ public class DynamicNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> put( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator allocator )
     {
+        Arrays.sort( labelIds );
+        return putSorted( labelIds, nodeStore, allocator );
+    }
+
+    Collection<DynamicRecord> putSorted( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator allocator )
+    {
         long existingLabelsField = node.getLabelField();
         long existingLabelsBits = parseLabelsBody( existingLabelsField );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/labels/InlineNodeLabels.java
@@ -66,13 +66,19 @@ public class InlineNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> put( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator allocator )
     {
+        Arrays.sort( labelIds );
+        return putSorted( labelIds, nodeStore, allocator );
+    }
+
+    Collection<DynamicRecord> putSorted( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator allocator )
+    {
         if ( tryInlineInNodeRecord( labelIds, node.getDynamicLabelRecords() ) )
         {
             return Collections.emptyList();
         }
         else
         {
-            return new DynamicNodeLabels( 0, node ).put( labelIds, nodeStore, allocator );
+            return new DynamicNodeLabels( 0, node ).putSorted( labelIds, nodeStore, allocator );
         }
     }
 
@@ -82,7 +88,7 @@ public class InlineNodeLabels implements NodeLabels
         long[] augmentedLabelIds = labelCount( labelField ) == 0 ? new long[]{labelId} :
                                    concatAndSort( parseInlined( labelField ), labelId );
 
-        return put( augmentedLabelIds, nodeStore, allocator );
+        return putSorted( augmentedLabelIds, nodeStore, allocator );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.batchinsert;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -637,11 +638,32 @@ public class BatchInserterImpl implements BatchInserter
     private long[] getOrCreateLabelIds( Label[] labels )
     {
         long[] ids = new long[labels.length];
+        int cursor = 0;
         for ( int i = 0; i < ids.length; i++ )
         {
-            ids[i] = getOrCreateLabelId( labels[i].name() );
+            int labelId = getOrCreateLabelId( labels[i].name() );
+            if ( !arrayContains( ids, cursor, labelId ) )
+            {
+                ids[cursor++] = labelId;
+            }
+        }
+        if ( cursor < ids.length )
+        {
+            ids = Arrays.copyOf( ids, cursor );
         }
         return ids;
+    }
+
+    private boolean arrayContains( long[] ids, int cursor, int labelId )
+    {
+        for ( int i = 0; i < cursor; i++ )
+        {
+            if ( ids[i] == labelId )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Fixed two bugs in batch inserter where
	o the same label is not created only once on a node
	o the labels are not sorted when they are inquired or created

Thanks Luanne Misquitta to provide the test cases for these bugs.