### PR TITLE
Make PageSwappers gracefully handle interrupts in force()

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -239,7 +239,24 @@ public class SingleFilePageSwapper implements PageSwapper
     @Override
     public void force() throws IOException
     {
-        channel.force( false );
+        try
+        {
+            channel.force( false );
+        }
+        catch ( ClosedChannelException e )
+        {
+            // AsynchronousCloseException is a subclass of
+            // ClosedChannelException, and ClosedByInterruptException is in
+            // turn a subclass of AsynchronousCloseException.
+            tryReopen( e );
+            boolean interrupted = Thread.interrupted();
+            // Recurse because this is hopefully a very rare occurrence.
+            force();
+            if ( interrupted )
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
PageSwappers have always been required to reopen channels that are closed by interrupts in write().
This commit extends this behaviour to the force() method as well.
This is important as MuninnPageCache.flushAndCloseWithoutFail can otherwise get into an infinite loop.