### PR TITLE
Remove unneccessary filters involving $$$_-variables from planning

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
@@ -59,7 +59,7 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[PlanTable],
           val candidatesPerIds: Map[Set[IdName], Seq[LogicalPlan]] =
             selected.foldLeft(Map.empty[Set[IdName], Seq[LogicalPlan]]) {
               case (acc, plan) =>
-                val ids = plan.availableSymbols.filterNot(idName => idName.name.endsWith("$$$_") || idName.name.endsWith("$$$"))
+                val ids = plan.availableSymbols.filterNot(_.name.endsWith("$$$"))
                 val candidates = acc.getOrElse(ids, Seq.empty) :+ plan
                 acc + (ids -> candidates)
             }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlannerList.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlannerList.scala
@@ -25,19 +25,6 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
 case class LeafPlannerList(leafPlanners: LeafPlanner*) {
   def candidates(qg: QueryGraph, f: (LogicalPlan, QueryGraph) => LogicalPlan)(implicit context: LogicalPlanningContext): Iterable[Seq[LogicalPlan]] = {
     val logicalPlans = leafPlanners.flatMap(_(qg)).map(f(_,qg))
-
-    /*
-     * The filterNot here is needed since we introduce new variables (ending with '$$$_') when using projectEndPoints
-     * in order to  enforce equality with nodes already in scope.  The problem here is that if we do not filter out
-     * those '$$$_-variables' when grouping, plans which differ only for such '$$$_'-variables are not grouped together
-     * and so not compared by our pickBestPlan causing troubles when planning.  Particularly, we have seen better plan
-     * to be discarded due to the fact that they were not grouped together with plans containing extra '$$$_'-variables
-     * and so not properly compared with each other and worse later wrongly discarded since they were covering 'less'
-     * (no '$$$_'-variables) wrt the other plans.
-     *
-     * This is definitely a sub-optimal solution but needed until projectEndPoint is changed to not introduce such
-     * offending '$$$_'-variables.
-     */
-    logicalPlans.groupBy(_.availableSymbols.filterNot(_.name.endsWith("$$$_"))).values
+    logicalPlans.groupBy(_.availableSymbols).values
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipeTest.scala
@@ -59,6 +59,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
     // then
     result should equal(List(Map("r" -> rel, "a" -> node1, "b" -> node2)))
   }
+
   test("projects endpoints of a directed, simple relationship with start in scope which doesn't match") {
     // given
 
@@ -68,6 +69,26 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     val left = newMockedPipe("r",
       row("r" -> rel, "a" -> node2)
+    )
+
+    // when
+    val result =
+      ProjectEndpointsPipe(left, "r", "a", startInScope = true, "b", endInScope = false, None, directed = true, simpleLength = true)().
+        createResults(queryState).toList
+
+    // then
+    result should be(empty)
+  }
+
+  test("should work if in scope there are non-node object with the same name as the start node") {
+    // given
+
+    val rel = newMockedRelationship(12, node1, node2)
+    when(query.relationshipStartNode(rel)).thenReturn(node1)
+    when(query.relationshipEndNode(rel)).thenReturn(node2)
+
+    val left = newMockedPipe("r",
+      row("r" -> rel, "a" -> 42)
     )
 
     // when


### PR DESCRIPTION
Add an extra test to ProjectEndpointsPipeTest when the variable in
scope has a type different from Node