### PR TITLE
Fix planner name in plan descriptions

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -266,7 +266,10 @@ case class CompatibilityPlanDescription(inner: InternalPlanDescription, version:
 
   def asJava: javacompat.PlanDescription = exceptionHandlerFor2_2.runSafely { asJava(self) }
 
-  override def toString: String = exceptionHandlerFor2_2.runSafely { s"Compiler CYPHER ${version.name}\n\nPlanner ${planner.toString.toUpperCase}\n\n$inner" }
+  override def toString: String = {
+    val NL = System.lineSeparator()
+    exceptionHandlerFor2_2.runSafely { s"Compiler CYPHER ${version.name}$NL${NL}Planner ${planner.name.toUpperCase}$NL$NL$inner" }
+  }
 
   def asJava(in: ExtendedPlanDescription): javacompat.PlanDescription = new javacompat.PlanDescription {
     def getProfilerStatistics: ProfilerStatistics = new ProfilerStatistics {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -228,14 +228,14 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
   test("reports COST planner when showing plan description") {
     val executionPlanDescription = eengine.execute("cypher 2.2 planner cost match n return n").executionPlanDescription()
-    executionPlanDescription.toString should include("Planner COST")
+    executionPlanDescription.toString should include("Planner COST" + System.lineSeparator())
   }
 
   test("reports RULE planner when showing plan description") {
     val executionPlanDescription = eengine.execute("cypher 2.2 planner cost create ()").executionPlanDescription()
 
     executionPlanDescription.toString should not include "Planner COST"
-    executionPlanDescription.toString should include("Planner RULE")
+    executionPlanDescription.toString should include("Planner RULE" + System.lineSeparator())
   }
 
   test("does not use Apply for aggregation and order by") {


### PR DESCRIPTION
An earlier commit made the plan descriptions say:

    Planner COSTPLANNER

by mistake. This fixes that output to say:

    Planner COST
