### PR TITLE
Make ImpermanentGraphDatabase lighter in usage

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -172,7 +172,10 @@ import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
+import static org.neo4j.helpers.Settings.ANY;
 import static org.neo4j.helpers.Settings.STRING;
+import static org.neo4j.helpers.Settings.illegalValueMessage;
+import static org.neo4j.helpers.Settings.matches;
 import static org.neo4j.helpers.Settings.setting;
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 import static org.neo4j.kernel.extension.UnsatisfiedDependencyStrategies.fail;
@@ -471,7 +474,7 @@ public abstract class InternalAbstractGraphDatabase
         kernelEventHandlers = new KernelEventHandlers( logging.getMessagesLog( KernelEventHandlers.class ) );
 
         caches = createCaches();
-        diagnosticsManager = life.add( new DiagnosticsManager( logging.getMessagesLog( DiagnosticsManager.class ) ) );
+        diagnosticsManager = life.add( createDiagnosticsManager() );
         monitors.addMonitorListener( new RollingLogMonitor()
         {
             @Override
@@ -572,6 +575,11 @@ public abstract class InternalAbstractGraphDatabase
                 queryExecutor = QueryEngineProvider.noEngine();
             }
         } );
+    }
+
+    protected DiagnosticsManager createDiagnosticsManager()
+    {
+        return new DiagnosticsManager( logging.getMessagesLog( DiagnosticsManager.class ) );
     }
 
     protected UpgradeConfiguration createUpgradeConfiguration()
@@ -1301,6 +1309,9 @@ public abstract class InternalAbstractGraphDatabase
         public static final Setting<Boolean> execution_guard_enabled = GraphDatabaseSettings.execution_guard_enabled;
         public static final Setting<String> cache_type = GraphDatabaseSettings.cache_type;
         public static final Setting<Boolean> ephemeral = setting( "ephemeral", Settings.BOOLEAN, Settings.FALSE );
+        public static final Setting<String> ephemeral_keep_logical_logs = setting("keep_logical_logs", STRING, "1 files", illegalValueMessage( "must be `true`/`false` or of format '<number><optional unit> <type>' for example `100M size` for " +
+                            "limiting logical log space on disk to 100Mb," +
+                            " or `200k txs` for limiting the number of transactions to keep to 200 000", matches(ANY)));
         public static final Setting<File> store_dir = GraphDatabaseSettings.store_dir;
         public static final Setting<File> neo_store = GraphDatabaseSettings.neo_store;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -813,7 +813,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 new PhysicalLogFileInformation( logFiles, transactionMetadataCache, neoStore, logInformation );
 
         LogPruneStrategy logPruneStrategy = LogPruneStrategyFactory.fromConfigValue( fs, logFileInformation,
-                logFiles, neoStore, config.get( GraphDatabaseSettings.keep_logical_logs ) );
+                logFiles, neoStore, config.get( config.get(InternalAbstractGraphDatabase.Configuration.ephemeral) ? InternalAbstractGraphDatabase.Configuration.ephemeral_keep_logical_logs : GraphDatabaseSettings.keep_logical_logs ) );
 
         monitors.addMonitorListener( new LogPruning( logPruneStrategy, logging ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/DiagnosticsManager.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.info.DiagnosticsExtractor.VisitableDiagnostics;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
-public final class DiagnosticsManager implements Iterable<DiagnosticsProvider>, Lifecycle
+public class DiagnosticsManager implements Iterable<DiagnosticsProvider>, Lifecycle
 {
     private final List<DiagnosticsProvider> providers = new CopyOnWriteArrayList<DiagnosticsProvider>();
     private final StringLogger logger;

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.logging.SingleLoggingService;
 
@@ -149,6 +150,37 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
                 testThatDidNotCloseDb.printStackTrace();
             }
         }
+    }
+
+    @Override
+    protected DiagnosticsManager createDiagnosticsManager()
+    {
+        return new DiagnosticsManager( StringLogger.DEV_NULL )
+        {
+            @Override
+            public void init() throws Throwable
+            {
+                // Do nothing
+            }
+
+            @Override
+            public void start()
+            {
+                // Do nothing
+            }
+
+            @Override
+            public void stop() throws Throwable
+            {
+                // Do nothing
+            }
+
+            @Override
+            public void shutdown()
+            {
+                // Do nothing
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
Skip diagnostics output on start/stop
Always prune away log files.