### PR TITLE
Increases the number of Paxos instances stored in PaxosInstanceStore

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstance.java
@@ -28,8 +28,6 @@ import java.util.List;
  */
 public class PaxosInstance
 {
-
-
     enum State
     {
         empty,
@@ -37,7 +35,7 @@ public class PaxosInstance
         p1_ready,
         p2_pending,
         closed,
-        delivered;
+        delivered
     }
     PaxosInstanceStore store;
 
@@ -45,9 +43,9 @@ public class PaxosInstance
     State state = State.empty;
     long ballot = 0;
     List<URI> acceptors;
-    List<ProposerMessage.PromiseState> promises = new ArrayList<ProposerMessage.PromiseState>();
-    List<ProposerMessage.AcceptedState> accepts = new ArrayList<ProposerMessage.AcceptedState>();
-    List<ProposerMessage.RejectAcceptState> rejectedAccepts = new ArrayList<ProposerMessage.RejectAcceptState>();
+    List<ProposerMessage.PromiseState> promises = new ArrayList<>();
+    List<ProposerMessage.AcceptedState> accepts = new ArrayList<>();
+    List<ProposerMessage.RejectAcceptState> rejectedAccepts = new ArrayList<>();
     Object value_1;
     long phase1Ballot = 0;
     Object value_2;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStore.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStore.java
@@ -29,11 +29,42 @@ import java.util.Queue;
  */
 public class PaxosInstanceStore
 {
-    private static final int MAX_STORED = 100;
+    /*
+     * This represents the number of delivered paxos instances to keep in memory - it is essentially the length
+     * of the delivered queue and therefore the size of the instances map.
+     * The use of this is to server Learn requests. While learning is the final phase of the Paxos algo, it is also
+     * executed when an instance needs to catch up with events that happened in the cluster but it missed because it
+     * was temporarily disconnected.
+     * MAX_STORED therefore represents the maximum number of paxos instances a lagging member may be lagging behind
+     * and be able to recover from. This number must be large enough to account for a few minutes of downtime (like
+     * an extra long GC pause) during which intense broadcasting happens.
+     * Assuming 2 paxos instances per second gives us 120 instances per minute or 1200 instances for 10 minutes of
+     * downtime. We about 5x that here since instances are relatively small in size and we can spare the memory.
+     */
+    // TODO (slightly challenging) Prune this queue aggressively.
+    /*
+     * This queue, as it stands now, will always remain at full capacity. However, if we could figure out that
+     * all cluster members have learned a particular paxos instance then we can remove it since no one will ever
+     * request it. That way the MAX_STORED value should be reached only when an instance is know to be in the failed
+     * state.
+     */
+
+    private static final int MAX_STORED = 5000;
 
     private int queued = 0;
-    private Queue<InstanceId> delivered = new LinkedList<InstanceId>();
-    private Map<InstanceId, PaxosInstance> instances = new HashMap<InstanceId, PaxosInstance>();
+    private Queue<InstanceId> delivered = new LinkedList<>();
+    private Map<InstanceId, PaxosInstance> instances = new HashMap<>();
+    private final int maxInstancesToStore;
+
+    public PaxosInstanceStore()
+    {
+        this( MAX_STORED );
+    }
+
+    public PaxosInstanceStore( int maxInstancesToStore )
+    {
+        this.maxInstancesToStore = maxInstancesToStore;
+    }
 
     public PaxosInstance getPaxosInstance( InstanceId instanceId )
     {
@@ -56,7 +87,7 @@ public class PaxosInstanceStore
         queued++;
         delivered.offer( instanceId );
 
-        if ( queued > MAX_STORED )
+        if ( queued > maxInstancesToStore )
         {
             InstanceId removeInstanceId = delivered.poll();
             instances.remove( removeInstanceId );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStoreTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/PaxosInstanceStoreTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+public class PaxosInstanceStoreTest
+{
+    @Test
+    public void shouldReturnSameObjectWhenAskedById() throws Exception
+    {
+        // Given
+        PaxosInstanceStore theStore = new PaxosInstanceStore();
+        InstanceId currentInstanceId = new InstanceId( 1 );
+
+        // When
+        PaxosInstance currentInstance = theStore.getPaxosInstance( currentInstanceId );
+
+        // Then
+        assertSame( currentInstance, theStore.getPaxosInstance( currentInstanceId ) );
+    }
+
+    @Test
+    public void shouldKeepAtMostGivenNumberOfInstances() throws Exception
+    {
+        // Given
+        final int instancesToKeep = 10;
+        PaxosInstanceStore theStore = new PaxosInstanceStore( instancesToKeep );
+
+        // Keeps the first instance inserted, which is the first to be removed
+        PaxosInstance firstInstance = null;
+
+        // When
+        for ( int i = 0; i < instancesToKeep + 1; i++ )
+        {
+            InstanceId currentInstanceId = new InstanceId( i );
+            PaxosInstance currentInstance = theStore.getPaxosInstance( currentInstanceId );
+            theStore.delivered( currentInstance.id );
+            if ( firstInstance == null )
+            {
+                firstInstance = currentInstance;
+            }
+        }
+
+        // Then
+        // The first instance must have been removed now
+        PaxosInstance toTest = theStore.getPaxosInstance( firstInstance.id );
+        assertNotSame( firstInstance, toTest );
+    }
+
+    @Test
+    public void leaveShouldClearStoredInstances() throws Exception
+    {
+        // Given
+        PaxosInstanceStore theStore = new PaxosInstanceStore();
+        InstanceId currentInstanceId = new InstanceId( 1 );
+
+        // When
+        PaxosInstance currentInstance = theStore.getPaxosInstance( currentInstanceId );
+        theStore.leave();
+
+        // Then
+        assertNotSame( currentInstance, theStore.getPaxosInstance( currentInstanceId ) );
+    }
+}


### PR DESCRIPTION
The number of instances stored was 100, which meant that a cluster
 member being disconnected for more than 50 seconds with an
 average of 2 paxos instances per second executed during that time
 would lead the instance to be unable to catch up and remain
 in perpetual LearnFailed hell. This patch increases the number
 of stored paxos instances to 5k which should be enough for
 everybody.
Adds a set of tests for PaxosInstanceStore