### PR TITLE
Fix RRDB becoming invalid on master switch

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rrd/RrdFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/rrd/RrdFactory.java
@@ -26,11 +26,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.rrd4j.ConsolFun;
+import org.rrd4j.core.DsDef;
+import org.rrd4j.core.RrdDb;
+import org.rrd4j.core.RrdDef;
+import org.rrd4j.core.RrdToolkit;
+
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
@@ -40,12 +45,6 @@ import org.neo4j.server.database.RrdDbWrapper;
 import org.neo4j.server.rrd.sampler.NodeIdsInUseSampleable;
 import org.neo4j.server.rrd.sampler.PropertyCountSampleable;
 import org.neo4j.server.rrd.sampler.RelationshipCountSampleable;
-
-import org.rrd4j.ConsolFun;
-import org.rrd4j.core.DsDef;
-import org.rrd4j.core.RrdDb;
-import org.rrd4j.core.RrdDef;
-import org.rrd4j.core.RrdToolkit;
 
 import static java.lang.Double.NaN;
 import static java.util.Arrays.asList;
@@ -74,7 +73,7 @@ public class RrdFactory
 
     public org.neo4j.server.database.RrdDbWrapper createRrdDbAndSampler( final Database db, JobScheduler scheduler ) throws IOException
     {
-        NeoStore neoStore = db.getGraph().getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate();
+        NeoStoreProvider neoStore = db.getGraph().getDependencyResolver().resolveDependency( NeoStoreProvider.class );
 
         Sampleable[] primitives = {
                 new NodeIdsInUseSampleable( neoStore ),

--- a/community/server/src/main/java/org/neo4j/server/rrd/sampler/DatabasePrimitivesSampleableBase.java
+++ b/community/server/src/main/java/org/neo4j/server/rrd/sampler/DatabasePrimitivesSampleableBase.java
@@ -19,20 +19,21 @@
  */
 package org.neo4j.server.rrd.sampler;
 
-import org.neo4j.kernel.impl.store.NeoStore;
-import org.neo4j.server.rrd.Sampleable;
-
 import org.rrd4j.DsType;
+
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
+import org.neo4j.server.rrd.Sampleable;
 
 public abstract class DatabasePrimitivesSampleableBase implements Sampleable
 {
-    private final NeoStore neoStore;
+    private final NeoStoreProvider neoStore;
 
-    public DatabasePrimitivesSampleableBase( NeoStore neoStore )
+    public DatabasePrimitivesSampleableBase( NeoStoreProvider neoStore )
     {
         if( neoStore == null )
         {
-            throw new RuntimeException( "Database sampler needs a node manager to work, was given null." );
+            throw new RuntimeException( "Database sampler needs a NeoStore to work, was given null." );
         }
         this.neoStore = neoStore;
 
@@ -40,7 +41,7 @@ public abstract class DatabasePrimitivesSampleableBase implements Sampleable
 
     protected NeoStore getNeoStore()
     {
-        return neoStore;
+        return neoStore.evaluate();
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rrd/sampler/NodeIdsInUseSampleable.java
+++ b/community/server/src/main/java/org/neo4j/server/rrd/sampler/NodeIdsInUseSampleable.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.server.rrd.sampler;
 
-import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 import org.neo4j.server.rrd.UnableToSampleException;
 
 public class NodeIdsInUseSampleable extends DatabasePrimitivesSampleableBase
 {
 
-    public NodeIdsInUseSampleable( NeoStore neoStore )
+    public NodeIdsInUseSampleable( NeoStoreProvider neoStore )
     {
         super( neoStore );
     }

--- a/community/server/src/main/java/org/neo4j/server/rrd/sampler/PropertyCountSampleable.java
+++ b/community/server/src/main/java/org/neo4j/server/rrd/sampler/PropertyCountSampleable.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.server.rrd.sampler;
 
-import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 
 public class PropertyCountSampleable extends DatabasePrimitivesSampleableBase
 {
-    public PropertyCountSampleable( NeoStore neoStore )
+    public PropertyCountSampleable( NeoStoreProvider neoStore )
     {
         super( neoStore );
     }

--- a/community/server/src/main/java/org/neo4j/server/rrd/sampler/RelationshipCountSampleable.java
+++ b/community/server/src/main/java/org/neo4j/server/rrd/sampler/RelationshipCountSampleable.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.server.rrd.sampler;
 
-import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 
 public class RelationshipCountSampleable extends DatabasePrimitivesSampleableBase
 {
-    public RelationshipCountSampleable( NeoStore neoStore )
+    public RelationshipCountSampleable( NeoStoreProvider neoStore )
     {
         super( neoStore );
     }

--- a/community/server/src/test/java/org/neo4j/server/rrd/DatabasePrimitivesSampleableBaseDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/DatabasePrimitivesSampleableBaseDocTest.java
@@ -20,13 +20,11 @@
 package org.neo4j.server.rrd;
 
 import java.io.IOException;
-
 import javax.management.MalformedObjectNameException;
 
 import org.junit.Test;
 
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
 import org.neo4j.server.rrd.sampler.DatabasePrimitivesSampleableBase;
 import org.neo4j.server.rrd.sampler.NodeIdsInUseSampleable;
@@ -60,8 +58,8 @@ public class DatabasePrimitivesSampleableBaseDocTest
         db.shutdown();
     }
 
-    private NeoStore neoStore( GraphDatabaseAPI db )
+    private NeoStoreProvider neoStore( GraphDatabaseAPI db )
     {
-        return db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate();
+        return db.getDependencyResolver().resolveDependency( NeoStoreProvider.class );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rrd/NodeIdsInUseSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/NodeIdsInUseSampleableTest.java
@@ -68,7 +68,7 @@ public class NodeIdsInUseSampleableTest
     {
         db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
         DependencyResolver dependencyResolver = db.getDependencyResolver();
-        sampleable = new NodeIdsInUseSampleable( dependencyResolver.resolveDependency( NeoStoreProvider.class ).evaluate() );
+        sampleable = new NodeIdsInUseSampleable( dependencyResolver.resolveDependency( NeoStoreProvider.class ) );
     }
 
     @After

--- a/community/server/src/test/java/org/neo4j/server/rrd/PropertyCountSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/PropertyCountSampleableTest.java
@@ -50,7 +50,7 @@ public class PropertyCountSampleableTest
     {
         db = new WrappedDatabase( (InternalAbstractGraphDatabase) new TestGraphDatabaseFactory().newImpermanentDatabase() );
         DependencyResolver dependencyResolver = db.getGraph().getDependencyResolver();
-        sampleable = new PropertyCountSampleable( dependencyResolver.resolveDependency( NeoStoreProvider.class ).evaluate() );
+        sampleable = new PropertyCountSampleable( dependencyResolver.resolveDependency( NeoStoreProvider.class ) );
 
         Transaction tx = db.getGraph().beginTx();
         referenceNodeId = db.getGraph().createNode().getId();

--- a/community/server/src/test/java/org/neo4j/server/rrd/RelationshipCountSampleableTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rrd/RelationshipCountSampleableTest.java
@@ -68,7 +68,7 @@ public class RelationshipCountSampleableTest
     public void setUp() throws Exception
     {
         db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        sampleable = new RelationshipCountSampleable( db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ).evaluate() );
+        sampleable = new RelationshipCountSampleable( db.getDependencyResolver().resolveDependency( NeoStoreProvider.class ) );
     }
 
     @After


### PR DESCRIPTION
On master switch the NeoStore reference in RRDB becomes invalid. This fixes that by using NeoStoreProvider and resolve the NeoStore on each use.