### PR TITLE
Fix input position in syntax and semantic exceptions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/InputPosition.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/InputPosition.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_2
 
 case class InputPosition(offset: Int, line: Int, column: Int) {
+  self =>
 
   override def hashCode = 41 * offset
 
@@ -36,7 +37,12 @@ case class InputPosition(offset: Int, line: Int, column: Int) {
 
   def toOffsetString = offset.toString
 
-  def bumped() = new InputPosition(offset + 1, line, column)  // HACKISH
+  def withOffset(pos: Option[InputPosition]) = pos match {
+    case Some(p) => copy(offset + p.offset, line + p.line - 1, column + p.column - 1)
+    case None => self
+  }
+
+  def bumped() = copy(offset = offset + 1) // HACKISH
 }
 
 object InputPosition {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/SemanticChecker.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/SemanticChecker.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2
 import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 
 class SemanticChecker(semanticCheckMonitor: SemanticCheckMonitor) {
-  def check(queryText: String, statement: Statement): SemanticState = {
+  def check(queryText: String, statement: Statement, offset: Option[InputPosition]): SemanticState = {
     semanticCheckMonitor.startSemanticCheck(queryText)
     val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean)
 
@@ -37,7 +37,8 @@ class SemanticChecker(semanticCheckMonitor: SemanticCheckMonitor) {
     }
     semanticErrors.map {
       error =>
-        throw new SyntaxException(s"${error.msg} (${error.position})", queryText, error.position.offset)
+        val position = error.position.withOffset(offset)
+        throw new SyntaxException(s"${error.msg} ($position)", queryText, position.offset)
     }
 
     semanticState

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
@@ -112,7 +112,7 @@ trait Base extends Parser {
     ) memoMismatches) ~~> (_.reduce(_ + '`' + _))
   }
 
-  def parseOrThrow[T](input: String, rule: Rule1[Seq[T]], monitor: Option[ParserMonitor[T]]): T = {
+  def parseOrThrow[T](input: String, initialOffset: Option[InputPosition], rule: Rule1[Seq[T]], monitor: Option[ParserMonitor[T]]): T = {
     monitor.foreach(_.startParsing(input))
     val parsingResults = ReportingParseRunner(rule).run(input)
     parsingResults.result match {
@@ -137,7 +137,9 @@ trait Base extends Parser {
               case _ => error.getClass.getSimpleName
             }
           }
-          val position = BufferPosition(error.getInputBuffer, error.getStartIndex)
+
+          val bufferPosition = BufferPosition(error.getInputBuffer, error.getStartIndex)
+          val position = bufferPosition.withOffset(initialOffset)
           throw new SyntaxException(s"$message ($position)", input, position.offset)
         }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/BufferPosition.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/BufferPosition.scala
@@ -20,13 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_2.parser
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import org.parboiled.buffers.InputBuffer
 import org.parboiled.Context
+import org.parboiled.buffers.InputBuffer
 
 object BufferPosition {
   def apply(buffer: InputBuffer, offset: Int): InputPosition = {
     val position = buffer.getPosition(offset)
-    new InputPosition(offset, position.line, position.column)
+    InputPosition(offset, position.line, position.column)
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParser.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParser.scala
@@ -30,8 +30,8 @@ class CypherParser(monitor: ParserMonitor[ast.Statement]) extends Parser
 
 
   @throws(classOf[SyntaxException])
-  def parse(queryText: String): ast.Statement =
-    parseOrThrow(queryText, CypherParser.Statements, Some(monitor))
+  def parse(queryText: String, offset: Option[InputPosition] = None): ast.Statement =
+    parseOrThrow(queryText, offset, CypherParser.Statements, Some(monitor))
 }
 
 object CypherParser extends Parser with Statement with Expressions {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/CostBasedPipeBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/CostBasedPipeBuilder.scala
@@ -46,7 +46,10 @@ case class CostBasedPipeBuilder(monitors: Monitors,
   extends PipeBuilder {
 
   def producePlan(inputQuery: PreparedQuery, planContext: PlanContext): PipeInfo = {
-    CostBasedPipeBuilder.rewriteStatement(inputQuery.statement, inputQuery.scopeTree, inputQuery.semanticTable, inputQuery.conditions, monitors.newMonitor[AstRewritingMonitor]()) match {
+    val statement = CostBasedPipeBuilder.rewriteStatement(inputQuery.statement, inputQuery.scopeTree,
+                                                          inputQuery.semanticTable, inputQuery.conditions,
+                                                          monitors.newMonitor[AstRewritingMonitor]())
+    statement match {
       case (ast: Query, rewrittenSemanticTable) =>
         monitor.startedPlanning(inputQuery.queryText)
         val (logicalPlan, pipeBuildContext) = produceLogicalPlan(ast, rewrittenSemanticTable)(planContext)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -50,8 +50,10 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
         ast
 
     val semanticChecker = new SemanticChecker(mock[SemanticCheckMonitor])
-    val semanticState = semanticChecker.check(query, cleanedStatement)
-    val (rewrittenAst: Statement, _) = CostBasedPipeBuilder.rewriteStatement(astRewriter.rewrite(query, cleanedStatement, semanticState)._1, semanticState.scopeTree, SemanticTable(types = semanticState.typeTable), Set.empty, mock[AstRewritingMonitor])
+    val semanticState = semanticChecker.check(query, cleanedStatement, None)
+    val statement = astRewriter.rewrite(query, cleanedStatement, semanticState)._1
+    val semanticTable: SemanticTable = SemanticTable(types = semanticState.typeTable)
+    val (rewrittenAst: Statement, _) = CostBasedPipeBuilder.rewriteStatement(statement, semanticState.scopeTree, semanticTable, Set.empty, mock[AstRewritingMonitor])
 
     // This fakes pattern expression naming for testing purposes
     // In the actual code path, this renaming happens as part of planning

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteTest.scala
@@ -34,7 +34,7 @@ trait RewriteTest {
   protected def assertRewrite(originalQuery: String, expectedQuery: String) {
     val original = parseForRewriting(originalQuery)
     val expected = parseForRewriting(expectedQuery)
-    semanticChecker.check(originalQuery, original)
+    semanticChecker.check(originalQuery, original, None)
 
     val result = rewrite(original)
     assert(result === expected, "\n" + originalQuery)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
@@ -154,11 +154,11 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   def produceLogicalPlan(queryText: String)(implicit planner: CostBasedPipeBuilder, planContext: PlanContext): LogicalPlan = {
     val parsedStatement = parser.parse(queryText)
-    val semanticState = semanticChecker.check(queryText, parsedStatement)
+    val semanticState = semanticChecker.check(queryText, parsedStatement, None)
     val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryText, parsedStatement, semanticState)
     CostBasedPipeBuilder.rewriteStatement(rewrittenStatement, semanticState.scopeTree, SemanticTable(types = semanticState.typeTable), postConditions, monitors.newMonitor[AstRewritingMonitor]()) match {
       case (ast: Query, newTable)=>
-        val semanticState = semanticChecker.check(queryText, ast)
+        val semanticState = semanticChecker.check(queryText, ast, None)
         tokenResolver.resolve(ast)(newTable, planContext)
         val (logicalPlan, _) = planner.produceLogicalPlan(ast, newTable)(planContext)
         logicalPlan

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
@@ -143,9 +143,9 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
     def planFor(queryString: String): SemanticPlan = {
       val parsedStatement = parser.parse(queryString)
       val cleanedStatement: Statement = parsedStatement.endoRewrite(inSequence(normalizeReturnClauses, normalizeWithClauses))
-      val semanticState = semanticChecker.check(queryString, cleanedStatement)
+      val semanticState = semanticChecker.check(queryString, cleanedStatement, None)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, cleanedStatement, semanticState)
-      val postRewriteSemanticState = semanticChecker.check(queryString, rewrittenStatement)
+      val postRewriteSemanticState = semanticChecker.check(queryString, rewrittenStatement, None)
       val semanticTable = SemanticTable(types = postRewriteSemanticState.typeTable)
       CostBasedPipeBuilder.rewriteStatement(rewrittenStatement, postRewriteSemanticState.scopeTree, semanticTable, postConditions, mock[AstRewritingMonitor]) match {
         case (ast: Query, newTable) =>
@@ -162,7 +162,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
     def getLogicalPlanFor(queryString: String): (LogicalPlan, SemanticTable) = {
       val parsedStatement = parser.parse(queryString)
-      val semanticState = semanticChecker.check(queryString, parsedStatement)
+      val semanticState = semanticChecker.check(queryString, parsedStatement, None)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, parsedStatement, semanticState)
 
       CostBasedPipeBuilder.rewriteStatement(rewrittenStatement, semanticState.scopeTree, semanticTable, postConditions, mock[AstRewritingMonitor]) match {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphProducer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphProducer.scala
@@ -36,7 +36,7 @@ trait QueryGraphProducer extends MockitoSugar {
     val ast = parser.parse(q)
     val semanticChecker = new SemanticChecker(mock[SemanticCheckMonitor])
     val cleanedStatement: Statement = ast.endoRewrite(inSequence(normalizeReturnClauses, normalizeWithClauses))
-    val semanticState = semanticChecker.check(query, cleanedStatement)
+    val semanticState = semanticChecker.check(query, cleanedStatement, None)
 
     val (firstRewriteStep, _, postConditions) = astRewriter.rewrite(query, cleanedStatement, semanticState)
     val semanticTable = SemanticTable(types = semanticState.typeTable, recordedScopes = semanticState.recordedScopes)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOptionParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOptionParser.scala
@@ -19,16 +19,18 @@
  */
 package org.neo4j.cypher.internal
 
+import org.neo4j.cypher.internal.compiler.v2_2.InputPosition
 import org.neo4j.cypher.internal.compiler.v2_2.parser._
 import org.parboiled.scala._
 
-final case class CypherQueryWithOptions(statement: String, options: Seq[CypherOption] = Seq.empty)
+final case class CypherQueryWithOptions(statement: String, options: Seq[CypherOption], offset: InputPosition)
 
 case class CypherOptionParser(monitor: ParserMonitor[CypherQueryWithOptions]) extends Parser with Base {
-  def apply(input: String): CypherQueryWithOptions = parseOrThrow(input, QueryWithOptions, Some(monitor))
+  def apply(input: String): CypherQueryWithOptions = parseOrThrow(input, None, QueryWithOptions, Some(monitor))
 
   def QueryWithOptions: Rule1[Seq[CypherQueryWithOptions]] =
-    AllOptions ~ optional(WS) ~ AnySomething ~~> ( (options: Seq[CypherOption], text: String) => Seq(CypherQueryWithOptions(text, options)))
+    AllOptions ~ optional(WS) ~ AnySomething ~~>>
+      ( (options: Seq[CypherOption], text: String) => pos => Seq(CypherQueryWithOptions(text, options, pos)))
 
   def AllOptions: Rule1[Seq[CypherOption]] = zeroOrMore(AnyCypherOption, WS)
 
@@ -36,23 +38,22 @@ case class CypherOptionParser(monitor: ParserMonitor[CypherQueryWithOptions]) ex
 
   def AnySomething: Rule1[String] = rule("Query") { oneOrMore(org.parboiled.scala.ANY) ~> identity }
 
-  def Version: Rule1[VersionOption] =
-    rule("CYPHER") {
+  def Version: Rule1[VersionOption] = rule("CYPHER") {
       keyword("CYPHER") ~ WS ~ VersionNumber
     }
 
-  def Planner =rule("PLANNER") (
+  def Planner = rule("PLANNER") (
     keyword("PLANNER COST") ~ push(CostPlannerOption)
       | keyword("PLANNER IDP") ~ push(IDPPlannerOption)
       | keyword("PLANNER DP") ~ push(DPPlannerOption)
       | keyword("PLANNER RULE") ~ push(RulePlannerOption)
   )
 
-  def VersionNumber =
-    rule("Version") { group(Digits ~ "." ~ Digits) ~> VersionOption }
+  def VersionNumber = rule("Version") {
+    group(Digits ~ "." ~ Digits) ~> VersionOption
+  }
 
-  def Digits =
-    oneOrMore("0" - "9")
+  def Digits = oneOrMore("0" - "9")
 
   def Profile = keyword("PROFILE") ~ push(ProfileOption)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -62,6 +62,26 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with StringHelper {
     )
   }
 
+  test("should consider extra offset in syntax error messages when there are pre-parsing options") {
+    expectSyntaxError("PROFILE XX", "", 8)
+  }
+
+  test("should consider extra offset in semantic error messages when there are pre-parsing options") {
+    expectSyntaxError(
+      "explain match (a) where id(a) = 0 return dontDoIt(a)",
+      "Unknown function 'dontDoIt' (line 1, column 42 (offset: 41))",
+      41
+    )
+  }
+
+  test("should consider extra offset in semantic error messages when there are pre-parsing options - multiline") {
+    expectSyntaxError(
+      "explain\nmatch (a) where id(a) = 0 return dontDoIt(a)",
+      "Unknown function 'dontDoIt' (line 2, column 34 (offset: 41))",
+      41
+    )
+  }
+
   test("noIndexName") {
     expectSyntaxError(
       "start a = node(name=\"sebastian\") match a-[:WORKED_ON]-b return b",

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -269,12 +269,11 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   }
 
   test("should fail when reduce used with wrong separator") {
-    executeAndEnsureError("""
-        |MATCH topRoute = (s)<-[:CONNECTED_TO*1..3]-(e)
-        |WHERE id(s) = 1 AND id(e) = 2
-        |RETURN reduce(weight=0, r in relationships(topRoute) : weight+r.cost) AS score
-        |ORDER BY score ASC LIMIT 1
-      """.stripMargin,
+    executeAndEnsureError("""MATCH topRoute = (s)<-[:CONNECTED_TO*1..3]-(e)
+                            |WHERE id(s) = 1 AND id(e) = 2
+                            |RETURN reduce(weight=0, r in relationships(topRoute) : weight+r.cost) AS score
+                            |ORDER BY score ASC LIMIT 1
+                          """.stripMargin,
       "reduce(...) requires '| expression' (an accumulation expression) (line 3, column 8 (offset: 84))"
     )
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherOptionParserTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherOptionParserTest.scala
@@ -21,47 +21,65 @@ package org.neo4j.cypher.internal.compiler
 
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.InputPosition
 import org.neo4j.cypher.internal.compiler.v2_2.parser.ParserMonitor
 
 class CypherOptionParserTest extends CypherFunSuite {
+
+  private val pos = InputPosition(42, 3, 5)
 
   def parse(arg:String): CypherQueryWithOptions = {
     CypherOptionParser(mock[ParserMonitor[CypherQueryWithOptions]]).apply(arg)
   }
 
   test("should parse version") {
-    parse("CYPHER 1.9 MATCH") should equal(CypherQueryWithOptions("MATCH", Seq(VersionOption("1.9"))))
-    parse("CYPHER 2.0 THAT") should equal(CypherQueryWithOptions("THAT", Seq(VersionOption("2.0"))))
-    parse("CYPHER 2.1 YO") should equal(CypherQueryWithOptions("YO", Seq(VersionOption("2.1"))))
-    parse("CYPHER 2.2 HO") should equal(CypherQueryWithOptions("HO", Seq(VersionOption("2.2"))))
+    parse("CYPHER 1.9 MATCH") should equal(CypherQueryWithOptions("MATCH", Seq(VersionOption("1.9")), (1, 12, 11)))
+    parse("CYPHER 2.0 THAT") should equal(CypherQueryWithOptions("THAT", Seq(VersionOption("2.0")), (1, 12, 11)))
+    parse("CYPHER 2.1 YO") should equal(CypherQueryWithOptions("YO", Seq(VersionOption("2.1")), (1, 12, 11)))
+    parse("CYPHER 2.2 HO") should equal(CypherQueryWithOptions("HO", Seq(VersionOption("2.2")), (1, 12, 11)))
   }
 
   test("should parse profile") {
-    parse("PROFILE THINGS") should equal(CypherQueryWithOptions("THINGS", Seq(ProfileOption)))
+    parse("PROFILE THINGS") should equal(CypherQueryWithOptions("THINGS", Seq(ProfileOption), (1, 9, 8)))
   }
 
   test("should parse explain") {
-    parse("EXPLAIN THIS") should equal(CypherQueryWithOptions("THIS", Seq(ExplainOption)))
+    parse("EXPLAIN THIS") should equal(CypherQueryWithOptions("THIS", Seq(ExplainOption), (1, 9, 8)))
   }
 
   test("should parse multiple options") {
-    parse("CYPHER 2.2 PLANNER COST PROFILE PATTERN") should equal(CypherQueryWithOptions("PATTERN", Seq(VersionOption("2.2"), CostPlannerOption, ProfileOption)))
-    parse("EXPLAIN CYPHER 2.1 YALL") should equal(CypherQueryWithOptions("YALL", Seq(ExplainOption, VersionOption("2.1"))))
-  }
-
-  test("should require whitespace between option and query") {
-    parse("explainmatch") should equal(CypherQueryWithOptions("explainmatch"))
-    parse("explain match") should equal(CypherQueryWithOptions("match", Seq(ExplainOption)))
+    parse("CYPHER 2.2 PLANNER COST PROFILE PATTERN") should equal(
+      CypherQueryWithOptions("PATTERN", Seq(VersionOption("2.2"), CostPlannerOption, ProfileOption), (1, 33, 32))
+    )
+    parse("EXPLAIN CYPHER 2.1 YALL") should equal(
+      CypherQueryWithOptions("YALL", Seq(ExplainOption, VersionOption("2.1")), (1, 20, 19))
+    )
   }
 
   test("should parse version and planner/compiler") {
-    parse("CYPHER 2.2 PLANNER COST RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), CostPlannerOption)))
-    parse("PLANNER COST RETURN") should equal(CypherQueryWithOptions("RETURN",Seq(CostPlannerOption)))
-    parse("CYPHER 2.2 PLANNER RULE RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), RulePlannerOption)))
-    parse("PLANNER RULE RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(RulePlannerOption)))
-    parse("CYPHER 2.2 PLANNER IDP RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), IDPPlannerOption)))
-    parse("CYPHER 2.2 PLANNER DP RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), DPPlannerOption)))
-    parse("PLANNER IDP RETURN") should equal(CypherQueryWithOptions("RETURN",Seq(IDPPlannerOption)))
-    parse("PLANNER DP RETURN") should equal(CypherQueryWithOptions("RETURN",Seq(DPPlannerOption)))
+    parse("CYPHER 2.2 PLANNER COST RETURN") should equal(
+      CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), CostPlannerOption), (1, 25, 24))
+    )
+    parse("PLANNER COST RETURN") should equal(
+      CypherQueryWithOptions("RETURN",Seq(CostPlannerOption), (1, 14, 13))
+    )
+    parse("CYPHER 2.2 PLANNER RULE RETURN") should equal(
+      CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), RulePlannerOption), (1, 25, 24))
+    )
+    parse("PLANNER RULE RETURN") should equal(CypherQueryWithOptions("RETURN", Seq(RulePlannerOption), (1, 14, 13)))
+    parse("CYPHER 2.2 PLANNER IDP RETURN") should equal(
+      CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), IDPPlannerOption), (1, 24, 23))
+    )
+    parse("CYPHER 2.2 PLANNER DP RETURN") should equal(
+      CypherQueryWithOptions("RETURN", Seq(VersionOption("2.2"), DPPlannerOption), (1, 23, 22))
+    )
+    parse("PLANNER IDP RETURN") should equal(CypherQueryWithOptions("RETURN",Seq(IDPPlannerOption), (1, 13, 12)))
+    parse("PLANNER DP RETURN") should equal(CypherQueryWithOptions("RETURN",Seq(DPPlannerOption), (1, 12, 11)))
   }
+
+  test("should require whitespace between option and query") {
+    parse("explainmatch") should equal(CypherQueryWithOptions("explainmatch", Seq.empty, (1, 1, 0)))
+  }
+
+  private implicit def lift(pos: (Int, Int, Int)): InputPosition = InputPosition(pos._3, pos._1, pos._2)
 }


### PR DESCRIPTION
Previously the errors were reporting the wrong position due to the
fact that part of the string input was consumed by a pre-parser, now
we make sure to consider the pre-parsed offset when reporting errors.