### PR TITLE
Fix wrong `localEffects` definitions in several pipes

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2.mutation
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, Expression}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
@@ -64,5 +64,12 @@ case class DeleteEntityAction(elementToDelete: Expression)
 
   def symbolTableDependencies = elementToDelete.symbolTableDependencies
 
-  def localEffects(symbols: SymbolTable) = Effects.WRITES_ENTITIES
+  def localEffects(symbols: SymbolTable) = elementToDelete match {
+    case i: Identifier => symbols.identifiers(i.entityName) match {
+      case _: NodeType         => Effects.WRITES_NODES
+      case _: RelationshipType => Effects.WRITES_RELATIONSHIPS
+      case _                   => Effects.NONE
+    }
+    case _ => Effects.WRITES_ENTITIES
+  }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/MapPropertySetAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/MapPropertySetAction.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2.mutation
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, Expression}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.{IsMap, MapSupport}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryState
@@ -105,6 +105,16 @@ case class MapPropertySetAction(element: Expression, mapExpression: Expression, 
     case r: Relationship => r.getId
   }
 
-  def localEffects(symbols: SymbolTable) = mapExpression.effects | element.effects | Effects.WRITES_ENTITIES
+  def localEffects(symbols: SymbolTable) = mapExpression.effects | element.effects | {
+    element match {
+      case i: Identifier => symbols.identifiers(i.entityName) match {
+        case _: NodeType => Effects.WRITES_NODES
+        case _: RelationshipType => Effects.WRITES_RELATIONSHIPS
+        case _ => Effects.NONE
+      }
+      case _ => Effects.WRITES_ENTITIES
+    }
+  }
+
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ConstraintOperationPipe.scala
@@ -53,5 +53,5 @@ class ConstraintOperationPipe(op: UniqueConstraintOperation, label: KeyToken, pr
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def effects = Effects.NONE
+  override val localEffects = Effects.NONE
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerPipe.scala
@@ -31,6 +31,9 @@ case class EagerPipe(src: Pipe)(implicit pipeMonitor: PipeMonitor) extends PipeW
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.toList.toIterator
 
+  // reset effects to NONE by loading all input data in memory
+  override val localEffects = Effects.NONE
+
   override val effects = Effects.NONE
 
   def dup(sources: List[Pipe]): Pipe = {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EmptyResultPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EmptyResultPipe.scala
@@ -37,7 +37,9 @@ case class EmptyResultPipe(source: Pipe)(implicit pipeMonitor: PipeMonitor) exte
 
   def symbols = SymbolTable()
 
-  override def effects = Effects.NONE
+  // this pipe has no effects
+  override val localEffects = Effects.NONE
+  override val effects = Effects.NONE
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
@@ -21,11 +21,11 @@ package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Identifier
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects._
 import org.neo4j.cypher.internal.compiler.v2_2.mutation._
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.cypher.internal.helpers.CollectionSupport
 import org.neo4j.graphdb.NotInTransactionException
-import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects._
 
 import scala.collection.mutable
 
@@ -69,10 +69,7 @@ case class ExecuteUpdateCommandsPipe(source: Pipe, commands: Seq[UpdateAction])(
 
   def sourceSymbols: SymbolTable = source.symbols
 
-  override def localEffects = source match {
-    case pipe: ExecuteUpdateCommandsPipe => pipe.source.localEffects
-    case _ => commands.effects(source.symbols)
-  }
+  override def localEffects = commands.effects(sourceSymbols)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
@@ -96,7 +93,7 @@ trait NoLushEntityCreation {
     case CreateUniqueAction(links@_*) =>
       links.flatMap(l => Seq(l.start, l.end, l.rel))
     case MergePatternAction(_, _, _, Some(updates), _) =>
-      updates.flatMap(extractEntities(_))
+      updates.flatMap(extractEntities)
     case _ =>
       Seq()
   }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LegacySortPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LegacySortPipe.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.SortItem
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 
@@ -46,6 +47,9 @@ case class LegacySortPipe(source: Pipe, sortDescription: List[SortItem])
     copy(source = source)
   }
 
+  // no local effects
+  override val localEffects = Effects.NONE
+  // the global effects are the one produced by the expression of the SortItems
   override def effects = sortDescription.effects
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalMatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/OptionalMatchPipe.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_2.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders.{IfElseIterator, QueryStateSettingIterator}
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDescription, PlanDescriptionImpl, TwoChildren}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
@@ -56,12 +55,10 @@ case class OptionalMatchPipe(source: Pipe,
 
   override def localEffects = matchPipe.localEffects
 
-  def doMatch(state: QueryState)(ctx: ExecutionContext) = matchPipe.createResults(state)
+  private def doMatch(state: QueryState)(ctx: ExecutionContext) = matchPipe.createResults(state)
 
   def dup(sources: List[Pipe]): Pipe = {
-    val (l :: r :: Nil) = sources
-    copy(source = l, matchPipe = r)
+    val (source ::  Nil) = sources
+    copy(source = source)
   }
-
-  override val sources: Seq[Pipe] = Seq(source, matchPipe)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/Pipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/Pipe.scala
@@ -73,7 +73,7 @@ trait Pipe extends Effectful {
 
   def sources: Seq[Pipe]
 
-  def localEffects: Effects = Effects.ALL
+  def localEffects: Effects
 
   def effects: Effects = localEffects
 
@@ -126,8 +126,7 @@ abstract class PipeWithSource(source: Pipe, val monitor: PipeMonitor) extends Pi
 
   override val sources: Seq[Pipe] = Seq(source)
 
-  override def effects =
-    sources.foldLeft(localEffects)(_ | _.effects)
+  override def effects = sources.foldLeft(localEffects)(_ | _.effects)
 
   def exists(pred: Pipe => Boolean) = pred(this) || source.exists(pred)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ProjectEndpointsPipe.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v2_2.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
@@ -36,6 +37,8 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
   with RonjaPipe {
   val symbols: SymbolTable =
     source.symbols.add(start, CTNode).add(end, CTNode)
+
+  override val localEffects = if (!startInScope || !endInScope) Effects.READS_NODES else Effects.NONE
 
   type Projector = (ExecutionContext) => Iterator[ExecutionContext]
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SortPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/SortPipe.scala
@@ -39,7 +39,9 @@ case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
 
   def planDescription = source.planDescription.andThen(this, "Sort", identifiers, KeyNames(orderBy.map(_.id)))
 
-  override def effects = Effects.NONE
+  // since we load the whole input in memory this Pipe has no effects
+  override val localEffects = Effects.NONE
+  override val effects = Effects.NONE
 
   def symbols = source.symbols
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/TopPipe.scala
@@ -118,7 +118,9 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
 
   def symbols = source.symbols
 
-  override def effects = Effects.NONE
+  // the top pipe has no effects since it is at the top
+  override val localEffects = Effects.NONE
+  override val effects = Effects.NONE
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/PipeTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/PipeTestSupport.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.commons.CypherTestSupport
 import org.neo4j.cypher.internal.compiler.v2_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.symbols.SymbolTable
 import org.scalatest.mock.MockitoSugar
 
@@ -28,15 +29,14 @@ trait PipeTestSupport extends CypherTestSupport with MockitoSugar {
 
   val newMonitor = mock[PipeMonitor]
 
-  def pipeWithResults(f: QueryState => Iterator[ExecutionContext]) = new Pipe {
+  def pipeWithResults(f: QueryState => Iterator[ExecutionContext]): Pipe = new Pipe {
     protected def internalCreateResults(state: QueryState) = f(state)
     def exists(pred: (Pipe) => Boolean) = ???
     def planDescription = ???
     def symbols: SymbolTable = ???
     def monitor: PipeMonitor = newMonitor
-
     def dup(sources: List[Pipe]): Pipe = ???
-
     def sources: Seq[Pipe] = ???
+    def localEffects: Effects = ???
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/profiler/ProfilerTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.profiler
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{NestedPipeExpression, ProjectedPath}
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_2.pipes._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{Argument, InternalPlanDescription}
@@ -168,11 +169,12 @@ case class ProfilerTestPipe(source: Pipe, name: String, rows: Int, dbAccess: Int
     (0 until rows).map(x => ExecutionContext.empty).toIterator
   }
 
+  def localEffects: Effects = Effects.WRITES_NODES
+
   def symbols: SymbolTable = SymbolTable()
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources
-
     copy(source = source)
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -43,7 +43,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 object helpers {
-  implicit def monitorFailure(t: Throwable)(implicit monitor: QueryExecutionMonitor, session: QuerySession) = {
+  implicit def monitorFailure(t: Throwable)(implicit monitor: QueryExecutionMonitor, session: QuerySession): Unit = {
     monitor.endFailure(session, t)
   }
 }
@@ -147,7 +147,6 @@ trait CompatibilityFor2_2 {
     def run(graph: GraphDatabaseAPI, txInfo: TransactionInfo, executionMode: ExecutionMode, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult = {
       implicit val s = session
       exceptionHandlerFor2_2.runSafely {
-
         ExecutionResultWrapperFor2_2(inner.run(queryContext(graph, txInfo), executionMode, params), inner.plannerUsed)
       }
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1774,7 +1774,6 @@ return b
                   |  MERGE (project)–[:HAS_FOLDER]->(folder))
                   |RETURN DISTINCT project""".stripMargin
 
-
     //WHEN
     val first = eengine.execute(query).toList
     val second = eengine.execute(query).toList

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/RulePipeBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/RulePipeBuilderTest.scala
@@ -24,7 +24,6 @@ import java.util.concurrent._
 import org.junit.Assert._
 import org.mockito.Mockito._
 import org.neo4j.cypher.GraphDatabaseTestSupport
-import org.neo4j.cypher.internal.NormalMode
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, Literal}
@@ -235,18 +234,13 @@ class ExplodingPipeBuilder extends PlanBuilder with MockitoSugar {
 
   class ExplodingPipe extends Pipe {
     def internalCreateResults(state: QueryState) = throw new ExplodingException
-
     def symbols: SymbolTable = new SymbolTable()
-
     def planDescription: InternalPlanDescription = null
-
     def exists(pred: Pipe => Boolean) = ???
-
     val monitor = mock[PipeMonitor]
-
     def dup(sources: List[Pipe]): Pipe = ???
-
     def sources: scala.Seq[Pipe] = ???
+    def localEffects: Effects = ???
   }
 }
 


### PR DESCRIPTION
In particular `ArgumentPipe` was missing to override `localEffects` and the default implementation in `Pipe` was declaring `Effects.ALL` which is wrong for a read-only pipe.

In order to force correct definitions of `localEffects` in pipes, the default implementation has been removed from the Pipe trait.