### PR TITLE
Server port can now be zero

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
@@ -658,7 +658,7 @@ public final class Settings
     }
 
     public static final Function2<Integer, Function<String, String>, Integer> port =
-            illegalValueMessage( "must be a valid port number", range( 1, 65535 ) );
+            illegalValueMessage( "must be a valid port number", range( 0, 65535 ) );
 
     public static <T> Function2<T, Function<String, String>, T> illegalValueMessage( final String message,
                                                                                      final Function2<T,

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -21,9 +21,11 @@ package org.neo4j.server.web;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -35,7 +37,6 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
-
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.ServletException;
@@ -59,6 +60,7 @@ import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
+
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
@@ -69,6 +71,11 @@ import org.neo4j.server.security.ssl.SslSocketConnectorFactory;
 
 import static java.lang.String.format;
 
+/**
+ * This class handles the configuration and runtime management of a Jetty web server. The server is restartable.
+ *
+ * TODO: it really should be split up into a builder that returns a Closeable, to separate between the conf and runtime part.
+ */
 public class Jetty9WebServer implements WebServer
 {
     private boolean wadlEnabled;
@@ -374,6 +381,7 @@ public class Jetty9WebServer implements WebServer
         try
         {
             jetty.start();
+            console.log( "Web server started on port %d\n", ((InetSocketAddress)( (ServerSocketChannel) jetty.getConnectors()[0].getTransport() ).getLocalAddress()).getPort() );
         }
         catch ( Exception e )
         {

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.web;
 
+import java.io.IOException;
+
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -26,8 +28,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.util.TestLogging;
 import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.server.WrappingNeoServer;
+import org.neo4j.kernel.logging.SystemOutLogging;
 import org.neo4j.server.WrappingNeoServerBootstrapper;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerConfigurator;
@@ -42,44 +45,55 @@ import static org.neo4j.test.Mute.muteAll;
 
 public class TestJetty9WebServer
 {
-	@Test
-	public void shouldBeAbleToRestart() throws Throwable
-	{
-		// TODO: This is needed because WebServer has a cyclic
-		// dependency to NeoServer, which should be removed.
-		// Once that is done, we should instantiate WebServer
-		// here directly.
-		WrappingNeoServer neoServer = new WrappingNeoServer(dbRule.getGraphDatabaseAPI());
-		WebServer server = neoServer.getWebServer();
+    @Test
+    public void shouldBeAbleToUsePortZero() throws IOException
+    {
+        TestLogging logging = new TestLogging();
 
-		try
-		{
-			server.setAddress("127.0.0.1");
-			server.setPort(7878);
+        Jetty9WebServer webServer = new Jetty9WebServer( logging );
 
-			server.start();
-			server.stop();
-			server.start();
-		}
+        webServer.setPort( 0 );
+
+        webServer.start();
+
+        webServer.stop();
+
+        logging.getDelegatedConsoleLog( Jetty9WebServer.class ).
+                assertContainsMessageContaining( "Web server started on port" );
+    }
+
+    @Test
+    public void shouldBeAbleToRestart() throws Throwable
+    {
+        Jetty9WebServer server = new Jetty9WebServer( new SystemOutLogging() );
+        try
+        {
+            server.setAddress( "127.0.0.1" );
+            server.setPort( 7878 );
+
+            server.start();
+            server.stop();
+            server.start();
+        }
         finally
-		{
-			try
-			{
-				server.stop();
-			}
-            catch( Throwable t )
-			{
+        {
+            try
+            {
+                server.stop();
+            }
+            catch ( Throwable t )
+            {
 
-			}
-		}
-	}
+            }
+        }
+    }
 
     @Test
     public void shouldBeAbleToSetExecutionLimit() throws Throwable
     {
         @SuppressWarnings("deprecation")
         ImpermanentGraphDatabase db = new ImpermanentGraphDatabase( "path", stringMap(),
-                GraphDatabaseDependencies.newDependencies())
+                GraphDatabaseDependencies.newDependencies() )
         {
         };
 
@@ -114,7 +128,7 @@ public class TestJetty9WebServer
     {
         @SuppressWarnings("deprecation")
         ImpermanentGraphDatabase db = new ImpermanentGraphDatabase( "path", stringMap(),
-                GraphDatabaseDependencies.newDependencies())
+                GraphDatabaseDependencies.newDependencies() )
         {
         };
 
@@ -124,7 +138,8 @@ public class TestJetty9WebServer
 
         testBootstrapper.start();
 
-        try ( CloseableHttpClient httpClient = HttpClientBuilder.create().build() ) {
+        try ( CloseableHttpClient httpClient = HttpClientBuilder.create().build() )
+        {
             // Depends on specific resources exposed by the browser module; if this test starts to fail,
             // check whether the structure of the browser module has changed and adjust accordingly.
             assertEquals( 200, httpClient.execute( new HttpGet(


### PR DESCRIPTION
Allow server port to be set to zero, for random assignment. Actual port used is logged so that tools can find out what it was.