### PR TITLE
Use commands for all counts updates

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -36,20 +36,21 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.KernelHealth;
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.direct.DirectStoreAccess;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.impl.index.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProvider;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.NodeLabelsField;
+import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.StoreAccess;
-import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NeoStoreRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -118,13 +119,10 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
         protected abstract void transactionData( TransactionDataBuilder tx, IdGenerator next );
 
         public TransactionRepresentation representation( IdGenerator idGenerator, int masterId, int authorId,
-                                                         long lastCommittedTx, CountsTracker counts )
+                                                         long lastCommittedTx, NodeStore nodes )
         {
             TransactionWriter writer = new TransactionWriter();
-            try ( CountsAccessor.Updater updater = counts.apply( lastCommittedTx + 1 ).get() )
-            {
-                transactionData( new TransactionDataBuilder( writer, updater ), idGenerator );
-            }
+            transactionData( new TransactionDataBuilder( writer, nodes ), idGenerator );
             return writer.representation( new byte[0], masterId, authorId, startTimestamp, lastCommittedTx,
                    currentTimeMillis() );
         }
@@ -196,12 +194,12 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
     public static final class TransactionDataBuilder
     {
         private final TransactionWriter writer;
-        private final CountsAccessor.Updater counts;
+        private final NodeStore nodes;
 
-        public TransactionDataBuilder( TransactionWriter writer, CountsAccessor.Updater counts )
+        public TransactionDataBuilder( TransactionWriter writer, NodeStore nodes )
         {
             this.writer = writer;
-            this.counts = counts;
+            this.nodes = nodes;
         }
 
         public void createSchema( Collection<DynamicRecord> beforeRecords, Collection<DynamicRecord> afterRecords,
@@ -215,22 +213,17 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
 
         public void propertyKey( int id, String key )
         {
-            writer.propertyKey( id, key, id+1 );
+            writer.propertyKey( id, key, id + 1 );
         }
 
         public void nodeLabel( int id, String name )
         {
-            writer.label( id, name, id+1 );
+            writer.label( id, name, id + 1 );
         }
 
         public void relationshipType( int id, String relationshipType )
         {
-            writer.relationshipType( id, relationshipType, id+1 );
-        }
-
-        public void create( NodeRecord node )
-        {
-            writer.create( node );
+            writer.relationshipType( id, relationshipType, id + 1 );
         }
 
         public void update( NeoStoreRecord record )
@@ -238,13 +231,22 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
             writer.update( record );
         }
 
+        public void create( NodeRecord node )
+        {
+            updateCounts( node, 1 );
+            writer.create( node );
+        }
+
         public void update( NodeRecord before, NodeRecord after )
         {
+            updateCounts( before, -1 );
+            updateCounts( after, 1 );
             writer.update( before, after );
         }
 
         public void delete( NodeRecord node )
         {
+            updateCounts( node, -1 );
             writer.delete( node );
         }
 
@@ -293,14 +295,23 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
             writer.delete( before, property );
         }
 
+        private void updateCounts( NodeRecord node, int delta )
+        {
+            writer.incrementNodeCount( ReadOperations.ANY_LABEL, delta );
+            for ( long label : NodeLabelsField.parseLabelsField( node ).get( nodes ) )
+            {
+                writer.incrementNodeCount( (int)label, delta );
+            }
+        }
+
         public void incrementNodeCount( int labelId, long delta )
         {
-            counts.incrementNodeCount( labelId, delta );
+            writer.incrementNodeCount( labelId, delta );
         }
 
         public void incrementRelationshipCount( int startLabelId, int typeId, int endLabelId, long delta )
         {
-            counts.incrementRelationshipCount( startLabelId, typeId, endLabelId, delta );
+            writer.incrementRelationshipCount( startLabelId, typeId, endLabelId, delta );
         }
     }
 
@@ -350,9 +361,9 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
                             TransactionApplicationMode.EXTERNAL );
             TransactionIdStore transactionIdStore = database.getDependencyResolver().resolveDependency(
                     TransactionIdStore.class );
-            CountsTracker counts = database.getDependencyResolver().resolveDependency( NeoStore.class ).getCounts();
+            NodeStore nodes = database.getDependencyResolver().resolveDependency( NeoStore.class ).getNodeStore();
             commitProcess.commit( transaction.representation( idGenerator(), masterId(), myId(),
-                    transactionIdStore.getLastCommittedTransactionId(), counts ), locks,
+                    transactionIdStore.getLastCommittedTransactionId(), nodes ), locks,
                     CommitEvent.NULL );
         }
         finally

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/TransactionWriter.java
@@ -284,6 +284,16 @@ public class TransactionWriter
         addCommand( command );
     }
 
+    public void incrementNodeCount( int labelId, long delta )
+    {
+        addCommand( new Command.NodeCountsCommand().init( labelId, delta ) );
+    }
+
+    public void incrementRelationshipCount( int startLabelId, int typeId, int endLabelId, long delta )
+    {
+        addCommand( new Command.RelationshipCountsCommand().init( startLabelId, typeId, endLabelId, delta ) );
+    }
+
     private static <T extends TokenRecord> T withName( T record, int[] dynamicIds, String name )
     {
         if ( dynamicIds == null || dynamicIds.length == 0 )

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.consistency.checking.full;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.model.Statement;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -40,6 +29,17 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.model.Statement;
 
 import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.GraphStoreFixture;
@@ -89,8 +89,10 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.consistency.checking.RecordCheckTestBase.inUse;
 import static org.neo4j.consistency.checking.RecordCheckTestBase.notInUse;
 import static org.neo4j.consistency.checking.full.ExecutionOrderIntegrationTest.config;
@@ -100,6 +102,8 @@ import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
+import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 import static org.neo4j.kernel.impl.store.AbstractDynamicStore.readFullByteArrayFromHeavyRecords;
 import static org.neo4j.kernel.impl.store.DynamicArrayStore.allocateFromNumbers;
@@ -677,7 +681,7 @@ public class FullCheckIntegrationTest
 
         // then
         on( stats ).verify( RecordType.RELATIONSHIP, 2 )
-                   .verify( RecordType.COUNTS, 1 )
+                   .verify( RecordType.COUNTS, 3 )
                    .andThatsAllFolks();
     }
 
@@ -1182,6 +1186,8 @@ public class FullCheckIntegrationTest
                 tx.create( withNext( inUse( new RelationshipRecord( relA, otherNode, otherNode, typeId ) ), relB ) );
                 tx.create( withPrev( inUse( new RelationshipRecord( relB, otherNode, otherNode, typeId ) ), relA ) );
                 tx.create( withOwner( withRelationships( inUse( new RelationshipGroupRecord( group, typeId ) ), relB, relB, relB ), node ) );
+                tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 2 );
+                tx.incrementRelationshipCount( ANY_LABEL, typeId, ANY_LABEL, 2 );
             }
         } );
 
@@ -1356,6 +1362,8 @@ public class FullCheckIntegrationTest
                 tx.create( new RelationshipRecord( rel, otherNode, otherNode, typeB ) );
                 tx.create( withOwner( withRelationships( new RelationshipGroupRecord( group, typeA ),
                         rel, rel, rel ), node ) );
+                tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
+                tx.incrementRelationshipCount( ANY_LABEL, typeB, ANY_LABEL, 1 );
             }
         } );
 
@@ -1396,6 +1404,8 @@ public class FullCheckIntegrationTest
                 tx.create( new NodeRecord( nodeA, true, groupA, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( new NodeRecord( nodeB, false, rel, NO_NEXT_PROPERTY.intValue() ) );
                 tx.create( firstInChains( new RelationshipRecord( rel, nodeA, nodeB, typeA ), 1 ) );
+                tx.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
+                tx.incrementRelationshipCount( ANY_LABEL, typeA, ANY_LABEL, 1 );
 
                 tx.create( withOwner( withRelationship( withNext( new RelationshipGroupRecord( groupA, typeA ), groupB ),
                         Direction.OUTGOING, rel ), nodeA ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
@@ -32,9 +32,11 @@ import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NeoStoreCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyKeyTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipGroupCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipTypeTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.SchemaRuleCommand;
@@ -292,12 +294,26 @@ public class CommandApplierFacade implements NeoCommandHandler, Visitor<Command,
     }
 
     @Override
-    public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+    public boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException
     {
         boolean result = false;
         for ( NeoCommandHandler handler : handlers )
         {
-            if ( handler.visitUpdateCountsCommand( command ) )
+            if ( handler.visitNodeCountsCommand( command ) )
+            {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
+    {
+        boolean result = false;
+        for ( NeoCommandHandler handler : handlers )
+        {
+            if ( handler.visitRelationshipCountsCommand( command ) )
             {
                 result = true;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -78,7 +78,10 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
     @Override
     public void incrementRelationshipCount( int startLabelId, int typeId, int endLabelId, long delta )
     {
-        counts( relationshipKey( startLabelId, typeId, endLabelId ) ).increment( 0l, delta );
+        if ( delta != 0 )
+        {
+            counts( relationshipKey( startLabelId, typeId, endLabelId ) ).increment( 0l, delta );
+        }
     }
 
     @Override
@@ -283,11 +286,20 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
         }
 
         @Override
+        public void visitNodeCount( int labelId, long count )
+        {
+            if ( count != 0 )
+            {   // Only add commands for counts that actually change
+                commands.add( new Command.NodeCountsCommand().init( labelId, count ) );
+            }
+        }
+
+        @Override
         public void visitRelationshipCount( int startLabelId, int typeId, int endLabelId, long count )
         {
             if ( count != 0 )
             {   // Only add commands for counts that actually change
-                commands.add( new Command.CountsCommand().init( startLabelId, typeId, endLabelId, count ) );
+                commands.add( new Command.RelationshipCountsCommand().init( startLabelId, typeId, endLabelId, count ) );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -596,7 +596,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
 
     private class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
     {
-        private final RelationshipDataExtractor relationshipData = new RelationshipDataExtractor();
+        private final RelationshipDataExtractor edge = new RelationshipDataExtractor();
         private boolean clearState;
 
         void done()
@@ -618,6 +618,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         public void visitCreatedNode( long id )
         {
             recordState.nodeCreate( id );
+            counts.incrementNodeCount( ANY_LABEL, 1 );
         }
 
         @Override
@@ -625,10 +626,15 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             try
             {
+                counts.incrementNodeCount( ANY_LABEL, -1 );
                 PrimitiveIntIterator labels = storeLayer.nodeGetLabels( id );
                 if ( labels.hasNext() )
                 {
                     final int[] removed = PrimitiveIntCollections.asArray( labels );
+                    for ( int label : removed )
+                    {
+                        counts.incrementNodeCount( label, -1 );
+                    }
                     storeLayer.nodeVisitDegrees( id, new DegreeVisitor()
                     {
                         @Override
@@ -636,12 +642,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                         {
                             for ( int label : removed )
                             {
-                                // untyped
-                                counts.incrementRelationshipCount( label, -1, -1, -outgoing );
-                                counts.incrementRelationshipCount( -1, -1, label, -incoming );
-                                // typed
-                                counts.incrementRelationshipCount( label, type, -1, -outgoing );
-                                counts.incrementRelationshipCount( -1, type, label, -incoming );
+                                updateRelationshipsCountsFromDegrees( type, label, -outgoing, -incoming );
                             }
                         }
                     } );
@@ -659,19 +660,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             try
             {
-                // update counts
-                for ( PrimitiveIntIterator labels = labelsOf( startNode ); labels.hasNext(); )
-                {
-                    int label = labels.next();
-                    counts.incrementRelationshipCount( label, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
-                    counts.incrementRelationshipCount( label, type, ANY_LABEL, 1 );
-                }
-                for ( PrimitiveIntIterator labels = labelsOf( endNode ); labels.hasNext(); )
-                {
-                    int label = labels.next();
-                    counts.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, label, 1 );
-                    counts.incrementRelationshipCount( ANY_LABEL, type, label, 1 );
-                }
+                updateRelationshipCount( startNode, type, endNode, 1 );
             }
             catch ( EntityNotFoundException e )
             {
@@ -687,20 +676,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             try
             {
-                // update counts
-                storeLayer.relationshipVisit( id, relationshipData );
-                for ( PrimitiveIntIterator labels = labelsOf( relationshipData.startNode() ); labels.hasNext(); )
-                {
-                    int label = labels.next();
-                    counts.incrementRelationshipCount( label, ANY_RELATIONSHIP_TYPE, ANY_LABEL, -1 );
-                    counts.incrementRelationshipCount( label, relationshipData.type(), ANY_LABEL, -1 );
-                }
-                for ( PrimitiveIntIterator labels = labelsOf( relationshipData.endNode() ); labels.hasNext(); )
-                {
-                    int label = labels.next();
-                    counts.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, label, -1 );
-                    counts.incrementRelationshipCount( ANY_LABEL, relationshipData.type(), label, -1 );
-                }
+                storeLayer.relationshipVisit( id, edge );
+                updateRelationshipCount( edge.startNode(), edge.type(), edge.endNode(), -1 );
             }
             catch ( EntityNotFoundException e )
             {
@@ -710,11 +687,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
 
             // record the state changes to be made to the store
             recordState.relDelete( id );
-        }
-
-        private PrimitiveIntIterator labelsOf( long nodeId ) throws EntityNotFoundException
-        {
-            return StateHandlingStatementOperations.nodeGetLabels( storeLayer, txState, nodeId );
         }
 
         @Override
@@ -783,6 +755,14 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             // update counts
             if ( !(added.isEmpty() && removed.isEmpty()) )
             {
+                for ( Integer label : added )
+                {
+                    counts.incrementNodeCount( label, 1 );
+                }
+                for ( Integer label : removed )
+                {
+                    counts.incrementNodeCount( label, -1 );
+                }
                 // get the relationship counts from *before* this transaction,
                 // the relationship changes will compensate for what happens during the transaction
                 storeLayer.nodeVisitDegrees( id, new DegreeVisitor()
@@ -792,21 +772,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                     {
                         for ( Integer label : added )
                         {
-                            // untyped
-                            counts.incrementRelationshipCount( label, -1, -1, outgoing );
-                            counts.incrementRelationshipCount( -1, -1, label, incoming );
-                            // typed
-                            counts.incrementRelationshipCount( label, type, -1, outgoing );
-                            counts.incrementRelationshipCount( -1, type, label, incoming );
+                            updateRelationshipsCountsFromDegrees( type, label, outgoing, incoming );
                         }
                         for ( Integer label : removed )
                         {
-                            // untyped
-                            counts.incrementRelationshipCount( label, -1, -1, -outgoing );
-                            counts.incrementRelationshipCount( -1, -1, label, -incoming );
-                            // typed
-                            counts.incrementRelationshipCount( label, type, -1, -outgoing );
-                            counts.incrementRelationshipCount( -1, type, label, -incoming );
+                            updateRelationshipsCountsFromDegrees( type, label, -outgoing, -incoming );
                         }
                     }
                 } );
@@ -917,5 +887,34 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             legacyIndexTransactionState.createIndex( IndexEntityType.Relationship, name, config );
         }
+    }
+
+    private void updateRelationshipsCountsFromDegrees( int type, int label, int outgoing, int incoming )
+    {
+        // untyped
+        counts.incrementRelationshipCount( label, ANY_RELATIONSHIP_TYPE, ANY_LABEL, outgoing );
+        counts.incrementRelationshipCount( ANY_LABEL, ANY_RELATIONSHIP_TYPE, label, incoming );
+        // typed
+        counts.incrementRelationshipCount( label, type, ANY_LABEL, outgoing );
+        counts.incrementRelationshipCount( ANY_LABEL, type, label, incoming );
+    }
+
+    private void updateRelationshipCount( long startNode, int type, long endNode, int delta )
+            throws EntityNotFoundException
+    {
+        updateRelationshipsCountsFromDegrees( type, ANY_LABEL, delta, 0 );
+        for ( PrimitiveIntIterator startLabels = labelsOf( startNode ); startLabels.hasNext(); )
+        {
+            updateRelationshipsCountsFromDegrees( type, startLabels.next(), delta, 0 );
+        }
+        for ( PrimitiveIntIterator endLabels = labelsOf( endNode ); endLabels.hasNext(); )
+        {
+            updateRelationshipsCountsFromDegrees( type, endLabels.next(), 0, delta );
+        }
+    }
+
+    private PrimitiveIntIterator labelsOf( long nodeId ) throws EntityNotFoundException
+    {
+        return StateHandlingStatementOperations.nodeGetLabels( storeLayer, txState, nodeId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
@@ -40,7 +40,8 @@ import org.neo4j.kernel.impl.store.record.Abstract64BitRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.TokenRecord;
-import org.neo4j.kernel.impl.transaction.command.Command.CountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NeoStoreCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
@@ -186,9 +187,15 @@ public class HighIdTransactionApplier implements NeoCommandHandler
     }
 
     @Override
-    public boolean visitUpdateCountsCommand( CountsCommand command ) throws IOException
+    public boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException
     {
-        return delegate.visitUpdateCountsCommand( command );
+        return delegate.visitNodeCountsCommand( command );
+    }
+
+    @Override
+    public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
+    {
+        return delegate.visitRelationshipCountsCommand( command );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandHandler.java
@@ -31,9 +31,11 @@ import org.neo4j.kernel.impl.index.IndexDefineCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NeoStoreCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyKeyTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipGroupCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipTypeTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.SchemaRuleCommand;
@@ -90,7 +92,9 @@ public interface NeoCommandHandler extends AutoCloseable
 
     boolean visitIndexDefineCommand( IndexDefineCommand command ) throws IOException;
 
-    boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException;
+    boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException;
+
+    boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException;
 
     /**
      * Applies pending changes that might have been accumulated when visiting the commands.
@@ -198,7 +202,13 @@ public interface NeoCommandHandler extends AutoCloseable
         }
 
         @Override
-        public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+        public boolean visitNodeCountsCommand( NodeCountsCommand command )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
         {
             return false;
         }
@@ -314,9 +324,15 @@ public interface NeoCommandHandler extends AutoCloseable
         }
 
         @Override
-        public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+        public boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException
         {
-            return delegate.visitUpdateCountsCommand( command );
+            return delegate.visitNodeCountsCommand( command );
+        }
+
+        @Override
+        public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
+        {
+            return delegate.visitRelationshipCountsCommand( command );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandType.java
@@ -42,5 +42,6 @@ public interface NeoCommandType
     public static final byte INDEX_DELETE_COMMAND = (byte) 14;
     public static final byte INDEX_CREATE_COMMAND = (byte) 15;
 
-    byte UPDATE_COUNTS_COMMAND = (byte) 16;
+    byte UPDATE_RELATIONSHIP_COUNTS_COMMAND = (byte) 16;
+    byte UPDATE_NODE_COUNTS_COMMAND = (byte) 17;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV1.java
@@ -48,6 +48,8 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.CommandReaderFactory.DynamicRecordAdder;
 import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
 import org.neo4j.kernel.impl.transaction.log.ReadPastEndException;
@@ -158,9 +160,14 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
             command = new IndexCommand.CreateCommand();
             break;
         }
-        case NeoCommandType.UPDATE_COUNTS_COMMAND:
+        case NeoCommandType.UPDATE_RELATIONSHIP_COUNTS_COMMAND:
         {
-            command = new Command.CountsCommand();
+            command = new RelationshipCountsCommand();
+            break;
+        }
+        case NeoCommandType.UPDATE_NODE_COUNTS_COMMAND:
+        {
+            command = new NodeCountsCommand();
             break;
         }
         case NeoCommandType.NONE:
@@ -706,7 +713,16 @@ public class PhysicalLogNeoCommandReaderV1 implements CommandReader
         }
 
         @Override
-        public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+        public boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException
+        {
+            int labelId = channel.getInt();
+            long delta = channel.getLong();
+            command.init( labelId, delta );
+            return false;
+        }
+
+        @Override
+        public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
         {
             int startLabelId = channel.getInt();
             int typeId = channel.getInt();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/CommandWriter.java
@@ -41,6 +41,8 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandType;
 
@@ -270,9 +272,18 @@ public class CommandWriter implements NeoCommandHandler
     }
 
     @Override
-    public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+    public boolean visitNodeCountsCommand( NodeCountsCommand command ) throws IOException
     {
-        channel.put( NeoCommandType.UPDATE_COUNTS_COMMAND );
+        channel.put( NeoCommandType.UPDATE_NODE_COUNTS_COMMAND );
+        channel.putInt( command.labelId() )
+               .putLong( command.delta() );
+        return false;
+    }
+
+    @Override
+    public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
+    {
+        channel.put( NeoCommandType.UPDATE_RELATIONSHIP_COUNTS_COMMAND );
         channel.putInt( command.startLabelId() )
                .putInt( command.typeId() )
                .putInt( command.endLabelId() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreApplierTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
 
 import static org.mockito.Mockito.mock;
@@ -36,26 +34,25 @@ import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 public class CountsStoreApplierTest
 {
     private final CountsAccessor.Updater updater = mock( CountsAccessor.Updater.class );
-    private final NodeStore nodeStore = mock( NodeStore.class );
 
     @Test
     public void shouldNotifyCacheAccessOnHowManyUpdatesOnCountsWeHadSoFar() throws IOException
     {
         // GIVEN
-        final CountsStoreApplier applier = new CountsStoreApplier( updater, nodeStore );
+        final CountsStoreApplier applier = new CountsStoreApplier( updater );
 
         // WHEN
-        applier.visitNodeCommand( addNodeCommand() );
+        applier.visitNodeCountsCommand( addNodeCommand() );
         applier.apply();
 
         // THEN
         verify( updater, times( 1 ) ).incrementNodeCount( ANY_LABEL, 1 );
     }
 
-    private Command.NodeCommand addNodeCommand()
+    private Command.NodeCountsCommand addNodeCommand()
     {
-        final Command.NodeCommand command = new Command.NodeCommand();
-        command.init( new NodeRecord( 1, false, 2, 3, false ), new NodeRecord( 1, false, 2, 3, true ) );
+        final Command.NodeCountsCommand command = new Command.NodeCountsCommand();
+        command.init( ANY_LABEL, 1 );
         return command;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/KernelRecoveryTest.java
@@ -28,10 +28,12 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -75,11 +77,13 @@ public class KernelRecoveryTest
                     // Tx before recovery
                     startEntry( -1, -1 ),
                     commandEntry( node1, NodeCommand.class ),
+                    commandEntry( ReadOperations.ANY_LABEL, NodeCountsCommand.class ),
                     commitEntry( 2 ),
 
                     // Tx after recovery
                     startEntry( -1, -1 ),
                     commandEntry( node2, NodeCommand.class ),
+                    commandEntry( ReadOperations.ANY_LABEL, NodeCountsCommand.class ),
                     commitEntry( 3 )
                 )
         );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/LogTruncationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/LogTruncationTest.java
@@ -47,7 +47,8 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
-import org.neo4j.kernel.impl.transaction.command.Command.CountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.log.CommandWriter;
 import org.neo4j.kernel.impl.transaction.log.InMemoryLogChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
@@ -129,9 +130,12 @@ public class LogTruncationTest
         permutations.put( IndexDefineCommand.class, new Command[] { indexDefineCommand } );
 
         // Counts commands
-        CountsCommand countsCommand = new CountsCommand();
-        countsCommand.init( 17, 2, 13, -2 );
-        permutations.put( CountsCommand.class, new Command[]{ countsCommand } );
+        NodeCountsCommand nodeCounts = new NodeCountsCommand();
+        nodeCounts.init( 42, 11 );
+        permutations.put( NodeCountsCommand.class, new Command[]{nodeCounts} );
+        RelationshipCountsCommand relationshipCounts = new RelationshipCountsCommand();
+        relationshipCounts.init( 17, 2, 13, -2 );
+        permutations.put( RelationshipCountsCommand.class, new Command[]{relationshipCounts} );
     }
 
     @Test

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/DenseNodeTransactionTranslator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/DenseNodeTransactionTranslator.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCountsCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCountsCommand;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes;
@@ -388,7 +390,13 @@ public class DenseNodeTransactionTranslator implements Function<List<LogEntry>,L
         }
 
         @Override
-        public boolean visitUpdateCountsCommand( Command.CountsCommand command ) throws IOException
+        public boolean visitNodeCountsCommand( NodeCountsCommand command )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean visitRelationshipCountsCommand( RelationshipCountsCommand command ) throws IOException
         {
             return false;
         }


### PR DESCRIPTION
There was a issue with recovery where recovering counts would need to read the labels of a node as it existed before the command was applied. Since this data is not written to the log the counts recovery would read from the store which could lead to inconsistencies as well as failure to recover.

This is resolved by making sure that all counts updates are handled with explicit commands, and never inferred from other commands. This simplifies the counts update code, and ensures that counts deltas need only be computed once (when the transaction is created).