### PR TITLE
Fixes two problems related to files being kept open

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -51,14 +51,16 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Type;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.Arrays.asList;
+
 import static org.neo4j.collection.primitive.PrimitiveIntCollections.alwaysTrue;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.ArrayUtil.join;
@@ -276,12 +278,10 @@ public class ImportToolTest
         {
             ImportTool.main( arguments(
                     "--into",          dbRule.getStoreDir().getAbsolutePath(),
-                    "--nodes",         nodeHeader( config, "MyGroup" ) + MULTI_FILE_DELIMITER +
-                    nodeData( false, config, groupOneNodeIds, alwaysTrue() ),
-                    "--nodes",         nodeHeader( config ) + MULTI_FILE_DELIMITER +
-                    nodeData( false, config, groupTwoNodeIds, alwaysTrue() )
-
-                    ) );
+                    "--nodes",         nodeHeader( config, "MyGroup" ).getAbsolutePath() + MULTI_FILE_DELIMITER +
+                    nodeData( false, config, groupOneNodeIds, alwaysTrue() ).getAbsolutePath(),
+                    "--nodes",         nodeHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
+                    nodeData( false, config, groupTwoNodeIds, alwaysTrue() ).getAbsolutePath() ) );
             fail( "Should have failed" );
         }
         catch ( Exception e )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
@@ -61,6 +61,8 @@ public class RandomDataIterator<T> extends PrefetchingIterator<T> implements Inp
         this.labels = new Distribution<>( tokens( "Label", labelCount ) );
         this.relationshipTypes = new Distribution<>( tokens( "TYPE", relationshipTypeCount ) );
         this.sourceDescription = getClass().getSimpleName() + ":" + header;
+
+        this.deserialization.initialize();
     }
 
     private String[] tokens( String prefix, int count )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
@@ -42,6 +42,11 @@ class StringDeserialization implements Deserialization<String>
     }
 
     @Override
+    public void initialize()
+    {   // Do nothing
+    }
+
+    @Override
     public void handle( Entry entry, Object value )
     {
         if ( builder.length() > 0 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/StoreLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/StoreLocker.java
@@ -73,11 +73,7 @@ public class StoreLocker
             storeLockFileChannel = fileSystemAbstraction.open( storeLockFile, "rw" );
             storeLockFileLock = fileSystemAbstraction.tryLock( storeLockFile, storeLockFileChannel );
         }
-        catch ( OverlappingFileLockException e )
-        {
-            throw new StoreLockException( "Unable to obtain lock on store lock file: " + storeLockFile+". Please ensure no other process is using this database, and that the directory is writable (required even for read-only access)", e );
-        }
-        catch ( IOException e )
+        catch ( OverlappingFileLockException | IOException e )
         {
             throw new StoreLockException( "Unable to obtain lock on store lock file: " + storeLockFile+". Please ensure no other process is using this database, and that the directory is writable (required even for read-only access)", e );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -112,8 +112,8 @@ public class CsvInput implements Input
                         nodeHeaderFactory, config, idType )
                 {
                     @Override
-                    protected InputIterator<InputNode> entityDeserializer( CharSeeker dataStream, Header dataHeader,
-                            Function<InputNode,InputNode> decorator )
+                    protected InputEntityDeserializer<InputNode> entityDeserializer( CharSeeker dataStream,
+                            Header dataHeader, Function<InputNode,InputNode> decorator )
                     {
                         return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputNodeDeserialization( dataStream, dataHeader, groups, idType.idsAreExternal() ),
@@ -136,7 +136,7 @@ public class CsvInput implements Input
                         relationshipHeaderFactory, config, idType )
                 {
                     @Override
-                    protected InputIterator<InputRelationship> entityDeserializer( CharSeeker dataStream,
+                    protected InputEntityDeserializer<InputRelationship> entityDeserializer( CharSeeker dataStream,
                               Header dataHeader, Function<InputRelationship,InputRelationship> decorator )
                     {
                         return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Deserialization.java
@@ -32,6 +32,13 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 public interface Deserialization<ENTITY>
 {
     /**
+     * Called before any other call. Introduced to reduce complexity in error handling where too
+     * much happened in constructors and so resources weren't even assigned when error struck and
+     * cleanup would be tricky and involve duplication.
+     */
+    void initialize();
+
+    /**
      * Handles one value of a type described by the {@code entry}. One or more values will be able to
      * {@link #materialize()} into an entity later on.
      */

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
@@ -62,6 +62,11 @@ public class InputEntityDeserializer<ENTITY extends InputEntity>
         this.validator = validator;
     }
 
+    public void initialize()
+    {
+        deserialization.initialize();
+    }
+
     @Override
     protected ENTITY fetchNextOrNull()
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -39,7 +39,7 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
     private final Header.Factory headerFactory;
     private final Configuration config;
     private final IdType idType;
-    private InputIterator<ENTITY> currentInput = new InputIterator.Adapter<>();
+    private InputEntityDeserializer<ENTITY> currentInput;
     private long previousInputsCollectivePositions;
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
@@ -65,7 +65,9 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
         // from somewhere else, it's up to that factory.
         Header dataHeader = headerFactory.create( dataStream, config, idType );
 
-        return currentInput = entityDeserializer( dataStream, dataHeader, data.decorator() );
+        currentInput = entityDeserializer( dataStream, dataHeader, data.decorator() );
+        currentInput.initialize();
+        return currentInput;
     }
 
     private void closeCurrent()
@@ -78,7 +80,7 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
         }
     }
 
-    protected abstract InputIterator<ENTITY> entityDeserializer( CharSeeker dataStream, Header dataHeader,
+    protected abstract InputEntityDeserializer<ENTITY> entityDeserializer( CharSeeker dataStream, Header dataHeader,
             Function<ENTITY,ENTITY> decorator );
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
@@ -35,20 +35,29 @@ import static java.util.Arrays.copyOf;
  */
 public class InputNodeDeserialization extends InputEntityDeserialization<InputNode>
 {
-    private final Group group;
+    private final Header header;
+    private final Groups groups;
+
     private final boolean idsAreExternal;
+    private Group group;
     private Object id;
     private String[] labels = new String[10];
     private int labelsCursor;
 
-    public InputNodeDeserialization( SourceTraceability source,  Header header, Groups groups, boolean idsAreExternal )
+    public InputNodeDeserialization( SourceTraceability source, Header header, Groups groups, boolean idsAreExternal )
     {
         super( source );
+        this.header = header;
+        this.groups = groups;
+        this.idsAreExternal = idsAreExternal;
+    }
 
+    @Override
+    public void initialize()
+    {
         // ID header entry is optional
         Entry idEntry = header.entry( Type.ID );
         this.group = groups.getOrCreate( idEntry != null ? idEntry.groupName() : null );
-        this.idsAreExternal = idsAreExternal;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
@@ -30,8 +30,11 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
  */
 public class InputRelationshipDeserialization extends InputEntityDeserialization<InputRelationship>
 {
-    private final Group startNodeGroup;
-    private final Group endNodeGroup;
+    private final Header header;
+    private final Groups groups;
+
+    private Group startNodeGroup;
+    private Group endNodeGroup;
     private String type;
     private Object startNode;
     private Object endNode;
@@ -39,6 +42,13 @@ public class InputRelationshipDeserialization extends InputEntityDeserialization
     public InputRelationshipDeserialization( SourceTraceability source, Header header, Groups groups )
     {
         super( source );
+        this.header = header;
+        this.groups = groups;
+    }
+
+    @Override
+    public void initialize()
+    {
         this.startNodeGroup = groups.getOrCreate( header.entry( Type.START_ID ).groupName() );
         this.endNodeGroup = groups.getOrCreate( header.entry( Type.END_ID ).groupName() );
     }


### PR DESCRIPTION
Noticed since some tests were recently changed to delete those files. Those tests now break on Windows. The fixes are generic and makes the database behave better w/ regards to closing store lock and import input files in the event of errors.