### PR TITLE
Move UnsafeUtil to it's own module

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -29,7 +29,7 @@ import org.neo4j.io.pagecache.Page;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PageEvictionCallback;
 import org.neo4j.io.pagecache.PageSwapper;
-import org.neo4j.io.pagecache.impl.muninn.UnsafeUtil;
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /**
  * A simple PageSwapper implementation that directs all page swapping to a

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FlushTask.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FlushTask.java
@@ -21,7 +21,7 @@ package org.neo4j.io.pagecache.impl.muninn;
 
 /**
  * This runnable continuously flushes dirty pages in the background, such that future calls to
- * {@link MuninnPageCache#flush()} have less work to do.
+ * {@link MuninnPageCache#flushAndForce()} have less work to do.
  */
 final class FlushTask extends BackgroundTask
 {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MemoryReleaser.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MemoryReleaser.java
@@ -21,6 +21,8 @@ package org.neo4j.io.pagecache.impl.muninn;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 final class MemoryReleaser extends AtomicInteger
 {
     private final long[] rawPointers;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -32,9 +32,10 @@ import org.neo4j.io.pagecache.tracing.FlushEvent;
 import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.jsr166e.StampedLock;
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
-import static org.neo4j.io.pagecache.impl.muninn.UnsafeUtil.allowUnalignedMemoryAccess;
-import static org.neo4j.io.pagecache.impl.muninn.UnsafeUtil.storeByteOrderIsNative;
+import static org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.allowUnalignedMemoryAccess;
+import static org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.storeByteOrderIsNative;
 
 final class MuninnPage extends StampedLock implements Page
 {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -35,6 +35,7 @@ import org.neo4j.io.pagecache.tracing.EvictionRunEvent;
 import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /**
  * The Muninn {@link org.neo4j.io.pagecache.PageCache page cache} implementation.
@@ -255,10 +256,7 @@ public class MuninnPageCache implements PageCache
     private static void verifyHacks()
     {
         // Make sure that we have access to theUnsafe.
-        if ( !UnsafeUtil.hasUnsafe() )
-        {
-            throw new AssertionError( "MuninnPageCache requires access to sun.misc.Unsafe" );
-        }
+        UnsafeUtil.assertHasUnsafe();
     }
 
     private static void verifyCachePageSizeIsPowerOfTwo( int cachePageSize )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -31,9 +31,7 @@ import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
 import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
-
-import static org.neo4j.io.pagecache.impl.muninn.UnsafeUtil.arrayOffset;
-import static org.neo4j.io.pagecache.impl.muninn.UnsafeUtil.getAndSetObject;
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 final class MuninnPagedFile implements PagedFile
 {
@@ -270,7 +268,7 @@ final class MuninnPagedFile implements PagedFile
         int chunkId = computeChunkId( filePageId );
         long chunkOffset = computeChunkOffset( filePageId );
         Object[] chunk = translationTable[chunkId];
-        Object element = getAndSetObject( chunk, chunkOffset, null );
+        Object element = UnsafeUtil.getAndSetObject( chunk, chunkOffset, null );
         assert element instanceof MuninnPage: "Expected to evict a MuninnPage but found " + element;
         return (MuninnPage) element;
     }
@@ -312,6 +310,6 @@ final class MuninnPagedFile implements PagedFile
     long computeChunkOffset( long filePageId )
     {
         int index = (int) (filePageId & translationTableChunkSizeMask);
-        return arrayOffset( index, translationTableChunkArrayBase, translationTableChunkArrayScale );
+        return UnsafeUtil.arrayOffset( index, translationTableChunkArrayBase, translationTableChunkArrayScale );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 /**
  * Off-heap version of {@link IntArray} using {@code sun.misc.Unsafe}. Supports arrays with length beyond
  * Integer.MAX_VALUE.
@@ -39,18 +41,18 @@ public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
     @Override
     public int get( long index )
     {
-        return unsafe.getInt( addressOf( index ) );
+        return UnsafeUtil.getInt( addressOf( index ) );
     }
 
     @Override
     public void set( long index, int value )
     {
         long address = addressOf( index );
-        if ( unsafe.getInt( address ) == defaultValue )
+        if ( UnsafeUtil.getInt( address ) == defaultValue )
         {
             size++;
         }
-        unsafe.putInt( address, value );
+        UnsafeUtil.putInt( address, value );
         if ( index > highestSetIndex )
         {
             highestSetIndex = index;
@@ -74,13 +76,13 @@ public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
     {
         if ( isByteUniform( defaultValue ) )
         {
-            unsafe.setMemory( address, length << shift, (byte)defaultValue );
+            UnsafeUtil.setMemory( address, length << shift, (byte)defaultValue );
         }
         else
         {
             for ( long i = 0, adr = address; i < length; i++, adr += stride )
             {
-                unsafe.putInt( adr, defaultValue );
+                UnsafeUtil.putInt( adr, defaultValue );
             }
         }
         highestSetIndex = -1;
@@ -95,9 +97,9 @@ public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
 
         for ( int i = 0; i < numberOfEntries; i++, fromAddress += stride, toAddress += stride )
         {
-            int fromValue = unsafe.getInt( fromAddress );
-            unsafe.putInt( fromAddress, unsafe.getInt( toAddress ) );
-            unsafe.putInt( toAddress, fromValue );
+            int fromValue = UnsafeUtil.getInt( fromAddress );
+            UnsafeUtil.putInt( fromAddress, UnsafeUtil.getInt( toAddress ) );
+            UnsafeUtil.putInt( toAddress, fromValue );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 /**
  * Off-heap version of {@link LongArray} using {@code sun.misc.Unsafe}. Supports arrays with length beyond
  * Integer.MAX_VALUE.
@@ -39,18 +41,18 @@ public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
     @Override
     public long get( long index )
     {
-        return unsafe.getLong( addressOf( index ) );
+        return UnsafeUtil.getLong( addressOf( index ) );
     }
 
     @Override
     public void set( long index, long value )
     {
         long address = addressOf( index );
-        if ( unsafe.getLong( address ) == defaultValue )
+        if ( UnsafeUtil.getLong( address ) == defaultValue )
         {
             size++;
         }
-        unsafe.putLong( address, value );
+        UnsafeUtil.putLong( address, value );
         if ( index > highestSetIndex )
         {
             highestSetIndex = index;
@@ -74,13 +76,13 @@ public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
     {
         if ( isByteUniform( defaultValue ) )
         {
-            unsafe.setMemory( address, length << shift, (byte)defaultValue );
+            UnsafeUtil.setMemory( address, length << shift, (byte)defaultValue );
         }
         else
         {
             for ( long i = 0, adr = address; i < length; i++, adr += stride )
             {
-                unsafe.putLong( adr, defaultValue );
+                UnsafeUtil.putLong( adr, defaultValue );
             }
         }
         highestSetIndex = -1;
@@ -95,9 +97,9 @@ public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
 
         for ( int i = 0; i < numberOfEntries; i++, fromAddress += stride, toAddress += stride )
         {
-            long fromValue = unsafe.getLong( fromAddress );
-            unsafe.putLong( fromAddress, unsafe.getLong( toAddress ) );
-            unsafe.putLong( toAddress, fromValue );
+            long fromValue = UnsafeUtil.getLong( fromAddress );
+            UnsafeUtil.putLong( fromAddress, UnsafeUtil.getLong( toAddress ) );
+            UnsafeUtil.putLong( toAddress, fromValue );
         }
     }
 }

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -30,6 +30,7 @@
   </scm>
 
   <modules>
+    <module>unsafe</module>
     <module>primitive-collections</module>
     <module>io</module>
     <module>csv</module>

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 public class IntKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
 {
     public IntKeyUnsafeTable( int capacity, VALUE valueMarker )
@@ -29,7 +31,7 @@ public class IntKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
     @Override
     protected long internalKey( long keyAddress )
     {
-        return unsafe.getInt( keyAddress );
+        return UnsafeUtil.getInt( keyAddress );
     }
 
     @Override
@@ -38,7 +40,7 @@ public class IntKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
         assert (int)key == key : "Illegal key " + key + ", it's bigger than int";
 
         // We can "safely" cast to int here, assuming that this call trickles in via a PrimitiveIntCollection
-        unsafe.putInt( keyAddress, (int) key );
+        UnsafeUtil.putInt( keyAddress, (int) key );
     }
 
     @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
 {
     public LongKeyLongValueUnsafeTable( int capacity )
@@ -29,21 +31,21 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     @Override
     protected long internalKey( long keyAddress )
     {
-        return unsafe.getLong( keyAddress );
+        return UnsafeUtil.getLong( keyAddress );
     }
 
     @Override
     protected void internalPut( long keyAddress, long key, long[] value )
     {
-        unsafe.putLong( keyAddress, key );
-        unsafe.putLong( keyAddress+8, value[0] );
+        UnsafeUtil.putLong( keyAddress, key );
+        UnsafeUtil.putLong( keyAddress+8, value[0] );
     }
 
     @Override
     protected long[] internalRemove( long keyAddress )
     {
-        valueMarker[0] = unsafe.getLong( keyAddress+8 );
-        unsafe.putLong( keyAddress, -1 );
+        valueMarker[0] = UnsafeUtil.getLong( keyAddress+8 );
+        UnsafeUtil.putLong( keyAddress, -1 );
         return valueMarker;
     }
 
@@ -51,8 +53,8 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     public long[] putValue( int index, long[] value )
     {
         long valueAddress = valueAddress( index );
-        long oldValue = unsafe.getLong( valueAddress );
-        unsafe.putLong( valueAddress, value[0] );
+        long oldValue = UnsafeUtil.getLong( valueAddress );
+        UnsafeUtil.putLong( valueAddress, value[0] );
         return pack( oldValue );
     }
 
@@ -70,7 +72,7 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     @Override
     public long[] value( int index )
     {
-        long value = unsafe.getLong( valueAddress( index ) );
+        long value = UnsafeUtil.getLong( valueAddress( index ) );
         return pack( value );
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+
 public class LongKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
 {
     public LongKeyUnsafeTable( int capacity, VALUE valueMarker )
@@ -29,13 +31,13 @@ public class LongKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
     @Override
     protected long internalKey( long keyAddress )
     {
-        return unsafe.getLong( keyAddress );
+        return UnsafeUtil.getLong( keyAddress );
     }
 
     @Override
     protected void internalPut( long keyAddress, long key, VALUE value )
     {
-        unsafe.putLong( keyAddress, key );
+        UnsafeUtil.putLong( keyAddress, key );
     }
 
     @Override

--- a/community/unsafe/LICENSES.txt
+++ b/community/unsafe/LICENSES.txt
@@ -1,0 +1,4 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+

--- a/community/unsafe/NOTICE.txt
+++ b/community/unsafe/NOTICE.txt
@@ -1,0 +1,27 @@
+Neo4j
+Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+in this notice as "Neo Technology")
+   [http://neotechnology.com]
+
+This product includes software ("Software") developed by Neo Technology.
+
+The copyright in the bundled Neo4j graph database (including the
+Software) is owned by Neo Technology. The Software developed and owned
+by Neo Technology is licensed under the GNU GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/gpl-3.0.html) ("GPL")
+to all third parties and that license, as required by the GPL, is
+included in the LICENSE.txt file.
+
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the GPL and you may use the
+software solely pursuant to the terms of the relevant Commercial
+Agreement.
+
+Full license texts are found in LICENSES.txt.
+
+Third-party licenses
+--------------------
+

--- a/community/unsafe/pom.xml
+++ b/community/unsafe/pom.xml
@@ -8,24 +8,21 @@
   </parent>
 
   <properties>
-    <short-name>primitive-collections</short-name>
-    <bundle.namespace>org.neo4j.collection.primitive</bundle.namespace>
+    <short-name>unsafe</short-name>
+    <bundle.namespace>org.neo4j.unsafe</bundle.namespace>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>neo4j-primitive-collections</artifactId>
+  <artifactId>neo4j-unsafe</artifactId>
   <version>2.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
-  <name>Neo4j - Primitive Collections</name>
-  <description>Efficient collections for sets and maps that has primitive types as keys.</description>
+  <name>Neo4j - Unsafe Access</name>
+  <description>Internal component that provides access to unsafe memory
+    intrinsics</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
-
-  <scm>
-    <url>https://github.com/neo4j/neo4j/tree/master/community/primitive-collections</url>
-  </scm>
 
   <licenses>
     <license>
@@ -49,11 +46,6 @@ the relevant Commercial Agreement.
 
   <dependencies>
     <dependency>
-      <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-unsafe</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -61,11 +53,6 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This way we end up with just one place where we play with fire, and just one place where we have to cope with compatibility with CPU architectures, operating systems and JREs.

Issued against master so both 2.2 and 2.3+ get on common ground with this.