### PR TITLE
Avoids IndexingService monitor on commit if no index changes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdatesValidator.java
@@ -36,12 +36,11 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
+import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 import org.neo4j.kernel.impl.transaction.state.LazyIndexUpdates;
 import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
-
-import static org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
-import static org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 
 /**
  * Performs validation of index updates for transactions based on
@@ -101,6 +100,12 @@ public class IndexUpdatesValidator
             @Override
             public void close()
             {
+            }
+
+            @Override
+            public boolean hasChanges()
+            {
+                return !nodeIds.isEmpty();
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -66,6 +66,7 @@ import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.concatResourceIterators;
 import static org.neo4j.helpers.collection.Iterables.toList;
@@ -511,6 +512,12 @@ public class IndexingService extends LifecycleAdapter
                 {
                     indexUpdaters.close();
                 }
+            }
+
+            @Override
+            public boolean hasChanges()
+            {
+                return !updatesByIndex.isEmpty();
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
@@ -49,7 +49,18 @@ public interface ValidatedIndexUpdates extends AutoCloseable
         public void close()
         {
         }
+
+        @Override
+        public boolean hasChanges()
+        {
+            return false;
+        }
     };
+
+    /**
+     * @return whether or not there are any updates to be {@link #flush() flushed}.
+     */
+    boolean hasChanges();
 
     /**
      * Flush all validated and prepared index updates to corresponding indexes.


### PR DESCRIPTION
Committing a transaction goes through a number of appliers where one of
them, the IndexTransactionApplier synchronizes on IndexingService for
every commit. This is unnecessary if no index changes are made in the
transaction. So this commit adds a ValidatedIndexUpdate#hasChanges() where
the monitor is acquired, followed by #flush(), if that returns true. This
should reduce contention when committing otherwise uncontented data in
parallel.

Also removed an eager instantiation of an ArrayList in
IndexTransactionApplier.