### PR TITLE
Backup tool can choose to copy transaction logs

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -31,8 +31,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.monitoring.BackupMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
-import java.util.concurrent.CountDownLatch;
-
 class BackupImpl implements TheBackupInterface
 {
     private final BackupMonitor backupMonitor;
@@ -47,7 +45,6 @@ class BackupImpl implements TheBackupInterface
     private SPI spi;
     private final XaDataSourceManager xaDataSourceManager;
     private final KernelPanicEventGenerator kpeg;
-    private CountDownLatch countDownLatch;
 
     public BackupImpl( StringLogger logger, SPI spi, XaDataSourceManager xaDataSourceManager,
                        KernelPanicEventGenerator kpeg,
@@ -60,12 +57,12 @@ class BackupImpl implements TheBackupInterface
         this.backupMonitor = monitors.newMonitor( BackupMonitor.class, getClass() );
     }
     
-    public Response<Void> fullBackup( StoreWriter writer )
+    public Response<Void> fullBackup( StoreWriter writer, boolean forensics )
     {
         backupMonitor.startCopyingFiles();
         RequestContext context = ServerUtil.rotateLogsAndStreamStoreFiles( spi.getStoreDir(),
                 xaDataSourceManager,
-                kpeg, logger, false, writer, backupMonitor );
+                kpeg, logger, forensics, writer, backupMonitor );
         writer.done();
         backupMonitor.finishedCopyingStoreFiles();
         return packResponse( context );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -114,7 +114,7 @@ class BackupService
     }
 
     BackupOutcome doFullBackup( String sourceHostNameOrIp, int sourcePort, String targetDirectory,
-                                boolean checkConsistency, Config tuningConfiguration )
+                                boolean checkConsistency, Config tuningConfiguration, boolean forensics )
     {
         if ( directoryContainsDb( targetDirectory ) )
         {
@@ -130,7 +130,7 @@ class BackupService
         try
         {
             Response<Void> response = client.fullBackup( decorateWithProgressIndicator(
-                    new ToFileStoreWriter( new File( targetDirectory ) ) ) );
+                    new ToFileStoreWriter( new File( targetDirectory ) ) ), forensics );
             GraphDatabaseAPI targetDb = startTemporaryDb( targetDirectory,
                     VerificationLevel.NONE /* run full check instead */ );
             try
@@ -316,11 +316,11 @@ class BackupService
     }
 
     BackupOutcome doIncrementalBackupOrFallbackToFull( String sourceHostNameOrIp, int sourcePort, String targetDirectory,
-                                                       boolean verification, Config config )
+                                                       boolean verification, Config config, boolean forensics )
     {
         if(!directoryContainsDb( targetDirectory ))
         {
-            return doFullBackup( sourceHostNameOrIp, sourcePort, targetDirectory, verification, config );
+            return doFullBackup( sourceHostNameOrIp, sourcePort, targetDirectory, verification, config, forensics );
         }
 
         try
@@ -338,7 +338,7 @@ class BackupService
                 FileUtils.deleteRecursively( targetDirFile );
 
                 return doFullBackup( sourceHostNameOrIp, sourcePort, targetDirFile.getAbsolutePath(),
-                                                      verification, config );
+                                                      verification, config, forensics );
             }
             catch ( IOException fullBackupFailure )
             {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -58,6 +58,7 @@ public class BackupTool
     private static final String FROM = "from";
     private static final String VERIFY = "verify";
     private static final String CONFIG = "config";
+    private static final String FORENSICS = "gather-forensics";
     public static final String DEFAULT_SCHEME = "single";
 
     static final String MISMATCHED_STORE_ID = "You tried to perform a backup from database %s, " +
@@ -107,6 +108,7 @@ public class BackupTool
         String to = arguments.get( TO, null );
         boolean verify = arguments.getBoolean( VERIFY, true, true );
         Config tuningConfiguration = readTuningConfiguration( TO, arguments );
+        boolean forensics = arguments.getBoolean( FORENSICS, false, true );
 
         if (!from.contains( ":" ))
             from = "single://"+from;
@@ -175,7 +177,7 @@ public class BackupTool
             if (str.contains( "://" ))
                 str = str.split( "://" )[1];
             systemOut.println("Performing backup from '" + str + "'");
-            return doBackup( backupURI, to, verify, tuningConfiguration );
+            return doBackup( backupURI, to, verify, tuningConfiguration, forensics );
         }
         catch ( TransactionFailureException e )
         {
@@ -194,7 +196,7 @@ public class BackupTool
                             " - cannot continue, aborting.", e );
                 }
 
-                return doBackup( backupURI, to, verify, tuningConfiguration );
+                return doBackup( backupURI, to, verify, tuningConfiguration, forensics );
             }
             else
             {
@@ -243,12 +245,13 @@ public class BackupTool
         return new Config( specifiedProperties, GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
     }
 
-    private BackupOutcome doBackup( URI from, String to, boolean checkConsistency, Config tuningConfiguration ) throws ToolFailureException
+    private BackupOutcome doBackup( URI from, String to, boolean checkConsistency, Config tuningConfiguration,
+            boolean forensics ) throws ToolFailureException
     {
         try
         {
             BackupOutcome backupOutcome = backupService.doIncrementalBackupOrFallbackToFull( from.getHost(), extractPort( from ), to, checkConsistency,
-                tuningConfiguration );
+                tuningConfiguration, forensics );
             systemOut.println( "Done" );
             return backupOutcome;
         }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -41,6 +41,7 @@ public class OnlineBackup
 {
     private final String hostNameOrIp;
     private final int port;
+    private boolean forensics;
     private BackupService.BackupOutcome outcome;
 
     /**
@@ -91,7 +92,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory, true,
-                defaultConfig() );
+                defaultConfig(), forensics );
         return this;
     }
 
@@ -114,7 +115,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory, boolean verification )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
-                verification, defaultConfig() );
+                verification, defaultConfig(), forensics );
         return this;
     }
 
@@ -135,7 +136,7 @@ public class OnlineBackup
     public OnlineBackup backup( String targetDirectory, Config tuningConfiguration )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory, true,
-                tuningConfiguration );
+                tuningConfiguration, forensics );
         return this;
     }
 
@@ -159,7 +160,7 @@ public class OnlineBackup
                                 boolean verification )
     {
         outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
-                verification, tuningConfiguration );
+                verification, tuningConfiguration, forensics );
         return this;
     }
 
@@ -178,7 +179,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup full( String targetDirectory )
     {
-        outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, true, defaultConfig() );
+        outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, true, defaultConfig(), forensics );
         return this;
     }
 
@@ -199,7 +200,7 @@ public class OnlineBackup
     public OnlineBackup full( String targetDirectory, boolean verification )
     {
         outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, verification,
-                defaultConfig() );
+                defaultConfig(), forensics );
         return this;
     }
 
@@ -222,7 +223,7 @@ public class OnlineBackup
     public OnlineBackup full( String targetDirectory, boolean verification, Config tuningConfiguration )
     {
         outcome = new BackupService().doFullBackup( hostNameOrIp, port, targetDirectory, verification,
-                tuningConfiguration );
+                tuningConfiguration, forensics );
         return this;
     }
 
@@ -319,5 +320,15 @@ public class OnlineBackup
     private Config defaultConfig()
     {
         return new Config( stringMap(), GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
+    }
+
+    /**
+     * @param forensics whether or not additional information should be backed up, for example transaction
+     * @return The same OnlineBackup instance, possible to use for a new backup operation
+     */
+    public OnlineBackup gatheringForensics( boolean forensics )
+    {
+        this.forensics = forensics;
+        return this;
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/TheBackupInterface.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/TheBackupInterface.java
@@ -25,7 +25,7 @@ import org.neo4j.com.StoreWriter;
 
 public interface TheBackupInterface
 {
-    Response<Void> fullBackup( StoreWriter writer );
+    Response<Void> fullBackup( StoreWriter writer, boolean forensics );
     
     Response<Void> incrementalBackup( RequestContext context );
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import org.neo4j.backup.BackupClient.BackupRequestType;
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.RequestContext.Tx;
+import org.neo4j.com.Response;
+import org.neo4j.com.StoreWriter;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.impl.nioneo.store.StoreId;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.jboss.netty.buffer.ChannelBuffers.EMPTY_BUFFER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.kernel.configuration.Config.DEFAULT_DATA_SOURCE_NAME;
+
+public class BackupProtocolTest
+{
+    @Test
+    public void shouldGatherForensicsInFullBackupRequest() throws Exception
+    {
+        shouldGatherForensicsInFullBackupRequest( true );
+    }
+
+    @Test
+    public void shouldSkipGatheringForensicsInFullBackupRequest() throws Exception
+    {
+        shouldGatherForensicsInFullBackupRequest( false );
+    }
+
+    @Test
+    public void shouldHandleNoForensicsSpecifiedInFullBackupRequest() throws Exception
+    {
+        TheBackupInterface backup = mock( TheBackupInterface.class );
+        RequestContext ctx = new RequestContext( 0, 1, 0, new Tx[]{ new Tx( DEFAULT_DATA_SOURCE_NAME, 1)}, -1, 12 );
+        BackupRequestType.FULL_BACKUP.getTargetCaller().call( backup, ctx, EMPTY_BUFFER, null );
+        verify( backup ).fullBackup( any( StoreWriter.class ), eq( false ) );
+    }
+
+    private void shouldGatherForensicsInFullBackupRequest( boolean forensics ) throws Exception
+    {
+        // GIVEN
+        Response<Void> response = Response.EMPTY;
+        StoreId storeId = response.getStoreId();
+        DevNullLoggingService logging = new DevNullLoggingService();
+        Monitors monitors = new Monitors();
+        String host = "localhost";
+        int port = BackupServer.DEFAULT_PORT;
+        LifeSupport life = new LifeSupport();
+
+        BackupClient client = life.add( new BackupClient( host, port, logging,
+                monitors, storeId ) );
+        ControlledBackupInterface backup = new ControlledBackupInterface();
+        BackupServer server = life.add( new BackupServer( backup, new HostnamePort( host, port ),
+                logging, monitors ) );
+        life.start();
+
+        try
+        {
+            // WHEN
+            StoreWriter writer = mock( StoreWriter.class );
+            client.fullBackup( writer, forensics );
+
+            // THEN
+            assertEquals( forensics, backup.receivedForensics.booleanValue() );
+        }
+        finally
+        {
+            life.shutdown();
+        }
+    }
+
+    private static class ControlledBackupInterface implements TheBackupInterface
+    {
+        private Boolean receivedForensics;
+
+        @Override
+        public Response<Void> fullBackup( StoreWriter writer, boolean forensics )
+        {
+            this.receivedForensics = forensics;
+            writer.done();
+            return Response.EMPTY;
+        }
+
+        @Override
+        public Response<Void> incrementalBackup( RequestContext context )
+        {
+            throw new UnsupportedOperationException( "Should be required" );
+        }
+    }
+}

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -112,7 +112,7 @@ public class BackupServiceIT
         try
         {
             // when
-            new BackupService( fileSystem ).doFullBackup( "", 0, backupDir.getAbsolutePath(), true, new Config() );
+            new BackupService( fileSystem ).doFullBackup( "", 0, backupDir.getAbsolutePath(), true, new Config(), false );
         }
         catch ( RuntimeException ex )
         {
@@ -131,7 +131,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
         db.shutdown();
 
         // then
@@ -154,7 +154,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
         db.shutdown();
 
         // then
@@ -174,7 +174,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
         db.shutdown();
 
         // then
@@ -196,7 +196,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
         db.shutdown();
 
         // then
@@ -214,7 +214,7 @@ public class BackupServiceIT
         // when
         BackupService backupService = new BackupService( fileSystem );
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
         db.shutdown();
 
         // then
@@ -236,7 +236,7 @@ public class BackupServiceIT
 
         // A full backup
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
 
         // And the log the backup uses is rotated out
         createAndIndexNode( db, 2 );
@@ -279,7 +279,7 @@ public class BackupServiceIT
 
         // A full backup
         backupService.doFullBackup( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config( defaultBackupPortHostParams() ) );
+                new Config( defaultBackupPortHostParams() ), false );
 
         // And the log the backup uses is rotated out
         createAndIndexNode( db, 2 );
@@ -291,7 +291,7 @@ public class BackupServiceIT
 
 
         // when
-        backupService.doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, new Config(defaultBackupPortHostParams()));
+        backupService.doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false, new Config(defaultBackupPortHostParams()), false);
 
 
         // Then
@@ -312,7 +312,7 @@ public class BackupServiceIT
 
         // when
         backupService.doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir.getAbsolutePath(), false,
-                new Config(defaultBackupPortHostParams()));
+                new Config(defaultBackupPortHostParams()), false);
 
         // then
         db.shutdown();
@@ -475,7 +475,7 @@ public class BackupServiceIT
 
         BackupService.BackupOutcome backupOutcome = backupService.doFullBackup( BACKUP_HOST, backupPort,
                 backupDir.getAbsolutePath(), true,
-                new Config( params ) );
+                new Config( params ), false );
 
         backup.stop();
         executor.shutdown();

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolTest.java
@@ -58,7 +58,7 @@ public class BackupToolTest
 
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ),
-                eq( BackupServer.DEFAULT_PORT ), eq( "my_backup" ), eq( true ), any( Config.class ) );
+                eq( BackupServer.DEFAULT_PORT ), eq( "my_backup" ), eq( true ), any( Config.class ), eq( false ) );
         verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
@@ -75,7 +75,7 @@ public class BackupToolTest
 
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ), eq( BackupServer.DEFAULT_PORT ),
-                eq( "my_backup" ), eq( true ), any( Config.class ) );
+                eq( "my_backup" ), eq( true ), any( Config.class ), eq( false ) );
         verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
@@ -93,7 +93,7 @@ public class BackupToolTest
 
         // then
         verify( service ).doIncrementalBackupOrFallbackToFull( eq( "localhost" ), eq( BackupServer.DEFAULT_PORT ),
-                eq( "my_backup" ), eq( true ), any(Config.class) );
+                eq( "my_backup" ), eq( true ), any(Config.class), eq( false ) );
         verify( systemOut ).println( "Performing backup from 'localhost'" );
         verify( systemOut ).println( "Done" );
     }
@@ -113,7 +113,7 @@ public class BackupToolTest
         // then
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
         verify( service ).doIncrementalBackupOrFallbackToFull( anyString(), anyInt(), anyString(), anyBoolean(),
-                config.capture() );
+                config.capture(), eq( false ) );
         assertFalse( config.getValue().get( ConsistencyCheckSettings.consistency_check_property_owners ) );
         assertEquals( TaskExecutionOrder.MULTI_PASS,
                 config.getValue().get( ConsistencyCheckSettings.consistency_check_execution_order ) );
@@ -144,7 +144,7 @@ public class BackupToolTest
         // then
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
         verify( service ).doIncrementalBackupOrFallbackToFull( anyString(), anyInt(), anyString(), anyBoolean(),
-                config.capture() );
+                config.capture(), eq( false ) );
         assertTrue( config.getValue().get( ConsistencyCheckSettings.consistency_check_property_owners ) );
     }
 
@@ -254,4 +254,19 @@ public class BackupToolTest
         verifyZeroInteractions( service );
     }
 
+    @Test
+    public void shouldMakeUseOfDebugArgument() throws Exception
+    {
+        // given
+        String[] args = new String[]{"-from", "localhost", "-to", "my_backup", "-gather-forensics"};
+        BackupService service = mock( BackupService.class );
+        PrintStream systemOut = mock( PrintStream.class );
+
+        // when
+        new BackupTool( service, systemOut ).run( args );
+
+        // then
+        verify( service ).doIncrementalBackupOrFallbackToFull( anyString(), anyInt(), anyString(), anyBoolean(),
+                any( Config.class ), eq( true ) );
+    }
 }


### PR DESCRIPTION
using a -debug argument to the backup tool. This to enable access to
transaction logs, for forensics/debug purposes, w/o the need to manually
copying those or to take down the database server. The default behaviour
(leaving out -debug) will have the same behaviour as before, i.e. to not
copy transaction logs when doing full backup.