### PR TITLE
Ensure %NEO4J_HOME% as parent path when loading config files on windows

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j.bat
@@ -24,12 +24,4 @@ set classpath="-DserverClasspath=lib/*.jar;system/lib/*.jar;plugins/**/*.jar;./c
 set mainclass="-DserverMainClass=org.neo4j.server.Bootstrapper"
 set configFile="conf\neo4j-wrapper.conf"
 
-rem Go to the folder that contains this batch file, a.k.a. NEO4J_HOME\bin
-cd /d "%~dp0"
-rem Go to NEO4J_HOME
-cd ..
-rem It makes locating our files given by relative paths (e.g. "conf\neo4j.properties")
-rem easier after we've set the NEO4J_HOME as the working directory.
-
-rem %~dps0 still points to the folder path of this batch file
 call "%~dps0base.bat" %1 %2 %3 %4 %5

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jArbiter.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jArbiter.bat
@@ -24,12 +24,4 @@ set classpath="-DserverClasspath=lib/*.jar;system/lib/*.jar"
 set mainclass="-DserverMainClass=org.neo4j.server.enterprise.StandaloneClusterClient"
 set configFile="conf\arbiter-wrapper.conf"
 
-rem Go to the folder that contains this batch file, a.k.a. NEO4J_HOME\bin
-cd /d "%~dp0"
-rem Go to NEO4J_HOME
-cd ..
-rem It makes locating our files given by relative paths (e.g. "conf\neo4j.properties")
-rem easier after we've set the NEO4J_HOME as the working directory.
-
-rem %~dps0 still points to the folder path of this batch file
 call "%~dps0base.bat" %1 %2 %3 %4 %5"

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jInstaller.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4jInstaller.bat
@@ -11,7 +11,7 @@ set serviceStartType=auto
 set classpath="-DserverClasspath=lib/*.jar;system/lib/*.jar;plugins/**/*.jar;./conf*"
 set mainclass="-DserverMainClass=org.neo4j.server.Bootstrapper"
 set configFile="conf\neo4j-wrapper.conf"
-set loggingProperties="-Djava.util.logging.config.file=conf\windows-wrapper-logging.properties"
+set loggingProperties="-Djava.util.logging.config.file=%~dps0..\conf\windows-wrapper-logging.properties"
 set wrapperJarFilename=windows-service-wrapper-5.jar
 
 goto :main %1

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
@@ -132,7 +132,7 @@ goto:eof
   goto :eof
 
 :console
-  "%javapath%\bin\java.exe" -DworkingDir="%~dps0.." -Djava.util.logging.config.file=conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar "%~dps0%wrapperJarFilename%"
+  "%javapath%\bin\java.exe" -DworkingDir="%~dps0.." -Djava.util.logging.config.file=%~dps0../conf/windows-wrapper-logging.properties -DconfigFile=%configFile% %classpath% %mainclass% -jar "%~dps0%wrapperJarFilename%"
   goto :eof
 
 :help


### PR DESCRIPTION
The fix is simple. Instead of using relative paths, now we always use full path when loading windows-wrapper config file in bats.