### PR TITLE
Properly handle toInt for strings in cypher.

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ToIntFunction.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ToIntFunction.scala
@@ -39,16 +39,12 @@ case class ToIntFunction(a: Expression) extends NullInNullOutExpression(a) {
       v.longValue()
     case v: String =>
       try {
-        v.toLong
+        val d = BigDecimal(v)
+        if (d <= Long.MaxValue && d >= Long.MinValue) d.toLong
+        else throw new ParameterWrongTypeException(s"integer, $v, is too large")
       } catch {
         case e: NumberFormatException =>
-          try {
-            v.toFloat.toInt
-          } catch {
-            case e: NumberFormatException =>
-              null
-          }
-
+          null
       }
     case v =>
       throw new ParameterWrongTypeException("Expected a String or Number, got: " + v.toString)

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ToIntFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/commands/expressions/ToIntFunctionTest.scala
@@ -74,6 +74,31 @@ class ToIntFunctionTest extends CypherFunSuite {
     toInt(20.6f) should equal(20)
   }
 
+  test("should fail for larger integers larger that 8 bytes") {
+    evaluating { toInt("10508455564958384115") } should produce[ParameterWrongTypeException]
+  }
+
+  test("should handle floats larger than 2^31 - 1") {
+    //2^33 = 8589934592
+    toInt("8589934592.0") should equal(8589934592L)
+  }
+
+  test("should handle -2^63") {
+    toInt("-9223372036854775808") should equal(Long.MinValue)
+  }
+
+  test("cannot handle -2^63-1") {
+    evaluating { toInt("-9223372036854775809") } should produce[ParameterWrongTypeException]
+  }
+
+  test("should handle 2^63 - 1") {
+    toInt("9223372036854775807") should equal(Long.MaxValue)
+  }
+
+  test("cannot handle 2^63") {
+    evaluating { toInt("9223372036854775808") } should produce[ParameterWrongTypeException]
+  }
+
   private def toInt(orig: Any) = {
     ToIntFunction(Literal(orig))(ExecutionContext.empty)(QueryStateHelper.empty)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -441,6 +441,12 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     )
   }
 
+  test("fail when parsing larger than 64 bit integers") {
+    executeAndEnsureError(
+      "RETURN toInt('10508455564958384115')",
+      "integer, 10508455564958384115, is too large")
+  }
+
   def executeAndEnsureError(query: String, expected: String) {
     try {
       execute(query).toList


### PR DESCRIPTION
Prior to this fix strings were parsed using `toLong` and on failure they were
turned into floats which in turn were turned into ints (32 bit).