### PR TITLE
Some parallelism in node counts import stage

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -22,8 +22,7 @@ package org.neo4j.kernel.impl.store;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
-import org.neo4j.unsafe.impl.batchimport.NodeCountsProcessor;
-import org.neo4j.unsafe.impl.batchimport.NodeStoreProcessorStage;
+import org.neo4j.unsafe.impl.batchimport.NodeCountsStage;
 import org.neo4j.unsafe.impl.batchimport.RelationshipCountsStage;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
@@ -72,9 +71,8 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
         try
         {
             // Count nodes
-            superviseDynamicExecution( new NodeStoreProcessorStage( "COUNT NODES", Configuration.DEFAULT, nodes,
-                                                                    new NodeCountsProcessor( nodes, cache, highLabelId,
-                                                                                             countsUpdater ) ) );
+            superviseDynamicExecution( new NodeCountsStage( Configuration.DEFAULT, cache, nodes,
+                                                            highLabelId, countsUpdater ) );
             // Count relationships
             superviseDynamicExecution( new RelationshipCountsStage( Configuration.DEFAULT, cache, relationships,
                                                                     highLabelId, highRelationshipTypeId,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -175,12 +175,6 @@ public class DynamicNodeLabels implements NodeLabels
         return firstDynamicLabelRecordId( labelField );
     }
 
-    @Override
-    public void ensureHeavy( NodeStore nodeStore )
-    {
-        nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( labelField ) );
-    }
-
     public static long dynamicPointer( Collection<DynamicRecord> newRecords )
     {
         return 0x8000000000L | first( newRecords ).getId();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
@@ -102,12 +102,6 @@ public class InlineNodeLabels implements NodeLabels
         return Collections.emptyList();
     }
 
-    @Override
-    public void ensureHeavy( NodeStore nodeStore )
-    {
-        // no dynamic records
-    }
-
     static boolean tryInlineInNodeRecord( NodeRecord node, long[] ids, Collection<DynamicRecord> changedDynamicRecords )
     {
         // We reserve the high header bit for future extensions of the format of the in-lined label bits

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabels.java
@@ -35,7 +35,5 @@ public interface NodeLabels
 
     Collection<DynamicRecord> remove( long labelId, NodeStore nodeStore );
 
-    void ensureHeavy( NodeStore nodeStore );
-
     boolean isInlined();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -46,7 +46,6 @@ import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_READ_AHEAD;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.kernel.impl.store.AbstractDynamicStore.readFullByteArrayFromHeavyRecords;
-import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 
 /**
  * Implementation of the node store.
@@ -122,7 +121,10 @@ public class NodeStore extends AbstractRecordStore<NodeRecord> implements Store
 
     public void ensureHeavy( NodeRecord node )
     {
-        parseLabelsField( node ).ensureHeavy( this );
+        if ( NodeLabelsField.fieldPointsToDynamicRecordOfLabels( node.getLabelField() ) )
+        {
+            ensureHeavy( node, NodeLabelsField.firstDynamicLabelRecordId( node.getLabelField() ) );
+        }
     }
 
     public void ensureHeavy( NodeRecord node, long firstDynamicLabelRecord )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.api.CountsAccessor;
+import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
@@ -28,15 +29,14 @@ import org.neo4j.unsafe.impl.batchimport.staging.Stage;
  * Reads all records from {@link RelationshipStore} and process the counts in them. Uses a {@link NodeLabelsCache}
  * previously populated by f.ex {@link ProcessNodeCountsDataStep}.
  */
-public class RelationshipCountsStage extends Stage
+public class NodeCountsStage extends Stage
 {
-    public RelationshipCountsStage( Configuration config, NodeLabelsCache cache, RelationshipStore relationshipStore,
-            int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater )
+    public NodeCountsStage( Configuration config, NodeLabelsCache cache, NodeStore nodeStore,
+            int highLabelId, CountsAccessor.Updater countsUpdater )
     {
-        super( "Relationship counts", config, false );
-        add( new ReadRelationshipCountsDataStep( control(), config.batchSize(), config.movingAverageSize(),
-                relationshipStore ) );
-        add( new ProcessRelationshipCountsDataStep( control(), cache, config.workAheadSize(),
-                config.movingAverageSize(), highLabelId, highRelationshipTypeId, countsUpdater ) );
+        super( "Node counts", config, false );
+        add( new ReadNodeCountsDataStep( control(), config.batchSize(), config.movingAverageSize(), nodeStore ) );
+        add( new ProcessNodeCountsDataStep( control(), cache, config.workAheadSize(),
+                config.movingAverageSize(), nodeStore, highLabelId, countsUpdater ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessNodeCountsDataStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessNodeCountsDataStep.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.api.CountsAccessor;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.counts.CountsTracker;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutorServiceStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * Processes node count data received from {@link ReadNodeCountsDataStep} and stores the accumulated counts
+ * into {@link CountsTracker}.
+ */
+public class ProcessNodeCountsDataStep extends ExecutorServiceStep<NodeRecord[]>
+{
+    private final NodeCountsProcessor processor;
+
+    protected ProcessNodeCountsDataStep( StageControl control, NodeLabelsCache cache,
+            int workAheadSize, int movingAverageSize, NodeStore nodeStore,
+            int highLabelId, CountsAccessor.Updater countsUpdater )
+    {
+        super( control, "COUNT", workAheadSize, movingAverageSize, 1 );
+        this.processor = new NodeCountsProcessor( nodeStore, cache, highLabelId, countsUpdater );
+    }
+
+    @Override
+    protected Object process( long ticket, NodeRecord[] batch )
+    {
+        for ( NodeRecord node : batch )
+        {
+            if ( node != null )
+            {
+                processor.process( node );
+            }
+        }
+        return null; // end of line
+    }
+
+    @Override
+    protected void done()
+    {
+        processor.done();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeCountsDataStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeCountsDataStep.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.IoProducerStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static java.lang.Math.min;
+
+/**
+ * Reads from {@link NodeStore} and produces batches of {@link NodeRecord} for others to process.
+ *
+ * Future: Would be quite efficient just get a page cursor and read inUse+labelField and store
+ * all labelField values of a batch in one long[] or similar, instead of passing on a NodeRecord[].
+ */
+public class ReadNodeCountsDataStep extends IoProducerStep<NodeRecord[]>
+{
+    private final NodeStore nodeStore;
+    private final long highId;
+    private long id;
+
+    public ReadNodeCountsDataStep( StageControl control, int batchSize, int movingAverageSize, NodeStore nodeStore )
+    {
+        super( control, batchSize, movingAverageSize );
+        this.nodeStore = nodeStore;
+        this.highId = nodeStore.getHighId();
+    }
+
+    @Override
+    protected Object nextBatchOrNull( int batchSize )
+    {
+        int size = (int) min( batchSize, highId-id );
+        NodeRecord[] batch = new NodeRecord[size];
+        for ( int i = 0; i < size; i++ )
+        {
+            // Passing in null creates a new record if it's in use. Returning null is fine since our processor,
+            // i.e. consumer of these batches, will filter those out.
+            batch[i] = nodeStore.loadRecord( id++, null );
+        }
+        return size > 0 ? batch : null;
+    }
+
+    @Override
+    protected long position()
+    {
+        return id * NodeStore.RECORD_SIZE;
+    }
+}


### PR DESCRIPTION
Label decoding + counting happens separately from reading. Even though
reading dwarfs counting in comparison there's still perhaps a 10-20% gain
to be had here.