### PR TITLE
Cypher loads each relationship record once during iterating

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/helpers/BeansAPIRelationshipIterator.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/helpers/BeansAPIRelationshipIterator.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.helpers
+
+import org.neo4j.kernel.impl.api.store.RelationshipIterator
+import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions
+import org.neo4j.graphdb.Relationship
+import org.neo4j.kernel.impl.api.RelationshipVisitor
+import org.neo4j.kernel.impl.core.RelationshipProxy
+
+/**
+ * Converts a RelationshipIterator coming from the Kernel API into an Iterator[Relationship] while
+ * still sticking to the fact that each relationship record is only loaded once.
+ */
+class BeansAPIRelationshipIterator(relationships: RelationshipIterator,
+                                   actions: RelationshipActions)
+                                   extends Iterator[Relationship] with RelationshipVisitor[RuntimeException] {
+  var nextRelationship: Relationship = null
+
+  def hasNext = relationships.hasNext
+  def next(): Relationship = {
+    if (hasNext) {
+        val relationshipId = relationships.next()
+        relationships.relationshipVisit(relationshipId, this)
+        nextRelationship
+    } else {
+      throw new NoSuchElementException
+    }
+  }
+
+  def visit(relationshipId: Long, relationshipType: Int, startNode: Long, endNode: Long) {
+    nextRelationship = new RelationshipProxy(actions, relationshipId, startNode, relationshipType, endNode)
+  }
+}

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -279,6 +279,7 @@ public abstract class InternalAbstractGraphDatabase
     protected DataSourceManager dataSourceManager;
     private StartupStatisticsProvider startupStatistics;
     private QueryExecutionEngine queryExecutor = QueryEngineProvider.noEngine();
+    protected RelationshipActions relationshipActions;
 
     protected InternalAbstractGraphDatabase( String storeDir, Map<String,String> params, Dependencies dependencies )
     {
@@ -473,9 +474,11 @@ public abstract class InternalAbstractGraphDatabase
 
         threadToTransactionBridge = life.add( new ThreadToStatementContextBridge() );
 
+        relationshipActions = createRelationshipActions();
+
         nodeManager = createNodeManager();
 
-        transactionEventHandlers = new TransactionEventHandlers( createNodeActions(), createRelationshipActions(),
+        transactionEventHandlers = new TransactionEventHandlers( createNodeActions(), relationshipActions,
                 threadToTransactionBridge );
 
         indexStore = life.add( new IndexConfigStore( this.storeDir, fileSystem ) );
@@ -1571,6 +1574,10 @@ public abstract class InternalAbstractGraphDatabase
             else if ( PageCacheMonitor.class.isAssignableFrom( type ) )
             {
                 return type.cast( tracers.pageCacheTracer );
+            }
+            else if ( RelationshipActions.class.isAssignableFrom( type ) )
+            {
+                return type.cast( relationshipActions );
             }
             return null;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
 import org.neo4j.register.Register;
 
@@ -62,9 +63,9 @@ interface DataRead
      */
     PrimitiveLongIterator relationshipsGetAll();
 
-    PrimitiveLongIterator nodeGetRelationships( long nodeId, Direction direction, int... relTypes ) throws EntityNotFoundException;
+    RelationshipIterator nodeGetRelationships( long nodeId, Direction direction, int... relTypes ) throws EntityNotFoundException;
 
-    PrimitiveLongIterator nodeGetRelationships( long nodeId, Direction direction ) throws EntityNotFoundException;
+    RelationshipIterator nodeGetRelationships( long nodeId, Direction direction ) throws EntityNotFoundException;
 
     /**
      * Returns node id of unique node found in the given unique index for value or

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.api.operations.EntityOperations;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
 import org.neo4j.register.Register;
@@ -333,14 +334,14 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
+    public RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
                                                        int[] relTypes ) throws EntityNotFoundException
     {
         return entityReadOperations.nodeGetRelationships( statement, nodeId, direction, relTypes );
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction ) throws EntityNotFoundException
+    public RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction ) throws EntityNotFoundException
     {
         return entityReadOperations.nodeGetRelationships( statement, nodeId, direction );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
 import org.neo4j.register.Register;
 
@@ -265,7 +266,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
+    public RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
             int[] relTypes ) throws EntityNotFoundException
     {
         guard.check();
@@ -273,7 +274,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction )
+    public RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction )
             throws EntityNotFoundException
     {
         guard.check();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -65,6 +65,7 @@ import org.neo4j.kernel.impl.api.operations.LegacyIndexWriteOperations;
 import org.neo4j.kernel.impl.api.operations.LockOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
@@ -220,7 +221,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( long nodeId, Direction direction, int[] relTypes )
+    public RelationshipIterator nodeGetRelationships( long nodeId, Direction direction, int[] relTypes )
             throws EntityNotFoundException
     {
         statement.assertOpen();
@@ -228,7 +229,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public PrimitiveLongIterator nodeGetRelationships( long nodeId, Direction direction )
+    public RelationshipIterator nodeGetRelationships( long nodeId, Direction direction )
             throws EntityNotFoundException
     {
         statement.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.util.register.NeoRegister;
 import org.neo4j.register.Register;
 
@@ -117,10 +118,10 @@ public interface EntityReadOperations
 
     Iterator<DefinedProperty> graphGetAllProperties( KernelStatement state );
 
-    PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
+    RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
                                                 int[] relTypes ) throws EntityNotFoundException;
 
-    PrimitiveLongIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction ) throws EntityNotFoundException;
+    RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction ) throws EntityNotFoundException;
 
     int nodeGetDegree( KernelStatement statement, long nodeId, Direction direction, int relType ) throws EntityNotFoundException;
 


### PR DESCRIPTION
instead of twice, as before this commit. This effectively doubles
performance of iterating through relationships, iterator-wise, perhaps not
cypher-wise since there are lots of other things also happening.

Moving forward there will be full-blown cursors exposed by the Kernel API,
this is just an optimization until we have that.