### PR TITLE
Fixed invalid epoch exception in ClusterTopologyChangesIT

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -99,11 +99,13 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         context.setAvailableHaMasterId( null );
     }
 
+    @Override
     public void addHighAvailabilityMemberListener( HighAvailabilityMemberListener toAdd )
     {
         memberListeners = Listeners.addListener( toAdd, memberListeners );
     }
 
+    @Override
     public void removeHighAvailabilityMemberListener( HighAvailabilityMemberListener toRemove )
     {
         memberListeners = Listeners.removeListener( toRemove, memberListeners );
@@ -156,8 +158,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                         availabilityGuard.deny(HighAvailabilityMemberStateMachine.this);
                     }
 
-                    logger.debug( "Got masterIsElected(" + coordinatorId + "), changed " + oldState + " -> " +
-                            state + ". Previous elected master is " + previousElected );
+                    logger.debug( "Got masterIsElected(" + coordinatorId + "), moved to " + state + " from " + oldState
+                            + ". Previous elected master is " + previousElected );
                 }
             }
             catch ( Throwable t )
@@ -237,7 +239,13 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                  HighAvailabilityModeSwitcher.SLAVE.equals( role ) &&
                  state == HighAvailabilityMemberState.SLAVE )
             {
+                HighAvailabilityMemberState oldState = state;
                 changeStateToPending();
+                logger.debug( "Got memberIsUnavailable(" + unavailableId + "), moved to " + state + " from " + oldState );
+            }
+            else
+            {
+                logger.debug( "Got memberIsUnavailable(" + unavailableId + ")" );
             }
         }
 
@@ -246,7 +254,14 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         {
             if ( !isQuorum( getAliveCount(), getTotalCount() ) )
             {
+                HighAvailabilityMemberState oldState = state;
                 changeStateToPending();
+                logger.debug( "Got memberIsFailed(" + instanceId + ") and cluster lost quorum to continue, moved to "
+                        + state + " from " + oldState );
+            }
+            else
+            {
+                logger.debug( "Got memberIsFailed(" + instanceId + ")" );
             }
         }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -20,24 +20,32 @@
 package org.neo4j.kernel.ha;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Date;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.ClusterClient;
 import org.neo4j.cluster.com.NetworkReceiver;
+import org.neo4j.cluster.member.ClusterMemberEvents;
+import org.neo4j.cluster.member.ClusterMemberListener;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
 import org.neo4j.kernel.ha.com.master.InvalidEpochException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.AbstractClusterTest;
+import org.neo4j.test.RepeatRule;
+import org.neo4j.test.RepeatRule.Repeat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
+
 import static org.neo4j.helpers.Predicates.not;
 import static org.neo4j.test.ReflectionUtil.getPrivateField;
 import static org.neo4j.test.ha.ClusterManager.RepairKit;
@@ -116,14 +124,38 @@ public class ClusterTopologyChangesIT extends AbstractClusterTest
         slave1RepairKit.repair();
         slave2RepairKit.repair();
 
-        // whole cluster looks fine, but slaves have stale value of the epoch
+        // whole cluster looks fine, but slaves have stale value of the epoch if they rejoin the cluster in SLAVE state
         cluster.await( allSeesAllAsAvailable() );
         HighlyAvailableGraphDatabase newMaster = cluster.getMaster();
-        HighlyAvailableGraphDatabase newSlave1 = cluster.getAnySlave();
-        HighlyAvailableGraphDatabase newSlave2 = cluster.getAnySlave( newSlave1 );
+
+        final HighlyAvailableGraphDatabase newSlave1 = cluster.getAnySlave();
+        final HighlyAvailableGraphDatabase newSlave2 = cluster.getAnySlave( newSlave1 );
+
+        // now adding another failing listener and wait for the failure due to stale epoch
+        final CountDownLatch slave1Unavailable = new CountDownLatch( 1 );
+        final CountDownLatch slave2Unavailable = new CountDownLatch( 1 );
+        ClusterMemberEvents clusterEvents = ((GraphDatabaseAPI) newMaster).getDependencyResolver().resolveDependency(
+                ClusterMemberEvents.class );
+        clusterEvents.addClusterMemberListener( new ClusterMemberListener.Adapter()
+        {
+            @Override
+            public void memberIsUnavailable( String role, InstanceId unavailableId )
+            {
+                if ( instanceIdOf( newSlave1 ).equals( unavailableId ) )
+                {
+                    slave1Unavailable.countDown();
+                }
+                else if ( instanceIdOf( newSlave2 ).equals( unavailableId ) )
+                {
+                    slave2Unavailable.countDown();
+                }
+            }
+        } );
 
         // attempt to perform transactions on both slaves throws, election is triggered
         attemptTransactions( newSlave1, newSlave2 );
+        slave1Unavailable.await( 60, TimeUnit.SECONDS ); // set a timeout in case the instance does not have stale epoch
+        slave2Unavailable.await( 60, TimeUnit.SECONDS );
 
         // THEN: done with election, cluster feels good and able to serve transactions
         cluster.await( allSeesAllAsAvailable() );


### PR DESCRIPTION
Previously the test slaveShouldServeTxsAfterMasterLostQuorumWentToPendingAndThenQuorumWasRestored might throw InvalidEpochException at node creation after epoch fix. The error arises because we do not ensure that the node creation definitely happens after epoch fix. This pr adds a listener to ensure that node creation should always happen after epoch fix.
Also we refined logging info in HighAvailabilityMemberStateMachine.