### PR TITLE
CC: Introduce checkGraph config.

### DIFF
--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
@@ -55,7 +55,10 @@ public class ConsistencyCheckSettings
             "checking the native stores, so it may be useful to turn off this check for very large databases.")
     public static final Setting<Boolean> consistency_check_indexes = setting( "consistency_check_indexes", BOOLEAN, TRUE );
 
-    @Description("Window pool implementation to be used when running consistency check")
+    @Description("Perform checks between nodes, relationships, properties, types and tokens.")
+    public static final Setting<Boolean> consistency_check_graph = setting( "consistency_check_graph", BOOLEAN, TRUE );
+
+    @Description("Execution order of the individual consistency checking tasks. ")
     public static final Setting<TaskExecutionOrder> consistency_check_execution_order =
             setting( "consistency_check_execution_order", options( TaskExecutionOrder.class ), TaskExecutionOrder.MULTI_PASS.name() );
 

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -63,22 +63,25 @@ public class ConsistencyCheckTasks
     public List<StoppableRunnable> createTasks(
             StoreAccess nativeStores, LabelScanStore labelScanStore, IndexAccessors indexes,
             MultiPassStore.Factory multiPass, ConsistencyReporter reporter,
-            boolean checkLabelScanStore, boolean checkIndexes )
+            boolean checkLabelScanStore, boolean checkIndexes, boolean checkGraph )
     {
         List<StoppableRunnable> tasks = new ArrayList<>();
 
-        tasks.add( create( nativeStores.getNodeStore(),
-                multiPass.processors( PROPERTIES, RELATIONSHIPS ) ) );
+        if ( checkGraph )
+        {
+            tasks.add( create( nativeStores.getNodeStore(),
+                    multiPass.processors( PROPERTIES, RELATIONSHIPS ) ) );
 
-        tasks.add( create( nativeStores.getRelationshipStore(),
-                multiPass.processors(  NODES, PROPERTIES, RELATIONSHIPS  ) ) );
+            tasks.add( create( nativeStores.getRelationshipStore(),
+                    multiPass.processors( NODES, PROPERTIES, RELATIONSHIPS ) ) );
 
-        tasks.add( create( nativeStores.getPropertyStore(),
-                multiPass.processors(  PROPERTIES, STRINGS, ARRAYS  ) ) );
+            tasks.add( create( nativeStores.getPropertyStore(),
+                    multiPass.processors( PROPERTIES, STRINGS, ARRAYS ) ) );
 
-        tasks.add( create( nativeStores.getStringStore(), multiPass.processors( STRINGS ) ) );
+            tasks.add( create( nativeStores.getStringStore(), multiPass.processors( STRINGS ) ) );
 
-        tasks.add( create( nativeStores.getArrayStore(), multiPass.processors( ARRAYS ) ) );
+            tasks.add( create( nativeStores.getArrayStore(), multiPass.processors( ARRAYS ) ) );
+        }
 
         // The schema store is verified in multiple passes that share state since it fits into memory
         // and we care about the consistency of back references (cf. SemanticCheck)
@@ -97,13 +100,16 @@ public class ConsistencyCheckTasks
                 nativeStores.getSchemaStore(), "check_obligations", schemaCheck.forObligationChecking(), progress, order,
                 processor, processor ) );
 
-        tasks.add( create( nativeStores.getRelationshipTypeTokenStore() ) );
-        tasks.add( create( nativeStores.getPropertyKeyTokenStore() ) );
-        tasks.add( create( nativeStores.getLabelTokenStore() ) );
-        tasks.add( create( nativeStores.getRelationshipTypeNameStore() ) );
-        tasks.add( create( nativeStores.getPropertyKeyNameStore() ) );
-        tasks.add( create( nativeStores.getLabelNameStore() ) );
-        tasks.add( create( nativeStores.getNodeDynamicLabelStore() ) );
+        if ( checkGraph )
+        {
+            tasks.add( create( nativeStores.getRelationshipTypeTokenStore() ) );
+            tasks.add( create( nativeStores.getPropertyKeyTokenStore() ) );
+            tasks.add( create( nativeStores.getLabelTokenStore() ) );
+            tasks.add( create( nativeStores.getRelationshipTypeNameStore() ) );
+            tasks.add( create( nativeStores.getPropertyKeyNameStore() ) );
+            tasks.add( create( nativeStores.getLabelNameStore() ) );
+            tasks.add( create( nativeStores.getNodeDynamicLabelStore() ) );
+        }
 
         if ( checkLabelScanStore )
         {

--- a/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/enterprise/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -52,12 +52,14 @@ public class FullCheck
     private final TaskExecutionOrder order;
     private final ProgressMonitorFactory progressFactory;
     private final Long totalMappedMemory;
+    private final boolean checkGraph;
 
     public FullCheck( Config tuningConfiguration, ProgressMonitorFactory progressFactory )
     {
         this.checkPropertyOwners = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_property_owners );
         this.checkLabelScanStore = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_label_scan_store );
         this.checkIndexes = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_indexes );
+        this.checkGraph = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_graph );
         this.order = tuningConfiguration.get( ConsistencyCheckSettings.consistency_check_execution_order );
         this.totalMappedMemory = tuningConfiguration.get( GraphDatabaseSettings.all_stores_total_mapped_memory_size );
         this.progressFactory = progressFactory;
@@ -101,7 +103,8 @@ public class FullCheck
                     multiPass,
                     reporter,
                     checkLabelScanStore,
-                    checkIndexes
+                    checkIndexes,
+                    checkGraph
             );
 
             order.execute( tasks, progress.build() );


### PR DESCRIPTION
It defaults to enabled, but allows turning off consistency checks between nodes,
properties, relationships, types and tokens. Useful when for example only
schema consistency is interesting.