### PR TITLE
Handle undirected variable length in paths

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/LegacyVsNewPipeBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/LegacyVsNewPipeBuilder.scala
@@ -38,9 +38,6 @@ class LegacyVsNewPipeBuilder(oldBuilder: PipeBuilder,
         throw new CantHandleQueryException("Ronja does not handle update queries yet.")
       }
 
-      if (containsPlainVarLengthPattern(statement)) {
-        throw new CantHandleQueryException("Ronja does not handle var length queries yet.")
-      }
 
       newBuilder.producePlan(inputQuery, planContext)
     } catch {
@@ -48,21 +45,6 @@ class LegacyVsNewPipeBuilder(oldBuilder: PipeBuilder,
         monitor.unableToHandleQuery(queryText, statement, e)
         oldBuilder.producePlan(inputQuery, planContext)
     }
-  }
-
-  private def containsPlainVarLengthPattern(node: ASTNode): Boolean = node.treeFold(false) {
-    // only traverse expressions in node patterns in shortest path
-    case sp: ShortestPaths =>
-      (acc, children) =>
-        acc || sp.element.exists { case node: NodePattern => containsPlainVarLengthPattern(node) }
-
-    // check relationship patterns
-    case rel: RelationshipPattern =>
-      (acc, children) => if (acc || !rel.isSingleLength) true else children(false)
-
-    // bail out early
-    case _ =>
-      (acc, children) => if (acc) true else children(false)
   }
 
   private def containsUpdateClause(s: Statement) = s.exists {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
@@ -58,7 +58,7 @@ case class VarLengthExpandPipe(source: Pipe,
             }
           }
         }
-        val projectedRels = if (dir != projectedDir) {
+        val projectedRels = if (projectedDir == Direction.INCOMING) {
           rels.reverse
         } else {
           rels

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/VarLengthExpandPipe.scala
@@ -58,7 +58,8 @@ case class VarLengthExpandPipe(source: Pipe,
             }
           }
         }
-        val projectedRels = if (projectedDir == Direction.INCOMING) {
+        val needsFlipping = if (dir == Direction.BOTH) projectedDir == Direction.INCOMING else dir != projectedDir
+        val projectedRels = if (needsFlipping) {
           rels.reverse
         } else {
           rels

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/LogicalPlanProducer.scala
@@ -109,15 +109,18 @@ object LogicalPlanProducer extends CollectionSupport {
                     pattern: PatternRelationship,
                     predicates: Seq[(Identifier, Expression)],
                     allPredicates: Seq[Expression],
-                    mode: ExpansionMode) = pattern.length match {
+                    mode: ExpansionMode) =  pattern.length match {
     case l: VarPatternLength =>
-      VarExpand(left, from, dir, pattern.dir, pattern.types, to, pattern.name, l, mode, predicates)(
+      val projectedDir = if (dir == Direction.BOTH) {
+        if (from == pattern.left) Direction.OUTGOING else Direction.INCOMING
+      } else pattern.dir
+      VarExpand(left, from, dir, projectedDir, pattern.types, to, pattern.name, l, mode, predicates)(
         left.solved.updateGraph(_
           .addPatternRelationship(pattern)
           .addPredicates(allPredicates: _*)
         ))
 
-    case _                   => throw new InternalException("Expected a varlength path to be here")
+    case _ => throw new InternalException("Expected a varlength path to be here")
   }
 
   def planHiddenSelection(predicates: Seq[Expression], left: LogicalPlan) =

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/LegacyVsNewPipeBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/LegacyVsNewPipeBuilderTest.scala
@@ -33,7 +33,7 @@ class LegacyVsNewPipeBuilderTest extends CypherFunSuite {
   test("should delegate var length to old pipe builder") {
     new uses("MATCH ()-[r*]->() RETURN r") {
       result should equal(pipeInfo)
-      assertUsed(oldBuilder)
+      assertUsed(newBuilder)
     }
   }
 
@@ -47,7 +47,7 @@ class LegacyVsNewPipeBuilderTest extends CypherFunSuite {
   test("should delegate shortest path with var length expressions to old pipe builder") {
     new uses("MATCH shortestPath(()-[r*]->({x: ()-[:T*]->()})) RETURN r") {
       result should equal(pipeInfo)
-      assertUsed(oldBuilder)
+      assertUsed(newBuilder)
     }
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcAcceptanceTest.scala
@@ -34,12 +34,7 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
       ldbcQuery.constraintQueries.foreach(execute(_))
 
       //when
-      val result = try {
-        executeWithNewPlanner(s"PLANNER COST ${ldbcQuery.query}", ldbcQuery.params.toSeq: _*).result
-      } catch {
-        case e: Exception if e.getMessage.contains("Ronja does not handle var length queries yet") =>
-          executeWithOlderPlanner(s"${ldbcQuery.query}", ldbcQuery.params.toSeq: _*).toList.withArraysAsLists
-      }
+      val result = executeWithNewPlanner(s"PLANNER COST ${ldbcQuery.query}", ldbcQuery.params.toSeq: _*).result
 
       //then
       result should equal(ldbcQuery.expectedResult)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1908,4 +1908,22 @@ return b
       result.toSet should equal(Set(Map("paths" -> new PathImpl(node1, r, node2)), Map("paths" -> new PathImpl(node2, r, node1))))
     )
   }
+
+  test("should handle paths of containing undirected varlength") {
+    // given
+    val db1 = createLabeledNode("Start")
+    val db2 = createLabeledNode("End")
+    val mid = createNode()
+    val other = createNode()
+    relate(mid, db1, "CONNECTED_TO")
+    relate(mid, db2, "CONNECTED_TO")
+    relate(mid, db2, "CONNECTED_TO")
+    relate(mid, other, "CONNECTED_TO")
+    relate(mid, other, "CONNECTED_TO")
+
+    // when
+    val query = "PLANNER COST MATCH topRoute = (db1:Start)<-[:CONNECTED_TO]-()-[:CONNECTED_TO*3..3]-(db2:End) RETURN topRoute"
+
+    executeWithNewPlanner(query).toList should have size(4)
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1716,7 +1716,7 @@ return b
 
 
     //WHEN
-    val result = executeWithOlderPlanner(query)
+    val result = executeWithNewPlanner(query)
 
     //THEN
     result.toList should equal (List(Map("b" -> b)))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
@@ -60,7 +60,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val b = createLabeledNode("End")
     relate(a, b)
 
-    val resultPath = executeWithOlderPlanner("match (a:Start), (b:End) RETURN a-[*]->b as path")
+    val resultPath = executeWithNewPlanner("match (a:Start), (b:End) RETURN a-[*]->b as path")
       .toList.head("path").asInstanceOf[Seq[_]]
 
     resultPath should have size 1
@@ -141,7 +141,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val b = createLabeledNode("End")
     relate(a, b)
 
-    val resultPath = executeWithOlderPlanner("match (a:Start), (b:End) with a-[*]->b as path, count(a) as c return path, c")
+    val resultPath = executeWithNewPlanner("match (a:Start), (b:End) with a-[*]->b as path, count(a) as c return path, c")
       .toList.head("path").asInstanceOf[Seq[_]]
 
     resultPath should have size 1

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
@@ -57,7 +57,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(324234,666)
 
     // when
-    val result = executeScalarWithOlderPlanner[Node]("match (n:Start) where (n)-[*2 {prop: 42}]->() return n")
+    val result = executeScalarWithNewPlanner[Node]("match (n:Start) where (n)-[*2 {prop: 42}]->() return n")
 
     // then
     assert(start1 == result)
@@ -70,7 +70,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(55555, 7777)
 
     // when
-    val result = executeWithOlderPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
+    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2) == result)
@@ -84,7 +84,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(55555, 7777)
 
     // when
-    val result = executeWithOlderPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() OR n.p = 25 return n").columnAs[Node]("n").toList
+    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() OR n.p = 25 return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2, start3) == result)
@@ -97,7 +97,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(nodePropertyValue = 25, relPropertyValue = 42)
 
     // when
-    val result = executeWithOlderPlanner("match (n:Start) where n.p = 12 OR NOT (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
+    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR NOT (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2) == result)


### PR DESCRIPTION
When constructing paths from variable length patterns the relationships were in some cases in the wrong order which lead to invalid paths.

This PR also reenables variable length for the cost compiler - not by default but if asked for.