### PR TITLE
Ensures the correct instanceid is used when being demoted if switchToMaster fails

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -506,7 +506,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 monitors.newMonitor( MasterImpl.Monitor.class, MasterImpl.class ) );
 
         highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher( switchToSlaveInstance, switchToMasterInstance,
-                clusterClient, clusterMemberAvailability, getDependencyResolver(), logging );
+                clusterClient, clusterMemberAvailability, getDependencyResolver(), config.get( ClusterSettings.server_id ), logging );
 
         clusterClient.addBindingListener( highAvailabilityModeSwitcher );
         memberStateMachine.addHighAvailabilityMemberListener( highAvailabilityModeSwitcher );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
@@ -107,7 +107,6 @@ public class TestSlaveOnlyCluster
     private ClusterManager createCluster( String dirname, int... slaveIds ) throws URISyntaxException
     {
         final File dir = directory.cleanDirectory( dirname );
-        System.out.println( dir );
         final ClusterManager.Provider provider = fromXml( getClass().getResource( "/threeinstances.xml" ).toURI() );
         final Map<Integer, Map<String, String>> instanceConfig = new HashMap<>( slaveIds.length );
         for ( int slaveId : slaveIds )


### PR DESCRIPTION

The instance id used to broadcast the MemberIsUnavailable when the
 SwitchToMaster#switchToMaster fails was extracted by the HAMS#me
 instance field. However, that was wrong because that value
 was set by the NetworkReceiver and did not contain the serverId
 URI argument. Additionally, there was no reason to extract that
 value from any place other than the configuration.
This patch makes HAMS accept the instanceId as a constructor
 parameter and use that where the URI extraction was used before.