### PR TITLE
Split StoreCopyMonitor in Server and Client side monitors

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyClientMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyClientMonitor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.monitoring;
+
+public interface StoreCopyClientMonitor
+{
+    void startReceivingStoreFiles();
+    void finishedReceivingStoreFiles();
+    void startReceivingTransactions( long startTxId );
+    void finishReceivingTransactions( long endTxId );
+    void startRecoveringStore();
+    void finishRecoveringStore();
+
+    public static final StoreCopyClientMonitor NONE = new Adaptor();
+
+    class Adaptor implements StoreCopyClientMonitor {
+
+        @Override
+        public void startReceivingStoreFiles()
+        {
+
+        }
+
+        @Override
+        public void finishedReceivingStoreFiles()
+        {
+
+        }
+
+        @Override
+        public void startReceivingTransactions( long startTxId )
+        {
+
+        }
+
+        @Override
+        public void finishReceivingTransactions( long endTxId )
+        {
+
+        }
+
+        @Override
+        public void startRecoveringStore()
+        {
+
+        }
+
+        @Override
+        public void finishRecoveringStore()
+        {
+
+        }
+
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyServerMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/StoreCopyServerMonitor.java
@@ -19,56 +19,52 @@
  */
 package org.neo4j.kernel.monitoring;
 
-import java.io.File;
-
-public interface StoreCopyMonitor
+public interface StoreCopyServerMonitor
 {
+    void startFlushingEverything();
+    void finishFlushingEverything();
+    void startSendingStoreFiles();
+    void finishSendingStoreFiles();
+    void startSendingTransactions( long startTxId );
+    void finishSendingTransactions( long endTxId );
 
-    void startCopyingFiles();
-    void finishedCopyingStoreFiles();
-    void finishedRotatingLogicalLogs();
-    void streamedFile( File file );
-    void streamingFile( File file );
-    void recoveredStore();
+    public static final StoreCopyServerMonitor NONE = new Adaptor();
 
-
-    public static final StoreCopyMonitor NONE = new Adaptor();
-
-    class Adaptor implements StoreCopyMonitor
+    class Adaptor implements StoreCopyServerMonitor
     {
 
         @Override
-        public void startCopyingFiles()
+        public void startFlushingEverything()
         {
 
         }
 
         @Override
-        public void finishedCopyingStoreFiles()
+        public void finishFlushingEverything()
         {
 
         }
 
         @Override
-        public void finishedRotatingLogicalLogs()
+        public void startSendingStoreFiles()
         {
 
         }
 
         @Override
-        public void streamedFile( File file )
+        public void finishSendingStoreFiles()
         {
 
         }
 
         @Override
-        public void streamingFile( File file )
+        public void startSendingTransactions( long startTxId )
         {
 
         }
 
         @Override
-        public void recoveredStore()
+        public void finishSendingTransactions( long toEndAt )
         {
 
         }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -62,6 +62,6 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
     public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
     {
         return new OnlineBackupKernelExtension( dependencies.getConfig(), dependencies.getGraphDatabaseAPI(),
-                dependencies.kpeg(), dependencies.logging(), dependencies.monitors() );
+                dependencies.logging(), dependencies.monitors() );
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -37,7 +37,6 @@ import org.neo4j.helpers.Provider;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
@@ -73,8 +72,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
     private volatile URI me;
 
     public OnlineBackupKernelExtension( Config config, final GraphDatabaseAPI graphDatabaseAPI,
-                                        final KernelPanicEventGenerator kpeg, final Logging logging,
-                                        final Monitors monitors )
+                                        final Logging logging, final Monitors monitors )
     {
         this( config, graphDatabaseAPI, new BackupProvider()
         {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -28,23 +28,24 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.NeoStore.Position;
@@ -56,9 +57,11 @@ import org.neo4j.kernel.impl.transaction.log.LogRotation;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader;
-import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.kernel.monitoring.StoreCopyServerMonitor;
+import org.neo4j.test.Barrier;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.EmbeddedDatabaseRule;
@@ -73,7 +76,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.neo4j.test.DoubleLatch.awaitLatch;
 
 public class BackupServiceIT
 {
@@ -447,63 +449,82 @@ public class BackupServiceIT
     public void shouldContainTransactionsThatHappenDuringBackupProcess() throws Throwable
     {
         // given
-        defaultBackupPortHostParams();
+        File backupDir = target.cleanDirectory( "backup_dir" );
+        dbRule.setConfig( OnlineBackupSettings.online_backup_server, "localhost:" + backupPort );
         Config defaultConfig = dbRule.getConfigCopy();
         dbRule.setConfig( OnlineBackupSettings.online_backup_enabled, "false" );
         Config withOnlineBackupEnabled = dbRule.getConfigCopy();
 
-        final CountDownLatch firstStoreFinishedStreaming = new CountDownLatch( 1 );
-        final CountDownLatch transactionCommitted = new CountDownLatch( 1 );
-
         final GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
 
-        createAndIndexNode( db, 1 ); // create some data
+        createIndexAndALabelledNode( db, DynamicLabel.label( "Person" ) ); // create some data
+        createAndIndexNode( db, 1 );
+        rotateLog( db );
 
-        NeoStoreDataSource ds = db.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource();
-        long expectedLastTxId = ds.getNeoStore().getLastCommittedTransactionId();
+        final Barrier.Control barrier = new Barrier.Control();
+        final Monitors monitors = new Monitors();
+        monitors.addMonitorListener( new StoreCopyServerMonitor.Adaptor()
+        {
+            @Override
+            public void finishFlushingEverything()
+            {
+                try
+                {
+                    barrier.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
 
-        Monitors monitors = new Monitors();
+            @Override
+            public void startSendingStoreFiles()
+            {
+                barrier.release();
+            }
+        } );
 
         OnlineBackupKernelExtension backup = new OnlineBackupKernelExtension(
                 defaultConfig,
                 db,
-                db.getDependencyResolver().resolveDependency( KernelPanicEventGenerator.class ),
-                new DevNullLoggingService(),
+                DevNullLoggingService.DEV_NULL,
                 monitors );
+        backup.init();
         backup.start();
 
-
         // when
-        BackupService backupService = new BackupService( fileSystem );
+        final AtomicLong txId = new AtomicLong();
+
+        BackupService backupService = new BackupService( fileSystem, StringLogger.DEV_NULL, monitors );
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.execute( new Runnable()
         {
             @Override
             public void run()
             {
-                awaitLatch( firstStoreFinishedStreaming );
-
-                createAndIndexNode( db, 1 );
-                db.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource()
-                  .getNeoStore().flush();
-
-                transactionCommitted.countDown();
+                createNode( db, DynamicLabel.label( "Person" ) );
+                createAndIndexNode( db, 2 );
+                barrier.reached();
+                txId.set( lastTxId( db ) );
             }
         } );
 
-        BackupService.BackupOutcome backupOutcome = backupService.doFullBackup( BACKUP_HOST, backupPort,
+        BackupService.BackupOutcome backupOutcome = backupService.doFullBackup( "localhost", backupPort,
                 backupDir.getAbsolutePath(), true, withOnlineBackupEnabled, BackupClient.BIG_READ_TIMEOUT, false );
 
         backup.stop();
+        backup.shutdown();
+
         executor.shutdown();
-        executor.awaitTermination( 30, TimeUnit.SECONDS );
+        assertTrue( executor.awaitTermination( 30, TimeUnit.SECONDS ) );
 
         // then
         assertEquals( DbRepresentation.of( db ), DbRepresentation.of( backupDir ) );
         assertTrue( backupOutcome.isConsistent() );
 
         // also verify the last committed tx id is correctly set
-        checkPreviousCommittedTxIdFromFirstLog( expectedLastTxId );
+        assertEquals( txId.get(), new NeoStoreUtil( backupDir, fileSystem ).getLastCommittedTx() );
     }
 
     @Test
@@ -552,6 +573,11 @@ public class BackupServiceIT
         dbRule.setConfig( OnlineBackupSettings.online_backup_server, BACKUP_HOST + ":" + backupPort );
     }
 
+    private long lastTxId( GraphDatabaseAPI db )
+    {
+        return db.getDependencyResolver().resolveDependency( NeoStore.class ).getLastCommittedTransactionId();
+    }
+
     private void createAndIndexNode( GraphDatabaseService db, int i )
     {
         try ( Transaction tx = db.beginTx() )
@@ -562,6 +588,44 @@ public class BackupServiceIT
             index.add( node, "delete", "me" );
             tx.success();
         }
+    }
+
+    private void createIndexAndALabelledNode( GraphDatabaseService db, Label label )
+    {
+        IndexDefinition index;
+        try ( Transaction tx = db.beginTx() )
+        {
+
+            index = db.schema().indexFor( label ).on( "name" ).create();
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexOnline( index, 10, TimeUnit.SECONDS );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            createNode( db, label );
+            tx.success();
+        }
+    }
+
+    private void createNode( GraphDatabaseService db, Label label )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( label );
+            node.setProperty( "name", "name" + System.currentTimeMillis() );
+            tx.success();
+        }
+    }
+
+    private void rotateLog( GraphDatabaseAPI db ) throws IOException
+    {
+        db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
     }
 
     private BaseMatcher<File[]> hasFile( final String fileName )

--- a/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/monitor/RequestMonitor.java
@@ -29,4 +29,19 @@ public interface RequestMonitor
     void beginRequest( SocketAddress remoteAddress, RequestType<?> requestType, RequestContext requestContext );
 
     void endRequest( Throwable t );
+
+    public static final RequestMonitor NULL = new RequestMonitor()
+    {
+        @Override
+        public void beginRequest( SocketAddress remoteAddress, RequestType<?> requestType, RequestContext ctx )
+        {
+
+        }
+
+        @Override
+        public void endRequest( Throwable t )
+        {
+
+        }
+    };
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -113,7 +113,7 @@ import org.neo4j.kernel.logging.LogbackWeakDependency;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.kernel.monitoring.StoreCopyMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyClientMonitor;
 
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 import static org.neo4j.kernel.logging.LogbackWeakDependency.DEFAULT_TO_CLASSIC;
@@ -499,7 +499,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 monitors.newMonitor( ByteCounterMonitor.class, SlaveServer.class ),
                 monitors.newMonitor( RequestMonitor.class, SlaveServer.class ),
                 monitors.newMonitor( SwitchToSlave.Monitor.class ),
-                monitors.newMonitor( StoreCopyMonitor.class ) );
+                monitors.newMonitor( StoreCopyClientMonitor.class ) );
 
         SwitchToMaster switchToMasterInstance = new SwitchToMaster( logging, consoleLog, this,
                 (HaIdGeneratorFactory) idGeneratorFactory, config, dependencies.provideDependency( SlaveFactory.class ),

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -54,7 +54,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
-import org.neo4j.kernel.monitoring.StoreCopyMonitor;
+import org.neo4j.kernel.monitoring.StoreCopyClientMonitor;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
@@ -132,7 +132,7 @@ public class SwitchToSlaveTest
                 mock( ClusterMemberAvailability.class ), mock( RequestContextFactory.class ),
                 Iterables.<KernelExtensionFactory<?>>empty(), mock( MasterClientResolver.class ),
                 ByteCounterMonitor.NULL, mock( RequestMonitor.class ), mock( SwitchToSlave.Monitor.class ),
-                StoreCopyMonitor.NONE ) );
+                StoreCopyClientMonitor.NONE ) );
     }
 
     private static NeoStoreDataSource dataSourceMock()


### PR DESCRIPTION
`StoreCopyMonitor` was a monitor partially used from the client side and partially used from the server side. Hence the monitored events were confusing and partially visible depending on which side of the connection you were sitting.

The solution proposed by this change is to have two different interfaces: `StoreCopyClientMonitor` and `StoreCopyServerMonitor` which report all the events by looking at the status on one side only of the connection.

This PR also fixes `BackupServiceIT.shouldContainTransactionsThatHappenDuringBackupProcess`: the test was simply going in timeout on the `executor.awaitTermination` and the assertion checking the last tx id was wrong.
