### PR TITLE
Better handling of errors when using hints

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
@@ -88,6 +88,10 @@ class IndexHintException(identifier: String, label: String, property: String, me
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.indexHintException(identifier, label, property, message)
 }
 
+class LabelScanHintException(identifier: String, label: String, message: String) extends CypherException {
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.labelScanHintException(identifier, label, message)
+}
+
 class InvalidSemanticsException(message: String) extends CypherException {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidSemanticException(message)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
@@ -42,6 +42,8 @@ trait MapToPublicExceptions[T <: Throwable] {
 
   def indexHintException(identifier: String, label: String, property: String, message: String): T
 
+  def labelScanHintException(identifier: String, label: String, message: String): T
+
   def unknownLabelException(s: String): T
 
   def profilerStatisticsNotReadyException(): T

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -28,6 +28,8 @@ import org.neo4j.cypher.NewPlannerMonitor.{NewQuerySeen, UnableToHandleQuery, Ne
 import java.io.{PrintWriter, StringWriter}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.CantHandleQueryException
 
+import scala.util.Try
+
 object NewPlannerMonitor {
 
   sealed trait NewPlannerMonitorCall {
@@ -107,8 +109,11 @@ trait NewPlannerTestSupport extends CypherTestSupport {
 
   def monitoringNewPlanner[T](action: => T)(test: List[NewPlannerMonitorCall] => Unit): T = {
     newPlannerMonitor.clear()
-    val result = action
+    //if action fails we must wait to throw until after test has run
+    val result = Try(action)
     test(newPlannerMonitor.trace)
-    result
+
+    //now it is safe to throw
+    result.get
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -323,6 +323,15 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     )
   }
 
+  test("should fail if using an hint with property equality comparison") {
+    executeAndEnsureError(
+      "match (n:Person)-->(m:Person) using index n:Person(name) where n.name = m.name return n",
+      "Cannot use index hint in this context. Index hints require using a simple equality comparison " +
+        "or IN condition in WHERE (either directly or as part of a top-level AND). Note that the label " +
+        "and property comparison must be specified on a non-optional node (line 1, column 31 (offset: 30))"
+    )
+  }
+
   test("should fail if no parens around node") {
     executeAndEnsureError(
       "match n:Person return n",

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
@@ -110,7 +110,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeC, nodeD)
 
     evaluating {
-      execute("MATCH p = shortestPath((src:A)-[*2..3]->(dst:D)) RETURN nodes(p) AS nodes").toList
+      executeWithNewPlanner("MATCH p = shortestPath((src:A)-[*2..3]->(dst:D)) RETURN nodes(p) AS nodes").toList
     } should produce[SyntaxException]
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.graphdb.NotFoundException
 
 class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
@@ -29,7 +28,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN & THEN
     intercept[SyntaxException](
-      execute("start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n"))
+      executeWithNewPlanner("start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n"))
   }
 
   test("fail if using an identifier with label not used in match") {
@@ -64,7 +63,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Food", "name")
 
     // WHEN
-    intercept[NotFoundException](
+    intercept[SyntaxException](
       executeWithNewPlanner("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name = m.name return n"))
   }
 
@@ -170,7 +169,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN THEN
     val e = intercept[SyntaxException] {
-      execute(
+      executeWithNewPlanner(
         "MATCH (n:Entity:Person) " +
           "USING INDEX n:Person(first_name) " +
           "USING INDEX n:Entity(source) " +
@@ -184,7 +183,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("does not accept multiple scan hints for the same identifier") {
     val e = intercept[SyntaxException] {
-      execute(
+      executeWithNewPlanner(
         "MATCH (n:Entity:Person) " +
           "USING SCAN n:Person " +
           "USING SCAN n:Entity " +
@@ -198,7 +197,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("does not accept multiple mixed hints for the same identifier") {
     val e = intercept[SyntaxException] {
-      execute(
+      executeWithNewPlanner(
         "MATCH (n:Entity:Person) " +
           "USING SCAN n:Person " +
           "USING INDEX n:Entity(first_name) " +

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
@@ -27,7 +27,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN & THEN
     intercept[SyntaxException](
-      execute("start n=node(*) using index n:Person(name) where n:Person and n.name IN ['kabam'] return n"))
+      executeWithNewPlanner("start n=node(*) using index n:Person(name) where n:Person and n.name IN ['kabam'] return n"))
   }
 
   test("fail if using an identifier with label not used in match") {


### PR DESCRIPTION
For queries with `USING INDEX` when there were errors, e.g. no index available, we failed
to build plans and delegated to the legacy planner to do the error handling.