### PR TITLE
Do not round cardinality.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -211,7 +211,7 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
       }
 
       val cardinality = context.cardinality(plan, input)
-      result.withEstimatedCardinality(math.round(cardinality.amount))
+      result.withEstimatedCardinality(cardinality.amount)
     }
 
     object buildPipeExpressions extends Rewriter {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilderTest.scala
@@ -183,12 +183,4 @@ class PipeExecutionPlanBuilderTest extends CypherFunSuite with LogicalPlanningTe
       ExpandAllPipe( AllNodesScanPipe("c")(), "c", "r2", "b", Direction.INCOMING, LazyTypes.empty)()
     )())
   }
-
-  test("cardinality should be rounded properly") {
-    val logicalPlan = OptionalExpand(
-      AllNodesScan("a", Set.empty)(solved), "a", Direction.INCOMING, Seq(), "a", "r", ExpandInto)_
-    val pipeInfo: PipeInfo = build(logicalPlan)
-
-    pipeInfo.pipe.asInstanceOf[RonjaPipe].estimatedCardinality.get should equal(105000.0)
-  }
 }


### PR DESCRIPTION
Cardinality was always rounded to nearest integer and then presented with three decimal places,
leading to that all cardinalities were presented as `.000`.