### PR TITLE
introduces InputCache for caching Input data streams to disk

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGeneratorInput.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGeneratorInput.java
@@ -83,6 +83,12 @@ public class CsvDataGeneratorInput extends CsvDataGenerator<InputNode,InputRelat
             {
                 return nodeData();
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
+            }
         };
     }
 
@@ -95,6 +101,12 @@ public class CsvDataGeneratorInput extends CsvDataGenerator<InputNode,InputRelat
             public InputIterator<InputRelationship> iterator()
             {
                 return relationshipData();
+            }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
             }
         };
     }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/RandomDataIterator.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import org.neo4j.csv.reader.SourceTraceability;
 import org.neo4j.function.Function;
 import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.test.Randoms;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Deserialization;
@@ -40,6 +41,7 @@ public class RandomDataIterator<T> extends PrefetchingIterator<T> implements Inp
     private final Header header;
     private final long limit;
     private final Random random;
+    private final Randoms randoms;
     private final Deserialization<T> deserialization;
     private final long nodeCount;
     private final Distribution<String> labels;
@@ -56,6 +58,7 @@ public class RandomDataIterator<T> extends PrefetchingIterator<T> implements Inp
         this.header = header;
         this.limit = limit;
         this.random = random;
+        this.randoms = new Randoms( random, Randoms.DEFAULT );
         this.deserialization = deserialization.apply( this );
         this.nodeCount = nodeCount;
         this.labels = new Distribution<>( tokens( "Label", labelCount ) );
@@ -149,7 +152,7 @@ public class RandomDataIterator<T> extends PrefetchingIterator<T> implements Inp
         String type = entry.extractor().toString();
         if ( type.equals( "String" ) )
         {
-            return randomString( random );
+            return randoms.string( 5, 20, Randoms.CSA_LETTERS_AND_DIGITS );
         }
         else if ( type.equals( "long" ) )
         {
@@ -182,17 +185,6 @@ public class RandomDataIterator<T> extends PrefetchingIterator<T> implements Inp
         }
         position += length * 6;
         return result;
-    }
-
-    private String randomString( Random random )
-    {
-        char[] chars = new char[random.nextInt( 10 )+5];
-        for ( int i = 0; i < chars.length; i++ )
-        {
-            chars[i] = (char) ('a' + random.nextInt( 20 ));
-        }
-        position += chars.length;
-        return String.valueOf( chars );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -219,8 +219,17 @@ public abstract class ArrayUtil
      */
     public static <T> boolean contains( T[] array, T contains )
     {
-        for ( T item : array )
+        return contains( array, array.length, contains );
+    }
+
+    /**
+     * @return {@code true} if {@code contains} exists in {@code array}, otherwise {@code false}.
+     */
+    public static <T> boolean contains( T[] array, int arrayLength, T contains )
+    {
+        for ( int i = 0; i < arrayLength; i++ )
         {
+            T item = array[i];
             if ( nullSafeEquals( item, contains ) )
             {
                 return true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -603,6 +603,12 @@ public class StoreMigrator implements StoreMigrationParticipant
                     }
                 };
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
+            }
         };
     }
 
@@ -649,6 +655,12 @@ public class StoreMigrator implements StoreMigrationParticipant
                     {
                     }
                 };
+            }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannel.java
@@ -29,11 +29,17 @@ import static org.neo4j.helpers.Format.KB;
 public class PhysicalWritableLogChannel implements WritableLogChannel
 {
     private LogVersionedStoreChannel channel;
-    private final ByteBuffer buffer = ByteBuffer.allocate( 512*KB );
+    private final ByteBuffer buffer;
 
     public PhysicalWritableLogChannel( LogVersionedStoreChannel channel )
     {
+        this( channel, 512*KB );
+    }
+
+    public PhysicalWritableLogChannel( LogVersionedStoreChannel channel, int bufferSize )
+    {
         this.channel = channel;
+        this.buffer = ByteBuffer.allocate( bufferSize );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputEntityCacherStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputEntityCacherStep.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
+import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import org.neo4j.unsafe.impl.batchimport.input.Receiver;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutorServiceStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * Caches the incoming {@link InputEntity} to disk, for later use.
+ */
+public class InputEntityCacherStep<INPUT extends InputEntity>
+        extends ExecutorServiceStep<Batch<INPUT,? extends PrimitiveRecord>>
+{
+    private final Receiver<INPUT[],IOException> cacher;
+
+    public InputEntityCacherStep( StageControl control, int workAheadSize, int movingAverageSize,
+            Receiver<INPUT[],IOException> cacher )
+    {
+        super( control, "CACHE", workAheadSize, movingAverageSize, 1 );
+        this.cacher = cacher;
+    }
+
+    @Override
+    protected Object process( long ticket, Batch<INPUT,? extends PrimitiveRecord> batch ) throws IOException
+    {
+        cacher.receive( batch.input );
+        return batch;
+    }
+
+    @Override
+    protected void done()
+    {
+        try
+        {
+            cacher.close();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Couldn't close input cacher", e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIterable.java
@@ -27,5 +27,11 @@ import org.neo4j.graphdb.ResourceIterable;
 public interface InputIterable<T> extends ResourceIterable<T>
 {
     @Override
-    public InputIterator<T> iterator();
+    InputIterator<T> iterator();
+
+    /**
+     * @return whether or not multiple calls to {@link #iterator()} and therefore multiple passes
+     * over its data is supported.
+     */
+    boolean supportsMultiplePasses();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -109,6 +109,12 @@ public class Utils
                     }
                 };
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return false;
+            }
         };
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Group.java
@@ -91,16 +91,7 @@ public interface Group extends PrimitiveIntPredicate
         @Override
         public boolean equals( Object obj )
         {
-            if ( this == obj )
-                return true;
-            if ( obj == null )
-                return false;
-            if ( getClass() != obj.getClass() )
-                return false;
-            Adapter other = (Adapter) obj;
-            if ( id != other.id )
-                return false;
-            return true;
+            return obj instanceof Group && ((Group)obj).id() == id;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class Groups
 {
-    private final Map<String,Group> groups = new HashMap<>();
+    private final Map<String,Group> byName = new HashMap<>();
     private int nextId = 0;
     private Boolean globalMode;
 
@@ -60,10 +60,10 @@ public class Groups
             return Group.GLOBAL;
         }
 
-        Group group = groups.get( name );
+        Group group = byName.get( name );
         if ( group == null )
         {
-            groups.put( name, group = new Group.Adapter( nextId++, name ) );
+            byName.put( name, group = new Group.Adapter( nextId++, name ) );
         }
         return group;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.function.RawFunction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+
+import static org.neo4j.helpers.Format.KB;
+
+/**
+ * Cache of streams of {@link InputNode} or {@link InputRelationship} from an {@link Input} instance.
+ * Useful since {@link ParallelBatchImporter} may require multiple passes over the input data and so
+ * consecutive passes will be served by this thing instead.
+ *
+ * <pre>
+ * Properties format:
+ * - 2B property count, or {@link #HAS_FIRST_PROPERTY_ID} or {@link #END_OF_ENTITIES}
+ * - property...:
+ *   - 4B token id (token string->id mapping is in header file)
+ *   - ?B value, see {@link ValueType}
+ * </pre>
+ *
+ * <pre>
+ * Group format:
+ * - 1B, {@link #SAME_GROUP} or {@link #NEW_GROUP}
+ *   IF {@link #NEW_GROUP}
+ *   - 4B group if (if {@link #NEW_GROUP}
+ *   - 4B token id
+ * </pre>
+ *
+ * <pre>
+ * Node format:
+ * - properties (see "Properties format")
+ * - group (see "Group format")
+ * - id
+ *   - ?B id value, see {@link ValueType}
+ * - labels
+ *   - 1B label mode, {@link #HAS_LABEL_FIELD} or {@link #LABEL_ADDITION} or {@link #LABEL_REMOVAL} or
+ *     {@link #END_OF_LABEL_CHANGES}
+ *     WHILE NOT {@link #END_OF_LABEL_CHANGES}
+ *     - 4B token id, to add or remove
+ *     - 1B label mode, next mode
+ * </pre>
+ *
+ * <pre>
+ * Relationship format:
+ * - properties (see "Properties format")
+ * - specific id:
+ *   - 1B specific id boolean, {@link #SPECIFIC_ID} or {@link #UNSPECIFIED_ID}
+ *     IF {@link #SPECIFIC_ID}
+ *     - 8B specific relationship id
+ * - start node group (see "Group format")
+ * - end node group (see "Group format")
+ * - start node id
+ *   - ?B id value, see {@link ValueType}
+ * - end node id
+ *   - ?B id value, see {@link ValueType}
+ * - type
+ *   - 1B mode, {@link #SAME_TYPE} or {@link #NEW_TYPE} or {@link #HAS_TYPE_ID}
+ *     IF {@link #HAS_TYPE_ID}
+ *     4B type id
+ *     ELSE IF {@link #NEW_TYPE}
+ *     4B token id
+ * </pre>
+ */
+public class InputCache implements Closeable
+{
+    private static final String HEADER = "-header";
+    private static final String NODES = "nodes";
+    private static final String RELATIONSHIPS = "relationships";
+    private static final String NODES_HEADER = NODES + HEADER;
+    private static final String RELATIONSHIPS_HEADER = RELATIONSHIPS + HEADER;
+
+    static final byte SAME_GROUP = 0;
+    static final byte NEW_GROUP = 1;
+    static final byte TOKEN = 1;
+    static final short HAS_FIRST_PROPERTY_ID = -1;
+    static final byte HAS_LABEL_FIELD = 3;
+    static final byte LABEL_REMOVAL = 1;
+    static final byte LABEL_ADDITION = 2;
+    static final byte END_OF_LABEL_CHANGES = 0;
+    static final byte SPECIFIC_ID = 1;
+    static final byte UNSPECIFIED_ID = 0;
+    static final byte HAS_TYPE_ID = 2;
+    static final byte SAME_TYPE = 0;
+    static final byte NEW_TYPE = 1;
+    static final byte END_OF_HEADER = 0;
+    static final short END_OF_ENTITIES = -2;
+
+    private final FileSystemAbstraction fs;
+    private final File cacheDirectory;
+    private final int bufferSize;
+
+    public InputCache( FileSystemAbstraction fs, File cacheDirectory )
+    {
+        this( fs, cacheDirectory, 512*KB );
+    }
+
+    public InputCache( FileSystemAbstraction fs, File cacheDirectory, int bufferSize )
+    {
+        this.fs = fs;
+        this.cacheDirectory = cacheDirectory;
+        this.bufferSize = bufferSize;
+    }
+
+    public Receiver<InputNode[],IOException> cacheNodes() throws IOException
+    {
+        return new InputNodeCacher( channel( NODES, "rw" ), channel( NODES_HEADER, "rw" ), bufferSize );
+    }
+
+    public Receiver<InputRelationship[],IOException> cacheRelationships() throws IOException
+    {
+        return new InputRelationshipCacher( channel( RELATIONSHIPS, "rw" ),
+                channel( RELATIONSHIPS_HEADER, "rw" ), bufferSize );
+    }
+
+    private StoreChannel channel( String type, String mode ) throws IOException
+    {
+        return fs.open( file( type ), mode );
+    }
+
+    private File file( String type )
+    {
+        return new File( cacheDirectory, "input-" + type );
+    }
+
+    public InputIterable<InputNode> nodes()
+    {
+        return entities( new RawFunction<Void,InputIterator<InputNode>,IOException>()
+        {
+            @Override
+            public InputIterator<InputNode> apply( Void ignore ) throws IOException
+            {
+                return new InputNodeReader( channel( NODES, "r" ), channel( NODES_HEADER, "r" ), bufferSize );
+            }
+        } );
+    }
+
+    public InputIterable<InputRelationship> relationships()
+    {
+        return entities( new RawFunction<Void,InputIterator<InputRelationship>,IOException>()
+        {
+            @Override
+            public InputIterator<InputRelationship> apply( Void ignore ) throws IOException
+            {
+                return new InputRelationshipReader( channel( RELATIONSHIPS, "r" ),
+                        channel( RELATIONSHIPS_HEADER, "r" ), bufferSize );
+            }
+        } );
+    }
+
+    private <T extends InputEntity> InputIterable<T> entities(
+            final RawFunction<Void,InputIterator<T>,IOException> factory )
+    {
+        return new InputIterable<T>()
+        {
+            @Override
+            public InputIterator<T> iterator()
+            {
+                try
+                {
+                    return factory.apply( null );
+                }
+                catch ( IOException e )
+                {
+                    throw new InputException( "Unable to read cached relationship", e );
+                }
+            }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        fs.deleteFile( file( NODES ) );
+        fs.deleteFile( file( RELATIONSHIPS ) );
+        fs.deleteFile( file( NODES_HEADER ) );
+        fs.deleteFile( file( RELATIONSHIPS_HEADER ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
+import org.neo4j.kernel.impl.transaction.log.PhysicalWritableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
+
+import static org.neo4j.helpers.Format.KB;
+import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToShort;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_FIRST_PROPERTY_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_GROUP;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_ENTITIES;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_HEADER;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.TOKEN;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
+
+/**
+ * Abstract class for caching {@link InputEntity} or derivative to disk using a binary format.
+ */
+abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver<ENTITY[],IOException>
+{
+    protected final WritableLogChannel channel;
+    private final WritableLogChannel header;
+    private final StoreChannel storeChannel;
+    private final StoreChannel headerChannel;
+    private final int[] previousGroupIds;
+
+    private short nextKeyId;
+    private final Map<String,Short> tokens = new HashMap<>();
+
+    protected InputEntityCacher( StoreChannel channel, StoreChannel header, int bufferSize, int groupSlots )
+            throws IOException
+    {
+        this.storeChannel = channel;
+        this.headerChannel = header;
+        this.previousGroupIds = new int[groupSlots];
+        for ( int i = 0; i < groupSlots; i++ )
+        {
+            previousGroupIds[i] = Group.GLOBAL.id();
+        }
+        // We don't really care about versions, it's just that apart from that the WritableLogChannel
+        // does precisely what we want and there's certainly value in not duplicating that functionality.
+        this.channel = new PhysicalWritableLogChannel(
+                new PhysicalLogVersionedStoreChannel( channel, 0, (byte)0 ), bufferSize );
+        this.header = new PhysicalWritableLogChannel(
+                new PhysicalLogVersionedStoreChannel( header, 0, (byte)0 ), 8*KB );
+    }
+
+    @Override
+    public void receive( ENTITY[] batch ) throws IOException
+    {
+        for ( ENTITY entity : batch )
+        {
+            writeEntity( entity );
+        }
+    }
+
+    protected void writeEntity( ENTITY entity ) throws IOException
+    {
+        // properties
+        if ( entity.hasFirstPropertyId() )
+        {
+            channel.putShort( HAS_FIRST_PROPERTY_ID ).putLong( entity.firstPropertyId() );
+        }
+        else
+        {
+            Object[] properties = entity.properties();
+            channel.putShort( safeCastLongToShort( properties.length/2 ) );
+            for ( int i = 0; i < properties.length; i++ )
+            {
+                String key = (String) properties[i++];
+                Object value = properties[i];
+                if ( value == null )
+                {
+                    continue;
+                }
+                writeToken( key );
+                writeValue( value );
+            }
+        }
+    }
+
+    protected void writeGroup( Group group, int slot ) throws IOException
+    {
+        if ( group.id() == previousGroupIds[slot] )
+        {
+            channel.put( SAME_GROUP );
+        }
+        else
+        {
+            channel.put( NEW_GROUP );
+            channel.putInt( previousGroupIds[slot] = group.id() );
+            writeToken( group.name() );
+        }
+    }
+
+    protected void writeValue( Object value ) throws IOException
+    {
+        ValueType type = ValueType.typeOf( value );
+        channel.put( type.id() );
+        type.write( value, channel );
+    }
+
+    protected void writeToken( String key ) throws IOException
+    {
+        Short id = tokens.get( key );
+        if ( id == null )
+        {
+            tokens.put( key, id = nextKeyId++ );
+            header.put( TOKEN );
+            ValueType.stringType().write( key, header );
+        }
+        channel.putShort( id );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        header.put( END_OF_HEADER );
+        // This is a special value denoting the end of the stream. This is done like this since
+        // properties are the first thing read for every entity.
+        channel.putShort( END_OF_ENTITIES );
+
+        channel.close();
+        header.close();
+        storeChannel.close();
+        headerChannel.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
+import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+
+import static org.neo4j.helpers.Format.KB;
+import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_ENTITIES;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_FIRST_PROPERTY_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_GROUP;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.TOKEN;
+
+/**
+ * Abstract class for reading cached entities previously stored using {@link InputEntityCacher} or derivative.
+ */
+abstract class InputEntityReader<ENTITY extends InputEntity> extends PrefetchingIterator<ENTITY>
+        implements InputIterator<ENTITY>
+{
+    protected final ReadableLogChannel channel;
+    private final LogPositionMarker positionMarker = new LogPositionMarker();
+    private int lineNumber;
+    private final Group[] previousGroups;
+    private final PrimitiveIntObjectMap<String> tokens = Primitive.intObjectMap();
+
+    InputEntityReader( StoreChannel channel, StoreChannel header, int bufferSize, int groupSlots ) throws IOException
+    {
+        this.previousGroups = new Group[groupSlots];
+        for ( int i = 0; i < groupSlots; i++ )
+        {
+            previousGroups[i] = Group.GLOBAL;
+        }
+        this.channel = reader( channel, bufferSize );
+        readHeader( header );
+    }
+
+    private ReadAheadLogChannel reader( StoreChannel channel, int bufferSize ) throws IOException
+    {
+        return new ReadAheadLogChannel(
+                new PhysicalLogVersionedStoreChannel( channel, 0, (byte) 0 ), NO_MORE_CHANNELS, bufferSize );
+    }
+
+    private void readHeader( StoreChannel header ) throws IOException
+    {
+        try ( ReadableLogChannel reader = reader( header, 8*KB ) )
+        {
+            for ( short id = 0; reader.get() == TOKEN; id++ )
+            {
+                tokens.put( id, (String) ValueType.stringType().read( reader ) );
+            }
+        }
+    }
+
+    @Override
+    protected final ENTITY fetchNextOrNull()
+    {
+        try
+        {
+            lineNumber++;
+            Object properties = readProperties();
+            if ( properties == null )
+            {
+                return null;
+            }
+
+            return readNextOrNull( properties );
+        }
+        catch ( IOException e )
+        {
+            throw new InputException( "Couldn't read cached node data", e );
+        }
+    }
+
+    protected abstract ENTITY readNextOrNull( Object properties ) throws IOException;
+
+    private Object readProperties() throws IOException
+    {
+        short count = channel.getShort();
+        switch ( count )
+        {
+        // This is a special value denoting the end of the stream. This is done like this since
+        // properties are the first thing read for every entity.
+        case END_OF_ENTITIES: return null;
+        case HAS_FIRST_PROPERTY_ID: return channel.getLong();
+        case 0: return InputEntity.NO_PROPERTIES;
+        default:
+            Object[] properties = new Object[count*2];
+            for ( int i = 0; i < properties.length; i++ )
+            {
+                properties[i++] = readToken();
+                properties[i] = readValue();
+            }
+            return properties;
+        }
+    }
+
+    protected String readToken() throws IOException
+    {
+        short id = channel.getShort();
+        String name = tokens.get( id );
+        if ( name == null )
+        {
+            throw new IllegalArgumentException( "Unknown token " + id );
+        }
+        return name;
+    }
+
+    protected Object readValue() throws IOException
+    {
+        return ValueType.typeOf( channel.get() ).read( channel );
+    }
+
+    protected Group readGroup( int slot ) throws IOException
+    {
+        byte groupMode = channel.get();
+        switch ( groupMode )
+        {
+        case SAME_GROUP: return previousGroups[slot];
+        case NEW_GROUP: return previousGroups[slot] = new Group.Adapter( channel.getInt(), readToken() );
+        default: throw new IllegalArgumentException( "Unknown group mode " + groupMode );
+        }
+    }
+
+    @Override
+    public String sourceDescription()
+    {
+        return "cache"; // it's OK we shouldn't need these things the second time around
+    }
+
+    @Override
+    public long lineNumber()
+    {
+        return lineNumber;
+    }
+
+    @Override
+    public long position()
+    {
+        try
+        {
+            return channel.getCurrentPosition( positionMarker ).getByteOffset();
+        }
+        catch ( IOException e )
+        {
+            throw new InputException( "Couldn't get position from cached input data", e );
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        try
+        {
+            channel.close();
+        }
+        catch ( IOException e )
+        {
+            throw new InputException( "Couldn't close channel for cached input data", e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacher.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+
+import org.neo4j.io.fs.StoreChannel;
+
+import static org.neo4j.helpers.ArrayUtil.contains;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_LABEL_CHANGES;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_LABEL_FIELD;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_ADDITION;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_REMOVAL;
+
+/**
+ * Caches {@link InputNode} to disk using a binary format.
+ */
+public class InputNodeCacher extends InputEntityCacher<InputNode>
+{
+    private String[] previousLabels = InputEntity.NO_LABELS;
+
+    public InputNodeCacher( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    {
+        super( channel, header, bufferSize, 1 );
+    }
+
+    @Override
+    protected void writeEntity( InputNode node ) throws IOException
+    {
+        // properties
+        super.writeEntity( node );
+
+        // group
+        writeGroup( node.group(), 0 );
+
+        // id
+        writeValue( node.id() );
+
+        // labels
+        if ( node.hasLabelField() )
+        {   // label field
+            channel.put( HAS_LABEL_FIELD );
+            channel.putLong( node.labelField() );
+        }
+        else
+        {   // diff from previous node
+            String[] labels = node.labels();
+            writeDiff( LABEL_REMOVAL, previousLabels, labels );
+            writeDiff( LABEL_ADDITION, labels, previousLabels );
+            channel.put( END_OF_LABEL_CHANGES );
+            previousLabels = labels;
+        }
+    }
+
+    protected void writeDiff( byte mode, String[] compare, String[] with ) throws IOException
+    {
+        for ( int i = 0; i < compare.length; i++ )
+        {
+            if ( !contains( with, compare[i] ) )
+            {
+                channel.put( mode );
+                writeToken( compare[i] );
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeReader.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.neo4j.io.fs.StoreChannel;
+
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_LABEL_CHANGES;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_LABEL_FIELD;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_ADDITION;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_REMOVAL;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_LABELS;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
+
+/**
+ * Reads cached {@link InputNode} previously stored using {@link InputNodeCacher}.
+ */
+public class InputNodeReader extends InputEntityReader<InputNode>
+{
+    private String[] previousLabels = InputNode.NO_LABELS;
+
+    public InputNodeReader( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    {
+        super( channel, header, bufferSize, 1 );
+    }
+
+    @Override
+    protected InputNode readNextOrNull( Object properties ) throws IOException
+    {
+        // group
+        Group group = readGroup( 0 );
+
+        // id
+        Object id = readValue();
+
+        // labels (diff from previous node)
+        byte labelsMode = channel.get();
+        Object labels;
+        if ( labelsMode == HAS_LABEL_FIELD )
+        {
+            labels = channel.getLong();
+        }
+        else if ( labelsMode == END_OF_LABEL_CHANGES )
+        {   // Same as for previous node
+            labels = previousLabels;
+        }
+        else
+        {
+            String[] newLabels = previousLabels.clone();
+            int cursor = newLabels.length;
+            while ( labelsMode != END_OF_LABEL_CHANGES )
+            {
+                switch ( labelsMode )
+                {
+                case LABEL_REMOVAL: remove( readToken(), newLabels, cursor-- ); break;
+                case LABEL_ADDITION:
+                    (newLabels = ensureRoomForOneMore( newLabels, cursor ))[cursor++] = readToken(); break;
+                default: throw new IllegalArgumentException( "Unrecognized label mode " + labelsMode );
+                }
+                labelsMode = channel.get();
+            }
+            labels = previousLabels = cursor == newLabels.length ? newLabels : Arrays.copyOf( newLabels, cursor );
+        }
+
+        return new InputNode( sourceDescription(), lineNumber(), position(),
+                group, id,
+                properties.getClass().isArray() ? (Object[]) properties : NO_PROPERTIES,
+                properties.getClass().isArray() ? null : (Long) properties,
+                labels.getClass().isArray() ? (String[]) labels : NO_LABELS,
+                labels.getClass().isArray() ? null : (Long) labels );
+    }
+
+    private String[] ensureRoomForOneMore( String[] labels, int cursor )
+    {
+        return cursor >= labels.length ? Arrays.copyOf( labels, cursor+1 ) : labels;
+    }
+
+    private void remove( String item, String[] from, int cursor )
+    {
+        for ( int i = 0; i < cursor; i++ )
+        {
+            if ( item.equals( from[i] ) )
+            {
+                from[i] = from[cursor-1];
+                from[cursor-1] = null;
+                return;
+            }
+        }
+        throw new IllegalArgumentException( "Diff said to remove " + item + " from " +
+                    Arrays.toString( from ) + ", but it didn't contain it" );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
@@ -64,9 +64,10 @@ public class InputRelationship extends InputEntity
         this.typeId = typeId;
     }
 
-    public void setSpecificId( long id )
+    public InputRelationship setSpecificId( long id )
     {
         this.id = id;
+        return this;
     }
 
     public boolean hasSpecificId()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacher.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+
+import org.neo4j.io.fs.StoreChannel;
+
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_TYPE;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_TYPE;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SPECIFIC_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_TYPE_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.UNSPECIFIED_ID;
+
+/**
+ * Caches {@link InputRelationship} to disk using a binary format.
+ */
+public class InputRelationshipCacher extends InputEntityCacher<InputRelationship>
+{
+    private String previousType;
+
+    public InputRelationshipCacher( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    {
+        super( channel, header, bufferSize, 2 );
+    }
+
+    @Override
+    protected void writeEntity( InputRelationship relationship ) throws IOException
+    {
+        // properties
+        super.writeEntity( relationship );
+
+        // id
+        if ( relationship.hasSpecificId() )
+        {
+            channel.put( SPECIFIC_ID );
+            channel.putLong( relationship.specificId() );
+        }
+        else
+        {
+            channel.put( UNSPECIFIED_ID );
+        }
+
+        // groups
+        writeGroup( relationship.startNodeGroup(), 0 );
+        writeGroup( relationship.endNodeGroup(), 1 );
+
+        // ids
+        writeValue( relationship.startNode() );
+        writeValue( relationship.endNode() );
+
+        // type
+        if ( relationship.hasTypeId() )
+        {
+            channel.put( HAS_TYPE_ID );
+            channel.putInt( relationship.typeId() );
+        }
+        else
+        {
+            if ( previousType != null && relationship.type().equals( previousType ) )
+            {
+                channel.put( SAME_TYPE );
+            }
+            else
+            {
+                channel.put( NEW_TYPE );
+                writeToken( previousType = relationship.type() );
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipReader.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+
+import org.neo4j.io.fs.StoreChannel;
+
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_TYPE;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_TYPE;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SPECIFIC_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_TYPE_ID;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
+
+/**
+ * Reads cached {@link InputRelationship} previously stored using {@link InputRelationshipCacher}.
+ */
+public class InputRelationshipReader extends InputEntityReader<InputRelationship>
+{
+    private String previousType;
+
+    public InputRelationshipReader( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    {
+        super( channel, header, bufferSize, 2 );
+    }
+
+    @Override
+    protected InputRelationship readNextOrNull( Object properties ) throws IOException
+    {
+        // id
+        long specificId = channel.get() == SPECIFIC_ID ? channel.getLong() : -1;
+
+        // groups
+        Group startNodeGroup = readGroup( 0 );
+        Group endNodeGroup = readGroup( 1 );
+
+        // ids
+        Object startNodeId = readValue();
+        Object endNodeId = readValue();
+
+        // type
+        byte typeMode = channel.get();
+        Object type;
+        switch ( typeMode )
+        {
+        case SAME_TYPE: type = previousType; break;
+        case NEW_TYPE: type = previousType = readToken(); break;
+        case HAS_TYPE_ID: type = channel.getInt(); break;
+        default: throw new IllegalArgumentException( "Unrecognized type mode " + typeMode );
+        }
+
+        InputRelationship relationship = new InputRelationship( sourceDescription(), lineNumber(), position(),
+                properties.getClass().isArray() ? (Object[]) properties : NO_PROPERTIES,
+                properties.getClass().isArray() ? null : (Long) properties,
+                startNodeGroup, startNodeId,
+                endNodeGroup, endNodeId,
+                type instanceof String ? (String) type : null,
+                type instanceof String ? null : (Integer) type );
+        return specificId != -1 ? relationship.setSpecificId( specificId ) : relationship;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Receiver.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Receiver.java
@@ -17,41 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.transaction.log;
+package org.neo4j.unsafe.impl.batchimport.input;
 
 /**
- * Mutable marker that can create immutable {@link LogPosition} objects when requested to.
+ * A {@link Listener} which is designed to receive one or more items, to then finally be closed
+ * when all items have been received.
  */
-public class LogPositionMarker
+public interface Receiver<T,EXCEPTION extends Exception> extends AutoCloseable
 {
-    private long logVersion;
-    private long byteOffset;
-    private boolean specified;
+    void receive( T item ) throws EXCEPTION;
 
-    public void mark( long logVersion, long byteOffset )
-    {
-        this.logVersion = logVersion;
-        this.byteOffset = byteOffset;
-        this.specified = true;
-    }
-
-    public void unspecified()
-    {
-        specified = false;
-    }
-
-    public LogPosition newPosition()
-    {
-        return specified ? new LogPosition( logVersion, byteOffset ) : LogPosition.UNSPECIFIED;
-    }
-
-    public long getLogVersion()
-    {
-        return logVersion;
-    }
-
-    public long getByteOffset()
-    {
-        return byteOffset;
-    }
+    @Override
+    void close() throws EXCEPTION;
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/ValueType.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.helpers.UTF8;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
+
+/**
+ * Utility for reading and writing property values from/into a channel. Supports neo4j property types,
+ * including arrays.
+ */
+public abstract class ValueType
+{
+    private static final Map<Class<?>,ValueType> byClass = new HashMap<>();
+    private static final Map<Byte,ValueType> byId = new HashMap<>();
+    private static ValueType stringType;
+    private static byte next = 0;
+    static
+    {
+        add( new ValueType( Boolean.TYPE, Boolean.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.get() == 0 ? Boolean.FALSE : Boolean.TRUE;
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.put( (Boolean)value ? (byte)1 : (byte)0 );
+            }
+        } );
+        add( new ValueType( Byte.TYPE, Byte.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.get();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.put( (Byte)value );
+            }
+        } );
+        add( new ValueType( Short.TYPE, Short.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.getShort();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putShort( (Short)value );
+            }
+        } );
+        add( new ValueType( Character.TYPE, Character.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return (char)from.getInt();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putInt( (Character)value );
+            }
+        } );
+        add( new ValueType( Integer.TYPE, Integer.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.getInt();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putInt( (Integer) value );
+            }
+        } );
+        add( new ValueType( Long.TYPE, Long.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.getLong();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putLong( (Long)value );
+            }
+        } );
+        add( new ValueType( Float.TYPE, Float.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.getFloat();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putFloat( (Float)value );
+            }
+        } );
+        add( stringType = new ValueType( String.class )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                int length = from.getInt();
+                byte[] bytes = new byte[length]; // TODO wasteful
+                from.get( bytes, length );
+                return UTF8.decode( bytes );
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                byte[] bytes = UTF8.encode( (String)value );
+                into.putInt( bytes.length ).put( bytes, bytes.length );
+            }
+        } );
+        add( new ValueType( Double.class, Double.TYPE )
+        {
+            @Override
+            public Object read( ReadableLogChannel from ) throws IOException
+            {
+                return from.getDouble();
+            }
+
+            @Override
+            public void write( Object value, WritableLogChannel into ) throws IOException
+            {
+                into.putDouble( (Double)value );
+            }
+        } );
+    }
+    private static final ValueType arrayType = new ValueType()
+    {
+        @Override
+        public Object read( ReadableLogChannel from ) throws IOException
+        {
+            ValueType componentType = typeOf( from.get() );
+            int length = from.getInt();
+            Object value = Array.newInstance( componentType.componentClass(), length );
+            for ( int i = 0; i < length; i++ )
+            {
+                Array.set( value, i, componentType.read( from ) );
+            }
+            return value;
+        }
+
+        @Override
+        public void write( Object value, WritableLogChannel into ) throws IOException
+        {
+            ValueType componentType = typeOf( value.getClass().getComponentType() );
+            into.put( componentType.id() );
+            int length = Array.getLength( value );
+            into.putInt( length );
+            for ( int i = 0; i < length; i++ )
+            {
+                componentType.write( Array.get( value, i ), into );
+            }
+        }
+    };
+
+    private final Class<?>[] classes;
+    private final byte id = next++;
+
+    private ValueType( Class<?>... classes )
+    {
+        this.classes = classes;
+    }
+
+    private static void add( ValueType type )
+    {
+        for ( Class<?> cls : type.classes )
+        {
+            byClass.put( cls, type );
+        }
+        byId.put( type.id(), type );
+    }
+
+    public static ValueType typeOf( Object value )
+    {
+        return typeOf( value.getClass() );
+    }
+
+    public static ValueType typeOf( Class<?> cls )
+    {
+        if ( cls.isArray() )
+        {
+            return arrayType;
+        }
+
+        ValueType type = byClass.get( cls );
+        assert type != null : "Unrecognized value type " + cls;
+        return type;
+    }
+
+    public static ValueType typeOf( byte id )
+    {
+        if ( id == arrayType.id() )
+        {
+            return arrayType;
+        }
+
+        ValueType type = byId.get( id );
+        assert type != null : "Unrecognized value type id " + id;
+        return type;
+    }
+
+    public static ValueType stringType()
+    {
+        return stringType;
+    }
+
+    public Class<?> componentClass()
+    {
+        return classes[0];
+    }
+
+    public final byte id()
+    {
+        return id;
+    }
+
+    public abstract Object read( ReadableLogChannel from ) throws IOException;
+
+    public abstract void write( Object value, WritableLogChannel into ) throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -121,6 +121,12 @@ public class CsvInput implements Input
                     }
                 };
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
+            }
         };
     }
 
@@ -154,6 +160,12 @@ public class CsvInput implements Input
                                 } );
                     }
                 };
+            }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
@@ -140,7 +140,7 @@ public abstract class ExecutorServiceStep<T> extends AbstractStep<T>
     /**
      * @return the batch object to send downstream, {@code null} for nothing to send.
      */
-    protected abstract Object process( long ticket, T batch );
+    protected abstract Object process( long ticket, T batch ) throws Throwable;
 
     @Override
     public void close()

--- a/community/kernel/src/test/java/org/neo4j/test/RandomRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/RandomRule.java
@@ -126,4 +126,9 @@ public class RandomRule implements TestRule
     {
         return seed;
     }
+
+    public Random random()
+    {
+        return random;
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/Randoms.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Randoms.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.lang.reflect.Array;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.helpers.ArrayUtil;
+
+import static java.lang.Integer.bitCount;
+
+/**
+ * Set of useful randomizing utilities, for example randomizing a string or property value of random type and value.
+ */
+public class Randoms
+{
+    public interface Configuration
+    {
+        int stringMinLength();
+
+        int stringMaxLength();
+
+        int stringCharacterSets();
+
+        int arrayMinLength();
+
+        int arrayMaxLength();
+    }
+
+    public static class Default implements Configuration
+    {
+        @Override
+        public int stringMinLength()
+        {
+            return 5;
+        }
+
+        @Override
+        public int stringMaxLength()
+        {
+            return 20;
+        }
+
+        @Override
+        public int stringCharacterSets()
+        {
+            return CSA_LETTERS_AND_DIGITS;
+        }
+
+        @Override
+        public int arrayMinLength()
+        {
+            return 1;
+        }
+
+        @Override
+        public int arrayMaxLength()
+        {
+            return 10;
+        }
+    }
+
+    public static final Configuration DEFAULT = new Default();
+
+    public static final int CS_LOWERCASE_LETTERS = 0x1;
+    public static final int CS_UPPERCASE_LETTERS = 0x2;
+    public static final int CS_DIGITS = 0x3;
+    public static final int CS_SYMBOLS = 0x4;
+
+    public static final int CSA_LETTERS = CS_LOWERCASE_LETTERS | CS_UPPERCASE_LETTERS;
+    public static final int CSA_LETTERS_AND_DIGITS = CSA_LETTERS | CS_DIGITS;
+
+    private final Random random;
+    private final Configuration configuration;
+
+    public Randoms()
+    {
+        this( ThreadLocalRandom.current(), DEFAULT );
+    }
+
+    public Randoms( Random random, Configuration configuration )
+    {
+        this.random = random;
+        this.configuration = configuration;
+    }
+
+    public Randoms fork( Configuration configuration )
+    {
+        return new Randoms( random, configuration );
+    }
+
+    public Random random()
+    {
+        return random;
+    }
+
+    public int intBetween( int min, int max )
+    {
+        return min + random.nextInt( max-min+1 );
+    }
+
+    public String string()
+    {
+        return string( configuration.stringMinLength(), configuration.stringMaxLength(),
+                configuration.stringCharacterSets() );
+    }
+
+    public String string( int minLength, int maxLength, int characterSets )
+    {
+        char[] chars = new char[intBetween( minLength, maxLength )];
+        for ( int i = 0; i < chars.length; i++ )
+        {
+            chars[i] = character( characterSets );
+        }
+        return String.valueOf( chars );
+    }
+
+    public char character( int characterSets )
+    {
+        int setCount = bitCount( characterSets );
+        while ( true )
+        {
+            int bit = 1 << random.nextInt( setCount );
+            if ( (characterSets & bit) != 0 )
+            {
+                switch ( bit )
+                {
+                case CS_LOWERCASE_LETTERS: return (char) intBetween( 'a', 'z' );
+                case CS_UPPERCASE_LETTERS: return (char) intBetween( 'A', 'Z' );
+                case CS_DIGITS: return (char) intBetween( '0', '9' );
+                case CS_SYMBOLS: return symbol();
+                default: throw new IllegalArgumentException( "Unknown character set " + bit );
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public <T> T[] selection( T[] among, int min, int max, boolean allowDuplicates )
+    {
+        int length = min + random.nextInt( max-min );
+        T[] result = (T[]) Array.newInstance( among.getClass().getComponentType(), length );
+        for ( int i = 0; i < length; i++ )
+        {
+            while ( true )
+            {
+                T candidate = among( among );
+                if ( !allowDuplicates && ArrayUtil.contains( result, candidate ) )
+                {   // Try again
+                    continue;
+                }
+                result[i] = candidate;
+                break;
+            }
+        }
+        return result;
+    }
+
+    public <T> T among( T[] among )
+    {
+        return among[random.nextInt( among.length )];
+    }
+
+    public Object propertyValue()
+    {
+        return propertyValue( propertyType( true ) );
+    }
+
+    private byte propertyType( boolean allowArrays )
+    {
+        return (byte) random.nextInt( allowArrays ? 10 : 9 );
+    }
+
+    private Object propertyValue( byte type )
+    {
+        switch ( type )
+        {
+        case 0: return random.nextBoolean();
+        case 1: return (byte)random.nextInt();
+        case 2: return (short)random.nextInt();
+        case 3: return character( CSA_LETTERS_AND_DIGITS );
+        case 4: return random.nextInt();
+        case 5: return random.nextLong();
+        case 6: return random.nextFloat();
+        case 7: return random.nextDouble();
+        case 8: return string();
+        case 9:
+            int length = intBetween( configuration.arrayMinLength(), configuration.arrayMaxLength() );
+            byte componentType = propertyType( false );
+            Object itemType = propertyValue( componentType );
+            Object array = Array.newInstance( itemType.getClass(), length );
+            for ( int i = 0; i < length; i++ )
+            {
+                Array.set( array, i, propertyValue( componentType ) );
+            }
+            return array;
+        default: throw new IllegalArgumentException( "Unknown value type " + type );
+        }
+    }
+
+    private char symbol()
+    {
+        int range = random.nextInt( 5 );
+        switch ( range )
+        {
+        case 0: return (char) intBetween( 33,  47 );
+        case 1: return (char) intBetween( 58, 64 );
+        case 2: return (char) intBetween( 91, 96 );
+        case 3: return (char) intBetween( 123, 126 );
+        case 4: return ' ';
+        default: throw new IllegalArgumentException( "Unknown symbol range " + range );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -93,6 +93,12 @@ public class EncodingIdMapperTest
                     }
                 };
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return false;
+            }
         };
 
         // WHEN
@@ -439,6 +445,12 @@ public class EncodingIdMapperTest
                     return null;
                 }
             };
+        }
+
+        @Override
+        public boolean supportsMultiplePasses()
+        {
+            return false;
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputCacheTest.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.test.RandomRule;
+import org.neo4j.test.Randoms;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static java.lang.Math.abs;
+
+import static org.neo4j.helpers.Format.KB;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_LABELS;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
+
+public class InputCacheTest
+{
+    private static final int BATCH_SIZE = 100, BATCHES = 100;
+
+    @Test
+    public void shouldCacheAndRetrieveNodes() throws Exception
+    {
+        // GIVEN
+        try ( InputCache cache = new InputCache( fs, dir.directory(), 8*KB ) )
+        {
+            List<InputNode> nodes = new ArrayList<>();
+            Randoms random = new Randoms( randomRule.random(), Randoms.DEFAULT );
+            try ( Receiver<InputNode[],IOException> cacher = cache.cacheNodes() )
+            {
+                InputNode[] batch = new InputNode[BATCH_SIZE];
+                for ( int b = 0; b < BATCHES; b++ )
+                {
+                    for ( int i = 0; i < BATCH_SIZE; i++ )
+                    {
+                        InputNode node = randomNode( random );
+                        batch[i] = node;
+                        nodes.add( node );
+                    }
+                    cacher.receive( batch );
+                }
+            }
+
+            // WHEN/THEN
+            try ( InputIterator<InputNode> reader = cache.nodes().iterator() )
+            {
+                Iterator<InputNode> expected = nodes.iterator();
+                while ( expected.hasNext() )
+                {
+                    assertTrue( reader.hasNext() );
+                    InputNode expectedNode = expected.next();
+                    InputNode node = reader.next();
+                    assertNodesEquals( expectedNode, node );
+                }
+                assertFalse( reader.hasNext() );
+            }
+        }
+        assertNoFilesLeftBehind();
+    }
+
+    @Test
+    public void shouldCacheAndRetrieveRelationships() throws Exception
+    {
+        // GIVEN
+        try ( InputCache cache = new InputCache( fs, dir.directory(), 8*KB ) )
+        {
+            List<InputRelationship> relationships = new ArrayList<>();
+            Randoms random = new Randoms( randomRule.random(), Randoms.DEFAULT );
+            try ( Receiver<InputRelationship[],IOException> cacher = cache.cacheRelationships() )
+            {
+                InputRelationship[] batch = new InputRelationship[BATCH_SIZE];
+                for ( int b = 0; b < BATCHES; b++ )
+                {
+                    for ( int i = 0; i < BATCH_SIZE; i++ )
+                    {
+                        InputRelationship relationship = randomRelationship( random );
+                        batch[i] = relationship;
+                        relationships.add( relationship );
+                    }
+                    cacher.receive( batch );
+                }
+            }
+
+            // WHEN/THEN
+            try ( InputIterator<InputRelationship> reader = cache.relationships().iterator() )
+            {
+                Iterator<InputRelationship> expected = relationships.iterator();
+                while ( expected.hasNext() )
+                {
+                    assertTrue( reader.hasNext() );
+                    InputRelationship expectedRelationship = expected.next();
+                    InputRelationship relationship = reader.next();
+                    assertRelationshipsEquals( expectedRelationship, relationship );
+                }
+                assertFalse( reader.hasNext() );
+            }
+        }
+        assertNoFilesLeftBehind();
+    }
+
+    private void assertNoFilesLeftBehind()
+    {
+        assertEquals( 0, fs.listFiles( dir.directory() ).length );
+    }
+
+    private void assertRelationshipsEquals( InputRelationship expectedRelationship, InputRelationship relationship )
+    {
+        if ( expectedRelationship.hasSpecificId() )
+        {
+            assertEquals( expectedRelationship.specificId(), relationship.specificId() );
+        }
+        assertProperties( expectedRelationship, relationship );
+        assertEquals( expectedRelationship.startNode(), relationship.startNode() );
+        assertEquals( expectedRelationship.startNodeGroup(), relationship.startNodeGroup() );
+        assertEquals( expectedRelationship.endNode(), relationship.endNode() );
+        assertEquals( expectedRelationship.endNodeGroup(), relationship.endNodeGroup() );
+        if ( expectedRelationship.hasTypeId() )
+        {
+            assertEquals( expectedRelationship.typeId(), relationship.typeId() );
+        }
+        else
+        {
+            assertEquals( expectedRelationship.type(), relationship.type() );
+        }
+    }
+
+    private void assertProperties( InputEntity expected, InputEntity entity )
+    {
+        if ( expected.hasFirstPropertyId() )
+        {
+            assertEquals( expected.firstPropertyId(), entity.firstPropertyId() );
+        }
+        else
+        {
+            assertArrayEquals( expected.properties(), entity.properties() );
+        }
+    }
+
+    private InputRelationship randomRelationship( Randoms random )
+    {
+        if ( random.random().nextFloat() < 0.1f )
+        {
+            return new InputRelationship( null, 0, 0,
+                    NO_PROPERTIES, abs( random.random().nextLong() ),
+                    randomGroup( random, 0 ), randomId( random ),
+                    randomGroup( random, 1 ), randomId( random ),
+                    null, abs( random.random().nextInt( Short.MAX_VALUE ) ) );
+        }
+
+        return new InputRelationship( null, 0, 0,
+                randomProperties( random ), null,
+                randomGroup( random, 0 ), randomId( random ),
+                randomGroup( random, 1 ), randomId( random ),
+                randomType( random ), null );
+    }
+
+    private String randomType( Randoms random )
+    {
+        if ( previousType == null || random.random().nextFloat() < 0.1f )
+        {   // New type
+            return previousType = random.among( TOKENS );
+        }
+        // Keep same as previous
+        return previousType;
+    }
+
+    private void assertNodesEquals( InputNode expectedNode, InputNode node )
+    {
+        assertEquals( expectedNode.group(), node.group() );
+        assertEquals( expectedNode.id(), node.id() );
+        if ( expectedNode.hasFirstPropertyId() )
+        {
+            assertEquals( expectedNode.firstPropertyId(), node.firstPropertyId() );
+        }
+        else
+        {
+            assertArrayEquals( expectedNode.properties(), node.properties() );
+        }
+        if ( expectedNode.hasLabelField() )
+        {
+            assertEquals( expectedNode.labelField(), node.labelField() );
+        }
+        else
+        {
+            assertEquals( asSet( expectedNode.labels() ), asSet( node.labels() ) );
+        }
+    }
+
+    private InputNode randomNode( Randoms random )
+    {
+        if ( random.random().nextFloat() < 0.1f )
+        {
+            return new InputNode( null, 0, 0, randomId( random ),
+                    NO_PROPERTIES, abs( random.random().nextLong() ),
+                    NO_LABELS, abs( random.random().nextLong() ) );
+        }
+
+        return new InputNode( null, 0, 0,
+                randomGroup( random, 0 ), randomId( random ),
+                randomProperties( random ), null,
+                randomLabels( random ), null );
+    }
+
+    private Group randomGroup( Randoms random, int slot )
+    {
+        if ( random.random().nextFloat() < 0.01f )
+        {   // Next group
+            return previousGroups[slot] = new Group.Adapter( previousGroups[slot].id()+1, random.string() );
+        }
+        // Keep same as previous
+        return previousGroups[slot];
+    }
+
+    private String[] randomLabels( Randoms random )
+    {
+        if ( previousLabels == null || random.random().nextFloat() < 0.1 )
+        {   // Change set of labels
+            return previousLabels = random.selection( TOKENS, 1, 5, false );
+        }
+
+        // Keep same as previous
+        return previousLabels;
+    }
+
+    private Object[] randomProperties( Randoms random )
+    {
+        int length = random.random().nextInt( 10 );
+        Object[] properties = new Object[length*2];
+        for ( int i = 0; i < properties.length; i++ )
+        {
+            properties[i++] = random.among( TOKENS );
+            properties[i] = random.propertyValue();
+        }
+        return properties;
+    }
+
+    private Object randomId( Randoms random )
+    {
+        return abs( random.random().nextLong() );
+    }
+
+    private static final String[] TOKENS = new String[] { "One", "Two", "Three", "Four", "Five", "Six", "Seven" };
+    private final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+    public final @Rule TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+    public final @Rule RandomRule randomRule = new RandomRule();
+
+    private String[] previousLabels;
+    private final Group[] previousGroups = new Group[] { Group.GLOBAL, Group.GLOBAL };
+    private String previousType;
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/SimpleInputIteratorWrapper.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/SimpleInputIteratorWrapper.java
@@ -53,6 +53,12 @@ public class SimpleInputIteratorWrapper<T> extends SimpleInputIterator<T>
             {
                 return new SimpleInputIteratorWrapper<>( sourceDescription, source.iterator() );
             }
+
+            @Override
+            public boolean supportsMultiplePasses()
+            {
+                return true;
+            }
         };
     }
 }


### PR DESCRIPTION
for Input implementations that cannot provide the data streams multiple
times, something that the parallel batch importer requires. The cache
uses a binary format stored on disk. InputIterable can tell the importer
whether or not it supports multiple passes, if not then the importer will
cache the data streams the first run and use for consecutive runs.