### PR TITLE
Resources of remote calls in HA are properly released

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -324,7 +324,10 @@ class BackupService
             client.start();
             unpacker.start();
 
-            unpacker.unpackResponse( client.incrementalBackup( context ), handler );
+            try ( Response<Void> response = client.incrementalBackup( context ) )
+            {
+                unpacker.unpackResponse( response, handler );
+            }
 
             consistent = true;
         }

--- a/enterprise/com/src/main/java/org/neo4j/com/ChannelContext.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ChannelContext.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class ChannelContext
+{
+    private final Channel channel;
+    private final ChannelBuffer output;
+    private final ByteBuffer input;
+
+    public ChannelContext( Channel channel, ChannelBuffer output, ByteBuffer input )
+    {
+        this.channel = requireNonNull( channel );
+        this.output = requireNonNull( output );
+        this.input = requireNonNull( input );
+    }
+
+    public Channel channel()
+    {
+        return channel;
+    }
+
+    public ChannelBuffer output()
+    {
+        return output;
+    }
+
+    public ByteBuffer input()
+    {
+        return input;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ChannelContext{channel=" + channel + ", output=" + output + ", input=" + input + "}";
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/LoggingResourcePoolMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/LoggingResourcePoolMonitor.java
@@ -19,14 +19,9 @@
  */
 package org.neo4j.com;
 
-import java.nio.ByteBuffer;
-
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.Channel;
-import org.neo4j.helpers.Triplet;
 import org.neo4j.kernel.impl.util.StringLogger;
 
-public class LoggingResourcePoolMonitor extends ResourcePool.Monitor.Adapter<Triplet<Channel, ChannelBuffer, ByteBuffer>>
+public class LoggingResourcePoolMonitor extends ResourcePool.Monitor.Adapter<ChannelContext>
 {
     private final StringLogger msgLog;
     private int lastCurrentPeakSize = -1;
@@ -48,7 +43,7 @@ public class LoggingResourcePoolMonitor extends ResourcePool.Monitor.Adapter<Tri
     }
 
     @Override
-    public void created( Triplet <Channel, ChannelBuffer, ByteBuffer> resource  )
+    public void created( ChannelContext resource )
     {
         msgLog.debug( "ResourcePool create resource " + resource );
     }

--- a/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
@@ -104,9 +104,9 @@ public abstract class ResourcePool<R>
 
     public static final int DEFAULT_CHECK_INTERVAL = 60 * 1000;
 
-    private final LinkedList<R> unused = new LinkedList<R>();
-    private final Map<Thread, R> current = new ConcurrentHashMap<Thread, R>();
-    private final Monitor monitor;
+    private final LinkedList<R> unused = new LinkedList<>();
+    private final Map<Thread,R> current = new ConcurrentHashMap<>();
+    private final Monitor<R> monitor;
     private final int minSize;
     private final CheckStrategy checkStrategy;
     // Guarded by nothing. Those are estimates, losing some values doesn't matter much
@@ -115,10 +115,11 @@ public abstract class ResourcePool<R>
 
     protected ResourcePool( int minSize )
     {
-        this( minSize, new CheckStrategy.TimeoutCheckStrategy( DEFAULT_CHECK_INTERVAL, SYSTEM_CLOCK ), new Monitor.Adapter() );
+        this( minSize, new CheckStrategy.TimeoutCheckStrategy( DEFAULT_CHECK_INTERVAL, SYSTEM_CLOCK ),
+                new Monitor.Adapter<R>() );
     }
 
-    protected ResourcePool( int minSize, CheckStrategy strategy, Monitor monitor )
+    protected ResourcePool( int minSize, CheckStrategy strategy, Monitor<R> monitor )
     {
         this.minSize = minSize;
         this.currentPeakSize = 0;
@@ -165,7 +166,7 @@ public abstract class ResourcePool<R>
                     }
                     if ( garbage == null )
                     {
-                        garbage = new LinkedList<R>();
+                        garbage = new LinkedList<>();
                     }
                     garbage.add( resource );
                 }
@@ -226,7 +227,7 @@ public abstract class ResourcePool<R>
 
     public final void close( boolean force )
     {
-        List<R> dead = new LinkedList<R>();
+        List<R> dead = new LinkedList<>();
         synchronized ( unused )
         {
             dead.addAll( unused );

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -672,11 +672,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         @SuppressWarnings( "unchecked" )
         public void run()
         {
-            Map<String,String> requestContext = new HashMap<>();
-            requestContext.put( "type", type.toString() );
-            requestContext.put( "remoteClient", channel.getRemoteAddress().toString() );
-            requestContext.put( "slaveContext", context.toString() );
-            requestMonitor.beginRequest( requestContext );
+            requestMonitor.beginRequest( channel.getRemoteAddress(), type, context );
             Response<R> response = null;
             Throwable failure = null;
             try

--- a/enterprise/com/src/main/java/org/neo4j/com/TransactionStreamResponse.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/TransactionStreamResponse.java
@@ -32,8 +32,6 @@ import org.neo4j.kernel.impl.store.StoreId;
  */
 public class TransactionStreamResponse<T> extends Response<T>
 {
-    public static final byte RESPONSE_TYPE = 0;
-
     private final TransactionStream transactions;
 
     public TransactionStreamResponse( T response, StoreId storeId, TransactionStream transactions,

--- a/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
@@ -19,11 +19,14 @@
  */
 package org.neo4j.com.monitor;
 
-import java.util.Map;
+import java.net.SocketAddress;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.RequestType;
 
 public interface RequestMonitor
 {
-    void beginRequest( Map<String, String> requestContext );
+    void beginRequest( SocketAddress remoteAddress, RequestType<?> requestType, RequestContext requestContext );
 
     void endRequest( Throwable t );
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -119,7 +119,7 @@ public class StoreCopyClient
         cleanDirectory( tempStore );
 
         // Request store files and transactions that will need recovery
-        try ( Response response = requester.copyStore( decorateWithProgressIndicator(
+        try ( Response<?> response = requester.copyStore( decorateWithProgressIndicator(
                 new ToFileStoreWriter( tempStore ) ) ) )
         {
             // Update highest archived log id

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/AbstractTokenCreator.java
@@ -39,7 +39,10 @@ public abstract class AbstractTokenCreator implements TokenCreator
     @Override
     public final int getOrCreate( String name )
     {
-        return create( master, requestContextFactory.newRequestContext(), name ).response();
+        try ( Response<Integer> response = create( master, requestContextFactory.newRequestContext(), name ) )
+        {
+            return response.response();
+        }
     }
 
     protected abstract Response<Integer> create( Master master, RequestContext context, String name );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.ha;
 
 import java.io.IOException;
 
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.Response;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
@@ -49,7 +51,11 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
     {
         try
         {
-            return master.commit( requestContextFactory.newRequestContext(representation.getLockSessionId()), representation ).response();
+            RequestContext context = requestContextFactory.newRequestContext( representation.getLockSessionId() );
+            try ( Response<Long> response = master.commit( context, representation ) )
+            {
+                return response.response();
+            }
         }
         catch ( IOException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.LockSupport;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.com.ComException;
 import org.neo4j.com.RequestContext;
+import org.neo4j.com.Response;
 import org.neo4j.com.TransactionObligationResponse;
 import org.neo4j.com.TransactionStream;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
@@ -306,7 +307,10 @@ public class UpdatePuller implements Runnable, Lifecycle
         try
         {
             RequestContext context = requestContextFactory.newRequestContext();
-            master.pullUpdates( context );
+            try ( Response<Void> ignored = master.pullUpdates( context ) )
+            {
+                // Updates would be applied as part of response processing
+            }
         }
         catch ( ComException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -31,6 +31,7 @@ import org.jboss.netty.channel.Channel;
 import org.neo4j.com.Protocol;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
+import org.neo4j.com.Response;
 import org.neo4j.com.Server;
 import org.neo4j.com.TransactionNotPresentOnMasterException;
 import org.neo4j.com.TxChecksumVerifier;
@@ -69,7 +70,10 @@ public class MasterServer extends Server<Master, Void>
     {
         try
         {
-            getRequestTarget().endLockSession( context, false );
+            try ( Response<Void> ignored = getRequestTarget().endLockSession( context, false ) )
+            {
+                // Lock session is closed
+            }
         }
         catch ( TransactionNotPresentOnMasterException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
@@ -157,9 +157,7 @@ public class CommitPusher extends LifecycleAdapter
                             try
                             {
                                 PullUpdateFuture pullUpdateFuture = currentPulls.get( 0 );
-                                Response<Void> response =
-                                        pullUpdateFuture.getSlave().pullUpdates( pullUpdateFuture.getTxId() );
-                                response.close();
+                                askSlaveToPullUpdates( pullUpdateFuture );
 
                                 // Notify the futures
                                 for ( PullUpdateFuture currentPull : currentPulls )
@@ -185,5 +183,15 @@ public class CommitPusher extends LifecycleAdapter
             } );
         }
         return queue;
+    }
+
+    private void askSlaveToPullUpdates( PullUpdateFuture pullUpdateFuture )
+    {
+        Slave slave = pullUpdateFuture.getSlave();
+        long lastTxId = pullUpdateFuture.getTxId();
+        try ( Response<Void> ignored = slave.pullUpdates( lastTxId ) )
+        {
+            // Slave will come back to me(master) and pull updates
+        }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/monitoring/EideticRequestMonitor.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/monitoring/EideticRequestMonitor.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.ha.monitoring;
 
-import java.util.Map;
+import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.RequestType;
 import org.neo4j.com.monitor.RequestMonitor;
 
 /**
@@ -30,11 +32,11 @@ import org.neo4j.com.monitor.RequestMonitor;
  */
 public class EideticRequestMonitor implements RequestMonitor
 {
-    private AtomicInteger startedRequests = new AtomicInteger( 0 );
-    private AtomicInteger endedRequests = new AtomicInteger( 0 );
+    private final AtomicInteger startedRequests = new AtomicInteger( 0 );
+    private final AtomicInteger endedRequests = new AtomicInteger( 0 );
 
     @Override
-    public void beginRequest( Map<String, String> requestContext )
+    public void beginRequest( SocketAddress remoteAddress, RequestType<?> requestType, RequestContext requestContext )
     {
         startedRequests.incrementAndGet();
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/AbstractTokenCreatorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/AbstractTokenCreatorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.neo4j.com.ResourceReleaser.NO_OP;
 
 public class AbstractTokenCreatorTest
 {
@@ -45,7 +46,7 @@ public class AbstractTokenCreatorTest
     private final RequestContext context = new RequestContext( 1, 2, 3, 4, 5 );
 
     private final String label = "A";
-    private final Response<Integer> response = new TransactionStreamResponse<>( 42, null, null, null );
+    private final Response<Integer> response = new TransactionStreamResponse<>( 42, null, null, NO_OP );
 
     private final AbstractTokenCreator creator = new AbstractTokenCreator( master, requestContextFactory )
     {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -321,10 +321,10 @@ public class HighAvailabilityModeSwitcherTest
             {
                 ScheduledExecutorService executor = mock( ScheduledExecutorService.class );
 
-                doAnswer( new Answer()
+                doAnswer( new Answer<Future<?>>()
                 {
                     @Override
-                    public Object answer( InvocationOnMock invocation ) throws Throwable
+                    public Future<?> answer( InvocationOnMock invocation ) throws Throwable
                     {
                         ((Runnable) invocation.getArguments()[0]).run();
                         modeSwitchHappened.countDown();


### PR DESCRIPTION
Request sending is simplified primarily by changing a fairly complex type signature `Triplet<Channel,ChannelBuffer,ByteBuffer>` to `ChannelContext` in `Client` class.
Removed creation of `HashMap` required by `RequestMonitor` for every request/response.

All `Response` objects are put in try-with-resources so that `ChannelContext`s are properly returned to the pool `Client.channelPool`.