### PR TITLE
Turn flush() into flushAndForce() for both PageCache and PagedFile

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -42,7 +42,7 @@ public interface PageCache extends AutoCloseable
     PagedFile map( File file, int pageSize ) throws IOException;
 
     /** Flush all dirty pages */
-    void flush() throws IOException;
+    void flushAndForce() throws IOException;
 
     /** Flush all dirty pages and close the page cache. */
     void close() throws IOException;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -144,7 +144,7 @@ public interface PagedFile extends AutoCloseable
      * Note: Flushing has to take locks on pages, so you cannot call flush
      * while you have pages pinned.
      */
-    void flush() throws IOException;
+    void flushAndForce() throws IOException;
 
     /**
      * Force all changes to this file handle down to disk. Does not flush dirty pages.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -392,7 +392,7 @@ public class MuninnPageCache implements PageCache
         {
             try
             {
-                file.flush();
+                file.flushAndForce();
                 file.closeSwapper();
                 flushedAndClosed = true;
             }
@@ -415,7 +415,7 @@ public class MuninnPageCache implements PageCache
     }
 
     @Override
-    public synchronized void flush() throws IOException
+    public synchronized void flushAndForce() throws IOException
     {
         assertNotClosed();
         flushAllPages();
@@ -437,6 +437,13 @@ public class MuninnPageCache implements PageCache
                 {
                     page.unlockRead( stamp );
                 }
+            }
+
+            FileMapping fileMapping = mappedFiles;
+            while ( fileMapping != null )
+            {
+                fileMapping.pagedFile.force();
+                fileMapping = fileMapping.next;
             }
         }
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -162,7 +162,7 @@ final class MuninnPagedFile implements PagedFile
     }
 
     @Override
-    public void flush() throws IOException
+    public void flushAndForce() throws IOException
     {
         try ( MajorFlushEvent flushEvent = tracer.beginFileFlush( swapper ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -670,7 +670,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
     {
         try
         {
-            storeFile.flush();
+            storeFile.flushAndForce();
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
@@ -315,7 +315,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
             {
                 counts.rotate( getLastCommittedTransactionId() );
             }
-            pageCache.flush();
+            pageCache.flushAndForce();
         }
         catch ( IOException e )
         {
@@ -516,7 +516,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
             {
                 // make sure the new version value is persisted
                 // TODO this can be improved by flushing only the page containing that value rather than all pages
-                storeFile.flush();
+                storeFile.flushAndForce();
             }
             catch ( IOException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
@@ -390,7 +390,7 @@ class KeyValueWriter implements Closeable
             cursor = null;
             if ( opened )
             {
-                file.flush();
+                file.flushAndForce();
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
@@ -201,7 +201,7 @@ public class BatchingNeoStore implements AutoCloseable
 
     public void flush() throws IOException
     {
-        pageCache.flush();
+        pageCache.flushAndForce();
     }
 
     public long getLastCommittedTransactionId()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
@@ -184,11 +184,11 @@ public class BatchingPageCache implements PageCache
     }
 
     @Override
-    public void flush() throws IOException
+    public void flushAndForce() throws IOException
     {   // no need to do anything here
         for ( PagedFile file : pagedFiles.values() )
         {
-            file.flush();
+            file.flushAndForce();
         }
     }
 
@@ -268,12 +268,12 @@ public class BatchingPageCache implements PageCache
 
         public void closeFile() throws IOException
         {
-            flush();
+            flushAndForce();
             channel.close();
         }
 
         @Override
-        public void flush() throws IOException
+        public void flushAndForce() throws IOException
         {
             cursors[PF_SHARED_LOCK].flush();
             cursors[PF_EXCLUSIVE_LOCK].flush();

--- a/community/kernel/src/test/java/org/neo4j/kernel/ShutdownAndCommitRaceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/ShutdownAndCommitRaceTest.java
@@ -35,9 +35,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
-import org.neo4j.kernel.AvailabilityGuard;
-import org.neo4j.kernel.DatabaseAvailability;
-import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
@@ -47,7 +44,6 @@ import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.OtherThreadRule;
 
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.Exceptions.contains;
 
 public class ShutdownAndCommitRaceTest
@@ -179,7 +175,7 @@ public class ShutdownAndCommitRaceTest
     }
 
     /**
-     * {@link PageCache} that will coordinate with a {@link Barrier} in {@link #flush()} if the call comes
+     * {@link PageCache} that will coordinate with a {@link Barrier} in {@link #flushAndForce()} if the call comes
      * from {@link NeoStoreDataSource#stop()}.
      */
     private class ShutdownControlledPageCache implements PageCache
@@ -200,14 +196,14 @@ public class ShutdownAndCommitRaceTest
         }
 
         @Override
-        public void flush() throws IOException
+        public void flushAndForce() throws IOException
         {
             if ( enabled.get() )
             {
                 System.out.println( "flushing" );
                 beginBarrier.release();
             }
-            delegate.flush();
+            delegate.flushAndForce();
             if ( enabled.get() )
             {
                 System.out.println( "flushed" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/standard/FindHighestInUseRebuilderFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/standard/FindHighestInUseRebuilderFactoryTest.java
@@ -60,7 +60,7 @@ public class FindHighestInUseRebuilderFactoryTest
         store.write( new TestRecord(2001, 0) ); // 0 here marks this record as not in use
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = mock(StoreIdGenerator.class);
         StoreToolkit toolkit = mock(StoreToolkit.class);
@@ -92,7 +92,7 @@ public class FindHighestInUseRebuilderFactoryTest
         store.write( new TestRecord(2001, 1) ); // This is the record we expect this strategy to find
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = mock(StoreIdGenerator.class);
         StoreToolkit toolkit = mock(StoreToolkit.class);
@@ -123,7 +123,7 @@ public class FindHighestInUseRebuilderFactoryTest
         store.write( new TestRecord(2, 1) ); // Add a record at id 2, to emulate a header that happens to have a byte that aligns with the in_use byte
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = mock(StoreIdGenerator.class);
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/standard/FullDefragmentationRebuilderFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/standard/FullDefragmentationRebuilderFactoryTest.java
@@ -63,7 +63,7 @@ public class FullDefragmentationRebuilderFactoryTest
         store.write( new TestRecord(1001, 0) ); // 0 here marks this record as not in use
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = spy( new TestStoreIdGenerator() );
         StoreToolkit toolkit = mock(StoreToolkit.class);
@@ -101,7 +101,7 @@ public class FullDefragmentationRebuilderFactoryTest
 
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = spy( new TestStoreIdGenerator() );
         StoreToolkit toolkit = mock(StoreToolkit.class);
@@ -137,7 +137,7 @@ public class FullDefragmentationRebuilderFactoryTest
         store.write( new TestRecord(2, 1) ); // Add a record at id 2, to emulate a header that happens to have a byte that aligns with the in_use byte
 
         // Make sure file is flushed to disk
-        cache.flush();
+        cache.flushAndForce();
 
         StoreIdGenerator idGenerator = spy( new TestStoreIdGenerator() );
 

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -168,9 +168,9 @@ public class PageCacheRule extends ExternalResource
         }
 
         @Override
-        public void flush() throws IOException
+        public void flushAndForce() throws IOException
         {
-            pageCache.flush();
+            pageCache.flushAndForce();
         }
 
         @Override
@@ -228,9 +228,9 @@ public class PageCacheRule extends ExternalResource
         }
 
         @Override
-        public void flush() throws IOException
+        public void flushAndForce() throws IOException
         {
-            pagedFile.flush();
+            pagedFile.flushAndForce();
         }
 
         @Override

--- a/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
@@ -86,7 +86,7 @@ public class CountsStoreRecoveryTest
     {
         NeoStore neoStore = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( NeoStore.class );
         PagedFile storeFile = ReflectionUtil.getPrivateField( neoStore, "storeFile", PagedFile.class );
-        storeFile.flush();
+        storeFile.flushAndForce();
     }
 
     private CountsTracker counts()

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -19,17 +19,17 @@
  */
 package recovery;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
@@ -51,10 +51,8 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.register.Registers.newDoubleLongRegister;
 import static org.neo4j.test.EphemeralFileSystemRule.shutdownDb;
@@ -268,7 +266,7 @@ public class TestRecoveryScenarios
                     @Override
                     void flush( GraphDatabaseAPI db ) throws IOException
                     {
-                        db.getDependencyResolver().resolveDependency( PageCache.class ).flush();
+                        db.getDependencyResolver().resolveDependency( PageCache.class ).flushAndForce();
                     }
                 };
         final Object[] parameters = new Object[]{this};

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -58,9 +58,9 @@ public class ExternallyManagedPageCache implements PageCache
     }
 
     @Override
-    public void flush() throws IOException
+    public void flushAndForce() throws IOException
     {
-        delegate.flush();
+        delegate.flushAndForce();
     }
 
     @Override

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
@@ -142,7 +142,7 @@ public class DataGenerator
         finally
         {
             stores.close();
-            pageCache.flush();
+            pageCache.flushAndForce();
             pageCache.close();
         }
     }


### PR DESCRIPTION
This way, flushing also always implies forcing (fsync'ing) the underlying file channel, instead of the rather confusing inconsistency we had where we previously only forced the channel when forcing the PagedFile.