### PR TITLE
Improve estimation when planning by introducing 'operator cardinality' and 'produced rows'

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/AllNodesScanPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
-case class AllNodesScanPipe(ident: String)(val estimatedCardinality: Option[Double] = None)
+case class AllNodesScanPipe(ident: String)(val estimation: Estimation = Estimation.empty)
                            (implicit pipeMonitor: PipeMonitor) extends Pipe with RonjaPipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
@@ -49,5 +49,5 @@ case class AllNodesScanPipe(ident: String)(val estimatedCardinality: Option[Doub
 
   def sources: Seq[Pipe] = Seq.empty
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ApplyPipe.scala
@@ -24,8 +24,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{PlanDescriptionImpl, TwoChildren}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
-case class ApplyPipe(source: Pipe, inner: Pipe)(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+case class ApplyPipe(source: Pipe, inner: Pipe)(val estimation: Estimation = Estimation.empty)
+                    (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.flatMap {
@@ -43,12 +43,12 @@ case class ApplyPipe(source: Pipe, inner: Pipe)(val estimatedCardinality: Option
 
   def dup(sources: List[Pipe]): Pipe = {
     val (l :: r :: Nil) = sources
-    copy(source = l, inner= r)(estimatedCardinality)
+    copy(source = l, inner= r)(estimation)
   }
 
   override val sources: Seq[Pipe] = Seq(source, inner)
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ArgumentPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ArgumentPipe.scala
@@ -23,12 +23,11 @@ import org.neo4j.cypher.internal.compiler.v2_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDescription, NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.{SymbolTable, SymbolTypeAssertionCompiler, _}
 
-case class ArgumentPipe(symbols: SymbolTable)
-                       (val estimatedCardinality: Option[Double] = None)
+case class ArgumentPipe(symbols: SymbolTable)(val estimation: Estimation = Estimation.empty)
                        (implicit val monitor: PipeMonitor) extends Pipe with RonjaPipe {
   def sources = Seq.empty
 
-  def withEstimatedCardinality(estimated: Double): Pipe with RonjaPipe = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   def planDescription: InternalPlanDescription =
     new PlanDescriptionImpl(this, "Argument", NoChildren, Seq.empty, identifiers)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/CartesianProductPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/CartesianProductPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDescription, PlanDescriptionImpl, TwoChildren}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
-case class CartesianProductPipe(lhs: Pipe, rhs: Pipe)(val estimatedCardinality: Option[Double] = None)
+case class CartesianProductPipe(lhs: Pipe, rhs: Pipe)(val estimation: Estimation = Estimation.empty)
                                (implicit pipeMonitor: PipeMonitor) extends Pipe with RonjaPipe {
   def exists(pred: (Pipe) => Boolean): Boolean = lhs.exists(pred) || rhs.exists(pred)
 
@@ -44,12 +44,12 @@ case class CartesianProductPipe(lhs: Pipe, rhs: Pipe)(val estimatedCardinality: 
 
   def dup(sources: List[Pipe]): Pipe = {
     val (l :: r :: Nil) = sources
-    copy(lhs = l, rhs = r)(estimatedCardinality)
+    copy(lhs = l, rhs = r)(estimation)
   }
 
   def sources: Seq[Pipe] = Seq(lhs, rhs)
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -28,11 +28,10 @@ import org.neo4j.cypher.internal.helpers.CollectionSupport
 
 
 case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityByIdRhs, toNode: String, fromNode: String)
-                                           (val estimatedCardinality: Option[Double] = None)
+                                           (val estimation: Estimation = Estimation.empty)
                                            (implicit pipeMonitor: PipeMonitor)
-  extends Pipe
-  with CollectionSupport
-  with RonjaPipe {
+  extends Pipe with CollectionSupport with RonjaPipe {
+
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
@@ -65,5 +64,5 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityById
 
   override def localEffects = Effects.READS_ENTITIES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
@@ -28,10 +28,10 @@ import org.neo4j.cypher.internal.helpers._
 
 import scala.collection.mutable
 
-case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val estimatedCardinality: Option[Double] = None)
+case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val estimation: Estimation = Estimation.empty)
                        (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   val keyNames: Seq[String] = expressions.keys.toSeq
 
@@ -73,7 +73,7 @@ case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val 
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
   override def localEffects = expressions.effects

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable.{Map => MutableMap}
 // to emit aggregated results.
 // Cypher is lazy until it can't - this pipe will eagerly load the full match
 case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggregations: Map[String, AggregationExpression])
-                               (val estimatedCardinality: Option[Double] = None)
+                               (val estimation: Estimation = Estimation.empty)
                                (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   val symbols: SymbolTable = createSymbols()
@@ -100,10 +100,10 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
   override def localEffects = aggregations.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandAllPipe.scala
@@ -25,13 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionContext, InternalException}
 import org.neo4j.graphdb.{Direction, Node, Relationship}
 
-case class ExpandAllPipe(source: Pipe,
-                         fromName: String,
-                         relName: String,
-                         toName: String,
-                         dir: Direction,
-                         types: LazyTypes)(val estimatedCardinality: Option[Double] = None)
-                        (implicit pipeMonitor: PipeMonitor)
+case class ExpandAllPipe(source: Pipe, fromName: String, relName: String, toName: String, dir: Direction, types: LazyTypes)
+                        (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -67,8 +62,8 @@ case class ExpandAllPipe(source: Pipe,
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExpandIntoPipe.scala
@@ -27,13 +27,8 @@ import org.neo4j.graphdb.{Direction, Node, Relationship}
 import org.neo4j.helpers.collection.PrefetchingIterator
 import scala.collection.JavaConverters._
 
-case class ExpandIntoPipe(source: Pipe,
-                          fromName: String,
-                          relName: String,
-                          toName: String,
-                          dir: Direction,
-                          types: LazyTypes)(val estimatedCardinality: Option[Double] = None)
-                         (implicit pipeMonitor: PipeMonitor)
+case class ExpandIntoPipe(source: Pipe, fromName: String, relName: String, toName: String, dir: Direction, types: LazyTypes)
+                         (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   self =>
@@ -90,8 +85,8 @@ case class ExpandIntoPipe(source: Pipe,
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/FilterPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/FilterPipe.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.Predicate
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 
-case class FilterPipe(source: Pipe, predicate: Predicate)(val estimatedCardinality: Option[Double] = None)
+case class FilterPipe(source: Pipe, predicate: Predicate)(val estimation: Estimation = Estimation.empty)
                      (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
   val symbols = source.symbols
 
@@ -38,10 +38,10 @@ case class FilterPipe(source: Pipe, predicate: Predicate)(val estimatedCardinali
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
   override def localEffects = predicate.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSelectOrSemiApplyPipe.scala
@@ -26,9 +26,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{PlanDescriptionI
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
 case class LetSelectOrSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, predicate: Predicate, negated: Boolean)
-                                   (val estimatedCardinality: Option[Double] = None)
-                                   (implicit pipeMonitor: PipeMonitor)
+                                   (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
@@ -59,10 +59,10 @@ case class LetSelectOrSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: Strin
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: inner :: Nil) = sources
-    copy(source = source, inner = inner)(estimatedCardinality)
+    copy(source = source, inner = inner)(estimation)
   }
 
   override def localEffects = predicate.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LetSemiApplyPipe.scala
@@ -25,8 +25,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{PlanDescriptionI
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
 case class LetSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, negated: Boolean)
-                           (val estimatedCardinality: Option[Double] = None)
-                           (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+                           (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
+  extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map {
       (outerContext) =>
@@ -47,10 +48,10 @@ case class LetSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, negat
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: inner :: Nil) = sources
-    copy(source = source, inner = inner)(estimatedCardinality)
+    copy(source = source, inner = inner)(estimation)
   }
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LimitPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LimitPipe.scala
@@ -24,9 +24,10 @@ import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Expression,
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
-case class LimitPipe(source: Pipe, exp: Expression)
-                    (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class LimitPipe(source: Pipe, exp: Expression)(val estimation: Estimation = Estimation.empty)
+                    (implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with NumericHelper with RonjaPipe {
+
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     if(input.isEmpty)
       return Iterator.empty
@@ -51,10 +52,9 @@ case class LimitPipe(source: Pipe, exp: Expression)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
   override def localEffects = exp.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
-}
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)}

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByIdSeekPipe.scala
@@ -41,11 +41,8 @@ case class EntityByIdExprs(exprs: Seq[Expression]) extends EntityByIdRhs {
     exprs.map(_.apply(ctx)(state))
 }
 
-case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: EntityByIdRhs)
-                           (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
-  extends Pipe
-  with CollectionSupport
-  with RonjaPipe {
+case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: EntityByIdRhs)(val estimation: Estimation = Estimation.empty)
+                           (implicit pipeMonitor: PipeMonitor) extends Pipe with CollectionSupport with RonjaPipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
@@ -73,5 +70,5 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: EntityByIdRhs)
 
   override def localEffects = Effects.READS_NODES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeByLabelScanPipe.scala
@@ -25,10 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescr
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.{SymbolTable, _}
 
-case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
-                              (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
-  extends Pipe
-  with RonjaPipe {
+case class NodeByLabelScanPipe(ident: String, label: LazyLabel)(val estimation: Estimation = Estimation.empty)
+                              (implicit pipeMonitor: PipeMonitor) extends Pipe with RonjaPipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
 
@@ -59,5 +57,5 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
 
   override def localEffects = Effects.READS_NODES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeHashJoinPipe.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.Node
 import scala.collection.mutable
 
 case class NodeHashJoinPipe(nodeIdentifiers: Set[String], left: Pipe, right: Pipe)
-                           (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                           (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(left, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -71,12 +71,12 @@ case class NodeHashJoinPipe(nodeIdentifiers: Set[String], left: Pipe, right: Pip
 
   def dup(sources: List[Pipe]): Pipe = {
     val (left :: right :: Nil) = sources
-    copy(left = left, right = right)(estimatedCardinality)
+    copy(left = left, right = right)(estimation)
   }
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   private def buildProbeTable(input: Iterator[ExecutionContext]): mutable.HashMap[Vector[Long], mutable.MutableList[ExecutionContext]] = {
     val table = new mutable.HashMap[Vector[Long], mutable.MutableList[ExecutionContext]]

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/NodeIndexSeekPipe.scala
@@ -30,12 +30,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols.{CTNode, SymbolTable}
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.index.IndexDescriptor
 
-case class NodeIndexSeekPipe(ident: String,
-                             label: LabelToken,
-                             propertyKey: PropertyKeyToken,
-                             valueExpr: QueryExpression[Expression],
-                             unique: Boolean = false)
-                            (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class NodeIndexSeekPipe(ident: String, label: LabelToken, propertyKey: PropertyKeyToken,
+                             valueExpr: QueryExpression[Expression], unique: Boolean = false)
+                            (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends Pipe with RonjaPipe {
 
   val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
@@ -76,5 +73,5 @@ case class NodeIndexSeekPipe(ident: String,
 
   override def localEffects = Effects.READS_NODES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandAllPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.graphdb.{Direction, Node}
 
 case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String, toName: String, dir: Direction, types: LazyTypes, predicate: Predicate)
-                                (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                                (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -74,10 +74,10 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
   override def localEffects = predicate.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalExpandIntoPipe.scala
@@ -28,7 +28,7 @@ import org.neo4j.helpers.collection.PrefetchingIterator
 import scala.collection.JavaConverters._
 
 case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: String, toName: String, dir: Direction, types: LazyTypes, predicate: Predicate)
-                                (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                                (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -97,10 +97,10 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
   override def localEffects = predicate.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalPipe.scala
@@ -24,9 +24,8 @@ import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDescription, PlanDescriptionImpl, SingleChild}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
-case class OptionalPipe(nullableIdentifiers: Set[String], source: Pipe)
-                       (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+case class OptionalPipe(nullableIdentifiers: Set[String], source: Pipe)(val estimation: Estimation = Estimation.empty)
+                       (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
   val notFoundExecutionContext: ExecutionContext =
     nullableIdentifiers.foldLeft(ExecutionContext.empty)( (context, identifier) => context += identifier -> null )
@@ -47,10 +46,10 @@ case class OptionalPipe(nullableIdentifiers: Set[String], source: Pipe)
 
   def dup(sources: List[Pipe]) = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/Pipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/Pipe.scala
@@ -42,7 +42,7 @@ trait PipeMonitor {
  * the execute the query.
  */
 trait Pipe extends Effectful {
-  self: Pipe =>
+  self =>
 
   def monitor: PipeMonitor
 
@@ -86,6 +86,7 @@ trait Pipe extends Effectful {
 }
 
 case class SingleRowPipe()(implicit val monitor: PipeMonitor) extends Pipe with RonjaPipe {
+  self =>
 
   def symbols: SymbolTable = new SymbolTable()
 
@@ -98,14 +99,15 @@ case class SingleRowPipe()(implicit val monitor: PipeMonitor) extends Pipe with 
 
   override def localEffects = Effects.NONE
 
-  def dup(sources: List[Pipe]): Pipe = this
+  def dup(sources: List[Pipe]): this.type = self
 
   def sources: Seq[Pipe] = Seq.empty
 
-  def estimatedCardinality: Option[Double] = Some(1.0)
+  val estimation: Estimation = Estimation(Some(1.0), Some(1.0))
 
-  def withEstimatedCardinality(estimated: Double): Pipe with RonjaPipe = {
-    assert(estimated == 1.0)
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = {
+    assert(estimation.operatorCardinality.isDefined && estimation.operatorCardinality.get == 1.0)
+    assert(estimation.producedRows.isDefined && estimation.producedRows.get == 1.0)
     this
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipe.scala
@@ -30,7 +30,7 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
                                 start: String, startInScope: Boolean,
                                 end: String, endInScope: Boolean,
                                 relTypes: Option[LazyTypes], directed: Boolean, simpleLength: Boolean)
-                               (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                               (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor)
   with CollectionSupport
   with RonjaPipe {
@@ -48,10 +48,10 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   private def projector(qtx: QueryContext): Projector =
     if (simpleLength) project(qtx) else projectVarLength(qtx)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectionNewPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectionNewPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescr
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects._
 
-case class ProjectionNewPipe(source: Pipe, expressions: Map[String, Expression])(val estimatedCardinality: Option[Double] = None)
+case class ProjectionNewPipe(source: Pipe, expressions: Map[String, Expression])(val estimation: Estimation = Estimation.empty)
                             (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
   val symbols: SymbolTable = {
     val newIdentifiers = expressions.map {
@@ -56,10 +56,10 @@ case class ProjectionNewPipe(source: Pipe, expressions: Map[String, Expression])
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-    copy(source = source)(estimatedCardinality)
+    copy(source = source)(estimation)
   }
 
   override def localEffects = expressions.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/RonjaPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/RonjaPipe.scala
@@ -19,10 +19,21 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Cardinality
+
 // Marks a pipe being used by Ronja
 trait RonjaPipe {
   self: Pipe =>
 
-  def estimatedCardinality: Option[Double]
-  def withEstimatedCardinality(estimated: Double): Pipe with RonjaPipe
+  def estimation: Estimation
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe
+}
+
+case class Estimation(operatorCardinality: Option[Double], producedRows: Option[Double])
+
+object Estimation {
+  val empty = Estimation(None, None)
+
+  def apply(operatorCardinality: Cardinality, producedRows: Cardinality): Estimation =
+    new Estimation(Some(operatorCardinality.amount), Some(producedRows.amount))
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SelectOrSemiApplyPipe.scala
@@ -26,9 +26,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{PlanDescriptionI
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
 case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate, negated: Boolean)
-                                (val estimatedCardinality: Option[Double] = None)
-                                (implicit pipeMonitor: PipeMonitor)
+                                (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
@@ -58,10 +58,10 @@ case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: inner :: Nil) = sources
-    copy(source = source, inner = inner)(estimatedCardinality)
+    copy(source = source, inner = inner)(estimation)
   }
 
   override def localEffects = predicate.effects
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SemiApplyPipe.scala
@@ -24,9 +24,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{PlanDescriptionImpl, TwoChildren}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 
-case class SemiApplyPipe(source: Pipe, inner: Pipe, negated: Boolean)
-                        (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+case class SemiApplyPipe(source: Pipe, inner: Pipe, negated: Boolean)(val estimation: Estimation = Estimation.empty)
+                        (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.filter {
       (outerContext) =>
@@ -47,10 +47,10 @@ case class SemiApplyPipe(source: Pipe, inner: Pipe, negated: Boolean)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: inner :: Nil) = sources
-    copy(source = source, inner = inner)(estimatedCardinality)
+    copy(source = source, inner = inner)(estimation)
   }
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ShortestPathPipe.scala
@@ -31,9 +31,10 @@ import scala.collection.JavaConverters._
 /**
  * Shortest pipe inserts a single shortest path between two already found nodes
  */
-case class ShortestPathPipe(source: Pipe, ast: ShortestPath)
-                           (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class ShortestPathPipe(source: Pipe, ast: ShortestPath)(val estimation: Estimation = Estimation.empty)
+                           (implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with CollectionSupport with RonjaPipe {
+
   private def pathName = ast.pathName
   private val expression = ShortestPathExpression(ast)
 
@@ -65,10 +66,10 @@ case class ShortestPathPipe(source: Pipe, ast: ShortestPath)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
   override def localEffects = Effects.READS_ENTITIES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SortPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SortPipe.scala
@@ -30,9 +30,9 @@ trait SortDescription {
 case class Ascending(id:String) extends SortDescription
 case class Descending(id:String) extends SortDescription
 
-case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
-                   (val estimatedCardinality: Option[Double] = None)(implicit monitor: PipeMonitor)
-  extends PipeWithSource(source, monitor) with Comparer with RonjaPipe {
+case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])(val estimation: Estimation = Estimation.empty)
+                   (implicit monitor: PipeMonitor) extends PipeWithSource(source, monitor) with Comparer with RonjaPipe {
+
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.toList.
       sortWith((a, b) => compareBy(a, b, orderBy)(state)).iterator
@@ -59,8 +59,8 @@ case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/StartPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/StartPipe.scala
@@ -46,29 +46,33 @@ sealed abstract class StartPipe[T <: PropertyContainer](source: Pipe,
       .andThen(this, s"${createSource.producerType}", identifiers, createSource.arguments: _*)
 }
 
-case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node])(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node])
+                        (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends StartPipe[Node](source, name, createSource, pipeMonitor) {
+
   def identifierType = CTNode
   override def localEffects = Effects.READS_NODES
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 }
 
-case class RelationshipStartPipe(source: Pipe, name: String, createSource: EntityProducer[Relationship])(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class RelationshipStartPipe(source: Pipe, name: String, createSource: EntityProducer[Relationship])
+                                (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends StartPipe[Relationship](source, name, createSource, pipeMonitor) {
+
   def identifierType = CTRelationship
   override def localEffects = Effects.READS_RELATIONSHIPS
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
@@ -34,7 +34,7 @@ import scala.math._
  * returning the matching top results, we only keep the top results in heap, which allows us to release memory earlier
  */
 case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpression: Expression)
-                  (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                  (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with Comparer with RonjaPipe {
 
   val sortItems = sortDescription.toArray
@@ -122,8 +122,8 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.cypher.internal.helpers.CollectionSupport
 
 case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityByIdRhs, toNode: String, fromNode: String)
-                                             (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+                                             (val estimation: Estimation = Estimation.empty)(implicit pipeMonitor: PipeMonitor)
   extends Pipe
   with CollectionSupport
   with RonjaPipe {
@@ -56,5 +56,5 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: EntityBy
 
   def sources: Seq[Pipe] = Seq.empty
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnionPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnionPipe.scala
@@ -43,9 +43,9 @@ case class UnionPipe(sources: List[Pipe], columns:List[String])(implicit val mon
   override def localEffects = Effects.NONE
 }
 
-case class NewUnionPipe(l: Pipe, r: Pipe)
-                       (val estimatedCardinality: Option[Double] = None)(implicit val monitor: PipeMonitor)
-  extends Pipe with RonjaPipe {
+case class NewUnionPipe(l: Pipe, r: Pipe)(val estimation: Estimation = Estimation.empty)
+                       (implicit val monitor: PipeMonitor) extends Pipe with RonjaPipe {
+
   def planDescription: InternalPlanDescription =
     new PlanDescriptionImpl(this, "Union", TwoChildren(l.planDescription, r.planDescription), Seq.empty, identifiers)
 
@@ -58,12 +58,12 @@ case class NewUnionPipe(l: Pipe, r: Pipe)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (l :: r :: Nil) = sources
-    copy(l, r)(estimatedCardinality)
+    copy(l, r)(estimation)
   }
 
   def sources: Seq[Pipe] = Seq(l, r)
 
   override def localEffects = Effects.NONE
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
@@ -25,8 +25,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDesc
 import org.neo4j.cypher.internal.helpers.CollectionSupport
 
 case class UnwindPipe(source: Pipe, collection: Expression, identifier: String)
-                     (val estimatedCardinality: Option[Double] = None)(implicit monitor: PipeMonitor)
+                     (val estimation: Estimation = Estimation.empty)(implicit monitor: PipeMonitor)
   extends PipeWithSource(source, monitor) with CollectionSupport with RonjaPipe {
+
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
@@ -47,8 +48,8 @@ case class UnwindPipe(source: Pipe, collection: Expression, identifier: String)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
-    copy(source = head)(estimatedCardinality)
+    copy(source = head)(estimation)
   }
 
-  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+  def withEstimation(estimation: Estimation): Pipe with RonjaPipe = copy()(estimation = estimation)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -40,7 +40,8 @@ object PlanDescriptionArgumentSerializer {
       case DbHits(value) => Long.box(value)
       case _: EntityByIdRhs => arg.toString
       case Rows(value) => Long.box(value)
-      case EstimatedRows(value) => Double.box(value)
+      case EstimatedOperatorCardinality(value) => Double.box(value)
+      case EstimatedProducedRows(value) => Double.box(value)
       case Version(version) => version
       case Planner(planner) => planner
       case ExpandExpression(from, rel, typeNames, to, dir: Direction, varLength) =>

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -25,15 +25,14 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics.{QueryGraphCardinalityInput, QueryGraphCardinalityModel}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
 
-class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCardinalityModel)
-  extends Metrics.CardinalityModel {
-  def apply(plan: LogicalPlan, input: QueryGraphCardinalityInput): Cardinality =
-    computeCardinality(plan.solved, input)
+class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCardinalityModel) extends Metrics.CardinalityModel {
+
+  def apply(plan: LogicalPlan, input: QueryGraphCardinalityInput): Cardinality = computeCardinality(plan.solved, input)
 
   private def computeCardinality(query: PlannerQuery, input0: QueryGraphCardinalityInput): Cardinality = {
     val output = query.fold(input0) {
       case (input, PlannerQuery(graph, horizon, _)) =>
-        val QueryGraphCardinalityInput(newLabels, graphCardinality) = calculateCardinalityForQueryGraph(graph, input)
+        val (newLabels, graphCardinality) = calculateCardinalityForQueryGraph(graph, input)
         val horizonCardinality = calculateCardinalityForQueryHorizon(graphCardinality, horizon)
         QueryGraphCardinalityInput(newLabels, horizonCardinality)
     }
@@ -61,9 +60,9 @@ class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCar
       in
   }
 
-  private def calculateCardinalityForQueryGraph(graph: QueryGraph, input: QueryGraphCardinalityInput): QueryGraphCardinalityInput = {
+  private def calculateCardinalityForQueryGraph(graph: QueryGraph, input: QueryGraphCardinalityInput) = {
     val newLabels = input.labelInfo.fuse(graph.patternNodeLabels)(_ ++ _)
     val newCardinality = queryGraphCardinalityModel(graph, input)
-    QueryGraphCardinalityInput(newLabels, newCardinality)
+    (newLabels, newCardinality)
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/LogicalPlan.scala
@@ -23,7 +23,7 @@ import java.lang.reflect.Method
 
 import org.neo4j.cypher.internal.compiler.v2_2.Foldable._
 import org.neo4j.cypher.internal.compiler.v2_2.Rewritable._
-import org.neo4j.cypher.internal.compiler.v2_2.ast.{Identifier, Expression}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{Expression, Identifier}
 import org.neo4j.cypher.internal.compiler.v2_2.perty._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.PlannerQuery
 import org.neo4j.cypher.internal.compiler.v2_2.{InternalException, Rewritable}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EstimationIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EstimationIntegrationTest.scala
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.pipes
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.Monitors
+import org.neo4j.cypher.internal.compiler.v2_2.planner.execution.{PipeExecutionBuilderContext, PipeExecutionPlanBuilder}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Cardinality
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics.QueryGraphCardinalityInput
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{AllNodesScan, CartesianProduct, LogicalPlan}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.{LogicalPlanningTestSupport2, PlannerQuery, SemanticTable}
+import org.neo4j.cypher.internal.compiler.v2_2.spi.PlanContext
+import org.neo4j.helpers.Clock
+
+class EstimationIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+
+  test("should amend estimated produced rows when seeing a cartesian product") {
+    givenNodes(42)
+
+    val plan = CartesianProduct(
+      AllNodesScan("a", Set.empty)(solved),
+      AllNodesScan("b", Set.empty)(solved)
+    )(solved)
+
+    val result = builder.build(plan)
+
+    result.pipe.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0 * 42.0)
+    result.pipe.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0)
+
+    val (lhs :: rhs :: Nil) = result.pipe.sources
+
+    lhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    lhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0)
+
+    rhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    rhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0)
+  }
+
+  test("should amend estimated produced rows when seeing 2 cartesian products nested on the left") {
+    givenNodes(42)
+
+    val plan = CartesianProduct(
+      CartesianProduct(
+        AllNodesScan("a", Set.empty)(solved),
+        AllNodesScan("b", Set.empty)(solved)
+      )(solved),
+      AllNodesScan("c", Set.empty)(solved)
+    )(solved)
+
+    val result = builder.build(plan)
+
+    result.pipe.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0 * 42.0 * 42.0)
+    result.pipe.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0 * 42.0)
+
+    val (lhs :: rhs :: Nil) = result.pipe.sources
+
+    lhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0 * 42.0)
+    lhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0)
+
+    rhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    rhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0 * 42.0)
+
+    val (innerLhs :: innerRhs :: Nil) = lhs.sources
+
+    innerLhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    innerLhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0)
+
+    innerRhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    innerRhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0)
+  }
+
+  test("should amend estimated produced rows when seeing 2 cartesian products nested on the right") {
+    givenNodes(42)
+
+    val plan = CartesianProduct(
+      AllNodesScan("c", Set.empty)(solved),
+      CartesianProduct(
+        AllNodesScan("a", Set.empty)(solved),
+        AllNodesScan("b", Set.empty)(solved)
+      )(solved)
+    )(solved)
+
+    val result = builder.build(plan)
+
+    result.pipe.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0 * 42.0 * 42.0)
+    result.pipe.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0 * 42.0)
+
+    val (lhs :: rhs :: Nil) = result.pipe.sources
+
+    lhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    lhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0)
+
+    rhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0 * 42.0)
+    rhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0 * 42.0)
+
+    val (innerLhs :: innerRhs :: Nil) = rhs.sources
+
+    innerLhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    innerLhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0)
+
+    innerRhs.asInstanceOf[RonjaPipe].estimation.operatorCardinality.get should equal(42.0)
+    innerRhs.asInstanceOf[RonjaPipe].estimation.producedRows.get should equal(42.0 * 42.0 * 42.0)
+  }
+
+  private var builder: PipeExecutionPlanBuilder = null
+  private implicit var ctx: PipeExecutionBuilderContext = null
+  private implicit val planCtx = mock[PlanContext]
+  private val solved = mock[PlannerQuery]
+
+  private def givenNodes(nodes: Long) {
+    def model(plan: LogicalPlan, input: QueryGraphCardinalityInput): Cardinality = plan match {
+      case _: AllNodesScan => Cardinality(nodes)
+      case CartesianProduct(lhs, rhs) => model(lhs, input) * model(rhs, input)
+    }
+
+    builder = new PipeExecutionPlanBuilder(mock[Clock], mock[Monitors])
+    ctx = new PipeExecutionBuilderContext(model, mock[SemanticTable])
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -20,8 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planDescription
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{ExpandExpression,
-EstimatedRows, DbHits, Rows}
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.graphdb.Direction
 
 class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
@@ -31,7 +30,8 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
   test("serialization should leave numeric arguments as numbers") {
     serialize(new DbHits(12)) shouldBe a [java.lang.Number]
     serialize(new Rows(12)) shouldBe a [java.lang.Number]
-    serialize(new EstimatedRows(12)) shouldBe a [java.lang.Number]
+    serialize(new EstimatedOperatorCardinality(12)) shouldBe a [java.lang.Number]
+    serialize(new EstimatedProducedRows(12)) shouldBe a [java.lang.Number]
   }
 
   test("ExpandExpression should look like Cypher syntax") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/RenderPlanDescriptionDetailsTest.scala
@@ -53,11 +53,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n"))
 
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
-        |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |       |
-        |+----------+---------------+------+--------+-------------+-------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers | Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n |       |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
 
@@ -69,11 +69,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("a", "b", "c"))
 
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
-        |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |     a, b, c |       |
-        |+----------+---------------+------+--------+-------------+-------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers | Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |     a, b, c |       |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
 
@@ -85,11 +85,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("a", "b", "c", "d", "e", "f"))
 
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+------------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits |      Identifiers | Other |
-        |+----------+---------------+------+--------+------------------+-------+
-        ||     NAME |         1.000 |   42 |     33 | a, b, c, d, e, f |       |
-        |+----------+---------------+------+--------+------------------+-------+
+      """+----------+------------------------------+-----------------------+------+--------+------------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits |      Identifiers | Other |
+        |+----------+------------------------------+-----------------------+------+--------+------------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 | a, b, c, d, e, f |       |
+        |+----------+------------------------------+-----------------------+------+--------+------------------+-------+
         |""".stripMargin)
   }
 
@@ -99,11 +99,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n"))
 
     renderDetails(plan) should equal(
-      """+----------+---------------+-------------+-------+
-        || Operator | EstimatedRows | Identifiers | Other |
-        |+----------+---------------+-------------+-------+
-        ||     NAME |         1.000 |           n |       |
-        |+----------+---------------+-------------+-------+
+      """+----------+------------------------------+-----------------------+-------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Identifiers | Other |
+        |+----------+------------------------------+-----------------------+-------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |           n |       |
+        |+----------+------------------------------+-----------------------+-------------+-------+
         |""".stripMargin)
   }
 
@@ -115,12 +115,12 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val plan2 = PlanDescriptionImpl(pipe, "NAME", SingleChild(plan1), args2, Set("b"))
 
     renderDetails(plan2) should equal(
-      """+----------+---------------+------+--------+-------------+--------------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |        Other |
-        |+----------+---------------+------+--------+-------------+--------------+
-        ||  NAME(0) |         1.000 |    2 |    633 |           b | :Label(Prop) |
-        ||  NAME(1) |         1.000 |   42 |     33 |           a |              |
-        |+----------+---------------+------+--------+-------------+--------------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+--------------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |        Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+--------------+
+        ||  NAME(0) |                        1.000 |                 1.000 |    2 |    633 |           b | :Label(Prop) |
+        ||  NAME(1) |                        1.000 |                 1.000 |   42 |     33 |           a |              |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+--------------+
         |""".stripMargin)
   }
 
@@ -129,26 +129,26 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val arguments = Seq(
       Rows(42),
       DbHits(33))
-    val expandPipe = ExpandAllPipe(pipe, "from", "rel", "to", Direction.INCOMING, LazyTypes.empty)(Some(1L))(mock[PipeMonitor])
+    val expandPipe = ExpandAllPipe(pipe, "from", "rel", "to", Direction.INCOMING, LazyTypes.empty)(Estimation(Some(1.5), Some(1.6)))(mock[PipeMonitor])
 
     renderDetails(expandPipe.planDescription) should equal(
-      """+-------------+---------------+-------------+---------------------+
-        ||    Operator | EstimatedRows | Identifiers |               Other |
-        |+-------------+---------------+-------------+---------------------+
-        || Expand(All) |         1.000 |     rel, to | (from)<-[rel:]-(to) |
-        |+-------------+---------------+-------------+---------------------+
+      """+-------------+------------------------------+-----------------------+-------------+---------------------+
+        ||    Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Identifiers |               Other |
+        |+-------------+------------------------------+-----------------------+-------------+---------------------+
+        || Expand(All) |                        1.500 |                 1.600 |     rel, to | (from)<-[rel:]-(to) |
+        |+-------------+------------------------------+-----------------------+-------------+---------------------+
         |""".stripMargin)
   }
 
   test("Label scan should be just as pretty as you would expect") {
-    val pipe = NodeByLabelScanPipe("n", LazyLabel("Foo"))(Some(1L))(mock[PipeMonitor])
+    val pipe = NodeByLabelScanPipe("n", LazyLabel("Foo"))(Estimation(Some(1.5), Some(1.6)))(mock[PipeMonitor])
 
     renderDetails( pipe.planDescription ) should equal(
-      """+-----------------+---------------+-------------+-------+
-        ||        Operator | EstimatedRows | Identifiers | Other |
-        |+-----------------+---------------+-------------+-------+
-        || NodeByLabelScan |         1.000 |           n |  :Foo |
-        |+-----------------+---------------+-------------+-------+
+      """+-----------------+------------------------------+-----------------------+-------------+-------+
+        ||        Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Identifiers | Other |
+        |+-----------------+------------------------------+-----------------------+-------------+-------+
+        || NodeByLabelScan |                        1.500 |                 1.600 |           n |  :Foo |
+        |+-----------------+------------------------------+-----------------------+-------------+-------+
         |""".stripMargin )
   }
 
@@ -156,14 +156,14 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
     val arguments = Seq(
       Rows(42),
       DbHits(33))
-    val expandPipe = VarLengthExpandPipe(pipe, "from", "rel", "to", Direction.INCOMING, Direction.OUTGOING, LazyTypes.empty, 0, None, nodeInScope = false)(Some(1L))(mock[PipeMonitor])
+    val expandPipe = VarLengthExpandPipe(pipe, "from", "rel", "to", Direction.INCOMING, Direction.OUTGOING, LazyTypes.empty, 0, None, nodeInScope = false)(Estimation(Some(1.5), Some(1.6)))(mock[PipeMonitor])
 
     renderDetails(expandPipe.planDescription) should equal(
-      """+----------------------+---------------+-------------+----------------------+
-        ||             Operator | EstimatedRows | Identifiers |                Other |
-        |+----------------------+---------------+-------------+----------------------+
-        || VarLengthExpand(All) |         1.000 |     rel, to | (from)-[rel:*]->(to) |
-        |+----------------------+---------------+-------------+----------------------+
+      """+----------------------+------------------------------+-----------------------+-------------+----------------------+
+        ||             Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Identifiers |                Other |
+        |+----------------------+------------------------------+-----------------------+-------------+----------------------+
+        || VarLengthExpand(All) |                        1.500 |                 1.600 |     rel, to | (from)-[rel:*]->(to) |
+        |+----------------------+------------------------------+-----------------------+-------------+----------------------+
         |""".stripMargin)
   }
 
@@ -176,11 +176,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+------------------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |            Other |
-        |+----------+---------------+------+--------+-------------+------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | ()-[R:WHOOP]->() |
-        |+----------+---------------+------+--------+-------------+------------------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+------------------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |            Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+------------------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n | ()-[R:WHOOP]->() |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+------------------+
         |""".stripMargin)
   }
 
@@ -193,11 +193,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------------------------------------------------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |                                           Other |
-        |+----------+---------------+------+--------+-------------+-------------------------------------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | (source)-[through:SOME|:OTHER|:THING]->(target) |
-        |+----------+---------------+------+--------+-------------+-------------------------------------------------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-------------------------------------------------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |                                           Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------------------------------------------------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n | (source)-[through:SOME|:OTHER|:THING]->(target) |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------------------------------------------------+
         |""".stripMargin)
   }
 
@@ -209,11 +209,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-----------------------------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |                       Other |
-        |+----------+---------------+------+--------+-------------+-----------------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | NOT(anon[123] == anon[321]) |
-        |+----------+---------------+------+--------+-------------+-----------------------------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-----------------------------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |                       Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-----------------------------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n | NOT(anon[123] == anon[321]) |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-----------------------------+
         |""".stripMargin)
   }
 
@@ -226,11 +226,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+--------------------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |              Other |
-        |+----------+---------------+------+--------+-------------+--------------------+
-        ||     NAME |         1.000 |   42 |     33 |           n | hasLabel(x:Artist) |
-        |+----------+---------------+------+--------+-------------+--------------------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+--------------------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |              Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+--------------------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n | hasLabel(x:Artist) |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+--------------------+
         |""".stripMargin)
   }
 
@@ -243,11 +243,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-----------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers |     Other |
-        |+----------+---------------+------+--------+-------------+-----------+
-        ||     NAME |         1.000 |   42 |     33 |           n | length(n) |
-        |+----------+---------------+------+--------+-------------+-----------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-----------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers |     Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-----------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n | length(n) |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-----------+
         |""".stripMargin)
   }
 
@@ -260,11 +260,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
-        |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |    id |
-        |+----------+---------------+------+--------+-------------+-------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers | Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n |    id |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
 
@@ -278,11 +278,11 @@ class RenderPlanDescriptionDetailsTest extends CypherFunSuite with BeforeAndAfte
 
     val plan = PlanDescriptionImpl(pipe, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  UNNAMED2", "  UNNAMED24"))
     renderDetails(plan) should equal(
-      """+----------+---------------+------+--------+-------------+-------+
-        || Operator | EstimatedRows | Rows | DbHits | Identifiers | Other |
-        |+----------+---------------+------+--------+-------------+-------+
-        ||     NAME |         1.000 |   42 |     33 |           n |    id |
-        |+----------+---------------+------+--------+-------------+-------+
+      """+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        || Operator | EstimatedOperatorCardinality | EstimatedProducedRows | Rows | DbHits | Identifiers | Other |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
+        ||     NAME |                        1.000 |                 1.000 |   42 |     33 |           n |    id |
+        |+----------+------------------------------+-----------------------+------+--------+-------------+-------+
         |""".stripMargin)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -58,8 +58,10 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = eengine.execute("explain match n return n")
     result.toList
     assert(result.planDescriptionRequested, "result not marked with planDescriptionRequested")
-    result.executionPlanDescription().toString should include("EstimatedRows")
-    result.executionPlanDescription().asJava.toString should include("EstimatedRows")
+    result.executionPlanDescription().toString should include("EstimatedOperatorCardinality")
+    result.executionPlanDescription().toString should include("EstimatedProducedRows")
+    result.executionPlanDescription().asJava.toString should include("EstimatedOperatorCardinality")
+    result.executionPlanDescription().asJava.toString should include("EstimatedProducedRows")
   }
 
   test("match n where not n-[:FOO]->() return *") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -146,7 +146,8 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
   }
 
   test("EstimatedRows should be properly formatted") {
-    given("match n return n").planDescripton.getArguments.get("EstimatedRows") should equal(0)
+    given("match n return n").planDescripton.getArguments.get("EstimatedOperatorCardinality") should equal(0)
+    given("match n return n").planDescripton.getArguments.get("EstimatedProducedRows") should equal(0)
   }
 
   def given(query: String) = TestQuery(query)


### PR DESCRIPTION
Originally we had only estimated rows which was basically reflecting the cardinality estimation we computed for the given operator.  In some cases such number might be quite different from the field `rows` computed when profile since some operators trigger multiple times inner ones.  As an example consider CartesianProduct(lhs, rhs), the rhs has a given estimated cardinality N whilst since the CartesianProduct will call the rhs operator for every row coming from the lhs the produced row of the rhs would be N * card(lhs) which is different from the original estimated cardinality.

This change will make sure that both values (i.e., operator cardinality == estimated cardinality, produced rows == estimated rows to pass through the operator) are shown in plan description, in order to avoid confusion when comparing those numbers with profile output.