### PR TITLE
Added warning for unwanted cartesian products.

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ExplainExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ExplainExecutionResult.scala
@@ -25,11 +25,13 @@ import java.util.Collections
 
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
 import org.neo4j.graphdb.QueryExecutionType.{QueryType, explained}
-import org.neo4j.graphdb.ResourceIterator
+import org.neo4j.graphdb.{Notification, ResourceIterator}
 
 case class ExplainExecutionResult(closer: TaskCloser, columns: List[String],
-                                  executionPlanDescription: InternalPlanDescription, queryType: QueryType)
+                                  executionPlanDescription: InternalPlanDescription, queryType: QueryType,
+                                  notifications: Seq[InternalNotification])
   extends InternalExecutionResult {
 
   def javaIterator: ResourceIterator[util.Map[String, Any]] = new EmptyResourceIterator(close)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalNotificationLogger.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalNotificationLogger.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3
+
+import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
+
+/**
+ * A NotificationLogger records notifications.
+ */
+sealed trait InternalNotificationLogger {
+  def log(notification: InternalNotification )
+
+  def notifications: Seq[InternalNotification ]
+
+  def += (notification: InternalNotification) = log(notification)
+}
+
+/**
+ * A null implementation that discards all notifications.
+ */
+case object devNullLogger extends InternalNotificationLogger {
+  override def log(notification: InternalNotification ) {}
+
+  override def notifications: Seq[InternalNotification ] = Seq.empty
+}
+
+/**
+ * NotificationLogger that records all notifications for later retrieval.
+ */
+class RecordingNotificationLogger extends InternalNotificationLogger {
+  private val builder = Seq.newBuilder[InternalNotification]
+
+  def log(notification: InternalNotification ) = builder += notification
+  def notifications = builder.result()
+}
+

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
@@ -29,6 +29,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.{ExplainMode, ExecutionMode, ProfileMode}
+import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
 import org.neo4j.graphdb.QueryExecutionType.{QueryType, profiled, query}
 import org.neo4j.graphdb.ResourceIterator
 
@@ -101,5 +102,8 @@ class PipeExecutionResult(val result: ResultIterator,
   }
 
   def executionType = if (executionMode == ProfileMode) profiled(queryType) else query(queryType)
+
+  //notifications only present for EXPLAIN
+  override val notifications = Iterable.empty[InternalNotification]
 }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PreparedQuery.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PreparedQuery.scala
@@ -27,7 +27,10 @@ import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterConditi
 
 case class PreparedQuery(statement: Statement,
                          queryText: String,
-                         extractedParams: Map[String, Any])(val semanticTable: SemanticTable, val conditions: Set[RewriterCondition], val scopeTree: Scope) {
+                         extractedParams: Map[String, Any])(val semanticTable: SemanticTable,
+                                                            val conditions: Set[RewriterCondition],
+                                                            val scopeTree: Scope,
+                                                            val notificationLogger: InternalNotificationLogger) {
 
   def abstractQuery: AbstractQuery = statement.asQuery.setQueryText(queryText)
 
@@ -37,5 +40,5 @@ case class PreparedQuery(statement: Statement,
   }
 
   def rewrite(rewriter: Rewriter): PreparedQuery =
-    copy(statement = statement.endoRewrite(rewriter))(semanticTable, conditions, scopeTree)
+    copy(statement = statement.endoRewrite(rewriter))(semanticTable, conditions, scopeTree, notificationLogger)
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
@@ -22,9 +22,9 @@ package org.neo4j.cypher.internal.compiler.v2_3
 import org.neo4j.cypher.internal.compiler.v2_3.ast.Statement
 
 class SemanticChecker(semanticCheckMonitor: SemanticCheckMonitor) {
-  def check(queryText: String, statement: Statement): SemanticState = {
+  def check(queryText: String, statement: Statement, notificationLogger: InternalNotificationLogger = devNullLogger): SemanticState = {
     semanticCheckMonitor.startSemanticCheck(queryText)
-    val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean)
+    val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean.withNotificationLogger(notificationLogger))
 
     val scopeTreeIssues = ScopeTreeVerifier.verify(semanticState.scopeTree)
     if (scopeTreeIssues.nonEmpty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticState.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticState.scala
@@ -170,7 +170,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.SemanticState.ScopeLocation
 
 case class SemanticState(currentScope: ScopeLocation,
                          typeTable: ASTAnnotationMap[ast.Expression, ExpressionTypeInfo],
-                         recordedScopes: ASTAnnotationMap[ast.ASTNode, Scope]) {
+                         recordedScopes: ASTAnnotationMap[ast.ASTNode, Scope],
+                         notificationLogger: InternalNotificationLogger = devNullLogger) {
   def scopeTree = currentScope.rootScope
 
   def newChildScope = copy(currentScope = currentScope.newChildScope)
@@ -189,6 +190,8 @@ case class SemanticState(currentScope: ScopeLocation,
       case Some(symbol) =>
         Left(SemanticError(s"${identifier.name} already declared", identifier.position, symbol.positions.toSeq: _*))
     }
+
+  def withNotificationLogger(notificationLogger: InternalNotificationLogger) = copy(notificationLogger = notificationLogger)
 
   def implicitIdentifier(identifier: ast.Identifier, possibleTypes: TypeSpec): Either[SemanticError, SemanticState] =
     this.symbol(identifier.name) match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionPlanBuilder.scala
@@ -61,7 +61,7 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, statsDivergenceThreshold
 
     val columns = getQueryResultColumns(abstractQuery, pipe.symbols)
     val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns)
-    val func = getExecutionPlanFunction(periodicCommitInfo, abstractQuery.getQueryText, updating, resultBuilderFactory)
+    val func = getExecutionPlanFunction(periodicCommitInfo, abstractQuery.getQueryText, updating, resultBuilderFactory, inputQuery.notificationLogger)
 
     new ExecutionPlan {
       private val fingerprint = PlanFingerprintReference(clock, queryPlanTTL, statsDivergenceThreshold, fp)
@@ -101,7 +101,8 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, statsDivergenceThreshold
   private def getExecutionPlanFunction(periodicCommit: Option[PeriodicCommitInfo],
                                        queryId: AnyRef,
                                        updating: Boolean,
-                                       resultBuilderFactory: ExecutionResultBuilderFactory):
+                                       resultBuilderFactory: ExecutionResultBuilderFactory,
+                                       notificationLogger: InternalNotificationLogger):
   (QueryContext, ExecutionMode, Map[String, Any]) => InternalExecutionResult =
     (queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]) => {
       val builder = resultBuilderFactory.create()
@@ -119,6 +120,6 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, statsDivergenceThreshold
       if (profiling)
         builder.setPipeDecorator(new Profiler())
 
-      builder.build(graph, queryId, planType, params)
+      builder.build(graph, queryId, planType, params, notificationLogger)
     }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionResultBuilder.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.executionplan
 
 import org.neo4j.cypher.internal.ExecutionMode
-import org.neo4j.cypher.internal.compiler.v2_3.CypherException
+import org.neo4j.cypher.internal.compiler.v2_3.{InternalNotificationLogger, CypherException}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.graphdb.GraphDatabaseService
@@ -30,7 +30,7 @@ trait ExecutionResultBuilder {
   def setLoadCsvPeriodicCommitObserver(batchRowCount: Long)
   def setPipeDecorator(newDecorator: PipeDecorator)
   def setExceptionDecorator(newDecorator: CypherException => CypherException)
-  def build(graph: GraphDatabaseService, queryId: AnyRef, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult
+  def build(graph: GraphDatabaseService, queryId: AnyRef, planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult
 }
 
 trait ExecutionResultBuilderFactory {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/InternalExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/InternalExecutionResult.scala
@@ -23,6 +23,7 @@ import java.io.PrintWriter
 
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
 import org.neo4j.graphdb.{QueryExecutionType, ResourceIterator}
 
 trait InternalExecutionResult extends Iterator[Map[String, Any]] {
@@ -38,4 +39,5 @@ trait InternalExecutionResult extends Iterator[Map[String, Any]] {
   def close()
   def planDescriptionRequested: Boolean
   def executionType: QueryExecutionType
+  def notifications: Iterable[InternalNotification]
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
@@ -17,18 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.pipes
+package org.neo4j.cypher.internal.compiler.v2_3.notification
 
-import org.neo4j.cypher.internal.compiler.v2_3.{devNullLogger, ExecutionContext}
-import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v2_3.InputPosition
 
-object QueryStateHelper {
-  def empty: QueryState = emptyWith()
-
-  def emptyWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalResource = null,
-                params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
-                initialContext: Option[ExecutionContext] = None) =
-    QueryState(db = db, query = query, resources = resources, params = params, decorator = decorator,
-      initialContext = initialContext)
+/**
+ * Describes a notification
+ */
+sealed trait InternalNotification {
+  def position: InputPosition
 }
+
+case class CartesianProductNotification(position: InputPosition) extends InternalNotification

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ExplainExecutionResultTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ExplainExecutionResultTest.scala
@@ -28,7 +28,7 @@ class ExplainExecutionResultTest extends CypherFunSuite {
 
   private val closer = mock[TaskCloser]
   private val result =
-    new ExplainExecutionResult(closer, List.empty, mock[InternalPlanDescription], QueryType.READ_ONLY)
+    ExplainExecutionResult(closer, List.empty, mock[InternalPlanDescription], QueryType.READ_ONLY, Seq.empty)
 
   test("should call taskCloser close on close") {
     result.close()

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.Pipe
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
-import org.neo4j.cypher.internal.compiler.v2_3.{CostPlannerName, EagerResultIterator, ExplainExecutionResult, PipeExecutionResult}
+import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.{ExplainMode, NormalMode}
 import org.neo4j.graphdb.GraphDatabaseService
 
@@ -44,7 +44,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build(graph, "42", NormalMode, Map.empty)
+    val result = builder.build(graph, "42", NormalMode, Map.empty, devNullLogger)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result shouldBe a[EagerResultIterator]
   }
@@ -62,7 +62,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build(graph, "42", NormalMode, Map.empty)
+    val result = builder.build(graph, "42", NormalMode, Map.empty, devNullLogger)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result should not be an[EagerResultIterator]
   }
@@ -80,7 +80,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build(graph, "42", ExplainMode, Map.empty)
+    val result = builder.build(graph, "42", ExplainMode, Map.empty, devNullLogger)
     result shouldBe a [ExplainExecutionResult]
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/RulePipeBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/RulePipeBuilderTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.parser.{CypherParser, ParserMonit
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.SemanticTable
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v2_3.{Scope, Monitors, PreparedQuery}
+import org.neo4j.cypher.internal.compiler.v2_3.{devNullLogger, Scope, Monitors, PreparedQuery}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 class RulePipeBuilderTest extends CypherFunSuite {
@@ -108,7 +108,7 @@ class RulePipeBuilderTest extends CypherFunSuite {
 
   private def buildExecutionPipe(q: String): Pipe = {
     val statement = parser.parse(q)
-    val parsedQ = PreparedQuery(statement, q, Map.empty)(mock[SemanticTable], Set.empty, mock[Scope])
+    val parsedQ = PreparedQuery(statement, q, Map.empty)(mock[SemanticTable], Set.empty, mock[Scope], devNullLogger)
     planBuilder.producePlan(parsedQ, planContext).pipe
   }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
@@ -30,7 +30,10 @@ import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Notification;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+
+import scala.collection.JavaConversions;
 
 /**
  * Holds Cypher query result sets, in tabular form. Each row of the result is a map
@@ -58,7 +61,7 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
      * create an ExecutionResult directly, but instead use the result
      * returned from calling {@link ExecutionEngine#execute(String)}.
      */
-    public ExecutionResult( org.neo4j.cypher.ExtendedExecutionResult projection )
+    public ExecutionResult( org.neo4j.cypher.ExtendedExecutionResult projection)
     {
         inner = projection;
         iter = inner.javaIterator();
@@ -275,6 +278,12 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
     public void remove()
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<Notification> getNotifications()
+    {
+        return JavaConversions.asJavaIterable(inner.notifications());
     }
 
     private static class ExceptionConversion<T> implements ResourceIterator<T>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExtendedExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExtendedExecutionResult.scala
@@ -19,9 +19,10 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.graphdb.QueryExecutionType
+import org.neo4j.graphdb.{Notification, QueryExecutionType}
 
 trait ExtendedExecutionResult extends ExecutionResult {
   def planDescriptionRequested: Boolean
   def executionType: QueryExecutionType
+  def notifications: Iterable[Notification]
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
@@ -68,5 +68,7 @@ case class CompatibilityFor1_9(graph: GraphDatabaseService, queryCacheSize: Int,
     def isPeriodicCommit = false
 
     def isStale(lastTxId: () => Long, statement: Statement): Boolean = false
+
+    def notifications = Iterable.empty
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -203,9 +203,12 @@ case class ExecutionResultWrapperFor2_2(inner: InternalExecutionResult, planner:
       }
       def remove() =  exceptionHandlerFor2_2.runSafely{innerJavaIterator.remove}
     }
+
   }
 
-  def columnAs[T](column: String) = exceptionHandlerFor2_2.runSafely{inner.columnAs[T](column)}
+  def columnAs[T](column: String) = exceptionHandlerFor2_2.runSafely {
+    inner.columnAs[T](column)
+  }
 
   def columns = exceptionHandlerFor2_2.runSafely{inner.columns}
 
@@ -252,6 +255,8 @@ case class ExecutionResultWrapperFor2_2(inner: InternalExecutionResult, planner:
   }
 
   def executionType: QueryExecutionType = exceptionHandlerFor2_2.runSafely {inner.executionType}
+
+  def notifications = Seq.empty
 }
 
 case class CompatibilityPlanDescription(inner: InternalPlanDescription, version: CypherVersion, planner: PlannerName)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
@@ -99,6 +99,11 @@ case class LegacyExecutionResultWrapper(inner: ExecutionResult, planDescriptionR
 
   def executionType = if (planDescriptionRequested) profiled(queryType) else query(queryType)
 
+  def notifications = inner match {
+    case extended: ExtendedExecutionResult => extended.notifications
+    case _ => Iterable.empty
+  }
+
   // since we can't introspect the query result returned by the legacy planners, this is the best we can do
   private def queryType = if (schemaQuery(queryStatistics()))
     QueryType.SCHEMA_WRITE

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.mockito.Matchers._
+import org.mockito.Mockito.{verify, _}
+import org.neo4j.cypher.internal.NormalMode
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compatibility.{StringInfoLogger2_3, WrappedMonitors2_3}
+import org.neo4j.cypher.internal.compiler.v2_3.{InputPosition, CostPlannerName, CypherCompilerFactory, InternalNotificationLogger}
+import org.neo4j.cypher.internal.compiler.v2_3.notification.CartesianProductNotification
+import org.neo4j.helpers.Clock
+import org.neo4j.kernel.impl.util.StringLogger._
+
+class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
+
+  test("should warn when disconnected patterns") {
+    //given
+    val logger = mock[InternalNotificationLogger]
+    val compiler = createCompiler(logger)
+    val executionMode = NormalMode
+
+    //when
+    graph.inTx(compiler.planQuery("MATCH (a)-->(b), (c)-->(d) RETURN *", planContext, executionMode))
+
+    //then
+    verify(logger, times(1)) += CartesianProductNotification(InputPosition( 7, 1, 8 ))
+  }
+
+  test("should not warn when connected patterns") {
+    //given
+    val logger = mock[InternalNotificationLogger]
+    val compiler = createCompiler(logger)
+    val executionMode = NormalMode
+
+    //when
+    graph.inTx(compiler.planQuery("MATCH (a)-->(b), (a)-->(c) RETURN *", planContext, executionMode))
+
+    //then
+    verify(logger, never) += any()
+  }
+
+  test("should warn when one disconnected pattern in otherwise connected pattern") {
+    //given
+    val logger = mock[InternalNotificationLogger]
+    val compiler = createCompiler(logger)
+    val executionMode = NormalMode
+
+    //when
+    graph.inTx(compiler.planQuery("MATCH (a)-->(b), (b)-->(c), (x)-->(y), (c)-->(d), (d)-->(e) RETURN *", planContext, executionMode))
+
+    //then
+    verify(logger, times(1)) += CartesianProductNotification(InputPosition(29, 1, 30))
+  }
+
+  test("should not warn when disconnected patterns in multiple match clauses") {
+    //given
+    val logger = mock[InternalNotificationLogger]
+    val compiler = createCompiler(logger)
+    val executionMode = NormalMode
+
+    //when
+    graph.inTx(compiler.planQuery("MATCH (a)-->(b) MATCH (c)-->(d) RETURN *", planContext, executionMode))
+
+    //then
+    verify(logger, never) += any()
+  }
+
+  private def createCompiler(notificationLogger: InternalNotificationLogger) =
+    CypherCompilerFactory.costBasedCompiler(
+      graph, 128, 0.5, 1000L, Clock.SYSTEM_CLOCK,
+      new WrappedMonitors2_3(kernelMonitors),
+      new StringInfoLogger2_3(DEV_NULL),
+      _ => notificationLogger,
+      plannerName = CostPlannerName)
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -17,18 +17,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.pipes
+package org.neo4j.cypher
 
-import org.neo4j.cypher.internal.compiler.v2_3.{devNullLogger, ExecutionContext}
-import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v2_3.InputPosition
+import org.neo4j.cypher.internal.compiler.v2_3.notification.CartesianProductNotification
 
-object QueryStateHelper {
-  def empty: QueryState = emptyWith()
 
-  def emptyWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalResource = null,
-                params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
-                initialContext: Option[ExecutionContext] = None) =
-    QueryState(db = db, query = query, resources = resources, params = params, decorator = decorator,
-      initialContext = initialContext)
+class NotificationAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+
+  test("Warn for cartesian product") {
+    val result = executeWithNewPlanner("explain match (a)-->(b), (c)-->(d) return *")
+
+    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(7, 1, 8))))
+  }
+
+  test("Don't warn for cartesian product when not using explain") {
+    val result = executeWithNewPlanner("match (a)-->(b), (c)-->(d) return *")
+
+    result.notifications shouldBe empty
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfileRonjaPlanningTest.scala
@@ -33,7 +33,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.cardinality.Query
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{GraphStatistics, PlanContext, QueriedGraphStatistics}
 import org.neo4j.cypher.internal.spi.v2_3.{TransactionBoundPlanContext, TransactionBoundQueryContext}
-import org.neo4j.cypher.internal.{LRUCache, ProfileMode}
+import org.neo4j.cypher.internal.{NormalMode, LRUCache, ProfileMode}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.helpers.Clock
@@ -70,7 +70,7 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
     val cacheMonitor = monitors.newMonitor[AstCacheMonitor](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheMonitor)
 
-    val compiler = new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheMonitor, monitors)
+    val compiler = new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheMonitor, monitors, _=> devNullLogger)
 
     (compiler, events)
   }
@@ -103,7 +103,7 @@ class ProfileRonjaPlanningTest extends ExecutionEngineFunSuite with QueryStatist
     val (plan, parameters) = db.withTx {
       tx =>
         val planContext = new TransactionBoundPlanContext(db.statement, db) with RealStatistics
-        compiler.planQuery(query, planContext)
+        compiler.planQuery(query, planContext, NormalMode)
     }
 
     db.withTx {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -22,7 +22,10 @@ package org.neo4j.cypher.internal.compiler
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, STATISTICS_DIVERGENCE_THRESHOLD}
 import org.neo4j.cypher.internal.compatibility.WrappedMonitors2_3
-import org.neo4j.cypher.internal.compiler.v2_3.{CostPlannerName, CypherCompilerFactory, InfoLogger}
+import org.neo4j.cypher.internal.compiler.v2_3.InfoLogger
+
+import org.neo4j.cypher.internal.NormalMode
+import org.neo4j.cypher.internal.compiler.v2_3.{devNullLogger, CostPlannerName, CypherCompilerFactory}
 
 class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
@@ -151,7 +154,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
   def plan(query: String): (Double, Double) = {
     val compiler = createCurrentCompiler
-    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query))
+    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, NormalMode))
     val (planTime, _) = graph.inTx {
       measure(compiler.executionPlanBuilder.build(planContext, preparedQuery))
     }
@@ -174,6 +177,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
       clock = CLOCK,
       monitors = new WrappedMonitors2_3(kernelMonitors),
       logger = DEV_NULL,
+      notificationLoggerBuilder = _ => devNullLogger,
       plannerName = CostPlannerName
     )
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CompilerComparisonTest.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{GraphStatistics, PlanContext, QueriedGraphStatistics}
 import org.neo4j.cypher.internal.spi.v2_3.{TransactionBoundPlanContext, TransactionBoundQueryContext}
-import org.neo4j.cypher.internal.{LRUCache, ProfileMode}
+import org.neo4j.cypher.internal.{NormalMode, LRUCache, ProfileMode}
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
@@ -295,7 +295,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val cacheFlushMonitor = monitors.newMonitor[CypherCacheFlushingMonitor[CacheAccessor[Statement, ExecutionPlan]]](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheHitMonitor)
 
-    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors)
+    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors, _ => devNullLogger)
   }
 
   private def ronjaCompilerUsingIDPPlanner(metricsFactoryInput: MetricsFactory = SimpleMetricsFactory)(graph: GraphDatabaseService): CypherCompiler = {
@@ -315,7 +315,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val cacheFlushMonitor = monitors.newMonitor[CypherCacheFlushingMonitor[CacheAccessor[Statement, ExecutionPlan]]](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheHitMonitor)
 
-    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors)
+    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors, _ => devNullLogger)
   }
 
   private def legacyCompiler(graph: GraphDatabaseService): CypherCompiler = {
@@ -331,7 +331,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val cacheFlushMonitor = monitors.newMonitor[CypherCacheFlushingMonitor[CacheAccessor[Statement, ExecutionPlan]]](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheHitMonitor)
 
-    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors)
+    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors, _ => devNullLogger)
   }
 
   case class QueryExecutionResult(compiler: String, dbHits: Option[Long], plan: InternalPlanDescription) {
@@ -547,7 +547,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val (plan: ExecutionPlan, parameters) = db.withTx {
       tx =>
         val planContext = new TransactionBoundPlanContext(db.statement, db)
-        compiler.planQuery(query, planContext)
+        compiler.planQuery(query, planContext, NormalMode)
     }
 
     db.withTx {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompilerAstCacheAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
+import org.neo4j.cypher.internal.NormalMode
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compatibility.{StringInfoLogger2_3, WrappedMonitors2_3}
 import org.neo4j.cypher.internal.compiler.v2_3.ast.Statement
@@ -37,7 +38,10 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
                      clock: Clock = Clock.SYSTEM_CLOCK, logger: StringLogger = DEV_NULL) =
     CypherCompilerFactory.costBasedCompiler(
       graph, queryCacheSize, statsDivergenceThreshold, queryPlanTTL, clock,
-      new WrappedMonitors2_3(kernelMonitors), new StringInfoLogger2_3(logger), plannerName = CostPlannerName)
+      new WrappedMonitors2_3(kernelMonitors),
+      new StringInfoLogger2_3(logger),
+      _ => devNullLogger,
+      plannerName = CostPlannerName)
 
   case class CacheCounts(hits: Int = 0, misses: Int = 0, flushes: Int = 0, evicted: Int = 0) {
     override def toString = s"hits = $hits, misses = $misses, flushes = $flushes, evicted = $evicted"
@@ -68,7 +72,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val compiler = createCompiler()
     compiler.monitors.addMonitorListener(counter)
 
-    graph.inTx { compiler.planQuery("return 42", planContext) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
 
     counter.counts should equal(CacheCounts(hits = 0, misses = 1, flushes = 1))
   }
@@ -78,8 +82,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
-    graph.inTx { compiler.planQuery("return 42", planContext) }
-    graph.inTx { compiler.planQuery("return 42", planContext) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
 
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
@@ -89,8 +93,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
-    graph.inTx { compiler.planQuery("return 42", planContext) }
-    graph.inTx { compiler.planQuery("\treturn          42", planContext) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
+    graph.inTx { compiler.planQuery("\treturn          42", planContext, NormalMode) }
 
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
@@ -100,8 +104,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
-    graph.inTx { compiler.planQuery("return 42 as result", planContext) }
-    graph.inTx { compiler.planQuery("return 43 as result", planContext) }
+    graph.inTx { compiler.planQuery("return 42 as result", planContext, NormalMode) }
+    graph.inTx { compiler.planQuery("return 43 as result", planContext, NormalMode) }
 
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
@@ -111,9 +115,9 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val counter = new CacheCounter()
     compiler.monitors.addMonitorListener(counter)
 
-    graph.inTx { compiler.planQuery("return 42", planContext) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
     graph.createConstraint("Person", "id")
-    graph.inTx { compiler.planQuery("return 42", planContext) }
+    graph.inTx { compiler.planQuery("return 42", planContext, NormalMode) }
 
     counter.counts should equal(CacheCounts(hits = 0, misses = 2, flushes = 2))
   }
@@ -128,11 +132,11 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
 
     createLabeledNode("Dog")
     (0 until 50).foreach { _ => createLabeledNode("Person") }
-    graph.inTx { compiler.planQuery(query, planContext) }
+    graph.inTx { compiler.planQuery(query, planContext, NormalMode) }
 
     // when
     (0 until 1000).foreach { _ => createLabeledNode("Dog") }
-    graph.inTx { compiler.planQuery(query, planContext) }
+    graph.inTx { compiler.planQuery(query, planContext, NormalMode) }
 
     // then
     counter.counts should equal(CacheCounts(hits = 1, misses = 2, flushes = 1, evicted = 1))
@@ -146,17 +150,17 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val compiler = createCompiler(queryPlanTTL = 0, clock = clock, logger = logger)
     compiler.monitors.addMonitorListener(counter)
     val query: String = "match (n:Person:Dog) return n"
-    val statement = compiler.prepareQuery(query).statement
+    val statement = compiler.prepareQuery(query, NormalMode).statement
 
     createLabeledNode("Dog")
     (0 until 50).foreach { _ => createLabeledNode("Person") }
-    graph.inTx { compiler.planQuery(query, planContext) }
+    graph.inTx { compiler.planQuery(query, planContext, NormalMode) }
 
     // when
     (0 until 1000).foreach { _ => createLabeledNode("Dog") }
-    graph.inTx { compiler.planQuery(query, planContext) }
+    graph.inTx { compiler.planQuery(query, planContext, NormalMode) }
 
     // then
-    logger.assertExactly(LogCall.info(s"Discarded stale query from the query cache: ${statement}"))
+    logger.assertExactly(LogCall.info(s"Discarded stale query from the query cache: $statement"))
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/RulePipeBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/RulePipeBuilderTest.scala
@@ -54,7 +54,7 @@ class RulePipeBuilderTest
   val planner = CostBasedPipeBuilderFactory(mock[Monitors], SimpleMetricsFactory, mock[PlanningMonitor], Clock.SYSTEM_CLOCK)
 
   class FakePreparedQuery(q: AbstractQuery)
-    extends PreparedQuery(mock[Statement], "q", Map.empty)(SemanticTable(), Set.empty, Scope(Map.empty, Seq.empty)) {
+    extends PreparedQuery(mock[Statement], "q", Map.empty)(SemanticTable(), Set.empty, Scope(Map.empty, Seq.empty), devNullLogger) {
 
     override def abstractQuery: AbstractQuery = q
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/InputPosition.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/InputPosition.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * An input position refers to a specific point in a query string.
+ */
+public final class InputPosition
+{
+    private final int offset;
+    private final int line;
+    private final int column;
+
+
+    /**
+     * The empty position
+     */
+    public static InputPosition empty = new InputPosition(-1, -1, -1);
+
+    /**
+     * Creating a position from and offset, line number and a column number.
+     * @param offset the offset from the start of the string, starting from 0.
+     * @param line the line number, starting from 1.
+     * @param column the column number, starting from 1.
+     */
+    public InputPosition(int offset, int line, int column) {
+        this.offset = offset;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * The character offset referred to by this position; offset numbers start at 0.
+     * @return the offset of this position.
+     */
+    public int getOffset()
+    {
+        return offset;
+    }
+
+    /**
+     * The line number referred to by the position; line numbers start at 1.
+     * @return the line number of this position.
+     */
+    public int getLine()
+    {
+        return line;
+    }
+
+    /**
+     * The column number referred to by the position; column numbers start at 1.
+     * @return the column number of this position.
+     */
+    public int getColumn()
+    {
+        return column;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Notification.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Notification.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * Representation for notifications found when executing a query.
+ *
+ * A notification can be visualized in a client pinpointing problems or other information about the query.
+ */
+public interface Notification
+{
+    /**
+     * Returns a notification code for the discovered issue.
+     * @return the notification code
+     */
+    String getCode();
+
+    /**
+     * Returns a short summary of the notification.
+     * @return the title of the notification.
+     */
+    String getTitle();
+
+    /**
+     * Returns a longer description of the notification.
+     * @return the description of the notification.
+     */
+    String getDescription();
+
+    /**
+     * Returns the severity level of this notification.
+     * @return the severity level of the notification.
+     */
+    SeverityLevel getSeverity();
+
+    /**
+     * The position in the query where this notification points to.
+     * Not all notifications have a unique position to point to and should in
+     * that case return {@link org.neo4j.graphdb.InputPosition#empty}
+     *
+     * @return the position in the query where the issue was found, or
+     * {@link org.neo4j.graphdb.InputPosition#empty} if no position is associated with this notification.
+     */
+    InputPosition getPosition();
+}

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
@@ -178,4 +178,14 @@ public interface Result extends ResourceIterator<Map<String, Object>>
 
     /** Removing rows from the result is not supported. */
     void remove();
+
+    /**
+     * Provides notifications about the query producing this result.
+     *
+     * Notifications can be warnings about problematic queries or other valuable information that can be
+     * presented in a client.
+     *
+     * @return an iterable of all notifications created when running the query.
+     */
+    Iterable<Notification> getNotifications();
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/SeverityLevel.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/SeverityLevel.java
@@ -17,18 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.pipes
+package org.neo4j.graphdb;
 
-import org.neo4j.cypher.internal.compiler.v2_3.{devNullLogger, ExecutionContext}
-import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
-
-object QueryStateHelper {
-  def empty: QueryState = emptyWith()
-
-  def emptyWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalResource = null,
-                params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
-                initialContext: Option[ExecutionContext] = None) =
-    QueryState(db = db, query = query, resources = resources, params = params, decorator = decorator,
-      initialContext = initialContext)
+/**
+ * SeverityLevel indicates to a client the severity of a notification.
+ */
+public enum SeverityLevel
+{
+    WARNING, INFORMATION
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.impl.notification;
+
+
+import org.neo4j.graphdb.InputPosition;
+import org.neo4j.graphdb.SeverityLevel;
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Notification codes are status codes identifying the type of notification.
+ */
+public enum NotificationCode
+{
+    CARTESIAN_PRODUCT( SeverityLevel.WARNING,
+           Status.Statement.CartesianProduct,
+            "If a part of a query contains multiple disconnected patterns, this will build a " +
+                    "cartesian product between all those parts. This may produce a large amount of data and slow down" +
+                    " query processing. " +
+                    "While occasionally intended, it may often be possible to reformulate the query that avoids the " +
+                    "use of this cross " +
+                    "product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH" );
+
+    private final Status status;
+    private final String description;
+    private final SeverityLevel severity;
+    private NotificationCode( SeverityLevel severity, Status status, String description )
+    {
+        this.severity = severity;
+        this.status = status;
+        this.description = description;
+    }
+
+    public Notification notification( InputPosition position )
+    {
+        return new Notification( position );
+    }
+
+    private final class Notification implements org.neo4j.graphdb.Notification
+    {
+        private final InputPosition position;
+
+        public Notification( InputPosition position )
+        {
+            this.position = position;
+        }
+
+        public String getCode()
+        {
+            return status.code().serialize();
+        }
+
+        public String getTitle()
+        {
+            return status.code().description();
+        }
+
+        public String getDescription()
+        {
+            return description;
+        }
+
+        public InputPosition getPosition()
+        {
+            return position;
+        }
+
+        public SeverityLevel getSeverity()
+        {
+            return severity;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import static java.lang.String.format;
 
 import static org.neo4j.kernel.api.exceptions.Status.Classification.ClientError;
+import static org.neo4j.kernel.api.exceptions.Status.Classification.ClientNotification;
 import static org.neo4j.kernel.api.exceptions.Status.Classification.DatabaseError;
 import static org.neo4j.kernel.api.exceptions.Status.Classification.TransientError;
 
@@ -157,6 +158,7 @@ public interface Status
         // database
         ExecutionFailure( DatabaseError, "The database was unable to execute the statement." ),
         ExternalResourceFailure( TransientError, "The external resource is not available"),
+        CartesianProduct( ClientNotification, "This query builds a cartesian product between disconnected patterns." ),
         ;
 
         private final Code code;
@@ -401,6 +403,9 @@ public interface Status
         /** The Client sent a bad request - changing the request might yield a successful outcome. */
         ClientError( TransactionEffect.NONE,
                 "The Client sent a bad request - changing the request might yield a successful outcome." ),
+        /** There are notifications about the request sent by the client.*/
+        ClientNotification( TransactionEffect.NONE,
+                "There are notifications about the request sent by the client." ),
         /** The database failed to service the request. */
         DatabaseError( TransactionEffect.ROLLBACK,
                 "The database failed to service the request. " ),

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.InputPosition;
+import org.neo4j.graphdb.Notification;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
@@ -125,6 +127,67 @@ public class ExecutionResultSerializer
             throw loggedIOException( e );
         }
     }
+
+    public void notifications( Iterable<Notification> notifications ) throws IOException
+    {
+        //don't add anything if notifications are empty
+        if ( !notifications.iterator().hasNext() ) return;
+
+        try
+        {
+            ensureResultsFieldClosed();
+
+            out.writeArrayFieldStart( "notifications" );
+            try
+            {
+                for ( Notification notification : notifications )
+                {
+                    out.writeStartObject();
+                    try
+                    {
+                        out.writeStringField( "code", notification.getCode() );
+                        out.writeStringField( "severity", notification.getSeverity().toString() );
+                        out.writeStringField( "title", notification.getTitle() );
+                        out.writeStringField( "description", notification.getDescription() );
+                        writePosition( notification.getPosition() );
+
+                    }
+                    finally
+                    {
+                        out.writeEndObject();
+                    }
+                }
+
+            }
+            finally
+            {
+                out.writeEndArray();
+            }
+        }
+        catch ( IOException e )
+        {
+            throw loggedIOException( e );
+        }
+    }
+
+    private void writePosition( InputPosition position ) throws IOException
+    {
+        //do not add position if empty
+        if ( position == InputPosition.empty ) return;
+
+        out.writeObjectFieldStart( "position" );
+        try
+        {
+            out.writeNumberField( "offset", position.getOffset() );
+            out.writeNumberField( "line", position.getLine() );
+            out.writeNumberField( "column", position.getColumn() );
+        }
+        finally
+        {
+            out.writeEndObject();
+        }
+    }
+
 
     private void writeStats( QueryStatistics stats ) throws IOException
     {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -326,6 +326,7 @@ public class TransactionHandle implements TransactionTerminationHandle
                     Result result = engine.executeQuery( statement.statement(), statement.parameters(),
                             sessionFactory.create( request ) );
                     output.statementResult( result, statement.includeStats(), statement.resultDataContents() );
+                    output.notifications( result.getNotifications() );
                 }
                 catch ( KernelException | CypherException e )
                 {
@@ -376,6 +377,7 @@ public class TransactionHandle implements TransactionTerminationHandle
                         .create(request) );
                 ensureActiveTransaction();
                 output.statementResult( result, statement.includeStats(), statement.resultDataContents() );
+                output.notifications( result.getNotifications() );
                 closeContextAndCollectErrors(errors);
             }
             catch ( KernelException | CypherException e )

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -35,6 +35,7 @@ import org.mockito.stubbing.Answer;
 
 import org.neo4j.cypher.SyntaxException;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Notification;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
@@ -60,6 +61,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.anyCollectionOf;
 
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.server.rest.transactional.StubStatementDeserializer.statements;
@@ -94,6 +96,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
@@ -132,6 +135,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
@@ -175,7 +179,8 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
-        outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
@@ -214,6 +219,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -251,6 +257,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( result, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -317,6 +324,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
         outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
@@ -390,6 +398,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
+        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).errors( argThat( hasErrors( Status.Transaction.CouldNotCommit ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );


### PR DESCRIPTION
This commit also adds the minimal infrastructural changes needed to propagate notifications.
- Added `Iterable<Notification> getNotifications` to `Result`
- Created `NotificationLogger` that is sent around and records notifications
- Added `notifications: [...]` to json-response