### PR TITLE
Disallow directory listings.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -508,6 +508,7 @@ public class Jetty9WebServer implements WebServer
             staticContext.setServer( getJetty() );
             staticContext.setContextPath( mountPoint );
             staticContext.setSessionHandler( sessionHandler );
+            staticContext.setInitParameter( "org.eclipse.jetty.servlet.Default.dirAllowed", "false" );
             URL resourceLoc = getClass().getClassLoader()
                     .getResource( contentLocation );
             if ( resourceLoc != null )

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
@@ -22,11 +22,6 @@ package org.neo4j.server.web;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.server.WrappingNeoServer;
@@ -40,17 +35,8 @@ import org.neo4j.test.Mute;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.test.Mute.muteAll;
 
-@Path("/")
 public class TestJetty9WebServer
 {
-
-	@GET
-	public Response index()
-	{
-		return Response.status( Status.NO_CONTENT )
-                .build();
-	}
-
 	@Test
 	public void shouldBeAbleToRestart() throws Throwable
 	{


### PR DESCRIPTION
The default jetty behaviour serves an index page for static resources.
The 'directories' exposed through this behaviour are not file system
directories, but only a list of resources present on the classpath,
so there is no security vulnerability. However, it might seem like a
vulnerability to somebody without the context of how the whole stack
works, so to avoid confusion we disable the jetty behaviour.