### PR TITLE
Fix cardinality estimation for qg with arguments

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
@@ -231,6 +231,14 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
     shouldHaveQueryGraphCardinality(1000.0 / 500.0 * 13.0)
   }
 
+  test("input cardinality of zero on a different identifier should not affect cardinality estimation of the pattern") {
+    givenPattern("MATCH (a)").
+    withQueryGraphArgumentIds(IdName("e")).
+    withInboundCardinality(0.0).
+    withGraphNodes(500).
+    shouldHaveQueryGraphCardinality(500)
+  }
+
 
   // TODO: Add a test for a relpatterns where the number of matching nodes is zero
 


### PR DESCRIPTION
input cardinality of zero on a different identifier should not affect cardinality estimation of the pattern