### PR TITLE
IdMapper preparation executed as a stage

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
@@ -27,17 +27,17 @@ package org.neo4j.helpers.progress;
  *
  * @author Tobias Lindaaker <tobias.lindaaker@neotechnology.com>
  */
-public abstract class ProgressListener
+public interface ProgressListener
 {
-    public abstract void started();
+    void started();
 
-    public abstract void set( long progress );
+    void set( long progress );
 
-    public abstract void add( long progress );
+    void add( long progress );
 
-    public abstract void done();
+    void done();
 
-    public abstract void failed( Throwable e );
+    void failed( Throwable e );
 
     public static final ProgressListener NONE = new ProgressListener()
     {
@@ -72,7 +72,7 @@ public abstract class ProgressListener
         }
     };
 
-    static class SinglePartProgressListener extends ProgressListener
+    static class SinglePartProgressListener implements ProgressListener
     {
         final Indicator indicator;
         private final long totalCount;
@@ -161,7 +161,7 @@ public abstract class ProgressListener
         }
     }
 
-    static final class MultiPartProgressListener extends ProgressListener
+    static final class MultiPartProgressListener implements ProgressListener
     {
         private final Aggregator aggregator;
         final String part;
@@ -226,10 +226,4 @@ public abstract class ProgressListener
             INIT, LIVE
         }
     }
-
-    private ProgressListener()
-    {
-        // only internal implementations
-    }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MovingAverage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/MovingAverage.java
@@ -60,4 +60,14 @@ public class MovingAverage
         int trackedValues = numberOfCurrentlyTrackedValues();
         return trackedValues > 0 ? total.get() / trackedValues : 0;
     }
+
+    public void reset()
+    {
+        for ( int i = 0; i < values.length(); i++ )
+        {
+            values.set( i, 0 );
+        }
+        total.set( 0 );
+        valueCursor.set( 0 );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStep.java
@@ -44,20 +44,17 @@ public final class NodeEncoderStep extends ExecutorServiceStep<Batch<InputNode,N
     private final IdGenerator idGenerator;
     private final NodeStore nodeStore;
     private final BatchingLabelTokenRepository labelHolder;
-    private final InputIterable<Object> allIds;
 
     public NodeEncoderStep( StageControl control, Configuration config,
             IdMapper idMapper, IdGenerator idGenerator,
             BatchingLabelTokenRepository labelHolder,
-            NodeStore nodeStore,
-            InputIterable<Object> allIds )
+            NodeStore nodeStore )
     {
         super( control, "NODE", config.workAheadSize(), config.movingAverageSize(), 1 );
         this.idMapper = idMapper;
         this.idGenerator = idGenerator;
         this.nodeStore = nodeStore;
         this.labelHolder = labelHolder;
-        this.allIds = allIds;
     }
 
     @Override
@@ -91,15 +88,5 @@ public final class NodeEncoderStep extends ExecutorServiceStep<Batch<InputNode,N
             }
         }
         return batch;
-    }
-
-    @Override
-    protected void done()
-    {
-        super.done();
-        // We're done adding ids to the IdMapper, prepare for other stages querying it.
-        // We pass in allIds because they may be needed to sort out colliding values in case of String->long
-        // encoding.
-        idMapper.prepare( allIds );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
 import org.neo4j.function.primitive.PrimitiveIntPredicate;
+import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -57,10 +58,9 @@ public interface IdMapper
      *
      * @param all ids put earlier, in the event of difficult collisions so that more information have to be read
      * from the input data again, data that normally isn't necessary and hence discarded.
-     * TODO Providing the node data here is a bit leaky. Preferably there should be an abstraction encapsulating
-     * data and id mapping, so that this can be removed.
+     * @param progress reports preparation progress.
      */
-    void prepare( InputIterable<Object> allIds );
+    void prepare( InputIterable<Object> allIds, ProgressListener progress );
 
     /**
      * Returns an actual node id representing {@code inputId}. For this call to work {@link #prepare()} must have

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
+import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
@@ -49,7 +50,7 @@ public class IdMappers
         }
 
         @Override
-        public void prepare( InputIterable<Object> nodeData )
+        public void prepare( InputIterable<Object> nodeData, ProgressListener progress )
         {   // No need to prepare anything
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -39,7 +39,7 @@ import static java.lang.System.currentTimeMillis;
 public abstract class AbstractStep<T> implements Step<T>
 {
     private final StageControl control;
-    private final String name;
+    private volatile String name;
     @SuppressWarnings( "rawtypes" )
     private volatile Step downstream;
     private volatile boolean endOfUpstream;
@@ -80,7 +80,7 @@ public abstract class AbstractStep<T> implements Step<T>
     public void start( boolean orderedTickets )
     {
         this.orderedTickets = orderedTickets;   // Do nothing by default
-        startTime = currentTimeMillis();
+        resetStats();
     }
 
     /**
@@ -260,5 +260,21 @@ public abstract class AbstractStep<T> implements Step<T>
     @Override
     public void close()
     {
+    }
+
+    protected void changeName( String name )
+    {
+        this.name = name;
+    }
+
+    protected void resetStats()
+    {
+        downstreamIdleTime.set( 0 );
+        upstreamIdleTime.set( 0 );
+        queuedBatches.set( 0 );
+        doneBatches.set( 0 );
+        totalProcessingTime.reset();
+        startTime = currentTimeMillis();
+        endTime = 0;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/IdMapperPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/IdMapperPreparationStep.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import org.neo4j.helpers.progress.ProgressListener;
+import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
+
+/**
+ * Preparation of an {@link IdMapper}, {@link IdMapper#prepare(InputIterable, ProgressListener)}
+ * under running as a normal {@link Step} so that normal execution monitoring can be applied.
+ * Useful since preparing an {@link IdMapper} can take a significant amount of time.
+ */
+public class IdMapperPreparationStep extends LonelyProcessingStep
+{
+    private final IdMapper idMapper;
+    private final InputIterable<Object> allIds;
+
+    public IdMapperPreparationStep( StageControl control, int batchSize, int movingAverageSize,
+            IdMapper idMapper, InputIterable<Object> allIds )
+    {
+        super( control, "" /*named later in the progress listener*/, batchSize, movingAverageSize );
+        this.idMapper = idMapper;
+        this.allIds = allIds;
+    }
+
+    @Override
+    protected void process()
+    {
+        idMapper.prepare( allIds, new ProgressListener()
+        {
+            private final String[] stages = {"SORT", "DETECT", "RESOLVE"};
+            private volatile int stage = 0;
+
+            @Override
+            public void started()
+            {
+                resetStats();
+                changeName( stages[stage++] );
+            }
+
+            @Override
+            public void set( long progress )
+            {
+                throw new UnsupportedOperationException( "Shouldn't be required" );
+            }
+
+            @Override
+            public void failed( Throwable e )
+            {
+                issuePanic( e );
+            }
+
+            @Override
+            public synchronized void add( long progress )
+            {   // Directly feed into the progress of this step.
+                // Expected to be called by multiple threads, although quite rarely,
+                // so synchronization overhead should be negligible.
+                progress( progress );
+            }
+
+            @Override
+            public void done()
+            {   // Nothing to do
+            }
+        } );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStep.java
@@ -66,14 +66,24 @@ public abstract class LonelyProcessingStep extends AbstractStep<Void>
         return 0;
     }
 
+    /**
+     * Called once and signals the start of this step. Responsible for calling {@link #progress(int)}
+     * at least now and then.
+     */
     protected abstract void process();
 
-    protected void itemProcessed()
+    /**
+     * Called from {@link #process()}, reports progress so that statistics are updated appropriately.
+     * @param amount number of items processed since last call to this method.
+     */
+    protected void progress( long amount )
     {
-        if ( ++batch == batchSize )
+        batch += amount;
+        if ( batch >= batchSize )
         {
-            doneBatches.incrementAndGet();
-            batch = 0;
+            int batches = batch / batchSize;
+            batch %= batchSize;
+            doneBatches.addAndGet( batches );
             long time = currentTimeMillis();
             totalProcessingTime.add( time - lastProcessingTimestamp );
             lastProcessingTimestamp = time;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SpectrumExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SpectrumExecutionMonitor.java
@@ -114,10 +114,6 @@ public class SpectrumExecutionMonitor extends ExecutionMonitor.Adpter
     {
         long[] values = values( execution );
         long total = total( values );
-        if ( total == 0 )
-        {
-            return false;
-        }
 
         // reduce the width with the known extra characters we know we'll print in and around the spectrum
         width -= values.length + 1/*'|' chars*/ + 4 /*progress chars*/;
@@ -133,7 +129,7 @@ public class SpectrumExecutionMonitor extends ExecutionMonitor.Adpter
             {
                 break; // odd though
             }
-            long stepWidth = projection.step();
+            long stepWidth = total == 0 && stepIndex == 0 ? width : projection.step();
             boolean isBottleNeck = bottleNeck.first() == step;
             String name =
                     (isBottleNeck ? "*" : "") +


### PR DESCRIPTION
so that the ExecutionMonitor can report progress during.
ParallelSort/EncodingIdMapper have been enhanced with progress reporting
as well. ParallelSort does thread-local progress and reports to the total
progress now and then, to reduce overhead of progress reporting.

AbstractStep was enhanced to be able to reset stats and effectively
support multiple steps executed in sequence, to be able to
report IdMapper preparation in as much detail as possible.