### PR TITLE
Cache-busting for static HTML.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -519,6 +519,8 @@ public class Jetty9WebServer implements WebServer
                 log.debug( format( "Mounting static content from [%s] at [%s]", url, mountPoint ) );
 
                 addFiltersTo( staticContext );
+                staticContext.addFilter( new FilterHolder( new NoCacheHtmlFilter() ), "/*",
+                        EnumSet.of( DispatcherType.REQUEST, DispatcherType.FORWARD ) );
 
                 handlers.addHandler( staticContext );
             }

--- a/community/server/src/main/java/org/neo4j/server/web/NoCacheHtmlFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/NoCacheHtmlFilter.java
@@ -1,0 +1,37 @@
+package org.neo4j.server.web;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class NoCacheHtmlFilter implements Filter
+{
+    @Override
+    public void init( FilterConfig filterConfig ) throws ServletException
+    {
+    }
+
+    @Override
+    public void doFilter( ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain )
+            throws IOException, ServletException
+    {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        if ( request.getServletPath() != null && request.getServletPath().endsWith( ".html" ))
+        {
+            response.addHeader( "Cache-Control", "no-cache" );
+        }
+        filterChain.doFilter( servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/web/NoCacheHtmlFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/NoCacheHtmlFilterTest.java
@@ -1,0 +1,66 @@
+package org.neo4j.server.web;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class NoCacheHtmlFilterTest
+{
+    @Test
+    public void shouldAddCacheControlHeaderToHtmlResponses() throws Exception
+    {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn( "index.html" );
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock( FilterChain.class );
+
+        // when
+        new NoCacheHtmlFilter().doFilter( request, response, filterChain );
+
+        // then
+        verify( response ).addHeader( "Cache-Control", "no-cache" );
+        verify( filterChain ).doFilter( request, response );
+    }
+
+    @Test
+    public void shouldPassThroughRequestsForNotHtmlResources() throws Exception
+    {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn( "index.js" );
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock( FilterChain.class );
+
+        // when
+        new NoCacheHtmlFilter().doFilter( request, response, filterChain );
+
+        // then
+        verifyZeroInteractions( response );
+        verify( filterChain ).doFilter( request, response );
+    }
+
+    @Test
+    public void shouldPassThroughRequestsWithNullServletPath() throws Exception
+    {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn( null );
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain filterChain = mock( FilterChain.class );
+
+        // when
+        new NoCacheHtmlFilter().doFilter( request, response, filterChain );
+
+        // then
+        verifyZeroInteractions( response );
+        verify( filterChain ).doFilter( request, response );
+    }
+}


### PR DESCRIPTION
Without this change, web browsers cache the HTML and all of the
resources linked from it, especially javascript. The cached
javascript may may not be compaitible with the server if the
server has been upgraded since the cached version was originally
served.

HTML is the only resource type that needs this treatment, because
all the other resources are gien cache-busting names derived from
a hash of their content. Essentially the HTML is the root of
a cache invalidation tree that should ensure browsers always
get the correct version of all static assets.