### PR TITLE
Lucene index overflow throws user-friendly exception before commit

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -187,6 +187,7 @@ public interface Status
         NoSuchSchemaRule( DatabaseError, "The request referred to a schema rule that does not exist." ),
 
         LabelLimitReached( ClientError, "The maximum number of labels supported has been reached, no more labels can be created." ),
+        IndexLimitReached( ClientError, "The maximum number of index entries supported has been reached, no more entities can be indexed." ),
 
         ;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexCapacityExceededException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexCapacityExceededException.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.index;
+
+import org.neo4j.kernel.api.exceptions.KernelException;
+
+import static org.neo4j.kernel.api.exceptions.Status.Schema.IndexLimitReached;
+
+public class IndexCapacityExceededException extends KernelException
+{
+    private static final String RESERVATION_FAILED_MESSAGE =
+            "Unable to reserve %d entries for insertion into index. " +
+            "Index contains too many entries. Current limitation is %d entries per index. " +
+            "Currently there are %d index entities.";
+
+    private static final String INSERTION_FAILED_MESSAGE =
+            "Index contains too many entries. Current limitation is %d indexed entities per index. " +
+            "Currently there are %d index entities.";
+
+    public IndexCapacityExceededException( long reservation, long currentValue, long limit )
+    {
+        super( IndexLimitReached, RESERVATION_FAILED_MESSAGE, reservation, currentValue, limit );
+    }
+
+    public IndexCapacityExceededException( long currentValue, long limit )
+    {
+        super( IndexLimitReached, INSERTION_FAILED_MESSAGE, currentValue, limit );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.api.index.UpdateMode;
 import org.neo4j.kernel.impl.api.index.SwallowingIndexUpdater;
 
@@ -49,7 +50,8 @@ public interface IndexPopulator
      * @param nodeId node id to index.
      * @param propertyValue property value for the entry to index.
      */
-    void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException;
+    void add( long nodeId, Object propertyValue )
+            throws IndexEntryConflictException, IOException, IndexCapacityExceededException;
 
     /**
      * Verify constraints for all entries added so far.
@@ -91,7 +93,7 @@ public interface IndexPopulator
      * as {@link InternalIndexState#ONLINE} so that future invocations of its parent
      * {@link SchemaIndexProvider#getInitialState(long)} also returns {@link InternalIndexState#ONLINE}.
      */
-    void close( boolean populationCompletedSuccessfully ) throws IOException;
+    void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Called then a population failed. The failure string should be stored for future retrieval by

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
@@ -21,12 +21,17 @@ package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
 public interface IndexUpdater extends AutoCloseable
 {
-    void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException;
+    Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException, IndexCapacityExceededException;
+
+    void process( NodePropertyUpdate update )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     @Override
-    void close() throws IOException, IndexEntryConflictException;
+    void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     void remove( Iterable<Long> nodeIds ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/Reservation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/Reservation.java
@@ -17,14 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.impl.index;
+package org.neo4j.kernel.api.index;
 
-import java.io.IOException;
-
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.store.Directory;
-
-public interface LuceneIndexWriterFactory
+public interface Reservation
 {
-    IndexWriter create( Directory directory ) throws IOException;
+    static Reservation EMPTY = new Reservation()
+    {
+        @Override
+        public void release()
+        {
+        }
+    };
+
+    void release();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.nioneo.store.UnderlyingStorageException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
@@ -56,7 +57,7 @@ public interface LabelScanStore extends Lifecycle
      * @param updates the updates to store.
      * @throws IOException if there was a problem updating the store.
      */
-    void recover( Iterator<NodeLabelUpdate> updates ) throws IOException;
+    void recover( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Forces all changes to disk. Called at certain points from within Neo4j for example when
@@ -81,7 +82,7 @@ public interface LabelScanStore extends Lifecycle
      * Starts the store. After this has been called updates can be processed.
      */
     @Override
-    void start() throws IOException;
+    void start() throws IOException, IndexCapacityExceededException;
 
     @Override
     void stop() throws IOException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AggregatedReservation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AggregatedReservation.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.kernel.api.index.Reservation;
+
+class AggregatedReservation implements Reservation
+{
+    private final Reservation[] aggregates;
+    private int pointer;
+
+    AggregatedReservation( int size )
+    {
+        this.aggregates = new Reservation[size];
+    }
+
+    void add( Reservation reservation )
+    {
+        if ( pointer == aggregates.length )
+        {
+            throw new IndexOutOfBoundsException( "Too many aggregates, size = " + aggregates.length );
+        }
+        if ( this == reservation )
+        {
+            throw new IllegalArgumentException( "Recursive aggregates not allowed" );
+        }
+        aggregates[pointer++] = reservation;
+    }
+
+    @Override
+    public void release()
+    {
+        Throwable firstError = null;
+
+        for ( Reservation aggregate : aggregates )
+        {
+            if ( aggregate != null )
+            {
+                try
+                {
+                    aggregate.release();
+                }
+                catch ( Throwable t )
+                {
+                    if ( firstError == null )
+                    {
+                        firstError = t;
+                    }
+                }
+            }
+        }
+
+        if ( firstError != null )
+        {
+            throw Exceptions.launderedException( firstError );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -97,13 +98,14 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
             return new DelegatingIndexUpdater( super.newUpdater( mode ) )
             {
                 @Override
-                public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+                public void process( NodePropertyUpdate update )
+                        throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                 {
                     delegate.process( update );
                 }
 
                 @Override
-                public void close() throws IOException, IndexEntryConflictException
+                public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                 {
                     try
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
@@ -21,7 +21,10 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public abstract class DelegatingIndexUpdater implements IndexUpdater
 {
@@ -30,6 +33,13 @@ public abstract class DelegatingIndexUpdater implements IndexUpdater
     public DelegatingIndexUpdater( IndexUpdater delegate )
     {
         this.delegate = delegate;
+    }
+
+    @Override
+    public Reservation validate( Iterable<NodePropertyUpdate> updates )
+            throws IOException, IndexCapacityExceededException
+    {
+        return delegate.validate( updates );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.ExceptionDuringFlipKernelException;
 import org.neo4j.kernel.api.exceptions.index.FlipFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexProxyAlreadyClosedKernelException;
@@ -332,13 +333,14 @@ public class FlippableIndexProxy implements IndexProxy
         }
 
         @Override
-        public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+        public void process( NodePropertyUpdate update )
+                throws IOException, IndexEntryConflictException, IndexCapacityExceededException
         {
             delegate.process( update );
         }
 
         @Override
-        public void close() throws IOException, IndexEntryConflictException
+        public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
         {
             try
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -104,4 +104,9 @@ public final class IndexMap implements Cloneable
     {
         return indexesByDescriptor.keySet().iterator();
     }
+
+    public int size()
+    {
+        return indexesById.size();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -205,7 +206,7 @@ public class IndexPopulationJob implements Runnable
                     populator.add( update.getNodeId(), update.getValueAfter() );
                     populateFromQueueIfAvailable( update.getNodeId() );
                 }
-                catch ( IndexEntryConflictException | IOException conflict )
+                catch ( IndexEntryConflictException | IndexCapacityExceededException | IOException conflict )
                 {
                     throw new IndexPopulationFailedKernelException( descriptor, indexUserDescription, conflict );
                 }
@@ -225,7 +226,7 @@ public class IndexPopulationJob implements Runnable
     }
 
     private void populateFromQueueIfAvailable( final long highestIndexedNodeId )
-            throws IndexEntryConflictException, IOException
+            throws IndexEntryConflictException, IndexCapacityExceededException, IOException
     {
         if ( !queue.isEmpty() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -83,7 +84,7 @@ public class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
             {
                 updater.close();
             }
-            catch ( IOException | IndexEntryConflictException e )
+            catch ( IOException | IndexEntryConflictException | IndexCapacityExceededException e )
             {
                 if ( null == exceptions )
                 {
@@ -114,6 +115,11 @@ public class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
     public int size()
     {
         return updaterMap.size();
+    }
+
+    public int numberOfIndexes()
+    {
+        return indexMap.size();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -80,6 +81,12 @@ public class PopulatingIndexProxy implements IndexProxy
     {
         return new IndexUpdater()
         {
+            @Override
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
+            }
+
             @Override
             public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public final class SwallowingIndexUpdater implements IndexUpdater
 {
@@ -31,6 +32,12 @@ public final class SwallowingIndexUpdater implements IndexUpdater
 
     public SwallowingIndexUpdater()
     {
+    }
+
+    @Override
+    public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        return Reservation.EMPTY;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -58,7 +59,8 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
                 return new DelegatingIndexUpdater( target.accessor.newUpdater( mode ) )
                 {
                     @Override
-                    public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+                    public void process( NodePropertyUpdate update )
+                            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                     {
                         try
                         {
@@ -71,7 +73,7 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
                     }
 
                     @Override
-                    public void close() throws IOException, IndexEntryConflictException
+                    public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                     {
                         try
                         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -59,14 +60,14 @@ public abstract class UniquePropertyIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void close() throws IOException, IndexEntryConflictException
+    public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         // flush updates
         flushUpdates( updates );
     }
 
     protected abstract void flushUpdates( Iterable<NodePropertyUpdate> updates )
-            throws IOException, IndexEntryConflictException;
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     private DiffSets<Long> propertyValueDiffSet( Object value )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.kernel.api.index.IndexEntryConflictException;
+
+/**
+ * This class represents validated and prepared index updates that are ready to be flushed.
+ * Such updates are closely related to {@link org.neo4j.kernel.impl.api.index.IndexUpdates} and constructed from
+ * them, though permit only flushing and releasing of associated resources and not iteration.
+ * Flushing is performed with {@link ValidatedIndexUpdates#flush()} method.
+ * Releasing of resources is performed with {@link ValidatedIndexUpdates#close()} method.
+ * <p/>
+ * Notion of being 'prepared' indicates that index updates are placed in internal data structures and no
+ * pre-processing before {@link ValidatedIndexUpdates#flush()} is needed. Such data structure might represent simply
+ * a mapping 'Index -> [set of updates]'.
+ * <p/>
+ * Notion of being 'validated' indicates that all updates in this batch can be consumed by corresponding indexes.
+ * This mostly mean that index size permit new insertions {@see IndexCapacityExceededException}.
+ */
+public interface ValidatedIndexUpdates extends AutoCloseable
+{
+    static ValidatedIndexUpdates NO_UPDATES = new ValidatedIndexUpdates()
+    {
+        @Override
+        public void flush()
+        {
+        }
+
+        @Override
+        public Set<Long> changedNodeIds()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    };
+
+    /**
+     * Flush all validated and prepared index updates to corresponding indexes.
+     */
+    void flush() throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
+
+    /**
+     * Set of node ids touched by this batch of index updates. Used by recovery.
+     * Conceptually represent same set of ids as raw and non-validates updates {@link IndexUpdates#changedNodeIds()}.
+     */
+    Set<Long> changedNodeIds();
+
+    /**
+     * Release all possible resources used by this batch of index updates. Such resources might include
+     * {@link org.neo4j.kernel.api.index.IndexUpdater} and {@link org.neo4j.kernel.api.index.Reservation}.
+     */
+    @Override
+    void close();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/nioneo/store/PropertyStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
@@ -720,6 +721,23 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         {
             PropertyRecord propRecord = getLightRecord( nextProp );
             toReturn.add(propRecord);
+            nextProp = propRecord.getNextProp();
+        }
+        return toReturn;
+    }
+
+    public Collection<PropertyRecord> getPropertyRecordChain( long firstRecordId, Map<Long,PropertyRecord> propertyLookup )
+    {
+        long nextProp = firstRecordId;
+        List<PropertyRecord> toReturn = new ArrayList<>();
+        while ( nextProp != Record.NO_NEXT_PROPERTY.intValue() )
+        {
+            PropertyRecord propRecord = propertyLookup.get( nextProp );
+            if ( propRecord == null )
+            {
+                propRecord = getLightRecord( nextProp );
+            }
+            toReturn.add( propRecord );
             nextProp = propRecord.getNextProp();
         }
         return toReturn;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -54,6 +54,7 @@ import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.StoreLocker;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -357,7 +358,7 @@ public class BatchInserterImpl implements BatchInserter
         labelsTouched = true;
     }
 
-    private void repopulateAllIndexes() throws IOException
+    private void repopulateAllIndexes() throws IOException, IndexCapacityExceededException
     {
         if ( !labelsTouched )
         {
@@ -408,6 +409,10 @@ public class BatchInserterImpl implements BatchInserter
                             {
                                 throw conflict.notAllowed( rules[i].getLabel(), rules[i].getPropertyKey() );
                             }
+                            catch ( IndexCapacityExceededException e )
+                            {
+                                throw new UnderlyingStorageException( e );
+                            }
                         }
                     }
                 }
@@ -434,7 +439,14 @@ public class BatchInserterImpl implements BatchInserter
         @Override
         public boolean visit( NodeLabelUpdate update ) throws IOException
         {
-            writer.write( update );
+            try
+            {
+                writer.write( update );
+            }
+            catch ( IndexCapacityExceededException e )
+            {
+                throw new UnderlyingStorageException( e );
+            }
             return true;
         }
 
@@ -1062,7 +1074,7 @@ public class BatchInserterImpl implements BatchInserter
         {
             repopulateAllIndexes();
         }
-        catch ( IOException e )
+        catch ( IOException | IndexCapacityExceededException e )
         {
             throw new RuntimeException( e );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.batchinsert;
 import java.io.Closeable;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 
 public interface LabelScanWriter extends Closeable
@@ -29,7 +30,7 @@ public interface LabelScanWriter extends Closeable
     /**
      * Store a {@link NodeLabelUpdate}. Calls to this method MUST be ordered by ascending node id.
      */
-    void write( NodeLabelUpdate update ) throws IOException;
+    void write( NodeLabelUpdate update ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Close this writer and flush pending changes to the store.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 
@@ -70,7 +71,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
     }
 
     @Before
-    public void before() throws IOException
+    public void before() throws Exception
     {
         IndexConfiguration config = new IndexConfiguration( true );
         IndexPopulator populator = indexProvider.getPopulator( 17, descriptor, config );
@@ -100,7 +101,8 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         }
     }
 
-    private void updateAndCommit( List<NodePropertyUpdate> updates ) throws IOException, IndexEntryConflictException
+    private void updateAndCommit( List<NodePropertyUpdate> updates )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/AggregatedReservationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/AggregatedReservationTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import org.neo4j.kernel.api.index.Reservation;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+public class AggregatedReservationTest
+{
+    @Test
+    public void shouldThrowWhenTooManyAggregatesAdded()
+    {
+        // Given
+        int size = 5;
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( size );
+
+        for ( int i = 0; i < size; i++ )
+        {
+            aggregatedReservation.add( mock( Reservation.class ) );
+        }
+
+        try
+        {
+            // When
+            aggregatedReservation.add( mock( Reservation.class ) );
+            fail( "Should have thrown " + IndexOutOfBoundsException.class.getSimpleName() );
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Too many aggregates" ) );
+        }
+    }
+
+    @Test
+    public void releaseShouldBeNullSafe()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 10 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( null );
+        aggregatedReservation.add( aggregate3 );
+
+        // When
+        aggregatedReservation.release();
+
+        // Then
+        InOrder order = inOrder( aggregate1, aggregate3 );
+        order.verify( aggregate1 ).release();
+        order.verify( aggregate3 ).release();
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldReleaseAllAggregatedReservations()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 3 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate2 = mock( Reservation.class );
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( aggregate2 );
+        aggregatedReservation.add( aggregate3 );
+
+        // When
+        aggregatedReservation.release();
+
+        // Then
+        InOrder order = inOrder( aggregate1, aggregate2, aggregate3 );
+        order.verify( aggregate1 ).release();
+        order.verify( aggregate2 ).release();
+        order.verify( aggregate3 ).release();
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldReleaseAllAggregatedReservationsEvenIfOneOfThemThrows()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 3 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate2 = mock( Reservation.class );
+        IllegalStateException exception = new IllegalStateException();
+        doThrow( exception ).when( aggregate2 ).release();
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( aggregate2 );
+        aggregatedReservation.add( aggregate3 );
+
+        try
+        {
+            // When
+            aggregatedReservation.release();
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            assertSame( exception, e );
+        }
+
+        // Then
+        InOrder order = inOrder( aggregate1, aggregate2, aggregate3 );
+        order.verify( aggregate1 ).release();
+        order.verify( aggregate2 ).release();
+        order.verify( aggregate3 ).release();
+        order.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldThrowLaunderedException()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 1 );
+
+        Reservation reservation = mock( Reservation.class );
+        RuntimeException exception = new RuntimeException( "Error" );
+        doThrow( exception ).when( reservation ).release();
+        aggregatedReservation.add( reservation );
+
+        try
+        {
+            // When
+            aggregatedReservation.release();
+            fail( "Should have thrown " + RuntimeException.class.getSimpleName() );
+        }
+        catch ( RuntimeException e )
+        {
+            // Then
+            assertSame( e, exception );
+            assertNull( e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldNotAllowRecursiveAggregations()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 1 );
+
+        try
+        {
+            // When
+            aggregatedReservation.add( aggregatedReservation );
+            fail( "Should have thrown " + IllegalArgumentException.class.getSimpleName() );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Recursive" ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.test.DoubleLatch;
@@ -111,7 +112,7 @@ public class ContractCheckingIndexProxyTest
 
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotUpdateBeforeCreate() throws IOException, IndexEntryConflictException
+    public void shouldNotUpdateBeforeCreate() throws Exception
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
@@ -125,7 +126,7 @@ public class ContractCheckingIndexProxyTest
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotUpdateAfterClose() throws IOException, IndexEntryConflictException
+    public void shouldNotUpdateAfterClose() throws Exception
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
@@ -264,7 +265,7 @@ public class ContractCheckingIndexProxyTest
                     updater.process( null );
                     latch.startAndAwaitFinish();
                 }
-                catch ( IndexEntryConflictException e )
+                catch ( IndexEntryConflictException | IndexCapacityExceededException e )
                 {
                     throw new RuntimeException( e );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -413,6 +414,12 @@ public class IndexPopulationJobTest
             return new IndexUpdater()
             {
                 @Override
+                public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+                {
+                    return Reservation.EMPTY;
+                }
+
+                @Override
                 public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
                 {
                     switch ( update.getUpdateMode() )
@@ -484,6 +491,12 @@ public class IndexPopulationJobTest
         {
             return new IndexUpdater()
             {
+                @Override
+                public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+                {
+                    return Reservation.EMPTY;
+                }
+
                 @Override
                 public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 
@@ -210,6 +211,12 @@ class InMemoryIndex
         private InMemoryIndexUpdater( boolean applyIdempotently )
         {
             this.applyIdempotently = applyIdempotently;
+        }
+
+        @Override
+        public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+        {
+            return Reservation.EMPTY;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.UniquePropertyIndexUpdater;
@@ -69,6 +70,12 @@ class UniqueInMemoryIndex extends InMemoryIndex
                             add( update.getNodeId(), update.getValueAfter(), IndexUpdateMode.ONLINE == mode );
                     }
                 }
+            }
+
+            @Override
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.direct.NodeLabelRange;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -68,7 +69,7 @@ public class InMemoryLabelScanStore implements LabelScanStore
     }
 
     @Override
-    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException
+    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException
     {
         try(LabelScanWriter writer = newWriter()) {
             while ( updates.hasNext() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionCommandOrderingTest.java
@@ -172,7 +172,7 @@ public class WriteTransactionCommandOrderingTest
 
     private NeoStoreTransaction newWriteTransaction() {
         NeoStoreTransaction tx = new NeoStoreTransaction( 0l, mock( XaLogicalLog.class ), TransactionState.NO_STATE,
-                store, mock( CacheAccessBackDoor.class ), mock( IndexingService.class ),
+                store, mock( CacheAccessBackDoor.class ), mock( IndexingService.class, RETURNS_MOCKS ),
                 WriteTransactionTest.NO_LABEL_SCAN_STORE, mock( IntegrityValidator.class ),
                 mock( KernelTransactionImplementation.class ), mock( LockService.class, RETURNS_MOCKS ) );
         tx.setCommitTxId( store.getLastCommittedTx() + 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/nioneo/xa/WriteTransactionTest.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.nioneo.xa;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -52,6 +52,7 @@ import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.index.IndexUpdates;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.TransactionState;
 import org.neo4j.kernel.impl.locking.Lock;
@@ -62,6 +63,7 @@ import org.neo4j.kernel.impl.nioneo.store.DynamicRecord;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.store.IndexRule;
 import org.neo4j.kernel.impl.nioneo.store.NeoStore;
+import org.neo4j.kernel.impl.nioneo.store.NodeRecord;
 import org.neo4j.kernel.impl.nioneo.store.NodeStore;
 import org.neo4j.kernel.impl.nioneo.store.PropertyBlock;
 import org.neo4j.kernel.impl.nioneo.store.PropertyRecord;
@@ -69,6 +71,7 @@ import org.neo4j.kernel.impl.nioneo.store.Record;
 import org.neo4j.kernel.impl.nioneo.store.SchemaRule;
 import org.neo4j.kernel.impl.nioneo.store.SchemaStore;
 import org.neo4j.kernel.impl.nioneo.store.StoreFactory;
+import org.neo4j.kernel.impl.nioneo.store.labels.InlineNodeLabels;
 import org.neo4j.kernel.impl.nioneo.xa.Command.PropertyCommand;
 import org.neo4j.kernel.impl.nioneo.xa.Command.SchemaRuleCommand;
 import org.neo4j.kernel.impl.transaction.KernelHealth;
@@ -80,12 +83,14 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -93,6 +98,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
@@ -713,34 +719,35 @@ public class WriteTransactionTest
 
         // -- an index
         long ruleId = 0;
-        NeoStoreTransaction tx = newWriteTransaction( mockIndexing );
+        CapturingIndexingService indexingService = new CapturingIndexingService();
+        NeoStoreTransaction tx = newWriteTransaction( indexingService );
         SchemaRule rule = indexRule( ruleId, labelId, propertyKeyId, PROVIDER_DESCRIPTOR );
         tx.createSchemaRule( rule );
         prepareAndCommit( tx );
 
         // -- and a tx creating a node with that label and property key
-        IndexingService index = mock( IndexingService.class );
+        IndexingService index = mock( IndexingService.class, RETURNS_MOCKS );
         IteratorCollector<NodePropertyUpdate> indexUpdates = new IteratorCollector<>( 0 );
-        doAnswer( indexUpdates ).when( index ).updateIndexes( any( IndexUpdates.class ) );
+        doAnswer( indexUpdates ).when( index ).validate( any( IndexUpdates.class ) );
         CommandCapturingVisitor commandCapturingVisitor = new CommandCapturingVisitor();
         tx = newWriteTransaction( index, commandCapturingVisitor );
         tx.nodeCreate( nodeId );
         tx.addLabelToNode( labelId, nodeId );
         tx.nodeAddProperty( nodeId, propertyKeyId, "Neo" );
         prepareAndCommit( tx );
-        verify( index, times( 1 ) ).updateIndexes( any( IndexUpdates.class ) );
+        verify( index, times( 1 ) ).validate( any( IndexUpdates.class ) );
         indexUpdates.assertContent( expectedUpdate );
 
         reset( index );
         indexUpdates = new IteratorCollector<>( 0 );
-        doAnswer( indexUpdates ).when( index ).updateIndexes( any( IndexUpdates.class ) );
+        doAnswer( indexUpdates ).when( index ).validate( any( IndexUpdates.class ) );
 
         // WHEN
         // -- later recovering that tx, there should be only one update
         tx = newWriteTransaction( index );
         commandCapturingVisitor.injectInto( tx );
         prepareAndCommitRecovered( tx );
-        verify( index, times( 1 ) ).updateIndexes( any( IndexUpdates.class ) );
+        verify( index, times( 1 ) ).validate( any( IndexUpdates.class ) );
         indexUpdates.assertContent( expectedUpdate );
     }
 
@@ -804,6 +811,72 @@ public class WriteTransactionTest
         verify( locks, times( 2 ) ).acquireNodeLock( nodes[6], LockService.LockType.WRITE_LOCK );
     }
 
+    @Test
+    public void shouldValidateIndexUpdatesAsPartOfPrepare() throws Exception
+    {
+        // Given
+        NeoStoreTransaction tx = newWriteTransaction( mockIndexing );
+
+        tx.nodeCreate( 1 );
+        tx.addLabelToNode( 1, 1 );
+        tx.nodeAddProperty( 1, 1, "foo" );
+
+        tx.nodeCreate( 2 );
+        tx.addLabelToNode( 2, 2 );
+        tx.nodeAddProperty( 2, 2, "bar" );
+
+        // When
+        tx.prepare();
+
+        // Then
+        ArgumentCaptor<IndexUpdates> captor = ArgumentCaptor.forClass( IndexUpdates.class );
+        verify( mockIndexing ).validate( captor.capture() );
+        IndexUpdates updates = captor.getValue();
+
+        assertEquals(
+                asSet( add( 1, 1, "foo", new long[]{1} ), add( 2, 2, "bar", new long[]{2} ) ),
+                asSet( updates )
+        );
+        assertEquals( asSet( 1L, 2L ), updates.changedNodeIds() );
+    }
+
+    @Test
+    public void shouldValidateAndApplyIndexUpdatesAsPartOfCommitForRecoveredTx() throws Exception
+    {
+        // Given
+        long nodeId = neoStore.getNodeStore().nextId();
+        long labelId = neoStore.getLabelTokenStore().nextId();
+        long propertyId = neoStore.getPropertyStore().nextId();
+        long propertyKeyId = neoStore.getPropertyStore().getPropertyKeyTokenStore().nextId();
+        String value = "foo";
+
+        ValidatedIndexUpdates validatedIndexUpdates = mock( ValidatedIndexUpdates.class );
+        when( mockIndexing.validate( any( IndexUpdates.class ) ) ).thenReturn( validatedIndexUpdates );
+
+        NeoStoreTransaction tx = newWriteTransaction( mockIndexing );
+        tx.setRecovered();
+
+        tx.injectCommand( nodeCreateCommand( nodeId, labelId ) );
+
+        tx.injectCommand( propertyCommand( propertyId, nodeId, (int) propertyKeyId, value ) );
+
+        // When
+        try ( LockGroup locks = new LockGroup() )
+        {
+            tx.commit( locks );
+        }
+
+        // Then
+        ArgumentCaptor<IndexUpdates> captor = ArgumentCaptor.forClass( IndexUpdates.class );
+        verify( mockIndexing ).validate( captor.capture() );
+        IndexUpdates updates = captor.getValue();
+
+        assertEquals( asSet( add( nodeId, (int) propertyKeyId, value, new long[]{labelId} ) ), asSet( updates ) );
+        assertEquals( asSet( nodeId ), updates.changedNodeIds() );
+
+        verify( mockIndexing ).updateIndexes( validatedIndexUpdates );
+    }
+
     private String string( int length )
     {
         StringBuilder result = new StringBuilder();
@@ -813,6 +886,37 @@ public class WriteTransactionTest
             result.append( (char)((ch + (i%10))) );
         }
         return result.toString();
+    }
+
+    private Command.NodeCommand nodeCreateCommand( long nodeId, long labelId )
+    {
+        NodeRecord before = new NodeRecord( nodeId, Record.NO_NEXT_RELATIONSHIP.intValue(),
+                Record.NO_NEXT_PROPERTY.intValue() );
+        before.setInUse( false );
+
+        NodeRecord after = new NodeRecord( nodeId, Record.NO_NEXT_RELATIONSHIP.intValue(),
+                Record.NO_NEXT_PROPERTY.intValue() );
+        after.setInUse( true );
+
+        InlineNodeLabels nodeLabels = new InlineNodeLabels( -1, after );
+        nodeLabels.put( new long[]{labelId}, neoStore.getNodeStore() );
+
+        return new Command.NodeCommand( neoStore.getNodeStore(), before, after );
+    }
+
+    private Command.PropertyCommand propertyCommand( long recordId, long nodeId, int propertyKeyId, Object value )
+    {
+        PropertyRecord before = new PropertyRecord( recordId );
+        before.setInUse( false );
+
+        PropertyBlock block = new PropertyBlock();
+        neoStore.getPropertyStore().encodeValue( block, propertyKeyId, value );
+        PropertyRecord after = new PropertyRecord( recordId );
+        after.setInUse( true );
+        after.addPropertyBlock( block );
+        after.setNodeId( nodeId );
+
+        return new Command.PropertyCommand( neoStore.getPropertyStore(), before, after );
     }
 
     @Rule public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
@@ -903,7 +1007,7 @@ public class WriteTransactionTest
         }
     }
 
-    private final IndexingService mockIndexing = mock( IndexingService.class );
+    private final IndexingService mockIndexing = mock( IndexingService.class, RETURNS_MOCKS );
     private final KernelTransactionImplementation kernelTransaction = mock( KernelTransactionImplementation.class );
 
     private NeoStoreTransaction newWriteTransaction( IndexingService indexing )
@@ -935,13 +1039,20 @@ public class WriteTransactionTest
                     null,
                     new KernelSchemaStateStore(),
                     new SingleLoggingService( DEV_NULL ), IndexingService.NO_MONITOR
-                );
+            );
         }
 
         @Override
-        public void updateIndexes( IndexUpdates updates )
+        public ValidatedIndexUpdates validate( IndexUpdates updates )
         {
             this.updates.addAll( asCollection( updates ) );
+            return super.validate( updates );
+        }
+
+        @Override
+        public void updateIndexes( ValidatedIndexUpdates updates )
+        {
+            super.updateIndexes( updates );
         }
     }
 
@@ -1057,12 +1168,12 @@ public class WriteTransactionTest
         @SafeVarargs
         public final void assertContent( T... expected )
         {
-            assertEquals( Arrays.asList( expected ), elements );
+            assertEquals( asList( expected ), elements );
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public Object answer( InvocationOnMock invocation ) throws Throwable
+        public ValidatedIndexUpdates answer( InvocationOnMock invocation ) throws Throwable
         {
             Object iterator = invocation.getArguments()[arg];
             if ( iterator instanceof Iterable )
@@ -1073,7 +1184,7 @@ public class WriteTransactionTest
             {
                 collect( (Iterator) iterator );
             }
-            return null;
+            return mock( ValidatedIndexUpdates.class );
         }
 
         private void collect( Iterator<T> iterator )

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
@@ -22,6 +22,7 @@ package org.neo4j.index.lucene;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.impl.index.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.IndexWriterFactories;
 import org.neo4j.kernel.api.impl.index.LuceneLabelScanStore;
@@ -73,7 +74,7 @@ public class LuceneLabelScanStoreBuilder
                     DirectoryFactory.PERSISTENT,
                     // <db>/schema/label/lucene
                     new File( new File( new File( storeDir, "schema" ), "label" ), "lucene" ),
-                    fileSystem, IndexWriterFactories.standard(),
+                    fileSystem, IndexWriterFactories.tracking(),
                     fullStoreLabelUpdateStream( neoStoreProvider ),
                     LuceneLabelScanStore.loggerMonitor( logger ) );
 
@@ -82,7 +83,7 @@ public class LuceneLabelScanStoreBuilder
                 labelScanStore.init();
                 labelScanStore.start();
             }
-            catch ( IOException e )
+            catch ( IOException | IndexCapacityExceededException e )
             {
                 // Throw better exception
                 throw new RuntimeException( e );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactories.java
@@ -19,31 +19,64 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import java.io.IOException;
-
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
 
+import java.io.IOException;
+
 import org.neo4j.index.impl.lucene.LuceneDataSource;
 import org.neo4j.index.impl.lucene.MultipleBackupDeletionPolicy;
 
-public class IndexWriterFactories
+public final class IndexWriterFactories
 {
-    public static LuceneIndexWriterFactory standard()
+    private IndexWriterFactories()
     {
-        return new LuceneIndexWriterFactory()
+        throw new AssertionError( "Not for instantiation!" );
+    }
+
+    public static IndexWriterFactory<ReservingLuceneIndexWriter> reserving()
+    {
+        return new IndexWriterFactory<ReservingLuceneIndexWriter>()
         {
             @Override
-            public IndexWriter create( Directory directory ) throws IOException
+            public ReservingLuceneIndexWriter create( Directory directory ) throws IOException
             {
-                IndexWriterConfig writerConfig = new IndexWriterConfig( Version.LUCENE_36, LuceneDataSource.KEYWORD_ANALYZER );
-                writerConfig.setMaxBufferedDocs( 100000 ); // TODO figure out depending on environment?
-                writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
-                writerConfig.setTermIndexInterval( 14 );
-                return new IndexWriter( directory, writerConfig );
+                return new ReservingLuceneIndexWriter( directory, standardConfig() );
             }
         };
+    }
+
+    public static IndexWriterFactory<LuceneIndexWriter> tracking()
+    {
+        return new IndexWriterFactory<LuceneIndexWriter>()
+        {
+            @Override
+            public LuceneIndexWriter create( Directory directory ) throws IOException
+            {
+                return new TrackingLuceneIndexWriter( directory, standardConfig() );
+            }
+        };
+    }
+
+    public static IndexWriterFactory<LuceneIndexWriter> batchInsert( final IndexWriterConfig config )
+    {
+        return new IndexWriterFactory<LuceneIndexWriter>()
+        {
+            @Override
+            public LuceneIndexWriter create( Directory directory ) throws IOException
+            {
+                return new TrackingLuceneIndexWriter( directory, config );
+            }
+        };
+    }
+
+    private static IndexWriterConfig standardConfig()
+    {
+        IndexWriterConfig writerConfig = new IndexWriterConfig( Version.LUCENE_36, LuceneDataSource.KEYWORD_ANALYZER );
+        writerConfig.setMaxBufferedDocs( 100000 ); // TODO figure out depending on environment?
+        writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
+        writerConfig.setTermIndexInterval( 14 );
+        return writerConfig;
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactory.java
@@ -17,31 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.api.index;
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.store.Directory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
-import org.neo4j.kernel.api.index.IndexUpdater;
-import org.neo4j.kernel.api.index.NodePropertyUpdate;
-import org.neo4j.kernel.api.index.Reservation;
-
-public abstract class CollectingIndexUpdater implements IndexUpdater
+public interface IndexWriterFactory<W extends LuceneIndexWriter>
 {
-    protected final ArrayList<NodePropertyUpdate> updates = new ArrayList<>();
-
-    @Override
-    public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
-    {
-        return Reservation.EMPTY;
-    }
-
-    @Override
-    public void process( NodePropertyUpdate update )
-    {
-        if ( null != update )
-        {
-            updates.add( update );
-        }
-    }
+    W create( Directory directory ) throws IOException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterStatus.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterStatus.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.Directory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -33,7 +32,7 @@ class IndexWriterStatus
     private static final String KEY_STATUS = "status";
     private static final String ONLINE = "online";
 
-    public void commitAsOnline( IndexWriter writer ) throws IOException
+    public void commitAsOnline( LuceneIndexWriter writer ) throws IOException
     {
         writer.commit( stringMap( KEY_STATUS, ONLINE ) );
     }
@@ -59,7 +58,7 @@ class IndexWriterStatus
         }
     }
 
-    public void close( IndexWriter writer ) throws IOException
+    public void close( LuceneIndexWriter writer ) throws IOException
     {
         writer.close( true );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
 
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.util.PrimitiveLongIterator;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
@@ -43,7 +44,7 @@ public interface LabelScanStorageStrategy
 
     interface StorageService
     {
-        void updateDocument( Term documentTerm, Document document ) throws IOException;
+        void updateDocument( Term documentTerm, Document document ) throws IOException, IndexCapacityExceededException;
 
         void deleteDocuments( Term documentTerm ) throws IOException;
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
@@ -22,28 +22,28 @@ package org.neo4j.kernel.api.impl.index;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 
 public abstract class LuceneIndexPopulator implements IndexPopulator
 {
     protected final LuceneDocumentStructure documentStructure;
-    private final LuceneIndexWriterFactory indexWriterFactory;
+    private final IndexWriterFactory<LuceneIndexWriter> indexWriterFactory;
     private final IndexWriterStatus writerStatus;
     private final DirectoryFactory dirFactory;
     private final File dirFile;
     private final FailureStorage failureStorage;
     private final long indexId;
 
-    protected IndexWriter writer;
+    protected LuceneIndexWriter writer;
     private Directory directory;
 
     LuceneIndexPopulator(
-            LuceneDocumentStructure documentStructure, LuceneIndexWriterFactory indexWriterFactory,
+            LuceneDocumentStructure documentStructure, IndexWriterFactory<LuceneIndexWriter> indexWriterFactory,
             IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
             FailureStorage failureStorage, long indexId )
     {
@@ -92,7 +92,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void close( boolean populationCompletedSuccessfully ) throws IOException
+    public void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException
     {
         try
         {
@@ -121,5 +121,5 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
         failureStorage.storeIndexFailure( indexId, failure );
     }
 
-    protected abstract void flush() throws IOException;
+    protected abstract void flush() throws IOException, IndexCapacityExceededException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexWriter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexDeletionPolicy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SearcherFactory;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+public class LuceneIndexWriter implements Closeable
+{
+    // Lucene cannot allocate a full MAX_INT of documents, the deviation differs from JVM to JVM, but according to
+    // their source in future versions, the deviation can never be bigger than 128.
+    private static final long MAX_DOC_LIMIT = Integer.MAX_VALUE - 128;
+
+    protected final IndexWriter writer;
+
+    LuceneIndexWriter( Directory dir, IndexWriterConfig conf ) throws IOException
+    {
+        this.writer = new IndexWriter( dir, conf );
+    }
+
+    public void addDocument( Document document ) throws IOException, IndexCapacityExceededException
+    {
+        writer.addDocument( document );
+    }
+
+    public void updateDocument( Term term, Document document ) throws IOException, IndexCapacityExceededException
+    {
+        writer.updateDocument( term, document );
+    }
+
+    public void deleteDocuments( Term term ) throws IOException
+    {
+        writer.deleteDocuments( term );
+    }
+
+    public void deleteDocuments( Query query ) throws IOException
+    {
+        writer.deleteDocuments( query );
+    }
+
+    public void optimize() throws IOException
+    {
+        writer.optimize( true );
+    }
+
+    public SearcherManager createSearcherManager() throws IOException
+    {
+        return new SearcherManager( writer, true, new SearcherFactory() );
+    }
+
+    public void commit() throws IOException
+    {
+        writer.commit();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        close( true );
+    }
+
+    IndexDeletionPolicy getIndexDeletionPolicy()
+    {
+        return writer.getConfig().getIndexDeletionPolicy();
+    }
+
+    void commit( Map<String,String> commitUserData ) throws IOException
+    {
+        writer.commit( commitUserData );
+    }
+
+    void close( boolean waitForMerges ) throws IOException
+    {
+        writer.close( waitForMerges );
+    }
+
+    long maxDocLimit()
+    {
+        return MAX_DOC_LIMIT;
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
@@ -31,7 +31,7 @@ import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
 import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
 import org.neo4j.kernel.logging.Logging;
 
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
 import static org.neo4j.kernel.api.impl.index.LuceneLabelScanStore.loggerMonitor;
 import static org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.fullStoreLabelUpdateStream;
@@ -76,7 +76,7 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 // <db>/schema/label/lucene
                 directoryFactory, new File( new File( new File( storeDir, "schema" ), "label" ), "lucene" ),
 
-                dependencies.getFileSystem(), standard(),
+                dependencies.getFileSystem(), tracking(),
                 fullStoreLabelUpdateStream( dependencies.getNeoStoreProvider() ),
                 monitor != null ? monitor : loggerMonitor( dependencies.getLogging() ) );
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.Directory;
 
 import java.io.EOFException;
 import java.io.File;
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.store.Directory;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -40,6 +38,10 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 import org.neo4j.kernel.api.index.util.FolderLayout;
 import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 
 public class LuceneSchemaIndexProvider extends SchemaIndexProvider
 {
@@ -66,15 +68,14 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
         if ( config.isUnique() )
         {
             return new DeferredConstraintVerificationUniqueLuceneIndexPopulator(
-                    documentStructure, standard(), writerStatus,
-                    directoryFactory, folderLayout.getFolder( indexId ), failureStorage,
-                    indexId, descriptor );
+                    documentStructure, tracking(), writerStatus, directoryFactory,
+                    folderLayout.getFolder( indexId ), failureStorage, indexId, descriptor );
         }
         else
         {
             return new NonUniqueLuceneIndexPopulator(
-                    NonUniqueLuceneIndexPopulator.DEFAULT_QUEUE_THRESHOLD, documentStructure, standard(), writerStatus,
-                    directoryFactory, folderLayout.getFolder( indexId ), failureStorage, indexId );
+                    NonUniqueLuceneIndexPopulator.DEFAULT_QUEUE_THRESHOLD, documentStructure, tracking(),
+                    writerStatus, directoryFactory, folderLayout.getFolder( indexId ), failureStorage, indexId );
         }
     }
 
@@ -83,12 +84,12 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     {
         if ( config.isUnique() )
         {
-            return new UniqueLuceneIndexAccessor( documentStructure, standard(), writerStatus, directoryFactory,
+            return new UniqueLuceneIndexAccessor( documentStructure, reserving(), writerStatus, directoryFactory,
                     folderLayout.getFolder( indexId ) );
         }
         else
         {
-            return new NonUniqueLuceneIndexAccessor( documentStructure, standard(), writerStatus, directoryFactory,
+            return new NonUniqueLuceneIndexAccessor( documentStructure, reserving(), writerStatus, directoryFactory,
                     folderLayout.getFolder( indexId ) );
         }
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
@@ -36,9 +36,9 @@ public class LuceneSnapshotter
     private static final String NO_INDEX_COMMIT_TO_SNAPSHOT = "No index commit to snapshot";
     private static final String ID = "backup";
 
-    ResourceIterator<File> snapshot( File indexDir, IndexWriter writer ) throws IOException
+    ResourceIterator<File> snapshot( File indexDir, LuceneIndexWriter writer ) throws IOException
     {
-        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getConfig().getIndexDeletionPolicy();
+        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getIndexDeletionPolicy();
 
         try
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexAccessor.java
@@ -25,8 +25,9 @@ import java.io.IOException;
 class NonUniqueLuceneIndexAccessor extends LuceneIndexAccessor
 {
     NonUniqueLuceneIndexAccessor( LuceneDocumentStructure documentStructure,
-                                  LuceneIndexWriterFactory indexWriterFactory, IndexWriterStatus writerStatus,
-                                  DirectoryFactory dirFactory, File dirFile ) throws IOException
+                                  IndexWriterFactory<ReservingLuceneIndexWriter> indexWriterFactory,
+                                  IndexWriterStatus writerStatus, DirectoryFactory dirFactory,
+                                  File dirFile ) throws IOException
     {
         super( documentStructure, indexWriterFactory, writerStatus, dirFactory, dirFile );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriter.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+class ReservingLuceneIndexWriter extends LuceneIndexWriter
+{
+    private final AtomicLong reservedDocs = new AtomicLong();
+
+    ReservingLuceneIndexWriter( Directory directory, IndexWriterConfig config ) throws IOException
+    {
+        super( directory, config );
+    }
+
+    synchronized void reserveInsertions( int insertionsCount ) throws IOException, IndexCapacityExceededException
+    {
+        if ( insertionsCount <= 0 )
+        {
+            return;
+        }
+
+        if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+        {
+            // maxDoc is about to overflow, let's try to save our index
+
+            // try to merge deletes, maybe this will fix maxDoc
+            writer.forceMergeDeletes();
+
+            if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+            {
+                // if it did not then merge everything in single segment - horribly slow, last resort
+                writer.forceMerge( 1 );
+
+                if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+                {
+                    // merging did not help - throw exception
+                    throw new IndexCapacityExceededException( insertionsCount, writer.maxDoc(), maxDocLimit() );
+                }
+            }
+        }
+
+        // everything fine - able to reserve 'space' for new documents
+        reservedDocs.addAndGet( insertionsCount );
+    }
+
+    void removeReservedInsertions( int insertionsCount )
+    {
+        if ( insertionsCount > 0 )
+        {
+            reservedDocs.addAndGet( -insertionsCount );
+        }
+    }
+
+    private boolean totalNumberOfDocumentsExceededLuceneCapacity( int newAdditions )
+    {
+        return (reservedDocs.get() + writer.maxDoc() + newAdditions) >= maxDocLimit();
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriter.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+class TrackingLuceneIndexWriter extends LuceneIndexWriter
+{
+    TrackingLuceneIndexWriter( Directory directory, IndexWriterConfig config ) throws IOException
+    {
+        super( directory, config );
+    }
+
+    @Override
+    public void addDocument( Document document ) throws IOException, IndexCapacityExceededException
+    {
+        checkMaxDoc();
+        super.addDocument( document );
+    }
+
+    @Override
+    public void updateDocument( Term term, Document document ) throws IOException, IndexCapacityExceededException
+    {
+        checkMaxDoc();
+        super.updateDocument( term, document );
+    }
+
+    private void checkMaxDoc() throws IOException, IndexCapacityExceededException
+    {
+        int currentMaxDoc = writer.maxDoc();
+        long limit = maxDocLimit();
+
+        if ( currentMaxDoc >= limit )
+        {
+            throw new IndexCapacityExceededException( currentMaxDoc, limit );
+        }
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
@@ -22,17 +22,20 @@ package org.neo4j.kernel.api.impl.index;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.UniquePropertyIndexUpdater;
 
 class UniqueLuceneIndexAccessor extends LuceneIndexAccessor
 {
     public UniqueLuceneIndexAccessor( LuceneDocumentStructure documentStructure,
-                                      LuceneIndexWriterFactory indexWriterFactory, IndexWriterStatus writerStatus,
-                                      DirectoryFactory dirFactory, File dirFile ) throws IOException
+                                      IndexWriterFactory<ReservingLuceneIndexWriter> indexWriterFactory,
+                                      IndexWriterStatus writerStatus, DirectoryFactory dirFactory,
+                                      File dirFile ) throws IOException
     {
         super( documentStructure, indexWriterFactory, writerStatus, dirFactory, dirFile );
     }
@@ -91,13 +94,20 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor
 
         @Override
         protected void flushUpdates( Iterable<NodePropertyUpdate> updates )
-                throws IOException, IndexEntryConflictException
+                throws IOException, IndexEntryConflictException, IndexCapacityExceededException
         {
             for ( NodePropertyUpdate update : updates )
             {
                 delegate.process( update );
             }
             delegate.close();
+        }
+
+        @Override
+        public Reservation validate( Iterable<NodePropertyUpdate> updates )
+                throws IOException, IndexCapacityExceededException
+        {
+            return delegate.validate( updates );
         }
 
         @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulatorTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.kernel.api.impl.index.AllNodesCollector.getAllNodes;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.properties.Property.intProperty;
 import static org.neo4j.kernel.api.properties.Property.longProperty;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
@@ -430,7 +430,7 @@ public class DeferredConstraintVerificationUniqueLuceneIndexPopulatorTest
         propertyAccessor = mock( PropertyAccessor.class );
         populator = new
                 DeferredConstraintVerificationUniqueLuceneIndexPopulator(
-                documentLogic, standard(),
+                documentLogic, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory,
                 failureStorage, indexId, descriptor );
         populator.create();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -42,7 +43,7 @@ import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 
 public class LuceneIndexIT
 {
@@ -105,7 +106,7 @@ public class LuceneIndexIT
     public void before() throws Exception
     {
         dirFactory = DirectoryFactory.PERSISTENT;
-        accessor = new NonUniqueLuceneIndexAccessor( documentLogic, standard(), writerLogic, dirFactory, testDir.directory() );
+        accessor = new NonUniqueLuceneIndexAccessor( documentLogic, reserving(), writerLogic, dirFactory, testDir.directory() );
     }
 
     @After
@@ -121,7 +122,7 @@ public class LuceneIndexIT
     }
 
     private void updateAndCommit( List<NodePropertyUpdate> nodePropertyUpdates )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
@@ -46,6 +46,7 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.direct.NodeLabelRange;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.FullStoreChangeStream;
@@ -73,7 +74,7 @@ import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptyPrimitiveLongIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 import static org.neo4j.kernel.impl.util.FileUtils.deleteRecursively;
 
@@ -251,7 +252,7 @@ public class LuceneLabelScanStoreTest
             assertThat( labels, hasItem( label0Id ) );
         }
     }
-    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException
+    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException, IndexCapacityExceededException
     {
         try ( LabelScanWriter writer = store.newWriter() )
         {
@@ -444,7 +445,7 @@ public class LuceneLabelScanStoreTest
         monitor = new TrackingMonitor();
         store = life.add( new LuceneLabelScanStore(
                 strategy,
-                directoryFactory, dir, new DefaultFileSystemAbstraction(), standard(), asStream( existingData ),
+                directoryFactory, dir, new DefaultFileSystemAbstraction(), tracking(), asStream( existingData ),
                 monitor ) );
         life.start();
         assertTrue( monitor.initCalled );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -257,7 +258,7 @@ public class LuceneSchemaIndexPopulatorTest
         directory.close();
     }
 
-    private void assertIndexedValues( Hit... expectedHits ) throws IOException
+    private void assertIndexedValues( Hit... expectedHits ) throws IOException, IndexCapacityExceededException
     {
         switchToVerification();
         
@@ -275,7 +276,7 @@ public class LuceneSchemaIndexPopulatorTest
         }
     }
 
-    private void switchToVerification() throws IOException
+    private void switchToVerification() throws IOException, IndexCapacityExceededException
     {
         index.close( true );
         assertEquals( InternalIndexState.ONLINE, provider.getInitialState( indexId ) );
@@ -287,7 +288,7 @@ public class LuceneSchemaIndexPopulatorTest
             IndexPopulator populator,
             Iterable<NodePropertyUpdate> updates,
             PropertyAccessor accessor )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = populator.newPopulatingUpdater( accessor ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
@@ -43,19 +43,18 @@ public class LuceneSnapshotterTest
     private SnapshotDeletionPolicy snapshotPolicy;
 
     private IndexCommit luceneSnapshot;
-    private IndexWriter writer;
+    private LuceneIndexWriter writer;
 
     @Before
     public void setup() throws IOException
     {
-        writer = mock(IndexWriter.class);
+        writer = mock( LuceneIndexWriter.class );
         snapshotPolicy = mock(SnapshotDeletionPolicy.class);
         luceneSnapshot = mock(IndexCommit.class);
 
         IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
 
-        config.setIndexDeletionPolicy( snapshotPolicy );
-        when( writer.getConfig() ).thenReturn( config );
+        when( writer.getIndexDeletionPolicy() ).thenReturn( snapshotPolicy );
 
         when(snapshotPolicy.snapshot( anyString() )).thenReturn( luceneSnapshot );
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriterTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class ReservingLuceneIndexWriterTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldReserveWhenMaxDocLimitIsNotReached() throws Exception
+    {
+        // Given
+        int maxDocLimit = 42;
+        int toReserve = maxDocLimit - 20;
+
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        indexWriter.reserveInsertions( toReserve );
+
+        // Then
+        assertEquals( 0, indexWriter.createSearcherManager().acquire().getIndexReader().maxDoc() );
+    }
+
+    @Test
+    public void shouldWorkIfSumOfMaxDocAndReservedIsLessThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 100;
+        int toAdd = maxDocLimit / 2;
+        int toReserve = maxDocLimit - toAdd - 7;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        indexWriter.reserveInsertions( toReserve );
+
+        // Then
+        assertEquals( toAdd, indexWriter.createSearcherManager().acquire().maxDoc() );
+    }
+
+    @Test
+    public void shouldThrowIfMoreThanLimitDocsAreReserved() throws Exception
+    {
+        // Given
+        int maxDocLimit = 42;
+        int toReserve = maxDocLimit + 42;
+
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        try
+        {
+            // When
+            indexWriter.reserveInsertions( toReserve );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Unable to reserve" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenSumOfMaxDocAndReservedIsGreaterThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 100;
+        int toAdd = maxDocLimit / 2;
+        int toReserve = maxDocLimit - toAdd + 2;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        indexWriter.reserveInsertions( toAdd );
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.reserveInsertions( toReserve );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Unable to reserve" ) );
+        }
+    }
+
+    private ReservingLuceneIndexWriter newReservingLuceneIndexWriter( long maxDocLimit ) throws Exception
+    {
+        File luceneDir = new File( "lucene" );
+        fs.get().mkdir( luceneDir );
+        Directory directory = new DirectoryFactory.InMemoryDirectoryFactory().open( luceneDir );
+        IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
+        ReservingLuceneIndexWriter indexWriter = new ReservingLuceneIndexWriter( directory, config );
+        ReservingLuceneIndexWriter indexWriterSpy = spy( indexWriter );
+        when( indexWriterSpy.maxDocLimit() ).thenReturn( maxDocLimit );
+        return indexWriterSpy;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriterTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TrackingLuceneIndexWriterTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldSilentlyAddDocumentsWhenMaxDocIsLessThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+        int toAdd = maxDocLimit - 10;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        // Then
+        assertEquals( toAdd, indexWriter.createSearcherManager().acquire().getIndexReader().numDocs() );
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenTooManyDocumentsAreAdded() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        for ( int i = 0; i < maxDocLimit; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.addDocument( documentStructure.newDocument( maxDocLimit + 42 ) );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Index contains too many entries" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenTooManyDocumentsAreUpdated() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        for ( int i = 0; i < maxDocLimit; i++ )
+        {
+            indexWriter.updateDocument( new Term( "foo", "bar" ), documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.updateDocument( new Term( "foo", "bar" ), documentStructure.newDocument( maxDocLimit + 42 ) );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Index contains too many entries" ) );
+        }
+    }
+
+    private TrackingLuceneIndexWriter newTrackingLuceneIndexWriter( long maxDocLimit ) throws Exception
+    {
+        File luceneDir = new File( "lucene" );
+        fs.get().mkdir( luceneDir );
+        Directory directory = new DirectoryFactory.InMemoryDirectoryFactory().open( luceneDir );
+        IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
+        TrackingLuceneIndexWriter indexWriter = new TrackingLuceneIndexWriter( directory, config );
+        TrackingLuceneIndexWriter indexWriterSpy = spy( indexWriter );
+        when( indexWriterSpy.maxDocLimit() ).thenReturn( maxDocLimit );
+        return indexWriterSpy;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -36,7 +37,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 import static org.neo4j.helpers.collection.IteratorUtil.emptyListOf;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 
 public class UniqueLuceneIndexAccessorTest
 {
@@ -119,7 +120,7 @@ public class UniqueLuceneIndexAccessorTest
 
     private UniqueLuceneIndexAccessor createAccessor() throws IOException
     {
-        return new UniqueLuceneIndexAccessor( new LuceneDocumentStructure(), standard(), new IndexWriterStatus(),
+        return new UniqueLuceneIndexAccessor( new LuceneDocumentStructure(), reserving(), new IndexWriterStatus(),
                 directoryFactory, indexDirectory );
     }
 
@@ -144,7 +145,7 @@ public class UniqueLuceneIndexAccessorTest
     }
     
     private void updateAndCommit( IndexAccessor accessor, Iterable<NodePropertyUpdate> updates )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.kernel.api.impl.index.AllNodesCollector.getAllNodes;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
 
@@ -51,7 +51,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                documentStructure, standard(),
+                documentStructure, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
 
@@ -74,7 +74,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                documentStructure, standard(),
+                documentStructure, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
         int propertyKeyId = 100;
@@ -105,7 +105,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                new LuceneDocumentStructure(), standard(),
+                new LuceneDocumentStructure(), tracking(),
                 new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );
@@ -135,7 +135,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentLogic = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 2,
-                documentLogic, standard(),
+                documentLogic, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
 
@@ -163,7 +163,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                new LuceneDocumentStructure(), standard(),
+                new LuceneDocumentStructure(), tracking(),
                 new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
@@ -45,7 +45,7 @@ public class WriterLogicTest
     public void forceShouldSetOnlineStatus() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         writer.addDocument( newDocument() );
         logic.commitAsOnline( writer );
         
@@ -60,7 +60,7 @@ public class WriterLogicTest
     public void forceShouldKeepOnlineStatus() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         logic.commitAsOnline( writer );
         
         // WHEN
@@ -76,7 +76,7 @@ public class WriterLogicTest
     public void otherWriterSessionShouldKeepOnlineStatusEvenIfNotForcingBeforeClosing() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         logic.commitAsOnline( writer );
         writer.close( true );
         
@@ -105,10 +105,10 @@ public class WriterLogicTest
     {
         dirFactory.close();
     }
-    
-    private IndexWriter newWriter() throws IOException
+
+    private LuceneIndexWriter newWriter() throws IOException
     {
-        return new IndexWriter( directory, new IndexWriterConfig( Version.LUCENE_35, KEYWORD_ANALYZER ) );
+        return new LuceneIndexWriter( directory, new IndexWriterConfig( Version.LUCENE_35, KEYWORD_ANALYZER ) );
     }
     
     private Document newDocument()

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
@@ -89,6 +89,7 @@ public class TestLuceneBatchInsert
             index.add( id, map( "name", "Joe" + i, "other", "Schmoe" ) );
             ids.put( i, id );
         }
+        index.flush();
 
         for ( int i = 0; i < count; i++ )
         {
@@ -207,6 +208,8 @@ public class TestLuceneBatchInsert
         index.add( node1, map( "number", numeric( 45 ) ) );
         long node2 = inserter.createNode( null );
         index.add( node2, map( "number", numeric( 21 ) ) );
+        index.flush();
+
         assertContains( index.query( "number",
                 newIntRange( "number", 21, 50, true, true ) ), node1, node2 );
 
@@ -232,7 +235,8 @@ public class TestLuceneBatchInsert
         long nodeId1 = inserter.createNode( null );
         batchIndex.add( nodeId1, map( "number", new ValueContext[]{ numeric( 45 ), numeric( 98 ) } ) );
         long nodeId2 = inserter.createNode( null );
-        batchIndex.add( nodeId2, map( "number", new ValueContext[]{ numeric( 47 ), numeric( 100 ) } ) );
+        batchIndex.add( nodeId2, map( "number", new ValueContext[]{numeric( 47 ), numeric( 100 )} ) );
+        batchIndex.flush();
 
         IndexHits<Long> batchIndexResult1 = batchIndex.query( "number", newIntRange( "number", 47, 98, true, true ) );
         assertThat( batchIndexResult1, contains(nodeId1, nodeId2));
@@ -344,6 +348,7 @@ public class TestLuceneBatchInsert
         props.put( "key", "value" );
         index.add( id, props );
         index.updateOrAdd( id, props );
+        index.flush();
         assertEquals( 1, index.get( "key", "value" ).size() );
         index.flush();
         props.put( "key", "value2" );
@@ -425,6 +430,7 @@ public class TestLuceneBatchInsert
         index.setCacheCapacity( key, 100000 );
         assertCacheIsEmpty( index, key );
         index.add( 1, map( key, "Persson" ) );
+        index.flush();
         assertCacheIsEmpty( index, key );
         assertEquals( 1, index.get( key, "Persson" ).getSingle().intValue() );
         provider.shutdown();

--- a/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/enterprise/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -41,6 +41,7 @@ import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.direct.DirectStoreAccess;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -326,7 +327,8 @@ public class FullCheckIntegrationTest
         verifyInconsistency( result, RecordType.LABEL_SCAN_DOCUMENT );
     }
 
-    private void write( LabelScanStore labelScanStore, Iterable<NodeLabelUpdate> nodeLabelUpdates ) throws IOException
+    private void write( LabelScanStore labelScanStore, Iterable<NodeLabelUpdate> nodeLabelUpdates )
+            throws IOException, IndexCapacityExceededException
     {
         try ( LabelScanWriter writer = labelScanStore.newWriter() )
         {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -42,6 +42,7 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema.IndexState;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.Predicates;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.impl.index.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProvider;
 import org.neo4j.kernel.api.index.IndexAccessor;
@@ -435,7 +436,8 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+        public void add( long nodeId, Object propertyValue )
+                throws IndexEntryConflictException, IOException, IndexCapacityExceededException
         {
             delegate.add(nodeId, propertyValue);
             latch.startAndAwaitFinish();
@@ -454,7 +456,7 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void close( boolean populationCompletedSuccessfully ) throws IOException
+        public void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException
         {
             delegate.close(populationCompletedSuccessfully);
             assertTrue( "Expected population to succeed :(", populationCompletedSuccessfully );


### PR DESCRIPTION
Currently used lucene version 3.6.2 does not gracefully handle 2B documents limit overflow.
Inserts are not blocked when limit is reached but lookups fail with cryptic errors.

This commit adds tracking of 2B limit to Neo4j.
It is important for overflow to not result in exceptions on commit path so validation is made in NeoStoreTransaction#prepare, before actual commit.
With such overflow tracking inserts will stop working when limit is reached but lookups will continue to work.

Tracking logic:
* During index population and batch-insert every document addition simply checks maxDoc value
  and throws exception if 2B limit is reached.
* For online index each transaction reserves number of documents that it would add in prepare method,
  then on commit or rollback this reservation is withdrawn. If (reservation + maxDoc > 2B) then exception is thrown.