### PR TITLE
Ensure functionality of RebuildFromLogs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -115,4 +115,12 @@ public class TransactionRepresentationStoreApplier
         }
         return handlerOption.get();
     }
+
+    public TransactionRepresentationStoreApplier withLegacyIndexTransactionOrdering(
+            IdOrderingQueue legacyIndexTransactionOrdering )
+    {
+        return new TransactionRepresentationStoreApplier( indexingService, labelScanStore, neoStore, cacheAccess,
+                                                          lockService, legacyIndexProviderLookup, indexConfigStore,
+                                                          legacyIndexTransactionOrdering );
+    }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
@@ -58,6 +58,7 @@ import org.neo4j.kernel.impl.transaction.log.ReaderLogVersionBridge;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReaderFactory;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
+import org.neo4j.kernel.impl.util.IdOrderingQueue;
 import org.neo4j.kernel.impl.util.StringLogger;
 
 import static java.lang.String.format;
@@ -82,7 +83,7 @@ class RebuildFromLogs
         this.stores = new StoreAccess( graphdb );
         this.dataSource = graphdb.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource();
         this.storeApplier = graphdb.getDependencyResolver().resolveDependency(
-                TransactionRepresentationStoreApplier.class );
+                TransactionRepresentationStoreApplier.class ).withLegacyIndexTransactionOrdering( IdOrderingQueue.BYPASS);
         PropertyLoader propertyLoader = new PropertyLoader( stores.getRawNeoStore() );
         this.indexUpdatesValidator = new IndexUpdatesValidator( stores.getRawNeoStore(), propertyLoader,
                 graphdb.getDependencyResolver().resolveDependency( IndexingService.class ) );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.progress.ProgressListener;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.test.DbRepresentation;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.test.TargetDirectory.testDirForTest;
+
+@RunWith(Parameterized.class)
+public class RebuildFromLogsTest
+{
+    public final @Rule TargetDirectory.TestDirectory dir = testDirForTest( RebuildFromLogsTest.class );
+
+    @Test
+    public void shouldRebuildFromLog() throws Exception
+    {
+        // given
+        File prototypePath = new File( dir.graphDbDir(), "prototype" );
+        GraphDatabaseService prototype = db( prototypePath );
+        try
+        {
+            for ( Transaction transaction : work )
+            {
+                transaction.applyTo( prototype );
+            }
+        }
+        finally
+        {
+            prototype.shutdown();
+        }
+
+        // when
+        File rebuildPath = new File( dir.graphDbDir(), "rebuild" );
+        GraphDatabaseAPI rebuilt = db( rebuildPath );
+        try
+        {
+            new RebuildFromLogs( rebuilt ).applyTransactionsFrom( ProgressListener.NONE, prototypePath );
+        }
+        finally
+        {
+            rebuilt.shutdown();
+        }
+
+        // then
+        assertEquals( DbRepresentation.of( prototypePath ), DbRepresentation.of( rebuildPath ) );
+    }
+
+    private GraphDatabaseAPI db( File rebuiltPath )
+    {
+        return (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabase( rebuiltPath.getAbsolutePath() );
+    }
+
+    enum Transaction
+    {
+        CREATE_NODE
+                {
+                    @Override
+                    void applyTx( GraphDatabaseService graphDb )
+                    {
+                        graphDb.createNode();
+                    }
+                },
+        CREATE_NODE_WITH_PROPERTY
+                {
+                    @Override
+                    void applyTx( GraphDatabaseService graphDb )
+                    {
+                        graphDb.createNode().setProperty( name(), "value" );
+                    }
+                },
+        SET_PROPERTY( CREATE_NODE )
+                {
+                    @Override
+                    void applyTx( GraphDatabaseService graphDb )
+                    {
+                        firstNode( graphDb ).setProperty( name(), "value" );
+                    }
+                },
+        CHANGE_PROPERTY( CREATE_NODE_WITH_PROPERTY )
+                {
+                    @Override
+                    void applyTx( GraphDatabaseService graphDb )
+                    {
+                        for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+                        {
+                            if ( "value".equals( node.getProperty( CREATE_NODE_WITH_PROPERTY.name(), null ) ) )
+                            {
+                                node.setProperty( CREATE_NODE_WITH_PROPERTY.name(), "other" );
+                                break;
+                            }
+                        }
+                    }
+                },
+        LEGACY_INDEX_NODE( CREATE_NODE )
+                {
+                    @Override
+                    void applyTx( GraphDatabaseService graphDb )
+                    {
+                        Node node = firstNode( graphDb );
+                        graphDb.index().forNodes( name() ).add( node, "foo", "bar" );
+                    }
+                };
+
+        private static Node firstNode( GraphDatabaseService graphDb )
+        {
+            return Iterables.first( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+        }
+
+        private final Transaction[] dependencies;
+
+        private Transaction( Transaction... dependencies )
+        {
+            this.dependencies = dependencies;
+        }
+
+        void applyTo( GraphDatabaseService graphDb )
+        {
+            try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
+            {
+                applyTx( graphDb );
+
+                tx.success();
+            }
+        }
+
+        void applyTx( GraphDatabaseService graphDb )
+        {
+        }
+    }
+
+    static class WorkLog
+    {
+        static final WorkLog BASE = new WorkLog( EnumSet.noneOf( Transaction.class ) );
+        final EnumSet<Transaction> transactions;
+
+        WorkLog( EnumSet<Transaction> transactions )
+        {
+            this.transactions = transactions;
+        }
+
+        @Override
+        public boolean equals( Object that )
+        {
+            return this == that ||
+                   that instanceof WorkLog &&
+                   transactions.equals( ((WorkLog) that).transactions );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return transactions.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return transactions.toString();
+        }
+
+        Transaction[] transactions()
+        {
+            return transactions.toArray( new Transaction[transactions.size()] );
+        }
+
+        static Set<WorkLog> combinations()
+        {
+            Set<WorkLog> combinations = Collections.newSetFromMap( new LinkedHashMap<WorkLog, Boolean>() );
+            for ( Transaction transaction : Transaction.values() )
+            {
+                combinations.add( BASE.extend( transaction ) );
+            }
+            for ( Transaction transaction : Transaction.values() )
+            {
+                for ( WorkLog combination : new ArrayList<>( combinations ) )
+                {
+                    combinations.add( combination.extend( transaction ) );
+                }
+            }
+            return combinations;
+        }
+
+        private WorkLog extend( Transaction transaction )
+        {
+            EnumSet<Transaction> base = EnumSet.copyOf( transactions );
+            Collections.addAll( base, transaction.dependencies );
+            base.add( transaction );
+            return new WorkLog( base );
+        }
+    }
+
+    private final Transaction[] work;
+
+    public RebuildFromLogsTest( WorkLog work )
+    {
+        this.work = work.transactions();
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> commands()
+    {
+        List<Object[]> commands = new ArrayList<>();
+        for ( WorkLog combination : WorkLog.combinations() )
+        {
+            commands.add( new Object[]{combination} );
+        }
+        return commands;
+    }
+}


### PR DESCRIPTION
RebuildFromLogs now has test coverage to ensure that it continues working as intended.
The implementation has also been fixed to handle applying legacy index commands without first going through the transaction log writing process to set up the expectation for such commands.