### PR TITLE
Fix empty results in rows view.

### DIFF
--- a/community/browser/app/scripts/directives/neoTable.coffee
+++ b/community/browser/app/scripts/directives/neoTable.coffee
@@ -35,13 +35,16 @@ angular.module('neo4jApp.directives')
         escapeHtml = (string) ->
           String(string).replace(/[&<>"'\/]/g, (s) -> entityMap[s])
 
+        emptyMarker = ->
+          '<em>(empty)</em>'
+
         unbind = scope.$watch attr.tableData, (result) ->
           return unless result
           elm.html(render(result))
           unbind()
 
         json2html = (obj) ->
-          return '' unless Object.keys(obj).length
+          return emptyMarker() unless Object.keys(obj).length
           html  = "<table class='json-object'><tbody>"
           html += "<tr><th>#{k}</th><td>#{cell2html(v)}</td></tr>" for own k, v of obj
           html += "</tbody></table>"
@@ -49,6 +52,7 @@ angular.module('neo4jApp.directives')
 
         cell2html = (cell) ->
           if angular.isString(cell)
+            return emptyMarker() unless cell.length
             escapeHtml(cell)
           else if angular.isArray(cell)
             "["+((cell2html(el) for el in cell).join(', '))+"]"

--- a/community/browser/app/views/frame-cypher.jade
+++ b/community/browser/app/views/frame-cypher.jade
@@ -24,7 +24,7 @@ div(ng-controller="CypherResultCtrl", fullscreen)
                 | No graph view available. You have to&nbsp;
                 a(help-topic="RETURN")
                   | RETURN
-                | nodes, relationships or paths to see a graph visualization.
+                | &nbsp; nodes, relationships or paths to see a graph visualization.
             .graph-holder.result(ng-show='isAvailable("graph")')
               include partials/legend
               .graph-contents
@@ -45,7 +45,15 @@ div(ng-controller="CypherResultCtrl", fullscreen)
 
           .view-result-table.result(ng-show='isActive("table") && !frame.isTerminating')
             .table-holder
-              neo-table(table-data='frame.response.table', ng-show='frame.response.table._response.columns.length')
+              article.help.no-data.has-status-bar(ng-show='!frame.response.table._response.columns.length')
+                p(ng-show="getNonZeroStatisticsFields(frame).length")
+                  {{formatStatisticsOutput(updatesStatistics(frame))}}
+                p(ng-show="!getNonZeroStatisticsFields(frame).length")
+                  | (no changes, no rows)
+              article.help.no-data.has-status-bar(ng-show='!frame.response.table._response.data.length && frame.response.table._response.columns.length')
+                p
+                  | (no rows)
+              neo-table(table-data='frame.response.table', ng-show='frame.response.table._response.data.length')
             .status-bar
               .status
                 include partials/result-status


### PR DESCRIPTION
- Add text to hint the user why there's nothing to show.
It could be that nothing was returned or the returned
results were empty.

- Add `(empty)` holder to show that a returned node has no properties
OR that a returned string has no length (it exists, but is empty).