### PR TITLE
AstCache should use the ast statement as cache-key

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -126,7 +126,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
     engine.execute(query).toList
 
     // then
-    logger.assertAtLeastOnce(LogCall.info(s"Discarded stale query from the query cache: $query"))
+    logger.assertAtLeastOnce(LogCall.info(s"Discarded stale query from the query cache: CYPHER 2.2 PLANNER CONSERVATIVE $query"))
   }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
@@ -65,9 +65,9 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
     val planner = CostBasedPlannerFactory(monitors, metricsFactory, planningMonitor, clock)
     val pipeBuilder = new LegacyVsNewPipeBuilder(new LegacyPipeBuilder(monitors), planner, planBuilderMonitor)
     val execPlanBuilder = new ExecutionPlanBuilder(graph, statsDivergenceThreshold, queryPlanTTL, clock, pipeBuilder)
-    val planCacheFactory = () => new LRUCache[PreparedQuery, ExecutionPlan](queryCacheSize)
+    val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](queryCacheSize)
     val cacheMonitor = monitors.newMonitor[AstCacheMonitor](monitorTag)
-    val cache = new MonitoringCacheAccessor[PreparedQuery, ExecutionPlan](cacheMonitor)
+    val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheMonitor)
 
     val compiler = new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheMonitor, monitors)
 


### PR DESCRIPTION
`PreparedQuery` was used as cache key which lead to unnecessary cache misses whenever
there were only differences in the query text and/or the extracted parameters.