### PR TITLE
Add the RandomPageCacheTestHarness

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -66,6 +67,7 @@ import java.io.IOException;
 public interface PageCursor extends AutoCloseable
 {
     long UNBOUND_PAGE_ID = -1;
+    int UNBOUND_PAGE_SIZE = -1;
 
     /**
      * Get the signed byte at the current page offset, and then increment the offset by one.
@@ -252,11 +254,25 @@ public interface PageCursor extends AutoCloseable
 
     /**
      * Get the file page id that the cursor is currently positioned at, or
-     * UNBOUND_PAGE_ID if next() has not yet been called on this cursor.
+     * UNBOUND_PAGE_ID if next() has not yet been called on this cursor, or returned false.
      * A call to rewind() will make the current page id unbound as well, until
      * next() is called.
      */
     long getCurrentPageId();
+
+    /**
+     * Get the file page size of the page that the cursor is currently positioned at,
+     * or UNBOUND_PAGE_SIZE if next() has not yet been called on this cursor, or returned false.
+     * A call to rewind() will make the current page unbound as well, until next() is called.
+     */
+    int getCurrentPageSize();
+
+    /**
+     * Get the file the cursor is currently bound to, or {@code null} if next() has not yet been called on this
+     * cursor, or returned false.
+     * A call to rewind() will make the cursor unbound as well, until next() is called.
+     */
+    File getCurrentFile();
 
     /**
      * Rewinds the cursor to its initial condition, as if freshly returned from

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -206,6 +206,9 @@ public class MuninnPageCache implements PageCache
     // The accumulator for the flush task sleep debt. This is only accessed from the flush task.
     private long sleepDebtNanos;
 
+    // 'true' (the default) if we should print any exceptions we get when unmapping a file.
+    private boolean printExceptionsOnClose;
+
     public MuninnPageCache(
             PageSwapperFactory swapperFactory,
             int maxPages,
@@ -222,6 +225,7 @@ public class MuninnPageCache implements PageCache
         this.cursorPool = new CursorPool();
         this.tracer = tracer;
         this.pages = new MuninnPage[maxPages];
+        this.printExceptionsOnClose = true;
 
         MemoryReleaser memoryReleaser = new MemoryReleaser( maxPages );
         Object pageList = null;
@@ -396,7 +400,7 @@ public class MuninnPageCache implements PageCache
             }
             catch ( IOException e )
             {
-                if ( !printedFirstException )
+                if ( printExceptionsOnClose && !printedFirstException )
                 {
                     printedFirstException = true;
                     try
@@ -410,6 +414,11 @@ public class MuninnPageCache implements PageCache
             }
         }
         while ( !flushedAndClosed );
+    }
+
+    public void setPrintExceptionsOnClose( boolean enabled )
+    {
+        this.printExceptionsOnClose = enabled;
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache.impl.muninn;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.concurrent.BinaryLatch;
@@ -99,6 +100,19 @@ abstract class MuninnPageCursor implements PageCursor
     public final long getCurrentPageId()
     {
         return currentPageId;
+    }
+
+    @Override
+    public final int getCurrentPageSize()
+    {
+        return currentPageId == UNBOUND_PAGE_ID?
+               UNBOUND_PAGE_SIZE : pagedFile.pageSize();
+    }
+
+    @Override
+    public final File getCurrentFile()
+    {
+        return currentPageId == UNBOUND_PAGE_ID? null : pagedFile.file();
     }
 
     /**

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -149,6 +149,11 @@ final class MuninnPagedFile implements PagedFile
         return pageSize;
     }
 
+    File file()
+    {
+        return swapper.file();
+    }
+
     public void close() throws IOException
     {
         pageCache.unmap( this );

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
@@ -129,6 +129,12 @@ public interface PageCacheTracer extends PageCacheMonitor
         {
             return 0;
         }
+
+        @Override
+        public String toString()
+        {
+            return PageCacheTracer.class.getName() + ".NULL";
+        }
     };
 
     /**

--- a/community/io/src/test/java/org/neo4j/adversaries/AbstractAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/AbstractAdversary.java
@@ -31,6 +31,11 @@ public abstract class AbstractAdversary implements Adversary
         rng = new Random();
     }
 
+    public void setSeed( long seed )
+    {
+        rng.setSeed( seed );
+    }
+
     protected void throwOneOf( Class<? extends Throwable>... types )
     {
         int choice = rng.nextInt( types.length );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -32,12 +33,14 @@ import org.neo4j.io.pagecache.impl.ByteBufferPage;
 public class StubPageCursor implements PageCursor
 {
     private long pageId;
+    private int pageSize;
     protected ByteBufferPage page;
     private int currentOffset;
 
     public StubPageCursor( long initialPageId, int pageSize )
     {
         this.pageId = initialPageId;
+        this.pageSize = pageSize;
         this.page = new ByteBufferPage( ByteBuffer.allocate(pageSize) );
     }
 
@@ -45,6 +48,18 @@ public class StubPageCursor implements PageCursor
     public long getCurrentPageId()
     {
         return pageId;
+    }
+
+    @Override
+    public int getCurrentPageSize()
+    {
+        return pageSize;
+    }
+
+    @Override
+    public File getCurrentFile()
+    {
+        return new File( "" );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Action.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Action.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+abstract class Action
+{
+    private final Command command;
+    private final String format;
+    private final Object[] parameters;
+
+    protected Action( Command command, String format, Object... parameters )
+    {
+        this.command = command;
+        this.format = format;
+        this.parameters = parameters;
+    }
+
+    abstract void perform() throws Exception;
+
+    @Override
+    public String toString()
+    {
+        return String.format( command + format, parameters );
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Command.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Command.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+/**
+ * An enum of the commands that the RandomPageCacheTestHarness can perform, and their default probability factors.
+ */
+public enum Command
+{
+    ReadRecord( 0.3 ),
+    WriteRecord( 0.6 ),
+    FlushFile( 0.06 ),
+    FlushCache( 0.02 ),
+    MapFile( 0.01 ),
+    UnmapFile( 0.01 );
+
+    private final double defaultProbability;
+
+    Command( double defaultProbability )
+    {
+        this.defaultProbability = defaultProbability;
+    }
+
+    public double getDefaultProbabilityFactor()
+    {
+        return defaultProbability;
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/CommandPrimer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/CommandPrimer.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
+
+import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertThat;
+
+class CommandPrimer
+{
+    private final Random rng;
+    private final MuninnPageCache cache;
+    private final File[] files;
+    private final Map<File,PagedFile> fileMap;
+    private final Map<File,List<Integer>> recordsWrittenTo;
+    private final List<File> mappedFiles;
+    private final Set<File> filesTouched;
+    private final int filePageCount;
+    private final int filePageSize;
+    private final RecordFormat recordFormat;
+
+    public CommandPrimer(
+            Random rng,
+            MuninnPageCache cache,
+            File[] files,
+            Map<File,PagedFile> fileMap,
+            int filePageCount,
+            int filePageSize,
+            RecordFormat recordFormat )
+    {
+        this.rng = rng;
+        this.cache = cache;
+        this.files = files;
+        this.fileMap = fileMap;
+        this.filePageCount = filePageCount;
+        this.filePageSize = filePageSize;
+        this.recordFormat = recordFormat;
+        mappedFiles = new ArrayList<>();
+        mappedFiles.addAll( fileMap.keySet() );
+        filesTouched = new HashSet<>();
+        filesTouched.addAll( mappedFiles );
+        recordsWrittenTo = new HashMap<>();
+        for ( File file : files )
+        {
+            recordsWrittenTo.put( file, new ArrayList<Integer>() );
+        }
+    }
+
+    public List<File> getMappedFiles()
+    {
+        return mappedFiles;
+    }
+
+    public Set<File> getFilesTouched()
+    {
+        return filesTouched;
+    }
+
+    public Action prime( Command command )
+    {
+        switch ( command )
+        {
+        case FlushCache: return flushCache();
+        case FlushFile: return flushFile();
+        case MapFile: return mapFile();
+        case UnmapFile: return unmapFile();
+        case ReadRecord: return readRecord();
+        case WriteRecord: return writeRecord();
+        default: throw new IllegalArgumentException( "Unknown command: " + command );
+        }
+    }
+
+    private Action flushCache()
+    {
+        return new Action( Command.FlushCache, "" )
+        {
+            @Override
+            public void perform() throws Exception
+            {
+                cache.flushAndForce();
+            }
+        };
+    }
+
+    private Action flushFile()
+    {
+        if ( mappedFiles.size() > 0 )
+        {
+            final File file = mappedFiles.get( rng.nextInt( mappedFiles.size() ) );
+            return new Action( Command.FlushFile, "[file=%s]", file.getName() )
+            {
+                @Override
+                public void perform() throws Exception
+                {
+                    PagedFile pagedFile = fileMap.get( file );
+                    if ( pagedFile != null )
+                    {
+                        pagedFile.flushAndForce();
+                    }
+                }
+            };
+        }
+        return new Action( Command.FlushFile, "[no files mapped to flush]" )
+        {
+            @Override
+            public void perform() throws Exception
+            {
+            }
+        };
+    }
+
+    private Action mapFile()
+    {
+        final File file = files[rng.nextInt( files.length )];
+        mappedFiles.add( file );
+        filesTouched.add( file );
+        return new Action( Command.MapFile, "[file=%s]", file )
+        {
+            @Override
+            public void perform() throws Exception
+            {
+                fileMap.put( file, cache.map( file, filePageSize ) );
+            }
+        };
+    }
+
+    private Action unmapFile()
+    {
+        if ( mappedFiles.size() > 0 )
+        {
+            final File file = mappedFiles.remove( rng.nextInt( mappedFiles.size() ) );
+            return new Action( Command.UnmapFile, "[file=%s]", file )
+            {
+                @Override
+                public void perform() throws Exception
+                {
+                    fileMap.get( file ).close();
+                }
+            };
+        }
+        return null;
+    }
+
+    private Action readRecord()
+    {
+        int mappedFilesCount = mappedFiles.size();
+        if ( mappedFilesCount == 0 )
+        {
+            return null;
+        }
+        final File file = mappedFiles.get( rng.nextInt( mappedFilesCount ) );
+        List<Integer> recordsWritten = recordsWrittenTo.get( file );
+        int recordSize = recordFormat.getRecordSize();
+        int recordsPerPage = cache.pageSize() / recordSize;
+        final int recordId =
+                recordsWritten.isEmpty()?
+                rng.nextInt( filePageCount * recordsPerPage )
+                : recordsWritten.get( rng.nextInt( recordsWritten.size() ) );
+        final int pageId = recordId / recordsPerPage;
+        final int pageOffset = (recordId % recordsPerPage) * recordSize;
+        final Record expectedRecord = recordFormat.createRecord( file, recordId );
+        return new Action( Command.ReadRecord,
+                "[file=%s, recordId=%s, pageId=%s, pageOffset=%s, expectedRecord=%s]",
+                file, recordId, pageId, pageOffset, expectedRecord )
+        {
+            @Override
+            public void perform() throws Exception
+            {
+                PagedFile pagedFile = fileMap.get( file );
+                if ( pagedFile != null )
+                {
+                    try ( PageCursor cursor = pagedFile.io( pageId, PagedFile.PF_SHARED_LOCK ) )
+                    {
+                        if ( cursor.next() )
+                        {
+                            cursor.setOffset( pageOffset );
+                            Record actualRecord = recordFormat.readRecord( cursor );
+                            assertThat( actualRecord, isOneOf( expectedRecord, recordFormat.zeroRecord() ) );
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private Action writeRecord()
+    {
+        int mappedFilesCount = mappedFiles.size();
+        if ( mappedFilesCount == 0 )
+        {
+            return null;
+        }
+        final File file = mappedFiles.get( rng.nextInt( mappedFilesCount ) );
+        filesTouched.add( file );
+        int recordSize = 16;
+        int recordsPerPage = cache.pageSize() / recordSize;
+        final int recordId = rng.nextInt( filePageCount * recordsPerPage );
+        recordsWrittenTo.get( file ).add( recordId );
+        final int pageId = recordId / recordsPerPage;
+        final int pageOffset = (recordId % recordsPerPage) * recordSize;
+        final Record record = recordFormat.createRecord( file, recordId );
+        return new Action(  Command.WriteRecord,
+                "[file=%s, recordId=%s, pageId=%s, pageOffset=%s, record=%s]",
+                file, recordId, pageId, pageOffset, record )
+        {
+            @Override
+            public void perform() throws Exception
+            {
+                PagedFile pagedFile = fileMap.get( file );
+                if ( pagedFile != null )
+                {
+                    try ( PageCursor cursor = pagedFile.io( pageId, PagedFile.PF_EXCLUSIVE_LOCK ) )
+                    {
+                        if ( cursor.next() )
+                        {
+                            cursor.setOffset( pageOffset );
+                            recordFormat.write( record, cursor );
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PageCountRecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PageCountRecordFormat.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.neo4j.io.pagecache.PageCursor;
+
+public class PageCountRecordFormat extends RecordFormat
+{
+    @Override
+    public int getRecordSize()
+    {
+        return 16;
+    }
+
+    @Override
+    public Record createRecord( File file, int recordId )
+    {
+        return new PageCountRecord( recordId, getRecordSize() );
+    }
+
+    @Override
+    public Record readRecord( PageCursor cursor ) throws IOException
+    {
+        int offset = cursor.getOffset();
+        byte[] bytes = new byte[getRecordSize()];
+        do
+        {
+            cursor.setOffset( offset );
+            cursor.getBytes( bytes );
+        }
+        while ( cursor.shouldRetry() );
+        return new PageCountRecord( bytes );
+    }
+
+    @Override
+    public Record zeroRecord()
+    {
+        return new PageCountRecord( 0, getRecordSize() );
+    }
+
+    @Override
+    public void write( Record record, PageCursor cursor )
+    {
+        PageCountRecord r = (PageCountRecord) record;
+        for ( int i = 0; i < getRecordSize(); i++ )
+        {
+            cursor.putByte( r.getRecordId() );
+        }
+    }
+
+    private static final class PageCountRecord implements Record
+    {
+        private final byte[] bytes;
+
+        public PageCountRecord( int recordId, int recordSize )
+        {
+            if ( recordId > Byte.MAX_VALUE )
+            {
+                throw new IllegalArgumentException(
+                        "Record ID greater than Byte.MAX_VALUE: " + recordId );
+            }
+            if ( recordSize < 1 )
+            {
+                throw new IllegalArgumentException(
+                        "Record size must be positive: " + recordSize );
+            }
+            bytes = new byte[recordSize];
+            Arrays.fill( bytes, (byte) recordId );
+        }
+
+        public PageCountRecord( byte[] bytes )
+        {
+            if ( bytes.length == 0 )
+            {
+                throw new IllegalArgumentException( "Bytes cannot be empty" );
+            }
+            byte first = bytes[0];
+            for ( byte b : bytes )
+            {
+                if ( b != first )
+                {
+                    throw new IllegalArgumentException(
+                            "All bytes must be the same: " + Arrays.toString( bytes ) );
+                }
+            }
+            this.bytes = bytes;
+        }
+
+        public byte getRecordId()
+        {
+            return bytes[0];
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            { return true; }
+            if ( o == null || getClass() != o.getClass() )
+            { return false; }
+
+            PageCountRecord that = (PageCountRecord) o;
+
+            return Arrays.equals( bytes, that.bytes );
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Arrays.hashCode( bytes );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "PageCountRecord[" +
+                   "bytes=" + Arrays.toString( bytes ) +
+                   ']';
+        }
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Phase.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Phase.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.util.Set;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+
+public interface Phase
+{
+    void run( PageCache pageCache, EphemeralFileSystemAbstraction fs, Set<File> filesTouched ) throws Exception;
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Plan.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Plan.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+class Plan
+{
+    private final Action[] plan;
+    private final Map<File,PagedFile> fileMap;
+    private final List<File> mappedFiles;
+    private final Set<File> filesTouched;
+    private final long[] executedByThread;
+    private final AtomicInteger actionCounter;
+    private final CountDownLatch startLatch;
+
+    public Plan( Action[] plan, Map<File,PagedFile> fileMap, List<File> mappedFiles, Set<File> filesTouched )
+    {
+        this.plan = plan;
+        this.fileMap = fileMap;
+        this.mappedFiles = mappedFiles;
+        this.filesTouched = filesTouched;
+        executedByThread = new long[plan.length];
+        Arrays.fill( executedByThread, -1 );
+        actionCounter = new AtomicInteger();
+        startLatch = new CountDownLatch( 1 );
+    }
+
+    public void start()
+    {
+        startLatch.countDown();
+    }
+
+    public Action next() throws InterruptedException
+    {
+        startLatch.await();
+        int index = actionCounter.getAndIncrement();
+        if ( index < plan.length )
+        {
+            executedByThread[index] = Thread.currentThread().getId();
+            return plan[index];
+        }
+        return null;
+    }
+
+    public void close() throws IOException
+    {
+        for ( File mappedFile : mappedFiles )
+        {
+            PagedFile pagedFile = fileMap.get( mappedFile );
+            if ( pagedFile != null )
+            {
+                pagedFile.close();
+            }
+        }
+    }
+
+    public void print( PrintStream out )
+    {
+        out.println( "Plan: [thread; action]" );
+        for ( int i = 0; i < plan.length; i++ )
+        {
+            out.printf( "  % 3d : %s%n", executedByThread[i], plan[i] );
+        }
+    }
+
+    public Set<File> getFilesTouched()
+    {
+        return filesTouched;
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PlanRunner.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/PlanRunner.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.util.concurrent.Callable;
+
+class PlanRunner implements Callable<Void>
+{
+    private final Plan plan;
+
+    public PlanRunner( Plan plan )
+    {
+        this.plan = plan;
+    }
+
+    @Override
+    public Void call() throws Exception
+    {
+        Action action = plan.next();
+        while ( action != null )
+        {
+            try
+            {
+                action.perform();
+            }
+            catch ( Exception ignore )
+            {
+            }
+            action = plan.next();
+        }
+        return null;
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
@@ -1,0 +1,494 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.adversaries.RandomAdversary;
+import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageSwapperFactory;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+
+/**
+ * The RandomPageCacheTestHarness can plan and run random page cache tests, repeatably if necessary, and verify that
+ * the behaviour of the page cache is correct to some degree. For instance, it can verify that records don't end up
+ * overlapping each other in the mapped files, that records end up at the correct locations in the files, and that
+ * records don't end up in the wrong files. The harness can also execute separate preparation and verification steps,
+ * before and after executing the planned test respectively, and it can integrate with the adversarial file system
+ * for fault injection, and arbitrary PageCacheTracers.
+ *
+ * See {@link org.neo4j.test.LinearHistoryPageCacheTracerTest} for an example of how to configure and use the harness.
+ */
+public class RandomPageCacheTestHarness
+{
+    private double mischiefRate;
+    private double failureRate;
+    private double errorRate;
+    private int concurrencyLevel;
+    private int initialMappedFiles;
+    private int cachePageCount;
+    private int cachePageSize;
+    private int filePageCount;
+    private int filePageSize;
+    private PageCacheTracer tracer;
+    private int commandCount;
+    private double[] commandProbabilityFactors;
+    private long randomSeed;
+    private boolean fixedRandomSeed;
+    private EphemeralFileSystemAbstraction fs;
+    private boolean useAdversarialIO;
+    private Plan plan;
+    private Phase preparation;
+    private Phase verification;
+    private RecordFormat recordFormat;
+
+    public RandomPageCacheTestHarness()
+    {
+        mischiefRate = 0.1;
+        failureRate = 0.1;
+        errorRate = 0.0;
+        concurrencyLevel = 1;
+        initialMappedFiles = 2;
+        cachePageCount = 20;
+        cachePageSize = 8192;
+        filePageCount = cachePageCount * 10;
+        filePageSize = cachePageSize;
+        tracer = PageCacheTracer.NULL;
+        commandCount = 1000;
+
+        Command[] commands = Command.values();
+        commandProbabilityFactors = new double[commands.length];
+        for ( Command command : commands )
+        {
+            commandProbabilityFactors[command.ordinal()] = command.getDefaultProbabilityFactor();
+        }
+
+        useAdversarialIO = true;
+        recordFormat = new StandardRecordFormat();
+    }
+
+    /**
+     * Disable all of the given commands, by setting their probability factors to zero.
+     */
+    public void disableCommands( Command... commands )
+    {
+        for ( Command command : commands )
+        {
+            setCommandProbabilityFactor( command, 0 );
+        }
+    }
+
+    /**
+     * Set the probability factor of the given command. The default value is given by
+     * {@link Command#getDefaultProbabilityFactor()}. The effective probability is computed from the relative
+     * difference in probability factors between all the commands.
+     *
+     * Setting the probability factor to zero will disable that command.
+     */
+    public void setCommandProbabilityFactor( Command command, double probabilityFactor )
+    {
+        assert 0.0 <= probabilityFactor: "Probability factor cannot be negative";
+        commandProbabilityFactors[command.ordinal()] = probabilityFactor;
+    }
+
+    /**
+     * Set to "true" to execute the plans with fault injection from the {@link AdversarialFileSystemAbstraction}, or
+     * set to "false" to disable this feature.
+     *
+     * The default is "true".
+     */
+    public void setUseAdversarialIO( boolean useAdversarialIO )
+    {
+        this.useAdversarialIO = useAdversarialIO;
+    }
+
+    /**
+     * Set the PageCacheTracer that the page cache under test should be configured with.
+     */
+    public void setTracer( PageCacheTracer tracer )
+    {
+        this.tracer = tracer;
+    }
+
+    /**
+     * Set the mischief rate for the adversarial file system.
+     */
+    public void setMischiefRate( double rate )
+    {
+        mischiefRate = rate;
+    }
+
+    /**
+     * Set the failure rate for the adversarial file system.
+     */
+    public void setFailureRate( double rate )
+    {
+        failureRate = rate;
+    }
+
+    /**
+     * Set the error rate for the adversarial file system.
+     */
+    public void setErrorRate( double rate )
+    {
+        errorRate = rate;
+    }
+
+    /**
+     * Set the number of threads that will execute commands from the plan. If this number is greater than 1, then the
+     * plan will execute non-deterministically. The description of the iteration that
+     * {@link #describePreviousRun(PrintStream)} prints will include which thread performed which command.
+     */
+    public void setConcurrencyLevel( int concurrencyLevel )
+    {
+        this.concurrencyLevel = concurrencyLevel;
+    }
+
+    /**
+     * Set the number of files that should be mapped from the start of the plan. If you have set the probability of
+     * the {@link Command#MapFile} command to zero, then you must have a positive number of initial mapped files.
+     * Otherwise there will be no files to plan any work for.
+     *
+     * The default value is 2.
+     */
+    public void setInitialMappedFiles( int initialMappedFiles )
+    {
+        this.initialMappedFiles = initialMappedFiles;
+    }
+
+    public void setCachePageCount( int count )
+    {
+        this.cachePageCount = count;
+    }
+
+    public void setCachePageSize( int size )
+    {
+        this.cachePageSize = size;
+    }
+
+    public void setFilePageCount( int count )
+    {
+        this.filePageCount = count;
+    }
+
+    public void setFilePageSize( int size )
+    {
+        this.filePageSize = size;
+    }
+
+    /**
+     * Set the number of commands to plan in each iteration.
+     */
+    public void setCommandCount( int commandCount )
+    {
+        this.commandCount = commandCount;
+    }
+
+    /**
+     * Set the preparation phase to use. This phase is executed before all the planned commands. It can be used to
+     * prepare some file contents, or reset some external state, such as the
+     * {@link org.neo4j.test.LinearHistoryPageCacheTracer}.
+     *
+     * The preparation phase is executed before each iteration.
+     */
+    public void setPreparation( Phase preparation )
+    {
+        this.preparation = preparation;
+    }
+
+    /**
+     * Set the verification phase to use. This phase is executed after all the planned commands have executed
+     * completely, and can be used to verify the consistency of the data, or some other invariant.
+     *
+     * The verification phase is executed after each iteration.
+     */
+    public void setVerification( Phase verification )
+    {
+        this.verification = verification;
+    }
+
+    /**
+     * Set the record format to use. The record format is used to read, write and verify file contents.
+     */
+    public void setRecordFormat( RecordFormat recordFormat )
+    {
+        this.recordFormat = recordFormat;
+    }
+
+    /**
+     * Set and fix the random seed to the given value. All iterations run through this harness will then use that seed.
+     *
+     * If the random seed has not been configured, then each iteration will use a new seed.
+     */
+    public void setRandomSeed( long randomSeed )
+    {
+        this.randomSeed = randomSeed;
+        this.fixedRandomSeed = true;
+    }
+
+    /**
+     * Write out a textual description of the last run iteration, including the exact plan and what thread
+     * executed which command, and the random seed that can be used to recreate that plan for improved repeatability.
+     */
+    public void describePreviousRun( PrintStream out )
+    {
+        out.println( "randomSeed = " + randomSeed );
+        out.println( "commandCount = " + commandCount );
+        out.println( "concurrencyLevel (number of worker threads) = " + concurrencyLevel );
+        out.println( "initialMappedFiles = " + initialMappedFiles );
+        out.println( "cachePageCount = " + cachePageCount );
+        out.println( "cachePageSize = " + cachePageSize );
+        out.println( "tracer = " + tracer );
+        out.println( "useAdversarialIO = " + useAdversarialIO );
+        out.println( "mischeifRate = " + mischiefRate );
+        out.println( "failureRate = " + failureRate );
+        out.println( "errorRate = " + errorRate );
+        out.println( "Command probability factors:" );
+        Command[] commands = Command.values();
+        for ( int i = 0; i < commands.length; i++ )
+        {
+            out.print( "  " );
+            out.print( commands[i] );
+            out.print( " = " );
+            out.println( commandProbabilityFactors[i] );
+        }
+        if ( plan != null )
+        {
+            plan.print( out );
+        }
+    }
+
+    /**
+     * Run a single iteration with the current harness configuration.
+     *
+     * This will either complete within the given timeout, or throw an exception.
+     *
+     * If the run fails, then a description will be printed to System.err.
+     */
+    public void run( long iterationTimeout, TimeUnit unit ) throws Exception
+    {
+        run( 1, iterationTimeout, unit );
+    }
+
+    /**
+     * Run the given number of iterations with the given harness configuration.
+     *
+     * If the random seed has been set to a specific value, then all iterations will use that seed. Otherwise each
+     * iteration will use a new seed.
+     *
+     * The given timeout applies to the individual iteration, not to their combined run. This is effectively similar
+     * to calling {@link #run(long, TimeUnit)} the given number of times.
+     *
+     * The run will stop at the first failure, if any, and print a description of it to System.err.
+     */
+    public void run( int iterations, long iterationTimeout, TimeUnit unit ) throws Exception
+    {
+        try
+        {
+            for ( int i = 0; i < iterations; i++ )
+            {
+                runIteration( iterationTimeout, unit );
+            }
+        }
+        catch ( Exception e )
+        {
+            describePreviousRun( System.err );
+            throw e;
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private void runIteration( long timeout, TimeUnit unit ) throws Exception
+    {
+        assert filePageSize % recordFormat.getRecordSize() == 0 :
+                "File page size must be a multiple of the record size";
+
+        if ( !fixedRandomSeed )
+        {
+            randomSeed = ThreadLocalRandom.current().nextLong();
+        }
+
+        this.fs = new EphemeralFileSystemAbstraction();
+        FileSystemAbstraction fs = this.fs;
+        File[] files = buildFileNames();
+
+        RandomAdversary adversary = new RandomAdversary( mischiefRate, failureRate, errorRate );
+        adversary.setProbabilityFactor( 0.0 );
+        if ( useAdversarialIO )
+        {
+            adversary.setSeed( randomSeed );
+            fs = new AdversarialFileSystemAbstraction( adversary, fs );
+        }
+
+        PageSwapperFactory swapperFactory = new SingleFilePageSwapperFactory( fs );
+        MuninnPageCache cache = new MuninnPageCache( swapperFactory, cachePageCount, cachePageSize, tracer );
+        cache.setPrintExceptionsOnClose( false );
+        Map<File,PagedFile> fileMap = new HashMap<>( files.length );
+        for ( int i = 0; i < Math.min( files.length, initialMappedFiles ); i++ )
+        {
+            File file = files[i];
+            fileMap.put( file, cache.map( file, filePageSize ) );
+        }
+
+        plan = plan( cache, files, fileMap );
+
+        Callable<Void> planRunner = new PlanRunner( plan );
+        Future<Void>[] futures = new Future[concurrencyLevel];
+        ExecutorService executor = Executors.newFixedThreadPool( concurrencyLevel );
+        for ( int i = 0; i < concurrencyLevel; i++ )
+        {
+            futures[i] = executor.submit( planRunner );
+        }
+
+        if ( preparation != null )
+        {
+            preparation.run( cache, this.fs, plan.getFilesTouched() );
+        }
+
+        adversary.setProbabilityFactor( 1.0 );
+
+        plan.start();
+
+        long deadlineMillis = System.currentTimeMillis() + unit.toMillis( timeout );
+        long now;
+        try
+        {
+            for ( Future<Void> future : futures )
+            {
+                now = System.currentTimeMillis();
+                if ( deadlineMillis < now )
+                {
+                    throw new TimeoutException();
+                }
+                future.get( deadlineMillis - now, TimeUnit.MILLISECONDS );
+            }
+            if ( verification != null )
+            {
+                verification.run( cache, this.fs, plan.getFilesTouched() );
+            }
+        }
+        finally
+        {
+            adversary.setProbabilityFactor( 0.0 );
+            for ( Future<Void> future : futures )
+            {
+                future.cancel( true );
+            }
+            executor.shutdown();
+            now = System.currentTimeMillis();
+            executor.awaitTermination( deadlineMillis - now, TimeUnit.MILLISECONDS );
+            plan.close();
+            cache.close();
+            this.fs.shutdown();
+        }
+    }
+
+    private File[] buildFileNames() throws IOException
+    {
+        String s = "abcdefghijklmnopqrstuvwxyz";
+        File[] files = new File[s.length()];
+        for ( int i = 0; i < s.length(); i++ )
+        {
+            files[i] = new File( s.substring( i, i+1 ) );
+            fs.open( files[i], "rw" ).close();
+        }
+        return files;
+    }
+
+    private Plan plan( MuninnPageCache cache, File[] files, Map<File,PagedFile> fileMap )
+    {
+        Action[] plan = new Action[commandCount];
+
+        int[] commandWeights = computeCommandWeights();
+        int commandWeightSum = sum( commandWeights );
+        Random rng = new Random( randomSeed );
+        CommandPrimer primer = new CommandPrimer(
+                rng, cache, files, fileMap, filePageCount, filePageSize, recordFormat );
+
+        for ( int i = 0; i < plan.length; i++ )
+        {
+            Command command = pickCommand( rng.nextInt( commandWeightSum ), commandWeights );
+            Action action = primer.prime( command );
+            plan[i] = action;
+            if ( action == null )
+            {
+                i--;
+            }
+        }
+
+        return new Plan( plan, fileMap, primer.getMappedFiles(), primer.getFilesTouched() );
+    }
+
+    private int[] computeCommandWeights()
+    {
+        Command[] commands = Command.values();
+        int[] weights = new int[commands.length];
+
+        int base = 100_000_000;
+        for ( int i = 0; i < commands.length; i++ )
+        {
+            weights[i] = (int) (base * commandProbabilityFactors[i]);
+        }
+
+        return weights;
+    }
+
+    private int sum( int[] xs )
+    {
+        int sum = 0;
+        for ( int x : xs )
+        {
+            sum += x;
+        }
+        return sum;
+    }
+
+    private Command pickCommand( int randomPick, int[] commandWeights )
+    {
+        for ( int i = 0; i < commandWeights.length; i++ )
+        {
+            randomPick -= commandWeights[i];
+            if ( randomPick < 0 )
+            {
+                return Command.values()[i];
+            }
+        }
+        throw new AssertionError(
+                "Tried to pick randomPick = " + randomPick + " from weights = " + Arrays.toString( commandWeights ) );
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Record.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/Record.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+public interface Record
+{
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+
+import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertThat;
+
+public abstract class RecordFormat
+{
+    public abstract int getRecordSize();
+
+    public abstract Record createRecord( File file, int recordId );
+
+    public abstract Record readRecord( PageCursor cursor ) throws IOException;
+
+    public abstract Record zeroRecord();
+
+    public abstract void write( Record record, PageCursor cursor );
+
+    public final void writeRecord( PageCursor cursor )
+    {
+        int recordsPerPage = cursor.getCurrentPageSize() / getRecordSize();
+        writeRecordToPage( cursor, cursor.getCurrentPageId(), recordsPerPage );
+    }
+
+    public final void fillWithRecords( PageCursor cursor )
+    {
+        cursor.setOffset( 0 );
+        int recordsPerPage = cursor.getCurrentPageSize() / getRecordSize();
+        for ( int i = 0; i < recordsPerPage; i++ )
+        {
+            writeRecordToPage( cursor, cursor.getCurrentPageId(), recordsPerPage );
+        }
+    }
+
+    private void writeRecordToPage( PageCursor cursor, long pageId, int recordsPerPage )
+    {
+        int pageRecordId = cursor.getOffset() / getRecordSize();
+        int recordId = (int) (pageId * recordsPerPage + pageRecordId);
+        Record record = createRecord( cursor.getCurrentFile(), recordId );
+        write( record, cursor );
+    }
+
+    public final void assertRecordsWrittenCorrectly( PageCursor cursor ) throws IOException
+    {
+        int recordsPerPage = cursor.getCurrentPageSize() / getRecordSize();
+        for ( int pageRecordId = 0; pageRecordId < recordsPerPage; pageRecordId++ )
+        {
+            int recordId = (int) (cursor.getCurrentPageId() * recordsPerPage + pageRecordId);
+            Record expectedRecord = createRecord( cursor.getCurrentFile(), recordId );
+            Record actualRecord;
+            int offset = cursor.getOffset();
+            do
+            {
+                cursor.setOffset( offset );
+                actualRecord = readRecord( cursor );
+            }
+            while ( cursor.shouldRetry() );
+            assertThat( actualRecord, isOneOf( expectedRecord, zeroRecord() ) );
+        }
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/StandardRecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/StandardRecordFormat.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.randomharness;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+
+public class StandardRecordFormat extends RecordFormat
+{
+    @Override
+    public int getRecordSize()
+    {
+        return 16;
+    }
+
+    @Override
+    public Record createRecord( File file, int recordId )
+    {
+        return new StandardRecord( file, recordId );
+    }
+
+    @Override
+    public Record readRecord( PageCursor cursor ) throws IOException
+    {
+        int offset = cursor.getOffset();
+        byte t;
+        byte f;
+        short f1;
+        int r;
+        long f2;
+        do
+        {
+            cursor.setOffset( offset );
+            t = cursor.getByte();
+            f = cursor.getByte();
+            f1 = cursor.getShort();
+            r = cursor.getInt();
+            f2 = cursor.getLong();
+        }
+        while ( cursor.shouldRetry() );
+        return new StandardRecord( t, f, f1, r, f2 );
+    }
+
+    @Override
+    public Record zeroRecord()
+    {
+        byte z = 0;
+        return new StandardRecord( z, z, z, z, z );
+    }
+
+    @Override
+    public void write( Record record, PageCursor cursor )
+    {
+        StandardRecord r = (StandardRecord) record;
+        cursor.putByte( r.type );
+        cursor.putByte( r.file.getName().getBytes()[0] );
+        cursor.putShort( r.fill1 );
+        cursor.putInt( r.recordId );
+        cursor.putLong( r.fill2 );
+    }
+
+    static final class StandardRecord implements Record
+    {
+        final byte type;
+        final File file;
+        final int recordId;
+        final short fill1;
+        final long fill2;
+
+        public StandardRecord( File file, int recordId )
+        {
+            this.type = 42;
+            this.file = file;
+            this.recordId = recordId;
+            int fileHash = file.hashCode();
+
+            int a = xorshift( fileHash ^ xorshift( recordId ) );
+            int b = xorshift( a );
+            int c = xorshift( b );
+            long d = b;
+            d = d << 32;
+            d += c;
+            fill1 = (short) a;
+            fill2 = d;
+        }
+
+        public StandardRecord( byte type, byte fileName, short fill1, int recordId, long fill2 )
+        {
+            this.type = type;
+            this.file = fileName == 0? null : new File( new String( new byte[] {fileName} ) );
+            this.fill1 = fill1;
+            this.recordId = recordId;
+            this.fill2 = fill2;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            { return true; }
+            if ( o == null || getClass() != o.getClass() )
+            { return false; }
+
+            StandardRecord record = (StandardRecord) o;
+
+            return type == record.type
+                   && recordId == record.recordId
+                   && fill1 == record.fill1
+                   && fill2 == record.fill2
+                   && !(file != null ? !file.equals( record.file ) : record.file != null);
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = (int) type;
+            result = 31 * result + (file != null ? file.hashCode() : 0);
+            result = 31 * result + recordId;
+            result = 31 * result + (int) fill1;
+            result = 31 * result + (int) (fill2 ^ (fill2 >>> 32));
+            return result;
+        }
+
+        private static int xorshift( int x )
+        {
+            x ^= (x << 6);
+            x ^= (x >>> 21);
+            return x ^ (x << 7);
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( type, file, recordId, fill1, fill2 );
+        }
+
+        public String format( byte type, File file, int recordId, short fill1, long fill2 )
+        {
+            return String.format(
+                    "Record%s[file=%s, recordId=%s; %04x %016x]",
+                    type, file, recordId, fill1, fill2 );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
@@ -496,6 +496,19 @@ public class BatchingPageCache implements PageCache
         }
 
         @Override
+        public int getCurrentPageSize()
+        {
+            return currentPageId == -1? UNBOUND_PAGE_SIZE : pageSize;
+        }
+
+        @Override
+        public File getCurrentFile()
+        {
+            // We don't need this where the BatchingPageCache is being used.
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void rewind() throws IOException
         {
             throw new UnsupportedOperationException(

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -407,6 +407,18 @@ public class PageCacheRule extends ExternalResource
         }
 
         @Override
+        public int getCurrentPageSize()
+        {
+            return cursor.getCurrentPageSize();
+        }
+
+        @Override
+        public File getCurrentFile()
+        {
+            return cursor.getCurrentFile();
+        }
+
+        @Override
         public void rewind() throws IOException
         {
             cursor.rewind();


### PR DESCRIPTION
The harness makes it easier to write randomised page cache tests, and also tries to help with debugging when the tests fail.
A couple of tests have also been rewritten to make use of it.

Along side this work, the amount of work done in the `PageCacheTest.concurrentPageFaultingMustNotPutInterleavedDataIntoPages` has also been reduced, so it's not so prone to timeout on virtual machines where context switching is much more expensive.
