### PR TITLE
2.2 backup diagnostics

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1136,9 +1136,9 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
         return kernelModule.kernelAPI();
     }
 
-    public ResourceIterator<File> listStoreFiles() throws IOException
+    public ResourceIterator<File> listStoreFiles( boolean includeLogs ) throws IOException
     {
-        return kernelModule.fileListing().listStoreFiles();
+        return kernelModule.fileListing().listStoreFiles( includeLogs );
     }
 
     public void registerDiagnosticsWith( DiagnosticsManager manager )

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1073,8 +1073,12 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
     }
 
     @Override
-    public void stop()
+    public synchronized void stop()
     {
+        if ( !life.isRunning() )
+        {
+            return;
+        }
         transactionLogModule.logRotationControl().awaitAllTransactionsClosed();
         transactionLogModule.logRotationControl().forceEverything();
         /*

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -55,10 +55,10 @@ public class NeoStoreFileListing
         this.legacyIndexProviders = legacyIndexProviders;
     }
 
-    public ResourceIterator<File> listStoreFiles() throws IOException
+    public ResourceIterator<File> listStoreFiles( boolean includeLogs ) throws IOException
     {
         Collection<File> files = new ArrayList<>();
-        gatherNeoStoreFiles( files );
+        gatherNeoStoreFiles( files, includeLogs );
         Resource labelScanStoreSnapshot = gatherLabelScanStoreFiles( files );
         Resource schemaIndexSnapshots = gatherSchemaIndexFiles( files );
         Resource legacyIndexSnapshots = gatherLegacyIndexFiles( files );
@@ -99,7 +99,7 @@ public class NeoStoreFileListing
         return snapshot;
     }
 
-    private void gatherNeoStoreFiles( final Collection<File> targetFiles )
+    private void gatherNeoStoreFiles( final Collection<File> targetFiles, boolean includeTransactionLogs )
     {
         File neostoreFile = null;
         for ( File dbFile : nonNull( storeDir.listFiles() ) )
@@ -112,6 +112,10 @@ public class NeoStoreFileListing
                     neostoreFile = dbFile;
                 }
                 else if ( neoStoreFile( name ) )
+                {
+                    targetFiles.add( dbFile );
+                }
+                else if ( includeTransactionLogs && transactionLogFile( name ) )
                 {
                     targetFiles.add( dbFile );
                 }
@@ -134,6 +138,11 @@ public class NeoStoreFileListing
 
         return name.startsWith( NeoStore.DEFAULT_NAME ) &&
                 !name.startsWith( NeoStore.DEFAULT_NAME + ".transaction" );
+    }
+
+    private boolean transactionLogFile( String name )
+    {
+        return name.startsWith( NeoStore.DEFAULT_NAME + ".transaction" ) && !name.endsWith( ".active" );
     }
 
     private static final class MultiResource implements Resource

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -114,7 +114,7 @@ public class NeoStoreFileListingTest
         NeoStoreFileListing fileListing = newFileListing();
 
         // When
-        ResourceIterator<File> result = fileListing.listStoreFiles();
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
 
         // Then
         assertThat( asSetOfPaths( result ), equalTo( asSet(
@@ -146,7 +146,7 @@ public class NeoStoreFileListingTest
         NeoStoreFileListing fileListing = newFileListing();
 
         // When
-        ResourceIterator<File> result = fileListing.listStoreFiles();
+        ResourceIterator<File> result = fileListing.listStoreFiles( true );
 
         // Then
         Set<String> pathSet = asSetOfPaths( result );
@@ -166,7 +166,11 @@ public class NeoStoreFileListingTest
                 "neostore.relationshiptypestore.db",
                 "neostore.relationshiptypestore.db.names",
                 "neostore.schemastore.db",
-                "neostore" ) ) );
+                "neostore",
+                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "0",
+                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "1",
+                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "2"
+        ) ) );
     }
 
     @Test
@@ -179,7 +183,7 @@ public class NeoStoreFileListingTest
         NeoStoreFileListing fileListing = newFileListing();
 
         // When
-        ResourceIterator<File> result = fileListing.listStoreFiles();
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
 
         // Then
         Set<String> pathSet = asSetOfPaths( result );
@@ -212,7 +216,7 @@ public class NeoStoreFileListingTest
         NeoStoreFileListing fileListing = newFileListing();
 
         // When
-        ResourceIterator<File> result = fileListing.listStoreFiles();
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
 
         // Then
         assertThat( asSetOfPaths( result ), equalTo( asSet(
@@ -247,7 +251,7 @@ public class NeoStoreFileListingTest
         ResourceIterator<File> indexSnapshot = indexFilesAre( new String[]{"schema/index/my.index"} );
         NeoStoreFileListing fileListing = newFileListing();
 
-        ResourceIterator<File> result = fileListing.listStoreFiles();
+        ResourceIterator<File> result = fileListing.listStoreFiles( false );
 
         // When
         result.close();

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -62,7 +62,7 @@ class BackupImpl implements TheBackupInterface
         try ( StoreWriter storeWriter = writer )
         {
             storeCopyMonitor.startCopyingFiles();
-            RequestContext copyStartContext = storeCopyServer.flushStoresAndStreamStoreFiles( storeWriter );
+            RequestContext copyStartContext = storeCopyServer.flushStoresAndStreamStoreFiles( storeWriter, forensics );
             ResponsePacker responsePacker = new StoreCopyResponsePacker( logicalTransactionStore,
                     transactionIdStore, logFileInformation, storeId,
                     copyStartContext.lastAppliedTransaction() + 1 ); // mandatory transaction id

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import org.neo4j.backup.BackupClient.BackupRequestType;
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.Response;
+import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.com.storecopy.ResponseUnpacker;
+import org.neo4j.com.storecopy.StoreWriter;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+
+import static org.jboss.netty.buffer.ChannelBuffers.EMPTY_BUFFER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BackupProtocolTest
+{
+    @Test
+    public void shouldGatherForensicsInFullBackupRequest() throws Exception
+    {
+        shouldGatherForensicsInFullBackupRequest( true );
+    }
+
+    @Test
+    public void shouldSkipGatheringForensicsInFullBackupRequest() throws Exception
+    {
+        shouldGatherForensicsInFullBackupRequest( false );
+    }
+
+    @Test
+    public void shouldHandleNoForensicsSpecifiedInFullBackupRequest() throws Exception
+    {
+        TheBackupInterface backup = mock( TheBackupInterface.class );
+        RequestContext ctx = new RequestContext( 0, 1, 0, -1, 12 );
+        BackupRequestType.FULL_BACKUP.getTargetCaller().call( backup, ctx, EMPTY_BUFFER, null );
+        verify( backup ).fullBackup( any( StoreWriter.class ), eq( false ) );
+    }
+
+    private void shouldGatherForensicsInFullBackupRequest( boolean forensics ) throws Exception
+    {
+        // GIVEN
+        Response<Void> response = Response.EMPTY;
+        StoreId storeId = response.getStoreId();
+        DevNullLoggingService logging = new DevNullLoggingService();
+        String host = "localhost";
+        int port = BackupServer.DEFAULT_PORT;
+        LifeSupport life = new LifeSupport();
+
+        BackupClient client = life.add( new BackupClient( host, port, logging, storeId, 1000,
+                mock( ResponseUnpacker.class ), mock( ByteCounterMonitor.class ), mock( RequestMonitor.class ) ) );
+        ControlledBackupInterface backup = new ControlledBackupInterface();
+        life.add( new BackupServer( backup, new HostnamePort( host, port ), logging, mock( ByteCounterMonitor.class ),
+                mock( RequestMonitor.class )) );
+        life.start();
+
+        try
+        {
+            // WHEN
+            StoreWriter writer = mock( StoreWriter.class );
+            client.fullBackup( writer, forensics );
+
+            // THEN
+            assertEquals( forensics, backup.receivedForensics.booleanValue() );
+        }
+        finally
+        {
+            life.shutdown();
+        }
+    }
+
+    private static class ControlledBackupInterface implements TheBackupInterface
+    {
+        private Boolean receivedForensics;
+
+        @Override
+        public Response<Void> fullBackup( StoreWriter writer, boolean forensics )
+        {
+            this.receivedForensics = forensics;
+            writer.close();
+            return Response.EMPTY;
+        }
+
+        @Override
+        public Response<Void> incrementalBackup( RequestContext context )
+        {
+            throw new UnsupportedOperationException( "Should be required" );
+        }
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -66,7 +66,7 @@ public class StoreCopyServer
     /**
      * @return a {@link RequestContext} specifying at which point the store copy started.
      */
-    public RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer )
+    public RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer, boolean includeLogs )
     {
         try
         {
@@ -75,7 +75,7 @@ public class StoreCopyServer
             ByteBuffer temporaryBuffer = ByteBuffer.allocateDirect( 1024 * 1024 );
 
             // Copy the store files
-            try ( ResourceIterator<File> files = dataSource.listStoreFiles() )
+            try ( ResourceIterator<File> files = dataSource.listStoreFiles( includeLogs ) )
             {
                 while ( files.hasNext() )
                 {

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -251,7 +251,7 @@ public class StoreCopyClientTest
 
                     RequestContext requestContext = new StoreCopyServer(transactionIdStore, neoStoreDataSource,
                             logRotationControl, fs, new File(originalDir))
-                            .flushStoresAndStreamStoreFiles( writer );
+                            .flushStoresAndStreamStoreFiles( writer, false );
 
                     final StoreId storeId = original.getDependencyResolver().resolveDependency( StoreId.class );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -163,7 +163,7 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
         StoreCopyServer streamer = new StoreCopyServer( transactionIdStore, dataSource, graphDb.getDependencyResolver
                 ().resolveDependency( LogRotationControl.class ), fileSystem,
                 storeDir );
-        return streamer.flushStoresAndStreamStoreFiles( writer );
+        return streamer.flushStoresAndStreamStoreFiles( writer, false );
     }
 
     @Override


### PR DESCRIPTION
Completes the backup gather forensics functionality by allowing listing of transaction logs from the NeoStoreDataSource.
While working on this i had a test consistently fail because of consecutive calls to NSDS.stop() (which is a race since if the two calls happen very close together then there will be no failure). The first commit fixes that.