### PR TITLE
Fixes a race between internal panic and shutdown in DynamicTaskExecutor

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -46,7 +46,7 @@ public abstract class AbstractStep<T> implements Step<T>
     @SuppressWarnings( "rawtypes" )
     private volatile Step downstream;
     private volatile boolean endOfUpstream;
-    private volatile Throwable panic;
+    protected volatile Throwable panic;
     private volatile boolean completed;
     protected boolean orderedTickets;
     protected final PrimitiveLongPredicate rightTicket = new PrimitiveLongPredicate()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutorServiceStep.java
@@ -148,7 +148,7 @@ public abstract class ExecutorServiceStep<T> extends AbstractStep<T>
     public void close()
     {
         super.close();
-        executor.shutdown( true );
+        executor.shutdown( panic == null );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -287,6 +287,18 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Visitor<LineLogger
             }
             return builder.toString();
         }
+
+        public boolean isAt( Class<?> clz, String method )
+        {
+            for ( StackTraceElement element : stackTrace )
+            {
+                if ( element.getClassName().equals( clz.getName() ) && element.getMethodName().equals( method ) )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public Thread.State state()


### PR DESCRIPTION
Race could be observed as a call to DynamicTaskExecutor#shutdown(true)
hanging forever occasionally if there was a concurrent, already submitted
task, failing where the failing task would also like to shut down. This
would be a problem if there was only one processor currently, or rather
if all current processors failed at the same time. This would prevent
the original exception from propagating out to user.

Added a check in shutdown for a panic, which now can only be set by a
processor observing a failing task. The shutdown call would then exit
prematurely. For what TaskExecutor is used for, in import tool, this
behaviour is fine because the original exception will be thrown anyway by
means of the StageControl "panic propagation". To further alleviate this
problem ExecutorServiceStep was changed to pass in false (i.e. don't wait
for tasks to complete) in the event of panic.