### PR TITLE
Ensure unique constraints are correctly orphaned on recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptorProvider;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.kernel.InternalAbstractGraphDatabase.Dependencies;
 
@@ -39,6 +40,7 @@ public class GraphDatabaseFactoryState
     private List<CacheProvider> cacheProviders;
     private List<TransactionInterceptorProvider> txInterceptorProviders;
     private Logging logging;
+    private Monitors monitors;
 
     public GraphDatabaseFactoryState() {
         settingsClasses = new ArrayList<>();
@@ -59,6 +61,7 @@ public class GraphDatabaseFactoryState
         cacheProviders = new ArrayList<>( previous.cacheProviders );
         txInterceptorProviders = new ArrayList<>( previous.txInterceptorProviders );
         logging = previous.logging;
+        monitors = previous.monitors;
     }
 
     public Iterable<KernelExtensionFactory<?>> getKernelExtension()
@@ -114,9 +117,14 @@ public class GraphDatabaseFactoryState
         this.logging = logging;
     }
 
+    public void setMonitors(Monitors monitors)
+    {
+        this.monitors = monitors;
+    }
+
     public Dependencies databaseDependencies()
     {
-        return new GraphDatabaseDependencies(
+        return new GraphDatabaseDependencies(monitors,
                 logging,
                 settingsClasses,
                 kernelExtensions,

--- a/community/kernel/src/main/java/org/neo4j/kernel/DefaultGraphDatabaseDependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DefaultGraphDatabaseDependencies.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptorProvider;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
 
 public class DefaultGraphDatabaseDependencies extends GraphDatabaseDependencies
 {
@@ -38,18 +39,19 @@ public class DefaultGraphDatabaseDependencies extends GraphDatabaseDependencies
 
     public DefaultGraphDatabaseDependencies( Logging logging )
     {
-        this( logging, GraphDatabaseSettings.class );
+        this( logging, new Monitors(), GraphDatabaseSettings.class );
     }
 
     public DefaultGraphDatabaseDependencies( Class<?>... settingsClasses )
     {
-        this( null, settingsClasses );
+        this( null, new Monitors(),
+                settingsClasses );
     }
 
-    public DefaultGraphDatabaseDependencies( Logging logging, Class<?>... settingsClasses )
+    public DefaultGraphDatabaseDependencies( Logging logging, Monitors monitors, Class<?>... settingsClasses )
     {
         super(
-                logging,
+                monitors, logging,
                 Arrays.<Class<?>>asList( settingsClasses ),
                 Iterables.<KernelExtensionFactory<?>,KernelExtensionFactory>cast( Service.load( KernelExtensionFactory.class ) ),
                 Service.load( CacheProvider.class ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
@@ -23,9 +23,11 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.transaction.xaframework.TransactionInterceptorProvider;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
 
 public class GraphDatabaseDependencies implements InternalAbstractGraphDatabase.Dependencies
 {
+    private Monitors monitors;
     private final Logging logging;
     private final Iterable<Class<?>> settingsClasses;
     private final Iterable<KernelExtensionFactory<?>> kernelExtensions;
@@ -34,11 +36,12 @@ public class GraphDatabaseDependencies implements InternalAbstractGraphDatabase.
 
     @SuppressWarnings( "deprecation" )
     public GraphDatabaseDependencies(
-            Logging logging,
+            Monitors monitors, Logging logging,
             Iterable<Class<?>> settingsClasses,
             Iterable<KernelExtensionFactory<?>> kernelExtensions, Iterable<CacheProvider> cacheProviders,
             Iterable<TransactionInterceptorProvider> transactionInterceptorProviders )
     {
+        this.monitors = monitors;
         this.logging = logging;
         this.settingsClasses = settingsClasses;
         this.kernelExtensions = kernelExtensions;
@@ -50,6 +53,12 @@ public class GraphDatabaseDependencies implements InternalAbstractGraphDatabase.
     public Logging logging()
     {
         return logging;
+    }
+
+    @Override
+    public Monitors monitors()
+    {
+        return monitors;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -196,6 +196,8 @@ public abstract class InternalAbstractGraphDatabase
          */
         Logging logging();
 
+        Monitors monitors();
+
         Iterable<Class<?>> settingsClasses();
 
         Iterable<KernelExtensionFactory<?>> kernelExtensions();
@@ -296,6 +298,7 @@ public abstract class InternalAbstractGraphDatabase
         config = new Config( params, getSettingsClasses(
                 dependencies.settingsClasses(), dependencies.kernelExtensions(), dependencies.cacheProviders() ) );
         this.logging = dependencies.logging();
+        this.monitors = dependencies.monitors();
 
         this.kernelExtensions = new KernelExtensions(
                 dependencies.kernelExtensions(),
@@ -433,7 +436,10 @@ public abstract class InternalAbstractGraphDatabase
         }
 
         // Component monitoring
-        this.monitors = createMonitors();
+        if ( this.monitors == null )
+        {
+            this.monitors = createMonitors();
+        }
 
         // Apply autoconfiguration for memory settings
         AutoConfigurator autoConfigurator = new AutoConfigurator( fileSystem,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
@@ -220,7 +220,12 @@ public abstract class SchemaIndexProvider extends LifecycleAdapter implements Co
 
     protected File getRootDirectory( Config config, String key )
     {
-        return new File( new File( new File( config.get( store_dir ), "schema" ), "index" ), key );
+        return getRootDirectory( config.get( store_dir ), key );
+    }
+
+    public static File getRootDirectory( File storeDir, String key )
+    {
+        return new File( new File( new File( storeDir, "schema" ), "index" ), key );
     }
 
     public static class Descriptor

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedIndexProxy.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.impl.util.StringLogger;
 
 import static org.neo4j.helpers.FutureAdapter.VOID;
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
@@ -37,19 +38,24 @@ public class FailedIndexProxy extends AbstractSwallowingIndexProxy
 {
     protected final IndexPopulator populator;
     private final String indexUserDescription;
+    private final StringLogger logger;
 
-    public FailedIndexProxy(IndexDescriptor descriptor, SchemaIndexProvider.Descriptor providerDescriptor,
-                            String indexUserDescription,
-                            IndexPopulator populator, IndexPopulationFailure populationFailure)
+    public FailedIndexProxy( IndexDescriptor descriptor, SchemaIndexProvider.Descriptor providerDescriptor,
+            String indexUserDescription,
+            IndexPopulator populator, IndexPopulationFailure populationFailure, StringLogger logger )
     {
         super( descriptor, providerDescriptor, populationFailure );
         this.populator = populator;
         this.indexUserDescription = indexUserDescription;
+        this.logger = logger;
     }
 
     @Override
     public Future<Void> drop() throws IOException
     {
+        String message = "FailedIndexProxy#drop index on " + indexUserDescription + " dropped due to:\n" +
+                     getPopulationFailure().asString();
+        logger.info( message );
         populator.drop();
         return VOID;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api.index;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.impl.util.StringLogger;
 
 import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
 
@@ -31,16 +32,18 @@ public class FailedPopulatingIndexProxyFactory implements FailedIndexProxyFactor
     private final SchemaIndexProvider.Descriptor providerDescriptor;
     private final IndexPopulator populator;
     private final String indexUserDescription;
+    private final StringLogger logger;
 
     FailedPopulatingIndexProxyFactory( IndexDescriptor descriptor,
-                                       SchemaIndexProvider.Descriptor providerDescriptor,
-                                       IndexPopulator populator,
-                                       String indexUserDescription )
+            SchemaIndexProvider.Descriptor providerDescriptor,
+            IndexPopulator populator,
+            String indexUserDescription, StringLogger logger )
     {
         this.descriptor = descriptor;
         this.providerDescriptor = providerDescriptor;
         this.populator = populator;
         this.indexUserDescription = indexUserDescription;
+        this.logger = logger;
     }
 
     @Override
@@ -49,6 +52,6 @@ public class FailedPopulatingIndexProxyFactory implements FailedIndexProxyFactor
         return
             new FailedIndexProxy(
                 descriptor, providerDescriptor,
-                indexUserDescription, populator, failure( failure ) );
+                indexUserDescription, populator, failure( failure ), logger );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -58,14 +58,15 @@ public class PopulatingIndexProxy implements IndexProxy
                                  final IndexPopulator writer,
                                  FlippableIndexProxy flipper,
                                  IndexStoreView storeView, final String indexUserDescription,
-                                 UpdateableSchemaState updateableSchemaState, Logging logging )
+                                 UpdateableSchemaState updateableSchemaState, Logging logging,
+            IndexingService.Monitor monitor)
     {
         this.scheduler  = scheduler;
         this.descriptor = descriptor;
         this.providerDescriptor = providerDescriptor;
         this.job  = new IndexPopulationJob( descriptor, providerDescriptor,
                 indexUserDescription, failureDelegateFactory, writer, flipper, storeView,
-                updateableSchemaState, logging );
+                updateableSchemaState, logging, monitor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/AbstractDynamicStore.java
@@ -558,8 +558,8 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         setHighId( highId + 1 );
         stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId()
             + " (defragged=" + defraggedCount + ")" );
-        stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
-                " defragged count=" + defraggedCount, true );
+        stringLogger.debug( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
+                            " defragged count=" + defraggedCount );
         closeIdGenerator();
         openIdGenerator();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/CommonAbstractStore.java
@@ -238,7 +238,7 @@ public abstract class CommonAbstractStore implements IdSequence
             {
                 if ( stringLogger != null )
                 {
-                    stringLogger.logMessage( getStorageFileName() + " non clean shutdown detected", true );
+                    stringLogger.debug( getStorageFileName() + " non clean shutdown detected" );
                 }
             }
         }
@@ -321,8 +321,8 @@ public abstract class CommonAbstractStore implements IdSequence
             throw new UnderlyingStorageException(
                     "Unable to rebuild id generator " + getStorageFileName(), e );
         }
-        stringLogger.logMessage( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
-                " defragged count=" + defraggedCount, true );
+        stringLogger.debug( getStorageFileName() + " rebuild id generator, highId=" + getHighId() +
+                            " defragged count=" + defraggedCount );
         stringLogger.debug( "[" + getStorageFileName() + "] high id=" + getHighId() +
                 " (defragged=" + defraggedCount + ")" );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaLogicalLog.java
@@ -798,8 +798,8 @@ public class XaLogicalLog implements LogLoader
         long lastCommittedTx = header[1];
         previousLogLastCommittedTx = lastCommittedTx;
         positionCache.putHeader( logVersion, previousLogLastCommittedTx );
-        msgLog.logMessage( "[" + logFileName + "] logVersion=" + logVersion +
-                " with committed tx=" + lastCommittedTx, true );
+        msgLog.debug( "[" + logFileName + "] logVersion=" + logVersion +
+                      " with committed tx=" + lastCommittedTx );
         long logEntriesFound = 0;
         long lastEntryPos = fileChannel.position();
         fileChannel = new BufferedFileChannel( fileChannel, bufferMonitor );
@@ -814,8 +814,8 @@ public class XaLogicalLog implements LogLoader
         fileChannel = ((BufferedFileChannel) fileChannel).getSource();
         fileChannel.position( lastEntryPos );
 
-        msgLog.logMessage( "[" + logFileName + "] entries found=" + logEntriesFound +
-                " lastEntryPos=" + lastEntryPos, true );
+        msgLog.debug( "[" + logFileName + "] entries found=" + logEntriesFound +
+                      " lastEntryPos=" + lastEntryPos );
 
         // zero out the slow way since windows don't support truncate very well
         sharedBuffer.clear();
@@ -838,16 +838,16 @@ public class XaLogicalLog implements LogLoader
         fileChannel.position( lastEntryPos );
         scanIsComplete = true;
         String recoveryCompletedMessage = openedLogicalLogMessage( logFileName, lastRecoveredTx, false );
-        msgLog.logMessage( recoveryCompletedMessage );
+        msgLog.info( recoveryCompletedMessage );
 
         xaRm.checkXids();
         if ( xidIdentMap.size() == 0 )
         {
-            msgLog.logMessage( "Recovery on log [" + logFileName + "] completed." );
+            msgLog.debug( "Recovery on log [" + logFileName + "] completed." );
         }
         else
         {
-            msgLog.logMessage( "Recovery on log [" + logFileName +
+            msgLog.debug( "Recovery on log [" + logFileName +
                     "] completed with " + xidIdentMap + " prepared transactions found." );
             for ( LogEntry.Start startEntry : xidIdentMap.values() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/xaframework/XaResourceManager.java
@@ -711,8 +711,8 @@ public class XaResourceManager
 
     synchronized void checkXids() throws IOException
     {
-        msgLog.logMessage( "XaResourceManager[" + name + "] sorting " +
-                xidMap.size() + " xids" );
+        msgLog.debug( "XaResourceManager[" + name + "] sorting " +
+                      xidMap.size() + " xids" );
         Iterator<Xid> keyIterator = xidMap.keySet().iterator();
         LinkedList<Xid> xids = new LinkedList<>();
         while ( keyIterator.hasNext() )
@@ -769,7 +769,7 @@ public class XaResourceManager
     {
         if ( log.scanIsComplete() && recoveredTxCount == 0 )
         {
-            msgLog.logMessage( "XaResourceManager[" + name + "] checkRecoveryComplete " + xidMap.size() + " xids" );
+            msgLog.debug( "XaResourceManager[" + name + "] checkRecoveryComplete " + xidMap.size() + " xids" );
             // log.makeNewLog();
             tf.recoveryComplete();
             try
@@ -799,7 +799,7 @@ public class XaResourceManager
                 // TODO Why only printStackTrace?
                 e.printStackTrace();
             }
-            msgLog.logMessage( "XaResourceManager[" + name + "] recovery completed." );
+            msgLog.debug( "XaResourceManager[" + name + "] recovery completed." );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/DefaultGraphDatabaseDependenciesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DefaultGraphDatabaseDependenciesTest.java
@@ -23,7 +23,9 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.BufferingLogging;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -61,7 +63,8 @@ public class DefaultGraphDatabaseDependenciesTest
     public void canSpecifyLoggerAndSettingsClasses()
     {
         Logging logging = new BufferingLogging();
-        GraphDatabaseDependencies deps = new DefaultGraphDatabaseDependencies( logging, A.class, B.class );
+        GraphDatabaseDependencies deps = new DefaultGraphDatabaseDependencies( logging, new Monitors(),
+                A.class, B.class );
         assertThat( deps.logging(), sameInstance( logging ) );
         verifySettingsClasses( deps, A.class, B.class );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/FailedIndexProxyTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.index.IndexPopulator;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class FailedIndexProxyTest
+{
+    @Test
+    public void shouldLogReasonForDroppingIndex() throws IOException
+    {
+        // given
+        StringLogger log = mock( StringLogger.class );
+
+        // when
+        new FailedIndexProxy( new IndexDescriptor( 0, 0 ), new SchemaIndexProvider.Descriptor( "foo", "bar" ), "foo",
+                mock( IndexPopulator.class ), IndexPopulationFailure.failure( "it broke" ), log ).drop();
+
+        // then
+        verify(log).info( "FailedIndexProxy#drop index on foo dropped due to:\nit broke" );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -592,7 +592,7 @@ public class IndexPopulationJobTest
                 format( ":%s(%s)", label.name(), propertyKey ),
                 failureDelegateFactory,
                 populator, flipper, storeView,
-                stateHolder, new SingleLoggingService( logger ) );
+                stateHolder, new SingleLoggingService( logger ), IndexingService.NO_MONITOR );
     }
 
     private long createNode( Map<String, Object> properties, Label... labels )

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -27,6 +27,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.monitoring.Monitors;
 
 /**
  * Test factory for graph databases
@@ -79,6 +80,12 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
     public TestGraphDatabaseFactory setFileSystem( FileSystemAbstraction fileSystem )
     {
         getCurrentState().setFileSystem( fileSystem );
+        return this;
+    }
+
+    public GraphDatabaseFactory setMonitors( Monitors monitors )
+    {
+        getCurrentState().setMonitors( monitors );
         return this;
     }
     

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
@@ -21,6 +21,7 @@ package org.neo4j.test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
 
 public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
 {
@@ -44,6 +45,7 @@ public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
     {
         return fileSystem;
     }
+
 
     public void setFileSystem( FileSystemAbstraction fileSystem )
     {

--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralFileSystemAbstraction.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,6 +56,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.neo4j.helpers.Function;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.impl.nioneo.store.FileLock;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
@@ -343,14 +345,16 @@ public class EphemeralFileSystemAbstraction extends LifecycleAdapter implements 
             return null;
 
         List<String> directoryPathItems = splitPath( directory );
-        List<File> found = new ArrayList<>();
-        for ( Map.Entry<File, EphemeralFileData> file : files.entrySet() )
+
+        Set<File> found = new HashSet<>();
+        Iterable<File> files = Iterables.concat( this.files.keySet(), directories );
+        for ( File file : files )
         {
-            File fileName = file.getKey();
-            List<String> fileNamePathItems = splitPath( fileName );
+            List<String> fileNamePathItems = splitPath( file );
             if ( directoryMatches( directoryPathItems, fileNamePathItems ) )
                 found.add( constructPath( fileNamePathItems, directoryPathItems.size()+1 ) );
         }
+
         return found.toArray( new File[found.size()] );
     }
 
@@ -362,11 +366,11 @@ public class EphemeralFileSystemAbstraction extends LifecycleAdapter implements 
             return null;
 
         List<String> directoryPathItems = splitPath( directory );
-        List<File> found = new ArrayList<>();
-        for ( Map.Entry<File, EphemeralFileData> file : files.entrySet() )
+        Set<File> found = new HashSet<>();
+        Iterable<File> files = Iterables.concat( this.files.keySet(), directories );
+        for ( File file : files )
         {
-            File fileName = file.getKey();
-            List<String> fileNamePathItems = splitPath( fileName );
+            List<String> fileNamePathItems = splitPath( file );
             if ( directoryMatches( directoryPathItems, fileNamePathItems ) )
             {
                 File path = constructPath( fileNamePathItems, directoryPathItems.size() + 1 );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -74,11 +74,6 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
     }
 
     @Override
-    public void drop()
-    {
-    }
-
-    @Override
     protected void flush() throws IOException
     {
         // no need to do anything yet.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
 import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
 
 import java.io.EOFException;
@@ -54,7 +55,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     {
         super( LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR, 1 );
         this.directoryFactory = directoryFactory;
-        this.rootDirectory = getRootDirectory( config, LuceneSchemaIndexProviderFactory.KEY );
+        this.rootDirectory = getRootDirectory( config.get( store_dir ), LuceneSchemaIndexProviderFactory.KEY );
         this.folderLayout = new FolderLayout( rootDirectory );
         this.failureStorage = new FailureStorage( folderLayout );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProviderFactory.java
@@ -31,7 +31,7 @@ import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFa
 public class LuceneSchemaIndexProviderFactory extends
         KernelExtensionFactory<LuceneSchemaIndexProviderFactory.Dependencies>
 {
-    static final String KEY = "lucene";
+    public static final String KEY = "lucene";
 
     public static final SchemaIndexProvider.Descriptor PROVIDER_DESCRIPTOR =
             new SchemaIndexProvider.Descriptor( KEY, "1.0" );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.constraints;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.ConstraintViolationException;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProviderFactory;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.index.util.FailureStorage;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConstraintCreationIT
+{
+    private static final Label LABEL = DynamicLabel.label( "label1" );
+    private GraphDatabaseAPI db;
+
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldNotLeaveLuceneIndexFilesHangingAroundIfConstraintCreationFails()
+    {
+        // given
+        GraphDatabaseAPI db =
+                (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabase( testDirectory.directory().getPath() );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 2; i++ )
+            {
+                Node node1 = db.createNode( LABEL );
+                node1.setProperty( "prop", true );
+            }
+
+            tx.success();
+        }
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( LABEL ).assertPropertyIsUnique( "prop" ).create();
+            fail("Should have failed with ConstraintViolationException");
+            tx.success();
+        }
+        catch ( ConstraintViolationException ignored )  { }
+
+        // then
+        try(Transaction tx = db.beginTx())
+        {
+            assertEquals(0, Iterables.count(db.schema().getIndexes() ));
+        }
+
+        File schemaStorePath = SchemaIndexProvider
+                .getRootDirectory( new File( db.getStoreDir() ), LuceneSchemaIndexProviderFactory.KEY );
+
+        String indexId = "1";
+        File[] files = new File(schemaStorePath, indexId ).listFiles();
+        assertNotNull( files );
+        assertEquals(0, files.length);
+
+        db.shutdown();
+    }
+
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.constraints;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.ConstraintViolationException;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConstraintRecoveryIT
+{
+    private static final Label LABEL = DynamicLabel.label( "label1" );
+    @Rule
+    public EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
+    private GraphDatabaseAPI db;
+
+    @Test
+    public void shouldNotHaveAnIndexIfUniqueConstraintCreationOnRecoveryFails() throws IOException
+    {
+        // given
+        final EphemeralFileSystemAbstraction fs = fileSystemRule.get();
+        fs.mkdir( new File("/tmp") );
+        String pathToDb = "/tmp/bar2";
+
+        TestGraphDatabaseFactory dbFactory = new TestGraphDatabaseFactory();
+        dbFactory.setFileSystem( fs );
+
+        final EphemeralFileSystemAbstraction[] storeInNeedOfRecovery = new EphemeralFileSystemAbstraction[1];
+        final AtomicBoolean monitorCalled = new AtomicBoolean( false );
+
+        Monitors monitors = new Monitors();
+        monitors.addMonitorListener( new IndexingService.MonitorAdapter()
+        {
+            @Override
+            public void verifyDeferredConstraints()
+            {
+                monitorCalled.set( true );
+                db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate().getSchemaStore().flushAll();
+                storeInNeedOfRecovery[0] = fs.snapshot();
+            }
+        } );
+        dbFactory.setMonitors( monitors );
+
+
+        db = (GraphDatabaseAPI) dbFactory.newImpermanentDatabase( pathToDb );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 2; i++ )
+            {
+                Node node1 = db.createNode( LABEL );
+                node1.setProperty( "prop", true );
+            }
+
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( LABEL ).assertPropertyIsUnique( "prop" ).create();
+            fail("Should have failed with ConstraintViolationException");
+            tx.success();
+        }
+        catch ( ConstraintViolationException ignored )  { }
+
+        db.shutdown();
+
+        assertTrue( monitorCalled.get() );
+
+        // when
+        dbFactory = new TestGraphDatabaseFactory();
+        dbFactory.setFileSystem( storeInNeedOfRecovery[0] );
+        db = (GraphDatabaseAPI) dbFactory.newImpermanentDatabase( pathToDb );
+
+        // then
+        try(Transaction tx = db.beginTx())
+        {
+            db.schema().awaitIndexesOnline( 5000, TimeUnit.MILLISECONDS );
+        }
+
+        try(Transaction tx = db.beginTx())
+        {
+            assertEquals(2, Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+        }
+
+        try(Transaction tx = db.beginTx())
+        {
+            assertEquals(0, Iterables.count(Iterables.toList( db.schema().getConstraints() )));
+        }
+
+        try(Transaction tx = db.beginTx())
+        {
+            assertEquals(0, Iterables.count(Iterables.toList( db.schema().getIndexes() )));
+        }
+
+        db.shutdown();
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -134,7 +134,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                                          Iterable<CacheProvider> cacheProviders,
                                          Iterable<TransactionInterceptorProvider> txInterceptorProviders )
     {
-        this( storeDir, params, new GraphDatabaseDependencies( null,
+        this( storeDir, params, new GraphDatabaseDependencies( null, null,
                 Arrays.<Class<?>>asList( GraphDatabaseSettings.class, ClusterSettings.class, HaSettings.class ),
                 kernelExtensions, cacheProviders, txInterceptorProviders ) );
     }


### PR DESCRIPTION
* This commit contains a test which simulates the killing of Neo4j
  during the creation of a unique constraint. It leaves the store in
  the state where the index has been created and the IndexRule command
  added to the tx log but the constraint hasn't been created and can't
  be because we have nodes with duplicate property values.
  On recovery we'll try to apply the constraint again and fail so we
  should clean up the index which is done by RemoveOrphanConstraintIndexesOnStartup
* Updated the IndexingService.Monitor to allow us to do the simulation
* Added monitors to TestGraphDatabase so we can control it from the test
* Log the reason for dropping an index
* Make sure lucene files are removed if unique constraint creation fails during
  normal database runtime