### PR TITLE
Rewrite the heuristics for the default page cache memory settings

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -26,6 +26,9 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.io.File;
+import java.util.Collection;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;

--- a/community/embedded-examples/src/test/resources/neo4j.properties
+++ b/community/embedded-examples/src/test/resources/neo4j.properties
@@ -2,15 +2,15 @@
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true
 
-# The amount of memory to use for mapping the store files, either in bytes or
-# as a percentage of available memory. This will be clipped at the amount of
-# free memory observed when the database starts, and automatically be rounded
-# down to the nearest whole page. For example, if "500MB" is configured, but
-# only 450MB of memory is free when the database starts, then the database will
-# map at most 450MB. If "50%" is configured, and the system has a capacity of
-# 4GB, then at most 2GB of memory will be mapped, unless the database observes
-# that less than 2GB of memory is free when it starts.
-#dbms.pagecache.memory=50%
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
@@ -43,4 +43,3 @@ keep_logical_logs=true
 
 # The type of cache to use for nodes and relationships.
 #cache_type=soft
-

--- a/community/kernel/src/docs/ops/cache.asciidoc
+++ b/community/kernel/src/docs/ops/cache.asciidoc
@@ -50,10 +50,9 @@ IMPORTANT: Note that the block sizes can only be configured at store creation ti
 |========================================================
 | Parameter                 | Possible values   | Effect
 | dbms.pagecache.memory     |
-  The maximum amount of memory to use for the file buffer cache, either in bytes
-  (or greater byte-like units, such as `100M` for 100 mega-bytes, or `4G` for 4 giga-bytes)
-  or a percentage of the available amount of memory. |
-  The amount of memory to use for mapping the store files, either in bytes or as a percentage of available memory. This will be clipped at the amount of free memory observed when the database starts, and automatically be rounded down to the nearest whole page. For example, if `500MB` is configured, but only 450MB of memory is free when the database starts, then the database will map at most 450MB. If `50%` is configured, and the system has a capacity of 4GB, then at most 2GB of memory will be mapped, unless the database observes that less than 2GB of memory is free when it starts.
+  The maximum amount of memory to use for the file buffer cache, either in bytes, or greater byte-like units, such as `100m` for 100 mega-bytes, or `4g` for 4 giga-bytes. |
+  The amount of memory to use for mapping the store files, in a unit of bytes.
+  This will automatically be rounded down to the nearest whole page.
 | string_block_size .2+^.^| The number of bytes per block. |
   Specifies the block size for storing strings.
   This parameter is only honored when the store is created, otherwise it is ignored.

--- a/community/kernel/src/docs/ops/introduction.asciidoc
+++ b/community/kernel/src/docs/ops/introduction.asciidoc
@@ -5,16 +5,18 @@ Introduction
 To gain good performance, these are the things to look into first:
 
 * Make sure the JVM is not spending too much time performing garbage collection.
-  Monitoring heap usage on an application that uses Neo4j can be a bit confusing since Neo4j will increase the size of caches if there is available memory and decrease if the heap is getting full. 
+  Monitoring heap usage on an application that uses Neo4j can be a bit confusing since Neo4j will increase the size of caches if there is available memory and decrease if the heap is getting full.
   The goal is to have a large enough heap to make sure that heavy/peak load will not result in so called GC trashing (performance can drop as much as two orders of magnitude when GC trashing happens).
 * Start the JVM with the -server flag and a good sized heap (see <<configuration-jvm>>). Having too large heap may also hurt performance so you may have to try some different heap sizes.
-* Use the parallel/concurrent garbage collector (we found that +-XX:+UseConcMarkSweepGC+ works well in most use-cases) 
+* Use the parallel/concurrent garbage collector (we found that +-XX:+UseConcMarkSweepGC+ works well in most use-cases).
+* Give the Neo4j page cache as much memory as you can spare.
+  After configuring the JVM heap size, you can leave 2-4GBs for the operating system (assuming the machine is dedicated to running Neo4j), and assign the rest to the Neo4j page cache with the +dbms.pagecache.memory+ setting, unless you know your store will be small enough to fit in less.
 
 == How to add configuration settings ==
 
 When creating the embedded Neo4j instance it is possible to pass in parameters contained in a map where keys and values are strings, see <<tutorials-java-embedded-setup-config>> for an example.
 
-If no configuration is provided, the Database Kernel will try to determine suitable settings from the information available via the JVM settings and the underlying operating system. 
+If no configuration is provided, the Database Kernel will try to determine suitable settings from the information available via the JVM settings and the underlying operating system.
 
 The JVM is configured by passing command line flags when starting the JVM.
 The most important configuration parameters for Neo4j are the ones that control the memory and garbage collector, but some of the parameters for configuring the Just In Time compiler are also of interest.
@@ -26,7 +28,7 @@ This is an example of starting up your applications main class using 64-bit serv
 java -d64 -server -Xmx1024m -cp /path/to/neo4j-kernel.jar:/path/to/jta.jar:/path/to/your-application.jar com.example.yourapp.MainClass
 ----
 
-Looking at the example above you will also notice one of the most basic command line parameters: the one for specifying the classpath. The classpath is the path in which the JVM searches for your classes. It is usually a list of jar-files. Specifying the classpath is done by specifying the flag +-cp+ (or +-classpath+) and then the value of the classpath. For Neo4j applications this should at least include the path to the Neo4j +neo4j-kernel.jar+ and the Java Transaction API (+jta.jar+) as well as the path where the classes for your application are located. 
+Looking at the example above you will also notice one of the most basic command line parameters: the one for specifying the classpath. The classpath is the path in which the JVM searches for your classes. It is usually a list of jar-files. Specifying the classpath is done by specifying the flag +-cp+ (or +-classpath+) and then the value of the classpath. For Neo4j applications this should at least include the path to the Neo4j +neo4j-kernel.jar+ and the Java Transaction API (+jta.jar+) as well as the path where the classes for your application are located.
 
 [TIP]
 On Linux, Unix and Mac OS X each element in the path list are separated by a colon symbol (+:+), on Windows the path elements are separated by a semicolon (+;+).

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -20,6 +20,9 @@
 package org.neo4j.graphdb.factory;
 
 import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +57,6 @@ import static org.neo4j.helpers.Settings.min;
 import static org.neo4j.helpers.Settings.options;
 import static org.neo4j.helpers.Settings.port;
 import static org.neo4j.helpers.Settings.setting;
-import static org.neo4j.helpers.Settings.DirectMemoryUsage.directMemoryUsage;
 
 /**
  * Settings for Neo4j. Use this with {@link GraphDatabaseBuilder}.
@@ -211,15 +213,43 @@ public abstract class GraphDatabaseSettings
     @Internal
     public static final Setting<Long> mapped_memory_page_size = setting( "dbms.pagecache.pagesize", BYTES, "8192" );
 
-    @Description( "The amount of memory to use for mapping the store files, either in bytes or" +
-            " as a percentage of available memory. This will be clipped at the amount of" +
-            " free memory observed when the database starts, and automatically be rounded" +
-            " down to the nearest whole page. For example, if `500MB` is configured, but" +
-            " only 450MB of memory is free when the database starts, then the database will" +
-            " map at most 450MB. If `50%` is configured, and the system has a capacity of" +
-            " 4GB, then at most 2GB of memory will be mapped, unless the database observes" +
-            " that less than 2GB of memory is free when it starts." )
-    public static final Setting<Long> pagecache_memory = setting( "dbms.pagecache.memory", directMemoryUsage(), "50%" );
+    @Description( "The amount of memory to use for mapping the store files, in bytes (or kilobytes with the 'k' " +
+                  "suffix, megabytes with 'm' and gigabytes with 'g'). If Neo4j is running on a dedicated server, " +
+                  "then it is generally recommended to leave about 2-4 gigabytes for the operating system, give the " +
+                  "JVM enough heap to hold all your transaction state and query context, and then leave the rest for " +
+                  "the page cache. The default page cache memory assumes the machine is dedicated to running " +
+                  "Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size." )
+    public static final Setting<Long> pagecache_memory =
+            setting( "dbms.pagecache.memory", BYTES, defaultPageCacheMemory() );
+
+    private static String defaultPageCacheMemory()
+    {
+        // Try to compute (RAM - maxheap) * 0.75 if we can get reliable numbers...
+        long maxHeapMemory = Runtime.getRuntime().maxMemory();
+        if ( 0 < maxHeapMemory && maxHeapMemory < Long.MAX_VALUE )
+        {
+            try
+            {
+                OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+                Method getTotalPhysicalMemorySize = os.getClass().getMethod( "getTotalPhysicalMemorySize" );
+                getTotalPhysicalMemorySize.setAccessible( true );
+                long physicalMemory = (long) getTotalPhysicalMemorySize.invoke( os );
+                if ( 0 < physicalMemory && physicalMemory < Long.MAX_VALUE && maxHeapMemory < physicalMemory )
+                {
+                    long heuristic = (long) ((physicalMemory - maxHeapMemory) * 0.75);
+                    long min = 32 * 1024 * 1024; // We'd like at least 32 MiBs.
+                    long max = 1024 * 1024 * 1024 * 1024L; // Don't heuristically take more than 1 TiB.
+                    long memory = Math.min( max, Math.max( min, heuristic ) );
+                    return String.valueOf( memory );
+                }
+            }
+            catch ( Exception ignore )
+            {
+            }
+        }
+        // ... otherwise we just go with 2 GiBs.
+        return "2g";
+    }
 
     @Deprecated
     @Obsoleted( "This is no longer used" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
@@ -62,7 +62,7 @@ public class LifecycledPageCache extends LifecycleAdapter implements PageCache
         initialisePageCache();
     }
 
-    private void initialisePageCache()
+    protected void initialisePageCache()
     {
         pageCache = new MuninnPageCache(
                 swapperFactory,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/LifecycledPageCache.java
@@ -21,14 +21,15 @@ package org.neo4j.kernel.impl.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 
-import org.neo4j.helpers.Settings;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.PageSwapperFactory;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.RunnablePageCache;
 import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -138,14 +139,31 @@ public class LifecycledPageCache extends LifecycleAdapter implements PageCache
 
     public void dumpConfiguration( StringLogger messagesLog )
     {
-        long totalPhysicalMemMb = Settings.DirectMemoryUsage.totalPhysicalMemory() / 1024 / 1024;
+        long totalPhysicalMemory = totalPhysicalMemory();
+        String totalPhysicalMemMb = totalPhysicalMemory == -1? "?" : "" + totalPhysicalMemory / 1024 / 1024;
         long maxVmUsageMb = Runtime.getRuntime().maxMemory() / 1024 / 1024;
         long pageCacheMb = (maxCachedPages() * pageSize()) / 1024 / 1024;
-        String msg = "Physical mem: " + totalPhysicalMemMb + "MB," +
-                " Heap size: " + maxVmUsageMb + "MB," +
-                " Page cache size: " + pageCacheMb + "MB.";
+        String msg = "Physical mem: " + totalPhysicalMemMb + " MiB," +
+                " Heap size: " + maxVmUsageMb + " MiB," +
+                " Page cache size: " + pageCacheMb + " MiB.";
 
         messagesLog.info( msg );
+    }
+
+    public static long totalPhysicalMemory()
+    {
+        try
+        {
+            Class<?> beanClass = Thread.currentThread().getContextClassLoader().loadClass(
+                    "com.sun.management.OperatingSystemMXBean" );
+            Method method = beanClass.getMethod( "getTotalPhysicalMemorySize" );
+            return (long) method.invoke( ManagementFactory.getOperatingSystemMXBean() );
+        }
+        catch ( Exception | LinkageError e )
+        {
+            // We tried, but at this point we actually have no idea.
+            return -1;
+        }
     }
 
     public PageCache unwrap()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -258,7 +258,6 @@ public class StoreAccess
     private static Map<String, String> defaultParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put( GraphDatabaseSettings.pagecache_memory.name(), "50%" );
         params.put( GraphDatabaseSettings.rebuild_idgenerators_fast.name(), Settings.TRUE );
         return params;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -73,7 +73,6 @@ import org.neo4j.kernel.impl.storemigration.legacystore.v21.Legacy21Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v21.propertydeduplication.PropertyDeduplicator;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -194,17 +193,8 @@ public class StoreMigrator implements StoreMigrationParticipant
         if ( versionToUpgradeFrom( storeDir ).equals( Legacy21Store.LEGACY_VERSION ) )
         {
             // create counters from scratch
-            final LifeSupport life = new LifeSupport();
-            life.start();
-            try
-            {
-                removeDuplicateEntityProperties( storeDir, migrationDir, pageCache, schemaIndexProvider );
-                rebuildCountsFromScratch( storeDir, migrationDir, lastTxId, pageCache );
-            }
-            finally
-            {
-                life.shutdown();
-            }
+            removeDuplicateEntityProperties( storeDir, migrationDir, pageCache, schemaIndexProvider );
+            rebuildCountsFromScratch( storeDir, migrationDir, lastTxId, pageCache );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -294,7 +294,7 @@ public class BatchInserterImpl implements BatchInserter
     private Map<String, String> getDefaultParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put( GraphDatabaseSettings.pagecache_memory.name(), "1%" );
+        params.put( GraphDatabaseSettings.pagecache_memory.name(), "32m" );
         return params;
     }
 

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -40,6 +40,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.DefaultFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
@@ -51,8 +52,11 @@ import static org.junit.Assert.assertThat;
 public class BatchInsertDocTest
 {
     @Test
-    public void insert() throws InterruptedException
+    public void insert() throws Exception
     {
+        // Make sure our scratch directory is clean
+        FileUtils.deleteRecursively( new File( "target/batchinserter-example" ) );
+
         // START SNIPPET: insert
         BatchInserter inserter = null;
         try
@@ -108,7 +112,7 @@ public class BatchInsertDocTest
     {
         // START SNIPPET: configuredInsert
         Map<String, String> config = new HashMap<>();
-        config.put( "dbms.pagecache.memory", "3G" );
+        config.put( "dbms.pagecache.memory", "512m" );
         BatchInserter inserter = BatchInserters.inserter(
                 new File("target/batchinserter-example-config").getAbsolutePath(), fileSystem, config );
         // Insert data here ... and then shut down:
@@ -121,7 +125,7 @@ public class BatchInsertDocTest
     {
         try ( Writer fw = fileSystem.openAsWriter( new File( "target/docs/batchinsert-config" ).getAbsoluteFile(), "utf-8", false ) )
         {
-            fw.append( "dbms.pagecache.memory=3G" );
+            fw.append( "dbms.pagecache.memory=512m" );
         }
 
         // START SNIPPET: configFileInsert

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.factory;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class GraphDatabaseSettingsTest
+{
+    private static final long KiB = 1024;
+    private static final long MiB = KiB * 1024;
+    private static final long GiB = MiB * 1024;
+    @Test
+    public void mustHaveReasonableDefaultPageCacheMemorySizeInBytes() throws Exception
+    {
+        long bytes = new Config().get( GraphDatabaseSettings.pagecache_memory );
+        assertThat( bytes, greaterThanOrEqualTo( 32 * MiB ) );
+        assertThat( bytes, lessThanOrEqualTo( 1024 * GiB ) );
+    }
+
+    @Test
+    public void pageCacheSettingMustAcceptArbitraryUserSpecifiedValue() throws Exception
+    {
+        Setting<Long> setting = GraphDatabaseSettings.pagecache_memory;
+        String name = setting.name();
+        assertThat( new Config( stringMap( name, "244" ) ).get( setting ), is( 244L ) );
+        assertThat( new Config( stringMap( name, "2244g" ) ).get( setting ), is( 2244 * GiB ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
@@ -293,48 +293,6 @@ public class SettingsTest
     }
 
     @Test
-    public void testMemoryUse() throws Exception
-    {
-        // Given
-        Setting<Long> memUse = setting("mySetting", new Settings.DirectMemoryUsage( 1024, 100 ), "5%");
-
-        // When && Then
-        assertThat(memUse.apply( Functions.<String, String>constant( null )),  equalTo(51l));
-        assertThat(memUse.apply( Functions.<String, String>constant( "35M" )), equalTo(95l));
-        assertThat(memUse.apply( Functions.<String, String>constant( "85%" )), equalTo(95l));
-
-        try
-        {
-            memUse.apply( Functions.<String, String>constant( "bala%" ) );
-            fail("Should've thrown.");
-        }
-        catch(InvalidSettingException e)
-        {
-            assertThat(e.getMessage(), equalTo("Bad value 'bala%' for setting 'mySetting': Invalid memory fraction, expected a value between 0.0% and 100.0%." ));
-        }
-
-        try
-        {
-            memUse.apply( Functions.<String, String>constant( "110.14%" ) );
-            fail("Should've thrown.");
-        }
-        catch(InvalidSettingException e)
-        {
-            assertThat(e.getMessage(), equalTo("Bad value '110.14%' for setting 'mySetting': Invalid memory fraction, expected a value between 0.0% and 100.0%." ));
-        }
-    }
-
-    @Test
-    public void testMemoryUsageConfigFromSystemMemory() throws Exception
-    {
-        // Given
-        Setting<Long> memUse = setting("mySetting", Settings.DirectMemoryUsage.directMemoryUsage(), "100%");
-
-        // When && then
-        assertThat(memUse.apply( Functions.<String,String>constant( null ) ), greaterThan( 0l ));
-    }
-
-    @Test
     public void testNormalizedRelativeURI() throws Exception
     {
         // Given

--- a/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
@@ -73,7 +73,7 @@ public class DiagnosticsLoggingTest
                 newGraphDatabase();
 
         String messages = logger.getMessages();
-        assertThat( messages, containsString( "Page cache size: 8MB" ) );
+        assertThat( messages, containsString( "Page cache size: 8 MiB" ) );
         db.shutdown();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -41,13 +42,11 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableVersionableLogChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReaderFactory;
-import org.neo4j.test.ImpermanentGraphDatabase;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 public class TestLogPruning
@@ -148,17 +147,11 @@ public class TestLogPruning
     {
         this.rotateEveryNTransactions = rotateEveryNTransactions;
         fs = new EphemeralFileSystemAbstraction();
-        GraphDatabaseAPI db = new ImpermanentGraphDatabase( stringMap(
-                keep_logical_logs.name(), logPruning
-        ) )
-        {
-            @Override
-            protected FileSystemAbstraction createFileSystemAbstraction()
-            {
-                return fs;
-            }
-        };
-        this.db = db;
+        TestGraphDatabaseFactory gdf = new TestGraphDatabaseFactory();
+        gdf.setFileSystem( fs );
+        GraphDatabaseBuilder builder = gdf.newImpermanentDatabaseBuilder();
+        builder.setConfig( keep_logical_logs, logPruning );
+        this.db = (GraphDatabaseAPI) builder.newGraphDatabase();
         files = new PhysicalLogFiles( new File( db.getStoreDir() ), PhysicalLogFile.DEFAULT_NAME, fs );
         return db;
     }

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -22,16 +22,18 @@ package org.neo4j.metatest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.ImpermanentGraphDatabase;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.neo4j.test.GraphDatabaseServiceCleaner.cleanDatabaseContent;
 
 public class TestImpermanentGraphDatabase
@@ -41,7 +43,7 @@ public class TestImpermanentGraphDatabase
     @Before
     public void createDb()
     {
-        db = new ImpermanentGraphDatabase();
+        db = (ImpermanentGraphDatabase) new TestGraphDatabaseFactory().newImpermanentDatabase();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/test/AbstractSubProcessTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AbstractSubProcessTestBase.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.test;
 
+import org.junit.After;
+import org.junit.Before;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
-import org.junit.After;
-import org.junit.Before;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -175,7 +175,8 @@ public class AbstractSubProcessTestBase
         private Map<String, String> addVitalConfig( Map<String, String> dbConfiguration )
         {
             return stringMap( new HashMap<>( dbConfiguration ),
-                    GraphDatabaseSettings.keep_logical_logs.name(), Settings.TRUE );
+                    GraphDatabaseSettings.keep_logical_logs.name(), Settings.TRUE,
+                    GraphDatabaseSettings.pagecache_memory.name(), "8m" );
         }
 
         protected GraphDatabaseService startup()

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -37,6 +37,7 @@ import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -51,6 +52,7 @@ import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.StoreCopyMonitor;
+import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
@@ -68,6 +70,8 @@ public class StoreCopyClientTest
 {
     @Rule
     public TargetDirectory.TestDirectory testDir = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public PageCacheRule pageCacheRule = new PageCacheRule();
 
     private final DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
 
@@ -103,8 +107,9 @@ public class StoreCopyClientTest
             }
         };
 
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreCopyClient copier =
-                new StoreCopyClient( config, loadKernelExtensions(), console, logging, fs, storeCopyMonitor );
+                new StoreCopyClient( config, loadKernelExtensions(), console, logging, fs, pageCache, storeCopyMonitor );
 
         final GraphDatabaseAPI original =
                 (GraphDatabaseAPI) startDatabase( originalDir );
@@ -182,8 +187,9 @@ public class StoreCopyClientTest
             }
         };
 
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreCopyClient copier =
-                new StoreCopyClient( config, loadKernelExtensions(), console, logging, fs, storeCopyMonitor );
+                new StoreCopyClient( config, loadKernelExtensions(), console, logging, fs, pageCache, storeCopyMonitor );
 
         final GraphDatabaseAPI original =
                 (GraphDatabaseAPI) startDatabase( originalDir );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.StoreLockerLifecycleAdapter;
@@ -468,10 +469,11 @@ public class SwitchToSlave
                                       CancellationRequest cancellationRequest ) throws Throwable
     {
         FileSystemAbstraction fs = resolver.resolveDependency( FileSystemAbstraction.class );
+        PageCache pageCache = resolver.resolveDependency( PageCache.class );
 
         // This will move the copied db to the graphdb location
         console.log( "Copying store from master" );
-        new StoreCopyClient( config, kernelExtensions, console, logging, fs, storeCopyMonitor ).copyStore(
+        new StoreCopyClient( config, kernelExtensions, console, logging, fs, pageCache, storeCopyMonitor ).copyStore(
                 new StoreCopyClient.StoreCopyRequester()
                 {
                     @Override

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
@@ -2,15 +2,15 @@
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true
 
-# The amount of memory to use for mapping the store files, either in bytes or
-# as a percentage of available memory. This will be clipped at the amount of
-# free memory observed when the database starts, and automatically be rounded
-# down to the nearest whole page. For example, if "500MB" is configured, but
-# only 450MB of memory is free when the database starts, then the database will
-# map at most 450MB. If "50%" is configured, and the system has a capacity of
-# 4GB, then at most 2GB of memory will be mapped, unless the database observes
-# that less than 2GB of memory is free when it starts.
-#dbms.pagecache.memory=50%
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
@@ -43,4 +43,3 @@ keep_logical_logs=7 days
 
 # The type of cache to use for nodes and relationships.
 #cache_type=soft
-

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -8,15 +8,15 @@
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true
 
-# The amount of memory to use for mapping the store files, either in bytes or
-# as a percentage of available memory. This will be clipped at the amount of
-# free memory observed when the database starts, and automatically be rounded
-# down to the nearest whole page. For example, if "500MB" is configured, but
-# only 450MB of memory is free when the database starts, then the database will
-# map at most 450MB. If "50%" is configured, and the system has a capacity of
-# 4GB, then at most 2GB of memory will be mapped, unless the database observes
-# that less than 2GB of memory is free when it starts.
-#dbms.pagecache.memory=50%
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -8,15 +8,15 @@
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true
 
-# The amount of memory to use for mapping the store files, either in bytes or
-# as a percentage of available memory. This will be clipped at the amount of
-# free memory observed when the database starts, and automatically be rounded
-# down to the nearest whole page. For example, if "500MB" is configured, but
-# only 450MB of memory is free when the database starts, then the database will
-# map at most 450MB. If "50%" is configured, and the system has a capacity of
-# 4GB, then at most 2GB of memory will be mapped, unless the database observes
-# that less than 2GB of memory is free when it starts.
-#dbms.pagecache.memory=50%
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -8,15 +8,15 @@
 # Enable this to be able to upgrade a store from an older version.
 #allow_store_upgrade=true
 
-# The amount of memory to use for mapping the store files, either in bytes or
-# as a percentage of available memory. This will be clipped at the amount of
-# free memory observed when the database starts, and automatically be rounded
-# down to the nearest whole page. For example, if "500MB" is configured, but
-# only 450MB of memory is free when the database starts, then the database will
-# map at most 450MB. If "50%" is configured, and the system has a capacity of
-# 4GB, then at most 2GB of memory will be mapped, unless the database observes
-# that less than 2GB of memory is free when it starts.
-#dbms.pagecache.memory=50%
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0


### PR DESCRIPTION
We now use the formula `(RAM - maxheap) * 0.75` as the default page cache memory setting, assuming we can get those numbers. Otherwise we fall back to 2 GiBs.