### PR TITLE
Error in TaskExecutor surfaces when awaiting everything written

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SimplePool.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/SimplePool.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.util;
 
 import org.neo4j.collection.pool.Pool;
-import org.neo4j.function.Factory;
 
 /**
  * Just a little GC free pool with a fixed max size.
@@ -28,21 +27,16 @@ import org.neo4j.function.Factory;
  */
 public class SimplePool<T> implements Pool<T>
 {
-    private final Object[] items;
+    private final T[] items;
     private final boolean[] acquiredMarkers;
 
-    public SimplePool( int size, Factory<T> factory )
+    public SimplePool( T[] items )
     {
-        this.items = new Object[size];
-        for ( int i = 0; i < size; i++ )
-        {
-            items[i] = factory.newInstance();
-        }
-        this.acquiredMarkers = new boolean[size];
+        this.items = items;
+        this.acquiredMarkers = new boolean[items.length];
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public synchronized T acquire()
     {
         int availableItemIndex;
@@ -58,7 +52,7 @@ public class SimplePool<T> implements Pool<T>
             }
         }
         acquiredMarkers[availableItemIndex] = true;
-        return (T) items[availableItemIndex];
+        return items[availableItemIndex];
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Visitable;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.ReadOperations;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -56,7 +56,7 @@ public class DynamicTaskExecutor implements TaskExecutor
     @Override
     public synchronized void setNumberOfProcessors( int count )
     {
-        assertNotShutDown();
+        assertHealthy();
         assert count > 0;
         if ( count == processors.length )
         {
@@ -110,16 +110,17 @@ public class DynamicTaskExecutor implements TaskExecutor
     @Override
     public void submit( Callable<?> task )
     {
-        assertNotShutDown();
+        assertHealthy();
         while ( !queue.offer( task ) )
         {   // Then just stay here and try
             parkAWhile();
-            assertNotShutDown();
+            assertHealthy();
         }
         notifyProcessors();
     }
 
-    private void assertNotShutDown()
+    @Override
+    public void assertHealthy()
     {
         if ( shutDown )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
@@ -52,4 +52,13 @@ public interface TaskExecutor extends Parallelizable
      * executed and completed, before returning from this method.
      */
     void shutdown( boolean awaitAllCompleted );
+
+    /**
+     * Asserts that this {@link TaskExecutor} is healthy. Useful to call when deciding to wait on a condition
+     * this executor is expected to fulfill.
+     *
+     * @throws RuntimeException of some sort if this executor is in a bad stage, the original error that
+     * made this executor fail.
+     */
+    void assertHealthy();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoQueue.java
@@ -65,6 +65,7 @@ public class IoQueue implements WriterFactory
         long endTime = System.currentTimeMillis()+MINUTES.toMillis( 10 );
         while ( jobMonitor.hasActiveJobs() )
         {
+            executor.assertHealthy();
             try
             {
                 Thread.sleep( 10 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.util.dbstructure;
 import org.neo4j.helpers.collection.Visitable;
 import org.neo4j.kernel.impl.util.dbstructure.DbStructureVisitor;
 
-import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
 //

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/SimplePoolTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/SimplePoolTest.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.unsafe.impl.batchimport.store;
 
-import java.util.concurrent.Future;
-
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.helpers.Factory;
+import java.util.concurrent.Future;
+
 import org.neo4j.kernel.impl.util.SimplePool;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.OtherThreadRule;
@@ -38,22 +37,11 @@ public class SimplePoolTest
     @Rule
     public final OtherThreadRule<Void> t2 = new OtherThreadRule<>();
 
-    private final Factory<Item> ITEM_FACTORY = new Factory<Item>()
-    {
-        int itemIndex;
-
-        @Override
-        public Item newInstance()
-        {
-            return new Item( itemIndex++ );
-        }
-    };
-
     @Test
     public void shouldWaitForFreeItem() throws Exception
     {
         // GIVEN
-        final SimplePool<Item> pool = new SimplePool<>( 2, ITEM_FACTORY );
+        final SimplePool<Item> pool = new SimplePool<>( items( 2 ) );
 
         // WHEN/THEN
         Item first = pool.acquire();
@@ -78,7 +66,7 @@ public class SimplePoolTest
     public void shouldNotRelyOnAcquireReleaseOrdering()
     {
         // Given
-        SimplePool<Item> pool = new SimplePool<>( 2, ITEM_FACTORY );
+        SimplePool<Item> pool = new SimplePool<>( items( 2 ) );
 
         // When
         Item first = pool.acquire();
@@ -93,7 +81,7 @@ public class SimplePoolTest
     public void shouldThrowWhenNonPooledObjectIsReleased()
     {
         // Given
-        SimplePool<Item> pool = new SimplePool<>( 2, ITEM_FACTORY );
+        SimplePool<Item> pool = new SimplePool<>( items( 2 ) );
 
         // When/Then throw
         pool.release( new Item( 42 ) );
@@ -107,5 +95,15 @@ public class SimplePoolTest
         {
             this.id = id;
         }
+    }
+
+    private Item[] items( int length )
+    {
+        Item[] items = new Item[length];
+        for ( int i = 0; i < length; i++ )
+        {
+            items[i] = new Item( i );
+        }
+        return items;
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -29,8 +29,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.SearcherFactory;
-import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TermQuery;
 
 import java.io.File;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulatorTest.java
@@ -39,8 +39,6 @@ import java.util.Collections;
 
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.ReferenceManager;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.kernel.api.index.IndexDescriptor;


### PR DESCRIPTION
instead of just waiting for a condition that will never happen. The change
is that IoQueue#awaitEverythingWritten() checks inside the wait-loop that
the executor is healthy. If not then the internal error that made the
executor fail will be thrown and surfaced.

Root cause was OOM on really small heaps, much due to relationship store
page size in BatchingPageCache being so big. Limited it to max 10% of the
heap.