### PR TITLE
Make projectEndPoints be part of planSingleRelationship in IDP

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlannerList.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LeafPlannerList.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_2.{IndexHintException, LabelScanHintException}
 
 case class LeafPlannerList(leafPlanners: LeafPlanner*) {
-  def candidates(qg: QueryGraph, f: (LogicalPlan, QueryGraph) => LogicalPlan)(implicit context: LogicalPlanningContext): Iterable[Seq[LogicalPlan]] = {
+  def candidates(qg: QueryGraph, f: (LogicalPlan, QueryGraph) => LogicalPlan = (plan, _) => plan )(implicit context: LogicalPlanningContext): Iterable[Seq[LogicalPlan]] = {
     val logicalPlans = leafPlanners.flatMap(_(qg)).map(f(_,qg))
     //check so that we respect the provided hints
     assertHints(qg, logicalPlans)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LogicalPlanningFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/LogicalPlanningFunction.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy.GreedyPlanTable
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
 
 trait LogicalPlanningFunction0[+B] {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryPlannerConfiguration.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy.projectEndpoints
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{ProjectEndpoints, LogicalPlan}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.solveOptionalMatches.OptionalSolver
 
@@ -29,7 +29,7 @@ object QueryPlannerConfiguration {
   val default = QueryPlannerConfiguration(
     pickBestCandidate = pickBestPlanUsingHintsAndCost,
     applySelections = selectPatternPredicates(selectCovered, pickBestPlanUsingHintsAndCost),
-    projectEndpoints = projectEndpoints.all,
+    projectAllEndpoints = projectEndpoints.all,
     optionalSolvers = Seq(
       applyOptional,
       outerHashJoin
@@ -60,7 +60,7 @@ object QueryPlannerConfiguration {
 
 case class QueryPlannerConfiguration(leafPlanners: LeafPlannerList,
                                      applySelections: PlanTransformer[QueryGraph],
-                                     projectEndpoints: PlanTransformer[QueryGraph],
+                                     projectAllEndpoints: PlanTransformer[QueryGraph],
                                      optionalSolvers: Seq[OptionalSolver],
                                      pickBestCandidate: LogicalPlanningFunction0[CandidateSelector]) {
 
@@ -68,12 +68,12 @@ case class QueryPlannerConfiguration(leafPlanners: LeafPlannerList,
     QueryPlannerKit(
       qg = qg,
       select = plan => applySelections(plan, qg),
-      projectEndpoints = (plan: LogicalPlan, qg: QueryGraph) => projectEndpoints(plan, qg),
+      projectAllEndpoints = (plan: LogicalPlan, qg: QueryGraph) => projectAllEndpoints(plan, qg),
       pickBest = pickBestCandidate(context)
     )
 }
 
 case class QueryPlannerKit(qg: QueryGraph,
                            select: LogicalPlan => LogicalPlan,
-                           projectEndpoints: (LogicalPlan, QueryGraph) => LogicalPlan,
+                           projectAllEndpoints: (LogicalPlan, QueryGraph) => LogicalPlan,
                            pickBest: CandidateSelector)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/greedy/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/greedy/GreedyQueryGraphSolver.scala
@@ -37,7 +37,7 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[GreedyPlanTable],
     val optionalMatchesSolver = solveOptionalMatches(config.optionalSolvers, kit.pickBest)
 
     def generateLeafPlanTable(): GreedyPlanTable = {
-      val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, kit.projectEndpoints)
+      val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, kit.projectAllEndpoints)
       val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.iterator.map(_.map(kit.select))
       val bestLeafPlans: Iterator[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(kit.pickBest(_))
       val startTable: GreedyPlanTable = leafPlan.foldLeft(GreedyPlanTable.empty)(_ + _)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/idp/expandTableSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/idp/expandTableSolver.scala
@@ -34,12 +34,25 @@ object expandTableSolver extends IDPTableSolver {
            solved = goal - solvable;
            plan <- table(solved)
       ) yield {
-        Iterator(
-          planSinglePatternSide(qg, pattern, plan, pattern.left),
-          planSinglePatternSide(qg, pattern, plan, pattern.right)
-        ).flatten
+        if (plan.availableSymbols.contains(pattern.name))
+          Iterator(
+            planSingleProjectEndpoints(pattern, plan)
+          )
+        else
+          Iterator(
+            planSinglePatternSide(qg, pattern, plan, pattern.left),
+            planSinglePatternSide(qg, pattern, plan, pattern.right)
+          ).flatten
       }
-      result.flatten
+
+    result.flatten
+  }
+
+  def planSingleProjectEndpoints(patternRel: PatternRelationship, plan: LogicalPlan): LogicalPlan = {
+    val (start, end) = patternRel.inOrder
+    val isStartInScope = plan.availableSymbols(start)
+    val isEndInScope = plan.availableSymbols(end)
+    planEndpointProjection(plan, start, isStartInScope, end, isEndInScope, patternRel)
   }
 
   def planSinglePatternSide(qg: QueryGraph, patternRel: PatternRelationship, plan: LogicalPlan, nodeId: IdName): Option[LogicalPlan] = {
@@ -67,5 +80,4 @@ object expandTableSolver extends IDPTableSolver {
       None
     }
   }
-
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/leafPlanOptions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/leafPlanOptions.scala
@@ -28,9 +28,9 @@ object leafPlanOptions extends LogicalLeafPlan.Finder {
     val kit = config.toKit(queryGraph)
     val pickBest = config.pickBestCandidate(context)
 
-    val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, kit.projectEndpoints)
+    val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
     val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(kit.select))
-    val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
+    val bestLeafPlans = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
     bestLeafPlans.toSet
   }
 }


### PR DESCRIPTION
In this way projectEndpoints is planned (when possible) as a way of solving relationship patterns, instead of being forced on leaf plans as in Greedy planning, which was making the IDP solver to fail since
too many relationships would have been solved at the wrong size.

Moreover, in this way we can look at plans which mix projectEndPoints and expands.

Finally this change fixes a bug where the IDP solver would fail when multiple relationships are passed in as arguments as plain above.