### PR TITLE
Fix a data race in GraphDatabaseServiceTest

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
@@ -129,7 +129,7 @@ public class LockManagerImpl implements LockManager
     {
         if ( resource == null || tx == null )
         {
-            throw new IllegalResourceException( "Null parameter" );
+            throw new IllegalResourceException( "Null parameter: resource = " + resource + ", tx = " + tx );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.graphdb;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.MyRelTypes;
@@ -293,7 +293,9 @@ public class GraphDatabaseServiceTest
         }
         finally
         {
-            t2Tx.close();
+            t2n2Wait.get();
+            t2.execute( close( t2Tx ) );
+            t2.close();
         }
     }
 
@@ -318,6 +320,19 @@ public class GraphDatabaseServiceTest
             public Object doWork( Void state ) throws Exception
             {
                 entity.setProperty( key, value );
+                return null;
+            }
+        };
+    }
+
+    private WorkerCommand<Void, Void> close( final Transaction tx )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                tx.close();
                 return null;
             }
         };


### PR DESCRIPTION
The GraphDatabaseServiceTest.shouldLetDtectedDeadllocksDuringCommitBeThrownInTheirOriginalForm test created a transaction in a companion thread.
It then ended up closing this transaction from that other thread, which resulted in weird non-deterministic exceptions during KernelTransactionImplementation.close().