### PR TITLE
Fixes temporarily unavailable source traceability

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -39,8 +39,9 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
     private final Header.Factory headerFactory;
     private final Configuration config;
     private final IdType idType;
-    private InputEntityDeserializer<ENTITY> currentInput;
+    private InputIterator<ENTITY> currentInput = new InputIterator.Adapter<>();
     private long previousInputsCollectivePositions;
+    private volatile boolean currentInputOpen;
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
                              Configuration config, IdType idType )
@@ -65,18 +66,22 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
         // from somewhere else, it's up to that factory.
         Header dataHeader = headerFactory.create( dataStream, config, idType );
 
-        currentInput = entityDeserializer( dataStream, dataHeader, data.decorator() );
-        currentInput.initialize();
+        InputEntityDeserializer<ENTITY> input = entityDeserializer( dataStream, dataHeader, data.decorator() );
+        // It's important that we assign currentInput before calling initialize(), so that if something
+        // goes wrong in initialize() and our close() is called we close it properly.
+        currentInput = input;
+        currentInputOpen = true;
+        input.initialize();
         return currentInput;
     }
 
     private void closeCurrent()
     {
-        if ( currentInput != null )
+        if ( currentInputOpen )
         {
             previousInputsCollectivePositions += currentInput.position();
             currentInput.close();
-            currentInput = null;
+            currentInputOpen = false;
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.csv.reader.CharSeeker;
+import org.neo4j.function.Function;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.csv.reader.Readables.wrap;
+import static org.neo4j.function.Factories.given;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.IdType.INTEGER;
+
+public class InputGroupsDeserializerTest
+{
+    @Test
+    public void shouldBeAbleToAskForSourceInformationEvenBetweenTwoSources() throws Exception
+    {
+        // GIVEN
+        List<DataFactory<InputNode>> data = asList( data( ":ID\n1" ), data( "2" ) );
+        final AtomicInteger flips = new AtomicInteger();
+        InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<InputNode>(
+                data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS ), INTEGER )
+        {
+            @Override
+            protected InputEntityDeserializer<InputNode> entityDeserializer( CharSeeker dataStream, Header dataHeader,
+                    Function<InputNode,InputNode> decorator )
+            {
+                // This is the point where the currentInput field in InputGroupsDeserializer was null
+                // so ensure that's no longer the case, just by poking those source methods right here and now.
+                if ( flips.get() == 0 )
+                {
+                    assertNotNull( sourceDescription() );
+                }
+                else
+                {
+                    assertEquals( "" + flips.get(), sourceDescription() );
+                }
+
+                flips.incrementAndGet();
+                @SuppressWarnings( "unchecked" )
+                InputEntityDeserializer<InputNode> result = mock( InputEntityDeserializer.class );
+                when( result.sourceDescription() ).thenReturn( String.valueOf( flips.get() ) );
+                return result;
+            }
+        };
+
+        // WHEN running through the iterator
+        count( deserializer );
+
+        // THEN there should have been two data source flips
+        assertEquals( 2, flips.get() );
+    }
+
+    private Configuration lowBufferSize( Configuration conf )
+    {
+        return new Configuration.OverrideFromConfig( conf )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 100;
+            }
+        };
+    }
+
+    private DataFactory<InputNode> data( String string )
+    {
+        return DataFactories.data( NO_NODE_DECORATOR, given( wrap( new StringReader( string ) ) ) );
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/function/Factories.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/function/Factories.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.function;
+
+public class Factories
+{
+    public static <T> Factory<T> given( final T item )
+    {
+        return new Factory<T>()
+        {
+            @Override
+            public T newInstance()
+            {
+                return item;
+            }
+        };
+    }
+}


### PR DESCRIPTION
in between switching data sources in InputGroupDeserializer (batch import
CSV input deserializer) where an ExecutionMonitor would come in and ask
about progress and see a null variable, resulting in NPE