### PR TITLE
Implemented the visitor pattern for Result

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
@@ -19,21 +19,21 @@
  */
 package org.neo4j.cypher.javacompat;
 
+import scala.collection.JavaConversions;
+
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 
 import org.neo4j.cypher.CypherException;
 import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.Notification;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.Notification;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
-
-import scala.collection.JavaConversions;
 
 /**
  * Holds Cypher query result sets, in tabular form. Each row of the result is a map
@@ -281,9 +281,15 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
     }
 
     @Override
+    public void accept( ResultVisitor visitor )
+    {
+        inner.accept( visitor );
+    }
+
+    @Override
     public Iterable<Notification> getNotifications()
     {
-        return JavaConversions.asJavaIterable(inner.notifications());
+        return JavaConversions.asJavaIterable( inner.notifications() );
     }
 
     private static class ExceptionConversion<T> implements ResourceIterator<T>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExtendedExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExtendedExecutionResult.scala
@@ -19,10 +19,50 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.graphdb.{Notification, QueryExecutionType}
+import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
+import org.neo4j.graphdb._
 
 trait ExtendedExecutionResult extends ExecutionResult {
   def planDescriptionRequested: Boolean
   def executionType: QueryExecutionType
   def notifications: Iterable[Notification]
+
+  def accept(visitor: ResultVisitor): Unit = {
+    val row = new MapResultRow()
+    var continue = true
+    while (continue && hasNext) {
+      row.map = next()
+      continue = visitor.visit(row)
+    }
+  }
+}
+
+private class MapResultRow extends ResultRow {
+
+  var map: Map[String, Any] = Map.empty
+
+  override def getNode(key: String): Node = getWithType(key, classOf[Node])
+
+  override def getRelationship(key: String): Relationship = getWithType(key, classOf[Relationship])
+
+  override def get(key: String): Object = getWithType(key, classOf[Object])
+
+  override def getNumber(key: String): Number = getWithType(key, classOf[Number])
+
+  override def getBoolean(key: String): java.lang.Boolean = getWithType(key, classOf[java.lang.Boolean])
+
+  override def getPath(key: String): Path = getWithType(key, classOf[Path])
+
+  override def getString(key: String): String = getWithType(key, classOf[String])
+
+  private def getWithType[T](key: String, clazz: Class[T]): T = {
+    map.get(key) match {
+      case None =>
+        throw new IllegalArgumentException("No column \"" + key + "\" exists")
+      case Some(value) if clazz.isInstance(value) || value == null =>
+        clazz.cast(value)
+      case Some(value) =>
+        throw new NoSuchElementException("The current item in column \"" + key + "\" is not a " + clazz + ": \"" + value + "\"")
+    }
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/ExecutionResultWrapperFor2_3Test.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/ExecutionResultWrapperFor2_3Test.scala
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility
+
+import java.util.NoSuchElementException
+
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.PlannerName
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult
+import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
+import org.neo4j.graphdb.{Node, Relationship, ResourceIterator}
+import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QuerySession}
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Created by mats on 27/03/15.
+ */
+class ExecutionResultWrapperFor2_3Test extends CypherFunSuite {
+
+  test("visitor get works") {
+    val n = mock[Node]
+    val r = mock[Relationship]
+    val objectUnderTest = createInnerExecutionResult("a", "a", n, r)
+
+    val visitor = new CapturingResultVisitor(_.get("a"))
+    objectUnderTest.accept(visitor)
+
+    visitor.results should contain allOf("a", n, r)
+  }
+
+  test("visitor get string works") {
+    val objectUnderTest = createInnerExecutionResult("a", "a", "b", "c")
+
+    val visitor = new CapturingResultVisitor(_.getString("a"))
+    objectUnderTest.accept(visitor)
+
+    visitor.results should contain allOf("a", "b", "c")
+  }
+
+  test("visitor get node works") {
+    val n1 = mock[Node]
+    val n2 = mock[Node]
+    val n3 = mock[Node]
+    val objectUnderTest = createInnerExecutionResult("a", n1, n2, n3)
+
+    val visitor = new CapturingResultVisitor(_.getNode("a"))
+    objectUnderTest.accept(visitor)
+
+    visitor.results should contain allOf(n1, n2, n3)
+  }
+
+  test("when asking for a node when it is not a node") {
+    val objectUnderTest = createInnerExecutionResult("a", Long.box(42))
+
+    val visitor = new CapturingResultVisitor(_.getNode("a"))
+
+    try {
+      objectUnderTest.accept(visitor)
+      fail("Should have thrown " + classOf[NoSuchElementException])
+    }
+    catch {
+      case e: NoSuchElementException =>
+        e.getMessage should be("The current item in column \"a\" is not a " + classOf[Node] + ": \"42\"")
+    }
+  }
+
+  test("when asking for a non existing column throws") {
+    val objectUnderTest = createInnerExecutionResult("a", Int.box(42))
+
+    val visitor = new CapturingResultVisitor(_.getNode("does not exist"))
+
+    try {
+      objectUnderTest.accept(visitor)
+      fail("Should have thrown " + classOf[IllegalArgumentException])
+    }
+    catch {
+      case e: IllegalArgumentException =>
+        e.getMessage should be("No column \"does not exist\" exists")
+    }
+  }
+
+  test("when asking for a rel when it is not a rel") {
+    val objectUnderTest = createInnerExecutionResult("a", Long.box(42))
+
+    val visitor = new CapturingResultVisitor(_.getRelationship("a"))
+
+    try {
+      objectUnderTest.accept(visitor)
+      fail("Should have thrown " + classOf[NoSuchElementException])
+    }
+    catch {
+      case e: NoSuchElementException =>
+        e.getMessage should be("The current item in column \"a\" is not a " + classOf[Relationship] + ": \"42\"")
+    }
+  }
+
+  test("null key gives a friendly error") {
+    val objectUnderTest = createInnerExecutionResult("a", Int.box(42))
+
+    val visitor = new CapturingResultVisitor(_.getNumber(null))
+
+    try {
+      objectUnderTest.accept(visitor)
+      fail("Should have thrown " + classOf[IllegalArgumentException])
+    }
+    catch {
+      case e: IllegalArgumentException =>
+        e.getMessage should be("No column \"null\" exists")
+    }
+  }
+
+  test("when asking for a null value nothing bad happens") {
+    val objectUnderTest = createInnerExecutionResult("a", null)
+
+    val visitor = new CapturingResultVisitor(_.getRelationship("a"))
+
+    objectUnderTest.accept(visitor)
+    visitor.results should be(List(null))
+  }
+
+  test("stop on return false") {
+    val objectUnderTest = createInnerExecutionResult("a", Long.box(1), Long.box(2), Long.box(3), Long.box(4))
+
+    val result = ListBuffer[Any]()
+    val visitor = new ResultVisitor {
+      override def visit(row: ResultRow) = {
+        result += row.getNumber("a")
+        false
+      }
+    }
+
+    objectUnderTest.accept(visitor)
+    result should contain only 1
+  }
+
+  test("no unnecessary object creation") {
+    val objectUnderTest = createInnerExecutionResult("a", Long.box(1), Long.box(2))
+
+    val visitor = new CapturingResultVisitor(_.hashCode())
+
+    objectUnderTest.accept(visitor)
+    visitor.results.toSet should have size 1
+  }
+
+  test("no outofbounds on empty result") {
+    val objectUnderTest = createInnerExecutionResult("a")
+
+    val visitor = new CapturingResultVisitor(_ => {
+      fail("visit should never be called on empty result")
+    })
+
+    objectUnderTest.accept(visitor)
+  }
+
+  test("get boolean should return correct type") {
+    val objectUnderTest = createInnerExecutionResult("a", java.lang.Boolean.TRUE)
+
+    val visitor = new CapturingResultVisitor(_.getBoolean("a"))
+    objectUnderTest.accept(visitor)
+
+    visitor.results should contain only (java.lang.Boolean.TRUE)
+  }
+
+  private def createInnerExecutionResult(column: String, values: AnyRef*) = {
+    val mockObj = mock[InternalExecutionResult]
+    var offset = 0
+    when(mockObj.hasNext).thenAnswer(new Answer[Boolean] {
+      override def answer(invocationOnMock: InvocationOnMock) = offset < values.length
+    })
+    when(mockObj.next()).thenAnswer(new Answer[Map[String, AnyRef]] {
+      override def answer(invocationOnMock: InvocationOnMock) = {
+        val result = Map(column -> values(offset))
+        offset += 1
+        result
+      }
+    })
+    when(mockObj.javaIterator).thenReturn(mock[ResourceIterator[java.util.Map[String, Any]]])
+    new ExecutionResultWrapperFor2_3(mockObj, mock[PlannerName])(mock[QueryExecutionMonitor], mock[QuerySession])
+  }
+
+  private class CapturingResultVisitor(f: ResultRow => Any) extends ResultVisitor {
+
+    val results = ListBuffer[Any]()
+
+    override def visit(row: ResultRow): Boolean = {
+      results += f(row)
+      true
+    }
+  }
+
+}
+
+

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
@@ -188,4 +188,54 @@ public interface Result extends ResourceIterator<Map<String, Object>>
      * @return an iterable of all notifications created when running the query.
      */
     Iterable<Notification> getNotifications();
+
+    /**
+     * Visits all rows in this Result by iterating over them.
+     *
+     * This is an alternative to using the iterator form of Result. Using the visitor is better from a object
+     * creation perspective.
+     *
+     * @param visitor the ResultVisitor instance that will see the results of the visit.
+     */
+    void accept( ResultVisitor visitor );
+
+    /**
+     * Describes a row of a result. The contents of this object is only stable during the
+     * {@linkplain ResultVisitor#visit(ResultRow) visit} call. The data it contains can change between calls to
+     * {@linkplain ResultVisitor#visit(ResultRow) the visit method}. Instances of this type should thus not be saved
+     * for later, or shared with other threads, rather the content should be copied.
+     */
+    interface ResultRow
+    {
+        // TODO: Figure out type coercion around primitives
+        // TODO: Type safe getters for collections and maps?
+        Node getNode( String key );
+
+        Relationship getRelationship( String key );
+
+        Object get( String key );
+
+        String getString( String key );
+
+        Number getNumber( String key );
+
+        Boolean getBoolean( String key );
+
+        Path getPath( String key );
+    }
+
+    /**
+     * This is the visitor interface you need to implement to use the {@link Result#accept(ResultVisitor)} method.
+     */
+    interface ResultVisitor
+    {
+        /**
+         * Visits the specified row.
+         * @param row the row to visit. The row object is only guaranteed to be stable until flow of control has
+         *            returned from this method.
+         * @return true if the next row should also be visited. Returning false will terminate the iteration of
+         * result rows.
+         */
+        boolean visit( ResultRow row );
+    }
 }


### PR DESCRIPTION
Result now accepts a ResultVisitor, which is deferred to its inner ExtendedExecutionResult.