### PR TITLE
QuickImport utility

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/Distribution.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/Distribution.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import java.util.Random;
+
+/**
+ * Distributes the given items so that item[0] converges towards being returned 1/2 of the times,
+ * the next item, item[1] 1/4 of the times, item[2] 1/8 and so on.
+ */
+public class Distribution<T>
+{
+    private final T[] items;
+
+    public Distribution( T[] items )
+    {
+        this.items = items;
+    }
+
+    public T random( Random random )
+    {
+        float value = random.nextFloat();
+        float comparison = 0.5f;
+        for ( int i = 0; i < items.length; i++ )
+        {
+            if ( value >= comparison )
+            {
+                return items[i];
+            }
+            comparison /= 2f;
+        }
+        return items[items.length-1];
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import java.io.IOException;
+
+import org.neo4j.csv.reader.Extractors;
+import org.neo4j.helpers.Args;
+import org.neo4j.kernel.logging.SystemOutLogging;
+import org.neo4j.unsafe.impl.batchimport.BatchImporter;
+import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
+import org.neo4j.unsafe.impl.batchimport.input.Input;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header;
+import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
+
+import static org.neo4j.tooling.CsvDataGenerator.bareboneNodeHeader;
+import static org.neo4j.tooling.CsvDataGenerator.bareboneRelationshipHeader;
+import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
+import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors.defaultVisible;
+
+/**
+ * Uses all available shortcuts to as quickly as possible import as much data as possible. Usage of this
+ * utility is most likely just testing behavior of some components in the face of various dataset sizes,
+ * even quite big ones. Uses the import tool, or rather directly the {@link ParallelBatchImporter}.
+ *
+ * Quick comes from gaming terminology where you sometimes just want to play a quick game, without
+ * any settings or hazzle, just play.
+ *
+ * Uses {@link CsvDataGeneratorInput} as random data {@link Input}.
+ *
+ * For the time being the node/relationship data can't be controlled via command-line arguments,
+ * only through changing the code. The {@link CsvDataGeneratorInput} accepts two {@link Header headers}
+ * describing which sort of data it should generate.
+ */
+public class QuickImport
+{
+    public static void main( String[] arguments ) throws IOException
+    {
+        Args args = Args.parse( arguments );
+        long nodeCount = args.getNumber( "nodes", null ).longValue();
+        long relationshipCount = args.getNumber( "relationships", null ).longValue();
+        int labelCount = args.getNumber( "labels", 4 ).intValue();
+        int relationshipTypeCount = args.getNumber( "relationship-types", 4 ).intValue();
+        String dir = args.get( ImportTool.Options.STORE_DIR.key() );
+
+        Extractors extractors = new Extractors( COMMAS.arrayDelimiter() );
+        IdType idType = IdType.ACTUAL;
+        Input input = new CsvDataGeneratorInput(
+                bareboneNodeHeader( idType, extractors ), bareboneRelationshipHeader( idType, extractors ),
+                COMMAS, nodeCount, relationshipCount, new Groups(), idType, labelCount, relationshipTypeCount );
+        BatchImporter importer = new ParallelBatchImporter( dir, DEFAULT, new SystemOutLogging(), defaultVisible() );
+        importer.doImport( input );
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import java.util.Random;
+
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Deserialization;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
+
+import static java.lang.Math.abs;
+
+/**
+ * Generates random data based on a {@link Header} and some statistics, such as label/relationship type counts.
+ */
+public class RandomDataIterator<T> extends PrefetchingIterator<T> implements InputIterator<T>
+{
+    private final Header header;
+    private final long limit;
+    private final Random random;
+    private final Deserialization<T> deserialization;
+    private final long nodeCount;
+    private final Distribution<String> labels;
+    private final Distribution<String> relationshipTypes;
+
+    private long cursor;
+    private long position;
+
+    public RandomDataIterator( Header header, long limit, Random random,
+            Deserialization<T> deserialization, long nodeCount,
+            int labelCount, int relationshipTypeCount )
+    {
+        this.header = header;
+        this.limit = limit;
+        this.random = random;
+        this.deserialization = deserialization;
+        this.nodeCount = nodeCount;
+        this.labels = new Distribution<>( tokens( "Label", labelCount ) );
+        this.relationshipTypes = new Distribution<>( tokens( "TYPE", relationshipTypeCount ) );
+    }
+
+    private String[] tokens( String prefix, int count )
+    {
+        String[] result = new String[count];
+        for ( int i = 0; i < count; i++ )
+        {
+            result[i] = prefix + count;
+        }
+        return result;
+    }
+
+    @Override
+    protected T fetchNextOrNull()
+    {
+        if ( cursor < limit )
+        {
+            try
+            {
+                return generateDataLine();
+            }
+            finally
+            {
+                cursor++;
+            }
+        }
+        return null;
+    }
+
+    private T generateDataLine()
+    {
+        for ( Entry entry : header.entries() )
+        {
+            switch ( entry.type() )
+            {
+            case ID:
+                deserialization.handle( entry, idValue( entry, cursor ) );
+                break;
+            case PROPERTY:
+                deserialization.handle( entry, randomProperty( entry, random ) );
+                break;
+            case LABEL:
+                deserialization.handle( entry, randomLabels( random ) );
+                break;
+            case START_ID: case END_ID:
+                deserialization.handle( entry, idValue( entry, abs( random.nextLong() ) % nodeCount ) );
+                break;
+            case TYPE:
+                deserialization.handle( entry, randomRelationshipType( random ) );
+                break;
+            default:
+                throw new IllegalArgumentException( entry.toString() );
+            }
+        }
+        try
+        {
+            return deserialization.materialize();
+        }
+        finally
+        {
+            deserialization.clear();
+        }
+    }
+
+    private Object idValue( Entry entry, long id )
+    {
+        switch ( entry.extractor().toString() )
+        {
+        case "String": return "" + id;
+        case "long": return id;
+        default: throw new IllegalArgumentException( entry.toString() );
+        }
+    }
+
+    private String randomRelationshipType( Random random )
+    {
+        position += 6;
+        return relationshipTypes.random( random );
+    }
+
+    private Object randomProperty( Entry entry, Random random )
+    {
+        // TODO crude way of determining value type
+        String type = entry.extractor().toString();
+        if ( type.equals( "String" ) )
+        {
+            return randomString( random );
+        }
+        else if ( type.equals( "long" ) )
+        {
+            position += 8; // sort of
+            return random.nextInt( Integer.MAX_VALUE );
+        }
+        else if ( type.equals( "int" ) )
+        {
+            position += 4; // sort of
+            return random.nextInt( 20 );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "" + entry );
+        }
+    }
+
+    private String[] randomLabels( Random random )
+    {
+        int length = random.nextInt( 3 );
+        if ( length == 0 )
+        {
+            return InputEntity.NO_LABELS;
+        }
+
+        String[] result = new String[length];
+        for ( int i = 0; i < result.length; i++ )
+        {
+            result[i] = labels.random( random );
+        }
+        position += length * 6;
+        return result;
+    }
+
+    private String randomString( Random random )
+    {
+        char[] chars = new char[random.nextInt( 10 )+5];
+        for ( int i = 0; i < chars.length; i++ )
+        {
+            chars[i] = (char) ('a' + random.nextInt( 20 ));
+        }
+        position += chars.length;
+        return String.valueOf( chars );
+    }
+
+    @Override
+    public void close()
+    {   // Nothing to close
+    }
+
+    @Override
+    public long position()
+    {
+        return position;
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import java.lang.reflect.Array;
+
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Deserialization;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
+
+/**
+ * {@link Deserialization} that writes the values to a {@link StringBuilder}, suitable for piping the
+ * data straight down to a .csv file.
+ */
+class StringDeserialization implements Deserialization<String>
+{
+    private final StringBuilder builder = new StringBuilder();
+    private final Configuration config;
+
+    StringDeserialization( Configuration config )
+    {
+        this.config = config;
+    }
+
+    @Override
+    public void handle( Entry entry, Object value )
+    {
+        if ( builder.length() > 0 )
+        {
+            builder.append( config.delimiter() );
+        }
+        stringify( entry, value );
+    }
+
+    private void stringify( Entry entry, Object value )
+    {
+        if ( value instanceof String )
+        {
+            String string = (String) value;
+            boolean quote = string.indexOf( '.' ) != -1 || string.indexOf( config.quotationCharacter() ) != -1;
+            if ( quote )
+            {
+                builder.append( config.quotationCharacter() );
+            }
+            builder.append( string );
+            if ( quote )
+            {
+                builder.append( config.quotationCharacter() );
+            }
+        }
+        else if ( value.getClass().isArray() )
+        {
+            int length = Array.getLength( value );
+            builder.append( '[' );
+            for ( int i = 0; i < length; i++ )
+            {
+                Object item = Array.get( value, i );
+                if ( i > 0 )
+                {
+                    builder.append( config.arrayDelimiter() );
+                }
+                stringify( entry, item );
+            }
+            builder.append( ']' );
+        }
+        else if ( value instanceof Number )
+        {
+            Number number = (Number) value;
+            if ( value instanceof Float )
+            {
+                builder.append( number.floatValue() );
+            }
+            else if ( value instanceof Double )
+            {
+                builder.append( number.doubleValue() );
+            }
+            else
+            {
+                builder.append( number.longValue() );
+            }
+        }
+        else if ( value instanceof Boolean )
+        {
+            builder.append( ((Boolean) value ).booleanValue() );
+        }
+        else
+        {
+            throw new IllegalArgumentException( value.toString() + " " + value.getClass().getSimpleName() );
+        }
+    }
+
+    @Override
+    public String materialize()
+    {
+        return builder.toString();
+    }
+
+    @Override
+    public void clear()
+    {
+        builder.delete( 0, builder.length() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+/**
+ * Manages deserialization of one or more entry values, together forming some sort of entity.
+ * It has mutable state and the usage pattern should be:
+ *
+ * <ol>
+ * <li>One or more calls to {@link #handle(org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry, Object)}</li>
+ * <li>{@link #materialize()} to materialize the entity from the handled values</li>
+ * <li>{@link #clear()} to prepare for the next entity</li>
+ * </ol>
+ */
+public interface Deserialization<ENTITY>
+{
+    /**
+     * Handles one value of a type described by the {@code entry}. One or more values will be able to
+     * {@link #materialize()} into an entity later on.
+     */
+    void handle( Header.Entry entry, Object value );
+
+    /**
+     * Takes values received in {@link #handle(org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry, Object)}
+     * and materializes an entity from them.
+     */
+    ENTITY materialize();
+
+    /**
+     * Clears the mutable state, preparing for the next entity.
+     */
+    void clear();
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.function.Function;
 import org.neo4j.function.Functions;
+import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
@@ -48,7 +49,7 @@ import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
  */
 public class ExternalPropertiesDecorator implements Function<InputNode,InputNode>
 {
-    private final InputNodeDeserializer deserializer;
+    private final InputEntityDeserializer<InputNode> deserializer;
     private InputNode currentExternal;
     private final UpdateBehaviour updateBehaviour;
 
@@ -62,8 +63,9 @@ public class ExternalPropertiesDecorator implements Function<InputNode,InputNode
         this.updateBehaviour = updateBehaviour;
         CharSeeker dataStream = data.create( config ).stream();
         Header header = headerFactory.create( dataStream, config, idType );
-        this.deserializer = new InputNodeDeserializer( header, dataStream, config.delimiter(),
-                Functions.<InputNode>identity(), idType.idsAreExternal(), new Groups() );
+        this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
+                new InputNodeDeserialization( header, new Groups(), idType.idsAreExternal() ),
+                Functions.<InputNode>identity(), Validators.<InputNode>emptyValidator() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserialization.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import java.util.Arrays;
+
+import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
+
+/**
+ * Temporary data when building an {@link InputEntity}. Reusable for building multiple instances.
+ *
+ * @see InputEntity
+ */
+public abstract class InputEntityDeserialization<ENTITY extends InputEntity> implements Deserialization<ENTITY>
+{
+    private Object[] properties = new Object[10*2];
+    private int propertiesCursor;
+
+    public void addProperty( String name, Object value )
+    {
+        if ( value != null )
+        {
+            ensurePropertiesArrayCapacity( propertiesCursor+2 );
+            properties[propertiesCursor++] = name;
+            properties[propertiesCursor++] = value;
+        }
+        // else it's fine because no value was specified
+    }
+
+    protected Object[] properties()
+    {
+        return propertiesCursor > 0
+                ? Arrays.copyOf( properties, propertiesCursor )
+                : InputEntity.NO_PROPERTIES;
+    }
+
+    @Override
+    public void handle( Entry entry, Object value )
+    {
+        switch ( entry.type() )
+        {
+        case PROPERTY:
+            addProperty( entry.name(), value );
+            break;
+        case IGNORE: // value ignored
+            break;
+        default:
+            break;
+        }
+    }
+
+    private void ensurePropertiesArrayCapacity( int length )
+    {
+        if ( length > properties.length )
+        {
+            properties = Arrays.copyOf( properties, length );
+        }
+    }
+
+    @Override
+    public void clear()
+    {
+        propertiesCursor = 0;
+    }
+}


### PR DESCRIPTION
for just getting a dataset of size X imported as quickly as possible. Uses
CsvDataGenerator for generating very crude, random data of varying sizes.
Focuses on size more than layout of the data.

QuickImport uses CsvDataGenerator as Input to BatchImporter for
short-circuting the data generator and importer.

Made refactorings around InputEntityDeserializer (CharSeeker->InputEntity)
to allow for composition and reuse of code for this purpose.