### PR TITLE
Update GraphDatabaseSettings around query planning

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -142,7 +142,7 @@ class CypherCompiler(graph: GraphDatabaseService,
 
   private def getQueryPlanTTL: Long = {
     optGraphAs[InternalAbstractGraphDatabase]
-      .andThen(_.getConfig.get(GraphDatabaseSettings.query_plan_ttl).longValue())
+      .andThen(_.getConfig.get(GraphDatabaseSettings.query_planner_min_replan_interval).longValue())
       .applyOrElse(graph, (_: GraphDatabaseService) => DEFAULT_QUERY_PLAN_TTL)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -50,7 +50,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_plan_ttl.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
 
   test("should monitor cache miss") {
     // given

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -59,7 +59,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     }
   }
 
-  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_plan_ttl.name() -> "0")
+  override def databaseConfig(): Map[String,String] = Map(GraphDatabaseSettings.query_planner_min_replan_interval.name() -> "0")
 
   test("should monitor cache misses") {
     val counter = new CacheCounter()

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -101,14 +101,14 @@ public abstract class GraphDatabaseSettings
 
     @Description( "Set this to specify the default planner." )
     public static final Setting<String> query_planner_version = setting(
-            "query.planner.version",
-            options( "COST", "RULE"), NO_DEFAULT );
+            "dbms.query_planner.version",
+            options( "COST", "RULE", "IDP"), NO_DEFAULT );
 
     @Description( "The number of Cypher query execution plans that are cached." )
     public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "100", min( 0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
-    public static Setting<Long> query_plan_ttl = setting( "query_plan_ttl", DURATION, "1s" );
+    public static Setting<Long> query_planner_min_replan_interval = setting( "dbms.query_planner.min_replan_interval", DURATION, "1s" );
 
     @Description( "Determines if Cypher will allow using file URLs when loading data using `LOAD CSV`. Setting this "
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )


### PR DESCRIPTION
o Rename settings to use the dbms.query_planner namespace
o Add "IDP" option for the planner