### PR TITLE
Revert "Make our interpretation of the `lsof` output more robust"

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -144,7 +144,7 @@ detectrunning() {
   else
       ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
       ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F -Ts | grep '^\(p\|TST=LISTEN\)' | head -n 1)
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
       newpid=${newpid:1}
   fi
 }


### PR DESCRIPTION
This reverts commit 298d0a3ee1612407299e307de25e24c0a8bc2d38.