### PR TITLE
Don't generate ComponentVersion if there is no proper classpath

### DIFF
--- a/advanced/pom.xml
+++ b/advanced/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <short-name>advanced-build</short-name>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <componentversion.skip>true</componentversion.skip>
   </properties>
 
   <scm>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -24,6 +24,7 @@
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <componentversion.skip>true</componentversion.skip>
   </properties>
 
   <scm>

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -21,6 +21,7 @@
     <short-name>community-build</short-name>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <docs-plugin.skip>true</docs-plugin.skip>
+    <componentversion.skip>true</componentversion.skip>
   </properties>
 
   <scm>

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <short-name>enterprise-build</short-name>
+    <componentversion.skip>true</componentversion.skip>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <id>generate-version</id>
             <phase>generate-sources</phase>
             <configuration>
-              <target if="version-package">
+              <target if="version-package" unless="componentversion.skip">
                 <macrodef name="generate-version">
                   <attribute name="package" />
                   <sequential>


### PR DESCRIPTION
This av avoids the "cannot compile" issue when rebuilding the whole project in IntelliJ.
