### PR TITLE
Render estimated rows with two significant digits.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/renderDetails.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 
+import java.math.MathContext
+
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.UnNamedNameGenerator._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments._
 import scala.collection.mutable
@@ -37,7 +39,7 @@ object renderDetails extends (InternalPlanDescription => String) {
       p =>
         val name = Some(names(p))
         val rows = p.arguments.collectFirst { case Rows(count) => count.toString}
-        val estimatedRows = p.arguments.collectFirst { case EstimatedRows(count) => "%.3f".format(count) }
+        val estimatedRows = p.arguments.collectFirst { case EstimatedRows(count) => format(count) }
         val dbHits = p.arguments.collectFirst { case DbHits(count) => count.toString}
         val ids = Some(p.orderedIdentifiers.filter(_.isNamed).mkString(", "))
         val other = Some(p.arguments.collect {
@@ -64,6 +66,9 @@ object renderDetails extends (InternalPlanDescription => String) {
 
     renderTable(headers.filter(headersInUse.contains), rowsInUse)
   }
+
+  private def format(v: Double) = if (v.isNaN) v.toString else BigDecimal(v, new MathContext(2)).bigDecimal.toPlainString
+
 
   private def renderTable(header: Seq[String], rows: Seq[Seq[String]]): String = {
     val columnWidth = mutable.ArrayBuffer[Int](header.map(_.length): _*)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
@@ -21,6 +21,8 @@ package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 
 import java.util.Locale
 
+import org.mockito.Mockito
+import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.commands._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, LengthFunction}
@@ -56,7 +58,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
         |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |       |
+        ||     NAME |           1.0 |   42 |     33 |           n |       |
         |+----------+---------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
@@ -72,7 +74,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
         |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |     a, b, c |       |
+        ||     NAME |           1.0 |   42 |     33 |     a, b, c |       |
         |+----------+---------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
@@ -88,7 +90,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+------------------+-------+
         || Operator | EstimatedRows | Rows | DbHits |      Identifiers | Other |
         |+----------+---------------+------+--------+------------------+-------+
-        ||     NAME |         1.000 |   42 |     33 | a, b, c, d, e, f |       |
+        ||     NAME |           1.0 |   42 |     33 | a, b, c, d, e, f |       |
         |+----------+---------------+------+--------+------------------+-------+
         |""".stripMargin)
   }
@@ -102,7 +104,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+-------------+-------+
         || Operator | EstimatedRows | Identifiers | Other |
         |+----------+---------------+-------------+-------+
-        ||     NAME |         1.000 |           n |       |
+        ||     NAME |           1.0 |           n |       |
         |+----------+---------------+-------------+-------+
         |""".stripMargin)
   }
@@ -118,8 +120,8 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+--------------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |        Other |
         |+----------+---------------+------+--------+-------------+--------------+
-        ||  NAME(0) |         1.000 |    2 |    633 |           b | :Label(Prop) |
-        ||  NAME(1) |         1.000 |   42 |     33 |           a |              |
+        ||  NAME(0) |           1.0 |    2 |    633 |           b | :Label(Prop) |
+        ||  NAME(1) |           1.0 |   42 |     33 |           a |              |
         |+----------+---------------+------+--------+-------------+--------------+
         |""".stripMargin)
   }
@@ -135,7 +137,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+-------------+---------------+-------------+---------------------+
         ||    Operator | EstimatedRows | Identifiers |               Other |
         |+-------------+---------------+-------------+---------------------+
-        || Expand(All) |         1.000 |     rel, to | (from)<-[rel:]-(to) |
+        || Expand(All) |           1.0 |     rel, to | (from)<-[rel:]-(to) |
         |+-------------+---------------+-------------+---------------------+
         |""".stripMargin)
   }
@@ -147,7 +149,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+-----------------+---------------+-------------+-------+
         ||        Operator | EstimatedRows | Identifiers | Other |
         |+-----------------+---------------+-------------+-------+
-        || NodeByLabelScan |         1.000 |           n |  :Foo |
+        || NodeByLabelScan |           1.0 |           n |  :Foo |
         |+-----------------+---------------+-------------+-------+
         |""".stripMargin )
   }
@@ -162,7 +164,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------------------+---------------+-------------+----------------------+
         ||             Operator | EstimatedRows | Identifiers |                Other |
         |+----------------------+---------------+-------------+----------------------+
-        || VarLengthExpand(All) |         1.000 |     rel, to | (from)-[rel:*]->(to) |
+        || VarLengthExpand(All) |           1.0 |     rel, to | (from)-[rel:*]->(to) |
         |+----------------------+---------------+-------------+----------------------+
         |""".stripMargin)
   }
@@ -179,7 +181,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+------------------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |            Other |
         |+----------+---------------+------+--------+-------------+------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | ()-[R:WHOOP]->() |
+        ||     NAME |           1.0 |   42 |     33 |           n | ()-[R:WHOOP]->() |
         |+----------+---------------+------+--------+-------------+------------------+
         |""".stripMargin)
   }
@@ -196,7 +198,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-------------------------------------------------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |                                           Other |
         |+----------+---------------+------+--------+-------------+-------------------------------------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | (source)-[through:SOME|:OTHER|:THING]->(target) |
+        ||     NAME |           1.0 |   42 |     33 |           n | (source)-[through:SOME|:OTHER|:THING]->(target) |
         |+----------+---------------+------+--------+-------------+-------------------------------------------------+
         |""".stripMargin)
   }
@@ -212,7 +214,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-----------------------------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |                       Other |
         |+----------+---------------+------+--------+-------------+-----------------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | NOT(anon[123] == anon[321]) |
+        ||     NAME |           1.0 |   42 |     33 |           n | NOT(anon[123] == anon[321]) |
         |+----------+---------------+------+--------+-------------+-----------------------------+
         |""".stripMargin)
   }
@@ -229,7 +231,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+--------------------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |              Other |
         |+----------+---------------+------+--------+-------------+--------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | hasLabel(x:Artist) |
+        ||     NAME |           1.0 |   42 |     33 |           n | hasLabel(x:Artist) |
         |+----------+---------------+------+--------+-------------+--------------------+
         |""".stripMargin)
   }
@@ -246,7 +248,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-----------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers |     Other |
         |+----------+---------------+------+--------+-------------+-----------+
-        ||     NAME |         1.000 |   42 |     33 |           n | length(n) |
+        ||     NAME |           1.0 |   42 |     33 |           n | length(n) |
         |+----------+---------------+------+--------+-------------+-----------+
         |""".stripMargin)
   }
@@ -263,7 +265,7 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
         |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |    id |
+        ||     NAME |           1.0 |   42 |     33 |           n |    id |
         |+----------+---------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
@@ -281,8 +283,29 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
       """+----------+---------------+------+--------+-------------+-------+
         || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
         |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |    id |
+        ||     NAME |           1.0 |   42 |     33 |           n |    id |
         |+----------+---------------+------+--------+-------------+-------+
         |""".stripMargin)
+  }
+
+  test("use two significant digits in EstimatedRows") {
+    val pipe1 = NodeByLabelScanPipe("n", LazyLabel("Foo"))(Some(0.00123456789))(mock[PipeMonitor])
+    val pipe2 = NodeByLabelScanPipe("n", LazyLabel("Foo"))(Some(123456789))(mock[PipeMonitor])
+
+    renderDetails( pipe1.planDescription ) should equal(
+      """+-----------------+---------------+-------------+-------+
+        ||        Operator | EstimatedRows | Identifiers | Other |
+        |+-----------------+---------------+-------------+-------+
+        || NodeByLabelScan |        0.0012 |           n |  :Foo |
+        |+-----------------+---------------+-------------+-------+
+        |""".stripMargin )
+
+    renderDetails(pipe2.planDescription ) should equal(
+      """+-----------------+---------------+-------------+-------+
+        ||        Operator | EstimatedRows | Identifiers | Other |
+        |+-----------------+---------------+-------------+-------+
+        || NodeByLabelScan |     120000000 |           n |  :Foo |
+        |+-----------------+---------------+-------------+-------+
+        |""".stripMargin )
   }
 }


### PR DESCRIPTION
Suggestion: Instead of always render `EstimatedRows` with three decimal digits,
render it with two significant digits.