### PR TITLE
Narrow query time so it's more realistic.

### DIFF
--- a/community/browser/app/scripts/controllers/CypherResult.coffee
+++ b/community/browser/app/scripts/controllers/CypherResult.coffee
@@ -84,7 +84,7 @@ angular.module('neo4jApp.controllers')
           messages.push "returned #{frame.response.table.size} #{if frame.response.table.size is 1 then 'row' else 'rows'}"
         if messages.length is 0
           messages.push "statement executed"
-        messages[messages.length - 1] += " in #{frame.runTime} ms"
+        messages[messages.length - 1] += " in #{frame.response.responseTime} ms"
         if (frame.response.table.size > frame.response.table.displayedSize)
           messages.push "displaying first #{frame.response.table.displayedSize} rows"
 

--- a/community/browser/app/scripts/init/commandInterpreters.coffee
+++ b/community/browser/app/scripts/init/commandInterpreters.coffee
@@ -22,7 +22,8 @@ angular.module('neo4jApp')
 .config([
   'FrameProvider'
   'Settings'
-  (FrameProvider, Settings) ->
+  'Timer'
+  (FrameProvider, Settings, Timer) ->
 
     cmdchar = Settings.cmdchar
 
@@ -330,11 +331,13 @@ angular.module('neo4jApp')
         (input, q) ->
           current_transaction = Cypher.transaction()
           commit_fn = () ->
+            timer = Timer.start()
             current_transaction.commit(input).then(
               (response) ->
                 if response.size > Settings.maxRows
                   response.displayedSize = Settings.maxRows
                 q.resolve(
+                  responseTime: timer.stop().time()
                   table: response
                   graph: extractGraphModel(response, CypherGraphModel)
                 )

--- a/community/browser/app/scripts/init/commandInterpreters.coffee
+++ b/community/browser/app/scripts/init/commandInterpreters.coffee
@@ -22,8 +22,7 @@ angular.module('neo4jApp')
 .config([
   'FrameProvider'
   'Settings'
-  'Timer'
-  (FrameProvider, Settings, Timer) ->
+  (FrameProvider, Settings) ->
 
     cmdchar = Settings.cmdchar
 
@@ -326,7 +325,7 @@ angular.module('neo4jApp')
         pattern = new RegExp("^[^#{cmdchar}]")
         input.match(pattern)
       templateUrl: 'views/frame-cypher.html'
-      exec: ['Cypher', 'CypherGraphModel', 'CypherParser', (Cypher, CypherGraphModel, CypherParser) ->
+      exec: ['Cypher', 'CypherGraphModel', 'CypherParser', 'Timer', (Cypher, CypherGraphModel, CypherParser, Timer) ->
         # Return the function that handles the input
         (input, q) ->
           current_transaction = Cypher.transaction()

--- a/community/browser/app/scripts/services/Frame.coffee
+++ b/community/browser/app/scripts/services/Frame.coffee
@@ -31,9 +31,8 @@ angular.module('neo4jApp.services')
       '$q'
       'Collection'
       'Settings'
-      'Timer'
       'Utils'
-      ($injector, $q, Collection, Settings, Timer, Utils) ->
+      ($injector, $q, Collection, Settings, Utils) ->
         class Frame
           constructor: (data = {})->
             @templateUrl = null
@@ -49,7 +48,7 @@ angular.module('neo4jApp.services')
           exec: ->
             query = Utils.stripComments(@input.trim())
             return unless query
-            # Find first matching input interpretator
+            # Find first matching input interpreter
             intr = frames.interpreterFor(query)
             return unless intr
             @type = intr.type
@@ -65,8 +64,7 @@ angular.module('neo4jApp.services')
             @closeAttempts = 0
             @response  = null
             @templateUrl = intr.templateUrl
-            timer = Timer.start()
-            @startTime = timer.started()
+            @startTime = (new Date).getTime()
             intrPromise = intrFn(query, $q.defer())
             @terminate = =>
               @resetError()
@@ -92,14 +90,11 @@ angular.module('neo4jApp.services')
               (result) =>
                 @isLoading = no
                 @response = result
-                @runTime = timer.stop().time()
               ,
               (result = {}) =>
                 @isLoading = no
                 @response = null
                 @setError result
-                @runTime = timer.stop().time()
-
             )
             @
           setProperties: (intr) ->


### PR DESCRIPTION
Previously the reported time included both the query execution request,
and the preceding request that begins a cancellable transaction.
This could vastly inflate reported time when network latency is more
significant than actual execution time.