### PR TITLE
Fixed port bind exception when trying to reuse a port in TIME_WAIT state

### DIFF
--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -72,7 +72,7 @@
     <!-- Don't write new code using this, use neo-server.external instead -->
     <webdriver.override.neo-server.baseuri/>
 
-    <jetty.version>9.2.1.v20140609</jetty.version>
+    <jetty.version>9.2.4.v20141103</jetty.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -670,11 +670,6 @@ public class ComponentVersion extends Version
         <version>1.9.13</version>
       </dependency>
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
-        <version>6.1.26</version>
-      </dependency>
-      <dependency>
         <groupId>org.rrd4j</groupId>
         <artifactId>rrd4j</artifactId>
         <version>2.2</version>


### PR DESCRIPTION
In the previous jetty ServerConnector class, the SO_REUSEADDR option is set after binding, which causes the bind error when open a socket on a port in TIME_WAIT state. In order to set SO_REUSEADDR prior to binding, upgrade jetty from version 9.2.1 to 9.2.4