### PR TITLE
Better grass (graph styling) engine

### DIFF
--- a/community/browser/app/scripts/controllers/Inspector.coffee
+++ b/community/browser/app/scripts/controllers/Inspector.coffee
@@ -102,7 +102,7 @@ angular.module('neo4jApp.controllers')
         item.style = graphStyle.changeForSelector(item.style.selector, { caption: caption})
 
       $scope.isSelectedCaption = (item, caption) ->
-        grassProps = graphStyle.findRule(item.style.selector).props
+        grassProps = item.style.props
         grassProps.caption is "#{caption}" or (!grassProps.caption and caption in ["<id>", "<type>"])
 
       $scope.selectScheme = (item, scheme) ->

--- a/community/browser/app/scripts/controllers/Legend.coffee
+++ b/community/browser/app/scripts/controllers/Legend.coffee
@@ -45,15 +45,15 @@ angular.module('neo4jApp')
           label: ''
           attrs: []
           count: 0
-          style: graphStyle.forNode()
+          style: graphStyle.calculateStyle(graphStyle.newSelector('node'))
         stats.labels[''].count++
 
-        for label, idx in node.labels
+        for label, ignored in node.labels
           stats.labels[label] ?=
             label: label
             attrs: Object.keys(node.propertyMap)
             count: 0
-            style: graphStyle.forNode(node, idx)
+            style: graphStyle.calculateStyle(graphStyle.newSelector('node', [label]))
 
           stats.labels[label].count++
 
@@ -62,14 +62,14 @@ angular.module('neo4jApp')
           type: ''
           attrs: []
           count: 0
-          style: graphStyle.forRelationship()
+          style: graphStyle.calculateStyle(graphStyle.newSelector('relationship'))
         stats.types[''].count++
 
         stats.types[rel.type] ?=
           type: rel.type
           attrs: Object.keys(rel.propertyMap)
           count: 0
-          style: graphStyle.forRelationship(rel)
+          style: graphStyle.calculateStyle(graphStyle.newSelector('relationship', [rel.type]))
 
         stats.types[rel.type].count++
 

--- a/community/browser/app/scripts/services/GraphStyle.coffee
+++ b/community/browser/app/scripts/services/GraphStyle.coffee
@@ -40,6 +40,7 @@ angular.module('neo4jApp.services')
         'padding': '3px'
         'text-color-external': '#000000'
         'text-color-internal': '#FFFFFF'
+        'caption': '<type>'
 
     # Default node sizes that user can choose from
     @defaultSizes = [

--- a/community/browser/app/scripts/services/GraphStyle.coffee
+++ b/community/browser/app/scripts/services/GraphStyle.coffee
@@ -74,28 +74,27 @@ angular.module('neo4jApp.services')
     ]
 
     class Selector
-      constructor: (selector) ->
-        [@tag, @klass] = if selector.indexOf('.') > 0
-          selector.split('.')
-        else
-          [selector, undefined]
+      constructor: (@tag, @classes) ->
 
       toString: ->
         str = @tag
-        str += ".#{@klass}" if @klass?
+        for classs in @classes
+          if classs?
+            str += ".#{classs}"
         str
 
     class StyleRule
       constructor: (@selector, @props) ->
 
       matches: (selector) ->
-        if @selector.tag is selector.tag
-          if @selector.klass is selector.klass or not @selector.klass
-            return yes
-        return no
+        return no unless @selector.tag is selector.tag
+        for classs in @selector.classes
+          if classs? and selector.classes.indexOf(classs) is -1
+            return no
+        yes
 
       matchesExact: (selector) ->
-        @selector.tag is selector.tag and @selector.klass is selector.klass
+        @matches(selector) and @selector.classes.length is selector.classes.length
 
     class StyleElement
       constructor: (selector) ->
@@ -103,18 +102,13 @@ angular.module('neo4jApp.services')
         @props = {}
 
       applyRules: (rules) ->
-        # Two passes
-        for rule in rules when rule.matches(@selector)
-          angular.extend(@props, rule.props)
-          break
-        for rule in rules when rule.matchesExact(@selector)
-          angular.extend(@props, rule.props)
-          break
+        for rule in rules
+          if rule.matches(@selector)
+            angular.extend(@props, rule.props)
         @
 
       get: (attr) ->
         @props[attr] or ''
-
 
     class GraphStyle
       constructor: (@storage) ->
@@ -130,6 +124,9 @@ angular.module('neo4jApp.services')
         else if item.isRelationship
           @relationshipSelector(item)
 
+      newSelector: (tag, classes) ->
+        new Selector(tag, classes)
+
       #
       # Methods for calculating applied style for elements
       #
@@ -139,15 +136,14 @@ angular.module('neo4jApp.services')
       forEntity: (item) ->
         @calculateStyle(@selector(item))
 
-      forNode: (node = {}, idx = 0) ->
-        selector = @nodeSelector(node, idx)
+      forNode: (node = {}) ->
+        selector = @nodeSelector(node)
         if node.labels?.length > 0
-          @setDefaultStyling(selector, node)
+          @setDefaultNodeStyling(selector, node)
         @calculateStyle(selector)
 
       forRelationship: (rel) ->
         selector = @relationshipSelector(rel)
-        @setDefaultRelationshipStyling(selector, rel)
         @calculateStyle(selector)
 
       findAvailableDefaultColor: () ->
@@ -162,45 +158,25 @@ angular.module('neo4jApp.services')
 
         return provider.defaultColors[0]
 
-      setDefaultRelationshipStyling: (selector, relationship) ->
-        rule = @findRule(selector)
+      setDefaultNodeStyling: (selector, item) ->
+        defaultColor = yes
+        defaultCaption = yes
+        for rule in @rules
+          if rule.matches(selector) and rule.selector.classes.length > 0
+            if rule.props.hasOwnProperty('color')
+              defaultColor = no
+            if rule.props.hasOwnProperty('caption')
+              defaultCaption = no
 
-        if not rule?
-          rule = new StyleRule(selector, angular.extend(provider.defaultStyle.relationship, @getDefaultRelationshipCaption()))
-          @rules.push(rule)
-          @persist()
-        if not rule.props.caption?
-          default_caption = @getDefaultRelationshipCaption()
-          angular.extend(rule.props, default_caption)
-          @persist()
+        if defaultColor
+          @changeForSelector(selector, @findAvailableDefaultColor())
+        if defaultCaption
+          @changeForSelector(selector, @getDefaultNodeCaption(item))
 
-      setDefaultStyling: (selector, item) ->
-        rule = @findRule(selector)
-
-        if not rule?
-          rule = new StyleRule(selector, angular.extend(@findAvailableDefaultColor(), @getDefaultCaption(item)))
-          @rules.push(rule)
-          @persist()
-        if not rule.props.caption?
-          default_caption = @getDefaultCaption(item)
-          angular.extend(rule.props, default_caption)
-          @rules.push(rule)
-          @persist()
-
-      getDefaultCaption: (item) ->
+      getDefaultNodeCaption: (item) ->
         return {caption: '<id>'} if not item or not item.propertyList?.length > 0
         default_caption = {caption: "{#{item.propertyList?[0].key}}"}
         default_caption
-
-      getDefaultRelationshipCaption: (item) ->
-        return {caption: '<type>'} 
-
-      #
-      # Methods for getting and modifying rules
-      #
-      change: (item, props) ->
-        selector = @selector(item)
-        @changeForSelector(selector, props)
 
       changeForSelector: (selector, props) ->
         rule = @findRule(selector)
@@ -217,24 +193,24 @@ angular.module('neo4jApp.services')
         @persist()
 
       findRule: (selector) ->
-        rule = r for r in @rules when r.matchesExact(selector)
-        rule
+        for r in @rules
+          if r.matchesExact(selector)
+            return r
+        undefined
 
-      #
-      # Selector helpers
-      #
-      # FIXME: until we support styling nodes with multiple labels separately.
-      # Provide an option to select which label to use
-      nodeSelector: (node = {}, labelIdx = 0) ->
-        selector = 'node'
-        if node.labels?.length > 0
-          selector += ".#{node.labels[labelIdx]}"
-        new Selector(selector)
+      nodeSelector: (node = {}) ->
+        classes = if node.labels?
+          node.labels
+        else
+          []
+        new Selector('node', classes)
 
       relationshipSelector: (rel = {}) ->
-        selector = 'relationship'
-        selector += ".#{rel.type}" if rel.type?
-        new Selector(selector)
+        classes = if rel.type?
+          [rel.type]
+        else
+          []
+        new Selector('relationship', classes)
 
       #
       # Import/export
@@ -248,11 +224,15 @@ angular.module('neo4jApp.services')
         catch e
           return
 
+      parseSelector = (key) ->
+        tokens = key.split('.')
+        new Selector(tokens[0], tokens.slice(1))
+
       loadRules: (data) ->
         data = provider.defaultStyle unless angular.isObject(data)
         @rules.length = 0
-        for rule, props of data
-          @rules.push(new StyleRule(new Selector(rule), angular.copy(props)))
+        for key, props of data
+          @rules.push(new StyleRule(parseSelector(key), angular.copy(props)))
         @
 
       parse: (string)->

--- a/community/browser/app/scripts/services/GraphStyle.coffee
+++ b/community/browser/app/scripts/services/GraphStyle.coffee
@@ -74,7 +74,7 @@ angular.module('neo4jApp.services')
     ]
 
     class Selector
-      constructor: (@tag, @classes) ->
+      constructor: (@tag, @classes = []) ->
 
       toString: ->
         str = @tag
@@ -162,16 +162,17 @@ angular.module('neo4jApp.services')
         defaultColor = yes
         defaultCaption = yes
         for rule in @rules
-          if rule.matches(selector) and rule.selector.classes.length > 0
+          if rule.selector.classes.length > 0 and rule.matches(selector)
             if rule.props.hasOwnProperty('color')
               defaultColor = no
             if rule.props.hasOwnProperty('caption')
               defaultCaption = no
 
+        minimalSelector = new Selector(selector.tag, selector.classes.sort().slice(0, 1))
         if defaultColor
-          @changeForSelector(selector, @findAvailableDefaultColor())
+          @changeForSelector(minimalSelector, @findAvailableDefaultColor())
         if defaultCaption
-          @changeForSelector(selector, @getDefaultNodeCaption(item))
+          @changeForSelector(minimalSelector, @getDefaultNodeCaption(item))
 
       getDefaultNodeCaption: (item) ->
         return {caption: '<id>'} if not item or not item.propertyList?.length > 0
@@ -304,7 +305,6 @@ angular.module('neo4jApp.services')
       #
       # Misc.
       #
-      nextDefaultColor: 0
       defaultSizes: -> provider.defaultSizes
       defaultArrayWidths: -> provider.defaultArrayWidths
       defaultColors: -> angular.copy(provider.defaultColors)

--- a/community/browser/test/spec/services/GraphStyle.coffee
+++ b/community/browser/test/spec/services/GraphStyle.coffee
@@ -115,6 +115,18 @@ node {
       expect(GraphStyle.forNode(labels: ['Movie']).get('color')).toBe('#A5ABB6')
       expect(GraphStyle.forNode(labels: ['Animal']).get('color')).toBe('#A5ABB6')
 
+  describe '#forRelationship: ', ->
+    it 'default style should give relationships a caption', ->
+      GraphStyle.loadRules(GraphStyle.defaultStyle)
+      expect(GraphStyle.forRelationship({type: 'ACTED_IN'}).get('caption')).toBe('<type>')
+
+    it 'should override relationship caption and color', ->
+      GraphStyle.loadRules(GraphStyle.defaultStyle)
+      GraphStyle.changeForSelector(GraphStyle.newSelector('relationship', ['RATED']), {caption: '{stars}'})
+      GraphStyle.changeForSelector(GraphStyle.newSelector('relationship', ['RATED']), {color: '#00F'})
+      expect(GraphStyle.forRelationship({type: 'RATED'}).get('caption')).toBe('{stars}')
+      expect(GraphStyle.forRelationship({type: 'RATED'}).get('color')).toBe('#00F')
+
   describe '#parse:', ->
     it 'should parse rules from grass text', ->
       expect(GraphStyle.parse(grass).node).toEqual(jasmine.any(Object))


### PR DESCRIPTION
Grass logic now works more like CSS. e.g.

* Style is now accumulated from multiple matching rules (previously only _one rule_ would could apply for each node or relationship, necessitating every attribute to be listed explicitly in every rule).
* Rules apply sequentially and conflicts are resolved by last-rule-wins.
* Rules apply to nodes with multiple labels so long as the node's labels match the rule's selector.
* Selectors support multiple _class names_, so that you can write rules that target a specific combination of labels. Note that this is still no way to create these rules in the GUI - you'll have to type them in by hand.
