### PR TITLE
Fix NPE in MapRepresentation by not assuming map keys to be not null

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/repr/MapRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/MapRepresentation.java
@@ -21,13 +21,13 @@ package org.neo4j.server.rest.repr;
 
 import java.util.Map;
 
-import static java.lang.reflect.Array.get;
-import static java.lang.reflect.Array.getLength;
-import static java.util.Arrays.asList;
-
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+
+import static java.lang.reflect.Array.get;
+import static java.lang.reflect.Array.getLength;
+import static java.util.Arrays.asList;
 
 public class MapRepresentation extends MappingRepresentation
 {
@@ -46,47 +46,48 @@ public class MapRepresentation extends MappingRepresentation
         for ( Object key : value.keySet() )
         {
             Object val = value.get( key );
+            String keyString = key == null ? "null" : key.toString();
             if ( val instanceof Number )
             {
-                serializer.putNumber( key.toString(), (Number) val );
+                serializer.putNumber( keyString, (Number) val );
             }
             else if ( val instanceof Boolean )
             {
-                serializer.putBoolean( key.toString(), (Boolean) val );
+                serializer.putBoolean( keyString, (Boolean) val );
             }
             else if ( val instanceof String )
             {
-                serializer.putString( key.toString(), (String) val );
+                serializer.putString( keyString, (String) val );
             }
             else if (val instanceof Path )
             {
                 PathRepresentation<Path> representation = new PathRepresentation<>( (Path) val );
-                serializer.putMapping( key.toString(), representation );
+                serializer.putMapping( keyString, representation );
             }
             else if ( val instanceof Iterable )
             {
-                serializer.putList( key.toString(), ObjectToRepresentationConverter.getListRepresentation( (Iterable)
+                serializer.putList( keyString, ObjectToRepresentationConverter.getListRepresentation( (Iterable)
                         val ) );
             }
             else if ( val instanceof Map )
             {
-                serializer.putMapping( key.toString(), ObjectToRepresentationConverter.getMapRepresentation( (Map)
+                serializer.putMapping( keyString, ObjectToRepresentationConverter.getMapRepresentation( (Map)
                         val ) );
             }
             else if (val == null)
             {
-                serializer.putString( key.toString(), null );
+                serializer.putString( keyString, null );
             }
             else if (val.getClass().isArray())
             {
                 Object[] objects = toArray( val );
 
-                serializer.putList( key.toString(), ObjectToRepresentationConverter.getListRepresentation( asList(objects) ) );
+                serializer.putList( keyString, ObjectToRepresentationConverter.getListRepresentation( asList(objects) ) );
             }
             else if (val instanceof Node || val instanceof Relationship )
             {
                 Representation representation = ObjectToRepresentationConverter.getSingleRepresentation( val );
-                serializer.putMapping( key.toString(), (MappingRepresentation) representation );
+                serializer.putMapping( keyString, (MappingRepresentation) representation );
             }
             else
             {

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.PropertyContainer;
 
 public class Neo4jJsonCodec extends ObjectMapper
 {
-
     public Neo4jJsonCodec()
     {
         getSerializationConfig().without( SerializationConfig.Feature.FLUSH_AFTER_WRITE_VALUE );
@@ -77,7 +76,7 @@ public class Neo4jJsonCodec extends ObjectMapper
             for ( Map.Entry e : set )
             {
                 Object key = e.getKey();
-                out.writeFieldName( key == null ? null : key.toString() );
+                out.writeFieldName( key == null ? "null" : key.toString() );
                 writeValue( out, e.getValue() );
             }
         }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/MapRepresentationTest.java
@@ -19,11 +19,12 @@
  */
 package org.neo4j.server.rest.repr;
 
+import org.junit.Test;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.repr.formats.JsonFormat;
 
@@ -32,6 +33,9 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
@@ -130,5 +134,42 @@ public class MapRepresentationTest
         assertThat( (String) ((Map) ((List) map.get( "a list with a map in it" )).get( 0 )).get( "foo" ), is( "bar" ) );
         assertThat( (Boolean) ((Map) ((List) map.get( "a list with a map in it" )).get( 0 )).get( "baz" ),
                 is( false ) );
+    }
+
+    @Test
+    public void shouldSerializeMapsWithNullKeys() throws Exception
+    {
+        Object[] values = {null,
+                "string",
+                42,
+                true,
+                new String[]{"a string", "another string"},
+                new int[]{42, 87},
+                new boolean[]{true, false},
+                asList( true, false, true ),
+                map( "numbers", 42, null, "something" ),
+                map( "a list", asList( 42, 87 ), null, asList( "a", "b" ) ),
+                asList( map( "foo", "bar", null, false ) )};
+
+        for ( Object value : values )
+        {
+            MapRepresentation rep = new MapRepresentation( map( (Object) null, value ) );
+            OutputFormat format = new OutputFormat( new JsonFormat(), new URI( "http://localhost/" ), null );
+
+            String serializedMap = format.assemble( rep );
+
+            Map<String,Object> map = JsonHelper.jsonToMap( serializedMap );
+
+            assertEquals( 1, map.size() );
+            Object actual = map.get( "null" );
+            if ( value == null )
+            {
+                assertNull( actual );
+            }
+            else
+            {
+                assertNotNull( actual );
+            }
+        }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/Neo4jJsonCodecTest.java
@@ -174,6 +174,6 @@ public class Neo4jJsonCodecTest
         jsonCodec.writeValue( jsonGenerator, map );
 
         // then
-        verify( jsonGenerator, times( 1 ) ).writeFieldName( (String) null );
+        verify( jsonGenerator, times( 1 ) ).writeFieldName( "null" );
     }
 }


### PR DESCRIPTION
Transform null-keys in "null" when trying to stringify them.

Use same approach in Neo4jJsonCodec since some JsonGenerator do not
handle nullable fieldnames.