### PR TITLE
Lucene index overflow throws user-friendly exception before commit

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.consistency.checking;
 
-import java.io.File;
-import java.util.Collection;
-
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.io.File;
+import java.util.Collection;
+
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -44,6 +45,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.NodeLabelsField;
@@ -351,12 +353,15 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
         GraphDatabaseAPI database = (GraphDatabaseAPI) builder.newGraphDatabase();
         try ( LockGroup locks = new LockGroup() )
         {
+            DependencyResolver dependencyResolver = database.getDependencyResolver();
+
             TransactionRepresentationCommitProcess commitProcess =
                     new TransactionRepresentationCommitProcess(
-                            database.getDependencyResolver().resolveDependency( LogicalTransactionStore.class ),
-                            database.getDependencyResolver().resolveDependency( KernelHealth.class ),
-                            database.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate(),
-                            database.getDependencyResolver().resolveDependency( TransactionRepresentationStoreApplier.class ),
+                            dependencyResolver.resolveDependency( LogicalTransactionStore.class ),
+                            dependencyResolver.resolveDependency( KernelHealth.class ),
+                            dependencyResolver.resolveDependency( NeoStoreProvider.class ).evaluate(),
+                            dependencyResolver.resolveDependency( TransactionRepresentationStoreApplier.class ),
+                            dependencyResolver.resolveDependency( IndexUpdatesValidator.class ),
                             TransactionApplicationMode.EXTERNAL );
             TransactionIdStore transactionIdStore = database.getDependencyResolver().resolveDependency(
                     TransactionIdStore.class );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -52,6 +52,7 @@ import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.direct.DirectStoreAccess;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -314,7 +315,8 @@ public class FullCheckIntegrationTest
                    .andThatsAllFolks();
     }
 
-    private void write( LabelScanStore labelScanStore, Iterable<NodeLabelUpdate> nodeLabelUpdates ) throws IOException
+    private void write( LabelScanStore labelScanStore, Iterable<NodeLabelUpdate> nodeLabelUpdates )
+            throws IOException, IndexCapacityExceededException
     {
         try ( LabelScanWriter writer = labelScanStore.newWriter() )
         {

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -19,17 +19,6 @@
  */
 package org.neo4j.consistency.checking.full;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +30,19 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.model.Statement;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.GraphStoreFixture;
 import org.neo4j.consistency.report.ConsistencySummaryStatistics;
@@ -90,10 +92,8 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.consistency.checking.RecordCheckTestBase.inUse;
 import static org.neo4j.consistency.checking.RecordCheckTestBase.notInUse;
 import static org.neo4j.consistency.checking.full.ExecutionOrderIntegrationTest.config;
@@ -424,7 +424,7 @@ public class FullCheckIntegrationTest
                    .andThatsAllFolks();
     }
 
-    private long[] asArray( List<Integer> in )
+    private long[] asArray( List<? extends Number> in )
     {
         long[] longs = new long[in.size()];
         for ( int i = 0; i < in.size(); i++ )
@@ -432,6 +432,11 @@ public class FullCheckIntegrationTest
             longs[i] = in.get( i ).longValue();
         }
         return longs;
+    }
+
+    private PrimitiveLongSet asPrimitiveLongSet( List<? extends Number> in )
+    {
+        return PrimitiveLongCollections.setOf( asArray( in ) );
     }
 
     @Test
@@ -471,7 +476,7 @@ public class FullCheckIntegrationTest
             IndexAccessor accessor = fixture.directStoreAccess().indexes().getOnlineAccessor(
                     indexRule.getId(), new IndexConfiguration( indexRule.isConstraintIndex() ), samplingConfig );
             IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE );
-            updater.remove( indexedNodes );
+            updater.remove( asPrimitiveLongSet( indexedNodes ) );
             updater.close();
             accessor.close();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -88,6 +88,7 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
@@ -224,7 +225,8 @@ public abstract class InternalAbstractGraphDatabase
         public TransactionCommitProcess create( LogicalTransactionStore logicalTransactionStore,
                                                 KernelHealth kernelHealth, NeoStore neoStore,
                                                 TransactionRepresentationStoreApplier storeApplier,
-                                                NeoStoreInjectedTransactionValidator validator,
+                                                NeoStoreInjectedTransactionValidator txValidator,
+                                                IndexUpdatesValidator indexUpdatesValidator,
                                                 TransactionApplicationMode mode, Config config )
         {
             if ( config.get( GraphDatabaseSettings.read_only ) )
@@ -234,7 +236,7 @@ public abstract class InternalAbstractGraphDatabase
             else
             {
                 return new TransactionRepresentationCommitProcess( logicalTransactionStore, kernelHealth,
-                        neoStore, storeApplier, mode );
+                        neoStore, storeApplier, indexUpdatesValidator, mode );
             }
         }
     };

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -205,6 +205,7 @@ public interface Status
         NoSuchSchemaRule( DatabaseError, "The request referred to a schema rule that does not exist." ),
 
         LabelLimitReached( ClientError, "The maximum number of labels supported has been reached, no more labels can be created." ),
+        IndexLimitReached( ClientError, "The maximum number of index entries supported has been reached, no more entities can be indexed." ),
 
         ModifiedConcurrently( TransientError, "The database schema was modified while this transaction was running, the transaction should be retried." ),
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexCapacityExceededException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexCapacityExceededException.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.index;
+
+import org.neo4j.kernel.api.exceptions.KernelException;
+
+import static org.neo4j.kernel.api.exceptions.Status.Schema.IndexLimitReached;
+
+/**
+ * This exception is thrown when the underlying index implementation is not able to index more entities.
+ * It can either be thrown during index population or during insertions at runtime.
+ */
+public class IndexCapacityExceededException extends KernelException
+{
+    private static final String RESERVATION_FAILED_MESSAGE =
+            "Unable to reserve %d entries for insertion into index. " +
+            "Index contains too many entries. Current limitation is %d entries per index. " +
+            "Currently there are %d index entities.";
+
+    private static final String INSERTION_FAILED_MESSAGE =
+            "Index contains too many entries. Current limitation is %d indexed entities per index. " +
+            "Currently there are %d index entities.";
+
+    public IndexCapacityExceededException( long reservation, long currentValue, long limit )
+    {
+        super( IndexLimitReached, RESERVATION_FAILED_MESSAGE, reservation, currentValue, limit );
+    }
+
+    public IndexCapacityExceededException( long currentValue, long limit )
+    {
+        super( IndexLimitReached, INSERTION_FAILED_MESSAGE, currentValue, limit );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.api.index.SwallowingIndexUpdater;
 import org.neo4j.kernel.impl.api.index.UpdateMode;
 
@@ -51,7 +52,8 @@ public interface IndexPopulator
      * @param nodeId node id to index.
      * @param propertyValue property value for the entry to index.
      */
-    void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException;
+    void add( long nodeId, Object propertyValue )
+            throws IndexEntryConflictException, IOException, IndexCapacityExceededException;
 
     /**
      * Verify constraints for all entries added so far.
@@ -93,7 +95,7 @@ public interface IndexPopulator
      * as {@link InternalIndexState#ONLINE} so that future invocations of its parent
      * {@link SchemaIndexProvider#getInitialState(long)} also returns {@link InternalIndexState#ONLINE}.
      */
-    void close( boolean populationCompletedSuccessfully ) throws IOException;
+    void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Called then a population failed. The failure string should be stored for future retrieval by

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
@@ -22,12 +22,17 @@ package org.neo4j.kernel.api.index;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
 public interface IndexUpdater extends AutoCloseable
 {
-    void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException;
+    Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException, IndexCapacityExceededException;
+
+    void process( NodePropertyUpdate update )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     @Override
-    void close() throws IOException, IndexEntryConflictException;
+    void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     void remove( Collection<Long> nodeIds ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
-import java.util.Collection;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 
 public interface IndexUpdater extends AutoCloseable
@@ -34,5 +34,5 @@ public interface IndexUpdater extends AutoCloseable
     @Override
     void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
-    void remove( Collection<Long> nodeIds ) throws IOException;
+    void remove( PrimitiveLongSet nodeIds ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/Reservation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/Reservation.java
@@ -17,14 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.impl.index;
+package org.neo4j.kernel.api.index;
 
-import java.io.IOException;
-
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.store.Directory;
-
-public interface LuceneIndexWriterFactory
+public interface Reservation
 {
-    IndexWriter create( Directory directory ) throws IOException;
+    Reservation EMPTY = new Reservation()
+    {
+        @Override
+        public void release()
+        {
+        }
+    };
+
+    void release();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
@@ -56,7 +57,7 @@ public interface LabelScanStore extends Lifecycle
      * @param updates the updates to store.
      * @throws IOException if there was a problem updating the store.
      */
-    void recover( Iterator<NodeLabelUpdate> updates ) throws IOException;
+    void recover( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Forces all changes to disk. Called at certain points from within Neo4j for example when
@@ -81,7 +82,7 @@ public interface LabelScanStore extends Lifecycle
      * Starts the store. After this has been called updates can be processed.
      */
     @Override
-    void start() throws IOException;
+    void start() throws IOException, IndexCapacityExceededException;
 
     @Override
     void stop() throws IOException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api;
 
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
@@ -29,6 +30,7 @@ public interface CommitProcessFactory
 {
     TransactionCommitProcess create( LogicalTransactionStore logicalTransactionStore, KernelHealth kernelHealth,
                                      NeoStore neoStore, TransactionRepresentationStoreApplier storeApplier,
-                                     NeoStoreInjectedTransactionValidator validator, TransactionApplicationMode mode,
+                                     NeoStoreInjectedTransactionValidator txValidator,
+                                     IndexUpdatesValidator indexUpdatesValidator, TransactionApplicationMode mode,
                                      Config config );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AggregatedReservation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AggregatedReservation.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.kernel.api.index.Reservation;
+
+/**
+ * Represents a set of {@link org.neo4j.kernel.api.index.Reservation} objects that could be atomically
+ * released via {@link org.neo4j.kernel.impl.api.index.AggregatedReservation#release()}.
+ * Method {@link org.neo4j.kernel.api.index.Reservation#release()} is called on all underlying reservations even if
+ * some of them throw exceptions.
+ */
+class AggregatedReservation implements Reservation
+{
+    private final Reservation[] aggregates;
+    private int pointer;
+
+    AggregatedReservation( int size )
+    {
+        this.aggregates = new Reservation[size];
+    }
+
+    void add( Reservation reservation )
+    {
+        if ( pointer == aggregates.length )
+        {
+            throw new IndexOutOfBoundsException( "Too many aggregates, size = " + aggregates.length );
+        }
+        if ( this == reservation )
+        {
+            throw new IllegalArgumentException( "Recursive aggregates not allowed" );
+        }
+        aggregates[pointer++] = reservation;
+    }
+
+    @Override
+    public void release()
+    {
+        Throwable firstError = null;
+
+        for ( Reservation aggregate : aggregates )
+        {
+            if ( aggregate != null )
+            {
+                try
+                {
+                    aggregate.release();
+                }
+                catch ( Throwable t )
+                {
+                    if ( firstError == null )
+                    {
+                        firstError = t;
+                    }
+                }
+            }
+        }
+
+        if ( firstError != null )
+        {
+            throw Exceptions.launderedException( firstError );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
@@ -24,9 +24,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
-import org.neo4j.kernel.api.index.NodePropertyUpdate;
 
 /**
  * {@link IndexProxy} layer that enforces the dynamic contract of {@link IndexProxy} (cf. Test)
@@ -97,13 +97,7 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
             return new DelegatingIndexUpdater( super.newUpdater( mode ) )
             {
                 @Override
-                public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
-                {
-                    delegate.process( update );
-                }
-
-                @Override
-                public void close() throws IOException, IndexEntryConflictException
+                public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                 {
                     try
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
-import java.util.Collection;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -52,7 +52,7 @@ public abstract class DelegatingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void remove( Collection<Long> nodeIds ) throws IOException
+    public void remove( PrimitiveLongSet nodeIds ) throws IOException
     {
         delegate.remove( nodeIds );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/DelegatingIndexUpdater.java
@@ -22,7 +22,11 @@ package org.neo4j.kernel.impl.api.index;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public abstract class DelegatingIndexUpdater implements IndexUpdater
 {
@@ -31,6 +35,20 @@ public abstract class DelegatingIndexUpdater implements IndexUpdater
     public DelegatingIndexUpdater( IndexUpdater delegate )
     {
         this.delegate = delegate;
+    }
+
+    @Override
+    public Reservation validate( Iterable<NodePropertyUpdate> updates )
+            throws IOException, IndexCapacityExceededException
+    {
+        return delegate.validate( updates );
+    }
+
+    @Override
+    public void process( NodePropertyUpdate update )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
+    {
+        delegate.process( update );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.exceptions.index.ExceptionDuringFlipKernelException;
 import org.neo4j.kernel.api.exceptions.index.FlipFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexProxyAlreadyClosedKernelException;
@@ -40,7 +41,6 @@ import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
-import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 
 public class FlippableIndexProxy implements IndexProxy
@@ -352,13 +352,7 @@ public class FlippableIndexProxy implements IndexProxy
         }
 
         @Override
-        public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
-        {
-            delegate.process( update );
-        }
-
-        @Override
-        public void close() throws IOException, IndexEntryConflictException
+        public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
         {
             try
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -104,4 +104,9 @@ public final class IndexMap implements Cloneable
     {
         return indexesByDescriptor.keySet().iterator();
     }
+
+    public int size()
+    {
+        return indexesById.size();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -83,7 +84,7 @@ public class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
             {
                 updater.close();
             }
-            catch ( IOException | IndexEntryConflictException e )
+            catch ( IOException | IndexEntryConflictException | IndexCapacityExceededException e )
             {
                 if ( null == exceptions )
                 {
@@ -114,6 +115,11 @@ public class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
     public int size()
     {
         return updaterMap.size();
+    }
+
+    public int numberOfIndexes()
+    {
+        return indexMap.size();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidator.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+import org.neo4j.kernel.impl.transaction.state.LazyIndexUpdates;
+import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
+
+import static org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import static org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
+
+/**
+ * Performs validation of index updates for transactions based on
+ * {@link org.neo4j.kernel.impl.transaction.command.Command}s in transaction state.
+ * It is done by inferring {@link org.neo4j.kernel.api.index.NodePropertyUpdate}s from commands and asking
+ * {@link org.neo4j.kernel.impl.api.index.IndexingService} to check those via
+ * {@link org.neo4j.kernel.impl.api.index.IndexingService#validate(Iterable)}.
+ */
+public class IndexUpdatesValidator
+{
+    private final NodeStore nodeStore;
+    private final PropertyStore propertyStore;
+    private final PropertyLoader propertyLoader;
+    private final IndexingService indexing;
+
+    public IndexUpdatesValidator( NeoStore neoStore, PropertyLoader propertyLoader, IndexingService indexing )
+    {
+        this.nodeStore = neoStore.getNodeStore();
+        this.propertyStore = neoStore.getPropertyStore();
+        this.propertyLoader = propertyLoader;
+        this.indexing = indexing;
+    }
+
+    public ValidatedIndexUpdates validate( TransactionRepresentation transaction, TransactionApplicationMode mode )
+            throws IOException
+    {
+        NodePropertyCommandsExtractor extractor = new NodePropertyCommandsExtractor();
+        transaction.accept( extractor );
+
+        if ( extractor.noCommandsExtracted() )
+        {
+            return ValidatedIndexUpdates.NONE;
+        }
+
+        if ( mode == TransactionApplicationMode.RECOVERY )
+        {
+            return newValidatedRecoveredUpdates( extractor.changedNodeIds(), indexing );
+        }
+
+        Iterable<NodePropertyUpdate> updates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                extractor.nodeCommandsById, extractor.propertyCommandsByNodeIds );
+
+        return indexing.validate( updates );
+    }
+
+    private static ValidatedIndexUpdates newValidatedRecoveredUpdates( final Set<Long> nodeIds,
+            final IndexingService indexing )
+    {
+        return new ValidatedIndexUpdates()
+        {
+            @Override
+            public void flush()
+            {
+                indexing.addRecoveredNodeIds( nodeIds );
+            }
+
+            @Override
+            public void close()
+            {
+            }
+        };
+    }
+
+    private static class NodePropertyCommandsExtractor
+            extends NeoCommandHandler.Adapter implements Visitor<Command,IOException>
+    {
+        final Map<Long,NodeCommand> nodeCommandsById = new HashMap<>();
+        final Map<Long,List<PropertyCommand>> propertyCommandsByNodeIds = new HashMap<>();
+
+        @Override
+        public boolean visit( Command element ) throws IOException
+        {
+            element.handle( this );
+            return false;
+        }
+
+        @Override
+        public boolean visitNodeCommand( NodeCommand command ) throws IOException
+        {
+            nodeCommandsById.put( command.getKey(), command );
+            return false;
+        }
+
+        @Override
+        public boolean visitPropertyCommand( PropertyCommand command ) throws IOException
+        {
+            PropertyRecord record = command.getAfter();
+            if ( record.isNodeSet() )
+            {
+                long nodeId = command.getAfter().getNodeId();
+                List<PropertyCommand> group = propertyCommandsByNodeIds.get( nodeId );
+                if ( group == null )
+                {
+                    propertyCommandsByNodeIds.put( nodeId, group = new ArrayList<>() );
+                }
+                group.add( command );
+            }
+            return false;
+        }
+
+        boolean noCommandsExtracted()
+        {
+            return nodeCommandsById.isEmpty() && propertyCommandsByNodeIds.isEmpty();
+        }
+
+        Set<Long> changedNodeIds()
+        {
+            Set<Long> nodeIds = new HashSet<>( nodeCommandsById.size() + propertyCommandsByNodeIds.size(), 1 );
+            nodeIds.addAll( nodeCommandsById.keySet() );
+            nodeIds.addAll( propertyCommandsByNodeIds.keySet() );
+            return nodeIds;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
@@ -32,8 +33,10 @@ import java.util.concurrent.Future;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.BiConsumer;
 import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
@@ -42,6 +45,7 @@ import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
@@ -59,9 +63,9 @@ import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.concatResourceIterators;
+import static org.neo4j.helpers.collection.Iterables.toList;
 import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
 
 /**
@@ -378,37 +382,142 @@ public class IndexingService extends LifecycleAdapter
         indexMapRef.setIndexMap( indexMap );
     }
 
-    public void updateIndexes( IndexUpdates updates, long transactionId, boolean forceIdempotency )
+    public void addRecoveredNodeIds( Set<Long> nodeIds )
     {
+        if ( state != State.NOT_STARTED )
+        {
+            throw new IllegalStateException(
+                    "Can't queue recovered node ids " + nodeIds + " while indexing service is " + state );
+        }
+
+        recoveredNodeIds.addAll( nodeIds );
+    }
+
+    public ValidatedIndexUpdates validate( Iterable<NodePropertyUpdate> updates )
+    {
+        IndexUpdateMode updateMode;
         if ( state == State.RUNNING )
         {
-
-            IndexUpdateMode mode = forceIdempotency ? IndexUpdateMode.RECOVERY : IndexUpdateMode.ONLINE;
-            try ( IndexUpdaterMap updaterMap = indexMapRef.createIndexUpdaterMap( mode ) )
-            {
-                applyUpdates( updates, updaterMap );
-            }
+            updateMode = IndexUpdateMode.ONLINE;
+        }
+        else if ( state == State.STARTING )
+        {
+            updateMode = IndexUpdateMode.RECOVERY;
         }
         else
         {
-            if( state == State.NOT_STARTED )
+            throw new IllegalStateException(
+                    "Can't validate index updates " + toList( updates ) + " while indexing service is " + state );
+        }
+
+        IndexUpdaterMap updaterMap = indexMapRef.createIndexUpdaterMap( updateMode );
+
+        boolean updaterMapShouldBeClosed = true;
+        try
+        {
+            Map<IndexDescriptor,List<NodePropertyUpdate>> updatesByIndex =
+                    groupUpdatesByIndexDescriptor( updates, updaterMap );
+
+            if ( updatesByIndex.isEmpty() )
             {
-                recoveredNodeIds.addAll( updates.changedNodeIds() );
+                return ValidatedIndexUpdates.NONE;
             }
-            else
+
+            AggregatedReservation aggregatedReservation = new AggregatedReservation( updatesByIndex.size() );
+            for ( Map.Entry<IndexDescriptor,List<NodePropertyUpdate>> entry : updatesByIndex.entrySet() )
             {
-                // This is a temporary measure to resolve a corruption bug. We believe that it's caused by stray
-                // HA transactions, and we know that this measure will fix it. It appears, however, that the correct
-                // fix will be, as it is for several other issues, to modify the system to allow us to kill running
-                // transactions before state switches.
-                throw new IllegalStateException( "Cannot queue index updates while index service is " + state );
+                validateAndRecordReservation( entry.getValue(), aggregatedReservation, updaterMap,
+                        entry.getKey() );
+            }
+
+            ValidatedIndexUpdates validatedUpdates =
+                    newValidatedIndexUpdates( updaterMap, updatesByIndex, aggregatedReservation );
+
+            updaterMapShouldBeClosed = false;
+
+            return validatedUpdates;
+        }
+        finally
+        {
+            if ( updaterMapShouldBeClosed )
+            {
+                updaterMap.close();
             }
         }
     }
 
-    protected void applyRecoveredUpdates() throws IOException
+    private void validateAndRecordReservation( List<NodePropertyUpdate> indexUpdates,
+            AggregatedReservation aggregatedReservation, IndexUpdaterMap updaterMap, IndexDescriptor descriptor )
     {
-        logger.debug( "Applying recovered updates: " + recoveredNodeIds );
+        boolean exceptionThrown = false;
+        try
+        {
+            IndexUpdater updater = updaterMap.getUpdater( descriptor );
+            Reservation reservation = updater.validate( indexUpdates );
+            aggregatedReservation.add( reservation );
+        }
+        catch ( IOException | IndexCapacityExceededException e )
+        {
+            exceptionThrown = true;
+            String indexName = descriptor.userDescription( tokenNameLookup );
+            throw new UnderlyingStorageException( "Validation of updates for index " + indexName + " failed", e );
+        }
+        catch ( Throwable t )
+        {
+            exceptionThrown = true;
+            throw t;
+        }
+        finally
+        {
+            if ( exceptionThrown )
+            {
+                aggregatedReservation.release();
+            }
+        }
+    }
+
+    private static ValidatedIndexUpdates newValidatedIndexUpdates( final IndexUpdaterMap indexUpdaters,
+            final Map<IndexDescriptor,List<NodePropertyUpdate>> updatesByIndex, final Reservation reservation )
+    {
+        return new ValidatedIndexUpdates()
+        {
+            @Override
+            public void flush() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
+            {
+                for ( Map.Entry<IndexDescriptor,List<NodePropertyUpdate>> entry : updatesByIndex.entrySet() )
+                {
+                    IndexDescriptor indexDescriptor = entry.getKey();
+                    List<NodePropertyUpdate> updates = entry.getValue();
+
+                    IndexUpdater updater = indexUpdaters.getUpdater( indexDescriptor );
+                    for ( NodePropertyUpdate update : updates )
+                    {
+                        updater.process( update );
+                    }
+                }
+            }
+
+            @Override
+            public void close()
+            {
+                try
+                {
+                    reservation.release();
+                }
+                finally
+                {
+                    indexUpdaters.close();
+                }
+            }
+        };
+    }
+
+    private void applyRecoveredUpdates() throws IOException
+    {
+        if ( logger.isDebugEnabled() )
+        {
+            logger.debug( "Applying recovered updates: " + recoveredNodeIds );
+        }
         monitor.applyingRecoveredData( recoveredNodeIds );
         if ( !recoveredNodeIds.isEmpty() )
         {
@@ -418,19 +527,33 @@ public class IndexingService extends LifecycleAdapter
                 {
                     updater.remove( recoveredNodeIds );
                 }
-                for ( long nodeId : recoveredNodeIds )
-                {
-                    Iterable<NodePropertyUpdate> updates = storeView.nodeAsUpdates( nodeId );
-                    applyUpdates( updates, updaterMap );
-                    monitor.appliedRecoveredData( updates );
-                }
+            }
+
+            List<NodePropertyUpdate> recoveredUpdates = new ArrayList<>();
+            for ( long nodeId : recoveredNodeIds )
+            {
+                Iterables.addAll( recoveredUpdates, storeView.nodeAsUpdates( nodeId ) );
+            }
+
+            try ( ValidatedIndexUpdates validatedUpdates = validate( recoveredUpdates ) )
+            {
+                validatedUpdates.flush();
+                monitor.appliedRecoveredData( recoveredUpdates );
+            }
+            catch ( IndexEntryConflictException | IndexCapacityExceededException e )
+            {
+                throw new UnderlyingStorageException( e );
             }
         }
         recoveredNodeIds.clear();
     }
 
-    private void applyUpdates( Iterable<NodePropertyUpdate> updates,  IndexUpdaterMap updaterMap )
+    private static Map<IndexDescriptor,List<NodePropertyUpdate>> groupUpdatesByIndexDescriptor(
+            Iterable<NodePropertyUpdate> updates, IndexUpdaterMap updaterMap )
     {
+        int numberOfIndexes = updaterMap.numberOfIndexes();
+        Map<IndexDescriptor,List<NodePropertyUpdate>> updatesByIndex = new HashMap<>( numberOfIndexes, 1 );
+
         for ( NodePropertyUpdate update : updates )
         {
             int propertyKeyId = update.getPropertyKeyId();
@@ -440,7 +563,7 @@ public class IndexingService extends LifecycleAdapter
                 for ( int len = update.getNumberOfLabelsAfter(), i = 0; i < len; i++ )
                 {
                     IndexDescriptor descriptor = new IndexDescriptor( update.getLabelAfter( i ), propertyKeyId );
-                    processUpdateIfIndexExists( updaterMap, update, descriptor );
+                    storeUpdateIfIndexExists( updaterMap, update, descriptor, updatesByIndex );
                 }
                 break;
 
@@ -448,7 +571,7 @@ public class IndexingService extends LifecycleAdapter
                 for ( int len = update.getNumberOfLabelsBefore(), i = 0; i < len; i++ )
                 {
                     IndexDescriptor descriptor = new IndexDescriptor( update.getLabelBefore( i ), propertyKeyId );
-                    processUpdateIfIndexExists( updaterMap, update, descriptor );
+                    storeUpdateIfIndexExists( updaterMap, update, descriptor, updatesByIndex );
                 }
                 break;
 
@@ -464,7 +587,7 @@ public class IndexingService extends LifecycleAdapter
                     if ( labelBefore == labelAfter )
                     {
                         IndexDescriptor descriptor = new IndexDescriptor( labelAfter, propertyKeyId );
-                        processUpdateIfIndexExists( updaterMap, update, descriptor );
+                        storeUpdateIfIndexExists( updaterMap, update, descriptor, updatesByIndex );
                         i++;
                         j++;
                     }
@@ -483,24 +606,23 @@ public class IndexingService extends LifecycleAdapter
                 break;
             }
         }
+
+        return updatesByIndex;
     }
 
-    private IndexDescriptor processUpdateIfIndexExists(  IndexUpdaterMap updaterMap, NodePropertyUpdate update, IndexDescriptor descriptor )
+    private static void storeUpdateIfIndexExists( IndexUpdaterMap updaterMap, NodePropertyUpdate update,
+            IndexDescriptor descriptor, Map<IndexDescriptor,List<NodePropertyUpdate>> updatesByIndex )
     {
-        try
+        IndexUpdater updater = updaterMap.getUpdater( descriptor );
+        if ( updater != null )
         {
-            IndexUpdater updater = updaterMap.getUpdater( descriptor );
-            if ( null != updater )
+            List<NodePropertyUpdate> indexUpdates = updatesByIndex.get( descriptor );
+            if ( indexUpdates == null )
             {
-                updater.process( update );
-                return descriptor;
+                updatesByIndex.put( descriptor, indexUpdates = new ArrayList<>() );
             }
+            indexUpdates.add( update );
         }
-        catch ( IOException | IndexEntryConflictException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-        return null;
     }
 
     public void dropIndex( IndexRule rule )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -21,9 +21,9 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.Future;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
@@ -222,7 +222,7 @@ public class PopulatingIndexProxy implements IndexProxy
         }
 
         @Override
-        public void remove( Collection<Long> nodeIds )
+        public void remove( PrimitiveLongSet nodeIds )
         {
             throw new UnsupportedOperationException( "Should not remove() from populating index." );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexConfiguration;
@@ -37,6 +38,7 @@ import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -207,6 +209,13 @@ public class PopulatingIndexProxy implements IndexProxy
 
     private abstract class PopulatingIndexUpdater implements IndexUpdater
     {
+        @Override
+        public Reservation validate( Iterable<NodePropertyUpdate> updates )
+                throws IOException, IndexCapacityExceededException
+        {
+            return Reservation.EMPTY;
+        }
+
         @Override
         public void close() throws IOException, IndexEntryConflictException
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public final class SwallowingIndexUpdater implements IndexUpdater
 {
@@ -32,6 +33,12 @@ public final class SwallowingIndexUpdater implements IndexUpdater
 
     public SwallowingIndexUpdater()
     {
+    }
+
+    @Override
+    public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        return Reservation.EMPTY;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/SwallowingIndexUpdater.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
-import java.util.Collection;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -54,7 +54,7 @@ public final class SwallowingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void remove( Collection<Long> nodeIds )
+    public void remove( PrimitiveLongSet nodeIds )
     {
         // intentionally swallow these removals
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -58,7 +59,8 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
                 return new DelegatingIndexUpdater( target.accessor.newUpdater( mode ) )
                 {
                     @Override
-                    public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+                    public void process( NodePropertyUpdate update )
+                            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                     {
                         try
                         {
@@ -71,7 +73,7 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
                     }
 
                     @Override
-                    public void close() throws IOException, IndexEntryConflictException
+                    public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
                     {
                         try
                         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -59,14 +60,14 @@ public abstract class UniquePropertyIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void close() throws IOException, IndexEntryConflictException
+    public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         // flush updates
         flushUpdates( updates );
     }
 
     protected abstract void flushUpdates( Iterable<NodePropertyUpdate> updates )
-            throws IOException, IndexEntryConflictException;
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
 
     private DiffSets<Long> propertyValueDiffSet( Object value )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateCountingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateCountingIndexUpdater.java
@@ -22,10 +22,12 @@ package org.neo4j.kernel.impl.api.index;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public class UpdateCountingIndexUpdater implements IndexUpdater
 {
@@ -43,14 +45,22 @@ public class UpdateCountingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+    public Reservation validate( Iterable<NodePropertyUpdate> updates )
+            throws IOException, IndexCapacityExceededException
+    {
+        return delegate.validate( updates );
+    }
+
+    @Override
+    public void process( NodePropertyUpdate update )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         delegate.process( update );
         updates++;
     }
 
     @Override
-    public void close() throws IOException, IndexEntryConflictException
+    public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         delegate.close();
         storeView.incrementIndexUpdates( descriptor, updates );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateCountingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UpdateCountingIndexUpdater.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
-import java.util.Collection;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -67,7 +67,7 @@ public class UpdateCountingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void remove( Collection<Long> nodeIds ) throws IOException
+    public void remove( PrimitiveLongSet nodeIds ) throws IOException
     {
         delegate.remove( nodeIds );
         updates += nodeIds.size();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.kernel.api.index.IndexEntryConflictException;
+
+/**
+ * This class represents validated and prepared index updates that are ready to be flushed.
+ * Flushing is performed with {@link ValidatedIndexUpdates#flush()} method.
+ * Releasing of resources is performed with {@link ValidatedIndexUpdates#close()} method.
+ * <p/>
+ * Notion of being 'prepared' indicates that index updates are placed in internal data structures and no
+ * pre-processing before {@link ValidatedIndexUpdates#flush()} is needed. Such data structure might represent simply
+ * a mapping 'Index -> [set of updates]'.
+ * <p/>
+ * Notion of being 'validated' indicates that all updates in this batch can be consumed by corresponding indexes.
+ * This mostly mean that index size permit new insertions {@see IndexCapacityExceededException}.
+ */
+public interface ValidatedIndexUpdates extends AutoCloseable
+{
+    ValidatedIndexUpdates NONE = new ValidatedIndexUpdates()
+    {
+        @Override
+        public void flush()
+        {
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    };
+
+    /**
+     * Flush all validated and prepared index updates to corresponding indexes.
+     */
+    void flush() throws IOException, IndexEntryConflictException, IndexCapacityExceededException;
+
+    /**
+     * Release all possible resources used by this batch of index updates. Such resources might include
+     * {@link org.neo4j.kernel.api.index.IndexUpdater} and {@link org.neo4j.kernel.api.index.Reservation}.
+     */
+    @Override
+    void close();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -25,8 +25,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
+import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.IteratorUtil;
@@ -667,7 +667,7 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         return toReturn;
     }
 
-    public Collection<PropertyRecord> getPropertyRecordChain( long firstRecordId, Map<Long,PropertyRecord> propertyLookup )
+    public Collection<PropertyRecord> getPropertyRecordChain( long firstRecordId, PrimitiveLongObjectMap<PropertyRecord> propertyLookup )
     {
         long nextProp = firstRecordId;
         List<PropertyRecord> toReturn = new ArrayList<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.UTF8;
@@ -661,6 +662,23 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord> implement
         {
             PropertyRecord propRecord = getLightRecord( nextProp );
             toReturn.add(propRecord);
+            nextProp = propRecord.getNextProp();
+        }
+        return toReturn;
+    }
+
+    public Collection<PropertyRecord> getPropertyRecordChain( long firstRecordId, Map<Long,PropertyRecord> propertyLookup )
+    {
+        long nextProp = firstRecordId;
+        List<PropertyRecord> toReturn = new ArrayList<>();
+        while ( nextProp != Record.NO_NEXT_PROPERTY.intValue() )
+        {
+            PropertyRecord propRecord = propertyLookup.get( nextProp );
+            if ( propRecord == null )
+            {
+                propRecord = getLightRecord( nextProp );
+            }
+            toReturn.add( propRecord );
             nextProp = propRecord.getNextProp();
         }
         return toReturn;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.transaction.state;
 
 import java.util.Collection;
-import java.util.Map;
 
+import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.NodeStore;
@@ -58,7 +58,7 @@ public class PropertyLoader
         loadProperties( nodeRecord.getNextProp(), receiver );
     }
 
-    public void nodeLoadProperties( NodeRecord node, Map<Long,PropertyRecord> propertiesById, PropertyReceiver receiver )
+    public void nodeLoadProperties( NodeRecord node, PrimitiveLongObjectMap<PropertyRecord> propertiesById, PropertyReceiver receiver )
     {
         loadProperties( node.getNextProp(), propertiesById, receiver );
     }
@@ -87,7 +87,7 @@ public class PropertyLoader
         }
     }
 
-    private void loadProperties( long nextProp, Map<Long,PropertyRecord> propertiesById, PropertyReceiver receiver )
+    private void loadProperties( long nextProp, PrimitiveLongObjectMap<PropertyRecord> propertiesById, PropertyReceiver receiver )
     {
         Collection<PropertyRecord> chain = propertyStore.getPropertyRecordChain( nextProp, propertiesById );
         if ( chain != null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyLoader.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.transaction.state;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -57,6 +58,11 @@ public class PropertyLoader
         loadProperties( nodeRecord.getNextProp(), receiver );
     }
 
+    public void nodeLoadProperties( NodeRecord node, Map<Long,PropertyRecord> propertiesById, PropertyReceiver receiver )
+    {
+        loadProperties( node.getNextProp(), propertiesById, receiver );
+    }
+
     public void relLoadProperties( long relId, PropertyReceiver receiver )
     {
         RelationshipRecord relRecord = relationshipStore.getRecord( relId );
@@ -75,6 +81,15 @@ public class PropertyLoader
     private void loadProperties( long nextProp, PropertyReceiver receiver )
     {
         Collection<PropertyRecord> chain = propertyStore.getPropertyRecordChain( nextProp );
+        if ( chain != null )
+        {
+            loadPropertyChain( chain, receiver );
+        }
+    }
+
+    private void loadProperties( long nextProp, Map<Long,PropertyRecord> propertiesById, PropertyReceiver receiver )
+    {
+        Collection<PropertyRecord> chain = propertyStore.getPropertyRecordChain( nextProp, propertiesById );
         if ( chain != null )
         {
             loadPropertyChain( chain, receiver );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecoveryVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecoveryVisitor.java
@@ -22,12 +22,16 @@ package org.neo4j.kernel.impl.transaction.state;
 import java.io.IOException;
 
 import org.neo4j.helpers.collection.CloseableVisitor;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.RECOVERY;
 
 public class RecoveryVisitor implements CloseableVisitor<CommittedTransactionRepresentation,IOException>
 {
@@ -38,15 +42,19 @@ public class RecoveryVisitor implements CloseableVisitor<CommittedTransactionRep
 
     private final TransactionIdStore store;
     private final TransactionRepresentationStoreApplier storeApplier;
+    private final IndexUpdatesValidator indexUpdatesValidator;
     private final Monitor monitor;
     private long lastTransactionIdApplied = -1;
     private long lastTransactionChecksum;
 
     public RecoveryVisitor( TransactionIdStore store,
-                            TransactionRepresentationStoreApplier storeApplier, Monitor monitor )
+                            TransactionRepresentationStoreApplier storeApplier,
+                            IndexUpdatesValidator indexUpdatesValidator,
+                            Monitor monitor )
     {
         this.store = store;
         this.storeApplier = storeApplier;
+        this.indexUpdatesValidator = indexUpdatesValidator;
         this.monitor = monitor;
     }
 
@@ -54,11 +62,14 @@ public class RecoveryVisitor implements CloseableVisitor<CommittedTransactionRep
     public boolean visit( CommittedTransactionRepresentation transaction ) throws IOException
     {
         long txId = transaction.getCommitEntry().getTxId();
-        try ( LockGroup locks = new LockGroup() )
+        TransactionRepresentation txRepresentation = transaction.getTransactionRepresentation();
+
+        try ( LockGroup locks = new LockGroup();
+              ValidatedIndexUpdates indexUpdates = prepareIndexUpdates( txRepresentation ) )
         {
-            storeApplier.apply( transaction.getTransactionRepresentation(), locks, txId,
-                    TransactionApplicationMode.RECOVERY );
+            storeApplier.apply( txRepresentation, indexUpdates, locks, txId, RECOVERY );
         }
+
         lastTransactionIdApplied = txId;
         lastTransactionChecksum = LogEntryStart.checksum( transaction.getStartEntry() );
         monitor.transactionRecovered( txId );
@@ -72,5 +83,17 @@ public class RecoveryVisitor implements CloseableVisitor<CommittedTransactionRep
         {
             store.setLastCommittedAndClosedTransactionId( lastTransactionIdApplied, lastTransactionChecksum );
         }
+    }
+
+    /**
+     * Recovery operates under a condition that all index updates are valid because otherwise they have no chance to
+     * appear in write ahead log.
+     * This step is still needed though, because it is not only about validation of index sizes but also about
+     * inferring {@link org.neo4j.kernel.api.index.NodePropertyUpdate}s from commands in transaction state and
+     * grouping those by {@link org.neo4j.kernel.api.index.IndexUpdater}s.
+     */
+    private ValidatedIndexUpdates prepareIndexUpdates( TransactionRepresentation txRepresentation ) throws IOException
+    {
+        return indexUpdatesValidator.validate( txRepresentation, RECOVERY );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/LabelScanWriter.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.batchinsert;
 import java.io.Closeable;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 
 public interface LabelScanWriter extends Closeable
@@ -29,7 +30,7 @@ public interface LabelScanWriter extends Closeable
     /**
      * Store a {@link NodeLabelUpdate}. Calls to this method MUST be ordered by ascending node id.
      */
-    void write( NodeLabelUpdate update ) throws IOException;
+    void write( NodeLabelUpdate update ) throws IOException, IndexCapacityExceededException;
 
     /**
      * Close this writer and flush pending changes to the store.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -19,18 +19,18 @@
  */
 package org.neo4j.graphdb;
 
-import java.util.Map;
-
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Map;
+
 import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.graphdb.Neo4jMatchers.containsOnly;
 import static org.neo4j.graphdb.Neo4jMatchers.createIndex;
 import static org.neo4j.graphdb.Neo4jMatchers.findNodesByLabelAndProperty;
@@ -398,7 +398,6 @@ public class IndexingAcceptanceTest
         }
     }
 
-
     @Test( expected = MultipleFoundException.class )
     public void shouldThrowWhenMulitpleResultsForSingleNode() throws Exception
     {
@@ -420,6 +419,56 @@ public class IndexingAcceptanceTest
         try ( Transaction tx = graph.beginTx() )
         {
             graph.findNode( LABEL1, "name", "Stefan" );
+        }
+    }
+
+    @Test
+    public void shouldAddIndexedPropertyToNodeWithDynamicLabels()
+    {
+        // Given
+        int indexesCount = 20;
+        String labelPrefix = "foo";
+        String propertyKeyPrefix = "bar";
+        String propertyValuePrefix = "baz";
+        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+
+        for ( int i = 0; i < indexesCount; i++ )
+        {
+            createIndex( db, DynamicLabel.label( labelPrefix + i ), propertyKeyPrefix + i );
+        }
+
+        // When
+        long nodeId;
+        try ( Transaction tx = db.beginTx() )
+        {
+            nodeId = db.createNode().getId();
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.getNodeById( nodeId );
+            for ( int i = 0; i < indexesCount; i++ )
+            {
+                node.addLabel( DynamicLabel.label( labelPrefix + i ) );
+                node.setProperty( propertyKeyPrefix + i, propertyValuePrefix + i );
+            }
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < indexesCount; i++ )
+            {
+                Label label = DynamicLabel.label( labelPrefix + i );
+                String key = propertyKeyPrefix + i;
+                String value = propertyValuePrefix + i;
+
+                ResourceIterable<Node> nodes = db.findNodesByLabelAndProperty( label, key, value );
+                assertEquals( 1, Iterables.count( nodes ) );
+            }
+            tx.success();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/LogRotationDeadlockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/LogRotationDeadlockTest.java
@@ -34,10 +34,9 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.locking.LockGroup;
-import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
-import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.transaction.DeadSimpleTransactionIdStore;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.BatchingPhysicalTransactionAppender;
@@ -49,6 +48,8 @@ import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
@@ -109,7 +110,7 @@ public class LogRotationDeadlockTest
         when( txStore.getAppender() ).thenReturn( appender );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( txStore,
                 health, txIdStore, mock( TransactionRepresentationStoreApplier.class ),
-                TransactionApplicationMode.INTERNAL );
+                mock( IndexUpdatesValidator.class ), TransactionApplicationMode.INTERNAL );
 
         // WHEN
         // trapping an appender in between having its transaction committed and closed

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexAccessorCompatibility.java
@@ -19,23 +19,25 @@
  */
 package org.neo4j.kernel.api.index;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 @Ignore( "Not a test. This is a compatibility suite that provides test cases for verifying" +
         " SchemaIndexProvider implementations. Each index provider that is to be tested by this suite" +
@@ -72,7 +74,7 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
     }
 
     @Before
-    public void before() throws IOException
+    public void before() throws Exception
     {
         IndexConfiguration indexConfig = new IndexConfiguration( true );
         IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( new Config() );
@@ -103,7 +105,8 @@ public class UniqueIndexAccessorCompatibility extends IndexProviderCompatibility
         }
     }
 
-    private void updateAndCommit( List<NodePropertyUpdate> updates ) throws IOException, IndexEntryConflictException
+    private void updateAndCommit( List<NodePropertyUpdate> updates )
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
@@ -19,17 +19,18 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import org.junit.Test;
+import org.mockito.Matchers;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-
-import org.junit.Test;
-import org.mockito.Matchers;
 
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
@@ -51,7 +52,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.util.function.Optionals.some;
 
 public class TransactionRepresentationStoreApplierTest
@@ -84,7 +84,7 @@ public class TransactionRepresentationStoreApplierTest
 
         try ( LockGroup locks = new LockGroup() )
         {
-            applier.apply( transaction, locks, transactionId, TransactionApplicationMode.INTERNAL );
+            applier.apply( transaction, ValidatedIndexUpdates.NONE, locks, transactionId, TransactionApplicationMode.INTERNAL );
         }
 
         verify( transaction, times( 1 ) ).accept( Matchers.<Visitor<Command, IOException>>any() );
@@ -104,7 +104,7 @@ public class TransactionRepresentationStoreApplierTest
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
-            applier.apply( transaction, locks, transactionId, TransactionApplicationMode.EXTERNAL );
+            applier.apply( transaction, ValidatedIndexUpdates.NONE, locks, transactionId, TransactionApplicationMode.EXTERNAL );
         }
         verify( nodeStore, times( 1 ) ).setHighestPossibleIdInUse( nodeId );
     }
@@ -136,7 +136,7 @@ public class TransactionRepresentationStoreApplierTest
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
-            applier.apply( transaction, locks, transactionId, TransactionApplicationMode.INTERNAL );
+            applier.apply( transaction, ValidatedIndexUpdates.NONE, locks, transactionId, TransactionApplicationMode.INTERNAL );
         }
 
         // THEN

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/AggregatedReservationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/AggregatedReservationTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.index.Reservation;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AggregatedReservationTest
+{
+    @Test
+    public void shouldThrowWhenTooManyAggregatesAdded()
+    {
+        // Given
+        int size = 5;
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( size );
+
+        for ( int i = 0; i < size; i++ )
+        {
+            aggregatedReservation.add( mock( Reservation.class ) );
+        }
+
+        try
+        {
+            // When
+            aggregatedReservation.add( mock( Reservation.class ) );
+            fail( "Should have thrown " + IndexOutOfBoundsException.class.getSimpleName() );
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Too many aggregates" ) );
+        }
+    }
+
+    @Test
+    public void releaseShouldBeNullSafe()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 10 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( null );
+        aggregatedReservation.add( aggregate3 );
+
+        // When
+        aggregatedReservation.release();
+
+        // Then
+        verify( aggregate1 ).release();
+        verify( aggregate3 ).release();
+    }
+
+    @Test
+    public void shouldReleaseAllAggregatedReservations()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 3 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate2 = mock( Reservation.class );
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( aggregate2 );
+        aggregatedReservation.add( aggregate3 );
+
+        // When
+        aggregatedReservation.release();
+
+        // Then
+        verify( aggregate1 ).release();
+        verify( aggregate2 ).release();
+        verify( aggregate3 ).release();
+    }
+
+    @Test
+    public void shouldReleaseAllAggregatedReservationsEvenIfOneOfThemThrows()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 3 );
+
+        Reservation aggregate1 = mock( Reservation.class );
+        Reservation aggregate2 = mock( Reservation.class );
+        IllegalStateException exception = new IllegalStateException();
+        doThrow( exception ).when( aggregate2 ).release();
+        Reservation aggregate3 = mock( Reservation.class );
+
+        aggregatedReservation.add( aggregate1 );
+        aggregatedReservation.add( aggregate2 );
+        aggregatedReservation.add( aggregate3 );
+
+        try
+        {
+            // When
+            aggregatedReservation.release();
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            assertSame( exception, e );
+        }
+
+        // Then
+        verify( aggregate1 ).release();
+        verify( aggregate2 ).release();
+        verify( aggregate3 ).release();
+    }
+
+    @Test
+    public void shouldThrowLaunderedException()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 1 );
+
+        Reservation reservation = mock( Reservation.class );
+        RuntimeException exception = new RuntimeException( "Error" );
+        doThrow( exception ).when( reservation ).release();
+        aggregatedReservation.add( reservation );
+
+        try
+        {
+            // When
+            aggregatedReservation.release();
+            fail( "Should have thrown " + RuntimeException.class.getSimpleName() );
+        }
+        catch ( RuntimeException e )
+        {
+            // Then
+            assertSame( e, exception );
+            assertNull( e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldNotAllowRecursiveAggregations()
+    {
+        // Given
+        AggregatedReservation aggregatedReservation = new AggregatedReservation( 1 );
+
+        try
+        {
+            // When
+            aggregatedReservation.add( aggregatedReservation );
+            fail( "Should have thrown " + IllegalArgumentException.class.getSimpleName() );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Recursive" ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
@@ -19,14 +19,22 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 
 public abstract class CollectingIndexUpdater implements IndexUpdater
 {
     protected final ArrayList<NodePropertyUpdate> updates = new ArrayList<>();
+
+    @Override
+    public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+    {
+        return Reservation.EMPTY;
+    }
 
     @Override
     public void process( NodePropertyUpdate update )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.test.DoubleLatch;
@@ -111,7 +112,7 @@ public class ContractCheckingIndexProxyTest
 
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotUpdateBeforeCreate() throws IOException, IndexEntryConflictException
+    public void shouldNotUpdateBeforeCreate() throws Exception
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
@@ -125,7 +126,7 @@ public class ContractCheckingIndexProxyTest
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldNotUpdateAfterClose() throws IOException, IndexEntryConflictException
+    public void shouldNotUpdateAfterClose() throws Exception
     {
         // GIVEN
         IndexProxy inner = mockIndexProxy();
@@ -264,7 +265,7 @@ public class ContractCheckingIndexProxyTest
                     updater.process( null );
                     latch.startAndAwaitFinish();
                 }
-                catch ( IndexEntryConflictException e )
+                catch ( IndexEntryConflictException | IndexCapacityExceededException e )
                 {
                     throw new RuntimeException( e );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -26,12 +26,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -247,7 +247,7 @@ public class IndexCRUDIT
                 }
 
                 @Override
-                public void remove( Collection<Long> nodeIds ) throws IOException
+                public void remove( PrimitiveLongSet nodeIds ) throws IOException
                 {
                     throw new UnsupportedOperationException( "not expected" );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.mockito.Matchers;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -34,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -479,7 +479,7 @@ public class IndexPopulationJobTest
                 }
 
                 @Override
-                public void remove( Collection<Long> nodeIds )
+                public void remove( PrimitiveLongSet nodeIds )
                 {
                     throw new UnsupportedOperationException( "not expected" );
                 }
@@ -559,7 +559,7 @@ public class IndexPopulationJobTest
                 }
 
                 @Override
-                public void remove( Collection<Long> nodeIds )
+                public void remove( PrimitiveLongSet nodeIds )
                 {
                     throw new UnsupportedOperationException( "not expected" );
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -52,6 +52,7 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
@@ -75,6 +76,7 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -88,9 +90,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.lang.String.format;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.helpers.collection.MapUtil.map;
@@ -454,6 +453,12 @@ public class IndexPopulationJobTest
             return new IndexUpdater()
             {
                 @Override
+                public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+                {
+                    return Reservation.EMPTY;
+                }
+
+                @Override
                 public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
                 {
                     switch ( update.getUpdateMode() )
@@ -525,6 +530,12 @@ public class IndexPopulationJobTest
         {
             return new IndexUpdater()
             {
+                @Override
+                public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+                {
+                    return Reservation.EMPTY;
+                }
+
                 @Override
                 public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -28,7 +28,6 @@ import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -36,6 +35,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -404,12 +405,17 @@ public class IndexRecoveryIT
                 }
 
                 @Override
-                public void remove( Collection<Long> nodeIds ) throws IOException
+                public void remove( PrimitiveLongSet nodeIds ) throws IOException
                 {
-                    for ( Long nodeId : nodeIds )
+                    nodeIds.visitKeys( new PrimitiveLongVisitor<RuntimeException>()
                     {
-                        recoveredNodes.add( nodeId );
-                    }
+                        @Override
+                        public boolean visited( long nodeId ) throws RuntimeException
+                        {
+                            recoveredNodes.add( nodeId );
+                            return false;
+                        }
+                    } );
                 }
             };
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidatorTest.java
@@ -1,0 +1,406 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.kernel.impl.store.InlineNodeLabels;
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.state.LazyIndexUpdates;
+import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.RECOVERY;
+import static org.neo4j.kernel.impl.store.record.Record.NO_LABELS_FIELD;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
+
+public class IndexUpdatesValidatorTest
+{
+    private final NeoStore neoStore = mock( NeoStore.class );
+
+    private final IndexingService indexingService = mock( IndexingService.class );
+    private final NodeStore nodeStore = mock( NodeStore.class );
+    private final PropertyStore propertyStore = mock( PropertyStore.class );
+    private final PropertyLoader propertyLoader = mock( PropertyLoader.class );
+
+    private final Map<Long,NodeCommand> emptyNodeCommands = Collections.emptyMap();
+    private final Map<Long,List<PropertyCommand>> emptyPropCommands = Collections.emptyMap();
+
+    @Test
+    public void shouldValidateIndexesOnNodeCommands() throws IOException
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        NodeRecord before = new NodeRecord( 11 );
+        NodeRecord after = new NodeRecord( 12 );
+        after.setId( 5 );
+        NodeCommand command = new NodeCommand().init( before, after );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Arrays.<Command>asList( command ) );
+
+        // When
+        ValidatedIndexUpdates updates = validator.validate( tx, INTERNAL );
+
+        // Then
+        assertNotSame( updates, ValidatedIndexUpdates.NONE );
+
+        LazyIndexUpdates expectedUpdates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                groupedById( command ), emptyPropCommands );
+
+        verify( indexingService ).validate( eq( expectedUpdates ) );
+    }
+
+    @Test
+    public void shouldValidateIndexUpdatesOnPropertyCommandsWhenThePropertyIsOnANode() throws IOException
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        PropertyRecord before = new PropertyRecord( 11 );
+        PropertyRecord after = new PropertyRecord( 12 );
+        after.setNodeId( 42 );
+        PropertyCommand command = new PropertyCommand().init( before, after );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Arrays.<Command>asList( command ) );
+
+        // When
+        ValidatedIndexUpdates updates = validator.validate( tx, INTERNAL );
+
+        // Then
+        assertNotSame( updates, ValidatedIndexUpdates.NONE );
+
+        LazyIndexUpdates expectedUpdates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                emptyNodeCommands, groupedByNodeId( command ) );
+
+        verify( indexingService ).validate( expectedUpdates );
+    }
+
+    @Test
+    public void shouldNotUpdateIndexesOnPropertyCommandsWhenThePropertyIsNotOnANode() throws Exception
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        PropertyRecord before = new PropertyRecord( 11 );
+        PropertyRecord after = new PropertyRecord( 12 );
+        PropertyCommand command = new PropertyCommand().init( before, after );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Arrays.<Command>asList( command ) );
+
+        // When
+        ValidatedIndexUpdates updates = validator.validate( tx, INTERNAL );
+
+        // Then
+        assertSame( updates, ValidatedIndexUpdates.NONE );
+        verify( indexingService, never() ).validate( any( LazyIndexUpdates.class ) );
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    public void shouldNotUseIndexingServiceToValidateRecoveredUpdates() throws IOException
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        PropertyRecord before = new PropertyRecord( 11 );
+        PropertyRecord after = new PropertyRecord( 12 );
+        after.setNodeId( 42 );
+        PropertyCommand command = new PropertyCommand().init( before, after );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Arrays.<Command>asList( command ) );
+
+        // When
+        ValidatedIndexUpdates updates = validator.validate( tx, RECOVERY );
+
+        // Then
+        assertNotSame( updates, ValidatedIndexUpdates.NONE );
+        verify( indexingService, never() ).validate( any( Iterable.class ) );
+    }
+
+    @Test
+    public void recoveredValidatedUpdatesShouldFlushRecoveredNodeIds() throws Exception
+    {
+        // Given
+        long nodeId1 = 42;
+        long nodeId2 = 4242;
+        long nodeId3 = 424242;
+
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( asList(
+                nodeAddRandomLabelsCommand( nodeId1 ),
+                nodeAddRandomLabelsCommand( nodeId2 ),
+                nodeAddRandomLabelsCommand( nodeId3 )
+        ) );
+
+        // When
+        ValidatedIndexUpdates updates = validator.validate( tx, RECOVERY );
+        verifyZeroInteractions( indexingService );
+        updates.flush();
+
+        // Then
+        verify( indexingService ).addRecoveredNodeIds( asSet( nodeId1, nodeId2, nodeId3 ) );
+    }
+
+    @Test
+    public void shouldRethrowExceptionThrownByIndexUpdatersValidationProcedure() throws IOException
+    {
+        // Given
+        long node = 1;
+        int label = 2;
+        int property = 2;
+
+        NodePropertyCommands commands = createNodeWithLabelAndPropertyCommands( node, label, property );
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( commands );
+        LazyIndexUpdates updates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                commands.node(), commands.property() );
+
+        IndexCapacityExceededException error = new IndexCapacityExceededException( 100, 100 );
+        doThrow( new UnderlyingStorageException( error ) ).when( indexingService ).validate( updates );
+
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        try
+        {
+            // When
+            validator.validate( tx, INTERNAL );
+            fail( "Should have thrown " + UnderlyingStorageException.class.getSimpleName() );
+        }
+        catch ( UnderlyingStorageException e )
+        {
+            // Then
+            assertSame( error, e.getCause() );
+        }
+    }
+
+    @Test
+    public void shouldValidateIndexUpdatesWhenNodeCreated() throws IOException
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        NodeCommand createNode1 = createNodeWithLabel( 1, 1 );
+        NodeCommand createNode2 = createNodeWithLabel( 2, 2 );
+
+        PropertyCommand addProperty1ToNode1 = addProperty( 1, 1 );
+        PropertyCommand addProperty2ToNode1 = addProperty( 1, 2 );
+
+        PropertyCommand addProperty1ToNode2 = addProperty( 2, 2 );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( asList(
+                createNode1, addProperty1ToNode1, addProperty2ToNode1,
+                createNode2, addProperty1ToNode2
+        ) );
+
+        // When
+        ValidatedIndexUpdates validatedUpdates = validator.validate( tx, INTERNAL );
+
+        // Then
+        assertNotSame( ValidatedIndexUpdates.NONE, validatedUpdates );
+
+        LazyIndexUpdates expectedUpdates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                groupedById( createNode1, createNode2 ),
+                groupedByNodeId( addProperty1ToNode1, addProperty2ToNode1, addProperty1ToNode2 ) );
+
+        verify( indexingService ).validate( expectedUpdates );
+    }
+
+    @Test
+    public void shouldValidateIndexUpdatesWhenNodeDeleted() throws IOException
+    {
+        // Given
+        IndexUpdatesValidator validator = newIndexUpdatesValidatorWithMockedDependencies();
+
+        NodeCommand deleteNode1 = deleteNode( 1 );
+        NodeCommand deleteNode2 = deleteNode( 1 );
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation(
+                Arrays.<Command>asList( deleteNode1, deleteNode2 )
+        );
+
+        // When
+        ValidatedIndexUpdates validatedUpdates = validator.validate( tx, INTERNAL );
+
+        // Then
+        assertNotSame( ValidatedIndexUpdates.NONE, validatedUpdates );
+
+        LazyIndexUpdates expectedUpdates = new LazyIndexUpdates( nodeStore, propertyStore, propertyLoader,
+                groupedById( deleteNode1, deleteNode2 ), emptyPropCommands );
+
+        verify( indexingService ).validate( expectedUpdates );
+    }
+
+    private IndexUpdatesValidator newIndexUpdatesValidatorWithMockedDependencies()
+    {
+        when( neoStore.getNodeStore() ).thenReturn( nodeStore );
+        when( neoStore.getPropertyStore() ).thenReturn( propertyStore );
+        return new IndexUpdatesValidator( neoStore, propertyLoader, indexingService );
+    }
+
+    private static Command nodeAddRandomLabelsCommand( long nodeId )
+    {
+        NodeRecord before = new NodeRecord( nodeId, true, false, NO_NEXT_RELATIONSHIP.intValue(),
+                NO_NEXT_PROPERTY.intValue(), NO_LABELS_FIELD.intValue() );
+        NodeRecord after = new NodeRecord( nodeId, true, false, NO_NEXT_RELATIONSHIP.intValue(),
+                NO_NEXT_PROPERTY.intValue(), ThreadLocalRandom.current().nextLong( 100 ) );
+        NodeCommand command = new NodeCommand();
+        command.init( before, after );
+        return command;
+    }
+
+    private static NodePropertyCommands createNodeWithLabelAndPropertyCommands( long nodeId, int label, int property )
+    {
+        NodeCommand nodeCommand = createNodeWithLabel( nodeId, label );
+        PropertyCommand propCommand = addProperty( nodeId, property );
+        return new NodePropertyCommands( nodeCommand, propCommand );
+    }
+
+    private static NodeCommand createNodeWithLabel( long nodeId, int label )
+    {
+        NodeRecord before = new NodeRecord( nodeId, false, false, NO_NEXT_RELATIONSHIP.intValue(),
+                NO_NEXT_PROPERTY.intValue(), NO_LABELS_FIELD.intValue() );
+        NodeRecord after = new NodeRecord( nodeId, true, false, NO_NEXT_RELATIONSHIP.intValue(),
+                NO_NEXT_PROPERTY.intValue(), NO_LABELS_FIELD.intValue() );
+        new InlineNodeLabels( after.getLabelField(), after ).put( new long[]{label}, null, null );
+        return new NodeCommand().init( before, after );
+    }
+
+    private static NodeCommand deleteNode( long nodeId )
+    {
+        NodeRecord before = new NodeRecord( nodeId, true, false, 42, 42, NO_LABELS_FIELD.intValue() );
+        new InlineNodeLabels( before.getLabelField(), before ).put( new long[]{42}, null, null );
+        NodeRecord after = new NodeRecord( nodeId, false, false, NO_NEXT_RELATIONSHIP.intValue(),
+                NO_NEXT_PROPERTY.intValue(), NO_LABELS_FIELD.intValue() );
+        return new NodeCommand().init( before, after );
+    }
+
+    private static PropertyCommand addProperty( long nodeId, int property )
+    {
+        PropertyRecord before = new PropertyRecord( 1 );
+        before.setInUse( false );
+        PropertyRecord after = new PropertyRecord( 2 );
+        after.setInUse( true );
+        after.setCreated();
+        after.setNodeId( nodeId );
+        PropertyBlock block = new PropertyBlock();
+        block.setSingleBlock( 42 );
+        block.setKeyIndexId( property );
+        after.setPropertyBlock( block );
+        return new PropertyCommand().init( before, after );
+    }
+
+    private static Map<Long,NodeCommand> groupedById( NodeCommand... commands )
+    {
+        Map<Long,NodeCommand> result = new HashMap<>( commands.length, 1 );
+        for ( NodeCommand command : commands )
+        {
+            result.put( command.getAfter().getId(), command );
+        }
+        return result;
+    }
+
+    private static Map<Long,List<PropertyCommand>> groupedByNodeId( PropertyCommand... commands )
+    {
+        Map<Long,List<PropertyCommand>> result = new HashMap<>( commands.length, 1 );
+        for ( PropertyCommand command : commands )
+        {
+            List<PropertyCommand> propCommands = result.get( command.getNodeId() );
+            if ( propCommands == null )
+            {
+                result.put( command.getNodeId(), propCommands = new ArrayList<>() );
+            }
+            propCommands.add( command );
+        }
+        return result;
+    }
+
+    private static class NodePropertyCommands extends AbstractCollection<Command>
+    {
+        final NodeCommand nodeCommand;
+        final PropertyCommand propCommand;
+
+        NodePropertyCommands( NodeCommand nodeCommand, PropertyCommand propCommand )
+        {
+            this.nodeCommand = nodeCommand;
+            this.propCommand = propCommand;
+        }
+
+        @Override
+        public Iterator<Command> iterator()
+        {
+            return IteratorUtil.iterator( nodeCommand, propCommand );
+        }
+
+        @Override
+        public int size()
+        {
+            return IteratorUtil.count( iterator() );
+        }
+
+        Map<Long,List<PropertyCommand>> property()
+        {
+            return singletonMap( propCommand.getNodeId(), asList( propCommand ) );
+        }
+
+        Map<Long,NodeCommand> node()
+        {
+            return singletonMap( nodeCommand.getAfter().getId(), nodeCommand );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.helpers.collection.IteratorUtil;
@@ -490,13 +492,15 @@ public class IndexingServiceTest
     public void recordingOfRecoveredNodesShouldThrowIfServiceIsStarted() throws Exception
     {
         // Given
+        PrimitiveLongSet recoveredNodeIds = PrimitiveLongCollections.setOf( 1 );
+
         IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
         life.start();
 
         try
         {
             // When
-            indexingService.addRecoveredNodeIds( asSet( 1L, 2L, 3L ) );
+            indexingService.addRecoveredNodeIds( recoveredNodeIds );
             fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
         }
         catch ( IllegalStateException e )
@@ -650,7 +654,7 @@ public class IndexingServiceTest
         // Given
         final long nodeId1 = 1;
         final long nodeId2 = 2;
-        final Set<Long> nodeIds = asSet( nodeId1, nodeId2 );
+        final PrimitiveLongSet nodeIds = PrimitiveLongCollections.setOf( nodeId1, nodeId2 );
 
         final NodePropertyUpdate nodeUpdate1 = add( nodeId1, "foo" );
         final NodePropertyUpdate nodeUpdate2 = add( nodeId2, "bar" );
@@ -666,7 +670,7 @@ public class IndexingServiceTest
         IndexingService.Monitor monitor = new IndexingService.MonitorAdapter()
         {
             @Override
-            public void applyingRecoveredData( Set<Long> recoveredNodeIds )
+            public void applyingRecoveredData( PrimitiveLongSet recoveredNodeIds )
             {
                 assertEquals( nodeIds, recoveredNodeIds );
                 applyingRecoveredDataCalled.set( true );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -29,7 +29,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.ArrayIterator;
@@ -44,6 +46,7 @@ import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.UpdateableSchemaState;
@@ -66,13 +69,16 @@ import org.neo4j.register.Register.DoubleLongRegister;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
@@ -84,6 +90,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 import static org.neo4j.helpers.collection.IteratorUtil.loop;
 import static org.neo4j.kernel.api.index.InternalIndexState.ONLINE;
@@ -145,7 +152,7 @@ public class IndexingServiceTest
     public void indexCreationShouldBeIdempotent() throws Exception
     {
         // given
-        when( accessor.newUpdater( any( IndexUpdateMode.class ) ) ).thenReturn(updater);
+        when( accessor.newUpdater( any( IndexUpdateMode.class ) ) ).thenReturn( updater );
 
         IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
 
@@ -232,11 +239,11 @@ public class IndexingServiceTest
 
         // then
         assertEquals( InternalIndexState.POPULATING, proxy.getState() );
-        InOrder order = inOrder( populator, accessor, updater);
+        InOrder order = inOrder( populator, accessor, updater );
         order.verify( populator ).create();
         order.verify( populator ).close( true );
         order.verify( accessor ).newUpdater( IndexUpdateMode.ONLINE );
-        order.verify(updater).process( add( 10, "foo") );
+        order.verify(updater).process( add( 10, "foo" ) );
         order.verify(updater).close();
     }
 
@@ -275,7 +282,10 @@ public class IndexingServiceTest
         IndexRule populatingIndex = indexRule( 2, 1, 2, PROVIDER_DESCRIPTOR );
         IndexRule failedIndex     = indexRule( 3, 2, 2, PROVIDER_DESCRIPTOR );
 
-        IndexingService indexingService = life.add( IndexingService.create( new IndexSamplingConfig( new Config() ), mock( JobScheduler.class ), providerMap, mock( IndexStoreView.class ), mockLookup, mock( UpdateableSchemaState.class ), asList( onlineIndex, populatingIndex, failedIndex ), mockLogging( logger ), IndexingService.NO_MONITOR ) );
+        IndexingService indexingService = life.add( IndexingService.create( new IndexSamplingConfig( new Config() ),
+                mock( JobScheduler.class ), providerMap, mock( IndexStoreView.class ), mockLookup,
+                mock( UpdateableSchemaState.class ), asList( onlineIndex, populatingIndex, failedIndex ),
+                mockLogging( logger ), IndexingService.NO_MONITOR ) );
 
 
         when( provider.getInitialState( onlineIndex.getId() ) ).thenReturn( ONLINE );
@@ -283,9 +293,9 @@ public class IndexingServiceTest
         when( provider.getInitialState( failedIndex.getId() ) ).thenReturn( InternalIndexState.FAILED );
 
         when(mockLookup.labelGetName( 1 )).thenReturn( "LabelOne" );
-        when(mockLookup.labelGetName( 2 )).thenReturn( "LabelTwo" );
-        when(mockLookup.propertyKeyGetName( 1 )).thenReturn( "propertyOne" );
-        when(mockLookup.propertyKeyGetName( 2 )).thenReturn( "propertyTwo" );
+        when( mockLookup.labelGetName( 2 ) ).thenReturn( "LabelTwo" );
+        when( mockLookup.propertyKeyGetName( 1 ) ).thenReturn( "propertyOne" );
+        when( mockLookup.propertyKeyGetName( 2 ) ).thenReturn( "propertyTwo" );
 
         // when
         life.init();
@@ -312,7 +322,9 @@ public class IndexingServiceTest
         IndexRule populatingIndex = indexRule( 2, 1, 2, PROVIDER_DESCRIPTOR );
         IndexRule failedIndex     = indexRule( 3, 2, 2, PROVIDER_DESCRIPTOR );
 
-        IndexingService indexingService = IndexingService.create( new IndexSamplingConfig( new Config() ), mock( JobScheduler.class ), providerMap, storeView, mockLookup, mock( UpdateableSchemaState.class ), asList( onlineIndex, populatingIndex, failedIndex ), mockLogging( logger ), IndexingService.NO_MONITOR );
+        IndexingService indexingService = IndexingService.create( new IndexSamplingConfig( new Config() ),
+                mock( JobScheduler.class ), providerMap, storeView, mockLookup, mock( UpdateableSchemaState.class ),
+                asList( onlineIndex, populatingIndex, failedIndex ), mockLogging( logger ), IndexingService.NO_MONITOR );
 
         when( provider.getInitialState( onlineIndex.getId() ) ).thenReturn( ONLINE );
         when( provider.getInitialState( populatingIndex.getId() ) ).thenReturn( InternalIndexState.POPULATING );
@@ -375,7 +387,7 @@ public class IndexingServiceTest
         IndexRule rule1 = indexRule( indexId, 2, 3, PROVIDER_DESCRIPTOR );
         IndexRule rule2 = indexRule( indexId2, 4, 5, PROVIDER_DESCRIPTOR );
 
-        IndexAccessor indexAccessor = mock(IndexAccessor.class);
+        IndexAccessor indexAccessor = mock( IndexAccessor.class );
         IndexingService indexing = newIndexingServiceWithMockedDependencies(
                 mock( IndexPopulator.class ), indexAccessor,
                 new DataUpdates( new NodePropertyUpdate[0] ), rule1, rule2 );
@@ -384,7 +396,8 @@ public class IndexingServiceTest
         when( indexAccessor.snapshotFiles()).thenAnswer( newResourceIterator( theFile ) );
         when( indexProvider.getInitialState( indexId ) ).thenReturn( ONLINE );
         when( indexProvider.getInitialState( indexId2 ) ).thenReturn( ONLINE );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) ).thenReturn( newDoubleLongRegister( 32l, 32l ) );
+        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) )
+                .thenReturn( newDoubleLongRegister( 32l, 32l ) );
 
         life.start();
 
@@ -473,10 +486,221 @@ public class IndexingServiceTest
                 info( "Manual trigger for sampling index " + userDescription + " [" + mode + "]" ) );
     }
 
-    private Answer waitForLatch( final CountDownLatch latch ) {
-        return new Answer() {
+    @Test
+    public void recordingOfRecoveredNodesShouldThrowIfServiceIsStarted() throws Exception
+    {
+        // Given
+        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+        life.start();
+
+        try
+        {
+            // When
+            indexingService.addRecoveredNodeIds( asSet( 1L, 2L, 3L ) );
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Can't queue recovered node ids" ) );
+        }
+    }
+
+    @Test
+    public void validationOfIndexUpdatesShouldThrowIfServiceIsNotStarted() throws IOException
+    {
+        // Given
+        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+
+        try
+        {
+            // When
+            indexingService.validate( asSet( add( 1, "foo" ) ) );
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Can't validate index updates" ) );
+        }
+    }
+
+    @Test
+    public void validationOfIndexUpdatesShouldThrowIfServiceIsStopped() throws IOException
+    {
+        // Given
+        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+        life.start();
+        life.stop();
+
+        try
+        {
+            // When
+            indexingService.validate( asSet( add( 1, "foo" ) ) );
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Can't validate index updates" ) );
+        }
+    }
+
+    @Test
+    public void validatedUpdatesShouldFlush() throws Exception
+    {
+        // Given
+        when( accessor.newUpdater( any( IndexUpdateMode.class ) ) ).thenReturn( updater );
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+        life.start();
+
+        indexing.createIndex( indexRule( 0, labelId, propertyKeyId, PROVIDER_DESCRIPTOR ) );
+        verify( populator, timeout( 1000 ) ).close( true );
+
+        // When
+        try ( ValidatedIndexUpdates updates = indexing.validate( asList( add( 1, "foo" ), add( 2, "bar" ) ) ) )
+        {
+            updates.flush();
+        }
+
+        // Then
+        InOrder inOrder = inOrder( updater );
+        inOrder.verify( updater ).validate( asList( add( 1, "foo" ), add( 2, "bar" ) ) );
+        inOrder.verify( updater ).process( add( 1, "foo" ) );
+        inOrder.verify( updater ).process( add( 2, "bar" ) );
+        inOrder.verify( updater ).close();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    public void closingOfValidatedUpdatesShouldRemoveReservation() throws Exception
+    {
+        // Given
+        Reservation reservation = mock( Reservation.class );
+        when( updater.validate( any( Iterable.class ) ) ).thenReturn( reservation );
+        when( accessor.newUpdater( any( IndexUpdateMode.class ) ) ).thenReturn( updater );
+
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+        life.start();
+
+        indexing.createIndex( indexRule( 0, labelId, propertyKeyId, PROVIDER_DESCRIPTOR ) );
+        verify( populator, timeout( 1000 ) ).close( true );
+
+        // When
+        try ( ValidatedIndexUpdates updates = indexing.validate( asList( add( 1, "1" ), add( 2, "2" ) ) ) )
+        {
+            verifyZeroInteractions( reservation );
+            updates.flush();
+            verifyZeroInteractions( reservation );
+        }
+
+        // Then
+        verify( reservation ).release();
+    }
+
+    @Test
+    public void closingOfValidatedUpdatesShouldCloseUpdaters() throws Exception
+    {
+        // Given
+        long indexId1 = 1;
+        long indexId2 = 2;
+
+        int labelId1 = 24;
+        int labelId2 = 42;
+
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+
+        IndexAccessor accessor1 = mock( IndexAccessor.class );
+        IndexUpdater updater1 = mock( IndexUpdater.class );
+        when( accessor1.newUpdater( IndexUpdateMode.ONLINE ) ).thenReturn( updater1 );
+
+        IndexAccessor accessor2 = mock( IndexAccessor.class );
+        IndexUpdater updater2 = mock( IndexUpdater.class );
+        when( accessor2.newUpdater( IndexUpdateMode.ONLINE ) ).thenReturn( updater2 );
+
+        when( indexProvider.getOnlineAccessor( eq( 1L ), any( IndexConfiguration.class ),
+                any( IndexSamplingConfig.class ) ) ).thenReturn( accessor1 );
+        when( indexProvider.getOnlineAccessor( eq( 2L ), any( IndexConfiguration.class ),
+                any( IndexSamplingConfig.class ) ) ).thenReturn( accessor2 );
+
+        life.start();
+
+        indexing.createIndex( indexRule( indexId1, labelId1, propertyKeyId, PROVIDER_DESCRIPTOR ) );
+        indexing.createIndex( indexRule( indexId2, labelId2, propertyKeyId, PROVIDER_DESCRIPTOR ) );
+
+        verify( populator, timeout( 1000 ).times( 2 ) ).close( true );
+
+        // When
+        try ( ValidatedIndexUpdates updates = indexing.validate( asList(
+                NodePropertyUpdate.add( 1, propertyKeyId, "foo", new long[]{labelId1} ),
+                NodePropertyUpdate.add( 2, propertyKeyId, "bar", new long[]{labelId2} ) ) ) )
+        {
+            updates.flush();
+        }
+
+        // Then
+        verify( updater1 ).close();
+        verify( updater2 ).close();
+    }
+
+    @Test
+    public void recoveredUpdatesShouldBeApplied() throws IOException
+    {
+        // Given
+        final long nodeId1 = 1;
+        final long nodeId2 = 2;
+        final Set<Long> nodeIds = asSet( nodeId1, nodeId2 );
+
+        final NodePropertyUpdate nodeUpdate1 = add( nodeId1, "foo" );
+        final NodePropertyUpdate nodeUpdate2 = add( nodeId2, "bar" );
+        final Set<NodePropertyUpdate> nodeUpdates = asSet( nodeUpdate1, nodeUpdate2 );
+
+        final AtomicBoolean applyingRecoveredDataCalled = new AtomicBoolean();
+        final AtomicBoolean appliedRecoveredDataCalled = new AtomicBoolean();
+
+        // Mockito not used here because it does not work well with mutable objects (set of recovered node ids in
+        // this case, which is cleared at the end of recovery).
+        // See https://code.google.com/p/mockito/issues/detail?id=126 and
+        // https://groups.google.com/forum/#!topic/mockito/_A4BpsEAY9s
+        IndexingService.Monitor monitor = new IndexingService.MonitorAdapter()
+        {
             @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+            public void applyingRecoveredData( Set<Long> recoveredNodeIds )
+            {
+                assertEquals( nodeIds, recoveredNodeIds );
+                applyingRecoveredDataCalled.set( true );
+            }
+
+            @Override
+            public void appliedRecoveredData( Iterable<NodePropertyUpdate> updates )
+            {
+                assertEquals( nodeUpdates, asSet( updates ) );
+                appliedRecoveredDataCalled.set( true );
+            }
+        };
+
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData(), monitor );
+
+        when( storeView.nodeAsUpdates( nodeId1 ) ).thenReturn( asSet( nodeUpdate1 ) );
+        when( storeView.nodeAsUpdates( nodeId2 ) ).thenReturn( asSet( nodeUpdate2 ) );
+
+        // When
+        indexing.addRecoveredNodeIds( nodeIds );
+        life.start();
+
+        // Then
+        assertTrue( "applyingRecoveredData was not called", applyingRecoveredDataCalled.get() );
+        assertTrue( "appliedRecoveredData was not called", appliedRecoveredDataCalled.get() );
+    }
+
+    private Answer<Void> waitForLatch( final CountDownLatch latch )
+    {
+        return new Answer<Void>()
+        {
+            @Override
+            public Void answer( InvocationOnMock invocationOnMock ) throws Throwable
+            {
                 latch.await();
                 return null;
             }
@@ -512,6 +736,15 @@ public class IndexingServiceTest
                                                                       DataUpdates data,
                                                                       IndexRule... rules ) throws IOException
     {
+        return newIndexingServiceWithMockedDependencies( populator, accessor, data, IndexingService.NO_MONITOR, rules );
+    }
+
+    private IndexingService newIndexingServiceWithMockedDependencies( IndexPopulator populator,
+                                                                      IndexAccessor accessor,
+                                                                      DataUpdates data,
+                                                                      IndexingService.Monitor monitor,
+                                                                      IndexRule... rules ) throws IOException
+    {
         UpdateableSchemaState schemaState = mock( UpdateableSchemaState.class );
 
         when( indexProvider.getProviderDescriptor() ).thenReturn( PROVIDER_DESCRIPTOR );
@@ -537,7 +770,7 @@ public class IndexingServiceTest
                         schemaState,
                         loop( iterator( rules ) ),
                         logging,
-                        IndexingService.NO_MONITOR )
+                        monitor )
         );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -22,9 +22,10 @@ package org.neo4j.kernel.impl.api.index.inmemory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.BoundedIterable;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -47,6 +48,16 @@ class InMemoryIndex
     protected final InMemoryIndexImplementation indexData;
     private InternalIndexState state = InternalIndexState.POPULATING;
     String failure;
+
+    private final PrimitiveLongVisitor<RuntimeException> removeFromIndex = new PrimitiveLongVisitor<RuntimeException>()
+    {
+        @Override
+        public boolean visited( long nodeId ) throws RuntimeException
+        {
+            indexData.remove( nodeId );
+            return false;
+        }
+    };
 
     InMemoryIndex()
     {
@@ -266,12 +277,9 @@ class InMemoryIndex
         }
 
         @Override
-        public void remove( Collection<Long> nodeIds )
+        public void remove( PrimitiveLongSet nodeIds )
         {
-            for ( Long nodeId : nodeIds )
-            {
-                indexData.remove( nodeId );
-            }
+            nodeIds.visitKeys( removeFromIndex );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
@@ -231,6 +232,12 @@ class InMemoryIndex
         private InMemoryIndexUpdater( boolean applyIdempotently )
         {
             this.applyIdempotently = applyIdempotently;
+        }
+
+        @Override
+        public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+        {
+            return Reservation.EMPTY;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.UniquePropertyIndexUpdater;
@@ -70,6 +71,12 @@ class UniqueInMemoryIndex extends InMemoryIndex
                             add( update.getNodeId(), update.getValueAfter(), IndexUpdateMode.ONLINE == mode );
                     }
                 }
+            }
+
+            @Override
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStore.java
@@ -35,6 +35,7 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.direct.NodeLabelRange;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -68,7 +69,7 @@ public class InMemoryLabelScanStore implements LabelScanStore
     }
 
     @Override
-    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException
+    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException
     {
         try(LabelScanWriter writer = newWriter()) {
             while ( updates.hasNext() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.locking.LockGroup;
@@ -110,9 +111,8 @@ public class NeoTransactionStoreApplierTest
         when( neoStore.getPropertyKeyTokenStore() ).thenReturn( propertyKeyTokenStore );
         when( neoStore.getSchemaStore() ).thenReturn( schemaStore );
         when( nodeStore.getDynamicLabelStore() ).thenReturn( dynamicLabelStore );
-        when( lockService.acquireNodeLock( anyLong(), Matchers.<LockService.LockType>any() ) ).
-                                                                                                      thenReturn(
-                                                                                                              LockService.NO_LOCK );
+        when( lockService.acquireNodeLock( anyLong(), Matchers.<LockService.LockType>any() ) )
+                .thenReturn( LockService.NO_LOCK );
     }
 
     // NODE COMMAND
@@ -571,8 +571,8 @@ public class NeoTransactionStoreApplierTest
     {
         // given
         final NeoCommandHandler applier = newApplier( false );
-        final NeoCommandHandler indexApplier = new IndexTransactionApplier( indexingService, labelScanStore,
-                nodeStore, propertyStore, cacheAccess, null, transactionId, TransactionApplicationMode.INTERNAL );
+        final NeoCommandHandler indexApplier = new IndexTransactionApplier( indexingService,
+                ValidatedIndexUpdates.NONE, labelScanStore, cacheAccess );
         final DynamicRecord record = DynamicRecord.dynamicRecord( 21, true );
         record.setCreated();
         final Collection<DynamicRecord> recordsAfter = Arrays.asList( record );
@@ -759,8 +759,7 @@ public class NeoTransactionStoreApplierTest
 
     private NeoCommandHandler newIndexApplier( TransactionApplicationMode mode )
     {
-        return new IndexTransactionApplier( indexingService, labelScanStore, nodeStore, propertyStore,
-                cacheAccess, null, transactionId, mode );
+        return new IndexTransactionApplier( indexingService, ValidatedIndexUpdates.NONE, labelScanStore, cacheAccess );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
@@ -116,7 +117,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -936,7 +936,7 @@ public class NeoStoreTransactionTest
         // WHEN
         // -- later recovering that tx, there should be only one update
         commit( recoverer.getAsRecovered(), TransactionApplicationMode.RECOVERY );
-        verify( mockIndexing, times( 1 ) ).addRecoveredNodeIds( eq( asSet( nodeId ) ) );
+        verify( mockIndexing, times( 1 ) ).addRecoveredNodeIds( PrimitiveLongCollections.setOf( nodeId ) );
         verify( mockIndexing, never() ).validate( any( Iterable.class ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
@@ -19,20 +19,18 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
-
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStore;
-import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
@@ -52,7 +50,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.impl.store.UniquenessConstraintRule.uniquenessConstraintRule;
@@ -211,8 +208,7 @@ public class SchemaRuleCommandTest
     private final NeoStoreTransactionApplier storeApplier = new NeoStoreTransactionApplier( neoStore,
             mock( CacheAccessBackDoor.class ), LockService.NO_LOCK_SERVICE, new LockGroup(), txId );
     private final IndexTransactionApplier indexApplier = new IndexTransactionApplier( indexes,
-            labelScanStore, mock( NodeStore.class ), mock( PropertyStore.class ), mock( CacheAccessBackDoor.class ),
-            mock( PropertyLoader.class ), txId, TransactionApplicationMode.INTERNAL );
+            ValidatedIndexUpdates.NONE, labelScanStore, mock( CacheAccessBackDoor.class ) );
     private final PhysicalLogNeoCommandReaderV2 reader = new PhysicalLogNeoCommandReaderV2();
     private final IndexRule rule = IndexRule.indexRule( id, labelId, propertyKey, PROVIDER_DESCRIPTOR );
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
@@ -22,6 +22,7 @@ package org.neo4j.index.lucene;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.impl.index.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.IndexWriterFactories;
 import org.neo4j.kernel.api.impl.index.LuceneLabelScanStore;
@@ -73,7 +74,7 @@ public class LuceneLabelScanStoreBuilder
                     DirectoryFactory.PERSISTENT,
                     // <db>/schema/label/lucene
                     new File( new File( new File( storeDir, "schema" ), "label" ), "lucene" ),
-                    fileSystem, IndexWriterFactories.standard(),
+                    fileSystem, IndexWriterFactories.tracking(),
                     fullStoreLabelUpdateStream( neoStoreProvider ),
                     LuceneLabelScanStore.loggerMonitor( logger ) );
 
@@ -82,7 +83,7 @@ public class LuceneLabelScanStoreBuilder
                 labelScanStore.init();
                 labelScanStore.start();
             }
-            catch ( IOException e )
+            catch ( IOException | IndexCapacityExceededException e )
             {
                 // Throw better exception
                 throw new RuntimeException( e );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -40,12 +40,14 @@ import java.util.List;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.index.sampling.UniqueIndexSampler;
@@ -62,14 +64,14 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
     private ReferenceManager<IndexSearcher> searcherManager;
 
     DeferredConstraintVerificationUniqueLuceneIndexPopulator( LuceneDocumentStructure documentStructure,
-                                                              LuceneIndexWriterFactory indexWriterFactory,
+                                                              IndexWriterFactory<LuceneIndexWriter> writers,
                                                               SearcherManagerFactory searcherManagerFactory,
                                                               IndexWriterStatus writerStatus,
                                                               DirectoryFactory dirFactory, File dirFile,
                                                               FailureStorage failureStorage, long indexId,
                                                               IndexDescriptor descriptor )
     {
-        super( documentStructure, indexWriterFactory, writerStatus, dirFactory, dirFile, failureStorage, indexId );
+        super( documentStructure, writers, writerStatus, dirFactory, dirFile, failureStorage, indexId );
         this.descriptor = descriptor;
         this.sampler = new UniqueIndexSampler();
         this.searcherManagerFactory = searcherManagerFactory;
@@ -102,7 +104,8 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
     }
 
     @Override
-    public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+    public void add( long nodeId, Object propertyValue )
+            throws IndexEntryConflictException, IOException, IndexCapacityExceededException
     {
         sampler.increment( 1 );
         Fieldable encodedValue = documentStructure.encodeAsFieldable( propertyValue );
@@ -159,7 +162,14 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
             List<Object> updatedPropertyValues = new ArrayList<>();
 
             @Override
-            public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
+            }
+
+            @Override
+            public void process( NodePropertyUpdate update )
+                    throws IOException, IndexEntryConflictException, IndexCapacityExceededException
             {
                 long nodeId = update.getNodeId();
                 switch ( update.getUpdateMode() )
@@ -238,7 +248,7 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
     }
 
     @Override
-    public void close( boolean populationCompletedSuccessfully ) throws IOException
+    public void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException
     {
         try
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -34,9 +34,9 @@ import org.apache.lucene.search.TermQuery;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.api.exceptions.KernelException;
@@ -234,7 +234,7 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
             }
 
             @Override
-            public void remove( Collection<Long> nodeIds )
+            public void remove( PrimitiveLongSet nodeIds )
             {
                 throw new UnsupportedOperationException( "should not remove() from populating index" );
             }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterFactory.java
@@ -17,13 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.api.index;
+package org.neo4j.kernel.api.impl.index;
 
-import java.util.Set;
+import org.apache.lucene.store.Directory;
 
-import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import java.io.IOException;
 
-public interface IndexUpdates extends Iterable<NodePropertyUpdate>
+public interface IndexWriterFactory<W extends LuceneIndexWriter>
 {
-    Set<Long> changedNodeIds();
+    W create( Directory directory ) throws IOException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterStatus.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterStatus.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.Directory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -33,7 +32,7 @@ class IndexWriterStatus
     private static final String KEY_STATUS = "status";
     private static final String ONLINE = "online";
 
-    public void commitAsOnline( IndexWriter writer ) throws IOException
+    public void commitAsOnline( LuceneIndexWriter writer ) throws IOException
     {
         writer.commit( stringMap( KEY_STATUS, ONLINE ) );
     }
@@ -59,7 +58,7 @@ class IndexWriterStatus
         }
     }
 
-    public void close( IndexWriter writer ) throws IOException
+    public void close( LuceneIndexWriter writer ) throws IOException
     {
         writer.close( true );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LabelScanStorageStrategy.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import java.io.IOException;
-import java.util.Iterator;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 public interface LabelScanStorageStrategy
@@ -43,7 +44,7 @@ public interface LabelScanStorageStrategy
 
     interface StorageService
     {
-        void updateDocument( Term documentTerm, Document document ) throws IOException;
+        void updateDocument( Term documentTerm, Document document ) throws IOException, IndexCapacityExceededException;
 
         void deleteDocuments( Term documentTerm ) throws IOException;
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessor.java
@@ -20,10 +20,8 @@
 package org.neo4j.kernel.api.impl.index;
 
 import org.apache.lucene.document.Fieldable;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.SearcherFactory;
-import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -40,20 +38,23 @@ import org.neo4j.helpers.TaskControl;
 import org.neo4j.helpers.TaskCoordinator;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.api.direct.BoundedIterable;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.api.index.UpdateMode;
 
 import static org.neo4j.kernel.api.impl.index.DirectorySupport.deleteDirectoryContents;
 
 abstract class LuceneIndexAccessor implements IndexAccessor
 {
     protected final LuceneDocumentStructure documentStructure;
-    protected final SearcherManager searcherManager;
-    protected final IndexWriter writer;
+    protected final ReferenceManager<IndexSearcher> searcherManager;
+    protected final ReservingLuceneIndexWriter writer;
 
     private final IndexWriterStatus writerStatus;
     private final Directory dir;
@@ -61,7 +62,8 @@ abstract class LuceneIndexAccessor implements IndexAccessor
     private final int bufferSizeLimit;
     private final TaskCoordinator taskCoordinator = new TaskCoordinator( 10, TimeUnit.MILLISECONDS );
 
-    LuceneIndexAccessor( LuceneDocumentStructure documentStructure, LuceneIndexWriterFactory indexWriterFactory,
+    LuceneIndexAccessor( LuceneDocumentStructure documentStructure,
+                         IndexWriterFactory<ReservingLuceneIndexWriter> indexWriterFactory,
                          IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
                          int bufferSizeLimit ) throws IOException
     {
@@ -71,7 +73,7 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         this.dir = dirFactory.open( dirFile );
         this.writer = indexWriterFactory.create( dir );
         this.writerStatus = writerStatus;
-        this.searcherManager = new SearcherManager( writer, true, new SearcherFactory() );
+        this.searcherManager = writer.createSearcherManager();
     }
 
     @Override
@@ -159,7 +161,7 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         return new LuceneSnapshotter().snapshot( this.dirFile, writer );
     }
 
-    private void addRecovered( long nodeId, Object value ) throws IOException
+    private void addRecovered( long nodeId, Object value ) throws IOException, IndexCapacityExceededException
     {
         IndexSearcher searcher = searcherManager.acquire();
         try
@@ -182,13 +184,13 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         }
     }
 
-    protected void add( long nodeId, Object value ) throws IOException
+    protected void add( long nodeId, Object value ) throws IOException, IndexCapacityExceededException
     {
         Fieldable encodedValue = documentStructure.encodeAsFieldable( value );
         writer.addDocument( documentStructure.newDocumentRepresentingProperty( nodeId, encodedValue ) );
     }
 
-    protected void change( long nodeId, Object value ) throws IOException
+    protected void change( long nodeId, Object value ) throws IOException, IndexCapacityExceededException
     {
         Fieldable encodedValue = documentStructure.encodeAsFieldable( value );
         writer.updateDocument( documentStructure.newQueryForChangeOrRemove( nodeId ),
@@ -198,6 +200,13 @@ abstract class LuceneIndexAccessor implements IndexAccessor
     protected void remove( long nodeId ) throws IOException
     {
         writer.deleteDocuments( documentStructure.newQueryForChangeOrRemove( nodeId ) );
+    }
+
+    // This method should be synchronized because we need every thread to perform actual refresh
+    // and not just skip it because some other refresh is in progress
+    private synchronized void refreshSearcherManager() throws IOException
+    {
+        searcherManager.maybeRefresh();
     }
 
     private class LuceneIndexUpdater implements IndexUpdater
@@ -210,7 +219,43 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         }
 
         @Override
-        public void process( NodePropertyUpdate update ) throws IOException
+        public Reservation validate( Iterable<NodePropertyUpdate> updates )
+                throws IOException, IndexCapacityExceededException
+        {
+            int insertionsCount = 0;
+            for ( NodePropertyUpdate update : updates )
+            {
+                // Only count additions and updates, since removals will not affect the size of the index
+                // until it is merged. Each update is in fact atomic (delete + add).
+                if ( update.getUpdateMode() == UpdateMode.ADDED || update.getUpdateMode() == UpdateMode.CHANGED )
+                {
+                    insertionsCount++;
+                }
+            }
+
+            writer.reserveInsertions( insertionsCount );
+
+            final int insertions = insertionsCount;
+            return new Reservation()
+            {
+                boolean released;
+
+                @Override
+                public void release()
+                {
+                    if ( released )
+                    {
+                        throw new IllegalStateException( "Reservation was already released. " +
+                                                         "Previously reserved " + insertions + " insertions" );
+                    }
+                    writer.removeReservedInsertions( insertions );
+                    released = true;
+                }
+            };
+        }
+
+        @Override
+        public void process( NodePropertyUpdate update ) throws IOException, IndexCapacityExceededException
         {
             switch ( update.getUpdateMode() )
             {
@@ -236,11 +281,9 @@ abstract class LuceneIndexAccessor implements IndexAccessor
         }
 
         @Override
-        public synchronized void close() throws IOException, IndexEntryConflictException
+        public void close() throws IOException, IndexEntryConflictException
         {
-            // This method should be synchronized because we need every thread to perform actual refresh
-            // and not just skip it because some other refresh is in progress
-            searcherManager.maybeRefresh();
+            refreshSearcherManager();
         }
 
         @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexPopulator.java
@@ -19,30 +19,31 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Directory;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.store.Directory;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 
 public abstract class LuceneIndexPopulator implements IndexPopulator
 {
     protected final LuceneDocumentStructure documentStructure;
-    private final LuceneIndexWriterFactory indexWriterFactory;
+    private final IndexWriterFactory<LuceneIndexWriter> indexWriterFactory;
     private final IndexWriterStatus writerStatus;
     private final DirectoryFactory dirFactory;
     private final File dirFile;
     private final FailureStorage failureStorage;
     private final long indexId;
 
-    protected IndexWriter writer;
+    protected LuceneIndexWriter writer;
     private Directory directory;
 
     LuceneIndexPopulator(
-            LuceneDocumentStructure documentStructure, LuceneIndexWriterFactory indexWriterFactory,
+            LuceneDocumentStructure documentStructure, IndexWriterFactory<LuceneIndexWriter> indexWriterFactory,
             IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
             FailureStorage failureStorage, long indexId )
     {
@@ -91,7 +92,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void close( boolean populationCompletedSuccessfully ) throws IOException
+    public void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException
     {
         try
         {
@@ -120,5 +121,5 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
         failureStorage.storeIndexFailure( indexId, failure );
     }
 
-    protected abstract void flush() throws IOException;
+    protected abstract void flush() throws IOException, IndexCapacityExceededException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexWriter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexDeletionPolicy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SearcherFactory;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+/**
+ * A thin wrapper around {@link org.apache.lucene.index.IndexWriter} that exposes only some part of it's
+ * functionality that it really needed.
+ * Serves as a base class for {@link org.neo4j.kernel.api.impl.index.ReservingLuceneIndexWriter} and
+ * {@link org.neo4j.kernel.api.impl.index.TrackingLuceneIndexWriter}.
+ */
+public class LuceneIndexWriter implements Closeable
+{
+    // Lucene cannot allocate a full MAX_INT of documents, the deviation differs from JVM to JVM, but according to
+    // their source in future versions, the deviation can never be bigger than 128.
+    private static final long MAX_DOC_LIMIT = Integer.MAX_VALUE - 128;
+
+    protected final IndexWriter writer;
+
+    /**
+     * Package private *only* for subclasses and testing.
+     */
+    LuceneIndexWriter( Directory dir, IndexWriterConfig conf ) throws IOException
+    {
+        this.writer = new IndexWriter( dir, conf );
+    }
+
+    public void addDocument( Document document ) throws IOException, IndexCapacityExceededException
+    {
+        writer.addDocument( document );
+    }
+
+    public void updateDocument( Term term, Document document ) throws IOException, IndexCapacityExceededException
+    {
+        writer.updateDocument( term, document );
+    }
+
+    public void deleteDocuments( Term term ) throws IOException
+    {
+        writer.deleteDocuments( term );
+    }
+
+    public void deleteDocuments( Query query ) throws IOException
+    {
+        writer.deleteDocuments( query );
+    }
+
+    public void optimize() throws IOException
+    {
+        writer.optimize( true );
+    }
+
+    public SearcherManager createSearcherManager() throws IOException
+    {
+        return new SearcherManager( writer, true, new SearcherFactory() );
+    }
+
+    public void commit() throws IOException
+    {
+        writer.commit();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        close( true );
+    }
+
+    IndexDeletionPolicy getIndexDeletionPolicy()
+    {
+        return writer.getConfig().getIndexDeletionPolicy();
+    }
+
+    void commit( Map<String,String> commitUserData ) throws IOException
+    {
+        writer.commit( commitUserData );
+    }
+
+    void close( boolean waitForMerges ) throws IOException
+    {
+        writer.close( waitForMerges );
+    }
+
+    long maxDocLimit()
+    {
+        return MAX_DOC_LIMIT;
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStore.java
@@ -26,10 +26,8 @@ import java.util.Iterator;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockObtainFailedException;
@@ -37,6 +35,7 @@ import org.apache.lucene.store.LockObtainFailedException;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -52,13 +51,13 @@ public class LuceneLabelScanStore
 {
     private final LabelScanStorageStrategy strategy;
     private final DirectoryFactory directoryFactory;
-    private final LuceneIndexWriterFactory writerFactory;
+    private final IndexWriterFactory<LuceneIndexWriter> writerFactory;
     // We get in a full store stream here in case we need to fully rebuild the store if it's missing or corrupted.
     private final FullStoreChangeStream fullStoreStream;
     private final Monitor monitor;
     private Directory directory;
     private SearcherManager searcherManager;
-    private IndexWriter writer;
+    private LuceneIndexWriter writer;
     private boolean needsRebuild;
     private final File directoryLocation;
     private final FileSystemAbstraction fs;
@@ -123,7 +122,7 @@ public class LuceneLabelScanStore
     }
 
     public LuceneLabelScanStore( LabelScanStorageStrategy strategy, DirectoryFactory directoryFactory,
-            File directoryLocation, FileSystemAbstraction fs, LuceneIndexWriterFactory writerFactory,
+            File directoryLocation, FileSystemAbstraction fs, IndexWriterFactory<LuceneIndexWriter> writerFactory,
             FullStoreChangeStream fullStoreStream, Monitor monitor )
     {
         this.strategy = strategy;
@@ -142,7 +141,8 @@ public class LuceneLabelScanStore
     }
 
     @Override
-    public void updateDocument( Term documentTerm, Document document ) throws IOException
+    public void updateDocument( Term documentTerm, Document document )
+            throws IOException, IndexCapacityExceededException
     {
         writer.updateDocument( documentTerm, document );
     }
@@ -172,7 +172,7 @@ public class LuceneLabelScanStore
     }
 
     @Override
-    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException
+    public void recover( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException
     {
         // The way we update and commit fits for recovery as well since we use writer.updateDocument(...)
         // which deletes any existing documents and just adds the new and up-to-date version.
@@ -270,11 +270,11 @@ public class LuceneLabelScanStore
                     "To trigger a rebuild, ensure the database is stopped, delete the files in '" +
                     directoryLocation.getAbsolutePath() + "', and then start the database again." );
         }
-        searcherManager = new SearcherManager( writer, true, new SearcherFactory() );
+        searcherManager = writer.createSearcherManager();
     }
 
     @Override
-    public void start() throws IOException
+    public void start() throws IOException, IndexCapacityExceededException
     {
         if ( needsRebuild )
         {   // we saw in init() that we need to rebuild the index, so do it here after the
@@ -286,7 +286,7 @@ public class LuceneLabelScanStore
         }
     }
 
-    private void write( Iterator<NodeLabelUpdate> updates ) throws IOException
+    private void write( Iterator<NodeLabelUpdate> updates ) throws IOException, IndexCapacityExceededException
     {
         try ( LabelScanWriter writer = newWriter() )
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreExtension.java
@@ -31,7 +31,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 import org.neo4j.kernel.logging.Logging;
 
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
 import static org.neo4j.kernel.api.impl.index.LuceneLabelScanStore.loggerMonitor;
 import static org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.fullStoreLabelUpdateStream;
@@ -76,7 +76,7 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 // <db>/schema/label/lucene
                 directoryFactory, new File( new File( new File( storeDir, "schema" ), "label" ), "lucene" ),
 
-                dependencies.getFileSystem(), standard(),
+                dependencies.getFileSystem(), tracking(),
                 fullStoreLabelUpdateStream( dependencies.getNeoStoreProvider() ),
                 monitor != null ? monitor : loggerMonitor( dependencies.getLogging() ) );
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanWriter.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Fieldable;
 import org.apache.lucene.index.Term;
@@ -32,8 +26,16 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.impl.index.bitmaps.Bitmap;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 public class LuceneLabelScanWriter implements LabelScanWriter
@@ -56,7 +58,7 @@ public class LuceneLabelScanWriter implements LabelScanWriter
     }
 
     @Override
-    public void write( NodeLabelUpdate update ) throws IOException
+    public void write( NodeLabelUpdate update ) throws IOException, IndexCapacityExceededException
     {
         long range = format.bitmapFormat().rangeOf( update.getNodeId() );
 
@@ -77,9 +79,19 @@ public class LuceneLabelScanWriter implements LabelScanWriter
     @Override
     public void close() throws IOException
     {
-        flush();
-        storage.releaseSearcher( searcher );
-        storage.refreshSearcher();
+        try
+        {
+            flush();
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+        finally
+        {
+            storage.releaseSearcher( searcher );
+            storage.refreshSearcher();
+        }
     }
 
     private Map<Long/*range*/, Bitmap> readLabelBitMapsInRange( IndexSearcher searcher, long range ) throws IOException
@@ -103,7 +115,7 @@ public class LuceneLabelScanWriter implements LabelScanWriter
     }
 
 
-    private void flush() throws IOException
+    private void flush() throws IOException, IndexCapacityExceededException
     {
         if ( currentRange < 0 )
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexProvider.java
@@ -77,7 +77,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
         if ( config.isUnique() )
         {
             return new DeferredConstraintVerificationUniqueLuceneIndexPopulator(
-                    documentStructure, IndexWriterFactories.standard(), SearcherManagerFactories.standard() ,
+                    documentStructure, IndexWriterFactories.tracking(), SearcherManagerFactories.standard() ,
                     writerStatus, directoryFactory, folderLayout.getFolder( indexId ), failureStorage,
                     indexId, descriptor );
         }
@@ -85,7 +85,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
         {
             return new NonUniqueLuceneIndexPopulator(
                     NonUniqueLuceneIndexPopulator.DEFAULT_QUEUE_THRESHOLD, documentStructure,
-                    IndexWriterFactories.standard(), writerStatus, directoryFactory, folderLayout.getFolder( indexId ),
+                    IndexWriterFactories.tracking(), writerStatus, directoryFactory, folderLayout.getFolder( indexId ),
                     failureStorage, indexId, samplingConfig );
         }
     }
@@ -96,12 +96,12 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     {
         if ( config.isUnique() )
         {
-            return new UniqueLuceneIndexAccessor( documentStructure, IndexWriterFactories.standard(), writerStatus,
+            return new UniqueLuceneIndexAccessor( documentStructure, IndexWriterFactories.reserving(), writerStatus,
                     directoryFactory, folderLayout.getFolder( indexId ) );
         }
         else
         {
-            return new NonUniqueLuceneIndexAccessor( documentStructure, IndexWriterFactories.standard(),
+            return new NonUniqueLuceneIndexAccessor( documentStructure, IndexWriterFactories.reserving(),
                     writerStatus, directoryFactory, folderLayout.getFolder( indexId ), samplingConfig.bufferSize() );
         }
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotter.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api.impl.index;
 
 import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 
 import java.io.File;
@@ -37,9 +36,9 @@ public class LuceneSnapshotter
     private static final String NO_INDEX_COMMIT_TO_SNAPSHOT = "No index commit to snapshot";
     private static final String ID = "backup";
 
-    ResourceIterator<File> snapshot( File indexDir, IndexWriter writer ) throws IOException
+    ResourceIterator<File> snapshot( File indexDir, LuceneIndexWriter writer ) throws IOException
     {
-        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getConfig().getIndexDeletionPolicy();
+        SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getIndexDeletionPolicy();
 
         try
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexAccessor.java
@@ -25,8 +25,9 @@ import java.io.IOException;
 class NonUniqueLuceneIndexAccessor extends LuceneIndexAccessor
 {
     NonUniqueLuceneIndexAccessor( LuceneDocumentStructure documentStructure,
-                                  LuceneIndexWriterFactory indexWriterFactory, IndexWriterStatus writerStatus,
-                                  DirectoryFactory dirFactory, File dirFile, int bufferSizeLimit ) throws IOException
+                                  IndexWriterFactory<ReservingLuceneIndexWriter> indexWriterFactory,
+                                  IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
+                                  int bufferSizeLimit ) throws IOException
     {
         super( documentStructure, indexWriterFactory, writerStatus, dirFactory, dirFile, bufferSizeLimit );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
@@ -27,10 +27,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.NonUniqueIndexSampler;
@@ -44,7 +46,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     private final List<NodePropertyUpdate> updates = new ArrayList<>();
 
     NonUniqueLuceneIndexPopulator( int queueThreshold, LuceneDocumentStructure documentStructure,
-                                   LuceneIndexWriterFactory indexWriterFactory,
+                                   IndexWriterFactory<LuceneIndexWriter> indexWriterFactory,
                                    IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
                                    FailureStorage failureStorage, long indexId, IndexSamplingConfig samplingConfig )
     {
@@ -54,7 +56,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     }
 
     @Override
-    public void add( long nodeId, Object propertyValue ) throws IOException
+    public void add( long nodeId, Object propertyValue ) throws IOException, IndexCapacityExceededException
     {
         Fieldable encodedValue = documentStructure.encodeAsFieldable( propertyValue );
         sampler.include( encodedValue.stringValue() );
@@ -72,6 +74,12 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     {
         return new IndexUpdater()
         {
+            @Override
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
+            }
+
             @Override
             public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
             {
@@ -101,7 +109,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
             }
 
             @Override
-            public void close() throws IOException, IndexEntryConflictException
+            public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
             {
                 if ( updates.size() > queueThreshold )
                 {
@@ -126,7 +134,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     }
 
     @Override
-    protected void flush() throws IOException
+    protected void flush() throws IOException, IndexCapacityExceededException
     {
         for ( NodePropertyUpdate update : this.updates )
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/NonUniqueLuceneIndexPopulator.java
@@ -24,9 +24,9 @@ import org.apache.lucene.document.Fieldable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -120,7 +120,7 @@ class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
             }
 
             @Override
-            public void remove( Collection<Long> nodeIds ) throws IOException
+            public void remove( PrimitiveLongSet nodeIds ) throws IOException
             {
                 throw new UnsupportedOperationException( "Should not remove() from populating index." );
             }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+/**
+ * Index writer that supports a concept of reservations {@see org.neo4j.kernel.api.index.Reservation}.
+ * Reservation via {@link org.neo4j.kernel.api.impl.index.ReservingLuceneIndexWriter#reserveInsertions(int)} should
+ * precede any operation that modifies size of the index like insert or update (atomic delete + insert in Lucene).
+ * This index writer is intended to be used for online index at runtime.
+ */
+class ReservingLuceneIndexWriter extends LuceneIndexWriter
+{
+    private final AtomicLong reservedDocs = new AtomicLong();
+
+    ReservingLuceneIndexWriter( Directory directory, IndexWriterConfig config ) throws IOException
+    {
+        super( directory, config );
+    }
+
+    synchronized void reserveInsertions( int insertionsCount ) throws IOException, IndexCapacityExceededException
+    {
+        if ( insertionsCount <= 0 )
+        {
+            return;
+        }
+
+        if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+        {
+            // maxDoc is about to overflow, let's try to save our index
+
+            // try to merge deletes, maybe this will fix maxDoc
+            writer.forceMergeDeletes();
+
+            if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+            {
+                // if it did not then merge everything in single segment - horribly slow, last resort
+                writer.forceMerge( 1 );
+
+                if ( totalNumberOfDocumentsExceededLuceneCapacity( insertionsCount ) )
+                {
+                    // merging did not help - throw exception
+                    throw new IndexCapacityExceededException( insertionsCount, writer.maxDoc(), maxDocLimit() );
+                }
+            }
+        }
+
+        // everything fine - able to reserve 'space' for new documents
+        reservedDocs.addAndGet( insertionsCount );
+    }
+
+    void removeReservedInsertions( int insertionsCount )
+    {
+        if ( insertionsCount > 0 )
+        {
+            reservedDocs.addAndGet( -insertionsCount );
+        }
+    }
+
+    private boolean totalNumberOfDocumentsExceededLuceneCapacity( int newAdditions )
+    {
+        return (reservedDocs.get() + writer.maxDoc() + newAdditions) >= maxDocLimit();
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactories.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactories.java
@@ -19,11 +19,8 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
-import org.apache.lucene.search.SearcherFactory;
-import org.apache.lucene.search.SearcherManager;
 
 import java.io.IOException;
 
@@ -39,9 +36,9 @@ public final class SearcherManagerFactories
         return new SearcherManagerFactory()
         {
             @Override
-            public ReferenceManager<IndexSearcher> create( IndexWriter indexWriter ) throws IOException
+            public ReferenceManager<IndexSearcher> create( LuceneIndexWriter indexWriter ) throws IOException
             {
-                return new SearcherManager( indexWriter, true, new SearcherFactory() );
+                return indexWriter.createSearcherManager();
             }
         };
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/SearcherManagerFactory.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ReferenceManager;
 
@@ -27,5 +26,5 @@ import java.io.IOException;
 
 public interface SearcherManagerFactory
 {
-    ReferenceManager<IndexSearcher> create( IndexWriter indexWriter ) throws IOException;
+    ReferenceManager<IndexSearcher> create( LuceneIndexWriter indexWriter ) throws IOException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+
+/**
+ * Overflow aware index writer that tracks number of documents in lucene.
+ * Every method that modifies index size might throw
+ * {@link org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException}.
+ * This writer is intended to be used during index population.
+ */
+class TrackingLuceneIndexWriter extends LuceneIndexWriter
+{
+    TrackingLuceneIndexWriter( Directory directory, IndexWriterConfig config ) throws IOException
+    {
+        super( directory, config );
+    }
+
+    @Override
+    public void addDocument( Document document ) throws IOException, IndexCapacityExceededException
+    {
+        checkMaxDoc();
+        super.addDocument( document );
+    }
+
+    @Override
+    public void updateDocument( Term term, Document document ) throws IOException, IndexCapacityExceededException
+    {
+        checkMaxDoc();
+        super.updateDocument( term, document );
+    }
+
+    private void checkMaxDoc() throws IOException, IndexCapacityExceededException
+    {
+        int currentMaxDoc = writer.maxDoc();
+        long limit = maxDocLimit();
+
+        if ( currentMaxDoc >= limit )
+        {
+            throw new IndexCapacityExceededException( currentMaxDoc, limit );
+        }
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
@@ -24,8 +24,8 @@ import org.apache.lucene.search.IndexSearcher;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -123,7 +123,7 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor
         }
 
         @Override
-        public void remove( Collection<Long> nodeIds ) throws IOException
+        public void remove( PrimitiveLongSet nodeIds ) throws IOException
         {
             delegate.remove( nodeIds );
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
@@ -27,10 +27,10 @@ import org.apache.lucene.search.TopDocs;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -156,7 +156,7 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
             }
 
             @Override
-            public void remove( Collection<Long> nodeIds )
+            public void remove( PrimitiveLongSet nodeIds )
             {
                 throw new UnsupportedOperationException( "should not remove() from populating index" );
             }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulator.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.api.impl.index;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Fieldable;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TopDocs;
 
@@ -32,11 +31,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.util.FailureStorage;
 import org.neo4j.register.Register;
 
@@ -52,7 +53,7 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
     private Map<Object, Long> currentBatch = newBatchMap();
 
     UniqueLuceneIndexPopulator( int batchSize, LuceneDocumentStructure documentStructure,
-                                LuceneIndexWriterFactory indexWriterFactory,
+                                IndexWriterFactory<LuceneIndexWriter> indexWriterFactory,
                                 IndexWriterStatus writerStatus, DirectoryFactory dirFactory, File dirFile,
                                 FailureStorage failureStorage, long indexId )
     {
@@ -69,7 +70,7 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
     public void create() throws IOException
     {
         super.create();
-        searcherManager = new SearcherManager( writer, true, new SearcherFactory() );
+        searcherManager = writer.createSearcherManager();
     }
 
     @Override
@@ -85,7 +86,8 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
     }
 
     @Override
-    public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+    public void add( long nodeId, Object propertyValue )
+            throws IndexEntryConflictException, IOException, IndexCapacityExceededException
     {
         Long previousEntry = currentBatch.get( propertyValue );
         if ( previousEntry == null )
@@ -136,7 +138,14 @@ class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
         return new IndexUpdater()
         {
             @Override
-            public void process( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+            public Reservation validate( Iterable<NodePropertyUpdate> updates ) throws IOException
+            {
+                return Reservation.EMPTY;
+            }
+
+            @Override
+            public void process( NodePropertyUpdate update )
+                    throws IOException, IndexEntryConflictException, IndexCapacityExceededException
             {
                 add( update.getNodeId(), update.getValueAfter() );
             }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RecoveryIT.java
@@ -53,7 +53,6 @@ public class RecoveryIT
         process.destroy();
         process.waitFor();
 
-        System.out.println( path );
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( path );
         Transaction transaction = db.beginTx();
         try

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReservationsTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReservationsTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.store.Directory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.InOrder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.kernel.api.impl.index.DirectoryFactory.InMemoryDirectoryFactory;
+import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+import org.neo4j.kernel.api.index.Reservation;
+import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith( Parameterized.class )
+public class LuceneIndexAccessorReservationsTest
+{
+    private static final int PROPERTY_KEY = 42;
+    private static final long[] LABELS = {42};
+
+    @Parameter( 0 )
+    public String name;
+    @Parameter( 1 )
+    public AccessorFactory accessorFactory;
+
+    @Test
+    public void reservationShouldAllowReleaseOnlyOnce() throws Exception
+    {
+        // Given
+        IndexUpdater updater = newIndexUpdater( mock( ReservingLuceneIndexWriter.class ) );
+
+        Reservation reservation = updater.validate( asList( add( 1, "foo" ), add( 2, "bar" ) ) );
+        reservation.release();
+
+        try
+        {
+            // When
+            reservation.release();
+            fail( "Should have thrown " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Reservation was already released" ) );
+        }
+    }
+
+    @Test
+    public void updaterShouldReserveDocumentsForAdditions() throws Exception
+    {
+        // Given
+        ReservingLuceneIndexWriter indexWriter = mock( ReservingLuceneIndexWriter.class );
+        IndexUpdater updater = newIndexUpdater( indexWriter );
+
+        // When
+        updater.validate( asList( add( 1, "value1" ), add( 2, "value2" ), add( 3, "value3" ) ) );
+
+        // Then
+        verify( indexWriter ).reserveInsertions( 3 );
+    }
+
+    @Test
+    public void updaterShouldReserveDocumentsForUpdates() throws Exception
+    {
+        // Given
+        ReservingLuceneIndexWriter indexWriter = mock( ReservingLuceneIndexWriter.class );
+        IndexUpdater updater = newIndexUpdater( indexWriter );
+
+        // When
+        updater.validate( asList( change( 1, "before1", "after1" ), change( 2, "before2", "after2" ) ) );
+
+        // Then
+        verify( indexWriter ).reserveInsertions( 2 );
+    }
+
+
+    @Test
+    public void updaterShouldNotReserveDocumentsForDeletions() throws Exception
+    {
+        // Given
+        ReservingLuceneIndexWriter indexWriter = mock( ReservingLuceneIndexWriter.class );
+        IndexUpdater updater = newIndexUpdater( indexWriter );
+
+        // When
+        updater.validate( asList( remove( 1, "value1" ), remove( 2, "value2" ), remove( 3, "value3" ) ) );
+
+        // Then
+        verify( indexWriter ).reserveInsertions( 0 );
+    }
+
+    @Test
+    public void updaterShouldReserveDocuments() throws Exception
+    {
+        // Given
+        ReservingLuceneIndexWriter indexWriter = mock( ReservingLuceneIndexWriter.class );
+        IndexUpdater updater = newIndexUpdater( indexWriter );
+
+        // When
+        updater.validate( asList(
+                add( 1, "foo" ),
+                add( 2, "bar" ),
+                add( 3, "baz" ) ) );
+
+        updater.validate( asList(
+                change( 1, "foo1", "bar1" ),
+                add( 2, "foo2" ),
+                add( 3, "foo3" ),
+                change( 4, "foo4", "bar4" ),
+                remove( 5, "foo5" ) ) );
+
+        updater.validate( asList(
+                change( 1, "foo1", "bar1" ),
+                remove( 2, "foo2" ),
+                remove( 3, "foo3" ) ) );
+
+        // Then
+        InOrder order = inOrder( indexWriter );
+        order.verify( indexWriter ).createSearcherManager();
+        order.verify( indexWriter ).reserveInsertions( 3 );
+        order.verify( indexWriter ).reserveInsertions( 4 );
+        order.verify( indexWriter ).reserveInsertions( 1 );
+        verifyNoMoreInteractions( indexWriter );
+    }
+
+    @Test
+    public void updaterShouldReturnCorrectReservation() throws Exception
+    {
+        // Given
+        ReservingLuceneIndexWriter indexWriter = mock( ReservingLuceneIndexWriter.class );
+        IndexUpdater updater = newIndexUpdater( indexWriter );
+
+        // When
+        Reservation reservation = updater.validate( asList(
+                add( 1, "foo" ),
+                change( 2, "bar", "baz" ),
+                remove( 3, "qux" ) ) );
+
+        reservation.release();
+
+        // Then
+        InOrder inOrder = inOrder( indexWriter );
+        inOrder.verify( indexWriter ).reserveInsertions( 2 );
+        inOrder.verify( indexWriter ).removeReservedInsertions( 2 );
+    }
+
+    private IndexUpdater newIndexUpdater( ReservingLuceneIndexWriter writer ) throws IOException
+    {
+        return accessorFactory.create( writer ).newUpdater( IndexUpdateMode.ONLINE );
+    }
+
+    @Parameters( name = "{0}" )
+    public static List<Object[]> accessorFactories()
+    {
+        return Arrays.asList(
+                new Object[]{
+                        UniqueLuceneIndexAccessor.class.getSimpleName(),
+                        new AccessorFactory()
+                        {
+                            @Override
+                            public IndexAccessor create( ReservingLuceneIndexWriter writer ) throws IOException
+                            {
+                                return new UniqueLuceneIndexAccessor( new LuceneDocumentStructure(),
+                                        factoryOfOne( writer ), new IndexWriterStatus(), new InMemoryDirectoryFactory(),
+                                        new File( "unique" ) );
+                            }
+                        }},
+                new Object[]{
+                        NonUniqueLuceneIndexAccessor.class.getSimpleName(),
+                        new AccessorFactory()
+                        {
+                            @Override
+                            public IndexAccessor create( ReservingLuceneIndexWriter writer ) throws IOException
+                            {
+                                return new NonUniqueLuceneIndexAccessor( new LuceneDocumentStructure(),
+                                        factoryOfOne( writer ), new IndexWriterStatus(), new InMemoryDirectoryFactory(),
+                                        new File( "non-unique" ), 100_000 );
+                            }
+                        }}
+        );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static IndexWriterFactory<ReservingLuceneIndexWriter> factoryOfOne( ReservingLuceneIndexWriter writer )
+            throws IOException
+    {
+        IndexWriterFactory<ReservingLuceneIndexWriter> factory = mock( IndexWriterFactory.class );
+        doReturn( writer ).when( factory ).create( any( Directory.class ) );
+        return factory;
+    }
+
+    private static NodePropertyUpdate add( long nodeId, Object value )
+    {
+        return NodePropertyUpdate.add( nodeId, PROPERTY_KEY, value, LABELS );
+    }
+
+    private static NodePropertyUpdate remove( long nodeId, Object value )
+    {
+        return NodePropertyUpdate.remove( nodeId, PROPERTY_KEY, value, LABELS );
+    }
+
+    private static NodePropertyUpdate change( long nodeId, Object valueBefore, Object valueAfter )
+    {
+        return NodePropertyUpdate.change( nodeId, PROPERTY_KEY, valueBefore, LABELS, valueAfter, LABELS );
+    }
+
+    private static interface AccessorFactory
+    {
+        IndexAccessor create( ReservingLuceneIndexWriter writer ) throws IOException;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 
 import org.neo4j.function.RawFunction;
 import org.neo4j.helpers.TaskCoordinator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexReader;
@@ -51,7 +52,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 import static org.neo4j.test.ThreadingRule.stackTracePredicate;
 
 @RunWith( Parameterized.class )
@@ -195,9 +196,8 @@ public class LuceneIndexAccessorTest
                     public LuceneIndexAccessor apply( DirectoryFactory dirFactory )
                             throws IOException
                     {
-                        return new NonUniqueLuceneIndexAccessor( documentLogic, standard(), writerLogic, dirFactory,
-                                dir,
-                                100_000 );
+                        return new NonUniqueLuceneIndexAccessor( documentLogic, reserving(), writerLogic, dirFactory,
+                                dir, 100_000 );
                     }
 
                     @Override
@@ -212,7 +212,7 @@ public class LuceneIndexAccessorTest
                     public LuceneIndexAccessor apply( DirectoryFactory dirFactory )
                             throws IOException
                     {
-                        return new UniqueLuceneIndexAccessor( documentLogic, standard(), writerLogic, dirFactory, dir );
+                        return new UniqueLuceneIndexAccessor( documentLogic, reserving(), writerLogic, dirFactory, dir );
                     }
 
                     @Override
@@ -259,7 +259,7 @@ public class LuceneIndexAccessorTest
     }
 
     private void updateAndCommit( List<NodePropertyUpdate> nodePropertyUpdates )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -43,7 +44,7 @@ import static org.junit.Assert.assertThat;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 
 public class LuceneIndexIT
 {
@@ -99,7 +100,7 @@ public class LuceneIndexIT
     {
         dirFactory = DirectoryFactory.PERSISTENT;
         accessor = new NonUniqueLuceneIndexAccessor(
-                documentLogic, standard(), writerLogic, dirFactory, testDir.directory(), 100_000
+                documentLogic, reserving(), writerLogic, dirFactory, testDir.directory(), 100_000
         );
     }
 
@@ -116,7 +117,7 @@ public class LuceneIndexIT
     }
 
     private void updateAndCommit( List<NodePropertyUpdate> nodePropertyUpdates )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneLabelScanStoreTest.java
@@ -48,6 +48,7 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.api.direct.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.direct.NodeLabelRange;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.FullStoreChangeStream;
@@ -73,7 +74,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 import static org.neo4j.io.fs.FileUtils.deleteRecursively;
 
@@ -251,7 +252,7 @@ public class LuceneLabelScanStoreTest
             assertThat( labels, hasItem( label0Id ) );
         }
     }
-    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException
+    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException, IndexCapacityExceededException
     {
         try ( LabelScanWriter writer = store.newWriter() )
         {
@@ -444,7 +445,7 @@ public class LuceneLabelScanStoreTest
         monitor = new TrackingMonitor();
         store = life.add( new LuceneLabelScanStore(
                 strategy,
-                directoryFactory, dir, new DefaultFileSystemAbstraction(), standard(), asStream( existingData ),
+                directoryFactory, dir, new DefaultFileSystemAbstraction(), tracking(), asStream( existingData ),
                 monitor ) );
         life.start();
         assertTrue( monitor.initCalled );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulatorTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexConfiguration;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -257,7 +258,7 @@ public class LuceneSchemaIndexPopulatorTest
         directory.close();
     }
 
-    private void assertIndexedValues( Hit... expectedHits ) throws IOException
+    private void assertIndexedValues( Hit... expectedHits ) throws IOException, IndexCapacityExceededException
     {
         switchToVerification();
 
@@ -275,7 +276,7 @@ public class LuceneSchemaIndexPopulatorTest
         }
     }
 
-    private void switchToVerification() throws IOException
+    private void switchToVerification() throws IOException, IndexCapacityExceededException
     {
         index.close( true );
         assertEquals( InternalIndexState.ONLINE, provider.getInitialState( indexId ) );
@@ -287,7 +288,7 @@ public class LuceneSchemaIndexPopulatorTest
             IndexPopulator populator,
             Iterable<NodePropertyUpdate> updates,
             PropertyAccessor accessor )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = populator.newPopulatingUpdater( accessor ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSnapshotterTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api.impl.index;
 
 import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.util.Version;
@@ -32,6 +31,7 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.ResourceIterator;
 
+import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static org.mockito.Matchers.anyString;
@@ -40,8 +40,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import static java.util.Arrays.asList;
-
 public class LuceneSnapshotterTest
 {
 
@@ -49,19 +47,18 @@ public class LuceneSnapshotterTest
     private SnapshotDeletionPolicy snapshotPolicy;
 
     private IndexCommit luceneSnapshot;
-    private IndexWriter writer;
+    private LuceneIndexWriter writer;
 
     @Before
     public void setup() throws IOException
     {
-        writer = mock(IndexWriter.class);
+        writer = mock( LuceneIndexWriter.class );
         snapshotPolicy = mock(SnapshotDeletionPolicy.class);
         luceneSnapshot = mock(IndexCommit.class);
 
         IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
 
-        config.setIndexDeletionPolicy( snapshotPolicy );
-        when( writer.getConfig() ).thenReturn( config );
+        when( writer.getIndexDeletionPolicy() ).thenReturn( snapshotPolicy );
 
         when(snapshotPolicy.snapshot( anyString() )).thenReturn( luceneSnapshot );
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/ReservingLuceneIndexWriterTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class ReservingLuceneIndexWriterTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldReserveWhenMaxDocLimitIsNotReached() throws Exception
+    {
+        // Given
+        int maxDocLimit = 42;
+        int toReserve = maxDocLimit - 20;
+
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        indexWriter.reserveInsertions( toReserve );
+
+        // Then
+        assertEquals( 0, indexWriter.createSearcherManager().acquire().getIndexReader().maxDoc() );
+    }
+
+    @Test
+    public void shouldWorkIfSumOfMaxDocAndReservedIsLessThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 100;
+        int toAdd = maxDocLimit / 2;
+        int toReserve = maxDocLimit - toAdd - 7;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        indexWriter.reserveInsertions( toReserve );
+
+        // Then
+        assertEquals( toAdd, indexWriter.createSearcherManager().acquire().maxDoc() );
+    }
+
+    @Test
+    public void shouldThrowIfMoreThanLimitDocsAreReserved() throws Exception
+    {
+        // Given
+        int maxDocLimit = 42;
+        int toReserve = maxDocLimit + 42;
+
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        try
+        {
+            // When
+            indexWriter.reserveInsertions( toReserve );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Unable to reserve" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenSumOfMaxDocAndReservedIsGreaterThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 100;
+        int toAdd = maxDocLimit / 2;
+        int toReserve = maxDocLimit - toAdd + 2;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        ReservingLuceneIndexWriter indexWriter = newReservingLuceneIndexWriter( maxDocLimit );
+
+        indexWriter.reserveInsertions( toAdd );
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.reserveInsertions( toReserve );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Unable to reserve" ) );
+        }
+    }
+
+    private ReservingLuceneIndexWriter newReservingLuceneIndexWriter( long maxDocLimit ) throws Exception
+    {
+        File luceneDir = new File( "lucene" );
+        fs.get().mkdir( luceneDir );
+        Directory directory = new DirectoryFactory.InMemoryDirectoryFactory().open( luceneDir );
+        IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
+        ReservingLuceneIndexWriter indexWriter = new ReservingLuceneIndexWriter( directory, config );
+        ReservingLuceneIndexWriter indexWriterSpy = spy( indexWriter );
+        when( indexWriterSpy.maxDocLimit() ).thenReturn( maxDocLimit );
+        return indexWriterSpy;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/TrackingLuceneIndexWriterTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TrackingLuceneIndexWriterTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldSilentlyAddDocumentsWhenMaxDocIsLessThanLimit() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+        int toAdd = maxDocLimit - 10;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        // When
+        for ( int i = 0; i < toAdd; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        // Then
+        assertEquals( toAdd, indexWriter.createSearcherManager().acquire().getIndexReader().numDocs() );
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenTooManyDocumentsAreAdded() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        for ( int i = 0; i < maxDocLimit; i++ )
+        {
+            indexWriter.addDocument( documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.addDocument( documentStructure.newDocument( maxDocLimit + 42 ) );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Index contains too many entries" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenTooManyDocumentsAreUpdated() throws Exception
+    {
+        // Given
+        int maxDocLimit = 1_000;
+
+        LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
+        TrackingLuceneIndexWriter indexWriter = newTrackingLuceneIndexWriter( maxDocLimit );
+
+        for ( int i = 0; i < maxDocLimit; i++ )
+        {
+            indexWriter.updateDocument( new Term( "foo", "bar" ), documentStructure.newDocument( i ) );
+        }
+
+        try
+        {
+            // When
+            indexWriter.updateDocument( new Term( "foo", "bar" ), documentStructure.newDocument( maxDocLimit + 42 ) );
+            fail( "Should have thrown " + IndexCapacityExceededException.class.getSimpleName() );
+        }
+        catch ( IndexCapacityExceededException e )
+        {
+            // Then
+            assertThat( e.getMessage(), startsWith( "Index contains too many entries" ) );
+        }
+    }
+
+    private TrackingLuceneIndexWriter newTrackingLuceneIndexWriter( long maxDocLimit ) throws Exception
+    {
+        File luceneDir = new File( "lucene" );
+        fs.get().mkdir( luceneDir );
+        Directory directory = new DirectoryFactory.InMemoryDirectoryFactory().open( luceneDir );
+        IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_36, null );
+        TrackingLuceneIndexWriter indexWriter = new TrackingLuceneIndexWriter( directory, config );
+        TrackingLuceneIndexWriter indexWriterSpy = spy( indexWriter );
+        when( indexWriterSpy.maxDocLimit() ).thenReturn( maxDocLimit );
+        return indexWriterSpy;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessorTest.java
@@ -19,12 +19,13 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Test;
-
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
@@ -32,11 +33,9 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.collection.IteratorUtil.emptyListOf;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
 
 public class UniqueLuceneIndexAccessorTest
 {
@@ -119,7 +118,7 @@ public class UniqueLuceneIndexAccessorTest
 
     private UniqueLuceneIndexAccessor createAccessor() throws IOException
     {
-        return new UniqueLuceneIndexAccessor( new LuceneDocumentStructure(), standard(), new IndexWriterStatus(),
+        return new UniqueLuceneIndexAccessor( new LuceneDocumentStructure(), reserving(), new IndexWriterStatus(),
                 directoryFactory, indexDirectory );
     }
 
@@ -144,7 +143,7 @@ public class UniqueLuceneIndexAccessorTest
     }
     
     private void updateAndCommit( IndexAccessor accessor, Iterable<NodePropertyUpdate> updates )
-            throws IOException, IndexEntryConflictException
+            throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexPopulatorTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.kernel.api.impl.index.AllNodesCollector.getAllNodes;
-import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.standard;
+import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.tracking;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
 
@@ -51,7 +51,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                documentStructure, standard(),
+                documentStructure, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
 
@@ -74,7 +74,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentStructure = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                documentStructure, standard(),
+                documentStructure, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
         int propertyKeyId = 100;
@@ -105,7 +105,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                new LuceneDocumentStructure(), standard(),
+                new LuceneDocumentStructure(), tracking(),
                 new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );
@@ -135,7 +135,7 @@ public class UniqueLuceneIndexPopulatorTest
         File indexDirectory = new File( "target/whatever" );
         final LuceneDocumentStructure documentLogic = new LuceneDocumentStructure();
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 2,
-                documentLogic, standard(),
+                documentLogic, tracking(),
                 new IndexWriterStatus(), directoryFactory, indexDirectory, failureStorage, indexId );
         populator.create();
 
@@ -163,7 +163,7 @@ public class UniqueLuceneIndexPopulatorTest
     {
         // given
         UniqueLuceneIndexPopulator populator = new UniqueLuceneIndexPopulator( 100,
-                new LuceneDocumentStructure(), standard(),
+                new LuceneDocumentStructure(), tracking(),
                 new IndexWriterStatus(), new DirectoryFactory.InMemoryDirectoryFactory(), new File( "target/whatever" ),
                 failureStorage, indexId
         );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/WriterLogicTest.java
@@ -23,7 +23,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Version;
@@ -35,7 +34,6 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.index.impl.lucene.LuceneDataSource.KEYWORD_ANALYZER;
 
 public class WriterLogicTest
@@ -45,7 +43,7 @@ public class WriterLogicTest
     public void forceShouldSetOnlineStatus() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         writer.addDocument( newDocument() );
         logic.commitAsOnline( writer );
 
@@ -60,7 +58,7 @@ public class WriterLogicTest
     public void forceShouldKeepOnlineStatus() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         logic.commitAsOnline( writer );
 
         // WHEN
@@ -76,7 +74,7 @@ public class WriterLogicTest
     public void otherWriterSessionShouldKeepOnlineStatusEvenIfNotForcingBeforeClosing() throws Exception
     {
         // GIVEN
-        IndexWriter writer = newWriter();
+        LuceneIndexWriter writer = newWriter();
         logic.commitAsOnline( writer );
         writer.close( true );
 
@@ -106,9 +104,9 @@ public class WriterLogicTest
         dirFactory.close();
     }
 
-    private IndexWriter newWriter() throws IOException
+    private LuceneIndexWriter newWriter() throws IOException
     {
-        return new IndexWriter( directory, new IndexWriterConfig( Version.LUCENE_35, KEYWORD_ANALYZER ) );
+        return new LuceneIndexWriter( directory, new IndexWriterConfig( Version.LUCENE_36, KEYWORD_ANALYZER ) );
     }
 
     private Document newDocument()

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
@@ -88,6 +88,7 @@ public class TestLuceneBatchInsert
             index.add( id, map( "name", "Joe" + i, "other", "Schmoe" ) );
             ids.put( i, id );
         }
+        index.flush();
 
         for ( int i = 0; i < count; i++ )
         {
@@ -206,6 +207,8 @@ public class TestLuceneBatchInsert
         index.add( node1, map( "number", numeric( 45 ) ) );
         long node2 = inserter.createNode( null );
         index.add( node2, map( "number", numeric( 21 ) ) );
+        index.flush();
+
         assertContains( index.query( "number",
                 newIntRange( "number", 21, 50, true, true ) ), node1, node2 );
 
@@ -231,7 +234,8 @@ public class TestLuceneBatchInsert
         long nodeId1 = inserter.createNode( null );
         batchIndex.add( nodeId1, map( "number", new ValueContext[]{ numeric( 45 ), numeric( 98 ) } ) );
         long nodeId2 = inserter.createNode( null );
-        batchIndex.add( nodeId2, map( "number", new ValueContext[]{ numeric( 47 ), numeric( 100 ) } ) );
+        batchIndex.add( nodeId2, map( "number", new ValueContext[]{numeric( 47 ), numeric( 100 )} ) );
+        batchIndex.flush();
 
         IndexHits<Long> batchIndexResult1 = batchIndex.query( "number", newIntRange( "number", 47, 98, true, true ) );
         assertThat( batchIndexResult1, contains(nodeId1, nodeId2));
@@ -343,6 +347,7 @@ public class TestLuceneBatchInsert
         props.put( "key", "value" );
         index.add( id, props );
         index.updateOrAdd( id, props );
+        index.flush();
         assertEquals( 1, index.get( "key", "value" ).size() );
         index.flush();
         props.put( "key", "value2" );
@@ -424,6 +429,7 @@ public class TestLuceneBatchInsert
         index.setCacheCapacity( key, 100000 );
         assertCacheIsEmpty( index, key );
         index.add( 1, map( key, "Persson" ) );
+        index.flush();
         assertCacheIsEmpty( index, key );
         assertEquals( 1, index.get( key, "Persson" ).getSingle().intValue() );
         provider.shutdown();

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
@@ -21,6 +21,7 @@ package org.neo4j.collection.primitive;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.neo4j.collection.primitive.base.Empty;
 import org.neo4j.function.primitive.FunctionFromPrimitiveLong;
@@ -697,6 +698,17 @@ public class PrimitiveLongCollections
         return Empty.EMPTY_PRIMITIVE_LONG_SET;
     }
 
+    public static PrimitiveLongSet setOf( long... values )
+    {
+        Objects.requireNonNull( values, "Values array is null" );
+        PrimitiveLongSet set = Primitive.longSet( values.length );
+        for ( long value : values )
+        {
+            set.add( value );
+        }
+        return set;
+    }
+
     public static <T> Iterator<T> map( final FunctionFromPrimitiveLong<T> mapFunction,
             final PrimitiveLongIterator source )
     {
@@ -732,5 +744,11 @@ public class PrimitiveLongCollections
                 return next( value );
             }
         };
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public static <T> PrimitiveLongObjectMap<T> emptyObjectMap()
+    {
+        return Empty.EMPTY_PRIMITIVE_LONG_OBJECT_MAP;
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
@@ -28,6 +28,8 @@ import org.neo4j.collection.primitive.PrimitiveIntVisitor;
 import org.neo4j.collection.primitive.PrimitiveLongCollection;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
+import org.neo4j.collection.primitive.PrimitiveLongObjectVisitor;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 
@@ -157,4 +159,50 @@ public class Empty
     }
 
     public static final PrimitiveIntSet EMPTY_PRIMITIVE_INT_SET = new EmptyPrimitiveIntSet();
+
+    public static class EmptyPrimitiveLongObjectMap<T> extends EmptyPrimitiveCollection implements PrimitiveLongObjectMap<T>
+    {
+        @Override
+        public T put( long key, T t )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean containsKey( long key )
+        {
+            return false;
+        }
+
+        @Override
+        public T get( long key )
+        {
+            return null;
+        }
+
+        @Override
+        public T remove( long key )
+        {
+            return null;
+        }
+
+        @Override
+        public <E extends Exception> void visitEntries( PrimitiveLongObjectVisitor<T,E> visitor ) throws E
+        {   // No entries to visit
+        }
+
+        @Override
+        public <E extends Exception> void visitKeys( PrimitiveLongVisitor<E> visitor ) throws E
+        {   // No keys to visit
+        }
+
+        @Override
+        public PrimitiveLongIterator iterator()
+        {
+            return PrimitiveLongCollections.emptyIterator();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static final PrimitiveLongObjectMap EMPTY_PRIMITIVE_LONG_OBJECT_MAP = new EmptyPrimitiveLongObjectMap<>();
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -93,6 +93,7 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.cache.CacheProvider;
 import org.neo4j.kernel.impl.core.Caches;
 import org.neo4j.kernel.impl.core.ReadOnlyTokenCreator;
@@ -441,22 +442,23 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
             public TransactionCommitProcess create( LogicalTransactionStore logicalTransactionStore,
                                                     KernelHealth kernelHealth, NeoStore neoStore,
                                                     TransactionRepresentationStoreApplier storeApplier,
-                                                    NeoStoreInjectedTransactionValidator validator,
+                                                    NeoStoreInjectedTransactionValidator txValidator,
+                                                    IndexUpdatesValidator indexUpdatesValidator,
                                                     TransactionApplicationMode mode, Config config )
             {
                 if ( config.get( GraphDatabaseSettings.read_only ) )
                 {
                     return defaultCommitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore,
-                            storeApplier, validator, mode, config );
+                            storeApplier, txValidator, indexUpdatesValidator, mode, config );
                 }
                 else
                 {
 
                     TransactionCommitProcess inner =
                             defaultCommitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore,
-                                    storeApplier, validator, mode, config );
+                                    storeApplier, txValidator, indexUpdatesValidator, mode, config );
                     new CommitProcessSwitcher( pusher, master, commitProcessDelegate, requestContextFactory,
-                            memberStateMachine, validator, inner );
+                            memberStateMachine, txValidator, inner );
 
                     return (TransactionCommitProcess) Proxy
                             .newProxyInstance( TransactionCommitProcess.class.getClassLoader(),

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -43,6 +43,7 @@ import org.neo4j.graphdb.schema.Schema.IndexState;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.Predicates;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.impl.index.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProvider;
 import org.neo4j.kernel.api.index.IndexAccessor;
@@ -437,7 +438,8 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void add( long nodeId, Object propertyValue ) throws IndexEntryConflictException, IOException
+        public void add( long nodeId, Object propertyValue )
+                throws IndexEntryConflictException, IOException, IndexCapacityExceededException
         {
             delegate.add(nodeId, propertyValue);
             latch.startAndAwaitFinish();
@@ -456,7 +458,7 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void close( boolean populationCompletedSuccessfully ) throws IOException
+        public void close( boolean populationCompletedSuccessfully ) throws IOException, IndexCapacityExceededException
         {
             delegate.close(populationCompletedSuccessfully);
             assertTrue( "Expected population to succeed :(", populationCompletedSuccessfully );


### PR DESCRIPTION
Currently used lucene version 3.6.2 does not gracefully handle 2B documents limit overflow.
Inserts are not blocked when limit is reached but lookups fail with cryptic errors.

This commit adds tracking of 2B limit to Neo4j.
It is important for overflow to not result in exceptions on commit path so validation is made in NeoStoreTransaction#prepare, before actual commit.
With such overflow tracking inserts will stop working when limit is reached but lookups will continue to work.

Tracking logic:
 * During index population and batch-insert every document addition simply checks maxDoc value and throws exception if 2B limit is reached.
 * For online index each transaction reserves number of documents that it would add in prepare method,
   then on commit or rollback this reservation is withdrawn. If (reservation + maxDoc > 2B) then exception is thrown.

Validation of index capacities is a separate stage in commit process which is executed before writing to WAL.
It is performed by IndexUpdatesValidator class.