### PR TITLE
DBHits for path expressions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/commands/ExpressionConverters.scala
@@ -388,7 +388,7 @@ object ExpressionConverters {
   }
 
   implicit class NestedExpressionPipeConverter(val e: ast.NestedPipeExpression) extends AnyVal {
-    def asPipeCommand: CommandExpression = commandexpressions.NestedPipe(e.pipe, e.path.asCommandProjectedPath)
+    def asPipeCommand: CommandExpression = commandexpressions.NestedPipeExpression(e.pipe, e.path.asCommandProjectedPath)
   }
 
   implicit class PathConverter(val e: ast.PathExpression) extends AnyVal {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/NestedPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/NestedPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 case class NestedPipe(pipe: Pipe, path: ProjectedPath) extends Expression {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
     val innerState = state.copy(initialContext = Some(ctx))
-    pipe.createResults(innerState).map(ctx => path(ctx)).toSeq
+    pipe.createResults(innerState.withDecorator(innerState.decorator.innerDecorator )).map(ctx => path(ctx)).toSeq
   }
 
   def rewrite(f: (Expression) => Expression) = f(this)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/NestedPipeExpression.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/NestedPipeExpression.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
-case class NestedPipe(pipe: Pipe, path: ProjectedPath) extends Expression {
+case class NestedPipeExpression(pipe: Pipe, path: ProjectedPath) extends Expression {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
     val innerState = state.copy(initialContext = Some(ctx))
     pipe.createResults(innerState.withDecorator(innerState.decorator.innerDecorator )).map(ctx => path(ctx)).toSeq

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -34,6 +34,9 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityById
   with CollectionSupport
   with RonjaPipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     val ctx = state.initialContext.getOrElse(ExecutionContext.empty)
     val relIds = relIdExpr.expressions(ctx, state).flatMap(Option(_))
     new DirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
@@ -36,6 +36,8 @@ case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val 
   val keyNames: Seq[String] = expressions.keys.toSeq
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
 
     // Run the return item expressions, and replace the execution context's with their values
     val returnExpressions = input.map(ctx => {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
@@ -48,6 +48,9 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
   }
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     // This is the temporary storage used while the aggregation is going on
     val result = MutableMap[NiceHasher, (ExecutionContext, Seq[AggregationFunction])]()
     val keyNames: Seq[String] = keyExpressions.toSeq

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExtractPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExtractPipe.scala
@@ -96,8 +96,12 @@ case class ExtractPipe(source: Pipe, expressions: Map[String, Expression], hack_
       applyExpressionsOverwritingOriginal
   }
 
-  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) =
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.map( ctx => applyExpressions(ctx, state) )
+  }
 
   override def planDescription = {
     val arguments = expressions.map(_._1).toSeq

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/FilterPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/FilterPipe.scala
@@ -27,8 +27,12 @@ case class FilterPipe(source: Pipe, predicate: Predicate)(val estimatedCardinali
                      (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
   val symbols = source.symbols
 
-  protected def internalCreateResults(input: Iterator[ExecutionContext],state: QueryState) =
+  protected def internalCreateResults(input: Iterator[ExecutionContext],state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.filter(ctx => predicate.isTrue(ctx)(state))
+  }
 
   def planDescription = source.planDescription.andThen(this, "Filter", identifiers, LegacyExpression(predicate))
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LegacySortPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LegacySortPipe.scala
@@ -30,9 +30,13 @@ case class LegacySortPipe(source: Pipe, sortDescription: List[SortItem])
               (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with ExecutionContextComparer {
   def symbols = source.symbols
 
-  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) =
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.toList.
       sortWith((a, b) => compareBy(a, b, sortDescription)(state)).iterator
+  }
 
   def planDescription =
     source.planDescription.andThen(this, "Sort", identifiers, sortDescription.map(item => LegacyExpression(item.expression)):_*)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSelectOrSemiApplyPipe.scala
@@ -30,6 +30,9 @@ case class LetSelectOrSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: Strin
                                    (implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.map {
       (outerContext) =>
         val holds = predicate.isTrue(outerContext)(state) || {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LimitPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LimitPipe.scala
@@ -31,6 +31,9 @@ case class LimitPipe(source: Pipe, exp: Expression)
     if(input.isEmpty)
       return Iterator.empty
 
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     implicit val s = state
 
     val first: ExecutionContext = input.next()

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LoadCSVPipe.scala
@@ -59,6 +59,9 @@ case class LoadCSVPipe(source: Pipe,
   }
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.flatMap(context => {
       implicit val s = state
       val url = checkURL(urlExpression(context).asInstanceOf[String], state.query)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/MatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/MatchPipe.scala
@@ -34,6 +34,9 @@ case class MatchPipe(source: Pipe,
   val identifiersBoundInSource = identifiersInClause intersect source.symbols.keys.toSet
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.flatMap {
       ctx =>
         if (identifiersBoundInSource.exists(i => ctx(i) == null))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByIdSeekPipe.scala
@@ -48,6 +48,9 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: EntityByIdRhs)
   with RonjaPipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     val ctx = state.initialContext.getOrElse(ExecutionContext.empty)
     val nodeIds = nodeIdsExpr.expressions(ctx, state)
     new NodeIdSeekIterator(ident, ctx, state.query.nodeOps, nodeIds.iterator)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeIndexSeekPipe.scala
@@ -47,6 +47,9 @@ case class NodeIndexSeekPipe(ident: String,
       (state: QueryState) => (x: Any) => state.query.exactIndexSearch(descriptor, x)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     val index = indexFactory(state)
     val baseContext = state.initialContext.getOrElse(ExecutionContext.empty)
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKey.name)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandAllPipe.scala
@@ -30,6 +30,8 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
 
     implicit val s = state
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandIntoPipe.scala
@@ -32,6 +32,8 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
 
     implicit val s = state
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/PipeDecorator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/PipeDecorator.scala
@@ -31,6 +31,18 @@ trait PipeDecorator {
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext]
 
   def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription
+
+  /*
+   * Returns the inner decorator of this decorator. The inner decorator is used for nested expressions
+   * where the `decorate` should refer to the parent pipe instead of the calling pipe.
+   */
+  def innerDecorator: PipeDecorator
+
+  /*
+   * Registers a parent pipe. Used by the innerDecorator to associate data with the parent pipe instead of
+   * the calling pipe.
+   */
+  def registerParentPipe(pipe: Pipe): Unit
 }
 
 object NullPipeDecorator extends PipeDecorator {
@@ -39,4 +51,8 @@ object NullPipeDecorator extends PipeDecorator {
   def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription = plan
 
   def decorate(pipe: Pipe, state: QueryState): QueryState = state
+
+  def innerDecorator: PipeDecorator = NullPipeDecorator
+
+  def registerParentPipe(pipe: Pipe) {}
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectionNewPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectionNewPipe.scala
@@ -35,7 +35,9 @@ case class ProjectionNewPipe(source: Pipe, expressions: Map[String, Expression])
     source.symbols.add(newIdentifiers)
   }
 
-  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) =
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
     input.map {
       original =>
         val m = MutableMaps.create(expressions.size)
@@ -46,6 +48,7 @@ case class ProjectionNewPipe(source: Pipe, expressions: Map[String, Expression])
 
         ExecutionContext(m)
     }
+  }
 
   override def planDescription =
     source.planDescription

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/QueryState.scala
@@ -57,6 +57,8 @@ case class QueryState(db: GraphDatabaseService,
     params.getOrElse(key, throw new ParameterNotFoundException("Expected a parameter named " + key))
 
   def getStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
+
+  def withDecorator(decorator: PipeDecorator) = copy(decorator = decorator)
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SelectOrSemiApplyPipe.scala
@@ -30,6 +30,9 @@ case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate
                                 (implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.filter {
       (outerContext) =>
         predicate.isTrue(outerContext)(state) || {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SkipPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SkipPipe.scala
@@ -28,6 +28,9 @@ case class SkipPipe(source: Pipe, exp: Expression)
                    (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with NumericHelper with RonjaPipe {
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     if(input.isEmpty)
       return Iterator.empty
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SlicePipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SlicePipe.scala
@@ -31,6 +31,9 @@ case class SlicePipe(source: Pipe, skip: Option[Expression], limit: Option[Expre
   val symbols = source.symbols
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     implicit val s = state
 
     if(input.isEmpty)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
@@ -66,6 +66,9 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
   def arrayEntry(ctx : ExecutionContext)(implicit qtx : QueryState) : SortDataWithContext = (sortItems.map(_(ctx)),ctx)
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     implicit val s = state
     if (input.isEmpty)
       Iterator.empty

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TraversalMatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TraversalMatchPipe.scala
@@ -30,6 +30,9 @@ case class TraversalMatchPipe(source: Pipe, matcher: TraversalMatcher, trail: Tr
                              (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.flatMap {
 
       case ctx =>

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -31,6 +31,9 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityBy
   with CollectionSupport
   with RonjaPipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     val ctx = state.initialContext.getOrElse(ExecutionContext.empty)
     val relIds = relIdExpr.expressions(ctx, state).flatMap(Option(_))
     new UndirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
@@ -27,12 +27,16 @@ import org.neo4j.cypher.internal.helpers.CollectionSupport
 case class UnwindPipe(source: Pipe, collection: Expression, identifier: String)
                      (val estimatedCardinality: Option[Double] = None)(implicit monitor: PipeMonitor)
   extends PipeWithSource(source, monitor) with CollectionSupport with RonjaPipe {
-  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.flatMap {
       context =>
         val seq = makeTraversable(collection(context)(state))
         seq.map(x => context.newWith1(identifier, x))
     }
+  }
 
   def planDescription: InternalPlanDescription =
     PlanDescriptionImpl(this, "UNWIND", SingleChild(source.planDescription), Seq(), identifiers)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
@@ -70,6 +70,9 @@ case class VarLengthExpandPipe(source: Pipe,
   }
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
     input.flatMap {
       row => {
         val fromNode: Any = getFromNode(row)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.profiler
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{NestedPipe, ProjectedPath}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{Argument, InternalPlanDescription}
@@ -36,7 +37,7 @@ class ProfilerTest extends CypherFunSuite {
   test("should report simplest case") {
     //GIVEN
     val start = SingleRowPipe()
-    val pipe = new ProfilerPipe(start, "foo", rows = 10, dbAccess = 20)
+    val pipe = new ProfilerTestPipe(start, "foo", rows = 10, dbAccess = 20)
     val queryContext = mock[QueryContext]
     val profiler = new Profiler
     val queryState = QueryStateHelper.emptyWith(query = queryContext, decorator = profiler)
@@ -52,9 +53,9 @@ class ProfilerTest extends CypherFunSuite {
   test("should report multiple pipes case") {
     //GIVEN
     val start = SingleRowPipe()
-    val pipe1 = new ProfilerPipe(start, "foo", rows = 10, dbAccess = 25)
-    val pipe2 = new ProfilerPipe(pipe1, "bar", rows = 20, dbAccess = 40)
-    val pipe3 = new ProfilerPipe(pipe2, "baz", rows = 1, dbAccess = 2)
+    val pipe1 = new ProfilerTestPipe(start, "foo", rows = 10, dbAccess = 25)
+    val pipe2 = new ProfilerTestPipe(pipe1, "bar", rows = 20, dbAccess = 40)
+    val pipe3 = new ProfilerTestPipe(pipe2, "baz", rows = 1, dbAccess = 2)
     val queryContext = mock[QueryContext]
     val profiler = new Profiler
     val queryState = QueryStateHelper.emptyWith(query = queryContext, decorator = profiler)
@@ -83,8 +84,8 @@ class ProfilerTest extends CypherFunSuite {
 
   test("should count stuff going through Apply multiple times") {
     // GIVEN
-    val lhs = new ProfilerPipe(SingleRowPipe(), "lhs", rows = 10, dbAccess = 10)
-    val rhs = new ProfilerPipe(SingleRowPipe(), "rhs", rows = 20, dbAccess = 30)
+    val lhs = new ProfilerTestPipe(SingleRowPipe(), "lhs", rows = 10, dbAccess = 10)
+    val rhs = new ProfilerTestPipe(SingleRowPipe(), "rhs", rows = 20, dbAccess = 30)
     val apply = new ApplyPipe(lhs, rhs)()
     val queryContext = mock[QueryContext]
     val profiler = new Profiler
@@ -98,15 +99,56 @@ class ProfilerTest extends CypherFunSuite {
     assertRecorded(decoratedResult, "rhs", expectedRows = 10*20, expectedDbHits = 10*30)
   }
 
+  test("count dbhits for NestedPipes") {
+    // GIVEN
+    val projectedPath = mock[ProjectedPath]
+    val DB_HITS = 100
+    val innerPipe = NestedPipe(new ProfilerTestPipe(SingleRowPipe(), "nested pipe", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
+
+    val queryContext = mock[QueryContext]
+    val profiler = new Profiler
+    val queryState = QueryStateHelper.emptyWith(query = queryContext, decorator = profiler)
+
+    // WHEN we create the results,
+    materialize(pipeUnderInspection.createResults(queryState))
+    val description = pipeUnderInspection.planDescription
+    val decoratedResult = profiler.decorate(description, isProfileReady = true)
+
+    // THEN the ProjectionNewPipe has correctly recorded the dbhits
+    assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS)
+  }
+
+  test("count dbhits for deeply nested NestedPipes") {
+    // GIVEN
+    val projectedPath = mock[ProjectedPath]
+    val DB_HITS = 100
+    val nestedExpression = NestedPipe(new ProfilerTestPipe(SingleRowPipe(), "nested pipe1", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val innerInnerPipe = ProjectionNewPipe(SingleRowPipe(), Map("y"->nestedExpression))()
+    val innerPipe = NestedPipe(new ProfilerTestPipe(innerInnerPipe, "nested pipe2", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
+
+    val queryContext = mock[QueryContext]
+    val profiler = new Profiler
+    val queryState = QueryStateHelper.emptyWith(query = queryContext, decorator = profiler)
+
+    // WHEN we create the results,
+    materialize(pipeUnderInspection.createResults(queryState))
+    val description = pipeUnderInspection.planDescription
+    val decoratedResult = profiler.decorate(description, isProfileReady = true)
+
+    // THEN the ProjectionNewPipe has correctly recorded the dbhits
+    assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS * 2)
+  }
+
   private def assertRecorded(result: InternalPlanDescription, name: String, expectedRows: Int, expectedDbHits: Int) {
     val pipeArgs: Seq[Argument] = result.find(name).flatMap(_.arguments)
-
-    pipeArgs.foreach {
+    pipeArgs shouldNot be(empty)
+    pipeArgs.collect {
       case DbHits(count) => count should equal(expectedDbHits)
-      case _ =>
     }
 
-    pipeArgs.collectFirst {
+    pipeArgs.collect {
       case Rows(seenRows) => seenRows should equal(expectedRows)
     }
   }
@@ -116,7 +158,7 @@ class ProfilerTest extends CypherFunSuite {
   }
 }
 
-case class ProfilerPipe(source: Pipe, name: String, rows: Int, dbAccess: Int)
+case class ProfilerTestPipe(source: Pipe, name: String, rows: Int, dbAccess: Int)  // MATCH a, ()-[r]->() WHERE id(r) = length(a-->())
                   (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
   def planDescription: InternalPlanDescription = source.planDescription.andThen(this, name, Set())
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.profiler
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
-import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{NestedPipe, ProjectedPath}
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{NestedPipeExpression, ProjectedPath}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{Argument, InternalPlanDescription}
@@ -103,7 +103,7 @@ class ProfilerTest extends CypherFunSuite {
     // GIVEN
     val projectedPath = mock[ProjectedPath]
     val DB_HITS = 100
-    val innerPipe = NestedPipe(new ProfilerTestPipe(SingleRowPipe(), "nested pipe", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val innerPipe = NestedPipeExpression(new ProfilerTestPipe(SingleRowPipe(), "nested pipe", rows = 10, dbAccess = DB_HITS), projectedPath)
     val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
 
     val queryContext = mock[QueryContext]
@@ -123,9 +123,9 @@ class ProfilerTest extends CypherFunSuite {
     // GIVEN
     val projectedPath = mock[ProjectedPath]
     val DB_HITS = 100
-    val nestedExpression = NestedPipe(new ProfilerTestPipe(SingleRowPipe(), "nested pipe1", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val nestedExpression = NestedPipeExpression(new ProfilerTestPipe(SingleRowPipe(), "nested pipe1", rows = 10, dbAccess = DB_HITS), projectedPath)
     val innerInnerPipe = ProjectionNewPipe(SingleRowPipe(), Map("y"->nestedExpression))()
-    val innerPipe = NestedPipe(new ProfilerTestPipe(innerInnerPipe, "nested pipe2", rows = 10, dbAccess = DB_HITS), projectedPath)
+    val innerPipe = NestedPipeExpression(new ProfilerTestPipe(innerInnerPipe, "nested pipe2", rows = 10, dbAccess = DB_HITS), projectedPath)
     val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
 
     val queryContext = mock[QueryContext]


### PR DESCRIPTION
Profiling was not keeping track of dbhits coming from nested expressions which lead
to errors in the reporting of dbhits.