### PR TITLE
Cypher cache cleanup

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -202,12 +202,12 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
     val version = CypherVersion(optGraphSetting[String](
       graph, GraphDatabaseSettings.cypher_parser_version, CypherVersion.vDefault.name))
     val planner = PlannerName(optGraphSetting[String](
-      graph, GraphDatabaseSettings.query_planner_version, PlannerName.default.name))
+      graph, GraphDatabaseSettings.cypher_planner, PlannerName.default.name))
     if (version != CypherVersion.v2_2 && (planner == CostPlannerName || planner == IDPPlannerName)) {
       logger.error(s"Cannot combine configurations: ${GraphDatabaseSettings.cypher_parser_version.name}=${version.name} " +
-        s"with ${GraphDatabaseSettings.query_planner_version.name} = ${planner.name}")
+        s"with ${GraphDatabaseSettings.cypher_planner.name} = ${planner.name}")
       throw new IllegalStateException(s"Cannot combine configurations: ${GraphDatabaseSettings.cypher_parser_version.name}=${version.name} " +
-        s"with ${GraphDatabaseSettings.query_planner_version.name} = ${planner.name}")
+        s"with ${GraphDatabaseSettings.cypher_planner.name} = ${planner.name}")
     }
     val optionParser = CypherOptionParser(kernelMonitors.newMonitor(classOf[ParserMonitor[CypherQueryWithOptions]]))
     new CypherCompiler(graph, kernel, kernelMonitors, version, planner, optionParser, logger)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -142,7 +142,7 @@ class CypherCompiler(graph: GraphDatabaseService,
 
   private def getMinimumTimeBeforeReplanning: Long = {
     optGraphAs[InternalAbstractGraphDatabase]
-      .andThen(_.getConfig.get(GraphDatabaseSettings.query_planner_min_replan_interval).longValue())
+      .andThen(_.getConfig.get(GraphDatabaseSettings.cypher_min_replan_interval).longValue())
       .applyOrElse(graph, (_: GraphDatabaseService) => DEFAULT_QUERY_PLAN_TTL)
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -51,7 +51,7 @@ class CypherCompiler(graph: GraphDatabaseService,
   import CypherCompiler._
 
   private val queryCacheSize: Int = getQueryCacheSize
-  private val queryPlanTTL: Long = getQueryPlanTTL
+  private val queryPlanTTL: Long = getMinimumTimeBeforeReplanning
   private val compatibilityFor1_9 = CompatibilityFor1_9(graph, queryCacheSize, kernelMonitors)
   private val compatibilityFor2_0 = CompatibilityFor2_0(graph, queryCacheSize, kernelMonitors)
   private val compatibilityFor2_1 = CompatibilityFor2_1(graph, queryCacheSize, kernelMonitors, kernelAPI)
@@ -140,9 +140,9 @@ class CypherCompiler(graph: GraphDatabaseService,
       .applyOrElse(graph, (_: GraphDatabaseService) => DEFAULT_QUERY_CACHE_SIZE)
 
 
-  private def getQueryPlanTTL: Long = {
+  private def getMinimumTimeBeforeReplanning: Long = {
     optGraphAs[InternalAbstractGraphDatabase]
-      .andThen(_.getConfig.get(GraphDatabaseSettings.query_plan_ttl).longValue())
+      .andThen(_.getConfig.get(GraphDatabaseSettings.query_planner_min_replan_interval).longValue())
       .applyOrElse(graph, (_: GraphDatabaseService) => DEFAULT_QUERY_PLAN_TTL)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -50,7 +50,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_plan_ttl.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
 
   test("should monitor cache miss") {
     // given

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -50,7 +50,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.cypher_min_replan_interval.name() -> "0")
 
   test("should monitor cache miss") {
     // given

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -47,7 +47,7 @@ class ExecutionEngineIT extends CypherFunSuite {
     //given
     val db = new TestGraphDatabaseFactory()
       .newImpermanentDatabaseBuilder()
-      .setConfig(GraphDatabaseSettings.query_planner_version, "RULE")
+      .setConfig(GraphDatabaseSettings.cypher_planner, "RULE")
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.2").newGraphDatabase()
 
     //when
@@ -61,7 +61,7 @@ class ExecutionEngineIT extends CypherFunSuite {
     //given
     val db = new TestGraphDatabaseFactory()
       .newImpermanentDatabaseBuilder()
-      .setConfig(GraphDatabaseSettings.query_planner_version, "COST")
+      .setConfig(GraphDatabaseSettings.cypher_planner, "COST")
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.2").newGraphDatabase()
 
     //when
@@ -76,7 +76,7 @@ class ExecutionEngineIT extends CypherFunSuite {
     intercept[Exception] {
       val db = new TestGraphDatabaseFactory()
         .newImpermanentDatabaseBuilder()
-        .setConfig(GraphDatabaseSettings.query_planner_version, "COST")
+        .setConfig(GraphDatabaseSettings.cypher_planner, "COST")
         .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.0").newGraphDatabase()
 
       db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -59,7 +59,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_plan_ttl.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
 
   test("should monitor cache misses") {
     val counter = new CacheCounter()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -59,7 +59,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.cypher_min_replan_interval.name() -> "0")
 
   test("should monitor cache misses") {
     val counter = new CacheCounter()

--- a/community/cypher/docs/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -32,7 +32,7 @@ This planner uses the statistics service in Neo4j to assign cost to alternative 
 While this should lead to superior execution plans in most cases, it is still under development.
 
 By default, Neo4j 2.2 will use the cost planner for some queries, but not all.
-You can force it to use a specific planner by using the `query.planner.version` configuration setting (see <<config_query.planner.version>>), or by prepending your query with `PLANNER COST` or `PLANNER RULE`.
+You can force it to use a specific planner by using the `query.planner.version` configuration setting (see <<config_dbms.cypher.planner>>), or by prepending your query with `PLANNER COST` or `PLANNER RULE`.
 Neo4j might still not use the planner you selected -- not all queries are solvable by the cost planner at this point.
 
 You can see which planner was used by looking at the execution plan.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -105,7 +105,7 @@ public abstract class GraphDatabaseSettings
             options( "COST", "RULE"), NO_DEFAULT );
 
     @Description( "The number of Cypher query execution plans that are cached." )
-    public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "100", min( 0 ) );
+    public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "1000", min( 0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
     public static Setting<Long> query_planner_min_replan_interval = setting( "dbms.query_planner.min_replan_interval", DURATION, "1s" );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -100,15 +100,15 @@ public abstract class GraphDatabaseSettings
             options( "1.9", "2.0", "2.1", "2.2"), NO_DEFAULT );
 
     @Description( "Set this to specify the default planner." )
-    public static final Setting<String> query_planner_version = setting(
-            "dbms.query_planner.version",
+    public static final Setting<String> cypher_planner = setting(
+            "dbms.cypher.planner",
             options( "COST", "RULE"), NO_DEFAULT );
 
     @Description( "The number of Cypher query execution plans that are cached." )
     public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "1000", min( 0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
-    public static Setting<Long> query_planner_min_replan_interval = setting( "dbms.query_planner.min_replan_interval", DURATION, "1s" );
+    public static Setting<Long> cypher_min_replan_interval = setting( "dbms.cypher.min_replan_interval", DURATION, "1s" );
 
     @Description( "Determines if Cypher will allow using file URLs when loading data using `LOAD CSV`. Setting this "
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -101,14 +101,14 @@ public abstract class GraphDatabaseSettings
 
     @Description( "Set this to specify the default planner." )
     public static final Setting<String> query_planner_version = setting(
-            "query.planner.version",
+            "dbms.query_planner.version",
             options( "COST", "RULE"), NO_DEFAULT );
 
     @Description( "The number of Cypher query execution plans that are cached." )
     public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "100", min( 0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
-    public static Setting<Long> query_plan_ttl = setting( "query_plan_ttl", DURATION, "1s" );
+    public static Setting<Long> query_planner_min_replan_interval = setting( "dbms.query_planner.min_replan_interval", DURATION, "1s" );
 
     @Description( "Determines if Cypher will allow using file URLs when loading data using `LOAD CSV`. Setting this "
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )


### PR DESCRIPTION
This PR changes a public facing setting - `query_plan_ttl`. It is a confusing name, since it does not control the time to live of a query plan. It specifies how long time must pass before a query is considered for re-planning. 