### PR TITLE
No RelationshipRecord instantiations during iterating

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
@@ -30,7 +30,9 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.state.NodeState;
 import org.neo4j.kernel.impl.api.state.RelationshipState;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.util.diffsets.ReadableDiffSets;
+import org.neo4j.kernel.impl.util.diffsets.ReadableRelationshipDiffSets;
 
 /**
  * Kernel transaction state.
@@ -54,7 +56,7 @@ public interface ReadableTxState
     ReadableDiffSets<Long> addedAndRemovedNodes();
 
     /** Returns rels that have been added and removed in this tx. */
-    ReadableDiffSets<Long> addedAndRemovedRelationships();
+    ReadableRelationshipDiffSets<Long> addedAndRemovedRelationships();
 
     /** Nodes that have had labels, relationships, or properties modified in this tx. */
     Iterable<NodeState> modifiedNodes();
@@ -89,10 +91,10 @@ public interface ReadableTxState
     boolean nodeModifiedInThisTx( long nodeId );
 
     // TODO: refactor so that these are the same!
-    PrimitiveLongIterator augmentRelationships( long nodeId, Direction direction, PrimitiveLongIterator stored );
+    RelationshipIterator augmentRelationships( long nodeId, Direction direction, RelationshipIterator stored );
 
-    PrimitiveLongIterator augmentRelationships( long nodeId, Direction direction, int[] relTypes,
-                                                PrimitiveLongIterator stored );
+    RelationshipIterator augmentRelationships( long nodeId, Direction direction, int[] relTypes,
+            RelationshipIterator stored );
 
     PrimitiveLongIterator addedRelationships( long nodeId, int[] relTypes, Direction direction );
 
@@ -104,7 +106,7 @@ public interface ReadableTxState
 
     PrimitiveLongIterator augmentNodesGetAll( PrimitiveLongIterator committed );
 
-    PrimitiveLongIterator augmentRelationshipsGetAll( PrimitiveLongIterator committed );
+    RelationshipIterator augmentRelationshipsGetAll( RelationshipIterator committed );
 
     /**
      * @return {@code true} if the relationship was visited in this state, i.e. if it was created

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipVisitor.java
@@ -21,5 +21,11 @@ package org.neo4j.kernel.impl.api;
 
 public interface RelationshipVisitor<EXCEPTION extends Exception>
 {
+    interface Home
+    {
+        <EXCEPTION extends Exception> boolean relationshipVisit( long relId,
+                RelationshipVisitor<EXCEPTION> visitor ) throws EXCEPTION;
+    }
+
     void visit( long relId, int type, long startNode, long endNode ) throws EXCEPTION;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LabelState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LabelState.java
@@ -129,7 +129,7 @@ public abstract class LabelState
     static abstract class Defaults extends StateDefaults<Integer, LabelState, Mutable>
     {
         @Override
-        Mutable createValue( Integer key )
+        Mutable createValue( Integer key, TxState state )
         {
             return new Mutable( key );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipState.java
@@ -72,7 +72,7 @@ public interface RelationshipState extends PropertyContainerState
     abstract class Defaults extends StateDefaults<Long, RelationshipState, RelationshipState.Mutable>
     {
         @Override
-        Mutable createValue( Long id )
+        Mutable createValue( Long id, TxState state )
         {
             return new Mutable( id );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
@@ -92,7 +92,7 @@ abstract class StateDefaults<KEY, RO, RW extends RO>
         RW value = map.get( key );
         if ( value == null )
         {
-            map.put( key, value = createValue( key ) );
+            map.put( key, value = createValue( key, state ) );
         }
         return value;
     }
@@ -115,8 +115,9 @@ abstract class StateDefaults<KEY, RO, RW extends RO>
     /** Implemented for the value holder - set the map to the state field. */
     abstract void setMap( TxState state, Map<KEY, RW> map );
 
-    /** Implemented for the value type - initializes state by creating a new instance. */
-    abstract RW createValue( KEY key );
+    /** Implemented for the value type - initializes state by creating a new instance.
+     * @param state */
+    abstract RW createValue( KEY key, TxState state );
 
     /** Implemented for the value type - returns a default read-only version of the value type. */
     abstract RO defaultValue();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -398,14 +398,14 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongIterator nodeListRelationships( long nodeId, Direction direction )
+    public RelationshipIterator nodeListRelationships( long nodeId, Direction direction )
             throws EntityNotFoundException
     {
         return diskLayer.nodeListRelationships( nodeId, direction );
     }
 
     @Override
-    public PrimitiveLongIterator nodeListRelationships( long nodeId, Direction direction,
+    public RelationshipIterator nodeListRelationships( long nodeId, Direction direction,
                                                         int[] relTypes ) throws EntityNotFoundException
     {
         return diskLayer.nodeListRelationships( nodeId, direction, relTypes );
@@ -479,7 +479,7 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongIterator relationshipsGetAll()
+    public RelationshipIterator relationshipsGetAll()
     {
         return diskLayer.relationshipsGetAll();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/RelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/RelationshipIterator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongCollections.PrimitiveLongBaseIterator;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+
+public interface RelationshipIterator extends PrimitiveLongIterator, RelationshipVisitor.Home
+{
+    /**
+     * Can be called to visit the data about the most recent id returned from {@link #next()}.
+     */
+    @Override
+    <EXCEPTION extends Exception> boolean relationshipVisit( long relationshipId,
+            RelationshipVisitor<EXCEPTION> visitor ) throws EXCEPTION;
+
+    class Empty extends PrimitiveLongCollections.PrimitiveLongBaseIterator implements RelationshipIterator
+    {
+        @Override
+        public <EXCEPTION extends Exception> boolean relationshipVisit( long relationshipId,
+                RelationshipVisitor<EXCEPTION> visitor )
+        {   // Nothing to visit
+            return false;
+        }
+
+        @Override
+        protected boolean fetchNext()
+        {
+            return false;
+        }
+    }
+
+    RelationshipIterator EMPTY = new Empty();
+
+    abstract class BaseIterator extends PrimitiveLongBaseIterator implements RelationshipIterator
+    {
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -59,10 +59,10 @@ public interface StoreReadLayer
 
     PrimitiveIntIterator nodeGetLabels( long nodeId ) throws EntityNotFoundException;
 
-    PrimitiveLongIterator nodeListRelationships( long nodeId, Direction direction)
+    RelationshipIterator nodeListRelationships( long nodeId, Direction direction)
             throws EntityNotFoundException;
 
-    PrimitiveLongIterator nodeListRelationships( long nodeId, Direction direction,
+    RelationshipIterator nodeListRelationships( long nodeId, Direction direction,
             int[] relTypes ) throws EntityNotFoundException;
 
     int nodeGetDegree( long nodeId, Direction direction )
@@ -166,7 +166,7 @@ public interface StoreReadLayer
 
     PrimitiveLongIterator nodesGetAll();
 
-    PrimitiveLongIterator relationshipsGetAll();
+    RelationshipIterator relationshipsGetAll();
 
     /**
      * Reserves a node id for future use.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeToken.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.core;
 
 import org.neo4j.graphdb.RelationshipType;
 
-class RelationshipTypeToken extends Token implements RelationshipType
+public class RelationshipTypeToken extends Token implements RelationshipType
 {
     public RelationshipTypeToken( String name, int id )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
@@ -97,30 +97,14 @@ public class RelationshipStore extends AbstractRecordStore<RelationshipRecord> i
     public RelationshipRecord getRecord( long id )
     {
         RelationshipRecord record = new RelationshipRecord( id );
-
-        if ( fillRecord( id, record, RecordLoad.NORMAL ) )
-        {
-            return record;
-        }
-        else
-        {
-            return null;
-        }
+        return fillRecord( id, record, RecordLoad.NORMAL ) ? record : null;
     }
 
     @Override
     public RelationshipRecord forceGetRecord( long id )
     {
         RelationshipRecord record = new RelationshipRecord( -1 );
-
-        if ( fillRecord( id, record, RecordLoad.FORCE ) )
-        {
-            return record;
-        }
-        else
-        {
-            return null;
-        }
+        return fillRecord( id, record, RecordLoad.FORCE ) ? record : null;
     }
 
     @Override
@@ -138,15 +122,7 @@ public class RelationshipStore extends AbstractRecordStore<RelationshipRecord> i
     public RelationshipRecord getLightRel( long id )
     {
         RelationshipRecord record = new RelationshipRecord( id );
-
-        if( fillRecord( id, record, RecordLoad.CHECK ) )
-        {
-            return record;
-        }
-        else
-        {
-            return null;
-        }
+        return fillRecord( id, record, RecordLoad.CHECK ) ? record : null;
     }
 
     public boolean fillRecord( long id, RelationshipRecord target, RecordLoad loadMode )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipRecord.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.store.record;
 
-
 public class RelationshipRecord extends PrimitiveRecord
 {
     private long firstNode;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
@@ -30,9 +30,9 @@ import org.neo4j.graphdb.Resource;
  * Applies a diffset to the given source PrimitiveLongIterator.
  * If the given source is a Resource, then so is this DiffApplyingPrimitiveLongIterator.
  */
-public final class DiffApplyingPrimitiveLongIterator extends PrimitiveLongBaseIterator implements Resource
+public class DiffApplyingPrimitiveLongIterator extends PrimitiveLongBaseIterator implements Resource
 {
-    private enum Phase
+    protected enum Phase
     {
         FILTERED_SOURCE
         {
@@ -68,7 +68,7 @@ public final class DiffApplyingPrimitiveLongIterator extends PrimitiveLongBaseIt
     private final Iterator<?> addedElementsIterator;
     private final Set<?> addedElements;
     private final Set<?> removedElements;
-    private Phase phase;
+    protected Phase phase;
 
     public DiffApplyingPrimitiveLongIterator( PrimitiveLongIterator source,
                                               Set<?> addedElements, Set<?> removedElements )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingRelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingRelationshipIterator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.util.Set;
+
+import org.neo4j.graphdb.Resource;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+
+/**
+ * Applies a diffset to the given source {@link RelationshipIterator}.
+ * If the given source is a {@link Resource}, then so is this {@link DiffApplyingRelationshipIterator}.
+ */
+public class DiffApplyingRelationshipIterator extends DiffApplyingPrimitiveLongIterator implements RelationshipIterator
+{
+    private final RelationshipVisitor.Home sourceHome;
+    private final RelationshipVisitor.Home addedHome;
+
+    public DiffApplyingRelationshipIterator( RelationshipIterator source,
+                                             Set<?> addedElements, Set<?> removedElements,
+                                             RelationshipVisitor.Home addedHome )
+    {
+        super( source, addedElements, removedElements );
+        this.sourceHome = source;
+        this.addedHome = addedHome;
+    }
+
+    @Override
+    public <EXCEPTION extends Exception> boolean relationshipVisit( long relId,
+            RelationshipVisitor<EXCEPTION> visitor ) throws EXCEPTION
+    {
+        assert relId == next;
+        switch ( phase )
+        {
+        case FILTERED_SOURCE: return sourceHome.relationshipVisit( next, visitor );
+        case ADDED_ELEMENTS: return addedHome.relationshipVisit( next, visitor );
+        default: throw new IllegalStateException( "Shouldn't have come here in phase " + phase );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/ReadableRelationshipDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/ReadableRelationshipDiffSets.java
@@ -24,31 +24,33 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.helpers.Predicate;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 
-public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLongIterator>
+public interface ReadableRelationshipDiffSets<T> extends SuperReadableDiffSets<T,RelationshipIterator>
 {
     @Override
-    ReadableDiffSets<T> filterAdded( Predicate<T> addedFilter );
+    ReadableRelationshipDiffSets<T> filterAdded( Predicate<T> addedFilter );
 
     @Override
-    ReadableDiffSets<T> filter( Predicate<T> filter );
+    ReadableRelationshipDiffSets<T> filter( Predicate<T> filter );
 
-    static final class Empty<T> implements ReadableDiffSets<T>
+    static final class Empty<T> implements ReadableRelationshipDiffSets<T>
     {
         @SuppressWarnings( "unchecked" )
-        public static <T> ReadableDiffSets<T> instance()
+        public static <T> ReadableRelationshipDiffSets<T> instance()
         {
             return INSTANCE;
         }
 
-        public static <T> ReadableDiffSets<T> ifNull( ReadableDiffSets<T> diffSets )
+        @SuppressWarnings( "unchecked" )
+        public static <T> ReadableRelationshipDiffSets<T> ifNull( ReadableRelationshipDiffSets<T> diffSets )
         {
-            return diffSets == null ? Empty.<T>instance() : diffSets;
+            return diffSets == null ? INSTANCE : diffSets;
         }
 
-        private static final ReadableDiffSets INSTANCE = new Empty();
+        @SuppressWarnings( "rawtypes" )
+        private static final ReadableRelationshipDiffSets INSTANCE = new Empty();
 
         private Empty()
         {
@@ -98,7 +100,7 @@ public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLo
         }
 
         @Override
-        public PrimitiveLongIterator augment( PrimitiveLongIterator source )
+        public RelationshipIterator augment( RelationshipIterator source )
         {
             return source;
         }
@@ -110,25 +112,25 @@ public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLo
         }
 
         @Override
-        public PrimitiveLongIterator augmentWithRemovals( PrimitiveLongIterator source )
+        public RelationshipIterator augmentWithRemovals( RelationshipIterator source )
         {
             return source;
         }
 
         @Override
-        public PrimitiveLongIterator augmentWithAdditions( PrimitiveLongIterator source )
+        public RelationshipIterator augmentWithAdditions( RelationshipIterator source )
         {
             return source;
         }
 
         @Override
-        public ReadableDiffSets<T> filterAdded( Predicate<T> addedFilter )
+        public ReadableRelationshipDiffSets<T> filterAdded( Predicate<T> addedFilter )
         {
             return this;
         }
 
         @Override
-        public ReadableDiffSets<T> filter( Predicate<T> filter )
+        public ReadableRelationshipDiffSets<T> filter( Predicate<T> filter )
         {
             return this;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.diffsets;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.helpers.Predicate;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.util.VersionedHashMap;
+
+import static java.lang.String.format;
+import static java.util.Collections.newSetFromMap;
+
+import static org.neo4j.helpers.collection.Iterables.concat;
+
+/**
+ * Super class of readable diffsets where use of {@link PrimitiveLongIterator} can be parameterized
+ * to a specific subclass instead.
+ */
+abstract class SuperDiffSets<T,LONGITERATOR extends PrimitiveLongIterator>
+        implements SuperReadableDiffSets<T,LONGITERATOR>
+{
+    private Set<T> addedElements;
+    private Set<T> removedElements;
+    private Predicate<T> filter;
+
+    public SuperDiffSets()
+    {
+        this( null, null );
+    }
+
+    public SuperDiffSets( Set<T> addedElements, Set<T> removedElements )
+    {
+        this.addedElements = addedElements;
+        this.removedElements = removedElements;
+    }
+
+    @Override
+    public void accept( DiffSetsVisitor<T> visitor )
+    {
+        for ( T element : added( false ) )
+        {
+            visitor.visitAdded( element );
+        }
+        for ( T element : removed( false ) )
+        {
+            visitor.visitRemoved( element );
+        }
+    }
+
+    public boolean add( T elem )
+    {
+        boolean wasRemoved = removed( false ).remove( elem );
+        // Add to the addedElements only if it was not removed from the removedElements
+        return wasRemoved || added( true ).add( elem );
+    }
+
+    public void replace( T toRemove, T toAdd )
+    {
+        Set<T> added = added( true ); // we're doing both add and remove on it, so pass in true
+        boolean removedFromAdded = added.remove( toRemove );
+        removed( false ).remove( toAdd );
+
+        added.add( toAdd );
+        if ( !removedFromAdded )
+        {
+            removed( true ).add( toRemove );
+        }
+    }
+
+    public boolean remove( T elem )
+    {
+        boolean removedFromAddedElements = added( false ).remove( elem );
+        // Add to the removedElements only if it was not removed from the addedElements.
+        return removedFromAddedElements || removed( true ).add( elem );
+    }
+
+    public void addAll( Iterator<T> elems )
+    {
+        while ( elems.hasNext() )
+        {
+            add( elems.next() );
+        }
+    }
+
+    public void removeAll( Iterator<T> elems )
+    {
+        while ( elems.hasNext() )
+        {
+            remove( elems.next() );
+        }
+    }
+
+    @Override
+    public boolean isAdded( T elem )
+    {
+        return added( false ).contains( elem );
+    }
+
+    @Override
+    public boolean isRemoved( T elem )
+    {
+        return removed( false ).contains( elem );
+    }
+
+    @Override
+    public Set<T> getAdded()
+    {
+        return resultSet( addedElements );
+    }
+
+    @Override
+    public Set<T> getRemoved()
+    {
+        return resultSet( removedElements );
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return added( false ).isEmpty() && removed( false ).isEmpty();
+    }
+
+    @Override
+    public Iterator<T> apply( Iterator<T> source )
+    {
+        Iterator<T> result = source;
+        if ( ( removedElements != null && !removedElements.isEmpty() ) ||
+             ( addedElements != null && !addedElements.isEmpty() ) )
+        {
+            ensureFilterHasBeenCreated();
+            result = Iterables.filter( filter, result );
+        }
+        if ( addedElements != null && !addedElements.isEmpty() )
+        {
+            result = concat( result, addedElements.iterator() );
+        }
+        return result;
+    }
+
+    protected Set<T> added( boolean create )
+    {
+        if ( addedElements == null )
+        {
+            if ( !create )
+            {
+                return Collections.emptySet();
+            }
+            addedElements = newSet();
+        }
+        return addedElements;
+    }
+
+    protected Set<T> removed( boolean create )
+    {
+        if ( removedElements == null )
+        {
+            if ( !create )
+            {
+                return Collections.emptySet();
+            }
+            removedElements = newSet();
+        }
+        return removedElements;
+    }
+
+    private void ensureFilterHasBeenCreated()
+    {
+        if ( filter == null )
+        {
+            filter = new Predicate<T>()
+            {
+                @Override
+                public boolean accept( T item )
+                {
+                    return !removed( false ).contains( item ) && !added( false ).contains( item );
+                }
+            };
+        }
+    }
+
+    @Override
+    public int delta()
+    {
+        return added( false ).size() - removed( false ).size();
+    }
+
+    private Set<T> newSet()
+    {
+        return newSetFromMap( new VersionedHashMap<T, Boolean>() );
+    }
+
+    private Set<T> resultSet( Set<T> coll )
+    {
+        return coll == null ? Collections.<T>emptySet() : Collections.unmodifiableSet( coll );
+    }
+
+    public boolean unRemove( T item )
+    {
+        return removed( false ).remove( item );
+    }
+
+    public void clear()
+    {
+        if(addedElements != null)
+        {
+            addedElements.clear();
+        }
+        if(removedElements != null)
+        {
+            removedElements.clear();
+        }
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        SuperDiffSets diffSets = (SuperDiffSets) o;
+
+        if ( addedElements != null ? !addedElements.equals( diffSets.addedElements ) : diffSets.addedElements != null )
+        {
+            return false;
+        }
+        if ( filter != null ? !filter.equals( diffSets.filter ) : diffSets.filter != null )
+        {
+            return false;
+        }
+        if ( removedElements != null ? !removedElements.equals( diffSets.removedElements ) : diffSets.removedElements
+                != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = addedElements != null ? addedElements.hashCode() : 0;
+        result = 31 * result + (removedElements != null ? removedElements.hashCode() : 0);
+        result = 31 * result + (filter != null ? filter.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "{+%s, -%s}", added( false ), removed( false ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperReadableDiffSets.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.diffsets;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.neo4j.collection.primitive.PrimitiveIntIterator;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.helpers.Predicate;
+
+/**
+ * Super class of diff sets where use of {@link PrimitiveLongIterator} can be parameterized
+ * to a specific subclass instead.
+ */
+public interface SuperReadableDiffSets<T,LONGITERATOR extends PrimitiveLongIterator>
+{
+    boolean isAdded( T elem );
+
+    boolean isRemoved( T elem );
+
+    Set<T> getAdded();
+
+    Set<T> getRemoved();
+
+    boolean isEmpty();
+
+    Iterator<T> apply( Iterator<T> source );
+
+    int delta();
+
+    LONGITERATOR augment( LONGITERATOR source );
+
+    PrimitiveIntIterator augment( PrimitiveIntIterator source );
+
+    LONGITERATOR augmentWithRemovals( LONGITERATOR source );
+
+    LONGITERATOR augmentWithAdditions( LONGITERATOR source );
+
+    SuperReadableDiffSets<T,LONGITERATOR> filterAdded( Predicate<T> addedFilter );
+
+    SuperReadableDiffSets<T,LONGITERATOR> filter( Predicate<T> filter );
+
+    void accept( DiffSetsVisitor<T> visitor );
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -43,7 +43,6 @@ import org.neo4j.graphdb.schema.ConstraintCreator;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexCreator;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.helpers.Function;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.IteratorWrapper;
 import org.neo4j.helpers.collection.Visitor;
@@ -80,7 +79,9 @@ import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.api.index.StoreScan;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.api.store.SchemaCache;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.coreapi.schema.BaseConstraintCreator;
 import org.neo4j.kernel.impl.coreapi.schema.IndexCreatorImpl;
@@ -139,7 +140,6 @@ import static java.lang.Boolean.parseBoolean;
 
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
 import static org.neo4j.graphdb.DynamicLabel.label;
-import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 import static org.neo4j.kernel.impl.store.PropertyStore.encodeString;
@@ -148,27 +148,6 @@ import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 public class BatchInserterImpl implements BatchInserter
 {
     private static final long MAX_NODE_ID = IdType.NODE.getMaxValue();
-
-    private final Function<RelationshipRecord,Long> REL_RECORD_TO_ID = new Function<RelationshipRecord,Long>()
-    {
-        @Override
-        public Long apply( RelationshipRecord relRecord )
-        {
-            return relRecord.getId();
-        }
-    };
-    private final Function<RelationshipRecord,BatchRelationship> REL_RECORD_TO_BATCH_REL =
-            new Function<RelationshipRecord,BatchRelationship>()
-    {
-        @Override
-        public BatchRelationship apply( RelationshipRecord relRecord )
-        {
-            RelationshipType type = new RelationshipTypeImpl(
-                    relationshipTypeTokens.nameOf( relRecord.getType() ) );
-            return new BatchRelationship( relRecord.getId(),
-                    relRecord.getFirstNode(), relRecord.getSecondNode(), type );
-        }
-    };
 
     private final LifeSupport life;
     private final NeoStore neoStore;
@@ -195,7 +174,7 @@ public class BatchInserterImpl implements BatchInserter
         @Override
         public Label apply( long from )
         {
-            return label( labelTokens.nameOf( safeCastLongToInt( from ) ) );
+            return label( labelTokens.byId( safeCastLongToInt( from ) ).name() );
         }
     };
 
@@ -568,7 +547,7 @@ public class BatchInserterImpl implements BatchInserter
 
     private int getOrCreatePropertyKeyId( String name )
     {
-        int propertyKeyId = getPropertyKeyId( name );
+        int propertyKeyId = tokenIdByName( propertyKeyTokens, name );
         if ( propertyKeyId == -1 )
         {
             propertyKeyId = createNewPropertyKeyId( name );
@@ -578,7 +557,7 @@ public class BatchInserterImpl implements BatchInserter
 
     private int getOrCreateRelationshipTypeToken( RelationshipType type )
     {
-        int typeId = relationshipTypeTokens.idOf( type.name() );
+        int typeId = tokenIdByName( relationshipTypeTokens, type.name() );
         if ( typeId == -1 )
         {
             typeId = createNewRelationshipType( type.name() );
@@ -586,14 +565,9 @@ public class BatchInserterImpl implements BatchInserter
         return typeId;
     }
 
-    private int getPropertyKeyId( String name )
-    {
-        return propertyKeyTokens.idOf( name );
-    }
-
     private int getOrCreateLabelId( String name )
     {
-        int labelId = getLabelId( name );
+        int labelId = tokenIdByName( labelTokens, name );
         if ( labelId == -1 )
         {
             labelId = createNewLabelId( name );
@@ -601,15 +575,15 @@ public class BatchInserterImpl implements BatchInserter
         return labelId;
     }
 
-    private int getLabelId( String name )
+    private int tokenIdByName( BatchTokenHolder tokens, String name )
     {
-        return labelTokens.idOf( name );
+        Token token = tokens.byName( name );
+        return token != null ? token.id() : -1;
     }
 
-    private boolean primitiveHasProperty( PrimitiveRecord record,
-                                          String propertyName )
+    private boolean primitiveHasProperty( PrimitiveRecord record, String propertyName )
     {
-        int propertyKeyId = propertyKeyTokens.idOf( propertyName );
+        int propertyKeyId = tokenIdByName( propertyKeyTokens, propertyName );
         return propertyKeyId != -1 && propertyTraverser.findPropertyRecordContaining( record, propertyKeyId,
                 recordAccess.getPropertyRecords(), false ) != Record.NO_NEXT_PROPERTY.intValue();
     }
@@ -752,7 +726,7 @@ public class BatchInserterImpl implements BatchInserter
     @Override
     public boolean nodeHasLabel( long node, Label label )
     {
-        int labelId = getLabelId( label.name() );
+        int labelId = tokenIdByName( labelTokens, label.name() );
         return labelId != -1 && nodeHasLabel( node, labelId );
     }
 
@@ -832,23 +806,45 @@ public class BatchInserterImpl implements BatchInserter
     @Override
     public Iterable<Long> getRelationshipIds( long nodeId )
     {
-        return map( REL_RECORD_TO_ID, new BatchRelationshipIterable( neoStore, nodeId ) );
+        return new BatchRelationshipIterable<Long>( neoStore, nodeId )
+        {
+            @Override
+            protected Long nextFrom( long relationshipId, RelationshipIterator storeIterator )
+            {
+                return relationshipId;
+            }
+        };
     }
 
     @Override
     public Iterable<BatchRelationship> getRelationships( long nodeId )
     {
-        return map( REL_RECORD_TO_BATCH_REL, new BatchRelationshipIterable( neoStore, nodeId ) );
+        return new BatchRelationshipIterable<BatchRelationship>( neoStore, nodeId )
+        {
+            private BatchRelationship batchRelationship;
+
+            @Override
+            protected BatchRelationship nextFrom( long relationshipId, RelationshipIterator storeIterator )
+            {
+                storeIterator.relationshipVisit( relationshipId, this );
+                return batchRelationship;
+            }
+
+            @Override
+            public void visit( long relId, int type, long startNode, long endNode ) throws RuntimeException
+            {
+                batchRelationship = new BatchRelationship( relId, startNode, endNode,
+                        (RelationshipType) relationshipTypeTokens.byId( type ) );
+            }
+        };
     }
 
     @Override
     public BatchRelationship getRelationshipById( long relId )
     {
         RelationshipRecord record = getRelationshipRecord( relId ).forReadingData();
-        RelationshipType type = new RelationshipTypeImpl(
-                relationshipTypeTokens.nameOf( record.getType() ) );
-        return new BatchRelationship( record.getId(), record.getFirstNode(),
-                                      record.getSecondNode(), type );
+        RelationshipType type = (RelationshipType) relationshipTypeTokens.byId( record.getType() );
+        return new BatchRelationship( record.getId(), record.getFirstNode(), record.getSecondNode(), type );
     }
 
     @Override
@@ -904,22 +900,6 @@ public class BatchInserterImpl implements BatchInserter
         return "EmbeddedBatchInserter[" + storeDir + "]";
     }
 
-    private static class RelationshipTypeImpl implements RelationshipType
-    {
-        private final String name;
-
-        RelationshipTypeImpl( String name )
-        {
-            this.name = name;
-        }
-
-        @Override
-        public String name()
-        {
-            return name;
-        }
-    }
-
     private Map<String, Object> getPropertyChain( long nextProp )
     {
         final Map<String, Object> map = new HashMap<>();
@@ -928,7 +908,7 @@ public class BatchInserterImpl implements BatchInserter
             @Override
             public void receive( PropertyBlock propBlock )
             {
-                String key = propertyKeyTokens.nameOf( propBlock.getKeyIndexId() );
+                String key = propertyKeyTokens.byId( propBlock.getKeyIndexId() ).name();
                 DefinedProperty propertyData = propBlock.newPropertyData( getPropertyStore() );
                 Object value = propertyData.value() != null ? propertyData.value() :
                     propBlock.getType().getValue( propBlock, getPropertyStore() );
@@ -950,7 +930,7 @@ public class BatchInserterImpl implements BatchInserter
         record.setNameId( (int) first( keyRecords ).getId() );
         record.addNameRecords( keyRecords );
         idxStore.updateRecord( record );
-        propertyKeyTokens.addToken( stringKey, keyId );
+        propertyKeyTokens.addToken( new Token( stringKey, keyId ) );
         return keyId;
     }
 
@@ -966,7 +946,7 @@ public class BatchInserterImpl implements BatchInserter
         record.setNameId( (int) first( keyRecords ).getId() );
         record.addNameRecords( keyRecords );
         labelTokenStore.updateRecord( record );
-        labelTokens.addToken( stringKey, keyId );
+        labelTokens.addToken( new Token( stringKey, keyId ) );
         return keyId;
     }
 
@@ -981,7 +961,7 @@ public class BatchInserterImpl implements BatchInserter
         record.setNameId( (int) first( nameRecords ).getId() );
         record.addNameRecords( nameRecords );
         typeStore.updateRecord( record );
-        relationshipTypeTokens.addToken( name, id );
+        relationshipTypeTokens.addToken( new RelationshipTypeToken( name, id ) );
         return id;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
@@ -21,182 +21,58 @@ package org.neo4j.unsafe.batchinsert;
 
 import java.util.Iterator;
 
+import org.neo4j.collection.primitive.PrimitiveIntCollections;
+import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.helpers.collection.PrefetchingIterator;
-import org.neo4j.kernel.impl.store.InvalidRecordException;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.StoreRelationshipIterable;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.store.NeoStore;
-import org.neo4j.kernel.impl.store.RelationshipGroupStore;
-import org.neo4j.kernel.impl.store.RelationshipStore;
-import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.store.record.Record;
-import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
-import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
-public class BatchRelationshipIterable implements Iterable<RelationshipRecord>
+import static org.neo4j.graphdb.Direction.BOTH;
+
+abstract class BatchRelationshipIterable<T> implements Iterable<T>, RelationshipVisitor<RuntimeException>
 {
-    private final NeoStore neoStore;
-    private final RelationshipStore relStore;
-    private final RelationshipGroupStore groupStore;
-    private final long nodeId;
+    protected final StoreRelationshipIterable storeIterable;
 
     public BatchRelationshipIterable( NeoStore neoStore, long nodeId )
     {
-        this.neoStore = neoStore;
-        this.relStore = neoStore.getRelationshipStore();
-        this.groupStore = neoStore.getRelationshipGroupStore();
-        this.nodeId = nodeId;
+        try
+        {
+            this.storeIterable = new StoreRelationshipIterable( neoStore, nodeId, PrimitiveIntCollections.alwaysTrue(), BOTH );
+        }
+        catch ( EntityNotFoundException e )
+        {
+            throw new NotFoundException( e.entityType() + " " + e.entityId() + " not found" );
+        }
     }
 
     @Override
-    public Iterator<RelationshipRecord> iterator()
+    public Iterator<T> iterator()
     {
-        NodeRecord nodeRecord = neoStore.getNodeStore().getRecord( nodeId );
-        if ( nodeRecord.isDense() )
+        return new PrefetchingIterator<T>()
         {
-            return new DenseIterator( nodeRecord );
-        }
-        return new SparseIterator( nodeRecord );
-    }
+            private final RelationshipIterator storeIterator = storeIterable.iterator();
 
-    public long nextRelationship( long relId, NodeRecord nodeRecord )
-    {
-        RelationshipRecord relRecord = relStore.getRecord( relId );
-        long firstNode = relRecord.getFirstNode();
-        long secondNode = relRecord.getSecondNode();
-        long nextRel;
-        if ( firstNode == nodeId )
-        {
-            nextRel = relRecord.getFirstNextRel();
-        }
-        else if ( secondNode == nodeId )
-        {
-            nextRel = relRecord.getSecondNextRel();
-        }
-        else
-        {
-            throw new InvalidRecordException( "Node[" + nodeId +
-                    "] not part of firstNode[" + firstNode +
-                    "] or secondNode[" + secondNode + "]" );
-        }
-        return nextRel;
-    }
-
-    public class SparseIterator extends PrefetchingIterator<RelationshipRecord>
-    {
-        private final NodeRecord nodeRecord;
-        private long nextRelId;
-
-        public SparseIterator( NodeRecord nodeRecord )
-        {
-            this.nodeRecord = nodeRecord;
-            this.nextRelId = nodeRecord.getNextRel();
-        }
-
-        @Override
-        protected RelationshipRecord fetchNextOrNull()
-        {
-            if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
+            @Override
+            protected T fetchNextOrNull()
             {
-                return null;
-            }
-
-            try
-            {
-                return relStore.getRecord( nextRelId );
-            }
-            finally
-            {
-                nextRelId = nextRelationship( nextRelId, nodeRecord );
-            }
-        }
-    }
-
-    public class DenseIterator extends PrefetchingIterator<RelationshipRecord>
-    {
-        private final NodeRecord nodeRecord;
-        private RelationshipGroupRecord groupRecord;
-        private int groupChainIndex;
-        private long nextRelId;
-
-        public DenseIterator( NodeRecord nodeRecord )
-        {
-            this.nodeRecord = nodeRecord;
-            this.groupRecord = groupStore.getRecord( nodeRecord.getNextRel() );
-            this.nextRelId = nextChainStart();
-        }
-
-        private long nextChainStart()
-        {
-            while ( groupRecord != null )
-            {
-                // Go to the next chain within the group
-                while ( groupChainIndex < GroupChain.values().length )
+                if ( !storeIterator.hasNext() )
                 {
-                    long chainStart = GroupChain.values()[groupChainIndex++].chainStart( groupRecord );
-                    if ( chainStart != Record.NO_NEXT_RELATIONSHIP.intValue() )
-                    {
-                        return chainStart;
-                    }
+                    return null;
                 }
-
-                // Go to the next group
-                groupRecord = groupRecord.getNext() != Record.NO_NEXT_RELATIONSHIP.intValue() ?
-                        groupStore.getRecord( groupRecord.getNext() ) : null;
-                groupChainIndex = 0;
-            }
-            return Record.NO_NEXT_RELATIONSHIP.intValue();
-        }
-
-        @Override
-        protected RelationshipRecord fetchNextOrNull()
-        {
-            if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
-            {
-                return null;
-            }
-
-            try
-            {
-                return relStore.getRecord( nextRelId );
-            }
-            finally
-            {
-                nextRelId = nextRelationship( nextRelId, nodeRecord );
-                if ( nextRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
-                {   // End of chain, try the next chain
-                    nextRelId = nextChainStart();
-                    // Potentially end of all chains here, and that's fine
-                }
-            }
-        }
-    }
-
-    private static enum GroupChain
-    {
-        OUT
-        {
-            @Override
-            long chainStart( RelationshipGroupRecord groupRecord )
-            {
-                return groupRecord.getFirstOut();
-            }
-        },
-        IN
-        {
-            @Override
-            long chainStart( RelationshipGroupRecord groupRecord )
-            {
-                return groupRecord.getFirstIn();
-            }
-        },
-        LOOP
-        {
-            @Override
-            long chainStart( RelationshipGroupRecord groupRecord )
-            {
-                return groupRecord.getFirstLoop();
+                long relationshipId = storeIterator.next();
+                return nextFrom( relationshipId, storeIterator );
             }
         };
-
-        abstract long chainStart( RelationshipGroupRecord groupRecord );
     }
+
+    @Override
+    public void visit( long relId, int type, long startNode, long endNode ) throws RuntimeException
+    {
+        throw new UnsupportedOperationException( "Should have been implemented by subclass using it" );
+    }
+
+    protected abstract T nextFrom( long relationshipId, RelationshipIterator storeIterator );
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchTokenHolder.java
@@ -19,49 +19,57 @@
  */
 package org.neo4j.unsafe.batchinsert;
 
-import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.util.ArrayMap;
 
 class BatchTokenHolder
 {
-    private final ArrayMap<String,Integer> nameToId =
-        new ArrayMap<String,Integer>( (byte)5, false, false);
-    private final ArrayMap<Integer,String> idToName =
-        new ArrayMap<Integer,String>( (byte)5, false, false);
-    
+    private final ArrayMap<String,Token> nameToToken = new ArrayMap<>( (byte) 5, false, false );
+    private final PrimitiveIntObjectMap<Token> idToToken = Primitive.intObjectMap( 20 );
+
     BatchTokenHolder( Token[] tokens )
     {
         for ( Token token : tokens )
         {
-            nameToId.put( token.name(), token.id() );
-            idToName.put( token.id(), token.name() );
+            addToken( token );
         }
     }
-    
-    void addToken( String stringKey, int keyId )
+
+    void addToken( Token token )
     {
-        nameToId.put( stringKey, keyId );
-        idToName.put( keyId, stringKey );
+        nameToToken.put( token.name(), token );
+        idToToken.put( token.id(), token );
     }
-    
-    int idOf( String stringKey )
+
+    Token byId( int id )
     {
-        Integer id = nameToId.get( stringKey );
-        if ( id != null )
-        {
-            return id;
-        }
-        return -1;
+        return idToToken.get( id );
     }
-    
-    String nameOf( int id )
+
+    Token byName( String name )
     {
-        String name = idToName.get( id );
-        if ( name == null )
-        {
-            throw new NotFoundException( "No token with id:" + id );
-        }
-        return name;
+        return nameToToken.get( name );
     }
+
+//    int idOf( String stringKey )
+//    {
+//        Integer id = nameToToken.get( stringKey );
+//        if ( id != null )
+//        {
+//            return id;
+//        }
+//        return -1;
+//    }
+//
+//    String nameOf( int id )
+//    {
+//        String name = idToName.get( id );
+//        if ( name == null )
+//        {
+//            throw new NotFoundException( "No token with id:" + id );
+//        }
+//        return name;
+//    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNodeTest.java
@@ -20,60 +20,48 @@
 package org.neo4j.kernel.impl.api.state;
 
 import org.junit.Test;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphdb.Direction;
 
-import static org.junit.Assert.*;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.kernel.impl.api.store.RelationshipIterator.EMPTY;
 public class RelationshipChangesForNodeTest
 {
-
-    public static final PrimitiveLongIterator EMPTY = new PrimitiveLongIterator()
-    {
-        @Override
-        public boolean hasNext()
-        {
-            return false;
-        }
-
-        @Override
-        public long next()
-        {
-            return -1;
-        }
-    };
-    public static final int REL_0 = 0;
-    public static final int REL_1 = 1;
-    public static final int TYPE_SELF = 0;
-    public static final int TYPE_DIR = 1;
+    private static final int REL_0 = 0;
+    private static final int REL_1 = 1;
+    private static final int TYPE_SELF = 0;
+    private static final int TYPE_DIR = 1;
 
     @Test
     public void testOutgoingRelsWithTypeAndLoop() throws Exception
     {
-        RelationshipChangesForNode changes = new RelationshipChangesForNode( RelationshipChangesForNode.DiffStrategy.ADD );
+        RelationshipChangesForNode changes = new RelationshipChangesForNode(
+                RelationshipChangesForNode.DiffStrategy.ADD, mock( RelationshipVisitor.Home.class ) );
         changes.addRelationship( REL_0, TYPE_SELF, Direction.BOTH );
         changes.addRelationship( REL_1, TYPE_DIR, Direction.OUTGOING );
 
-        PrimitiveLongIterator iterator = changes.augmentRelationships(
+        RelationshipIterator iterator = changes.augmentRelationships(
                 Direction.OUTGOING, new int[]{TYPE_DIR}, EMPTY );
         assertEquals( true, iterator.hasNext() );
         assertEquals( REL_1, iterator.next() );
-        assertEquals( "should have no next relationships but has ",
-                false,
-                iterator.hasNext() );
+        assertEquals( "should have no next relationships but has ", false, iterator.hasNext() );
     }
     @Test
     public void testIncomingRelsWithTypeAndLoop() throws Exception
     {
-        RelationshipChangesForNode changes = new RelationshipChangesForNode( RelationshipChangesForNode.DiffStrategy.ADD );
+        RelationshipChangesForNode changes = new RelationshipChangesForNode(
+                RelationshipChangesForNode.DiffStrategy.ADD, mock( RelationshipVisitor.Home.class ) );
         changes.addRelationship( REL_0, TYPE_SELF, Direction.BOTH );
         changes.addRelationship( REL_1, TYPE_DIR, Direction.INCOMING );
 
-        PrimitiveLongIterator iterator = changes.augmentRelationships(
+        RelationshipIterator iterator = changes.augmentRelationships(
                 Direction.INCOMING, new int[]{TYPE_DIR}, EMPTY );
         assertEquals( true, iterator.hasNext() );
         assertEquals( REL_1, iterator.next() );
-        assertEquals( "should have no next relationships but has ",
-                false,
-                iterator.hasNext() );
+        assertEquals( "should have no next relationships but has ", false, iterator.hasNext() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreExpandCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreExpandCursorTest.java
@@ -22,10 +22,10 @@ package org.neo4j.kernel.impl.api.store;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
+
 import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.state.TxStateTest;
 import org.neo4j.kernel.impl.util.Cursors;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
 import org.neo4j.register.Register;
@@ -34,7 +34,14 @@ import org.neo4j.register.Registers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.iterator;
 import static org.neo4j.kernel.impl.util.register.NeoRegisters.newNodeRegister;
 import static org.neo4j.kernel.impl.util.register.NeoRegisters.newRelTypeRegister;
 import static org.neo4j.kernel.impl.util.register.NeoRegisters.newRelationshipRegister;
@@ -46,7 +53,7 @@ public class StoreExpandCursorTest
     public void shouldDelegateToGetRelsAndRelVisitor() throws Exception
     {
         // Given
-        PrimitiveLongIterator rels = PrimitiveLongCollections.iterator( 1 );
+        RelationshipIterator rels = TxStateTest.wrapInRelationshipIterator( iterator( 1 ) );
 
         CacheLayer cache = mock(CacheLayer.class);
         when(cache.nodeListRelationships( anyLong(), any(Direction.class), any(int[].class) )).thenReturn( rels );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
@@ -386,22 +386,6 @@ public class TestRelationshipCount
         newTransaction();
         assertCounts( me, expectedCounts );
 
-//        System.out.println( "all" );
-//        System.out.println( "  total:" + me.getDegree() );
-//        for ( Direction direction : Direction.values() )
-//        {
-//            System.out.println( "  " + direction + ":" + me.getDegree( direction ) );
-//        }
-//        for ( RelationshipType type : me.getRelationshipTypes() )
-//        {
-//            System.out.println( "type:" + type );
-//            System.out.println( "  total:" + me.getDegree( type ) );
-//            for ( Direction direction : Direction.values() )
-//            {
-//                System.out.println( "  " + direction + ":" + me.getDegree( type, direction ) );
-//            }
-//        }
-
         // Delete one of each type/direction combination
         counter = 0;
         if ( dspecs == null )
@@ -504,7 +488,6 @@ public class TestRelationshipCount
 
     private void deleteOneRelationship( Node node, RelType type, Direction direction, int which )
     {
-        System.out.println( "deleting one relationship " + type + "/" + direction );
         Relationship last = null;
         int counter = 0;
         for ( Relationship rel : node.getRelationships( type, direction ) )
@@ -515,7 +498,6 @@ public class TestRelationshipCount
                 if ( counter++ == which )
                 {
                     rel.delete();
-                    System.out.println( "  deleted " + rel );
                     return;
                 }
             }
@@ -524,7 +506,6 @@ public class TestRelationshipCount
         if ( which == Integer.MAX_VALUE && last != null )
         {
             last.delete();
-            System.out.println( "  deleted last " + last );
             return;
         }
 


### PR DESCRIPTION
also made RelationshipIterator a RelationshipVisitor so that iterators may
access relationship data while iterating while at the same time not
exposing the (reused) RelationshipRecord.