### PR TITLE
Updates to auth

### DIFF
--- a/community/server/CHANGES.txt
+++ b/community/server/CHANGES.txt
@@ -1,6 +1,14 @@
+2.2.0-RC02
+---------
+
+o Disallow empty passwords for Auth
+o Return 404 for requests to user service when auth is disabled
+o Return correct content type with auth errors
+
 2.2.0-M04
 ---------
-o Authentication now applies to all REST endpoints, if enabled
+o Auth now applies to all REST endpoints, if enabled
+o Auth no longer uses tokens, relying only on username and password.
 o Returned paths ends with '/' in response to "GET /". This avoids an unnecessary redirect,
   for drivers that (properly) follow hyperlinks.
 o A couple of bugs regarding handling of labels in BatchInserter fixed.

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -158,7 +158,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
         this.database = life.add( dependencyResolver.satisfyDependency(dbFactory.newDatabase( dbConfig, dependencies)) );
 
-        FileUserRepository users = life.add( new FileUserRepository( configurator.configuration().get( ServerInternalSettings.authorization_store ).toPath(), dependencies.logging() ) );
+        FileUserRepository users = life.add( new FileUserRepository( configurator.configuration().get( ServerInternalSettings.auth_store ).toPath(), dependencies.logging() ) );
 
         this.authManager = life.add(new AuthManager( Clock.SYSTEM_CLOCK, users ));
         this.preFlight = dependencyResolver.satisfyDependency(createPreflightTasks());

--- a/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/Configurator.java
@@ -46,7 +46,7 @@ public interface Configurator
 {
     String SECURITY_RULES_KEY = ServerSettings.security_rules.name();
 
-    String AUTHORIZATION_STORE_FILE_KEY = ServerInternalSettings.authorization_store.name();
+    String AUTH_STORE_FILE_KEY = ServerInternalSettings.auth_store.name();
     String DB_TUNING_PROPERTY_FILE_KEY = ServerInternalSettings.legacy_db_config.name();
     String DEFAULT_CONFIG_DIR = File.separator + "etc" + File.separator + "neo";
     String DATABASE_LOCATION_PROPERTY_KEY = ServerInternalSettings.legacy_db_location.name();

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
@@ -150,6 +150,7 @@ public class AuthorizationFilter implements Filter
         void writeResponse( HttpServletResponse response ) throws IOException
         {
             response.setStatus( statusCode );
+            response.addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
             addHeaders( response );
             response.getOutputStream().write( JsonHelper.createJsonFrom( body() ).getBytes( Charsets.UTF_8 ) );
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
@@ -20,6 +20,7 @@
 package org.neo4j.server.rest.dbms;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -63,7 +64,8 @@ public class UserService
     @Path("/{username}")
     public Response getUser( @PathParam("username") String username, @Context HttpServletRequest req )
     {
-        if ( !req.getUserPrincipal().getName().equals( username ) )
+        Principal principal = req.getUserPrincipal();
+        if ( principal == null || !principal.getName().equals( username ) )
         {
             return output.notFound();
         }
@@ -80,7 +82,8 @@ public class UserService
     @Path("/{username}/password")
     public Response setPassword( @PathParam("username") String username, @Context HttpServletRequest req, String payload )
     {
-        if ( !req.getUserPrincipal().getName().equals( username ) )
+        Principal principal = req.getUserPrincipal();
+        if ( principal == null || !principal.getName().equals( username ) )
         {
             return output.notFound();
         }
@@ -107,6 +110,11 @@ public class UserService
                     new Neo4jError( Status.Request.InvalidFormat, String.format( "Expected '%s' to be a string.", PASSWORD ) ) ) );
         }
         String newPassword = (String) o;
+        if ( newPassword.length() == 0 )
+        {
+            return output.response( UNPROCESSABLE, new ExceptionRepresentation(
+                    new Neo4jError( Status.Request.Invalid, "Password cannot be empty." ) ) );
+        }
 
         final User currentUser = authManager.getUser( username );
         if (currentUser == null)

--- a/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
@@ -75,7 +75,7 @@ public class ServerInternalSettings
 
     public static final Setting<Long> startup_timeout = setting( "org.neo4j.server.startup_timeout", DURATION, "120s" );
 
-    public static final Setting<File> authorization_store = setting("dbms.security.authorization_location", PATH, "data/dbms/auth");
+    public static final Setting<File> auth_store = setting("dbms.security.auth_store.location", PATH, "data/dbms/auth");
 
     public static final Setting<File> legacy_db_location = setting( "org.neo4j.server.database.location", PATH, "data/graph.db" );
 

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -218,7 +218,7 @@ public class CommunityServerBuilder
         }
 
         properties.put( ServerSettings.auth_enabled.name(), "false" );
-        properties.put( ServerInternalSettings.authorization_store.name(), "neo4j-home/data/dbms/authorization" );
+        properties.put( ServerInternalSettings.auth_store.name(), "neo4j-home/data/dbms/authorization" );
 
         for ( Object key : arbitraryProperties.keySet() )
         {

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -150,6 +150,8 @@ public class AuthorizationFilterTest
         // Then
         verifyNoMoreInteractions( filterChain );
         verify( servletResponse ).setStatus( 401 );
+        verify( servletResponse ).addHeader( HttpHeaders.WWW_AUTHENTICATE, "None" );
+        verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthorizationFailed\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"message\" : \"No authorization header supplied.\"" ) );
     }
@@ -168,6 +170,7 @@ public class AuthorizationFilterTest
         // Then
         verifyNoMoreInteractions( filterChain );
         verify( servletResponse ).setStatus( 400 );
+        verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Request.InvalidFormat\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"message\" : \"Invalid Authorization header.\"" ) );
     }
@@ -190,6 +193,7 @@ public class AuthorizationFilterTest
         verifyNoMoreInteractions( filterChain );
         verify( logger ).warn( "Failed authentication attempt for '%s' from %s", "foo", "remote_ip_address" );
         verify( servletResponse ).setStatus( 401 );
+        verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthorizationFailed\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"message\" : \"Invalid username or password.\"" ) );
     }
@@ -229,6 +233,7 @@ public class AuthorizationFilterTest
         // Then
         verifyNoMoreInteractions( filterChain );
         verify( servletResponse ).setStatus( 403 );
+        verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"password_change\" : \"http://bar.baz:7474/user/foo/password\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthorizationFailed\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"message\" : \"User is required to change their password.\"" ) );
@@ -250,6 +255,7 @@ public class AuthorizationFilterTest
         // Then
         verifyNoMoreInteractions( filterChain );
         verify( servletResponse ).setStatus( 429 );
+        verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthenticationRateLimit\"" ) );
         assertThat( outputStream.toString( Charsets.UTF_8.name() ), containsString( "\"message\" : \"Too many failed authentication requests. Please wait 5 seconds and try again.\"" ) );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.dbms;
+
+import java.net.URI;
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+import org.neo4j.server.rest.repr.OutputFormat;
+import org.neo4j.server.rest.repr.formats.JsonFormat;
+import org.neo4j.server.security.auth.AuthManager;
+import org.neo4j.server.security.auth.Credential;
+import org.neo4j.server.security.auth.User;
+import org.neo4j.server.web.ServerInternalSettings;
+import org.neo4j.test.server.EntityOutputFormat;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UserServiceTest
+{
+    private static final Principal NEO4J_PRINCIPLE = new Principal()
+    {
+        @Override
+        public String getName()
+        {
+            return "neo4j";
+        }
+    };
+    private static final User NEO4J_USER = new User( "neo4j", Credential.forPassword( "neo4j" ), true );
+
+    @Test
+    public void shouldReturnValidUserRepresentation() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+        when( authManager.getUser( "neo4j" ) ).thenReturn( NEO4J_USER );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.getUser( "neo4j", req );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 200 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"username\" : \"neo4j\"" ) );
+        assertThat( json, containsString( "\"password_change\" : \"http://www.example.com/user/neo4j/password\"" ) );
+        assertThat( json, containsString( "\"password_change_required\" : true" ) );
+    }
+
+    @Test
+    public void shouldReturn404WhenRequestingUserIfNotAuthenticated() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.getUser( "neo4j", req );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+    }
+
+    @Test
+    public void shouldReturn404WhenRequestingUserIfDifferentUser() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.getUser( "fred", req );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+    }
+
+    @Test
+    public void shouldReturn404WhenRequestingUserIfUnknownUser() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+        when( authManager.getUser( "neo4j" ) ).thenReturn( null );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.getUser( "neo4j", req );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+    }
+
+    @Test
+    public void shouldChangePasswordAndReturnSuccess() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+        when( authManager.getUser( "neo4j" ) ).thenReturn( NEO4J_USER );
+        when( authManager.setPassword( "neo4j", "test" ) ).thenReturn( NEO4J_USER );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : \"test\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 200 ) );
+        verify( authManager ).setPassword( "neo4j", "test" );
+    }
+
+    @Test
+    public void shouldReturn404WhenChangingPasswordIfNotAuthenticated() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( null );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : \"test\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+    }
+
+    @Test
+    public void shouldReturn404WhenChangingPasswordIfDifferentUser() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "fred", req, "{ \"password\" : \"test\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+        verifyZeroInteractions( authManager );
+    }
+
+    @Test
+    public void shouldReturn404WhenChangingPasswordIfUnknownUser() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+        when( authManager.getUser( "neo4j" ) ).thenReturn( null );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : \"test\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 404 ) );
+        verify( authManager ).getUser( "neo4j" );
+        verifyNoMoreInteractions( authManager );
+    }
+
+    @Test
+    public void shouldReturn400IfPayloadIsInvalid() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "xxx" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 400 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"code\" : \"Neo.ClientError.Request.InvalidFormat\"" ) );
+    }
+
+    @Test
+    public void shouldReturn422IfMissingPassword() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"unknown\" : \"unknown\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 422 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"code\" : \"Neo.ClientError.Request.InvalidFormat\"" ) );
+        assertThat( json, containsString( "\"message\" : \"Required parameter 'password' is missing.\"" ) );
+    }
+
+    @Test
+    public void shouldReturn422IfInvalidPasswordType() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : 1 }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 422 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"code\" : \"Neo.ClientError.Request.InvalidFormat\"" ) );
+        assertThat( json, containsString( "\"message\" : \"Expected 'password' to be a string.\"" ) );
+    }
+
+    @Test
+    public void shouldReturn422IfEmptyPassword() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( mock( AuthManager.class ), new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : \"\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 422 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"code\" : \"Neo.ClientError.Request.Invalid\"" ) );
+        assertThat( json, containsString( "\"message\" : \"Password cannot be empty.\"" ) );
+    }
+
+    @Test
+    public void shouldReturn422IfPasswordIdentical() throws Exception
+    {
+        // Given
+        HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getUserPrincipal() ).thenReturn( NEO4J_PRINCIPLE );
+
+        AuthManager authManager = mock( AuthManager.class );
+        when( authManager.getUser( "neo4j" ) ).thenReturn( NEO4J_USER );
+
+        OutputFormat outputFormat = new EntityOutputFormat( new JsonFormat(), new URI( "http://www.example.com" ), null );
+        UserService userService = new UserService( authManager, new JsonFormat(), outputFormat );
+
+        // When
+        Response response = userService.setPassword( "neo4j", req, "{ \"password\" : \"neo4j\" }" );
+
+        // Then
+        assertThat( response.getStatus(), equalTo( 422 ) );
+        String json = new String( (byte[]) response.getEntity() );
+        assertNotNull( json );
+        assertThat( json, containsString( "\"code\" : \"Neo.ClientError.Request.Invalid\"" ) );
+        assertThat( json, containsString( "\"message\" : \"Old password and new password cannot be the same.\"" ) );
+    }
+}

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -86,7 +86,7 @@ public class DesktopConfigurator implements ConfigurationBuilder
     public void setDatabaseDirectory( File directory ) {
         File neo4jProperties = new File( directory, Installation.NEO4J_PROPERTIES_FILENAME );
 
-        map.put( Configurator.AUTHORIZATION_STORE_FILE_KEY, new File( directory, "./dbms/authorization" ).getAbsolutePath() );
+        map.put( Configurator.AUTH_STORE_FILE_KEY, new File( directory, "./dbms/auth" ).getAbsolutePath() );
         map.put( Configurator.DATABASE_LOCATION_PROPERTY_KEY, directory.getAbsolutePath() );
         map.put( Configurator.DB_TUNING_PROPERTY_FILE_KEY, neo4jProperties.getAbsolutePath() );
     }


### PR DESCRIPTION
- Return correct content-type header with Auth errors (resolves #4140)
- Don't accept empty passwords (resolves #4139)
- Return 404 for UserService requests when auth is disabled (resolves #4138)