### PR TITLE
:sysinfo and copyright fixes.

### DIFF
--- a/community/browser/app/content/guides/start.jade
+++ b/community/browser/app/content/guides/start.jade
@@ -48,6 +48,6 @@ article.guide
 
     footer.tight
       p.text-muted Copyright &copy;
-        a.no-icon(href='http://neotechnology.com/')  Neo Technology
+        a.no-icon(href='http://neo4j.com/')  Neo Technology
         | &nbsp;2002–
         span= new Date().getFullYear()

--- a/community/browser/app/content/info/sysinfo.jade
+++ b/community/browser/app/content/info/sysinfo.jade
@@ -1,25 +1,12 @@
 article.help(ng-controller="SysinfoController")
   .container-fluid
-    //- section.row
-    //-   .col-sm-12
-    //-     .panel.panel-default
-    //-       .panel-heading
-    //-         h4 Neo4j Info
-    //-       //- .panel-body
-    //-       //-   | {{foo}}
-    //-       table.table
-    //-         tr
-    //-           th Version
-    //-           td {{neo4j.version}}
-    //-           th Edition
-    //-           td {{neo4j.edition}}
     section.row
       .col-md-3.col-sm-4
         .panel.panel-default
           .panel-heading
             h4 Store Sizes
-          //- .panel-body
-          //-   | Bodae
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/jmx-mxbeans.html#jmx-store-file-sizes")
           table.table.table-condensed
             tr
               th Array Store
@@ -46,8 +33,8 @@ article.help(ng-controller="SysinfoController")
         .panel.panel-default
           .panel-heading
             h4 ID Allocation
-          //- .panel-body
-          //-   | Bodae
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/jmx-mxbeans.html#jmx-primitive-count")
           table.table.table-condensed
             tr
               th Node ID
@@ -65,6 +52,8 @@ article.help(ng-controller="SysinfoController")
         .panel.panel-default
           .panel-heading
             h4 Page Cache
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/jmx-mxbeans.html#jmx-page-cache")
           .panel-body(ng-hide="sysinfo.cache.available")
             p Not available.
           table.table.table-condensed(ng-show="sysinfo.cache.available")
@@ -103,6 +92,8 @@ article.help(ng-controller="SysinfoController")
         .panel.panel-default
           .panel-heading
             h4 Transactions
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/jmx-mxbeans.html#jmx-transactions")
           .panel-body(ng-hide="sysinfo.tx.available")
             p Not available.
           table.table.table-condensed(ng-show="sysinfo.tx.available")
@@ -125,6 +116,8 @@ article.help(ng-controller="SysinfoController")
         .panel.panel-default
           .panel-heading
             h4 High Availability
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/jmx-mxbeans.html#jmx-high-availability")
           .panel-body(ng-hide='sysinfo.ha.clustered')
             p Not enabled.
           table.table.table-condensed(ng-show='sysinfo.ha.clustered')
@@ -150,6 +143,8 @@ article.help(ng-controller="SysinfoController")
         .panel.panel-default
           .panel-heading
             h4 Cluster
+            .panel-heading-info-icon
+              a.fa.fa-info-circle.no-out-symbol(target="_blank", href="http://neo4j.com/docs/{{neo4j.version}}/ha-architecture.html")
           .panel-body(ng-hide='sysinfo.ha.clustered')
             p No cluster.
           table.table.table-condensed(ng-show='sysinfo.ha.clustered')

--- a/community/browser/app/content/info/sysinfo.jade
+++ b/community/browser/app/content/info/sysinfo.jade
@@ -70,12 +70,6 @@ article.help(ng-controller="SysinfoController")
               th Eviction Exceptions
               td {{sysinfo.cache.EvictionExceptions}}
             tr
-              th Pins
-              td {{sysinfo.cache.Pins}}
-              td &nbsp;
-              th Unpins
-              td {{sysinfo.cache.Unpins}}
-            tr
               th File Mappings
               td {{sysinfo.cache.FileMappings}}
               td &nbsp;

--- a/community/browser/app/styles/help.styl
+++ b/community/browser/app/styles/help.styl
@@ -4,6 +4,15 @@
 
 .view-result
   article.help, article.guide
+    .panel-heading-info-icon
+      float: right
+      font-size: 1.3em
+      color: #008cc1
+      border: 0
+      text-decoration: none
+      .fa:focus
+        text-decoration:none
+        color: #008cc1
     background-color #fff
     padding 0
     padding: 30px

--- a/community/browser/app/styles/main.styl
+++ b/community/browser/app/styles/main.styl
@@ -52,7 +52,7 @@ svg
   &.no-icon
     &:before
       padding-right: 0
-      content: ''
+      content: '' !important
 
 [play-topic], [server-topic]
   &:before
@@ -62,7 +62,7 @@ svg
   &:before
     content: "\f05a"
 
-a[target]
+a[target]:not(.no-out-symbol)
   &:before
     content: "\f14c"
 


### PR DESCRIPTION
- Change link in Copyright in start frame.
- Add info link to docs on all boxes in `:sysinfo`.
- Remove pins/unpins from page cache box in `:sysinfo`. 
