### PR TITLE
Removes support for backslash-escaped quotes inside quotes

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -39,7 +39,6 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
     private static final char EOL_CHAR = '\n';
     private static final char EOL_CHAR_2 = '\r';
     private static final char EOF_CHAR = (char) -1;
-    private static final char BACK_SLASH = '\\';
 
     private final CharReadable reader;
     private char[] buffer;
@@ -156,14 +155,6 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                         lineNumber++;
                     }
                     nextChar( skippedChars );
-                }
-                else if ( ch == BACK_SLASH )
-                {   // Legacy concern, support java style quote encoding
-                    int nextCh = peekChar();
-                    if ( nextCh == quoteChar )
-                    {   // Found a slash encoded quote
-                        repositionChar( bufferPos++, ++skippedChars );
-                    }
                 }
             }
         }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -373,23 +373,6 @@ public class BufferedCharSeekerTest
     }
 
     @Test
-    public void shouldHandleSlashEncodedQuotes() throws Exception
-    {
-        // GIVEN
-        seeker = seeker( "\"value \\\"one\\\"\"\t\"\\\"value\\\" two\"\t\"va\\\"lue\\\" three\"" );
-
-        // WHEN/THEN
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "value \"one\"", seeker.extract( mark, extractors.string() ).value() );
-
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "\"value\" two", seeker.extract( mark, extractors.string() ).value() );
-
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "va\"lue\" three", seeker.extract( mark, extractors.string() ).value() );
-    }
-
-    @Test
     public void shouldRecognizeStrayQuoteCharacters() throws Exception
     {
         // GIVEN


### PR DESCRIPTION
since escaping adds more complexity to the parser and the standard is
merely double-quotes.