### PR TITLE
CSV remove support for backslash-escaped quotes inside quotes

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -39,7 +39,6 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
     private static final char EOL_CHAR = '\n';
     private static final char EOL_CHAR_2 = '\r';
     private static final char EOF_CHAR = (char) -1;
-    private static final char BACK_SLASH = '\\';
 
     private final CharReadable reader;
     private char[] buffer;
@@ -141,7 +140,6 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                     if ( nextCh == quoteChar )
                     {   // Found a double quote, skip it and we're going down one more quote depth (quote-in-quote)
                         repositionChar( bufferPos++, ++skippedChars );
-                        quoteDepth = quoteDepth == 1 ? 2 : 1; // toggle between quote and quote-in-quote
                     }
                     else
                     {   // Found an ending quote, skip it and switch mode
@@ -156,14 +154,6 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                         lineNumber++;
                     }
                     nextChar( skippedChars );
-                }
-                else if ( ch == BACK_SLASH )
-                {   // Legacy concern, support java style quote encoding
-                    int nextCh = peekChar();
-                    if ( nextCh == quoteChar )
-                    {   // Found a slash encoded quote
-                        repositionChar( bufferPos++, ++skippedChars );
-                    }
                 }
             }
         }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -373,23 +373,6 @@ public class BufferedCharSeekerTest
     }
 
     @Test
-    public void shouldHandleSlashEncodedQuotes() throws Exception
-    {
-        // GIVEN
-        seeker = seeker( "\"value \\\"one\\\"\"\t\"\\\"value\\\" two\"\t\"va\\\"lue\\\" three\"" );
-
-        // WHEN/THEN
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "value \"one\"", seeker.extract( mark, extractors.string() ).value() );
-
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "\"value\" two", seeker.extract( mark, extractors.string() ).value() );
-
-        assertTrue( seeker.seek( mark, TAB ) );
-        assertEquals( "va\"lue\" three", seeker.extract( mark, extractors.string() ).value() );
-    }
-
-    @Test
     public void shouldRecognizeStrayQuoteCharacters() throws Exception
     {
         // GIVEN
@@ -437,6 +420,20 @@ public class BufferedCharSeekerTest
         seeker = seeker( "" );
 
         // WHEN/THEN
+        assertFalse( seeker.seek( mark, COMMA ) );
+    }
+
+    @Test
+    public void shouldSeeQuotesInQuotes() throws Exception
+    {
+        // GIVEN
+        //                4,     """",   "f\oo"
+        seeker = seeker( "4,\"\"\"\",\"f\\oo\"" );
+
+        // WHEN/THEN
+        assertNextValue( seeker, mark, COMMA, "4" );
+        assertNextValue( seeker, mark, COMMA, "\"" );
+        assertNextValue( seeker, mark, COMMA, "f\\oo" );
         assertFalse( seeker.seek( mark, COMMA ) );
     }
 


### PR DESCRIPTION
since escaping adds more complexity to the parser and the standard is
merely double-quotes.