### PR TITLE
Support ExpandInto mode in VarLengthExpandPipe

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.StatementCon
 import org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters.projectNamedPaths
 import org.neo4j.cypher.internal.compiler.v2_2.ast.{Expression, Identifier, NodeStartItem, RelTypeName}
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{AggregationExpression, Expression => CommandExpression}
-import org.neo4j.cypher.internal.compiler.v2_2.commands.{EntityProducerFactory, True, Predicate => CommandPredicate}
+import org.neo4j.cypher.internal.compiler.v2_2.commands.{EntityProducerFactory, Predicate => CommandPredicate, True}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{PipeInfo, PlanFingerprint}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.{LazyTypes, _}
@@ -125,7 +125,12 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
             }
           }
 
-          VarLengthExpandPipe(buildPipe(left, input), fromName, relName, toName, dir, projectedDir, LazyTypes(types), min, max, predicate)()
+          val nodeInScope = expansionMode match {
+            case ExpandAll => false
+            case ExpandInto => true
+          }
+          VarLengthExpandPipe(buildPipe(left, input), fromName, relName, toName, dir, projectedDir,
+            LazyTypes(types), min, max, nodeInScope, predicate)()
 
         case NodeHashJoin(nodes, left, right) =>
           NodeHashJoinPipe(nodes.map(_.name), buildPipe(left, input), buildPipe(right, input))()

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/GreedyQueryGraphSolver.scala
@@ -59,7 +59,7 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[PlanTable],
           val candidatesPerIds: Map[Set[IdName], Seq[LogicalPlan]] =
             selected.foldLeft(Map.empty[Set[IdName], Seq[LogicalPlan]]) {
               case (acc, plan) =>
-                val ids = plan.availableSymbols.filterNot(_.name.endsWith("$$$"))
+                val ids = plan.availableSymbols
                 val candidates = acc.getOrElse(ids, Seq.empty) :+ plan
                 acc + (ids -> candidates)
             }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
@@ -156,14 +156,14 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val arguments = Seq(
       Rows(42),
       DbHits(33))
-    val expandPipe = VarLengthExpandPipe(pipe, "from", "rel", "to", Direction.INCOMING, Direction.OUTGOING, LazyTypes.empty, 0, None)(Some(1L))(mock[PipeMonitor])
+    val expandPipe = VarLengthExpandPipe(pipe, "from", "rel", "to", Direction.INCOMING, Direction.OUTGOING, LazyTypes.empty, 0, None, nodeInScope = false)(Some(1L))(mock[PipeMonitor])
 
     renderDetails(expandPipe.planDescription) should equal(
-      """+-------------------+---------------+-------------+----------------------+
-        ||          Operator | EstimatedRows | Identifiers |                Other |
-        |+-------------------+---------------+-------------+----------------------+
-        || Var length expand |         1.000 |     rel, to | (from)-[rel:*]->(to) |
-        |+-------------------+---------------+-------------+----------------------+
+      """+----------------------+---------------+-------------+----------------------+
+        ||             Operator | EstimatedRows | Identifiers |                Other |
+        |+----------------------+---------------+-------------+----------------------+
+        || VarLengthExpand(All) |         1.000 |     rel, to | (from)-[rel:*]->(to) |
+        |+----------------------+---------------+-------------+----------------------+
         |""".stripMargin)
   }
 


### PR DESCRIPTION
There are 2 benefits:
1) avoid introducing fake $$$-variables by pushing node-filtering into VarLengthExpandPipe
2) simplify planning by removing special handling of $$$-variables