### PR TITLE
Tweak default node diameters.

### DIFF
--- a/community/browser/app/scripts/services/GraphStyle.coffee
+++ b/community/browser/app/scripts/services/GraphStyle.coffee
@@ -27,7 +27,7 @@ angular.module('neo4jApp.services')
     # Default style
     @defaultStyle =
       'node':
-        'diameter': '40px'
+        'diameter': '50px'
         'color': '#A5ABB6'
         'border-color': '#9AA1AC'
         'border-width': '2px'
@@ -46,8 +46,8 @@ angular.module('neo4jApp.services')
     @defaultSizes = [
       { diameter: '10px' }
       { diameter: '20px' }
-      { diameter: '30px' }
       { diameter: '50px' }
+      { diameter: '65px' }
       { diameter: '80px' }
     ]
 


### PR DESCRIPTION
Previous node diameters left a large gap between 50px and 80px, but this range is heavily used for making captions readable, so it makes sense to insert an intermediate size. Conversely, the small sizes are rarely used, so it's sensible to remove the 30px option. Also notice that the default size wasn't one of the preset options, which has now been aligned with the middle preset option, so that its possible to reset to the default size through the GUI.