### PR TITLE
Makes Learner give up properly when a value is impossible to learn

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
@@ -20,8 +20,11 @@
 package org.neo4j.cluster.protocol;
 
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.ConsoleLogger;
 
 public interface LoggingContext
 {
     StringLogger getLogger( Class loggingClass );
+
+    ConsoleLogger getConsoleLogger( Class loggingClass );
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
@@ -209,7 +209,6 @@ public enum LearnerState
                             }
                             else
                             {
-                                context.notifyLearnMiss(instanceId);
                                 outgoing.offer( message.copyHeadersTo( Message.respond( LearnerMessage.learnFailed,
                                         message,
                                         new LearnerMessage.LearnFailedState() ), org.neo4j.cluster.protocol
@@ -221,20 +220,7 @@ public enum LearnerState
                         case learnFailed:
                         {
                             InstanceId instanceId = new InstanceId( message );
-                            PaxosInstance instance = context.getPaxosInstance( instanceId );
-                            if ( !(instance.isState( PaxosInstance.State.closed ) || instance.isState( PaxosInstance
-                                    .State.delivered )) )
-                            {
-                                List<URI> nodes = context.getMemberURIs();
-                                URI learnDeniedNode = new URI( message.getHeader( Message.FROM ) );
-                                int nextPotentialLearnerIndex = (nodes.indexOf( learnDeniedNode ) + 1) % nodes.size();
-                                URI learnerNode = nodes.get( nextPotentialLearnerIndex );
-
-                                outgoing.offer( message.copyHeadersTo( Message.to( LearnerMessage.learnRequest,
-                                        learnerNode,
-                                        new LearnerMessage.LearnRequestState() ), InstanceId.INSTANCE ) );
-                            }
-
+                            context.notifyLearnMiss( instanceId );
                             break;
                         }
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -31,6 +31,7 @@ import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 
 import static org.neo4j.helpers.collection.Iterables.limit;
@@ -53,10 +54,17 @@ class AbstractContextImpl
         this.logging = logging;
         this.timeouts = timeouts;
     }
+
     @Override
     public StringLogger getLogger( Class loggingClass )
     {
         return logging.getMessagesLog( loggingClass );
+    }
+
+    @Override
+    public ConsoleLogger getConsoleLogger( Class loggingClass )
+    {
+        return logging.getConsoleLog( loggingClass );
     }
 
     // TimeoutsContext

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
@@ -49,7 +49,10 @@ class LearnerContextImpl
                 @Override
                 protected void triggered( InstanceId instanceId )
                 {
-                    getLogger( LearnerState.class ).debug( "Did not have learned value for instance " + instanceId );
+                    getConsoleLogger( LearnerState.class ).warn( "Did not have learned value for Paxos instance "
+                            + instanceId + ". This generally indicates that this instance has missed too many " +
+                            "cluster events and is failing to catch up. If this error does not resolve soon it " +
+                            "may become necessary to restart this cluster member so normal operation can resume.");
                 }
             };
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
@@ -80,5 +80,4 @@ public class LearnerContextTest
         assertThat( state.getLastKnownLearnedInstanceInCluster(), equalTo( -1l ) );
         assertThat( state.getLastKnownAliveUpToDateInstance(), equalTo( new org.neo4j.cluster.InstanceId( 2 ) ));
     }
-
 }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
@@ -20,21 +20,34 @@
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.cglib.core.CollectionUtils;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.protocol.omega.MessageArgumentMatcher;
 import org.neo4j.cluster.statemachine.State;
+import org.neo4j.test.AbstractSubProcessTestBase;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class LearnerStateTest
 {
-
     @Test
     public void shouldUseLastKnownOnlineClusterMemberAndSetTimeoutForCatchup() throws Throwable
     {
@@ -68,4 +81,107 @@ public class LearnerStateTest
         verify(ctx).setTimeout( "learn", Message.timeout( LearnerMessage.learnTimedout, message ) );
     }
 
+    @Test
+    public void learnerServingOldInstanceShouldNotLogErrorIfItDoesNotHaveIt() throws Throwable
+    {
+        // Given
+        LearnerState state = LearnerState.learner;
+        LearnerContext ctx = mock( LearnerContext.class );
+        MessageHolder outgoing = mock( MessageHolder.class );
+        // The instance will be asked for paxos instance 4...
+        InstanceId paxosInstanceIdIDontHave = new InstanceId( 4 );
+        Message<LearnerMessage> messageRequestingId = Message.to( LearnerMessage.learnRequest, URI.create( "c:/1" ))
+                .setHeader( Message.FROM, "c:/2" )
+                .setHeader( InstanceId.INSTANCE, "4" );
+        // ...but it does not have it yet
+        when( ctx.getPaxosInstance( paxosInstanceIdIDontHave ) )
+                .thenReturn( new PaxosInstance( mock( PaxosInstanceStore.class ), paxosInstanceIdIDontHave ) );
+
+        // When
+        state.handle( ctx, messageRequestingId, outgoing );
+
+        // Then
+        // verify there is no logging of the failure
+        verify( ctx, times( 0 )).notifyLearnMiss( paxosInstanceIdIDontHave );
+        // but the learn failed went out anyway
+        verify( outgoing, times( 1 ) ).offer(
+                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                        .onMessageType( LearnerMessage.learnFailed ).to( URI.create( "c:/2" ) ) )
+        );
+    }
+
+    @Test
+    public void learnerReceivingLearnFailedShouldLogIt() throws Throwable
+    {
+        // Given
+        LearnerState state = LearnerState.learner;
+        LearnerContext ctx = mock( LearnerContext.class );
+        MessageHolder outgoing = mock( MessageHolder.class );
+        InstanceId paxosInstanceIdIAskedFor = new InstanceId( 4 );
+        Message<LearnerMessage> theLearnFailure = Message.to( LearnerMessage.learnFailed, URI.create("c:/1"))
+                .setHeader( Message.FROM, "c:/2")
+                .setHeader( InstanceId.INSTANCE, "4" );
+        when( ctx.getPaxosInstance( paxosInstanceIdIAskedFor ) )
+                .thenReturn( new PaxosInstance( mock( PaxosInstanceStore.class ), paxosInstanceIdIAskedFor ) );
+        when( ctx.getMemberURIs() ).thenReturn( Collections.singletonList( URI.create("c:/2") ) );
+
+        // When
+        state.handle( ctx, theLearnFailure, outgoing );
+
+        // Then
+        // verify that the failure was logged
+        verify( ctx, times( 1 ) ).notifyLearnMiss( paxosInstanceIdIAskedFor );
+    }
+
+    @Test
+    public void learnerShouldAskAllAliveInstancesAndTheseOnlyForMissingValue() throws Throwable
+    {
+        // Given
+
+        List<URI> allMembers = new ArrayList<URI>( 3 );
+        URI instance1 = URI.create( "c:/1" ); // this one is failed
+        URI instance2 = URI.create( "c:/2" ); // this one is ok and will respond
+        URI instance3 = URI.create( "c:/3" ); // this one is the requesting instance
+        URI instance4 = URI.create( "c:/4" ); // and this one is ok and will respond too
+        allMembers.add( instance1 );
+        allMembers.add( instance2 );
+        allMembers.add( instance3 );
+        allMembers.add( instance4 );
+
+        Set<org.neo4j.cluster.InstanceId> aliveInstanceIds = new HashSet<org.neo4j.cluster.InstanceId>();
+        org.neo4j.cluster.InstanceId id2 = new org.neo4j.cluster.InstanceId( 2 );
+        org.neo4j.cluster.InstanceId id4 = new org.neo4j.cluster.InstanceId( 4 );
+        aliveInstanceIds.add( id2 );
+        aliveInstanceIds.add( id4 );
+
+        LearnerState state = LearnerState.learner;
+        LearnerContext ctx = mock( LearnerContext.class );
+        MessageHolder outgoing = mock( MessageHolder.class );
+        InstanceId paxosInstanceIdIAskedFor = new InstanceId( 4 );
+
+        when( ctx.getLastDeliveredInstanceId() ).thenReturn( 3l );
+        when( ctx.getLastKnownLearnedInstanceInCluster() ).thenReturn( 5l );
+        when( ctx.getMemberURIs() ).thenReturn( allMembers );
+        when( ctx.getAlive() ).thenReturn( aliveInstanceIds );
+        when( ctx.getUriForId( id2 ) ).thenReturn( instance2 );
+        when( ctx.getUriForId( id4 ) ).thenReturn( instance4 );
+        when( ctx.getPaxosInstance( paxosInstanceIdIAskedFor ) )
+                .thenReturn( new PaxosInstance( mock( PaxosInstanceStore.class ), paxosInstanceIdIAskedFor ) );
+
+        Message<LearnerMessage> theCause = Message.to( LearnerMessage.catchUp, instance2 ); // could be anything, really
+
+        // When
+        state.handle( ctx, Message.timeout( LearnerMessage.learnTimedout, theCause ), outgoing );
+
+        // Then
+        verify( outgoing, times( 1 ) ).offer(
+                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                        .onMessageType( LearnerMessage.learnRequest ).to( instance2 ) )
+        );
+        verify( outgoing, times( 1 ) ).offer(
+                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                        .onMessageType( LearnerMessage.learnRequest ).to( instance4 ) )
+        );
+        verifyNoMoreInteractions( outgoing );
+    }
 }


### PR DESCRIPTION
Cluster members previously would keep retrying to learn a Paxos
 instance they had missed even if all other cluster members already
 had responded with learnFailed. These retries would happen without
 any rate limiting and by definition they would never complete. One
 symptom of this bug was the filling up of messages.log with
 LearnFailure messages.
This patch removes that erroneous behaviour by simply logging
 the failure to learn on the delayed learner (and not on the
 properly up-to-date instances as before) instead of doing
 any retries. That is good enough because an instance when it
 realizes it misses a value it asks all live cluster members
 at once.
This patch also adds a bunch of tests on LearnerState to ensure
 proper responses on learn requests and learnFailed responses.