### PR TITLE
Resolves race conditions on counts store rotation

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.function.IOFunction;
 import org.neo4j.function.RawFunction;
 
 /**
@@ -121,7 +122,7 @@ public class Readables
         };
     }
 
-    private static final RawFunction<File,Reader,IOException> FROM_FILE = new RawFunction<File,Reader,IOException>()
+    private static final IOFunction<File, Reader> FROM_FILE = new IOFunction<File, Reader>()
     {
         @Override
         public Reader apply( final File file ) throws IOException
@@ -219,8 +220,7 @@ public class Readables
                name.contains( "/." );
     }
 
-    private static final RawFunction<Reader,Reader,IOException> IDENTITY =
-            new RawFunction<Reader,Reader,IOException>()
+    private static final IOFunction<Reader, Reader> IDENTITY = new IOFunction<Reader, Reader>()
     {
         @Override
         public Reader apply( Reader in )

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1174,7 +1174,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
 
     public void awaitAllTransactionsClosed()
     {
-        while ( !neoStoreModule.neoStore().closedTransactionIdIsOnParWithCommittedTransactionId() )
+        while ( !neoStoreModule.neoStore().closedTransactionIdIsOnParWithOpenedTransactionId() )
         {
             LockSupport.parkNanos( 1_000_000 ); // 1 ms
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -33,9 +33,9 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
 {
     public static void recomputeCounts( NeoStore stores )
     {
-        try ( CountsAccessor.Updater countsUpdater = stores.getCounts().reset() )
+        try ( CountsAccessor.Updater updater = stores.getCounts().reset( stores.getLastCommittedTransactionId() ) )
         {
-            new CountsComputer( stores ).initialize( countsUpdater );
+            new CountsComputer( stores ).initialize( updater );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
@@ -946,9 +946,9 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     }
 
     @Override
-    public boolean closedTransactionIdIsOnParWithCommittedTransactionId()
+    public boolean closedTransactionIdIsOnParWithOpenedTransactionId()
     {
-        boolean onPar = lastClosedTx.getHighestGapFreeNumber() == lastCommittedTx.getHighestGapFreeNumber();
+        boolean onPar = lastClosedTx.getHighestGapFreeNumber() == lastCommittingTxField.get();
         if ( !onPar )
         {   // Trigger some logging here, max logged every 30 secs or so
             transactionCloseWaitLogger.event( null );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -199,9 +199,9 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
         return new CountsUpdater( updater() );
     }
 
-    public CountsAccessor.Updater reset()
+    public CountsAccessor.Updater reset( long txId )
     {
-        return new CountsUpdater( resetter() );
+        return new CountsUpdater( resetter( txId ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -250,6 +250,10 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
                     {
                         state = next;
                     }
+                    finally
+                    {
+                        rotation.close();
+                    }
                     return version;
                 }
             };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -237,7 +237,7 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
                 @Override
                 public long rotate() throws IOException
                 {
-                    final long version = rotation.version();
+                    final long version = rotation.rotationVersion();
                     ProgressiveState<Key> next = rotation.rotate( rotationStrategy, new Consumer<Headers.Builder>()
                     {
                         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -180,25 +180,12 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
         }
     }
 
-    protected final EntryUpdater<Key> resetter()
+    protected final EntryUpdater<Key> resetter( long version )
     {
         try ( LockWrapper lock = writeLock( updateLock ) )
         {
-            return state.resetter( lock.get(), new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    try
-                    {
-                        prepareRotation( version( headers() ) ).rotate();
-                    }
-                    catch ( IOException e )
-                    {
-                        throw new UnderlyingStorageException( e );
-                    }
-                }
-            } );
+            ProgressiveState<Key> current = state;
+            return current.resetter( lock.get(), new RotationTask( version ) );
         }
     }
 
@@ -230,33 +217,7 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
                     }
                 };
             }
-            final RotationState<Key> rotation = prior.prepareRotation( version );
-            state = rotation;
-            return new PreparedRotation()
-            {
-                @Override
-                public long rotate() throws IOException
-                {
-                    final long version = rotation.rotationVersion();
-                    ProgressiveState<Key> next = rotation.rotate( rotationStrategy, new Consumer<Headers.Builder>()
-                    {
-                        @Override
-                        public void accept( Headers.Builder value )
-                        {
-                            updateHeaders( value, version );
-                        }
-                    } );
-                    try ( LockWrapper ignored = writeLock( updateLock ) )
-                    {
-                        state = next;
-                    }
-                    finally
-                    {
-                        rotation.close();
-                    }
-                    return version;
-                }
-            };
+            return new RotationTask( version );
         }
     }
 
@@ -281,6 +242,57 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
             }
         }
         return true;
+    }
+
+    private class RotationTask implements PreparedRotation, Runnable
+    {
+        private final RotationState<Key> rotation;
+
+        RotationTask( long version )
+        {
+            state = this.rotation = state.prepareRotation( version );
+        }
+
+        @Override
+        public long rotate() throws IOException
+        {
+            return rotate( false );
+        }
+
+        @Override
+        public void run()
+        {
+            try ( LockWrapper ignored = writeLock( updateLock ) )
+            {
+                rotate( true );
+            }
+            catch ( IOException e )
+            {
+                throw new UnderlyingStorageException( e );
+            }
+        }
+
+        private long rotate( boolean force ) throws IOException
+        {
+            final long version = rotation.rotationVersion();
+            ProgressiveState<Key> next = rotation.rotate( force, rotationStrategy, new Consumer<Headers.Builder>()
+            {
+                @Override
+                public void accept( Headers.Builder value )
+                {
+                    updateHeaders( value, version );
+                }
+            } );
+            try ( LockWrapper ignored = writeLock( updateLock ) )
+            {
+                state = next;
+            }
+            finally
+            {
+                rotation.close();
+            }
+            return version;
+        }
     }
 
     public static abstract class Reader<Value>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
@@ -225,6 +225,12 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
                 void close() throws IOException
                 {
                 }
+
+                @Override
+                long rotationVersion()
+                {
+                    return state.version();
+                }
             };
         }
 
@@ -282,6 +288,12 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
                 void close() throws IOException
                 {
                     state.close();
+                }
+
+                @Override
+                long rotationVersion()
+                {
+                    return state.rotationVersion();
                 }
             };
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
@@ -215,7 +215,8 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
             return new Rotation<Key, NeedsCreation<Key>>( this )
             {
                 @Override
-                ProgressiveState<Key> rotate( RotationStrategy strategy, Consumer<Headers.Builder> headers )
+                ProgressiveState<Key> rotate( boolean force, RotationStrategy strategy,
+                                              Consumer<Headers.Builder> headers )
                         throws IOException
                 {
                     return state;
@@ -278,10 +279,10 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
             return new Rotation<Key, RotationState.Rotation<Key>>( state.prepareRotation( version ) )
             {
                 @Override
-                ProgressiveState<Key> rotate( RotationStrategy strategy, Consumer<Headers.Builder> headers )
-                        throws IOException
+                ProgressiveState<Key> rotate( boolean force, RotationStrategy strategy,
+                                              Consumer<Headers.Builder> headers ) throws IOException
                 {
-                    return new Prepared<>( state.rotate( strategy, headers ) );
+                    return new Prepared<>( state.rotate( force, strategy, headers ) );
                 }
 
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/DeadState.java
@@ -220,6 +220,11 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
                 {
                     return state;
                 }
+
+                @Override
+                void close() throws IOException
+                {
+                }
             };
         }
 
@@ -271,6 +276,12 @@ abstract class DeadState<Key> extends ProgressiveState<Key>
                         throws IOException
                 {
                     return new Prepared<>( state.rotate( strategy, headers ) );
+                }
+
+                @Override
+                void close() throws IOException
+                {
+                    state.close();
                 }
             };
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
@@ -45,6 +45,8 @@ abstract class RotationState<Key> extends ProgressiveState<Key>
     @Override
     abstract void close() throws IOException;
 
+    abstract long rotationVersion();
+
     static final class Rotation<Key> extends RotationState<Key>
     {
         private final ActiveState<Key> preState;
@@ -81,6 +83,12 @@ abstract class RotationState<Key> extends ProgressiveState<Key>
         void close() throws IOException
         {
             preState.close();
+        }
+
+        @Override
+        long rotationVersion()
+        {
+            return threshold;
         }
 
         private Headers updateHeaders( Consumer<Headers.Builder> headersUpdater )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
@@ -42,6 +42,9 @@ abstract class RotationState<Key> extends ProgressiveState<Key>
         return "rotating";
     }
 
+    @Override
+    abstract void close() throws IOException;
+
     static final class Rotation<Key> extends RotationState<Key>
     {
         private final ActiveState<Key> preState;
@@ -71,14 +74,13 @@ abstract class RotationState<Key> extends ProgressiveState<Key>
             }
             Pair<File, KeyValueStoreFile> next = strategy
                     .next( file(), updateHeaders( headersUpdater ), keyFormat().filter( preState.dataProvider() ) );
-            try
-            {
-                return postState.create( ReadableState.store( preState.keyFormat(), next.other() ), next.first() );
-            }
-            finally
-            {
-                preState.close();
-            }
+            return postState.create( ReadableState.store( preState.keyFormat(), next.other() ), next.first() );
+        }
+
+        @Override
+        void close() throws IOException
+        {
+            preState.close();
         }
 
         private Headers updateHeaders( Consumer<Headers.Builder> headersUpdater )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotationControl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogRotationControl.java
@@ -44,7 +44,7 @@ public class LogRotationControl
 
     public void awaitAllTransactionsClosed()
     {
-        while ( !transactionIdStore.closedTransactionIdIsOnParWithCommittedTransactionId() )
+        while ( !transactionIdStore.closedTransactionIdIsOnParWithOpenedTransactionId() )
         {
             LockSupport.parkNanos( 1_000_000 ); // 1 ms
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
@@ -92,7 +92,7 @@ public class ReadOnlyTransactionIdStore implements TransactionIdStore
     }
 
     @Override
-    public boolean closedTransactionIdIsOnParWithCommittedTransactionId()
+    public boolean closedTransactionIdIsOnParWithOpenedTransactionId()
     {
         throw new UnsupportedOperationException( "Read-only transaction ID store" );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -34,7 +34,7 @@ package org.neo4j.kernel.impl.transaction.log;
  *   {@link #getLastCommittedTransactionId()} if all ids before it have also been committed.</li>
  *   <li>{@link #transactionClosed(long)} is called with this id again, this time after all changes the
  *   transaction imposes have been applied to the store. At this point this id is regarded in
- *   {@link #closedTransactionIdIsOnParWithCommittedTransactionId()} as well.
+ *   {@link #closedTransactionIdIsOnParWithOpenedTransactionId()} as well.
  * </ol>
  */
 public interface TransactionIdStore
@@ -104,7 +104,7 @@ public interface TransactionIdStore
      * @return {@code true} if the latest applied transaction (without any lower transaction id gaps)
      * is the same as the highest returned {@code committed transaction id}.
      */
-    boolean closedTransactionIdIsOnParWithCommittedTransactionId();
+    boolean closedTransactionIdIsOnParWithOpenedTransactionId();
 
     /**
      * Forces the transaction id counters to persistent storage.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
@@ -54,6 +54,12 @@ public class Optionals
         {
             return this;
         }
+
+        @Override
+        public String toString()
+        {
+            return "none";
+        }
     };
 
     @SuppressWarnings("unchecked")
@@ -95,6 +101,12 @@ public class Optionals
             public <To> Optional<To> map( Function<TYPE, ? extends To> conversion )
             {
                 return Optionals.<To>some( conversion.apply( obj ) );
+            }
+
+            @Override
+            public String toString()
+            {
+                return "some( " + obj.toString() + " )";
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -129,7 +129,8 @@ public class ParallelBatchImporter implements BatchImporter
                       fileSystem.openAsOutputStream( badFile, false ) );
               Collector<InputRelationship> badRelationships =
                       input.badRelationshipsCollector( badRelationshipsOutput );
-              CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset();
+              CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(
+                      neoStore.getLastCommittedTransactionId() );
               InputCache inputCache = new InputCache( fileSystem, storeDir ) )
         {
             // Some temporary caches and indexes in the import

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
@@ -23,6 +23,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.function.IOFunction;
 import org.neo4j.function.RawFunction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -151,7 +152,7 @@ public class InputCache implements Closeable
 
     public InputIterable<InputNode> nodes()
     {
-        return entities( new RawFunction<Void,InputIterator<InputNode>,IOException>()
+        return entities( new IOFunction<Void, InputIterator<InputNode>>()
         {
             @Override
             public InputIterator<InputNode> apply( Void ignore ) throws IOException
@@ -163,7 +164,7 @@ public class InputCache implements Closeable
 
     public InputIterable<InputRelationship> relationships()
     {
-        return entities( new RawFunction<Void,InputIterator<InputRelationship>,IOException>()
+        return entities( new IOFunction<Void, InputIterator<InputRelationship>>()
         {
             @Override
             public InputIterator<InputRelationship> apply( Void ignore ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
@@ -203,4 +203,9 @@ public class BatchingNeoStore implements AutoCloseable
     {
         pageCache.flush();
     }
+
+    public long getLastCommittedTransactionId()
+    {
+        return neoStore.getLastCommittedTransactionId();
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
@@ -27,7 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.function.Function;
-import org.neo4j.function.RawFunction;
+import org.neo4j.function.IOFunction;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.api.CountsVisitor;
@@ -377,7 +377,7 @@ public class CountsTrackerTest
         return oracle;
     }
 
-    private static class Rotation implements RawFunction<CountsTracker, Long, IOException>
+    private static class Rotation implements IOFunction<CountsTracker, Long>
     {
         private final long txId;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
@@ -101,7 +101,7 @@ public class DeadSimpleTransactionIdStore implements TransactionIdStore
     }
 
     @Override
-    public boolean closedTransactionIdIsOnParWithCommittedTransactionId()
+    public boolean closedTransactionIdIsOnParWithOpenedTransactionId()
     {
         return closedTransactionId.getHighestGapFreeNumber() == committedTransactionId.getHighestGapFreeNumber();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalTransactionAppenderTest.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,11 +29,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.transaction.log.BatchingPhysicalTransactionAppender;
@@ -58,11 +57,13 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReaderFactory;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
+import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
 import org.neo4j.kernel.impl.util.SynchronizedArrayIdOrderingQueue;
 import org.neo4j.test.CleanupRule;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -79,6 +80,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.kernel.impl.util.IdOrderingQueue.BYPASS;
 
@@ -315,7 +317,7 @@ public class PhysicalTransactionAppenderTest
     }
 
     @Test
-    public void shouldCloseTransactionThatWasAppendedAndMarkedAsCommitButFailedBeforeExitingAppend() throws Exception
+    public void shouldCloseTransactionThatWasAppendedButFailedBeforeExitingAppend() throws Exception
     {
         // GIVEN
         long txId = 3;
@@ -343,8 +345,6 @@ public class PhysicalTransactionAppenderTest
             // THEN
             assertTrue( contains( e, failureMessage, IOException.class ) );
             verify( transactionIdStore, times( 1 ) ).nextCommittingTransactionId();
-            verify( transactionIdStore, times( 1 ) ).transactionCommitted( txId, LogEntryStart.checksum(
-                    transaction.additionalHeader(), transaction.getMasterId(), transaction.getAuthorId() ) );
             verify( transactionIdStore, times( 1 ) ).transactionClosed( txId );
             verifyNoMoreInteractions( transactionIdStore );
         }

--- a/community/primitive-collections/src/main/java/org/neo4j/function/IOFunction.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/function/IOFunction.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.function;
+
+import java.io.IOException;
+
+public interface IOFunction<FROM, TO> extends RawFunction<FROM, TO, IOException>
+{
+}

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.impl.transaction.log.LogRotation;
+import org.neo4j.kernel.impl.util.Condition;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.logging.DevNullLoggingService;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static java.lang.System.currentTimeMillis;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+
+public class BackupServiceStressTestingBuilder
+{
+    private Condition untilCondition;
+    private File storeDir;
+    private File workingDirectory;
+    private String backupHostname = "localhost";
+    private int backupPort = 8200;
+
+    public static Condition untilTimeExpired( long duration, TimeUnit unit )
+    {
+        final long endTimeInMilliseconds = currentTimeMillis() + unit.toMillis( duration );
+        return new Condition()
+        {
+            @Override
+            public boolean evaluate()
+            {
+                return currentTimeMillis() <= endTimeInMilliseconds;
+            }
+        };
+    }
+
+    public BackupServiceStressTestingBuilder until( Condition untilCondition )
+    {
+        Objects.requireNonNull( untilCondition );
+        this.untilCondition = untilCondition;
+        return this;
+    }
+
+    public BackupServiceStressTestingBuilder withStore( File storeDir )
+    {
+        Objects.requireNonNull( storeDir );
+        assert storeDir.exists() && storeDir.isDirectory();
+        this.storeDir = storeDir;
+        return this;
+    }
+
+    public BackupServiceStressTestingBuilder withWorkingDirectory( File workingDirectory )
+    {
+        Objects.requireNonNull( workingDirectory );
+        assert workingDirectory.exists() && workingDirectory.isDirectory();
+        this.workingDirectory = workingDirectory;
+        return this;
+    }
+
+    public BackupServiceStressTestingBuilder withBackupAddress( String hostname, int port )
+    {
+        Objects.requireNonNull( hostname );
+        this.backupHostname = hostname;
+        this.backupPort = port;
+        return this;
+    }
+
+    public Callable<Integer> build()
+    {
+        Objects.requireNonNull( untilCondition, "must specify a condition" );
+        Objects.requireNonNull( storeDir, "must specify a directory containing the db to backup from" );
+        Objects.requireNonNull( workingDirectory, "must specify a directory where to save backups/broken stores" );
+        return new RunTest( untilCondition, storeDir, workingDirectory, backupHostname, backupPort );
+    }
+
+    private static class RunTest implements Callable<Integer>
+    {
+        private final FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
+
+        private final Condition until;
+        private final File storeDir;
+        private final String backupHostname;
+        private final int backupPort;
+        private final File backupDir;
+        private final File brokenDir;
+
+        private RunTest( Condition until, File storeDir, File workingDir, String backupHostname, int backupPort )
+        {
+            this.until = until;
+            this.storeDir = storeDir;
+            this.backupHostname = backupHostname;
+            this.backupPort = backupPort;
+            this.backupDir = new File( workingDir, "backup" );
+            fileSystem.mkdir( backupDir );
+            this.brokenDir = new File( workingDir, "broken_stores" );
+            fileSystem.mkdir( brokenDir );
+        }
+
+        @Override
+        public Integer call() throws Exception
+        {
+            final GraphDatabaseAPI db = (GraphDatabaseAPI) new GraphDatabaseFactory()
+                    .newEmbeddedDatabaseBuilder( storeDir.getAbsolutePath() )
+                    .setConfig( OnlineBackupSettings.online_backup_server, backupHostname + ":" + backupPort )
+                    .setConfig( GraphDatabaseSettings.keep_logical_logs, "true" )
+                    .newGraphDatabase();
+
+            try
+            {
+                createIndex( db );
+                createSomeData( db );
+                rotateLog( db );
+
+                final AtomicBoolean keepGoing = new AtomicBoolean( true );
+
+                // when
+                final OnlineBackupKernelExtension backup = new OnlineBackupKernelExtension(
+                        new Config(),
+                        db,
+                        db.getDependencyResolver().resolveDependency( KernelPanicEventGenerator.class ),
+                        new DevNullLoggingService(),
+                        new Monitors() );
+                try
+                {
+                    backup.init();
+                    backup.start();
+                }
+                catch ( Throwable t )
+                {
+                    throw new RuntimeException( t );
+                }
+
+                ExecutorService executor = Executors.newFixedThreadPool( 2 );
+                executor.execute( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        while ( keepGoing.get() && until.evaluate() )
+                        {
+                            createSomeData( db );
+                        }
+                    }
+                } );
+
+                final AtomicInteger inconsistentDbs = new AtomicInteger( 0 );
+                executor.execute( new Runnable()
+                {
+                    private final BackupService backupService = new BackupService(
+                            fileSystem, StringLogger.DEV_NULL, new Monitors() );
+
+                    @Override
+                    public void run()
+                    {
+                        while ( keepGoing.get() && until.evaluate() )
+                        {
+                            cleanup( backupDir );
+                            BackupService.BackupOutcome backupOutcome =
+                                    backupService.doFullBackup( backupHostname, backupPort,
+                                            backupDir.getAbsolutePath(), true, new Config(),
+                                            BackupClient.BIG_READ_TIMEOUT,
+                                            false );
+
+                            if ( !backupOutcome.isConsistent() )
+                            {
+                                keepGoing.set( false );
+                                int num = inconsistentDbs.incrementAndGet();
+                                File dir = new File( brokenDir, "" + num );
+                                fileSystem.mkdir( dir );
+                                copyRecursively( backupDir, dir );
+                            }
+                        }
+                    }
+
+                    private void copyRecursively( File from, File to )
+                    {
+                        try
+                        {
+                            fileSystem.copyRecursively( from, to );
+                        }
+                        catch ( IOException e )
+                        {
+                            throw new RuntimeException( e );
+                        }
+                    }
+
+                    private void cleanup( File dir )
+                    {
+                        try
+                        {
+                            fileSystem.deleteRecursively( dir );
+                        }
+                        catch ( IOException e )
+                        {
+                            throw new RuntimeException( e );
+                        }
+                    }
+
+                } );
+
+                while ( keepGoing.get() && until.evaluate() )
+                {
+                    Thread.sleep( 500 );
+                }
+
+                executor.shutdown();
+                assertTrue( executor.awaitTermination( 30, TimeUnit.SECONDS ) );
+
+                try
+                {
+                    backup.stop();
+                    backup.shutdown();
+                }
+                catch ( Throwable t )
+                {
+                    throw new RuntimeException( t );
+                }
+
+                return inconsistentDbs.get();
+            }
+            finally
+            {
+                db.shutdown();
+            }
+        }
+
+
+        private void createIndex( GraphDatabaseAPI db )
+        {
+            Random random = ThreadLocalRandom.current();
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().indexFor( label( "" + random.nextInt( 3 ) ) ).on( "name" ).create();
+                tx.success();
+            }
+        }
+
+        private void createSomeData( GraphDatabaseAPI db )
+        {
+            Random random = ThreadLocalRandom.current();
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node start = db.createNode( label( "" + random.nextInt( 3 ) ) );
+                start.setProperty( "name", "name " + random.nextInt() );
+                Node end = db.createNode( label( "" + random.nextInt( 3 ) ) );
+                end.setProperty( "name", "name " + random.nextInt() );
+                Relationship rel = start.createRelationshipTo( end, withName( "" + random.nextInt( 5 ) ) );
+                rel.setProperty( "something", "some " + random.nextInt() );
+                tx.success();
+            }
+        }
+
+        private void rotateLog( GraphDatabaseAPI db ) throws IOException
+        {
+            db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
+        }
+
+    }
+}

--- a/stresstests/pom.xml
+++ b/stresstests/pom.xml
@@ -11,9 +11,9 @@
   <artifactId>neo4j-stresstests</artifactId>
   <version>2.2-SNAPSHOT</version>
 
-  <name>Neo4j - Page Cache Stress Tests</name>
+  <name>Neo4j - Stress Tests</name>
   <packaging>jar</packaging>
-  <description>A package for page cache stress tests.</description>
+  <description>A package for stress tests.</description>
 
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
@@ -59,6 +59,19 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-backup</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-backup</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <exclusions>
@@ -71,11 +84,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.Long.parseLong;
+import static java.lang.System.getProperty;
+import static java.lang.System.getenv;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.backup.BackupServiceStressTestingBuilder.untilTimeExpired;
+
+/**
+ * Notice the class name: this is _not_ going to be run as part of the main build.
+ */
+public class BackupServiceStressTesting
+{
+    private static final String DEFAULT_DURATION_IN_MINUTES = "10";
+    private static final String DEFAULT_STORE_DIR = new File( getProperty( "java.io.tmpdir" ), "store" ).getPath();
+    private static final String DEFAULT_WORKING_DIR = new File( getProperty( "java.io.tmpdir" ), "work" ).getPath();
+    private static final String DEFAULT_HOSTNAME = "localhost";
+    private static final String DEFAULT_PORT = "8200";
+
+    @Test
+    public void shouldBehaveCorrectlyUnderStress() throws Exception
+    {
+        long durationInMinutes = parseLong( fromEnv( "BACKUP_SERVICE_STRESS_DURATION", DEFAULT_DURATION_IN_MINUTES ) );
+        String storeDirectory = fromEnv( "BACKUP_SERVICE_STRESS_STORE_DIRECTORY", DEFAULT_STORE_DIR );
+        String workingDirectory = fromEnv( "BACKUP_SERVICE_STRESS_WORKING_DIRECTORY", DEFAULT_WORKING_DIR );
+        String backupHostname = fromEnv( "BACKUP_SERVICE_STRESS_WORKING_DIRECTORY", DEFAULT_HOSTNAME );
+        int backupPort = parseInt( fromEnv( "BACKUP_SERVICE_STRESS_BACKUP_PORT", DEFAULT_PORT ) );
+
+        Callable<Integer> callable = new BackupServiceStressTestingBuilder()
+                .until( untilTimeExpired( durationInMinutes, MINUTES ) )
+                .withStore( ensureExists( storeDirectory ) )
+                .withWorkingDirectory( ensureExists( workingDirectory ) )
+                .withBackupAddress( backupHostname, backupPort )
+                .build();
+
+        int brokenStores = callable.call();
+
+        assertEquals( 0, brokenStores );
+    }
+
+    private File ensureExists( String directory )
+    {
+        File dir = new File( directory );
+        dir.mkdirs();
+        return dir;
+    }
+
+    private static String fromEnv( String environmentVariableName, String defaultValue )
+    {
+        String environmentVariableValue = getenv( environmentVariableName );
+        return environmentVariableValue == null ? defaultValue : environmentVariableValue;
+    }
+}


### PR DESCRIPTION
Resolves the following issues:

1. The previous state was closed before we grabbed the lock and transitioned from the rotation state to the next state.
2. The version assigned to the snapshot during rotation was the highest applied version, instead of the highest version in the previous state, this would lead to later transactions being ignored.
3. Rotation would not wait for the requested rotation version, it would only wait for all versions of the previous state to be perfectly sequential. This also allowed for a race condition where later transactions could sneak in (out of order) after the decision was made that rotation should commence.