### PR TITLE
Makes FlippableIndexProxy delegate volatile

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -45,10 +45,15 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernel
 
 public class FlippableIndexProxy implements IndexProxy
 {
-    private boolean closed;
+    private volatile boolean closed;
     private final ReadWriteLock lock = new ReentrantReadWriteLock( true );
-    private IndexProxyFactory flipTarget;
-    private IndexProxy delegate;
+    private volatile IndexProxyFactory flipTarget;
+    // This variable below is volatile because it can be changed in flip or flipTo
+    // and even though it may look like acquiring the read lock, when using this variable
+    // for various things, execution flow would go through a memory barrier of some sort.
+    // But it turns out that that may not be the case. F.ex. ReentrantReadWriteLock
+    // code uses unsafe compareAndSwap that sort of circumvents an equivalent of a volatile read.
+    private volatile IndexProxy delegate;
 
     public FlippableIndexProxy()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/DefaultGraphDatabaseDependenciesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DefaultGraphDatabaseDependenciesTest.java
@@ -23,7 +23,6 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.BufferingLogging;

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
@@ -21,7 +21,6 @@ package org.neo4j.test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
 import org.neo4j.kernel.impl.nioneo.store.FileSystemAbstraction;
-import org.neo4j.kernel.monitoring.Monitors;
 
 public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
 {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.PrefetchingIterator;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.util.Version;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
@@ -26,7 +26,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -23,14 +23,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.neo4j.graphdb.ConstraintViolationException;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.DynamicLabel;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -39,19 +33,9 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProviderFactory;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.api.index.util.FailureStorage;
-import org.neo4j.kernel.impl.api.index.IndexingService;
-import org.neo4j.kernel.impl.nioneo.xa.NeoStoreProvider;
-import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.test.impl.EphemeralFileSystemAbstraction;
-import org.neo4j.tooling.GlobalGraphOperations;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ConstraintCreationIT


### PR DESCRIPTION
to fix a race condition where a constraint index was flipped to f.ex
an OnlineIndexProxy and right after that another thread comes in and f.ex
tries to set a node property. Then it may see it in SchemaCache, otherwise
load from disk and then assert that the state is ONLINE. At this point the
thread setting the node property might still see the old reference to the
populating index proxy, so the state will be POPULATING and the lookup
will fail.