### PR TITLE
Efficient hand-over in ThreadAheadReadable

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.CharBuffer;
+
+import static java.lang.Math.min;
+
+/**
+ * Has a similar role to a {@link CharBuffer}, but is tailored to how {@link BufferedCharSeeker}
+ * works and to be able to take full advantage of {@link ThreadAheadReadable}.
+ *
+ * First of all this thing wraps a {@code char[]} where the array, while still being one array,
+ * is sectioned into two equally sized parts: the back and the front. The flow of things is as follows:
+ * <ol>
+ * <li>Characters are read from a {@link Reader} using {@link #readFrom(Reader)} into the front section,
+ * i.e. starting from the middle of the array and forwards.</li>
+ * <li>Consumer of the read characters access the {@link #array()} and starts reading from the {@link #pivot()}
+ * point, which is the middle, to finally reach the end, denoted by {@link #front()} (exclusive).
+ * During the reading typically characters are read into some sort of fields/values, and so the last characters
+ * of the array might represent an incomplete value.</li>
+ * <li>For this reason, before reading more values into the array, the characters making up the last incomplete
+ * value can be moved to the back section using {@link #compact(SectionedCharBuffer, int)} where
+ * after that call {@link #back()} will point to the index in the {@link #array()} containing the first value
+ * in the array.</li>
+ * <li>Now more characters can be read into the front section using {@link #readFrom(Reader)}.</li>
+ * </ol>
+ *
+ * This divide into back and front section enables a behaviour in {@link ThreadAheadReadable} where the
+ * thread that reads ahead reads into the front section of another buffer, a double buffer,
+ * and the current buffer that {@link BufferedCharSeeker} is working with can
+ * {@link #compact(SectionedCharBuffer, int)} its last incomplete characters into that double buffer
+ * and flip so that the {@link BufferedCharSeeker} continues to read from the other buffer, i.e. flips
+ * buffer every call to {@link ThreadAheadReadable#read(SectionedCharBuffer, int)}. Without these sections
+ * the entire double buffer would have to be copied into the char seekers buffer to get the same behavior.
+ */
+public class SectionedCharBuffer
+{
+    private final char[] buffer;
+    private final int pivot;
+    private int back;
+    private int front; // exclusive
+
+    /**
+     * @param effectiveBuffserSize Size of each section, i.e. effective buffer size that can be
+     * {@link #readFrom(Reader) read} each time.
+     */
+    public SectionedCharBuffer( int effectiveBuffserSize )
+    {
+        this.buffer = new char[effectiveBuffserSize*2];
+        this.front = this.pivot = effectiveBuffserSize;
+    }
+
+    /**
+     * @return the underlying array which characters are {@link #readFrom(Reader) read into}.
+     * {@link #back()}, {@link #pivot()} and {@link #front()} marks the noteworthy indexes into this array.
+     */
+    public char[] array()
+    {
+        return buffer;
+    }
+
+    /**
+     * Copies characters in the {@link #array()} from (and including) the given {@code from} index of the array
+     * and all characters forwards to {@link #front()} (excluding) index. These characters are copied into
+     * the {@link #array()} of the given {@code into} buffer, where the character {@code array[from]} will
+     * be be copied to {@code into.array[pivot-(front-from)]}, and so on. As an example:
+     *
+     * <pre>
+     * pivot (i.e. effective buffer size) = 16
+     * buffer A
+     * <------ back ------> <------ front ----->
+     * [    .    .    .    |abcd.efgh.ijkl.mnop]
+     *                                 ^ = 25
+     *
+     * A.compactInto( B, 25 )
+     *
+     * buffer B
+     * <------ back ------> <------ front ----->
+     * [    .    . jkl.mnop|    .    .    .    ]
+     * </pre>
+     *
+     * @param into which buffer to compact into.
+     * @param from the array index to start compacting from.
+     */
+    public void compact( SectionedCharBuffer into, int from )
+    {
+        assert buffer.length == into.buffer.length;
+        int diff = front-from;
+        into.back = pivot-diff;
+        System.arraycopy( buffer, from, into.buffer, into.back, diff );
+    }
+
+    /**
+     * Reads characters from {@code reader} into the front section of this buffer, setting {@link #front()}
+     * accordingly afterwards. If no characters were read due to end reached then {@link #hasAvailable()} will
+     * return {@code false} after this call, likewise {@link #available()} will return 0.
+     *
+     * @param reader {@link Reader} to read from.
+     * @throws IOException any exception from the {@link Reader}.
+     */
+    public void readFrom( Reader reader ) throws IOException
+    {
+        readFrom( reader, pivot );
+    }
+
+    /**
+     * Like {@link #readFrom(Reader)} but with added {@code max} argument for limiting the number of
+     * characters read from the {@link Reader}.
+     *
+     * @see #readFrom(Reader)
+     */
+    public void readFrom( Reader reader, int max ) throws IOException
+    {
+        int read = reader.read( buffer, pivot, min( max, pivot ) );
+        if ( read == -1 )
+        {   // we reached the end
+            front = pivot;
+        }
+        else
+        {   // we did read something
+            front = pivot + read;
+        }
+    }
+
+    /**
+     * Puts a character into the front section of the buffer and increments the front index.
+     * @param ch
+     */
+    public void append( char ch )
+    {
+        buffer[front++] = ch;
+    }
+
+    /**
+     * @return the pivot point of the {@link #array()}. Before the pivot there are characters saved
+     * from a previous {@link #compact(SectionedCharBuffer, int) compaction} and after (and including) this point
+     * are characters read from {@link #readFrom(Reader)}.
+     */
+    public int pivot()
+    {
+        return pivot;
+    }
+
+    /**
+     * @return index of first available character, might be before pivot point if there have been
+     * characters moved over from a previous compaction.
+     */
+    public int back()
+    {
+        return back;
+    }
+
+    /**
+     * @return index of the last available character plus one.
+     */
+    public int front()
+    {
+        return front;
+    }
+
+    /**
+     * @return whether or not there are characters read into the front section of the buffer.
+     */
+    public boolean hasAvailable()
+    {
+        return front > pivot;
+    }
+
+    /**
+     * @return the number of characters available in the front section of the buffer.
+     */
+    public int available()
+    {
+        return front-pivot;
+    }
+}

--- a/community/csv/src/test/java/org/neo4j/csv/reader/SectionedCharBufferTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/SectionedCharBufferTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import org.junit.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+
+public class SectionedCharBufferTest
+{
+    @Test
+    public void shouldCompactIntoItself() throws Exception
+    {
+        // GIVEN
+        Reader data = new StringReader( "01234567" );
+        SectionedCharBuffer buffer = new SectionedCharBuffer( 4 ); // will yield an 8-char array in total
+        buffer.readFrom( data );
+
+        // WHEN
+        buffer.compact( buffer, buffer.front()-2 );
+
+        // THEN
+        assertEquals( '2', buffer.array()[2] );
+        assertEquals( '3', buffer.array()[3] );
+    }
+
+    @Test
+    public void shouldCompactIntoAnotherBuffer() throws Exception
+    {
+        // GIVEN
+        Reader data = new StringReader( "01234567" );
+        SectionedCharBuffer buffer1 = new SectionedCharBuffer( 8 );
+        SectionedCharBuffer buffer2 = new SectionedCharBuffer( 8 );
+        buffer1.readFrom( data );
+
+        // WHEN
+        buffer2.readFrom( data );
+        // simulate reading 2 chars as one value, then reading 2 bytes and requesting more
+        buffer1.compact( buffer2, buffer1.pivot()+2 /*simulate reading 2 chars*/ );
+
+        // THEN
+        assertEquals( '2', buffer2.array()[2] );
+        assertEquals( '3', buffer2.array()[3] );
+        assertEquals( '4', buffer2.array()[4] );
+        assertEquals( '5', buffer2.array()[5] );
+        assertEquals( '6', buffer2.array()[6] );
+        assertEquals( '7', buffer2.array()[7] );
+    }
+}

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -362,7 +362,7 @@ public class ImportTool
                 args.interpretOption( Options.ARRAY_DELIMITER.key(), Converters.<Character>optional(), DELIMITER_CONVERTER );
         final Character specificQuote =
                 args.interpretOption( Options.QUOTE.key(), Converters.<Character>optional(), Converters.toCharacter() );
-        return new Configuration()
+        return new Configuration.Default()
         {
             @Override
             public char delimiter()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
@@ -42,12 +42,20 @@ public interface Configuration
      */
     char quotationCharacter();
 
+    int bufferSize();
+
     public static abstract class Default implements Configuration
     {
         @Override
         public char quotationCharacter()
         {
             return BufferedCharSeeker.DEFAULT_QUOTE_CHAR;
+        }
+
+        @Override
+        public int bufferSize()
+        {
+            return BufferedCharSeeker.DEFAULT_BUFFER_SIZE;
         }
     }
 
@@ -80,4 +88,38 @@ public interface Configuration
             return ',';
         }
     };
+
+    public static class OverrideFromConfig implements Configuration
+    {
+        private final Configuration defaults;
+
+        public OverrideFromConfig( Configuration defaults )
+        {
+            this.defaults = defaults;
+        }
+
+        @Override
+        public char delimiter()
+        {
+            return defaults.delimiter();
+        }
+
+        @Override
+        public char arrayDelimiter()
+        {
+            return defaults.arrayDelimiter();
+        }
+
+        @Override
+        public char quotationCharacter()
+        {
+            return defaults.quotationCharacter();
+        }
+
+        @Override
+        public int bufferSize()
+        {
+            return defaults.bufferSize();
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -43,7 +43,6 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.input.MissingHeaderException;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
 
-import static org.neo4j.csv.reader.BufferedCharSeeker.DEFAULT_BUFFER_SIZE;
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 import static org.neo4j.csv.reader.Readables.multipleFiles;
 
@@ -73,7 +72,7 @@ public class DataFactories
                     {
                         try
                         {
-                            return charSeeker( Readables.file( file ), DEFAULT_BUFFER_SIZE,
+                            return charSeeker( Readables.file( file ), config.bufferSize(),
                                     true, config.quotationCharacter() );
                         }
                         catch ( IOException e )
@@ -118,7 +117,7 @@ public class DataFactories
                     {
                         try
                         {
-                            return charSeeker( multipleFiles( files ), DEFAULT_BUFFER_SIZE,
+                            return charSeeker( multipleFiles( files ), config.bufferSize(),
                                                true, config.quotationCharacter() );
                         }
                         catch ( IOException e )
@@ -155,7 +154,7 @@ public class DataFactories
                     @Override
                     public CharSeeker stream()
                     {
-                        return charSeeker( readable.newInstance(), DEFAULT_BUFFER_SIZE,
+                        return charSeeker( readable.newInstance(), config.bufferSize(),
                                            true, config.quotationCharacter() );
                     }
 
@@ -278,7 +277,7 @@ public class DataFactories
         @Override
         public CharSeeker open( CharSeeker seeker, Configuration config ) throws IOException
         {
-            return charSeeker( readable, DEFAULT_BUFFER_SIZE, true, config.quotationCharacter() );
+            return charSeeker( readable, config.bufferSize(), true, config.quotationCharacter() );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -97,7 +97,7 @@ public class CsvInputBatchImportIT
         try
         {
             importer.doImport( csv( nodeDataAsFile( nodeData ), relationshipDataAsFile( relationshipData ),
-                    IdType.STRING, COMMAS ) );
+                    IdType.STRING, lowBufferSize( COMMAS ) ) );
             // THEN
             verifyImportedData( nodeData, relationshipData );
             success = true;
@@ -109,6 +109,19 @@ public class CsvInputBatchImportIT
                 System.err.println( "Seed " + seed );
             }
         }
+    }
+
+    private org.neo4j.unsafe.impl.batchimport.input.csv.Configuration lowBufferSize(
+            org.neo4j.unsafe.impl.batchimport.input.csv.Configuration actual )
+    {
+        return new org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.OverrideFromConfig( actual )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 10_000;
+            }
+        };
     }
 
     // ======================================================

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -597,7 +597,7 @@ public class CsvInputTest
 
     private Configuration customConfig( final char delimiter, final char arrayDelimiter, final char quote )
     {
-        return new Configuration()
+        return new Configuration.Default()
         {
             @Override
             public char quotationCharacter()
@@ -748,7 +748,7 @@ public class CsvInputTest
 
     private static CharSeeker charSeeker( String data )
     {
-        return new BufferedCharSeeker( wrap( new StringReader( data ) ) );
+        return new BufferedCharSeeker( wrap( new StringReader( data ) ), 1_000 );
     }
 
     @SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
-import java.io.IOException;
-import java.io.StringReader;
-
 import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 
 import org.neo4j.csv.reader.BufferedCharSeeker;
 import org.neo4j.csv.reader.CharReadable;
@@ -200,8 +201,8 @@ public class DataFactoriesTest
     public void shouldParseHeaderFromFirstLineOfFirstInputFile() throws Exception
     {
         // GIVEN
-        final CharReadable firstSource = wrap( new StringReader( "id:ID\tname:String\tbirth_date:long" ) );
-        final CharReadable secondSource = wrap( new StringReader( "0\tThe node\t123456789" ) );
+        final Reader firstSource = new StringReader( "id:ID\tname:String\tbirth_date:long" );
+        final Reader secondSource = new StringReader( "0\tThe node\t123456789" );
         DataFactory<InputNode> dataFactory = data( Functions.<InputNode>identity(), new Factory<CharReadable>()
         {
             @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
@@ -31,6 +31,7 @@ import org.neo4j.function.Function;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.OverrideFromConfig;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -52,7 +53,7 @@ public class ExternalPropertiesDecoratorTest
                 "1,mattiasp@someother.com\n" +
                 "3,chris@abc\n" +
                 "4,dude@yo";
-        Configuration config = Configuration.COMMAS;
+        Configuration config = config();
         IdType idType = IdType.STRING;
         Function<InputNode,InputNode> externalPropertiesDecorator = new ExternalPropertiesDecorator(
                 DataFactories.<InputNode>data( NO_NODE_DECORATOR, readable( propertyData ) ),
@@ -79,7 +80,7 @@ public class ExternalPropertiesDecoratorTest
                 "1,mattias@some.com;mattiasp@someother.com\n" +
                 "3,chris@abc\n" +
                 "4,dude@yo";
-        Configuration config = Configuration.COMMAS;
+        Configuration config = config();
         IdType idType = IdType.STRING;
         Function<InputNode,InputNode> externalPropertiesDecorator = new ExternalPropertiesDecorator(
                 DataFactories.<InputNode>data( NO_NODE_DECORATOR, readable( propertyData ) ),
@@ -131,6 +132,18 @@ public class ExternalPropertiesDecoratorTest
             public CharReadable newInstance()
             {
                 return Readables.wrap( new StringReader( data ) );
+            }
+        };
+    }
+
+    private OverrideFromConfig config()
+    {
+        return new Configuration.OverrideFromConfig( Configuration.COMMAS )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 1_000;
             }
         };
     }


### PR DESCRIPTION
ThreadAheadReadable is a CherReadable which reads ahead one buffer in a
dedicated thread, so that when your actual CharReadable runs out in its
current buffer and wants to go read more bytes, they are already available
and will just be nade available. It's this hand-over from the thread-ahead
buffer to the consumer that comes in and requesting more data that has
been made more efficient, virtually free.

The nature of BufferedCharSeeker, the main consumer of a CharReadable
imposes that each buffer cannot always be read fully before requesting a
new buffer, since the break-off point can come in the middle of a value
that is being read. For this reason some of the last characters must be
moved to the beginning of the buffer and new characters appended after it.
This makes the trivial case of double-buffering harder since the consumer
cannot simply hand in a buffer and get a new one back, since it still
needs some data from the buffer it passed in after reading more data.

This commit introuces a SectionedCharBuffer that deals with this by
wrapping a char[] but treating it like two equally sized parts. New data
is read into the front part, whereas data that is part of the last value
read, i.e. data that must be transferred from the current buffer to the
new buffer lives in the back section. Javadocs about SectionedCharBuffer
explains this in greater detail.

The point is that the hand-over of data used to consist of several
megabytes copied every time, now only a few bytes in are copied in the
normal cases, and two buffer references are flipped. This allows for
more efficient reading since the thread reading ahead basically never have
to wait for anything if it's the bottleneck.