### PR TITLE
Distribute Windows batch scripts; launch command prompt.

### DIFF
--- a/packaging/neo4j-desktop/neo4j-desktop.install4j
+++ b/packaging/neo4j-desktop/neo4j-desktop.install4j
@@ -27,6 +27,10 @@
       <fileEntry mountPoint="262" file="./target/neo4j-desktop-@NEO4J_VERSION@.jar" overwriteMode="4" shared="true" fileMode="644" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="262" file="./src/main/install4j/neo4j-community.vmoptions" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./src/main/install4j/install.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shell" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/Neo4jImport.bat" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/Neo4jShell.bat" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="386" file="./target/plugins/README.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="210" file="./target/licenses/LICENSES.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="210" file="./target/licenses/NOTICE.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
@@ -36,7 +40,10 @@
       <component name="Neo4j Community Launcher" id="155" customizedId="" displayDescription="false" hideHelpButton="false" selected="true" changeable="false" downloadable="false" hidden="false">
         <description />
         <include all="false">
-          <entry location="bin" fileType="regular" />
+          <entry location="bin/neo4j-desktop-@NEO4J_VERSION@.jar" fileType="regular" />
+          <entry location="bin/neo4j-community.vmoptions" fileType="regular" />
+          <entry location="bin/install.properties" fileType="regular" />
+          <entry location="bin/neo4j-community" fileType="launcher" />
           <entry location="plugins" fileType="regular" />
         </include>
         <dependencies>
@@ -49,6 +56,22 @@
           <entry location="LICENSES.txt" fileType="regular" />
           <entry location="NOTICE.txt" fileType="regular" />
           <entry location="LICENSE.txt" fileType="regular" />
+        </include>
+        <dependencies />
+      </component>
+      <component name="Windows batch files" id="448" customizedId="" displayDescription="false" hideHelpButton="false" selected="true" changeable="true" downloadable="false" hidden="false">
+        <description />
+        <include all="false">
+          <entry location="bin/Neo4jShell.bat" fileType="regular" />
+          <entry location="bin/Neo4jImport.bat" fileType="regular" />
+        </include>
+        <dependencies />
+      </component>
+      <component name="Shell scripts" id="449" customizedId="" displayDescription="false" hideHelpButton="false" selected="true" changeable="true" downloadable="false" hidden="false">
+        <description />
+        <include all="false">
+          <entry location="bin/neo4j-import" fileType="regular" />
+          <entry location="bin/neo4j-shell" fileType="regular" />
         </include>
         <dependencies />
       </component>
@@ -653,7 +676,9 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
         <commentFiles />
         <customAttributes />
       </autoUpdate>
-      <excludedComponents />
+      <excludedComponents>
+        <component id="449" />
+      </excludedComponents>
       <includedDownloadableComponents />
     </windows>
     <windows name="Windows32" id="26" customizedId="" mediaFileName="" installDir="Neo4j Community" overridePrincipalLanguage="false" jreBitType="32" runPostProcessor="false" postProcessor="" failOnPostProcessorError="false" useLegacyMediaFileIds="false" legacyMediaFileIds="" includedJRE="windows-x86-1.7.0_45" manualJREEntry="false" bundleType="1" jreURL="" jreShared="false" directDownload="false" installOnlyIfNecessary="true" customInstallBaseDir="" contentFilesType="1" downloadURL="" verifyIntegrity="true">
@@ -666,7 +691,9 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
         <commentFiles />
         <customAttributes />
       </autoUpdate>
-      <excludedComponents />
+      <excludedComponents>
+        <component id="449" />
+      </excludedComponents>
       <includedDownloadableComponents />
     </windows>
   </mediaSets>

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -135,19 +135,24 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>fix-license-line-endings</id>
+            <id>fetch-static-files</id>
             <phase>generate-resources</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
-              <target name="fix-license-line-endings">
+              <target name="fetch-static-files">
                 <mkdir dir="${project.build.directory}/licenses" />
                 <mkdir dir="${project.build.directory}/plugins" />
+                <mkdir dir="${project.build.directory}/shell-scripts" />
                 <fixcrlf file="${project.basedir}/../../community/LICENSE.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/community/LICENSES.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/community/NOTICE.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/plugins/README.txt" destDir="${project.build.directory}/plugins" eol="dos" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-import" todir="${project.build.directory}/shell-scripts" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-shell" todir="${project.build.directory}/shell-scripts" />
+                <fixcrlf file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4jImport.bat" destDir="${project.build.directory}/shell-scripts" eol="dos" />
+                <fixcrlf file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4jShell.bat" destDir="${project.build.directory}/shell-scripts" eol="dos" />
               </target>
             </configuration>
           </execution>

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/Environment.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/Environment.java
@@ -33,4 +33,6 @@ public interface Environment
     void editFile( File file ) throws IOException;
 
     void openDirectory( File directory ) throws IOException;
+
+    void openCommandPrompt( File binDirectory, File jreBinDirectory, File workingDirectory ) throws IOException;
 }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/Installation.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/Installation.java
@@ -102,4 +102,9 @@ public interface Installation
      * Get the directory where the neo4j-desktop.jar file has been installed into.
      */
     File getInstallationBinDirectory() throws URISyntaxException;
+
+    /**
+     * Get the directory where bundled JRE binaries are located.
+     */
+    File getInstallationJreBinDirectory() throws URISyntaxException;
 }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/portable/PortableInstallation.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/portable/PortableInstallation.java
@@ -74,6 +74,12 @@ public abstract class PortableInstallation implements Installation
         return appFile.getParentFile();
     }
 
+    @Override
+    public File getInstallationJreBinDirectory() throws URISyntaxException
+    {
+        return new File( getInstallationDirectory(), "jre/bin" );
+    }
+
     private static class PathAlreadyExistException extends RuntimeException
     {
         public PathAlreadyExistException( File path, String description )

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/unix/UnixEnvironment.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/unix/UnixEnvironment.java
@@ -62,4 +62,11 @@ class UnixEnvironment extends PortableEnvironment
 
         throw new UnsupportedOperationException( "Cannot open directory: " + directory );
     }
+
+    @Override
+    public void openCommandPrompt( File binDirectory, File jreBinDirectory, File workingDirectory ) throws IOException
+    {
+        throw new UnsupportedOperationException(
+                "Opening a command prompt is not currently supported on this operating system." );
+    }
 }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/windows/WindowsEnvironment.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/config/windows/WindowsEnvironment.java
@@ -26,6 +26,9 @@ import java.net.URISyntaxException;
 import org.neo4j.desktop.config.portable.PortableEnvironment;
 
 import static java.lang.Runtime.getRuntime;
+import static java.lang.String.format;
+
+import static org.apache.commons.lang.StringUtils.join;
 
 class WindowsEnvironment extends PortableEnvironment
 {
@@ -82,6 +85,29 @@ class WindowsEnvironment extends PortableEnvironment
         }
 
         windowsOpenDirectory( directory );
+    }
+
+    @Override
+    public void openCommandPrompt( File binDirectory, File jreBinDirectory, File workingDirectory ) throws IOException
+    {
+        String[] shellStartupCommands = {
+                format( "set PATH=\"%s\";\"%s\";%%PATH%%", jreBinDirectory, binDirectory ),
+                "set REPO=" + binDirectory,
+                "cd /D " + workingDirectory,
+                "echo Neo4j Command Prompt",
+                "echo.",
+                "echo This window is configured with Neo4j on the path.",
+                "echo.",
+                "echo Available commands:",
+                "echo * Neo4jShell",
+                "echo * Neo4jImport"
+        };
+        String[] cmdArray = {
+                "cmd",
+                "/C",
+                format( "start \"Neo4j Command Prompt\" cmd /K \"%s\"", join( shellStartupCommands, " && " ) )
+        };
+        getRuntime().exec( cmdArray );
     }
 
     private void windowsOpenDirectory( File directory ) throws IOException

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/Components.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/Components.java
@@ -30,21 +30,25 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.Border;
+
+import org.apache.commons.lang.StringUtils;
 
 import static java.awt.font.TextAttribute.UNDERLINE;
 import static java.awt.font.TextAttribute.UNDERLINE_ON;
 import static java.lang.String.format;
 import static javax.swing.JOptionPane.WARNING_MESSAGE;
+
 import static org.neo4j.desktop.ui.ScrollableOptionPane.showWrappedMessageDialog;
 
 @SuppressWarnings("MagicConstant")
 public final class Components
 {
     public static final int BASE_SPACING_SIZE = 5;
-    public static final int DEFAULT_TEXT_COLUMNS = 35;
+    public static final int DEFAULT_TEXT_COLUMNS = 50;
 
     private Components()
     {
@@ -118,7 +122,12 @@ public final class Components
 
     static JTextField createUnmodifiableTextField( String text )
     {
-        JTextField textField = new JTextField( text, DEFAULT_TEXT_COLUMNS );
+        return createUnmodifiableTextField( text, DEFAULT_TEXT_COLUMNS );
+    }
+
+    static JTextField createUnmodifiableTextField( String text, int columns )
+    {
+        JTextField textField = new JTextField( text, columns );
         textField.setEditable( false );
         textField.setForeground( Color.GRAY );
         return textField;
@@ -129,6 +138,11 @@ public final class Components
         JButton button = new JButton( text );
         button.addActionListener( actionListener );
         return button;
+    }
+
+    public static JLabel createLabel( String... textLines )
+    {
+        return new JLabel( format( "<html>%s</html>", StringUtils.join( textLines, "<br>" ) ) );
     }
 
     static String ellipsis( String input )

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/DesktopModel.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/DesktopModel.java
@@ -214,4 +214,12 @@ public class DesktopModel
     {
         installation.getEnvironment().openDirectory( directory );
     }
+
+    public void launchCommandPrompt() throws IOException, URISyntaxException
+    {
+        installation.getEnvironment().openCommandPrompt(
+                installation.getInstallationBinDirectory(),
+                installation.getInstallationJreBinDirectory(),
+                installation.getDatabaseDirectory().getParentFile() );
+    }
 }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/MainWindow.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/MainWindow.java
@@ -64,7 +64,6 @@ public class MainWindow
     private final JFrame frame;
     private final DatabaseActions databaseActions;
     private final JButton browseButton;
-    private final JButton settingsButton;
     private final JButton startButton;
     private final JButton stopButton;
     private final CardLayout statusPanelLayout;
@@ -85,16 +84,16 @@ public class MainWindow
         this.frame.setIconImages( Graphics.loadIcons() );
         this.sysTray = SysTray.install( new SysTrayActions(), frame );
 
-        this.directoryDisplay = createUnmodifiableTextField( model.getDatabaseDirectory().getAbsolutePath() );
+        this.directoryDisplay = createUnmodifiableTextField( model.getDatabaseDirectory().getAbsolutePath(), 35 );
         this.browseButton = createBrowseButton();
         this.statusPanelLayout = new CardLayout();
         this.statusPanel = createStatusPanel( statusPanelLayout );
         this.startButton = createStartButton();
         this.stopButton = createStopButton();
-        this.settingsButton = createSettingsButton();
 
+        JButton optionsButton = createOptionsButton();
         JPanel root =
-                createRootPanel( directoryDisplay, browseButton, statusPanel, startButton, stopButton, settingsButton );
+                createRootPanel( directoryDisplay, browseButton, statusPanel, startButton, stopButton, optionsButton );
 
         frame.add( root );
         frame.pack();
@@ -127,12 +126,12 @@ public class MainWindow
     private JPanel createActionPanel( JButton startButton, JButton stopButton, JButton settingsButton )
     {
         return withBoxLayout( BoxLayout.LINE_AXIS,
-            createPanel( settingsButton, Box.createHorizontalGlue(), stopButton, startButton ) );
+                createPanel( settingsButton, Box.createHorizontalGlue(), stopButton, startButton ) );
     }
 
-    private JButton createSettingsButton()
+    private JButton createOptionsButton()
     {
-        return Components.createTextButton( ellipsis( "Settings" ), new ActionListener()
+        return Components.createTextButton( ellipsis( "Options" ), new ActionListener()
         {
             @Override
             public void actionPerformed( ActionEvent e )
@@ -147,16 +146,13 @@ public class MainWindow
     private JPanel createSelectionPanel( JTextField directoryDisplay, JButton selectButton )
     {
         return withTitledBorder( "Database location", withBoxLayout( BoxLayout.LINE_AXIS,
-            createPanel( directoryDisplay, selectButton ) ) );
+                createPanel( directoryDisplay, selectButton ) ) );
     }
 
     protected void shutdown()
     {
         databaseActions.shutdown();
-        if ( debugWindow != null )
-        {
-            debugWindow.dispose();
-        }
+        debugWindow.dispose();
         frame.dispose();
         System.exit( 0 );
     }
@@ -219,7 +215,6 @@ public class MainWindow
     public void updateStatus( DatabaseStatus status )
     {
         browseButton.setEnabled( STOPPED == status );
-        settingsButton.setEnabled( STOPPED == status );
         startButton.setEnabled( STOPPED == status );
         stopButton.setEnabled( STARTED == status );
         statusPanelLayout.show( statusPanel, status.name() );


### PR DESCRIPTION
* Renamed 'Settings...' button to 'Options...'
* Options button is now enabled even when the database is running.
* Options dialog contains explanation of when config takes effect
  to mitigate confusion from changing config while database is running.
* Options dialog contains button to launch a command prompt.
* Currently command prompt is only functional on Windows.
* Command prompt opens a cmd window with bundled JVM on the path
  and REPO configured to find the main jar.
* Install4j config modified to include bat files in package.