### PR TITLE
improvements for neo4j-harness

### DIFF
--- a/community/neo4j-harness/CHANGES.txt
+++ b/community/neo4j-harness/CHANGES.txt
@@ -1,0 +1,5 @@
+2.3-SNAPSHOT
+------------------------
+o expose GraphDatabaseService to be used in assertions
+o support fixtures based on Function<GraphDatabaseService,Void>
+o support running Neo4jRule/TestServerBuilder with a existing databse 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
@@ -21,6 +21,8 @@ package org.neo4j.harness;
 
 import java.net.URI;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+
 /**
  * Control panel for a Neo4j test instance.
  */
@@ -38,4 +40,8 @@ public interface ServerControls extends AutoCloseable
     /** Stop the test instance and delete all files related to it on disk. */
     @Override
     void close();
+
+    /** expose the {@link org.neo4j.graphdb.GraphDatabaseService} used by the server */
+    GraphDatabaseService getGraphDatabaseService();
+
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -97,4 +97,11 @@ public interface TestServerBuilder
      * @return this builder instance
      */
     public TestServerBuilder withFixture( Function<GraphDatabaseService, Void> fixtureFunction );
+
+    /**
+     * prepopulate the server with a full copy of the supplied directory
+     * @param sourceDirectory
+     * @return
+     */
+    public TestServerBuilder copyFrom( File sourceDirectory );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -21,6 +21,8 @@ package org.neo4j.harness;
 
 import java.io.File;
 
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 
 /**
@@ -87,4 +89,12 @@ public interface TestServerBuilder
      * @return this builder instance
      */
     public TestServerBuilder withFixture( String fixtureStatement );
+
+    /**
+     * Data fixture to inject upon server start. This should be a user implemented fixture function
+     * operating on a {@link GraphDatabaseService} instance
+     * @param fixtureFunction
+     * @return this builder instance
+     */
+    public TestServerBuilder withFixture( Function<GraphDatabaseService, Void> fixtureFunction );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
@@ -38,11 +38,23 @@ public final class TestServerBuilders
     }
 
     /**
-     * Create a builder capable of starting an in-process Neo4j instance, running in the specified directory.
+     * Create a builder capable of starting an in-process Neo4j instance, running in a subdirectory of the specified directory.
      */
     public static TestServerBuilder newInProcessBuilder(File workingDirectory)
     {
         return new InProcessServerBuilder(workingDirectory );
+    }
+
+    /**
+     * Create a builder capable of starting an in-process Neo4j instance. Depending on a boolean flag a fresh subdirectory
+     * is created beforehand.
+     *
+     * @param workingDirectory base directory
+     * @param createSubDirectory if false, a pre-existing graph db can be used. If true, a subfolder will be created inside.
+     */
+    public static TestServerBuilder newInProcessBuilder(File workingDirectory, boolean createSubDirectory)
+    {
+        return new InProcessServerBuilder(workingDirectory, createSubDirectory );
     }
 
     private TestServerBuilders(){}

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
@@ -34,7 +34,7 @@ public final class TestServerBuilders
      */
     public static TestServerBuilder newInProcessBuilder()
     {
-        return new InProcessServerBuilder(new File(System.getProperty("java.io.tmpdir")));
+        return new InProcessServerBuilder();
     }
 
     /**
@@ -42,19 +42,7 @@ public final class TestServerBuilders
      */
     public static TestServerBuilder newInProcessBuilder(File workingDirectory)
     {
-        return new InProcessServerBuilder(workingDirectory );
-    }
-
-    /**
-     * Create a builder capable of starting an in-process Neo4j instance. Depending on a boolean flag a fresh subdirectory
-     * is created beforehand.
-     *
-     * @param workingDirectory base directory
-     * @param createSubDirectory if false, a pre-existing graph db can be used. If true, a subfolder will be created inside.
-     */
-    public static TestServerBuilder newInProcessBuilder(File workingDirectory, boolean createSubDirectory)
-    {
-        return new InProcessServerBuilder(workingDirectory, createSubDirectory );
+        return new InProcessServerBuilder( workingDirectory );
     }
 
     private TestServerBuilders(){}

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.commons.io.FileUtils;
+
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
@@ -62,20 +64,13 @@ public class InProcessServerBuilder implements TestServerBuilder
 
     public InProcessServerBuilder()
     {
-        this(new File( System.getProperty( "java.io.tmpdir" )));
+        this( new File( System.getProperty( "java.io.tmpdir" ) ) );
     }
 
     public InProcessServerBuilder( File workingDir )
     {
-        this(workingDir, true);
-    }
-
-    public InProcessServerBuilder( File workingDirectory, boolean createSubDirectory )
-    {
-        File storeDir = createSubDirectory ?
-            new File(workingDirectory, randomFolderName()).getAbsoluteFile() :
-                workingDirectory;
-        init(storeDir);
+        File storeDir = new File(workingDir, randomFolderName()).getAbsoluteFile();
+        init( storeDir );
     }
 
     private void init( File workingDir )
@@ -85,6 +80,21 @@ public class InProcessServerBuilder implements TestServerBuilder
         withConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         withConfig( WEBSERVER_PORT_PROPERTY_KEY, Integer.toString( freePort() ) );
     }
+
+
+    @Override
+    public InProcessServerBuilder copyFrom( File originalStoreDir ) {
+        try
+        {
+            FileUtils.copyDirectory( originalStoreDir, serverFolder );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+        return this;
+    }
+
 
     @Override
     public ServerControls newServer()

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerBuilder.java
@@ -60,7 +60,25 @@ public class InProcessServerBuilder implements TestServerBuilder
      */
     private final Map<String, String> config = new HashMap<>();
 
+    public InProcessServerBuilder()
+    {
+        this(new File( System.getProperty( "java.io.tmpdir" )));
+    }
+
     public InProcessServerBuilder( File workingDir )
+    {
+        this(workingDir, true);
+    }
+
+    public InProcessServerBuilder( File workingDirectory, boolean createSubDirectory )
+    {
+        File storeDir = createSubDirectory ?
+            new File(workingDirectory, randomFolderName()).getAbsoluteFile() :
+                workingDirectory;
+        init(storeDir);
+    }
+
+    private void init( File workingDir )
     {
         setDirectory( workingDir );
         withConfig( ServerSettings.auth_enabled, "false" );
@@ -140,7 +158,7 @@ public class InProcessServerBuilder implements TestServerBuilder
 
     private TestServerBuilder setDirectory( File dir )
     {
-        this.serverFolder = new File(dir, randomFolderName()).getAbsoluteFile();
+        this.serverFolder = dir;
         config.put( DATABASE_LOCATION_PROPERTY_KEY, serverFolder.getAbsolutePath() );
         logging = new ClassicLoggingService( new Config( stringMap( store_dir.name(), serverFolder.getAbsolutePath() ) ) );
         return this;

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileUtils;
@@ -89,5 +90,10 @@ public class InProcessServerControls implements ServerControls
         // Pure paranoia, and a silly check - but this decreases the likelihood that we delete something that isn't
         // our randomly generated folder significantly.
         return name.length() == 32;
+    }
+
+    public GraphDatabaseService getGraphDatabaseService()
+    {
+        return server.getDatabase().getGraph();
     }
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -53,12 +53,7 @@ public class Neo4jRule implements TestRule, TestServerBuilder
 
     public Neo4jRule(File workingDirectory)
     {
-        this(workingDirectory, true);
-    }
-
-    public Neo4jRule( File workingDirectory, boolean createSubFolder )
-    {
-        builder = TestServerBuilders.newInProcessBuilder( workingDirectory, createSubFolder );
+        builder = TestServerBuilders.newInProcessBuilder( workingDirectory );
     }
 
     @Override
@@ -129,6 +124,13 @@ public class Neo4jRule implements TestRule, TestServerBuilder
     public Neo4jRule withFixture( Function<GraphDatabaseService, Void> fixtureFunction )
     {
         builder = builder.withFixture( fixtureFunction );
+        return this;
+    }
+
+    @Override
+    public Neo4jRule copyFrom( File sourceDirectory )
+    {
+        builder = builder.copyFrom( sourceDirectory );
         return this;
     }
 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -53,7 +53,12 @@ public class Neo4jRule implements TestRule, TestServerBuilder
 
     public Neo4jRule(File workingDirectory)
     {
-        builder = TestServerBuilders.newInProcessBuilder( workingDirectory );
+        this(workingDirectory, true);
+    }
+
+    public Neo4jRule( File workingDirectory, boolean createSubFolder )
+    {
+        builder = TestServerBuilders.newInProcessBuilder( workingDirectory, createSubFolder );
     }
 
     @Override

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -25,6 +25,9 @@ import java.net.URI;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilder;
@@ -117,6 +120,13 @@ public class Neo4jRule implements TestRule, TestServerBuilder
         return this;
     }
 
+    @Override
+    public Neo4jRule withFixture( Function<GraphDatabaseService, Void> fixtureFunction )
+    {
+        builder = builder.withFixture( fixtureFunction );
+        return this;
+    }
+
     public URI httpURI()
     {
         if(controls == null)
@@ -133,5 +143,9 @@ public class Neo4jRule implements TestRule, TestServerBuilder
             throw new IllegalStateException( "Cannot access instance URI before or after the test runs." );
         }
         return controls.httpURI();
+    }
+
+    public GraphDatabaseService getGraphDatabaseService() {
+        return controls.getGraphDatabaseService();
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTest.java
@@ -24,6 +24,10 @@ import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
@@ -183,6 +187,37 @@ public class FixturesTest
         {
             assertThat(e.getMessage(), equalTo("Failed to install fixtures: Invalid input 't': expected <init> " +
                     "(line 1, column 1 (offset: 0))\n\"this is not a valid cypher statement\"\n ^"));
+        }
+    }
+
+    @Test
+    public void shouldHandleFunctionFixtures() throws Exception
+    {
+        // Given two files in the root folder
+        File targetFolder = testDir.directory();
+
+        // When
+        try ( ServerControls server = newInProcessBuilder( targetFolder )
+                .withFixture( new Function<GraphDatabaseService, Void>()
+                {
+                    @Override
+                    public Void apply( GraphDatabaseService graphDatabaseService ) throws RuntimeException
+                    {
+                        try ( Transaction tx = graphDatabaseService.beginTx() )
+                        {
+                            graphDatabaseService.createNode( DynamicLabel.label( "User" ) );
+                            tx.success();
+                        }
+                        return null;
+                    }
+                } )
+                .newServer() )
+        {
+            // Then
+            HTTP.Response response = HTTP.POST( server.httpURI().toString() + "db/data/transaction/commit",
+                    quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
+
+            assertThat( response.get( "results" ).get( 0 ).get( "data" ).size(), equalTo( 1 ) );
         }
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -19,11 +19,15 @@
  */
 package org.neo4j.harness;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.jackson.JsonNode;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -51,11 +55,13 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.server.HTTP;
 import org.neo4j.tooling.GlobalGraphOperations;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.harness.TestServerBuilders.newInProcessBuilder;
 
@@ -153,26 +159,76 @@ public class InProcessBuilderTest
     {
         // When
         // create graph db with one node upfront
-        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( testDir.absolutePath() );
-        try {
-            db.execute( "create ()" );
-        } finally {
-            db.shutdown();
-        }
-
-        try ( ServerControls server = newInProcessBuilder( testDir.directory(), false )
-                .newServer() )
+        Path dir = Files.createTempDirectory( getClass().getSimpleName() +
+                "_shouldRunBuilderOnExistingStorageDir" );
+        try
         {
-            // Then
-            try ( Transaction tx = server.getGraphDatabaseService().beginTx() )
-            {
-                ResourceIterable<Node> allNodes = GlobalGraphOperations.at(
-                        server.getGraphDatabaseService() ).getAllNodes();
 
-                assertTrue( IteratorUtil.count( allNodes ) > 0 );
-                tx.success();
+            GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            try
+            {
+                db.execute( "create ()" );
+            }
+            finally
+            {
+                db.shutdown();
+            }
+
+            try ( ServerControls server = newInProcessBuilder( testDir.directory() ).copyFrom( dir.toFile() )
+                    .newServer() )
+            {
+                // Then
+                try ( Transaction tx = server.getGraphDatabaseService().beginTx() )
+                {
+                    ResourceIterable<Node> allNodes = GlobalGraphOperations.at(
+                            server.getGraphDatabaseService() ).getAllNodes();
+
+                    assertTrue( IteratorUtil.count( allNodes ) > 0 );
+
+                    // When: create another node
+                    server.getGraphDatabaseService().createNode();
+                    tx.success();
+                }
+            }
+
+            // Then: we still only have one node since the server is supposed to work on a copy
+            db = new GraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            try
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    assertEquals( 1, IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+                    tx.success();
+                }
+            }
+            finally
+            {
+                db.shutdown();
             }
         }
+        finally
+        {
+            FileUtils.forceDelete( dir.toFile() );
+        }
+    }
+
+    @Test
+    public void shouldFailWhenProvidingANonDirectoryAsSource() throws IOException
+    {
+
+        File notADirectory = File.createTempFile( "prefix", "suffix" );
+        assertFalse( notADirectory.isDirectory() );
+
+        try ( ServerControls server = newInProcessBuilder( ).copyFrom( notADirectory )
+                .newServer() )
+        {
+            fail("server should not start");
+        } catch (RuntimeException rte) {
+            Throwable cause = rte.getCause();
+            assertTrue( cause instanceof IOException);
+            assertTrue( cause.getMessage().contains( "exists but is not a directory" ));
+        }
+
     }
 
     private void assertDBConfig( ServerControls server, String expected, String key ) throws JsonParseException

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
@@ -122,7 +122,7 @@ public class JUnitRuleTest
         }
 
         // When a rule with an pre-populated graph db directory is used
-        final Neo4jRule ruleWithDirectory = new Neo4jRule(testDirectory.directory(), false);
+        final Neo4jRule ruleWithDirectory = new Neo4jRule(testDirectory.directory()).copyFrom( testDirectory.directory());
         ruleWithDirectory.apply( new Statement()
         {
             @Override


### PR DESCRIPTION
3 small improvements for neo4j-harness: 
- expose GraphDatabaseService in ServerControls and Neo4jRule -> enables assertions based on GDB
- enable GDB based fixtures by using Function<GraphDatbaseService,Void>
- InProcessServerBuilder and Neo4jRule use a exisiting graph.db
