### PR TITLE
Fixes parallelization issues in import tool

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/IdGroupDistribution.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/IdGroupDistribution.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.util.Random;
+
+import org.neo4j.unsafe.impl.batchimport.input.Group;
+
+/**
+ * A little utility for randomizing dividing up nodes into {@link Group id spaces}.
+ * At least used by {@link RandomDataIterator}. Supplied with number of nodes to divide up and number of groups
+ * to divide into, the group sizes are randomized and together they will contain all nodes.
+ */
+public class IdGroupDistribution
+{
+    private final long[] groupCounts;
+    private final Group[] groups;
+
+    public IdGroupDistribution( long nodeCount, int numberOfGroups, Random random )
+    {
+        groupCounts = new long[numberOfGroups];
+        groups = new Group[numberOfGroups];
+
+        // Assign all except the last one
+        long total = 0;
+        long partSize = nodeCount/numberOfGroups;
+        float debt = 1f;
+        for ( int i = 0; i < numberOfGroups-1; i++ )
+        {
+            float part = random.nextFloat()*debt;
+            assignGroup( i, (long) (partSize*part) );
+            total += groupCounts[i];
+            debt = debt + 1.0f - part;
+        }
+
+        // Assign the rest to the last one
+        assignGroup( numberOfGroups-1, nodeCount - total );
+    }
+
+    private void assignGroup( int i, long count )
+    {
+        groupCounts[i] = count;
+        groups[i] = new Group.Adapter( i, "Group" + i );
+    }
+
+    public Group groupOf( long nodeInOrder )
+    {
+        long at = 0;
+        for ( int i = 0; i < groupCounts.length; i++ )
+        {
+            at += groupCounts[i];
+            if ( nodeInOrder < at )
+            {
+                return groups[i];
+            }
+        }
+        throw new IllegalArgumentException( "Strange, couldn't find group for node (import order) " + nodeInOrder +
+                ", counted to " + at + " as total number of " + at );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -27,6 +27,7 @@ import org.neo4j.unsafe.impl.batchimport.RelationshipCountsStage;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseDynamicExecution;
 
 public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
@@ -76,7 +77,7 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
             // Count relationships
             superviseDynamicExecution( new RelationshipCountsStage( Configuration.DEFAULT, cache, relationships,
                                                                     highLabelId, highRelationshipTypeId,
-                                                                    countsUpdater ) );
+                                                                    countsUpdater, AUTO ) );
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -103,6 +103,7 @@ import static org.neo4j.kernel.impl.storemigration.FileOperation.DELETE;
 import static org.neo4j.kernel.impl.storemigration.FileOperation.MOVE;
 import static org.neo4j.kernel.impl.util.StringLogger.DEV_NULL;
 import static org.neo4j.unsafe.impl.batchimport.WriterFactories.parallel;
+import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.withDynamicProcessorAssignment;
 
 /**
  * Migrates a neo4j kernel database from one version to the next.
@@ -336,9 +337,10 @@ public class StoreMigrator implements StoreMigrationParticipant
                 throw new IllegalStateException( "Unknown version to upgrade from: " + versionToUpgradeFrom( storeDir ) );
         }
 
+        Configuration importConfig = new Configuration.OverrideFromConfig( config );
         BatchImporter importer = new ParallelBatchImporter( migrationDir.getAbsolutePath(), fileSystem,
-                new Configuration.OverrideFromConfig( config ), logging,
-                migrationBatchImporterMonitor( legacyStore, progressMonitor ),
+                importConfig, logging, withDynamicProcessorAssignment( migrationBatchImporterMonitor(
+                        legacyStore, progressMonitor ), importConfig ),
                 parallel(), readAdditionalIds( storeDir, lastTxId, lastTxChecksum ) );
         InputIterable<InputNode> nodes = legacyNodesAsInput( legacyStore );
         InputIterable<InputRelationship> relationships = legacyRelationshipsAsInput( legacyStore );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -46,6 +46,7 @@ import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputCache;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.staging.DynamicProcessorAssigner;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
 import org.neo4j.unsafe.impl.batchimport.staging.IdMapperPreparationStep;
 import org.neo4j.unsafe.impl.batchimport.staging.InputIteratorBatcherStep;
@@ -61,7 +62,8 @@ import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
 import static org.neo4j.unsafe.impl.batchimport.Utils.idsOf;
 import static org.neo4j.unsafe.impl.batchimport.WriterFactories.parallel;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
-import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseDynamicExecution;
+import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseExecution;
+import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.withDynamicProcessorAssignment;
 
 /**
  * {@link BatchImporter} which tries to exercise as much of the available resources to gain performance.
@@ -106,10 +108,16 @@ public class ParallelBatchImporter implements BatchImporter
         this.writerFactory = writerFactory.apply( config );
     }
 
+    /**
+     * Instantiates {@link ParallelBatchImporter} with default services and behaviour.
+     * The provided {@link ExecutionMonitor} will be decorated with {@link DynamicProcessorAssigner} for
+     * optimal assignment of processors to bottleneck steps over time.
+     */
     public ParallelBatchImporter( String storeDir, Configuration config, Logging logging,
             ExecutionMonitor executionMonitor )
     {
-        this( storeDir, new DefaultFileSystemAbstraction(), config, logging, executionMonitor, parallel(), EMPTY );
+        this( storeDir, new DefaultFileSystemAbstraction(), config, logging,
+                withDynamicProcessorAssignment( executionMonitor, config ), parallel(), EMPTY );
     }
 
     @Override
@@ -232,7 +240,7 @@ public class ParallelBatchImporter implements BatchImporter
 
     private void executeStages( Stage... stages )
     {
-        superviseDynamicExecution( executionMonitor, config, stages );
+        superviseExecution( executionMonitor, config, stages );
     }
 
     public class NodeStage extends Stage

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -240,7 +240,7 @@ public class ParallelBatchImporter implements BatchImporter
         public NodeStage( InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
                 BatchingNeoStore neoStore, InputCache inputCache, StatsProvider memoryUsage ) throws IOException
         {
-            super( "Nodes", config, idGenerator.dependsOnInput() );
+            super( "Nodes", config, true );
             add( new InputIteratorBatcherStep<>( control(), config.batchSize(), config.movingAverageSize(),
                     nodes.iterator(), InputNode.class ) );
             if ( !nodes.supportsMultiplePasses() )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -194,7 +194,7 @@ public class ParallelBatchImporter implements BatchImporter
             // Stage 7 -- count label-[type]->label
             executeStages( new RelationshipCountsStage( config, nodeLabelsCache, neoStore.getRelationshipStore(),
                     neoStore.getLabelRepository().getHighId(),
-                    neoStore.getRelationshipTypeRepository().getHighId(), countsUpdater ) );
+                    neoStore.getRelationshipTypeRepository().getHighId(), countsUpdater, AUTO ) );
 
             // We're done, do some final logging about it
             long totalTimeMillis = currentTimeMillis() - startTime;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutorServiceStep;
 import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
 
@@ -38,16 +39,18 @@ public class ProcessRelationshipCountsDataStep extends ExecutorServiceStep<long[
     private final int highLabelId;
     private final int highRelationshipTypeId;
     private final CountsAccessor.Updater countsUpdater;
+    private final NumberArrayFactory cacheFactory;
 
     public ProcessRelationshipCountsDataStep( StageControl control, NodeLabelsCache cache,
             int workAheadSize, int movingAverageSize, int highLabelId, int highRelationshipTypeId,
-            CountsAccessor.Updater countsUpdater )
+            CountsAccessor.Updater countsUpdater, NumberArrayFactory cacheFactory )
     {
         super( control, "COUNT", workAheadSize, movingAverageSize, 1, true );
         this.cache = cache;
         this.highLabelId = highLabelId;
         this.highRelationshipTypeId = highRelationshipTypeId;
         this.countsUpdater = countsUpdater;
+        this.cacheFactory = cacheFactory;
     }
 
     @Override
@@ -68,7 +71,7 @@ public class ProcessRelationshipCountsDataStep extends ExecutorServiceStep<long[
         {   // This is OK since in this step implementation we use TaskExecutor which sticks to its threads.
             // deterministically.
             processors.put( Thread.currentThread(), processor = new RelationshipCountsProcessor(
-                    cache, highLabelId, highRelationshipTypeId, countsUpdater ) );
+                    cache, highLabelId, highRelationshipTypeId, countsUpdater, cacheFactory ) );
         }
         return processor;
     }
@@ -77,9 +80,21 @@ public class ProcessRelationshipCountsDataStep extends ExecutorServiceStep<long[
     protected void done()
     {
         super.done();
+        RelationshipCountsProcessor all = null;
         for ( RelationshipCountsProcessor processor : processors.values() )
         {
-            processor.done();
+            if ( all == null )
+            {
+                all = processor;
+            }
+            else
+            {
+                all.addCountsFrom( processor );
+            }
+        }
+        if ( all != null )
+        {
+            all.done();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -22,7 +22,9 @@ package org.neo4j.unsafe.impl.batchimport;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
 /**
  * Calculates counts as labelId --[type]--> labelId for relationships with the labels coming from its start/end nodes.
@@ -33,32 +35,48 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
     private static final boolean COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS = false;
     private final NodeLabelsCache nodeLabelCache;
     // start node label id | relationship type | end node label id. Roughly 8Mb for 100,100,100
-    private final long[][][] counts;
+    private final LongArray counts;
     private int[] startScratch = new int[20], endScratch = new int[20]; // and grows on demand
     private final CountsAccessor.Updater countsUpdater;
     private final int anyLabel;
     private final int anyRelationshipType;
     private final NodeLabelsCache.Client client;
+    private final int itemsPerType;
+    private final int itemsPerStartLabel;
 
     public RelationshipCountsProcessor( NodeLabelsCache nodeLabelCache,
-            int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater )
+            int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater,
+            NumberArrayFactory cacheFactory )
     {
         this.nodeLabelCache = nodeLabelCache;
         this.client = nodeLabelCache.newClient();
         this.countsUpdater = countsUpdater;
 
-        // Instantiate with high id + 1 since we need that extra slot for the ANY counts
-        this.counts = new long[highLabelId+1][highRelationshipTypeId+1][highLabelId+1];
+        // Make room for high id + 1 since we need that extra slot for the ANY counts
         this.anyLabel = highLabelId;
         this.anyRelationshipType = highRelationshipTypeId;
+        this.itemsPerType = anyLabel+1;
+        this.itemsPerStartLabel = (anyRelationshipType+1)*itemsPerType;
+        this.counts = cacheFactory.newLongArray( arrayIndex( highLabelId, highRelationshipTypeId, highLabelId )+1, 0 );
+    }
+
+    private int arrayIndex( int startLabel, int relationshipType, int endLabel )
+    {
+        return startLabel*itemsPerStartLabel + relationshipType*itemsPerType + endLabel;
+    }
+
+    private void increment( int startLabel, int relationshipType, int endLabel )
+    {
+        int index = arrayIndex( startLabel, relationshipType, endLabel );
+        counts.set( index, counts.get( index ) + 1 );
     }
 
     public void process( long startNode, int type, long endNode )
     {
         // Below is logic duplication of CountsState#addRelationship
 
-        counts[anyLabel][anyRelationshipType][anyLabel]++;
-        counts[anyLabel][type][anyLabel]++;
+        increment( anyLabel, anyRelationshipType, anyLabel );
+        increment( anyLabel, type, anyLabel );
         startScratch = nodeLabelCache.get( client, startNode, startScratch );
         for ( int startNodeLabelId : startScratch )
         {
@@ -67,8 +85,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                 break;
             }
 
-            counts[startNodeLabelId][anyRelationshipType][anyLabel]++;
-            counts[startNodeLabelId][type][anyLabel]++;
+            increment( startNodeLabelId, anyRelationshipType, anyLabel );
+            increment( startNodeLabelId, type, anyLabel );
             endScratch = nodeLabelCache.get( client, endNode, endScratch );
             for ( int endNodeLabelId : endScratch )
             {
@@ -77,8 +95,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                     break;
                 }
 
-                counts[startNodeLabelId][anyRelationshipType][endNodeLabelId]++;
-                counts[startNodeLabelId][type][endNodeLabelId]++;
+                increment( startNodeLabelId, anyRelationshipType, endNodeLabelId );
+                increment( startNodeLabelId, type, endNodeLabelId );
             }
         }
         endScratch = nodeLabelCache.get( client, endNode, endScratch );
@@ -89,8 +107,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                 break;
             }
 
-            counts[anyLabel][anyRelationshipType][endNodeLabelId]++;
-            counts[anyLabel][type][endNodeLabelId]++;
+            increment( anyLabel, anyRelationshipType, endNodeLabelId );
+            increment( anyLabel, type, endNodeLabelId );
         }
     }
 
@@ -105,13 +123,12 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
     @Override
     public void done()
     {
-        for ( int startNodeLabelId = 0; startNodeLabelId < counts.length; startNodeLabelId++ )
+        long index = 0;
+        for ( int startNodeLabelId = 0; startNodeLabelId <= anyLabel; startNodeLabelId++ )
         {
-            long[][] types = counts[startNodeLabelId];
-            for ( int typeId = 0; typeId < types.length; typeId++ )
+            for ( int typeId = 0; typeId <= anyRelationshipType; typeId++ )
             {
-                long[] endNodeLabelIds = types[typeId];
-                for ( int endNodeLabelId = 0; endNodeLabelId < endNodeLabelIds.length; endNodeLabelId++ )
+                for ( int endNodeLabelId = 0; endNodeLabelId <= anyLabel; endNodeLabelId++, index++ )
                 {
                     if ( !COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS )
                     {
@@ -123,10 +140,19 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                     int startLabel = startNodeLabelId == anyLabel ? ReadOperations.ANY_LABEL : startNodeLabelId;
                     int type = typeId == anyRelationshipType ? ReadOperations.ANY_RELATIONSHIP_TYPE : typeId;
                     int endLabel = endNodeLabelId == anyLabel ? ReadOperations.ANY_LABEL : endNodeLabelId;
-                    long count = endNodeLabelIds[endNodeLabelId];
+                    long count = counts.get( index );
                     countsUpdater.incrementRelationshipCount( startLabel, type, endLabel, count );
                 }
             }
+        }
+    }
+
+    public void addCountsFrom( RelationshipCountsProcessor from )
+    {
+        long length = counts.length();
+        for ( long i = 0; i < length; i++ )
+        {
+            counts.set( i, counts.get( i ) + from.counts.get( i ) );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 
 /**
@@ -31,12 +32,13 @@ import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 public class RelationshipCountsStage extends Stage
 {
     public RelationshipCountsStage( Configuration config, NodeLabelsCache cache, RelationshipStore relationshipStore,
-            int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater )
+            int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater,
+            NumberArrayFactory cacheFactory )
     {
         super( "Relationship counts", config, false );
         add( new ReadRelationshipCountsDataStep( control(), config.batchSize(), config.movingAverageSize(),
                 relationshipStore ) );
         add( new ProcessRelationshipCountsDataStep( control(), cache, config.workAheadSize(),
-                config.movingAverageSize(), highLabelId, highRelationshipTypeId, countsUpdater ) );
+                config.movingAverageSize(), highLabelId, highRelationshipTypeId, countsUpdater, cacheFactory ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ExecutionSupervisors.java
@@ -30,31 +30,46 @@ import static java.lang.Runtime.getRuntime;
  */
 public class ExecutionSupervisors
 {
+    /**
+     * Using an {@link ExecutionMonitors#invisible() invisible} monitor.
+     * @see #superviseDynamicExecution(ExecutionMonitor, Stage...)
+     */
     public static void superviseDynamicExecution( Stage... stages )
     {
-        superviseDynamicExecution( ExecutionMonitors.invisible(), Configuration.DEFAULT, stages );
+        superviseDynamicExecution( ExecutionMonitors.invisible(), stages );
     }
 
+    /**
+     * With {@link Configuration#DEFAULT}.
+     * @see #superviseDynamicExecution(ExecutionMonitor, Configuration, Stage...).
+     */
     public static void superviseDynamicExecution( ExecutionMonitor monitor, Stage... stages )
     {
         superviseDynamicExecution( monitor, Configuration.DEFAULT, stages );
     }
 
     /**
+     * Supervises an execution with the given monitor AND a {@link DynamicProcessorAssigner} to giv
+     * the execution a dynamic and optimal nature.
+     *
+     * @see #superviseExecution(ExecutionMonitor, Configuration, Stage...)
+     */
+    public static void superviseDynamicExecution( ExecutionMonitor monitor, Configuration config, Stage... stages )
+    {
+        superviseExecution( withDynamicProcessorAssignment( monitor, config ), config, stages );
+    }
+
+    /**
      * Executes a number of stages simultaneously, letting the given {@code monitor} get insight into the
-     * execution. A {@link DynamicProcessorAssigner} is also added as a {@link ExecutionMonitor} to give
-     * the execution a dynamic nature.
+     * execution.
      *
      * @param monitor {@link ExecutionMonitor} to get insight into the execution.
      * @param config {@link Configuration} for the execution.
      * @param stages {@link Stage stages} to execute.
      */
-    public static void superviseDynamicExecution( ExecutionMonitor monitor, Configuration config, Stage... stages )
+    public static void superviseExecution( ExecutionMonitor monitor, Configuration config, Stage... stages )
     {
-        DynamicProcessorAssigner dynamicProcessorAssigner = new DynamicProcessorAssigner( config,
-                min( config.maxNumberOfProcessors(), getRuntime().availableProcessors() ) );
-        ExecutionSupervisor supervisor = new ExecutionSupervisor( Clock.SYSTEM_CLOCK,
-                new MultiExecutionMonitor( monitor, dynamicProcessorAssigner ) );
+        ExecutionSupervisor supervisor = new ExecutionSupervisor( Clock.SYSTEM_CLOCK, monitor );
         try
         {
             StageExecution[] executions = new StageExecution[stages.length];
@@ -71,5 +86,21 @@ public class ExecutionSupervisors
                 stage.close();
             }
         }
+    }
+
+    /**
+     * Decorates an {@link ExecutionMonitor} with a {@link DynamicProcessorAssigner} responsible for
+     * constantly assigning and reevaluating an optimal number of processors to all individual steps.
+     *
+     * @param monitor {@link ExecutionMonitor} to decorate.
+     * @param config {@link Configuration} that the {@link DynamicProcessorAssigner} will use. Max total processors
+     * in a {@link Stage} will be the smallest of that value and {@link Runtime#availableProcessors()}.
+     * @return the decorated monitor with dynamic processor assignment capabilities.
+     */
+    public static ExecutionMonitor withDynamicProcessorAssignment( ExecutionMonitor monitor, Configuration config )
+    {
+        DynamicProcessorAssigner dynamicProcessorAssigner = new DynamicProcessorAssigner( config,
+                min( config.maxNumberOfProcessors(), getRuntime().availableProcessors() ) );
+        return new MultiExecutionMonitor( monitor, dynamicProcessorAssigner );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorAssignmentStrategies.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorAssignmentStrategies.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.helpers.Clock;
+import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+
+import static java.lang.String.format;
+
+/**
+ * Processor assigner strategies that are useful for testing {@link ParallelBatchImporter} as to exercise
+ * certain aspects of parallelism which would otherwise only be exercised on particular machines and datasets.
+ */
+public class ProcessorAssignmentStrategies
+{
+    /**
+     * Right of the bat assigns all permitted processors to random steps that allow multiple threads.
+     */
+    public static ExecutionMonitor eagerRandomSaturation( final int availableProcessor )
+    {
+        return new AbstractAssigner( Clock.SYSTEM_CLOCK, 10, TimeUnit.SECONDS )
+        {
+            @Override
+            public void start( StageExecution[] executions )
+            {
+                Random random = ThreadLocalRandom.current();
+                int processors = availableProcessor;
+                for ( int rounds = 0; rounds < availableProcessor && processors > 0; rounds++ )
+                {
+                    for ( StageExecution execution : executions )
+                    {
+                        for ( Step<?> step : execution.steps() )
+                        {
+                            if ( random.nextBoolean() && step.incrementNumberOfProcessors() && --processors == 0 )
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+                registerProcessorCount( executions );
+            }
+
+            @Override
+            public void check( StageExecution[] executions )
+            {   // We do everything in start
+            }
+        };
+    }
+
+    /**
+     * For every check assigns a random number of more processors to random steps that allow multiple threads.
+     */
+    public static ExecutionMonitor randomSaturationOverTime( final int availableProcessor )
+    {
+        return new AbstractAssigner( Clock.SYSTEM_CLOCK, 100, TimeUnit.MILLISECONDS )
+        {
+            private int processors = availableProcessor;
+
+            @Override
+            public void check( StageExecution[] executions )
+            {
+                if ( processors == 0 )
+                {
+                    return;
+                }
+
+                Random random = ThreadLocalRandom.current();
+                int maxThisCheck = random.nextInt( processors-1 )+1;
+                for ( StageExecution execution : executions )
+                {
+                    for ( Step<?> step : execution.steps() )
+                    {
+                        if ( random.nextBoolean() && step.incrementNumberOfProcessors() )
+                        {
+                            processors--;
+                            if ( --maxThisCheck == 0 )
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+                registerProcessorCount( executions );
+            }
+        };
+    }
+
+    private static abstract class AbstractAssigner extends ExecutionMonitor.Adpter
+    {
+        private final Map<String,Map<String,Integer>> processors = new HashMap<>();
+
+        protected AbstractAssigner( Clock clock, long time, TimeUnit unit )
+        {
+            super( clock, time, unit );
+        }
+
+        protected void registerProcessorCount( StageExecution[] executions )
+        {
+            for ( StageExecution execution : executions )
+            {
+                Map<String,Integer> byStage = new HashMap<>();
+                processors.put( execution.getStageName(), byStage );
+                for ( Step<?> step : execution.steps() )
+                {
+                    byStage.put( step.name(), step.numberOfProcessors() );
+                }
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            // For debugging purposes. Includes information about how many processors each step got.
+            StringBuilder builder = new StringBuilder();
+            for ( String stage : processors.keySet() )
+            {
+                builder.append( stage ).append( ':' );
+                Map<String,Integer> byStage = processors.get( stage );
+                for ( String step : byStage.keySet() )
+                {
+                    builder.append( format( "%n  %s:%d", step, byStage.get( step ) ) );
+                }
+                builder.append( format( "%n" ) );
+            }
+            return builder.toString();
+        }
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -21,11 +21,9 @@ package org.neo4j.server.web;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;


### PR DESCRIPTION
Each fixed by the two first commits 2040e473ef328ad67c6f76a2d8654e4d718c0baa and c18c9cb252c0a3c0020e3d2c882b9f3ef07ba961. The third commit extends `ParallelBatchImporterTest` to saturate all steps with as many processors as possible, to really exercise parallelization. The new version of this test could easily and consistently reproduce the two aforementioned issues.