### PR TITLE
Collect and reimplement all iterator utils into coherent place

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -563,6 +563,7 @@ public abstract class IteratorUtil
     {
         return addToCollection( iterable, new ArrayList<T>() );
     }
+    
     public static <T> Collection<T> asCollection( Iterator<T> iterable )
     {
         return addToCollection( iterable, new ArrayList<T>() );

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/NewIterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/NewIterables.java
@@ -1,0 +1,529 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+
+import org.neo4j.function.Function;
+import org.neo4j.function.Function2;
+import org.neo4j.helpers.CloneableInPublic;
+import org.neo4j.helpers.Predicate;
+
+/**
+ * {@link Iterable} wrappers around all available {@link Iterator iterators} found in {@link NewIterators}.
+ *
+ * @author Mattias Persson
+ * @see NewIterators
+ */
+public abstract class NewIterables
+{
+    private NewIterables()
+    {   // Singleton
+    }
+
+    // Array
+    @SafeVarargs
+    public static <T> Iterable<T> iterable( final T... items )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.iterator( items );
+            }
+        };
+    }
+
+    @SafeVarargs
+    public static <T> Iterable<T> reversed( final T... items )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.reversed( items );
+            }
+        };
+    }
+
+    // Caching
+    public static interface ListIterable<T> extends Iterable<T>
+    {
+        @Override
+        ListIterator<T> iterator();
+    }
+
+    public static <T> ListIterable<T> caching( final Iterable<T> source )
+    {
+        return new ListIterable<T>()
+        {
+            private final List<T> visited = new ArrayList<>();
+
+            @Override
+            public ListIterator<T> iterator()
+            {
+                return new NewIterators.CachingIterator<>( source.iterator(), visited );
+            }
+        };
+    }
+
+    // Catching
+    public static <T> Iterable<T> catching( Iterable<T> source, final Predicate<Throwable> catchAndIgnoreException )
+    {
+        return new CatchingIterable<T>( source )
+        {
+            @Override
+            protected boolean exceptionOk( Throwable t )
+            {
+                return catchAndIgnoreException.accept( t );
+            }
+        };
+    }
+
+    public static abstract class CatchingIterable<T> implements Iterable<T>
+    {
+        private final Iterable<T> source;
+
+        public CatchingIterable( Iterable<T> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Iterator<T> iterator()
+        {
+            return new NewIterators.CatchingIterator<T>( source.iterator() )
+            {
+                @Override
+                protected boolean exceptionOk( Throwable t )
+                {
+                    return CatchingIterable.this.exceptionOk( t );
+                }
+            };
+        }
+
+        protected abstract boolean exceptionOk( Throwable t );
+    }
+
+    // Concat
+    public static <T> Iterable<T> concat( final Iterable<Iterable<T>> iterables )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.concatIterables( iterables.iterator() );
+            }
+        };
+    }
+
+    public static <T> Iterable<T> prepend( final T item, final Iterable<T> source )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.prepend( item, source.iterator() );
+            }
+        };
+    }
+
+    public static <T> Iterable<T> append( final Iterable<T> source, final T item )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.append( source.iterator(), item );
+            }
+        };
+    }
+
+    // Interleaving
+    public static <T> Iterable<T> interleave( final Iterable<Iterable<T>> iterables )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return new NewIterators.InterleavingIterator<>(
+                        new MappingIterable<Iterable<T>,Iterator<T>>( iterables )
+                {
+                    @Override
+                    protected Iterator<T> map( Iterable<T> item )
+                    {
+                        return item.iterator();
+                    }
+                } );
+            }
+        };
+    }
+
+    // Filtering
+    public static <T> Iterable<T> filter( Iterable<T> source, final Predicate<T> filter )
+    {
+        return new FilteringIterable<T>( source )
+        {
+            @Override
+            public boolean accept( T item )
+            {
+                return filter.accept( item );
+            }
+        };
+    }
+
+    public static <T> Iterable<T> dedup( final Iterable<T> source )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.dedup( source.iterator() );
+            }
+        };
+    }
+
+    public static <T> Iterable<T> skip( final Iterable<T> source, final int skipTheFirstNItems )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.skip( source.iterator(), skipTheFirstNItems );
+            }
+        };
+    }
+
+    public static abstract class FilteringIterable<T> implements Iterable<T>, Predicate<T>
+    {
+        private final Iterable<T> source;
+
+        public FilteringIterable( Iterable<T> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Iterator<T> iterator()
+        {
+            return new NewIterators.FilteringIterator<T>( source.iterator() )
+            {
+                @Override
+                public boolean accept( T item )
+                {
+                    return FilteringIterable.this.accept( item );
+                }
+            };
+        }
+
+        @Override
+        public abstract boolean accept( T item );
+    }
+
+    // Limiting
+    public static <T> Iterable<T> limit( final Iterable<T> source, final int maxItems )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.limit( source.iterator(), maxItems );
+            }
+        };
+    }
+
+    // Mapping
+    public static abstract class MappingIterable<FROM,TO> implements Iterable<TO>
+    {
+        private final Iterable<FROM> source;
+
+        public MappingIterable( Iterable<FROM> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Iterator<TO> iterator()
+        {
+            return new NewIterators.MappingIterator<FROM,TO>( source.iterator() )
+            {
+                @Override
+                protected TO map( FROM item )
+                {
+                    return MappingIterable.this.map( item );
+                }
+            };
+        }
+
+        protected abstract TO map( FROM item );
+    }
+
+    // Nested
+    public static <FROM,TO> Iterable<TO> nested( Iterable<FROM> source, final Function<FROM,Iterator<TO>> nester )
+    {
+        return new NestedIterable<FROM, TO>( source )
+        {
+            @Override
+            protected Iterator<TO> nested( FROM item )
+            {
+                return nester.apply( item );
+            }
+        };
+    }
+
+    public static <FROM,TO> Iterable<TO> nestedIterables( Iterable<FROM> source,
+            final Function<FROM,Iterable<TO>> nester )
+    {
+        return new NestedIterable<FROM, TO>( source )
+        {
+            @Override
+            protected Iterator<TO> nested( FROM item )
+            {
+                return nester.apply( item ).iterator();
+            }
+        };
+    }
+
+    public static abstract class NestedIterable<FROM,TO> implements Iterable<TO>
+    {
+        private final Iterable<FROM> source;
+
+        public NestedIterable( Iterable<FROM> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Iterator<TO> iterator()
+        {
+            return new NewIterators.NestedIterator<FROM,TO>( source.iterator() )
+            {
+                @Override
+                protected Iterator<TO> nested( FROM item )
+                {
+                    return NestedIterable.this.nested( item );
+                }
+            };
+        }
+
+        protected abstract Iterator<TO> nested( FROM item );
+    }
+
+    // Casting
+    public static <FROM,TO> Iterable<TO> cast( final Iterable<FROM> source, final Class<TO> toClass )
+    {
+        return new Iterable<TO>()
+        {
+            @Override
+            public Iterator<TO> iterator()
+            {
+                return NewIterators.cast( source.iterator(), toClass );
+            }
+        };
+    }
+
+    // Range
+    public static Iterable<Integer> intRange( int end )
+    {
+        return intRange( 0, end );
+    }
+
+    public static Iterable<Integer> intRange( int start, int end )
+    {
+        return intRange( start, end, 1 );
+    }
+
+    public static Iterable<Integer> intRange( int start, int end, int stride )
+    {
+        return new RangeIterable<>( start, end, stride,
+                NewIterators.INTEGER_STRIDER, NewIterators.INTEGER_COMPARATOR );
+    }
+
+    public static class RangeIterable<T,S> implements Iterable<T>
+    {
+        private final T start;
+        private final T end;
+        private final S stride;
+        private final Function2<T, S, T> strider;
+        private final Comparator<T> comparator;
+
+        public RangeIterable( T start, T end, S stride, Function2<T, S, T> strider, Comparator<T> comparator )
+        {
+            this.start = start;
+            this.end = end;
+            this.stride = stride;
+            this.strider = strider;
+            this.comparator = comparator;
+        }
+
+        @Override
+        public Iterator<T> iterator()
+        {
+            return new NewIterators.RangeIterator<>( start, end, stride, strider, comparator );
+        }
+    }
+
+    // Singleton
+    public static <T> Iterable<T> singleton( final T item )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.singleton( item );
+            }
+        };
+    }
+
+    // Cloning
+    public static <T extends CloneableInPublic> Iterable<T> cloning( final Iterable<T> items,
+            final Class<T> itemClass )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return NewIterators.cloning( items.iterator(), itemClass );
+            }
+        };
+    }
+
+    // Reversed
+    public static <T> Iterable<T> reversed( Iterable<T> source )
+    {
+        List<T> allItems = new ArrayList<>();
+        for ( Iterator<T> iterator = source.iterator(); iterator.hasNext(); )
+        {
+            allItems.add( iterator.next() );
+        }
+        Collections.reverse( allItems );
+        return allItems;
+    }
+
+    // === Operations ===
+    public static <T> T first( Iterable<T> iterable )
+    {
+        return NewIterators.first( iterable.iterator() );
+    }
+
+    public static <T> T first( Iterable<T> iterable, T defaultItem )
+    {
+        return NewIterators.first( iterable.iterator(), defaultItem );
+    }
+
+    public static <T> T last( Iterable<T> iterable )
+    {
+        return NewIterators.last( iterable.iterator() );
+    }
+
+    public static <T> T last( Iterable<T> iterable, T defaultItem )
+    {
+        return NewIterators.last( iterable.iterator(), defaultItem );
+    }
+
+    public static <T> T single( Iterable<T> iterable )
+    {
+        return NewIterators.single( iterable.iterator() );
+    }
+
+    public static <T> T single( Iterable<T> iterable, T defaultItem )
+    {
+        return NewIterators.single( iterable.iterator(), defaultItem );
+    }
+
+    public static <T> T itemAt( Iterable<T> iterable, int index )
+    {
+        return NewIterators.itemAt( iterable.iterator(), index );
+    }
+
+    public static <T> T itemAt( Iterable<T> iterable, int index, T defaultItem )
+    {
+        return NewIterators.itemAt( iterable.iterator(), index, defaultItem );
+    }
+
+    public static <T> int indexOf( T item, Iterable<T> iterable )
+    {
+        return NewIterators.indexOf( item, iterable.iterator() );
+    }
+
+    public static boolean equals( Iterable<?> first, Iterable<?> other )
+    {
+        return NewIterators.equals( first.iterator(), other.iterator() );
+    }
+
+    public static <C extends Collection<T>,T> C addToCollection( Iterable<T> iterable, C collection,
+            Function2<T, C, Void> adder )
+    {
+        return NewIterators.addToCollection( iterable.iterator(), collection, adder );
+    }
+
+    public static <C extends Collection<T>,T> C addToCollection( Iterable<T> iterable, C collection )
+    {
+        return NewIterators.addToCollection( iterable.iterator(), collection );
+    }
+
+    public static <C extends Collection<T>,T> C addToCollectionAssertChanged( Iterable<T> iterable, C collection )
+    {
+        return NewIterators.addToCollectionAssertChanged( iterable.iterator(), collection );
+    }
+
+    public static <T> List<T> asList( Iterable<T> items )
+    {
+        return NewIterators.asList( items.iterator() );
+    }
+
+    public static <T> Set<T> asSet( Iterable<T> items )
+    {
+        return NewIterators.asSet( items.iterator() );
+    }
+
+    public static <T> Set<T> asSetAllowDuplicates( Iterable<T> items )
+    {
+        return NewIterators.asSetAllowDuplicates( items.iterator() );
+    }
+
+    public static int count( Iterable<?> iterable )
+    {
+        return NewIterators.count( iterable.iterator() );
+    }
+
+    public static <T> T[] asArray( Iterable<T> items, Class<T> itemClass )
+    {
+        return NewIterators.asArray( items.iterator(), itemClass );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/NewIterators.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/NewIterators.java
@@ -1,0 +1,1225 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.lang.reflect.Array;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.neo4j.function.Function;
+import org.neo4j.function.Function2;
+import org.neo4j.helpers.CloneableInPublic;
+import org.neo4j.helpers.Predicate;
+import org.neo4j.helpers.Predicates;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
+/**
+ * Collection of useful, common and generic implementations of {@link Iterator}. Most implementations
+ * extend {@link BaseIterator} due to it's one-method-simplicity as opposed to two-method of implementing
+ * {@link Iterator} directly. In here you'll find iterators that {@link #filter(Iterator, Predicate)},
+ * {@link #map(Iterator, Function)}, {@link #reversed(Iterator) reverse},
+ * {@link #catching(Iterator, Predicate) catches certain exceptions}, {@link #interleave(Iterable)},
+ * {@link #skip(Iterator, int)}, {@link #limit(Iterator, int)} and more.
+ *
+ * @author Mattias Persson
+ * @see NewIterables for {@link Iterable} versions of these iterators, basically.
+ */
+public abstract class NewIterators
+{
+    private NewIterators()
+    {   // Singleton
+    }
+
+    // Base
+    /**
+     * Convenient base class for when implementing an {@link Iterator}. Instead of implementing {@link #hasNext()}
+     * and {@link #next()} and keeping and clearing state between those, just implement {@link #fetchNextOrNull()}
+     * which marks the end of the iterator by returning {@code null}.
+     *
+     * @param <T> type of items in this iterator.
+     */
+    public static abstract class BaseIterator<T> implements Iterator<T>
+    {
+        private T next;
+
+        protected abstract T fetchNextOrNull();
+
+        @Override
+        public boolean hasNext()
+        {
+            if ( next == null )
+            {
+                next = fetchNextOrNull();
+            }
+            return next != null;
+        }
+
+        @Override
+        public T next()
+        {
+            try
+            {
+                if ( !hasNext() )
+                {
+                    throw new NoSuchElementException();
+                }
+                return next;
+            }
+            finally
+            {
+                next = null;
+            }
+        }
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    // Array
+    @SafeVarargs
+    public static <T> Iterator<T> iterator( final T... items )
+    {
+        return new BaseIterator<T>()
+        {
+            private int index = -1;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                return ++index < items.length ? items[index] : null;
+            }
+        };
+    }
+
+    @SafeVarargs
+    public static <T> Iterator<T> reversed( final T... items )
+    {
+        return new BaseIterator<T>()
+        {
+            private int index = items.length;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                return --index >= 0 ? items[index] : null;
+            }
+        };
+    }
+
+    // Caching
+    public static <T> ListIterator<T> caching( Iterator<T> source )
+    {
+        return new CachingIterator<>( source );
+    }
+
+    public static class CachingIterator<T> extends BaseIterator<T> implements ListIterator<T>
+    {
+        private final Iterator<T> source;
+        private final List<T> visited;
+        private int lastReturnedPosition = -1;
+
+        /**
+         * Creates a new caching iterator using {@code source} as its underlying
+         * {@link Iterator} to get items lazily from.
+         * @param source the underlying {@link Iterator} to lazily get items from.
+         */
+        public CachingIterator( Iterator<T> source )
+        {
+            this( source, new ArrayList<T>() );
+        }
+
+        public CachingIterator( Iterator<T> source, List<T> visited )
+        {
+            this.source = source;
+            this.visited = visited;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            T item = null;
+            int position = position();
+            if ( position < visited.size() )
+            {
+                item = visited.get( position );
+            }
+            else
+            {
+                if ( !source.hasNext() )
+                {
+                    return null;
+                }
+                item = source.next();
+                visited.add( item );
+            }
+
+            lastReturnedPosition++;
+            return item;
+        }
+
+        /**
+         * Returns the current position of the iterator, initially 0. The position
+         * represents the index of the item which will be returned by the next call
+         * to {@link #next()} and also the index of the next item returned by
+         * {@link #previous()} plus one. An example:
+         *
+         * <ul>
+         * <li>Instantiate an iterator which would iterate over the strings "first", "second" and "third".</li>
+         * <li>Get the two first items ("first" and "second") from it by using {@link #next()},
+         * {@link #position()} will now return 2.</li>
+         * <li>Call {@link #previous()} (which will return "second") and {@link #position()} will now be 1</li>
+         * </ul>
+         *
+         * @return the position of the iterator.
+         */
+        public int position()
+        {
+            return lastReturnedPosition + 1;
+        }
+
+        private int highestVisitedPosition()
+        {
+            return visited.size() - 1;
+        }
+
+        /**
+         * Sets the position of the iterator. {@code 0} means all the way back to
+         * the beginning. It is also possible to set the position to one higher
+         * than the last item, so that the next call to {@link #previous()} would
+         * return the last item. Items will be cached along the way if necessary.
+         *
+         * @param newPosition the position to set for the iterator, must be
+         * non-negative.
+         * @return the position before changing to the new position.
+         */
+        public int position( int newPosition )
+        {
+            if ( newPosition < 0 )
+            {
+                throw new IllegalArgumentException( "Position must be non-negative, was " + newPosition );
+            }
+
+            int previousPosition = position();
+            while ( newPosition > highestVisitedPosition() )
+            {
+                if ( source.hasNext() )
+                {
+                    visited.add( source.next() );
+                }
+                else
+                {
+                    throw new NoSuchElementException( "Requested position " + newPosition +
+                            ", but didn't get further than to " + highestVisitedPosition() );
+                }
+            }
+            lastReturnedPosition = newPosition;
+            return previousPosition;
+        }
+
+        /**
+         * Returns whether or not a call to {@link #previous()} will be able to
+         * return an item or not. So it will return {@code true} if
+         * {@link #position()} is bigger than 0.
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean hasPrevious()
+        {
+            return lastReturnedPosition >= 0;
+        }
+
+        @Override
+        public T previous()
+        {
+            if ( !hasPrevious() )
+            {
+                throw new NoSuchElementException( "Position is " + position() );
+            }
+            T item = visited.get( lastReturnedPosition-- );
+            return item;
+        }
+
+        /**
+         * Returns the last item returned by {@link #next()}/{@link #previous()}.
+         * If no call has been made to {@link #next()} or {@link #previous()} since
+         * this iterator was created or since a call to {@link #position(int)} has
+         * been made a {@link NoSuchElementException} will be thrown.
+         *
+         * @return the last item returned by {@link #next()}/{@link #previous()}.
+         * @throws NoSuchElementException if no call has been made to {@link #next()}
+         * or {@link #previous()} since this iterator was created or since a call to
+         * {@link #position(int)} has been made.
+         */
+        public T current()
+        {
+            if ( lastReturnedPosition == -1 )
+            {
+                throw new NoSuchElementException();
+            }
+            return visited.get( lastReturnedPosition );
+        }
+
+        @Override
+        public int nextIndex()
+        {
+            return lastReturnedPosition + 1;
+        }
+
+        @Override
+        public int previousIndex()
+        {
+            return lastReturnedPosition;
+        }
+
+        @Override
+        public void set( T e )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add( T e )
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    // Catching
+    public static <T> Iterator<T> catching( Iterator<T> source, final Predicate<Throwable> catchAndIgnoreException )
+    {
+        return new CatchingIterator<T>( source )
+        {
+            @Override
+            protected boolean exceptionOk( Throwable t )
+            {
+                return catchAndIgnoreException.accept( t );
+            }
+        };
+    }
+
+    public static abstract class CatchingIterator<T> extends BaseIterator<T>
+    {
+        private final Iterator<T> source;
+
+        public CatchingIterator( Iterator<T> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            while ( source.hasNext() )
+            {
+                T nextItem = null;
+                try
+                {
+                    return source.next();
+                }
+                catch ( Throwable t )
+                {
+                    if ( exceptionOk( t ) )
+                    {
+                        itemIgnored( nextItem );
+                        continue;
+                    }
+                    throw launderedException( t );
+                }
+            }
+            return null;
+        }
+
+        protected void itemIgnored( T item )
+        {   // Do nothing by default
+        }
+
+        protected abstract boolean exceptionOk( Throwable t );
+    }
+
+    // Concating
+    public static <T> Iterator<T> concat( Iterator<? extends Iterator<T>> iterators )
+    {
+        return new ConcatingIterator<>( iterators );
+    }
+
+    public static <T> Iterator<T> concatIterables( Iterator<Iterable<T>> iterables )
+    {
+        return new ConcatingIterator<>( new MappingIterator<Iterable<T>, Iterator<T>>( iterables )
+        {
+            @Override
+            protected Iterator<T> map( Iterable<T> item )
+            {
+                return item.iterator();
+            }
+        } );
+    }
+
+    public static <T> Iterator<T> prepend( final T item, final Iterator<T> iterator )
+    {
+        return new BaseIterator<T>()
+        {
+            private boolean singleItemReturned;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                if ( !singleItemReturned )
+                {
+                    singleItemReturned = true;
+                    return item;
+                }
+                return iterator.hasNext() ? iterator.next() : null;
+            }
+        };
+    }
+
+    public static <T> Iterator<T> append( final Iterator<T> iterator, final T item )
+    {
+        return new BaseIterator<T>()
+        {
+            private boolean singleItemReturned;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                if ( iterator.hasNext() )
+                {
+                    return iterator.next();
+                }
+                else if ( !singleItemReturned )
+                {
+                    singleItemReturned = true;
+                    return item;
+                }
+                return null;
+            }
+        };
+    }
+
+    public static class ConcatingIterator<T> extends BaseIterator<T>
+    {
+        private final Iterator<? extends Iterator<T>> iterators;
+        private Iterator<T> currentIterator;
+
+        public ConcatingIterator( Iterator<? extends Iterator<T>> iterators )
+        {
+            this.iterators = iterators;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            if ( currentIterator == null || !currentIterator.hasNext() )
+            {
+                while ( iterators.hasNext() )
+                {
+                    currentIterator = iterators.next();
+                    if ( currentIterator.hasNext() )
+                    {
+                        break;
+                    }
+                }
+            }
+            return currentIterator != null && currentIterator.hasNext() ? currentIterator.next() : null;
+        }
+
+        protected final Iterator<T> currentIterator()
+        {
+            return currentIterator;
+        }
+    }
+
+    // Interleaving
+    // Needs to be an Iterable<Iterator<T>> opposed to Iterator<Iterator<T>> since interleaving will
+    // go over the iterators multiple passes.
+    public static <T> Iterator<T> interleave( Iterable<Iterator<T>> iterators )
+    {
+        return new InterleavingIterator<>( iterators );
+    }
+
+    public static class InterleavingIterator<T> extends BaseIterator<T>
+    {
+        private final Iterable<Iterator<T>> iterators;
+        private Iterator<Iterator<T>> currentRound;
+
+        public InterleavingIterator( Iterable<Iterator<T>> iterators )
+        {
+            this.iterators = iterators;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            if ( currentRound == null || !currentRound.hasNext() )
+            {
+                currentRound = iterators.iterator();
+            }
+            while ( currentRound.hasNext() )
+            {
+                Iterator<T> iterator = currentRound.next();
+                if ( iterator.hasNext() )
+                {
+                    return iterator.next();
+                }
+            }
+            currentRound = null;
+            return null;
+        }
+    }
+
+    // Filtering
+    public static <T> Iterator<T> filter( Iterator<T> source, final Predicate<T> filter )
+    {
+        return new FilteringIterator<T>( source )
+        {
+            @Override
+            public boolean accept( T item )
+            {
+                return filter.accept( item );
+            }
+        };
+    }
+
+    public static <T> Iterator<T> dedup( Iterator<T> source )
+    {
+        // Overriding #accept saves one object instantiation (the Predicate)
+        return new FilteringIterator<T>( source )
+        {
+            private final Set<T> visitedItems = new HashSet<>();
+
+            @Override
+            public boolean accept( T item )
+            {
+                return visitedItems.add( item );
+            }
+        };
+    }
+
+    public static <T> Iterator<T> notNull( Iterator<T> source )
+    {
+        return filter( source, Predicates.<T>notNull() );
+    }
+
+    public static <T> Iterator<T> skip( Iterator<T> source, final int skipTheFirstNItems )
+    {
+        return new FilteringIterator<T>( source )
+        {
+            private int skipped = 0;
+
+            @Override
+            public boolean accept( T item )
+            {
+                if ( skipped < skipTheFirstNItems )
+                {
+                    skipped++;
+                    return false;
+                }
+                return true;
+            }
+        };
+    }
+
+    public static abstract class FilteringIterator<T> extends BaseIterator<T> implements Predicate<T>
+    {
+        private final Iterator<T> source;
+
+        public FilteringIterator( Iterator<T> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            while ( source.hasNext() )
+            {
+                T testItem = source.next();
+                if ( accept( testItem ) )
+                {
+                    return testItem;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public abstract boolean accept( T item );
+    }
+
+    // Limiting
+    public static <T> Iterator<T> limit( final Iterator<T> source, final int maxItems )
+    {
+        return new BaseIterator<T>()
+        {
+            private int visited;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                if ( visited++ < maxItems )
+                {
+                    if ( source.hasNext() )
+                    {
+                        return source.next();
+                    }
+                }
+                return null;
+            }
+        };
+    }
+
+    // Mapping
+    public static <FROM,TO> Iterator<TO> map( Iterator<FROM> source, final Function<FROM,TO> function )
+    {
+        return new MappingIterator<FROM,TO>( source )
+        {
+            @Override
+            protected TO map( FROM item )
+            {
+                return function.apply( item );
+            }
+        };
+    }
+
+    public static <FROM,TO> Iterator<TO> cast( Iterator<FROM> source, final Class<TO> to )
+    {
+        return new MappingIterator<FROM, TO>( source )
+        {
+            @Override
+            protected TO map( FROM item )
+            {
+                return to.cast( item );
+            }
+        };
+    }
+
+    public static abstract class MappingIterator<FROM,TO> extends BaseIterator<TO>
+    {
+        protected final Iterator<FROM> source;
+
+        public MappingIterator( Iterator<FROM> source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        protected TO fetchNextOrNull()
+        {
+            return source.hasNext() ? map( source.next() ) : null;
+        }
+
+        protected abstract TO map( FROM item );
+    }
+
+    // Nested
+    public static <FROM,TO> Iterator<TO> nested( Iterator<FROM> source, final Function<FROM,Iterator<TO>> nester )
+    {
+        return new NestedIterator<FROM,TO>( source )
+        {
+            @Override
+            protected Iterator<TO> nested( FROM surfaceItem )
+            {
+                return nester.apply( surfaceItem );
+            }
+        };
+    }
+
+    public static abstract class NestedIterator<FROM,TO> extends BaseIterator<TO>
+    {
+        private final Iterator<FROM> source;
+        private Iterator<TO> currentNestedIterator;
+        private FROM currentSurfaceItem;
+
+        public NestedIterator( Iterator<FROM> source )
+        {
+            this.source = source;
+        }
+
+        protected abstract Iterator<TO> nested( FROM item );
+
+        public FROM getCurrentSurfaceItem()
+        {
+            if ( this.currentSurfaceItem == null )
+            {
+                throw new IllegalStateException( "Has no surface item right now," +
+                    " you must do at least one next() first" );
+            }
+            return this.currentSurfaceItem;
+        }
+
+        @Override
+        protected TO fetchNextOrNull()
+        {
+            if ( currentNestedIterator == null || !currentNestedIterator.hasNext() )
+            {
+                while ( source.hasNext() )
+                {
+                    currentSurfaceItem = source.next();
+                    currentNestedIterator = nested( currentSurfaceItem );
+                    if ( currentNestedIterator.hasNext() )
+                    {
+                        break;
+                    }
+                }
+            }
+            return currentNestedIterator != null && currentNestedIterator.hasNext() ?
+                    currentNestedIterator.next() : null;
+        }
+    }
+
+    // Paging
+    public static <T> PagingIterator<T> page( Iterator<T> source, int pageSize )
+    {
+        return new PagingIterator<>( source, pageSize );
+    }
+
+    /**
+     * A {@link CachingIterator} which can more easily divide the items
+     * into pages, where optionally each page can be seen as its own
+     * {@link Iterator} instance for convenience using {@link #nextPage()}.
+     *
+     * @param <T> the type of items in this iterator.
+     */
+    public static class PagingIterator<T> extends CachingIterator<T>
+    {
+        private final int pageSize;
+
+        /**
+         * Creates a new paging iterator with {@code source} as its underlying
+         * {@link Iterator} to lazily get items from.
+         *
+         * @param source the underlying {@link Iterator} to lazily get items from.
+         * @param pageSize the max number of items in each page.
+         */
+        public PagingIterator( Iterator<T> source, int pageSize )
+        {
+            super( source );
+            this.pageSize = pageSize;
+        }
+
+        /**
+         * @return the page the iterator is currently at, starting a {@code 0}.
+         * This value is based on the {@link #position()} and the page size.
+         */
+        public int page()
+        {
+            return position()/pageSize;
+        }
+
+        /**
+         * Sets the current page of the iterator. {@code 0} means the first page.
+         * @param newPage the current page to set for the iterator, must be
+         * non-negative. The next item returned by the iterator will be the first
+         * item in that page.
+         * @return the page before changing to the new page.
+         */
+        public int page( int newPage )
+        {
+            int previousPage = page();
+            position( newPage*pageSize );
+            return previousPage;
+        }
+
+        /**
+         * Returns a new {@link Iterator} instance which exposes the current page
+         * as its own iterator, which fetches items lazily from the underlying
+         * iterator. It is discouraged to use an {@link Iterator} returned from
+         * this method at the same time as using methods like {@link #next()} or
+         * {@link #previous()}, where the results may be unpredictable. So either
+         * use only {@link #nextPage()} (in conjunction with {@link #page(int)} if
+         * necessary) or go with regular {@link #next()}/{@link #previous()}.
+         *
+         * @return the next page as an {@link Iterator}.
+         */
+        public Iterator<T> nextPage()
+        {
+            page( page() );
+            return new BaseIterator<T>()
+            {
+                private final int end = position()+pageSize;
+
+                @Override
+                protected T fetchNextOrNull()
+                {
+                    if ( position() >= end )
+                    {
+                        return null;
+                    }
+                    return PagingIterator.this.hasNext() ? PagingIterator.this.next() : null;
+                }
+            };
+        }
+    }
+
+    // Range
+    public static Iterator<Integer> intRange( int end )
+    {
+        return intRange( 0, end );
+    }
+
+    public static Iterator<Integer> intRange( int start, int end )
+    {
+        return intRange( start, end, 1 );
+    }
+
+    public static Iterator<Integer> intRange( int start, int end, int stride )
+    {
+        return new RangeIterator<>( start, end, stride, INTEGER_STRIDER, INTEGER_COMPARATOR );
+    }
+
+    public static class RangeIterator<T,S> extends BaseIterator<T>
+    {
+        private T current;
+        private final T end;
+        private final S stride;
+        private final Function2<T, S, T> strider;
+        private final Comparator<T> comparator;
+
+        public RangeIterator( T start, T end, S stride, Function2<T, S, T> strider, Comparator<T> comparator )
+        {
+            this.current = start;
+            this.end = end;
+            this.stride = stride;
+            this.strider = strider;
+            this.comparator = comparator;
+        }
+
+        @Override
+        protected T fetchNextOrNull()
+        {
+            try
+            {
+                return comparator.compare( current, end ) <= 0 ? current : null;
+            }
+            finally
+            {
+                current = strider.apply( current, stride );
+            }
+        }
+    }
+
+    static final Function2<Integer,Integer,Integer> INTEGER_STRIDER =
+            new Function2<Integer, Integer, Integer>()
+    {
+        @Override
+        public Integer apply( Integer from1, Integer from2 )
+        {
+            return from1 + from2;
+        }
+    };
+
+    static final Comparator<Integer> INTEGER_COMPARATOR = new Comparator<Integer>()
+    {
+        @Override
+        public int compare( Integer o1, Integer o2 )
+        {
+            return o1.intValue() - o2.intValue();
+        }
+    };
+
+    // Singleton
+    public static <T> Iterator<T> singleton( final T item )
+    {
+        return new BaseIterator<T>()
+        {
+            private T itemToReturn = item;
+
+            @Override
+            protected T fetchNextOrNull()
+            {
+                try
+                {
+                    return itemToReturn;
+                }
+                finally
+                {
+                    itemToReturn = null;
+                }
+            }
+        };
+    }
+
+    // Cloning
+    public static <T extends CloneableInPublic> Iterator<T> cloning( Iterator<T> items, final Class<T> itemClass )
+    {
+        return new MappingIterator<T,T>( items )
+        {
+            @Override
+            protected T map( T item )
+            {
+                return itemClass.cast( item.clone() );
+            }
+        };
+    }
+
+    // Reversed
+    public static <T> Iterator<T> reversed( Iterator<T> source )
+    {
+        List<T> allItems = asList( source );
+        Collections.reverse( allItems );
+        return allItems.iterator();
+    }
+
+    // === Operations ===
+    /**
+     * Returns the given iterator's first element. If no element is found a
+     * {@link NoSuchElementException} is thrown.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the first element in the {@code iterator}, or {@code null} if no
+     * element found.
+     */
+    public static <T> T first( Iterator<T> iterator )
+    {
+        return assertNotNull( iterator, first( iterator, null ) );
+    }
+
+    /**
+     * Returns the given iterator's first element or {@code defaultItem} if no
+     * element found.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the first element in the {@code iterator}.
+     * @throws NoSuchElementException if no element found.
+     */
+    public static <T> T first( Iterator<T> iterator, T defaultItem )
+    {
+        return iterator.hasNext() ? iterator.next() : defaultItem;
+    }
+
+    /**
+     * Returns the given iterator's last element. If no element is found a
+     * {@link NoSuchElementException} is thrown.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the last element in the {@code iterator}.
+     * @throws NoSuchElementException if no element found.
+     */
+    public static <T> T last( Iterator<T> iterator )
+    {
+        return assertNotNull( iterator, last( iterator, null ) );
+    }
+
+    /**
+     * Returns the given iterator's last element or {@code null} if no
+     * element found.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the last element in the {@code iterator}, or {@code null} if no
+     * element found.
+     */
+    public static <T> T last( Iterator<T> iterator, T defaultItem )
+    {
+        T result = defaultItem;
+        while ( iterator.hasNext() )
+        {
+            result = iterator.next();
+        }
+        return result;
+    }
+
+    /**
+     * Returns the given iterator's single element. If there are no elements
+     * or more than one element in the iterator a {@link NoSuchElementException}
+     * will be thrown.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the single element in the {@code iterator}.
+     * @throws NoSuchElementException if there isn't exactly one element.
+     */
+    public static <T> T single( Iterator<T> iterator )
+    {
+        return assertNotNull( iterator, single( iterator, null ) );
+    }
+
+    /**
+     * Returns the given iterator's single element or {@code null} if no
+     * element found. If there is more than one element in the iterator a
+     * {@link NoSuchElementException} will be thrown.
+     *
+     * @param <T> the type of elements in {@code iterator}.
+     * @param iterator the {@link Iterator} to get elements from.
+     * @return the single element in {@code iterator}, or {@code null} if no
+     * element found.
+     * @throws NoSuchElementException if more than one element was found.
+     */
+    public static <T> T single( Iterator<T> iterator, T defaultItem )
+    {
+        if ( !iterator.hasNext() )
+        {
+            return defaultItem;
+        }
+        T item = iterator.next();
+        if ( iterator.hasNext() )
+        {
+            throw new NoSuchElementException( "More than one item in " + iterator + ", first:" + item +
+                    ", second:" + iterator.next() );
+        }
+        return item;
+    }
+
+    public static <T> T itemAt( Iterator<T> iterator, int index )
+    {
+        return assertNotNull( iterator, itemAt( iterator, index, null ) );
+    }
+
+    public static <T> T itemAt( Iterator<T> iterator, int index, T defaultItem )
+    {
+        if ( index >= 0 )
+        {   // Look forwards
+            for ( int i = 0; iterator.hasNext() && i < index; i++ )
+            {
+                iterator.next();
+            }
+            return iterator.hasNext() ? iterator.next() : defaultItem;
+        }
+
+        // Look backwards
+        int fromEnd = index * -1;
+        Deque<T> trail = new ArrayDeque<>( fromEnd );
+        while ( iterator.hasNext() )
+        {
+            if ( trail.size() >= fromEnd )
+            {
+                trail.removeLast();
+            }
+            trail.addFirst( iterator.next() );
+        }
+        return trail.size() == fromEnd ? trail.getLast() : defaultItem;
+    }
+
+    /**
+     * Returns the index of the given item in the iterator(zero-based). If no items in {@code iterator}
+     * equals {@code item} {@code -1} is returned.
+     *
+     * @param item the item to look for.
+     * @param iterator of items.
+     * @return index of found item or -1 if not found.
+     */
+    public static <T> int indexOf( T item, Iterator<T> iterator )
+    {
+        for ( int i = 0; iterator.hasNext(); i++ )
+        {
+            if ( item.equals( iterator.next() ) )
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validates whether two {@link Iterator}s are equal or not, i.e. if they have contain same number of items
+     * and each orderly item equals one another.
+     *
+     * @param first the {@link Iterator} containing the first items.
+     * @param other the {@link Iterator} containing the other items.
+     * @return whether the two iterators are equal or not.
+     */
+    public static boolean equals( Iterator<?> first, Iterator<?> other )
+    {
+        boolean firstHasNext, otherHasNext;
+        // single | so that both iterator's hasNext() gets evaluated.
+        while ( (firstHasNext = first.hasNext()) | (otherHasNext = other.hasNext()) )
+        {
+            if ( firstHasNext != otherHasNext || !first.next().equals( other.next() ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static <T> T assertNotNull( Iterator<T> iterator, T result )
+    {
+        if ( result == null )
+        {
+            throw new NoSuchElementException( "No element found in " + iterator );
+        }
+        return result;
+    }
+
+    /**
+     * Adds all the items in {@code iterator} to {@code collection}.
+     * @param <C> the type of {@link Collection} to add to items to.
+     * @param <T> the type of items in the collection and iterator.
+     * @param iterator the {@link Iterator} to grab the items from.
+     * @param collection the {@link Collection} to add the items to.
+     * @return the {@code collection} which was passed in, now filled
+     * with the items from {@code iterator}.
+     */
+    public static <C extends Collection<T>,T> C addToCollection( Iterator<T> iterator, C collection,
+            Function2<T, C, Void> adder )
+    {
+        while ( iterator.hasNext() )
+        {
+            T item = iterator.next();
+            adder.apply( item, collection );
+        }
+        return collection;
+    }
+
+    public static <C extends Collection<T>,T> C addToCollection( Iterator<T> iterator, C collection )
+    {
+        return addToCollection( iterator, collection, NewIterators.<T,C>add() );
+    }
+
+    public static <C extends Collection<T>,T> C addToCollectionAssertChanged( Iterator<T> iterator, C collection )
+    {
+        return addToCollection( iterator, collection, NewIterators.<T,C>addUnique() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static final <T, C> Function2<T, C, Void> addUnique()
+    {
+        return ADD_UNIQUE;
+    }
+
+    public static class DuplicateItemException extends IllegalStateException
+    {
+        public DuplicateItemException( String message )
+        {
+            super( message );
+        }
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private static final Function2 ADD_UNIQUE = new Function2()
+    {
+        @SuppressWarnings( { "unchecked" } )
+        @Override
+        public Object apply( Object item, Object collection )
+        {
+            if ( !((Collection)collection).add( item ) )
+            {
+                throw new DuplicateItemException( "Encountered an already added item:" + item +
+                        " when adding items uniquely to a collection:" + collection );
+            }
+            return null;
+        }
+    };
+
+    @SuppressWarnings( "unchecked" )
+    private static final <T, C> Function2<T, C, Void> add()
+    {
+        return ADD;
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private static final Function2 ADD = new Function2()
+    {
+        @SuppressWarnings( { "unchecked" } )
+        @Override
+        public Object apply( Object item, Object collection )
+        {
+            ((Collection)collection).add( item );
+            return null;
+        }
+    };
+
+    public static <T> List<T> asList( Iterator<T> items )
+    {
+        return addToCollection( items, new ArrayList<T>() );
+    }
+
+    public static <T> Set<T> asSet( Iterator<T> items )
+    {
+        return addToCollectionAssertChanged( items, new HashSet<T>() );
+    }
+
+    public static <T> Set<T> asSetAllowDuplicates( Iterator<T> items )
+    {
+        return addToCollection( items, new HashSet<T>() );
+    }
+
+    /**
+     * Convenience method for looping over an {@link Iterator}. Converts the
+     * {@link Iterator} to an {@link Iterable} by wrapping it in an
+     * {@link Iterable} that returns the {@link Iterator}. It breaks the
+     * contract of {@link Iterable} in that it returns the supplied iterator
+     * instance for each call to {@code iterator()} on the returned
+     * {@link Iterable} instance. This method exists to make it easy to use an
+     * {@link Iterator} in a for-loop.
+     *
+     * @param <T> the type of items in the iterator.
+     * @param iterator the iterator to expose as an {@link Iterable}.
+     * @return the supplied iterator posing as an {@link Iterable}.
+     */
+    public static <T> Iterable<T> loop( final Iterator<T> iterator )
+    {
+        return new Iterable<T>()
+        {
+            @Override
+            public Iterator<T> iterator()
+            {
+                return iterator;
+            }
+        };
+    }
+
+    /**
+     * Counts the number of items in the {@code iterator} by looping
+     * through it.
+     * @param <T> the type of items in the iterator.
+     * @param iterator the {@link Iterator} to count items in.
+     * @return the number of found in {@code iterator}.
+     */
+    public static int count( Iterator<?> iterator )
+    {
+        int count = 0;
+        for ( ; iterator.hasNext(); iterator.next(), count++ )
+        {   // Just loop through this
+        }
+        return count;
+    }
+
+    /**
+     * Returns all items in {@code items} as an array.
+     * @param items the {@link Iterator} to get the items from.
+     * @param itemClass type of items in the iterator, and hence in the resulting array.
+     * @return an array of all items in the iterator.
+     */
+    @SuppressWarnings( "unchecked" )
+    public static <T> T[] asArray( Iterator<T> items, Class<T> itemClass )
+    {
+        List<T> allItems = asList( items );
+        return allItems.toArray( (T[]) Array.newInstance( itemClass, allItems.size() ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/PrefetchingIterator.java
@@ -33,8 +33,8 @@ import java.util.NoSuchElementException;
  */
 public abstract class PrefetchingIterator<T> implements Iterator<T>
 {
-    boolean hasFetchedNext;
-    T nextObject;
+    protected boolean hasFetchedNext;
+    protected T nextObject;
 
 	/**
 	 * @return {@code true} if there is a next item to be returned from the next

--- a/community/kernel/src/test/java/org/neo4j/helpers/collection/NewIteratorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/collection/NewIteratorsTest.java
@@ -1,0 +1,747 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.neo4j.helpers.CloneableInPublic;
+import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Predicate;
+import org.neo4j.helpers.collection.NewIterators.DuplicateItemException;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.NewIterators.iterator;
+
+public class NewIteratorsTest
+{
+    @Test
+    public void baseIteratorShouldEndWithNull() throws Exception
+    {
+        // GIVEN
+        final AtomicReference<Integer> ref = new AtomicReference<Integer>();
+        Iterator<Integer> iterator = new NewIterators.BaseIterator<Integer>()
+        {
+            @Override
+            protected Integer fetchNextOrNull()
+            {
+                return ref.get();
+            }
+        };
+        
+        // WHEN
+        ref.set( 1 );
+        assertNextEquals( 1, iterator );
+        ref.set( 2 );
+        assertNextEquals( 2, iterator );
+        
+        // THEN
+        ref.set( null );
+        assertNoMoreItems( iterator );
+    }
+    
+    @Test
+    public void arrayOfItemsAsIterator() throws Exception
+    {
+        // GIVEN
+        String[] items = new String[] {
+                "First",
+                "Second",
+                "Third"
+        };
+        
+        // WHEN
+        Iterator<String> iterator = NewIterators.iterator( items );
+        
+        // THEN
+        assertItems( iterator, items );
+    }
+
+    @Test
+    public void arrayOfReversedItemsAsIterator() throws Exception
+    {
+        // GIVEN
+        String[] items = new String[] {
+                "First",
+                "Second",
+                "Third"
+        };
+        
+        // WHEN
+        Iterator<String> iterator = NewIterators.reversed( items );
+        
+        // THEN
+        for ( int i = items.length; i --> 0; )
+        {
+            assertNextEquals( items[i], iterator );
+        }
+        assertNoMoreItems( iterator );
+    }
+    
+    // TODO test for caching iterator
+    // TODO test for catching iterator
+    
+    @Test
+    public void concatenateTwoIterators() throws Exception
+    {
+        // GIVEN
+        Iterator<String> firstItems = iterator( "First", "Second" );
+        Iterator<String> otherItems = iterator( "Third", "Fourth" );
+        
+        // WHEN
+        @SuppressWarnings( "unchecked" )
+        Iterable<Iterator<String>> iterators = asList( firstItems, otherItems );
+        Iterator<String> iterator = NewIterators.concat( iterators.iterator() );
+        
+        // THEN
+        assertItems( iterator, "First", "Second", "Third", "Fourth" );
+    }
+    
+    @Test
+    public void concatenateTwoIterables() throws Exception
+    {
+        // GIVEN
+        Iterable<String> firstItems = asList( "First", "Second" );
+        Iterable<String> otherItems = asList( "Third", "Fourth" );
+        
+        // WHEN
+        @SuppressWarnings( "unchecked" )
+        Iterable<Iterable<String>> iterables = asList( firstItems, otherItems );
+        Iterator<String> iterator = NewIterators.concatIterables( iterables.iterator() );
+        
+        // THEN
+        assertItems( iterator, "First", "Second", "Third", "Fourth" );
+    }
+    
+    @Test
+    public void prependItem() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second" );
+        String prepended = "Zeroth"; // :)
+        
+        // WHEN
+        Iterator<String> iterator = NewIterators.prepend( prepended, items );
+        
+        // THEN
+        assertItems( iterator, prepended, "First", "Second" );
+    }
+    
+    @Test
+    public void appendItem() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second" );
+        String appended = "Third";
+        
+        // WHEN
+        Iterator<String> iterator = NewIterators.append( items, appended );
+        
+        // THEN
+        assertItems( iterator, "First", "Second", appended );
+    }
+    
+    @Test
+    public void interleaveIterators() throws Exception
+    {
+        // GIVEN
+        Iterator<String> firstIterator = iterator( "1-First", "1-Second", "1-Third" );
+        Iterator<String> secondIterator = iterator( "2-First", "2-Second" );
+        Iterator<String> thirdIterator = iterator( "3-First", "3-Second", "3-Third", "3-Fourth" );
+        @SuppressWarnings( "unchecked" )
+        Collection<Iterator<String>> allIterators = asList( firstIterator, secondIterator, thirdIterator );
+        
+        // WHEN
+        Iterator<String> interleaved = NewIterators.interleave( allIterators );
+        
+        // THEN
+        assertItems( interleaved,
+                "1-First", "2-First", "3-First",
+                "1-Second", "2-Second", "3-Second",
+                "1-Third", "3-Third",
+                "3-Fourth" );
+    }
+    
+    @Test
+    public void filter() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        Iterator<String> filtered = NewIterators.filter( items, new Predicate<String>()
+        {
+            @Override
+            public boolean accept( String item )
+            {
+                return !"Second".equals( item );
+            }
+        } );
+        
+        // THEN
+        assertItems( filtered, "First", "Third" );
+    }
+    
+    @Test
+    public void dedup() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "First", "Second", "Third", "Second" );
+        
+        // WHEN
+        Iterator<String> deduped = NewIterators.dedup( items );
+        
+        // THEN
+        assertItems( deduped, "First", "Second", "Third" );
+    }
+    
+    @Test
+    public void filterNulls() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = asList( "First", null, "Second", null ).iterator();
+        
+        // WHEN
+        Iterator<String> nonNull = NewIterators.notNull( items );
+        
+        // THEN
+        assertItems( nonNull, "First", "Second" );
+    }
+    
+    @Test
+    public void limit() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        Iterator<String> limited = NewIterators.limit( items, 2 );
+        
+        // THEN
+        assertItems( limited, "First", "Second" );
+    }
+    
+    @Test
+    public void skip() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third", "Fourth" );
+        
+        // WHEN
+        Iterator<String> skipped = NewIterators.skip( items, 2 );
+        
+        // THEN
+        assertItems( skipped, "Third", "Fourth" );
+    }
+    
+    @Test
+    public void map() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "1", "2", "3", "4" );
+        
+        // WHEN
+        Iterator<Integer> mapped = NewIterators.map( items, new Function<String,Integer>()
+        {
+            @Override
+            public Integer apply( String from )
+            {
+                return new Integer( from );
+            }
+        } );
+        
+        // THEN
+        assertItems( mapped, 1, 2, 3, 4 );
+    }
+    
+    @Test
+    public void casting() throws Exception
+    {
+        // GIVEN
+        Iterator<Object> strings = NewIterators.<Object>iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        Iterator<String> casted = NewIterators.cast( strings, String.class );
+        
+        // THEN
+        assertItems( casted, "First", "Second", "Third" );
+    }
+    
+    @Test
+    public void nested() throws Exception
+    {
+        // GIVEN
+        Iterator<String> surfaceItems = iterator( "1", "2", "3" );
+        
+        // WHEN
+        Iterator<String> nested = NewIterators.nested( surfaceItems, new Function<String,Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> apply( String from )
+            {
+                return iterator( from + "-1", from + "-2", from + "-3" );
+            }
+        } );
+        
+        // THEN
+        assertItems( nested,
+                "1-1", "1-2", "1-3",
+                "2-1", "2-2", "2-3",
+                "3-1", "3-2", "3-3" );
+    }
+    
+    // TODO paging iterator
+    
+    @Test
+    public void intRange() throws Exception
+    {
+        // WHEN
+        Iterator<Integer> range = NewIterators.intRange( 5, 15, 3 );
+        
+        // THEN
+        assertItems( range, 5, 8, 11, 14 );
+    }
+    
+    @Test
+    public void singleton() throws Exception
+    {
+        // GIVEN
+        String item = "Item";
+        
+        // WHEN
+        Iterator<String> singleton = NewIterators.singleton( item );
+        
+        // THEN
+        assertItems( singleton, item );
+    }
+    
+    @Test
+    public void cloning() throws Exception
+    {
+        // GIVEN
+        Iterator<CloneableThing> things = iterator( new CloneableThing( "First" ), new CloneableThing( "Second" ) );
+        
+        // WHEN
+        Iterator<CloneableThing> cloned = NewIterators.cloning( things, CloneableThing.class );
+        
+        // THEN
+        CloneableThing first = cloned.next();
+        assertEquals( "First", first.value );
+        assertTrue( first.cloned );
+        CloneableThing second = cloned.next();
+        assertEquals( "Second", second.value );
+        assertTrue( second.cloned );
+        assertNoMoreItems( cloned );
+    }
+    
+    @Test
+    public void reversed() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        Iterator<String> reversed = NewIterators.reversed( items );
+        
+        // THEN
+        assertItems( reversed, "Third", "Second", "First" );
+    }
+    
+    @Test
+    public void first() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second" );
+        
+        // WHEN
+        try
+        {
+            NewIterators.first( iterator() );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {   // Good
+        }
+        String first = NewIterators.first( items );
+        
+        // THEN
+        assertEquals( "First", first );
+    }
+    
+    @Test
+    public void firstWithDefault() throws Exception
+    {
+        // GIVEN
+        String defaultValue = "Default";
+        
+        // WHEN
+        String firstOnEmpty = NewIterators.first( NewIterators.<String>iterator(), defaultValue );
+        String first = NewIterators.first( iterator( "First", "Second" ), defaultValue );
+        
+        // THEN
+        assertEquals( defaultValue, firstOnEmpty );
+        assertEquals( "First", first );
+    }
+    
+    @Test
+    public void last() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second" );
+        
+        // WHEN
+        try
+        {
+            NewIterators.last( iterator() );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {   // Good
+        }
+        String last = NewIterators.last( items );
+        
+        // THEN
+        assertEquals( "Second", last );
+    }
+    
+    @Test
+    public void lastWithDefault() throws Exception
+    {
+        // GIVEN
+        String defaultValue = "Default";
+        
+        // WHEN
+        String lastOnEmpty = NewIterators.last( NewIterators.<String>iterator(), defaultValue );
+        String last = NewIterators.last( iterator( "First", "Second" ), defaultValue );
+        
+        // THEN
+        assertEquals( defaultValue, lastOnEmpty );
+        assertEquals( "Second", last );
+    }
+    
+    @Test
+    public void single() throws Exception
+    {
+        try
+        {
+            NewIterators.single( iterator() );
+        }
+        catch ( NoSuchElementException e )
+        {
+            assertThat( e.getMessage(), containsString( "No" ) );
+        }
+        
+        assertEquals( "Single", NewIterators.single( iterator( "Single" ) ) );
+        
+        try
+        {
+            NewIterators.single( iterator( "First", "Second" ) );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {
+            assertThat( e.getMessage(), containsString( "More than one" ) );
+        }
+    }
+    
+    @Test
+    public void singleWithDefault() throws Exception
+    {
+        assertEquals( "Default", NewIterators.single( iterator(), "Default" ) );
+        assertEquals( "Single", NewIterators.single( iterator( "Single" ) ) );
+        try
+        {
+            NewIterators.single( iterator( "First", "Second" ) );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {   // Good
+            assertThat( e.getMessage(), containsString( "More than one" ) );
+        }
+    }
+    
+    @Test
+    public void itemAt() throws Exception
+    {
+        
+        // GIVEN
+        Iterable<String> items = asList( "First", "Second", "Third" );
+        
+        // THEN
+        try
+        {
+            NewIterators.itemAt( items.iterator(), 3 );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {
+            assertThat( e.getMessage(), containsString( "No element" ) );
+        }
+        try
+        {
+            NewIterators.itemAt( items.iterator(), -4 );
+            fail( "Should throw exception" );
+        }
+        catch ( NoSuchElementException e )
+        {
+            assertThat( e.getMessage(), containsString( "No element" ) );
+        }
+        assertEquals( "First", NewIterators.itemAt( items.iterator(), 0 ) );
+        assertEquals( "Second", NewIterators.itemAt( items.iterator(), 1 ) );
+        assertEquals( "Third", NewIterators.itemAt( items.iterator(), 2 ) );
+        assertEquals( "Third", NewIterators.itemAt( items.iterator(), -1 ) );
+        assertEquals( "Second", NewIterators.itemAt( items.iterator(), -2 ) );
+        assertEquals( "First", NewIterators.itemAt( items.iterator(), -3 ) );
+    }
+    
+    @Test
+    public void itemAtWithDefault() throws Exception
+    {
+        // GIVEN
+        Iterable<String> items = asList( "First", "Second", "Third" );
+        String defaultValue = "Default";
+        
+        // THEN
+        assertEquals( defaultValue, NewIterators.itemAt( items.iterator(), 3, defaultValue ) );
+        assertEquals( defaultValue, NewIterators.itemAt( items.iterator(), -4, defaultValue ) );
+        assertEquals( "First", NewIterators.itemAt( items.iterator(), 0 ) );
+        assertEquals( "Second", NewIterators.itemAt( items.iterator(), 1 ) );
+        assertEquals( "Third", NewIterators.itemAt( items.iterator(), 2 ) );
+        assertEquals( "Third", NewIterators.itemAt( items.iterator(), -1 ) );
+        assertEquals( "Second", NewIterators.itemAt( items.iterator(), -2 ) );
+        assertEquals( "First", NewIterators.itemAt( items.iterator(), -3 ) );
+    }
+    
+    @Test
+    public void indexOf() throws Exception
+    {
+        // GIVEN
+        Iterable<String> items = asList( "First", "Second", "Third" );
+        
+        // THEN
+        assertEquals( -1, NewIterators.indexOf( "Something", items.iterator() ) );
+        assertEquals( 0, NewIterators.indexOf( "First", items.iterator() ) );
+        assertEquals( 1, NewIterators.indexOf( "Second", items.iterator() ) );
+        assertEquals( 2, NewIterators.indexOf( "Third", items.iterator() ) );
+    }
+    
+    @Test
+    public void iteratorsEqual() throws Exception
+    {
+        // GIVEN
+        List<String> items1 = asList( "First", "Second", "Third" );
+        List<String> items2 = asList( "First", "Bacond", "Third" );
+        List<String> items3 = asList( "First", "Second", "Third", "Fourth" );
+        List<String> items4 = asList( "First", "Second", "Third" );
+        
+        // THEN
+        assertFalse( NewIterators.equals( items1.iterator(), items2.iterator() ) );
+        assertFalse( NewIterators.equals( items1.iterator(), items3.iterator() ) );
+        assertTrue( NewIterators.equals( items1.iterator(), items4.iterator() ) );
+    }
+    
+    @Test
+    public void addToCollection() throws Exception
+    {
+        // GIVEN
+        Collection<String> collection = new ArrayList<String>( asList( "First", "Second" ) );
+        
+        // WHEN
+        collection = NewIterators.addToCollection( iterator( "Third", "Fourth" ), collection );
+        
+        // THEN
+        assertItems( collection.iterator(), "First", "Second", "Third", "Fourth" );
+    }
+    
+    @Test
+    public void addToCollectionUnique() throws Exception
+    {
+        // GIVEN
+        Collection<String> collection = new HashSet<String>( asList( "First", "Second" ) );
+        
+        // WHEN
+        collection = NewIterators.addToCollection( iterator( "Third", "Fourth" ), collection );
+        
+        // THEN
+        assertEquals( collection, new HashSet<String>( asList( "First", "Second", "Third", "Fourth" ) ) );
+        try
+        {
+            NewIterators.addToCollectionAssertChanged( iterator( "Second" ), collection );
+            fail( "Should not be able to add that one again" );
+        }
+        catch ( DuplicateItemException e )
+        {   // good
+        }
+    }
+    
+    @Test
+    public void iteratorAsList() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        List<String> list = NewIterators.asList( items );
+        
+        // THEN
+        assertItems( list.iterator(), "First", "Second", "Third" );
+    }
+    
+    @Test
+    public void iteratorAsSet() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        Set<String> set = NewIterators.asSet( items );
+        
+        // THEN
+        assertEquals( new HashSet<String>( asList( "First", "Second", "Third" ) ), set );
+        try
+        {
+            NewIterators.asSet( iterator( "First", "Second", "First" ) );
+            fail( "Should fail on duplicates" );
+        }
+        catch ( IllegalStateException e )
+        {   // good
+        }
+    }
+    
+    @Test
+    public void iteratorAsSetALlowDuplicates() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "First" );
+        
+        // WHEN
+        Set<String> set = NewIterators.asSetAllowDuplicates( items );
+        
+        // THEN
+        assertEquals( new HashSet<String>( asList( "First", "Second" ) ), set );
+    }
+    
+    @Test
+    public void loop() throws Exception
+    {
+        // GIVEN
+        String[] items = new String[] { "First", "Second", "Third" };
+        Iterator<String> iterator = iterator( items );
+        
+        // WHEN
+        int i = 0;
+        for ( String item : NewIterators.loop( iterator ) )
+        {
+            // THEN
+            assertEquals( items[i++], item );
+        }
+        assertEquals( items.length, i );
+    }
+    
+    @Test
+    public void count() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        int count = NewIterators.count( items );
+        
+        // THEN
+        assertEquals( 3, count );
+    }
+    
+    @Test
+    public void asArray() throws Exception
+    {
+        // GIVEN
+        Iterator<String> items = iterator( "First", "Second", "Third" );
+        
+        // WHEN
+        String[] array = NewIterators.asArray( items, String.class );
+        
+        // THEN
+        assertTrue( Arrays.equals( new String[] { "First", "Second", "Third" }, array ) );
+    }
+    
+    private static class CloneableThing implements CloneableInPublic
+    {
+        private final String value;
+        private boolean cloned;
+
+        CloneableThing( String value )
+        {
+            this.value = value;
+            this.cloned = false;
+        }
+        
+        @Override
+        public CloneableThing clone()
+        {
+            CloneableThing clone = new CloneableThing( value );
+            clone.cloned = true;
+            return clone;
+        }
+    }
+    
+    private void assertNoMoreItems( Iterator<?> iterator )
+    {
+        assertFalse( iterator + " should have no more items", iterator.hasNext() );
+        try
+        {
+            iterator.next();
+            fail( "Invoking next() on " + iterator +
+                    " which has no items left should have thrown NoSuchElementException" );
+        }
+        catch ( NoSuchElementException e )
+        {   // Good
+        }
+    }
+
+    private <T> void assertNextEquals( T expected, Iterator<T> iterator )
+    {
+        assertTrue( iterator + " should have had more items", iterator.hasNext() );
+        assertEquals( expected, iterator.next() );
+    }
+    
+    private <T> void assertItems( Iterator<T> iterator, T... expectedItems )
+    {
+        for ( T expectedItem : expectedItems )
+        {
+            assertNextEquals( expectedItem, iterator );
+        }
+        assertNoMoreItems( iterator );
+    }
+}


### PR DESCRIPTION
Most utilities, such as filtering, mapping a.s.o can be accessed both
object-oriented (new MappingIterator { @Override TO map(FROM) } and
functional (map( iterator, new Function<FROM,TO> mapper ).

This aught to be able to, over time, replace all other iterator utilities
that are scattered around in the code. This commit doesn't make use of
these utilities, to do so everywhere would be an absolutely massive
commit. It's better to migrate over time.