### PR TITLE
Fixes a concurrency issue in NodeLabelsCache

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -38,11 +38,13 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
     private final CountsAccessor.Updater countsUpdater;
     private final int anyLabel;
     private final int anyRelationshipType;
+    private final NodeLabelsCache.Client client;
 
     public RelationshipCountsProcessor( NodeLabelsCache nodeLabelCache,
             int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater )
     {
         this.nodeLabelCache = nodeLabelCache;
+        this.client = nodeLabelCache.newClient();
         this.countsUpdater = countsUpdater;
 
         // Instantiate with high id + 1 since we need that extra slot for the ANY counts
@@ -57,7 +59,7 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
 
         counts[anyLabel][anyRelationshipType][anyLabel]++;
         counts[anyLabel][type][anyLabel]++;
-        startScratch = nodeLabelCache.get( startNode, startScratch );
+        startScratch = nodeLabelCache.get( client, startNode, startScratch );
         for ( int startNodeLabelId : startScratch )
         {
             if ( startNodeLabelId == -1 )
@@ -67,7 +69,7 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
 
             counts[startNodeLabelId][anyRelationshipType][anyLabel]++;
             counts[startNodeLabelId][type][anyLabel]++;
-            endScratch = nodeLabelCache.get( endNode, endScratch );
+            endScratch = nodeLabelCache.get( client, endNode, endScratch );
             for ( int endNodeLabelId : endScratch )
             {
                 if ( endNodeLabelId == -1 )
@@ -79,7 +81,7 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                 counts[startNodeLabelId][type][endNodeLabelId]++;
             }
         }
-        endScratch = nodeLabelCache.get( endNode, endScratch );
+        endScratch = nodeLabelCache.get( client, endNode, endScratch );
         for ( int endNodeLabelId : endScratch )
         {
             if ( endNodeLabelId == -1 )

--- a/community/kernel/src/test/java/org/neo4j/test/Race.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Race.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Simple race scenario, a utility for executing multiple threads coordinated to start at the same time.
+ * Add contestants with {@link #addContestant(Runnable)} and then when all have been added, start them
+ * simultaneously using {@link #go()}, which will block until all contestants have completed.
+ * Any errors from contestants are propagated out from {@link #go()}.
+ */
+public class Race
+{
+    private final List<Contestant> contestants = new ArrayList<>();
+    private volatile CountDownLatch readySet;
+    private final CountDownLatch go = new CountDownLatch( 1 );
+
+    public void addContestant( Runnable contestant )
+    {
+        contestants.add( new Contestant( contestant, contestants.size() ) );
+    }
+
+    public void go() throws Throwable
+    {
+        readySet = new CountDownLatch( contestants.size() );
+        for ( Contestant contestant : contestants )
+        {
+            contestant.start();
+        }
+        readySet.await();
+        go.countDown();
+
+        int errorCount = 0;
+        for ( Contestant contestant : contestants )
+        {
+            contestant.join();
+            if ( contestant.error != null )
+            {
+                errorCount++;
+            }
+        }
+
+        if ( errorCount > 1 )
+        {
+            Throwable errors = new Throwable( "Multiple errors found" );
+            for ( Contestant contestant : contestants )
+            {
+                if ( contestant.error != null )
+                {
+                    errors.addSuppressed( contestant.error );
+                }
+            }
+            throw errors;
+        }
+        if ( errorCount == 1 )
+        {
+            for ( Contestant contestant : contestants )
+            {
+                if ( contestant.error != null )
+                {
+                    throw contestant.error;
+                }
+            }
+        }
+    }
+
+    private class Contestant extends Thread
+    {
+        private volatile Throwable error;
+
+        Contestant( Runnable code, int nr )
+        {
+            super( code, "Contestant#" + nr );
+        }
+
+        @Override
+        public void run()
+        {
+            readySet.countDown();
+            try
+            {
+                go.await();
+            }
+            catch ( InterruptedException e )
+            {
+                error = e;
+                interrupt();
+                return;
+            }
+
+            try
+            {
+                super.run();
+            }
+            catch ( Throwable e )
+            {
+                error = e;
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
NodeLabelsCache was written with single-threaded use in mind. However
recent changes made counting happening in parallel and NodeLabelsCache
wasn't updated to support that. Even so no tests broke.

NodeLabelsCache was stateful to reduce garbage generation and increase
performance of interacting with it. This commit pulls out the stateful
state into an internal public class Client which can be created by each
thread calling get() on it, using NodeLabelsCache#newClient(). Each thread
creates their own Client and calls get() multiple times after that with
the same Client instance. This keeps the performance, but allows for
concurrency. Still only a single thread may call put, which still holds
true for the usage from the import tool.

Also, introduces a convenient utility for starting multiple threads at the
exact same time and having their success or failure propagate in one
place. See org.neo4j.test.Race.