### PR TITLE
Properly close SearcherManager when unique index is dropped

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactories.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.SearcherFactory;
+import org.apache.lucene.search.SearcherManager;
+
+import java.io.IOException;
+
+public final class SearcherManagerFactories
+{
+    private SearcherManagerFactories()
+    {
+        throw new AssertionError( "Not for instantiation!" );
+    }
+
+    public static SearcherManagerFactory standard()
+    {
+        return new SearcherManagerFactory()
+        {
+            @Override
+            public ReferenceManager<IndexSearcher> create( IndexWriter indexWriter ) throws IOException
+            {
+                return new SearcherManager( indexWriter, true, new SearcherFactory() );
+            }
+        };
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+
+import java.io.IOException;
+
+public interface SearcherManagerFactory
+{
+    ReferenceManager<IndexSearcher> create( IndexWriter indexWriter ) throws IOException;
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneAllDocumentsReaderTest.java
@@ -28,7 +28,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.ReferenceManager;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -123,28 +122,4 @@ public class LuceneAllDocumentsReaderTest
         }
     }
 
-    private static class SearcherManagerStub extends ReferenceManager<IndexSearcher>
-    {
-        SearcherManagerStub( IndexSearcher searcher )
-        {
-            this.current = searcher;
-        }
-
-        @Override
-        protected void decRef( IndexSearcher reference ) throws IOException
-        {
-        }
-
-        @Override
-        protected IndexSearcher refreshIfNeeded( IndexSearcher referenceToRefresh ) throws IOException
-        {
-            return null;
-        }
-
-        @Override
-        protected boolean tryIncRef( IndexSearcher reference )
-        {
-            return true;
-        }
-    }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SearcherManagerStub.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SearcherManagerStub.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+
+import java.io.IOException;
+
+public class SearcherManagerStub extends ReferenceManager<IndexSearcher>
+{
+    public SearcherManagerStub( IndexSearcher searcher )
+    {
+        this.current = searcher;
+    }
+
+    @Override
+    public void decRef( IndexSearcher reference ) throws IOException
+    {
+    }
+
+    @Override
+    public IndexSearcher refreshIfNeeded( IndexSearcher referenceToRefresh ) throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public boolean tryIncRef( IndexSearcher reference )
+    {
+        return true;
+    }
+
+    @Override
+    public void afterClose() throws IOException
+    {
+        super.afterClose();
+    }
+}


### PR DESCRIPTION
`DeferredConstraintVerificationUniqueLuceneIndexPopulator` was not able to remove lucene files on index drop because it did not close `SearcherManager`.
Only seems to reveal itself in Windows.