### PR TITLE
ClusterRule uses method names as names for test directories

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -120,7 +120,7 @@ public class ClusterRule extends ExternalResource
     @Override
     protected void before() throws Throwable
     {
-        this.storeDirectory = TargetDirectory.forTest( testClass ).directoryForDescription( description );
+        this.storeDirectory = TargetDirectory.forTest( testClass ).cleanDirectory( description.getMethodName() );
     }
 
     @Override


### PR DESCRIPTION
Which should be really convenient for test failure investigations.
Currently MD5 of method name is used.