### PR TITLE
4xx HTTP response codes should come with a ClientError status.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/ConstraintViolationException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/ConstraintViolationException.java
@@ -19,13 +19,15 @@
  */
 package org.neo4j.graphdb;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 /**
  * Thrown when the database is asked to modify data in a way that violates one or more
  * constraints that it is expected to uphold.
  *
  * For instance, if removing a node that still has relationships.
  */
-public class ConstraintViolationException extends RuntimeException
+public class ConstraintViolationException extends RuntimeException implements Status.HasStatus
 {
     public ConstraintViolationException( String msg )
     {
@@ -35,5 +37,11 @@ public class ConstraintViolationException extends RuntimeException
     public ConstraintViolationException( String msg, Throwable cause )
     {
         super(msg, cause);
+    }
+
+    @Override
+    public Status status()
+    {
+        return Status.Schema.ConstraintViolation;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -62,6 +62,7 @@ import org.neo4j.helpers.collection.ResourceClosingIterator;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
+import org.neo4j.kernel.api.EntityType;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
@@ -1056,13 +1057,15 @@ public abstract class InternalAbstractGraphDatabase
     {
         if ( id < 0 || id > MAX_NODE_ID )
         {
-            throw new NotFoundException( format( "Node %d not found", id ) );
+            throw new NotFoundException( format( "Node %d not found", id ),
+                    new EntityNotFoundException( EntityType.NODE, id ) );
         }
         try ( Statement statement = threadToTransactionBridge.instance() )
         {
             if ( !statement.readOperations().nodeExists( id ) )
             {
-                throw new NotFoundException( format( "Node %d not found", id ) );
+                throw new NotFoundException( format( "Node %d not found", id ),
+                        new EntityNotFoundException( EntityType.NODE, id ) );
             }
 
             return nodeManager.newNodeProxyById( id );
@@ -1074,13 +1077,15 @@ public abstract class InternalAbstractGraphDatabase
     {
         if ( id < 0 || id > MAX_RELATIONSHIP_ID )
         {
-            throw new NotFoundException( format( "Relationship %d not found", id ) );
+            throw new NotFoundException( format( "Relationship %d not found", id ),
+                    new EntityNotFoundException( EntityType.RELATIONSHIP, id ));
         }
         try ( Statement statement = threadToTransactionBridge.instance() )
         {
             if ( !statement.readOperations().relationshipExists( id ) )
             {
-                throw new NotFoundException( format( "Relationship %d not found", id ) );
+                throw new NotFoundException( format( "Relationship %d not found", id ),
+                        new EntityNotFoundException( EntityType.RELATIONSHIP, id ));
             }
 
             return nodeManager.newRelationshipProxy( id );

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/BadInputException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/BadInputException.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.server.rest.repr;
 
-public class BadInputException extends Exception
+import org.neo4j.kernel.api.exceptions.Status;
+
+public class BadInputException extends Exception implements Status.HasStatus
 {
     public BadInputException( Throwable cause )
     {
@@ -34,5 +36,11 @@ public class BadInputException extends Exception
     public BadInputException( String message, Throwable cause )
     {
         super( message, cause );
+    }
+
+    @Override
+    public Status status()
+    {
+        return Status.Request.InvalidFormat;
     }
 }

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/InvalidArgumentsException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/InvalidArgumentsException.java
@@ -17,15 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.server.rest.web;
+package org.neo4j.server.rest.repr;
 
-public class OperationFailureException extends Exception
+import org.neo4j.kernel.api.exceptions.Status;
+
+public class InvalidArgumentsException extends BadInputException
 {
-    public OperationFailureException( String message )
+    public InvalidArgumentsException( String message )
     {
         super( message );
     }
 
-    private static final long serialVersionUID = -4594462038185850546L;
-
+    @Override
+    public Status status()
+    {
+        return Status.Statement.InvalidArguments;
+    }
 }

--- a/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationFormat.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/repr/RepresentationFormat.java
@@ -297,7 +297,7 @@ public abstract class RepresentationFormat implements InputFormat
         }
         catch ( NotFoundException e )
         {
-            throw new RelationshipNotFoundException();
+            throw new RelationshipNotFoundException( e );
         }
     }
 

--- a/community/server-api/src/main/java/org/neo4j/server/rest/web/NodeNotFoundException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/web/NodeNotFoundException.java
@@ -23,14 +23,14 @@ import org.neo4j.graphdb.NotFoundException;
 
 public class NodeNotFoundException extends Exception
 {
-    public NodeNotFoundException( String message )
+    public NodeNotFoundException( String message, NotFoundException e )
     {
-        super(message);
+        super( message, e );
     }
 
     public NodeNotFoundException( NotFoundException e )
     {
-        super(e);
+        super( e );
     }
 
     private static final long serialVersionUID = 7292603734007524712L;

--- a/community/server-api/src/main/java/org/neo4j/server/rest/web/RelationshipNotFoundException.java
+++ b/community/server-api/src/main/java/org/neo4j/server/rest/web/RelationshipNotFoundException.java
@@ -24,4 +24,8 @@ public class RelationshipNotFoundException extends Exception
 {
     private static final long serialVersionUID = -1177555212368703516L;
 
+    public RelationshipNotFoundException( Throwable cause )
+    {
+        super( cause );
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/EndNodeNotFoundException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/EndNodeNotFoundException.java
@@ -19,8 +19,13 @@
  */
 package org.neo4j.server.rest.domain;
 
+import org.neo4j.server.rest.web.NodeNotFoundException;
+
 @SuppressWarnings( "serial" )
 public class EndNodeNotFoundException extends Exception
 {
-
+    public EndNodeNotFoundException( NodeNotFoundException e )
+    {
+        super( e );
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonHelper.java
@@ -78,25 +78,21 @@ public class JsonHelper
         }
     }
 
-    public static Object jsonToSingleValue( String json ) throws org.neo4j.server.rest.web.PropertyValueException
+    public static Object assertSupportedPropertyValue( Object jsonObject ) throws PropertyValueException
     {
-        Object jsonObject = readJson( json );
-        return jsonObject instanceof Collection<?> ? jsonObject : assertSupportedPropertyValue( jsonObject );
-    }
-
-    private static Object assertSupportedPropertyValue( Object jsonObject ) throws PropertyValueException
-    {
+        if ( jsonObject instanceof Collection<?> )
+        {
+            return jsonObject;
+        }
         if ( jsonObject == null )
         {
-            throw new org.neo4j.server.rest.web.PropertyValueException( "null value not supported" );
-
+            throw new PropertyValueException( "null value not supported" );
         }
-
         if ( !(jsonObject instanceof String ||
                jsonObject instanceof Number ||
                jsonObject instanceof Boolean) )
         {
-            throw new org.neo4j.server.rest.web.PropertyValueException(
+            throw new PropertyValueException(
                     "Unsupported value type " + jsonObject.getClass() + "."
                     + " Supported value types are all java primitives (byte, char, short, int, "
                     + "long, float, double) and String, as well as arrays of all those types" );

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/JsonParseException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/JsonParseException.java
@@ -19,22 +19,24 @@
  */
 package org.neo4j.server.rest.domain;
 
-@SuppressWarnings( "serial" )
-public class JsonParseException extends org.neo4j.server.rest.web.PropertyValueException
-{
+import org.neo4j.kernel.api.exceptions.Status;
 
+@SuppressWarnings( "serial" )
+public class JsonParseException extends Exception implements Status.HasStatus
+{
     public JsonParseException( String message, Throwable cause )
     {
         super( message, cause );
     }
 
-    public JsonParseException( String message )
-    {
-        super( message );
-    }
-
     public JsonParseException( Throwable cause )
     {
         super( cause );
+    }
+
+    @Override
+    public Status status()
+    {
+        return Status.Request.InvalidFormat;
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
@@ -138,7 +138,7 @@ public class PropertySettingStrategy
         }
         catch ( IllegalArgumentException e )
         {
-            throw new PropertyValueException( key, value );
+            throw new PropertyValueException( "Could not set property \"" + key + "\", unsupported type: " + value );
         }
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/StartNodeNotFoundException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/StartNodeNotFoundException.java
@@ -19,8 +19,13 @@
  */
 package org.neo4j.server.rest.domain;
 
+import org.neo4j.server.rest.web.NodeNotFoundException;
+
 @SuppressWarnings( "serial" )
 public class StartNodeNotFoundException extends Exception
 {
-
+    public StartNodeNotFoundException( NodeNotFoundException e )
+    {
+        super( e );
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/management/JmxService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/management/JmxService.java
@@ -44,7 +44,7 @@ import org.neo4j.jmx.Kernel;
 import org.neo4j.jmx.impl.JmxKernelExtension;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.repr.BadInputException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.InputFormat;
 import org.neo4j.server.rest.repr.ListRepresentation;
 import org.neo4j.server.rest.repr.OutputFormat;
@@ -153,7 +153,7 @@ public class JmxService implements AdvertisableService
             MBeanServer server = ManagementFactory.getPlatformMBeanServer();
 
             String json = dodgeStartingUnicodeMarker( query );
-            Collection<Object> queries = (Collection<Object>) JsonHelper.jsonToSingleValue( json );
+            Collection<Object> queries = (Collection<Object>) JsonHelper.readJson( json );
 
             ArrayList<JmxMBeanRepresentation> beans = new ArrayList<JmxMBeanRepresentation>();
             for ( Object queryObj : queries )
@@ -167,15 +167,14 @@ public class JmxService implements AdvertisableService
 
             return output.ok( new ListRepresentation( "jmxBean", beans ) );
         }
+        catch ( JsonParseException e )
+        {
+            return output.badRequest( e );
+        }
         catch ( MalformedObjectNameException e )
         {
             return output.badRequest( e );
         }
-        catch ( BadInputException e )
-        {
-            return output.badRequest( e );
-        }
-
     }
 
     @POST

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DefaultFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DefaultFormat.java
@@ -150,11 +150,11 @@ public class DefaultFormat extends RepresentationFormat
         {
             if ( missing.size() == 1 )
             {
-                throw new BadInputException( "Missing required key: \"" + missing.iterator().next() + "\"" );
+                throw new InvalidArgumentsException( "Missing required key: \"" + missing.iterator().next() + "\"" );
             }
             else
             {
-                throw new BadInputException( "Missing required keys: " + missing );
+                throw new InvalidArgumentsException( "Missing required keys: " + missing );
             }
         }
         return map;

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ExceptionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ExceptionRepresentation.java
@@ -90,7 +90,7 @@ public class ExceptionRepresentation extends MappingRepresentation
                 if (element.toString().matches( ".*(jetty|jersey|sun\\.reflect|mortbay|javax\\.servlet).*" )) continue;
                 lines.add( element.toString() );
             }
-            serializer.putList( "stacktrace", ListRepresentation.string( lines ) );
+            serializer.putList( "stackTrace", ListRepresentation.string( lines ) );
         }
 
         Throwable cause = exception.getCause();
@@ -117,7 +117,7 @@ public class ExceptionRepresentation extends MappingRepresentation
             serializer.putString( "message", error.getMessage() );
             if(error.shouldSerializeStackTrace())
             {
-                serializer.putString( "stacktrace", error.getStackTraceAsString() );
+                serializer.putString( "stackTrace", error.getStackTraceAsString() );
             }
         }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/CompactJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/CompactJsonFormat.java
@@ -42,6 +42,9 @@ import org.neo4j.server.rest.repr.MappingWriter;
 import org.neo4j.server.rest.repr.Representation;
 import org.neo4j.server.rest.repr.RepresentationFormat;
 
+import static org.neo4j.server.rest.domain.JsonHelper.assertSupportedPropertyValue;
+import static org.neo4j.server.rest.domain.JsonHelper.readJson;
+
 @Service.Implementation( RepresentationFormat.class )
 public class CompactJsonFormat extends RepresentationFormat
 {
@@ -219,7 +222,7 @@ public class CompactJsonFormat extends RepresentationFormat
         if ( empty( input ) ) return Collections.emptyMap();
         try
         {
-            return JsonHelper.jsonToSingleValue( stripByteOrderMark( input ) );
+            return assertSupportedPropertyValue( readJson( stripByteOrderMark( input ) ) );
         }
         catch ( JsonParseException ex )
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/HtmlFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/HtmlFormat.java
@@ -138,7 +138,7 @@ public class HtmlFormat extends RepresentationFormat
                 }
                 entity.append( "<p><pre>" )
                         .append( serialized.get( "exception" ) );
-                List<Object> tb = (List<Object>) serialized.get( "stacktrace" );
+                List<Object> tb = (List<Object>) serialized.get( "stackTrace" );
                 if ( tb != null )
                 {
                     for ( Object el : tb )

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/JsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/JsonFormat.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.ws.rs.core.MediaType;
 
 import org.neo4j.server.rest.domain.JsonHelper;
@@ -36,6 +35,9 @@ import org.neo4j.server.rest.repr.DefaultFormat;
 import org.neo4j.server.rest.repr.ListWriter;
 import org.neo4j.server.rest.repr.MappingWriter;
 import org.neo4j.server.rest.repr.RepresentationFormat;
+
+import static org.neo4j.server.rest.domain.JsonHelper.assertSupportedPropertyValue;
+import static org.neo4j.server.rest.domain.JsonHelper.readJson;
 
 public class JsonFormat extends RepresentationFormat
 {
@@ -117,7 +119,7 @@ public class JsonFormat extends RepresentationFormat
         if ( empty( input ) ) return Collections.emptyMap();
         try
         {
-            return JsonHelper.jsonToSingleValue( stripByteOrderMark( input ) );
+            return assertSupportedPropertyValue( readJson( stripByteOrderMark( input ) ) );
         }
         catch ( JsonParseException ex )
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/NullFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/NullFormat.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.neo4j.server.rest.repr.BadInputException;
+import org.neo4j.server.rest.repr.InvalidArgumentsException;
 import org.neo4j.server.rest.repr.ListWriter;
 import org.neo4j.server.rest.repr.MappingWriter;
 import org.neo4j.server.rest.repr.MediaTypeNotSupportedException;
@@ -75,7 +76,7 @@ public class NullFormat extends RepresentationFormat
             if ( requiredKeys.length != 0 )
             {
                 String missingKeys = Arrays.toString( requiredKeys );
-                throw new BadInputException( "Missing required keys: " + missingKeys );
+                throw new InvalidArgumentsException( "Missing required keys: " + missingKeys );
             }
             return Collections.emptyMap();
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormat.java
@@ -46,6 +46,9 @@ import org.neo4j.server.rest.repr.MappingWriter;
 import org.neo4j.server.rest.repr.RepresentationFormat;
 import org.neo4j.server.rest.repr.StreamingFormat;
 
+import static org.neo4j.server.rest.domain.JsonHelper.assertSupportedPropertyValue;
+import static org.neo4j.server.rest.domain.JsonHelper.readJson;
+
 @Service.Implementation(RepresentationFormat.class)
 public class StreamingJsonFormat extends RepresentationFormat implements StreamingFormat
 {
@@ -163,7 +166,7 @@ public class StreamingJsonFormat extends RepresentationFormat implements Streami
         }
         try
         {
-            return JsonHelper.jsonToSingleValue( stripByteOrderMark( input ) );
+            return assertSupportedPropertyValue( readJson( stripByteOrderMark( input ) ) );
         }
         catch ( JsonParseException ex )
         {

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -37,6 +37,7 @@ import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.rest.repr.BadInputException;
 import org.neo4j.server.rest.repr.CypherResultRepresentation;
 import org.neo4j.server.rest.repr.InputFormat;
+import org.neo4j.server.rest.repr.InvalidArgumentsException;
 import org.neo4j.server.rest.repr.OutputFormat;
 import org.neo4j.server.rest.transactional.CommitOnSuccessfulStatusCodeRepresentationWriteHandler;
 
@@ -81,7 +82,7 @@ public class CypherService
         Map<String,Object> command = input.readMap( body );
 
         if( !command.containsKey(QUERY_KEY) ) {
-            return output.badRequest(new BadInputException( "You have to provide the 'query' parameter." ));
+            return output.badRequest( new InvalidArgumentsException( "You have to provide the 'query' parameter." ) );
         }
 
         String query = (String) command.get( QUERY_KEY );

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -83,6 +83,7 @@ import org.neo4j.server.rest.repr.DatabaseRepresentation;
 import org.neo4j.server.rest.repr.IndexDefinitionRepresentation;
 import org.neo4j.server.rest.repr.IndexRepresentation;
 import org.neo4j.server.rest.repr.IndexedEntityRepresentation;
+import org.neo4j.server.rest.repr.InvalidArgumentsException;
 import org.neo4j.server.rest.repr.ListRepresentation;
 import org.neo4j.server.rest.repr.NodeIndexRepresentation;
 import org.neo4j.server.rest.repr.NodeIndexRootRepresentation;
@@ -173,7 +174,7 @@ public class DatabaseActions
         catch ( NotFoundException e )
         {
             throw new NodeNotFoundException( String.format(
-                    "Cannot find node with id [%d] in database.", id ) );
+                    "Cannot find node with id [%d] in database.", id ), e );
         }
     }
 
@@ -186,7 +187,7 @@ public class DatabaseActions
         }
         catch ( NotFoundException e )
         {
-            throw new RelationshipNotFoundException();
+            throw new RelationshipNotFoundException( e );
         }
     }
 
@@ -220,13 +221,13 @@ public class DatabaseActions
         return new NodeRepresentation( node( nodeId ) );
     }
 
-    public void deleteNode( long nodeId ) throws NodeNotFoundException, OperationFailureException
+    public void deleteNode( long nodeId ) throws NodeNotFoundException, ConstraintViolationException
     {
         Node node = node( nodeId );
 
         if ( node.hasRelationship() )
         {
-            throw new OperationFailureException(
+            throw new ConstraintViolationException(
                     String.format(
                             "The node with id %d cannot be deleted. Check that the node is orphaned before deletion.",
                             nodeId ) );
@@ -315,7 +316,7 @@ public class DatabaseActions
                 node.addLabel( label( labelName ) );
             }
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             throw new BadInputException( "Unable to add label, see nested exception.", e );
         }
@@ -341,7 +342,7 @@ public class DatabaseActions
                 node.addLabel( label( labelName ) );
             }
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             throw new BadInputException( "Unable to add label, see nested exception.", e );
         }
@@ -541,7 +542,7 @@ public class DatabaseActions
         }
         catch ( NodeNotFoundException e )
         {
-            throw new StartNodeNotFoundException();
+            throw new StartNodeNotFoundException( e );
         }
         try
         {
@@ -549,7 +550,7 @@ public class DatabaseActions
         }
         catch ( NodeNotFoundException e )
         {
-            throw new EndNodeNotFoundException();
+            throw new EndNodeNotFoundException( e );
         }
 
         Relationship rel = start.createRelationshipTo( end,
@@ -876,7 +877,7 @@ public class DatabaseActions
         {
             if ( properties != null )
             {
-                throw new BadInputException( "Cannot specify properties for a new node, " +
+                throw new InvalidArgumentsException( "Cannot specify properties for a new node, " +
                         "when a node to index is specified." );
             }
             Node node = node( nodeOrNull );
@@ -922,7 +923,7 @@ public class DatabaseActions
         {
             if ( startNode != null || type != null || endNode != null || properties != null )
             {
-                throw new BadInputException( "Either specify a relationship to index uniquely, " +
+                throw new InvalidArgumentsException( "Either specify a relationship to index uniquely, " +
                         "or the means for creating it." );
             }
             Relationship relationship = relationship( relationshipOrNull );
@@ -940,7 +941,7 @@ public class DatabaseActions
         }
         else if ( startNode == null || type == null || endNode == null )
         {
-            throw new BadInputException( "Either specify a relationship to index uniquely, " +
+            throw new InvalidArgumentsException( "Either specify a relationship to index uniquely, " +
                     "or the means for creating it." );
         }
         else

--- a/community/server/src/main/java/org/neo4j/server/rest/web/ExtensionService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/ExtensionService.java
@@ -100,7 +100,7 @@ public class ExtensionService
         }
         catch ( NotFoundException e )
         {
-            throw new RelationshipNotFoundException();
+            throw new RelationshipNotFoundException( e );
         }
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/web/NoSuchPropertyException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/NoSuchPropertyException.java
@@ -20,8 +20,9 @@
 package org.neo4j.server.rest.web;
 
 import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.kernel.api.exceptions.Status;
 
-public class NoSuchPropertyException extends Exception
+public class NoSuchPropertyException extends Exception implements Status.HasStatus
 {
     private static final long serialVersionUID = -2078314214014212029L;
 
@@ -30,4 +31,9 @@ public class NoSuchPropertyException extends Exception
         super( entity + " does not have a property \"" + key + "\"" );
     }
 
+    @Override
+    public Status status()
+    {
+        return Status.Statement.NoSuchProperty;
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/PropertyValueException.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/PropertyValueException.java
@@ -19,22 +19,13 @@
  */
 package org.neo4j.server.rest.web;
 
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.repr.BadInputException;
 
 //TODO: move this to another package. domain? or repr?
 public class PropertyValueException extends BadInputException
 {
     private static final long serialVersionUID = -7810255514347322861L;
-
-    public PropertyValueException( String key, Object value )
-    {
-        super( "Could not set property \"" + key + "\", unsupported type: " + value );
-    }
-
-    public PropertyValueException( String message, Throwable cause )
-    {
-        super( message, cause );
-    }
 
     public PropertyValueException( String message )
     {
@@ -44,5 +35,11 @@ public class PropertyValueException extends BadInputException
     public PropertyValueException( Throwable cause )
     {
         super( cause );
+    }
+
+    @Override
+    public Status status()
+    {
+        return Status.Statement.InvalidArguments;
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/RestfulGraphDatabase.java
@@ -55,6 +55,7 @@ import org.neo4j.server.rest.domain.TraverserReturnType;
 import org.neo4j.server.rest.repr.BadInputException;
 import org.neo4j.server.rest.repr.IndexedEntityRepresentation;
 import org.neo4j.server.rest.repr.InputFormat;
+import org.neo4j.server.rest.repr.InvalidArgumentsException;
 import org.neo4j.server.rest.repr.ListEntityRepresentation;
 import org.neo4j.server.rest.repr.ListRepresentation;
 import org.neo4j.server.rest.repr.OutputFormat;
@@ -283,7 +284,7 @@ public class RestfulGraphDatabase
         {
             return output.notFound( e );
         }
-        catch ( OperationFailureException e )
+        catch ( ConstraintViolationException e )
         {
             return output.conflict( e );
         }
@@ -311,7 +312,7 @@ public class RestfulGraphDatabase
         {
             return output.notFound( e );
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             return output.conflict( e );
         }
@@ -353,7 +354,7 @@ public class RestfulGraphDatabase
         {
             return output.notFound( e );
         }
-        catch ( ConstraintViolationException e)
+        catch ( org.neo4j.graphdb.ConstraintViolationException e)
         {
             return output.conflict( e );
         }
@@ -437,7 +438,7 @@ public class RestfulGraphDatabase
             }
             else
             {
-                throw new BadInputException( format( "Label name must be a string. Got: '%s'", rawInput ) );
+                throw new InvalidArgumentsException( format( "Label name must be a string. Got: '%s'", rawInput ) );
             }
         }
         catch ( BadInputException e )
@@ -464,7 +465,7 @@ public class RestfulGraphDatabase
             Object rawInput = input.readValue( body );
             if ( !(rawInput instanceof Collection) )
             {
-                throw new BadInputException( format( "Input must be an array of Strings. Got: '%s'", rawInput ) );
+                throw new InvalidArgumentsException( format( "Input must be an array of Strings. Got: '%s'", rawInput ) );
             }
             else
             {
@@ -523,7 +524,7 @@ public class RestfulGraphDatabase
         {
             if ( labelName.isEmpty() )
             {
-                throw new BadInputException( "Empty label name" );
+                throw new InvalidArgumentsException( "Empty label name" );
             }
 
             Map<String, Object> properties = toMap( map( queryParamsToProperties, uriInfo.getQueryParameters().entrySet()));
@@ -1166,7 +1167,7 @@ public class RestfulGraphDatabase
         {
             return null;
         }
-        throw new BadInputException( "\"" + key + "\" should be a string" );
+        throw new InvalidArgumentsException( "\"" + key + "\" should be a string" );
     }
 
     @SuppressWarnings("unchecked")
@@ -1181,7 +1182,7 @@ public class RestfulGraphDatabase
         {
             return null;
         }
-        throw new BadInputException( "\"" + key + "\" should be a map" );
+        throw new InvalidArgumentsException( "\"" + key + "\" should be a map" );
     }
 
     @GET
@@ -1635,7 +1636,7 @@ public class RestfulGraphDatabase
     {
         if ( leaseTimeInSeconds < 1 )
         {
-            throw new BadInputException( "Lease time less than 1 second is not supported" );
+            throw new InvalidArgumentsException( "Lease time less than 1 second is not supported" );
         }
     }
 
@@ -1643,7 +1644,7 @@ public class RestfulGraphDatabase
     {
         if ( pageSize < 1 )
         {
-            throw new BadInputException( "Page size less than 1 is not permitted" );
+            throw new InvalidArgumentsException( "Page size less than 1 is not permitted" );
         }
     }
 
@@ -1719,7 +1720,7 @@ public class RestfulGraphDatabase
         {
             return output.badRequest( e );
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             return output.conflict( e );
         }
@@ -1763,7 +1764,7 @@ public class RestfulGraphDatabase
                 return output.notFound();
             }
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             return output.conflict( e );
         }
@@ -1806,7 +1807,7 @@ public class RestfulGraphDatabase
         {
             return output.badRequest( e );
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             return output.conflict( e );
         }
@@ -1828,7 +1829,7 @@ public class RestfulGraphDatabase
                 return output.notFound();
             }
         }
-        catch ( ConstraintViolationException e )
+        catch ( org.neo4j.graphdb.ConstraintViolationException e )
         {
             return output.conflict( e );
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/StreamingBatchOperations.java
@@ -84,7 +84,7 @@ public class StreamingBatchOperations extends BatchOperations
         {
             final String message = "Error " + status + " executing batch operation: " + ((id!=null) ? id + ". ":"") + method + " " + path + " " + body;
             results.writeError( status, res.getReason() );
-            throw new BatchOperationFailedException(status, message, new OperationFailureException(res.getReason()) );
+            throw new BatchOperationFailedException( status, message, new Exception( res.getReason() ) );
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.Pair;
 import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.web.PropertyValueException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.TestData;
@@ -198,10 +198,10 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         Collection<?> hits;
         try
         {
-            hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+            hits = (Collection<?>) JsonHelper.readJson( entity );
             assertEquals( expectedSize, hits.size() );
         }
-        catch ( PropertyValueException e )
+        catch ( JsonParseException e )
         {
             throw new RuntimeException( e );
         }

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.ServerTestUtils;
 import org.neo4j.server.rest.domain.JsonHelper;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.tooling.GlobalGraphOperations;
@@ -399,7 +400,7 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     @Test
     @Graph("Peter likes Jazz")
     public void shouldHandleEscapedStrings() throws ClientHandlerException,
-            UniformInterfaceException, JSONException, PropertyValueException
+            UniformInterfaceException, JSONException, JsonParseException
     {
     	String string = "Jazz";
         Node gnode = getNode( string );

--- a/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
@@ -144,7 +144,7 @@ public class CypherDocIT extends AbstractRestFunctionalTestBase {
         Map<String, Object> output = jsonToMap( response );
         assertTrue( output.toString(), output.containsKey( "message" ) );
         assertTrue( output.containsKey( "exception" ) );
-        assertTrue( output.containsKey( "stacktrace" ) );
+        assertTrue( output.containsKey( "stackTrace" ) );
     }
 
     /**
@@ -294,7 +294,7 @@ public class CypherDocIT extends AbstractRestFunctionalTestBase {
 
         Map<String, Object> output = jsonToMap( response );
         assertTrue( output.containsKey( "message" ) );
-        assertTrue( output.containsKey( "stacktrace" ) );
+        assertTrue( output.containsKey( "stackTrace" ) );
     }
 
     /**

--- a/community/server/src/test/java/org/neo4j/server/rest/DegreeDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DegreeDocIT.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.web.PropertyValueException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription;
 
 import static junit.framework.TestCase.assertEquals;
@@ -40,7 +40,7 @@ public class DegreeDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( {"Root knows Mattias", "Root knows Johan"} )
-    public void get_degree() throws PropertyValueException
+    public void get_degree() throws JsonParseException
     {
         Map<String,Node> nodes = data.get();
         String nodeUri = getNodeUri( nodes.get( "Root" ) );
@@ -63,7 +63,7 @@ public class DegreeDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( {"Root knows Mattias", "Root knows Johan"} )
-    public void get_degree_by_direction() throws PropertyValueException
+    public void get_degree_by_direction() throws JsonParseException
     {
         Map<String,Node> nodes = data.get();
         String nodeUri = getNodeUri( nodes.get( "Root" ) );
@@ -86,7 +86,7 @@ public class DegreeDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( {"Root KNOWS Mattias", "Root KNOWS Johan", "Root LIKES Cookie"} )
-    public void get_degree_by_direction_and_type() throws PropertyValueException
+    public void get_degree_by_direction_and_type() throws JsonParseException
     {
         Map<String,Node> nodes = data.get();
         String nodeUri = getNodeUri( nodes.get( "Root" ) );

--- a/community/server/src/test/java/org/neo4j/server/rest/GetNodePropertiesDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/GetNodePropertiesDocIT.java
@@ -84,7 +84,7 @@ public class GetNodePropertiesDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldGetCorrectContentEncodingRetrievingProperties() throws PropertyValueException
+    public void shouldGetCorrectContentEncodingRetrievingProperties() throws JsonParseException
     {
         String asianText = "\u4f8b\u5b50";
         String germanText = "öäüÖÄÜß";
@@ -95,11 +95,12 @@ public class GetNodePropertiesDocIT extends AbstractRestFunctionalTestBase
         String entity = JsonHelper.createJsonFrom( Collections.singletonMap( "foo", complicatedString ));
         final RestRequest request = req;
         JaxRsResponse createResponse = request.post(functionalTestHelper.dataUri() + "node/", entity);
-        String response = (String) JsonHelper.jsonToSingleValue( request.get( getPropertyUri( createResponse.getLocation().toString(), "foo" ) ).getEntity() );
+        String response = (String) JsonHelper.readJson( request.get( getPropertyUri( createResponse.getLocation()
+                .toString(), "foo" ) ).getEntity() );
         assertEquals( complicatedString, response );
     }
     @Test
-    public void shouldGetCorrectContentEncodingRetrievingPropertiesWithStreaming() throws PropertyValueException
+    public void shouldGetCorrectContentEncodingRetrievingPropertiesWithStreaming() throws JsonParseException
     {
         String asianText = "\u4f8b\u5b50";
         String germanText = "öäüÖÄÜß";
@@ -109,7 +110,8 @@ public class GetNodePropertiesDocIT extends AbstractRestFunctionalTestBase
         String entity = JsonHelper.createJsonFrom( Collections.singletonMap( "foo", complicatedString ) );
         final RestRequest request = req.header( StreamingJsonFormat.STREAM_HEADER,"true");
         JaxRsResponse createResponse = request.post(functionalTestHelper.dataUri() + "node/", entity);
-        String response = (String) JsonHelper.jsonToSingleValue( request.get( getPropertyUri( createResponse.getLocation().toString(), "foo" ) , new MediaType( "application","json", stringMap( "stream", "true" ) )).getEntity() );
+        String response = (String) JsonHelper.readJson( request.get( getPropertyUri( createResponse.getLocation()
+                .toString(), "foo" ), new MediaType( "application", "json", stringMap( "stream", "true" ) ) ).getEntity() );
         assertEquals( complicatedString, response );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexNodeDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexNodeDocIT.java
@@ -48,7 +48,6 @@ import org.neo4j.server.rest.domain.GraphDbHelper;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.domain.URIHelper;
-import org.neo4j.server.rest.web.PropertyValueException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -95,7 +94,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldGetListOfNodeIndexesWhenOneExist() throws PropertyValueException
+    public void shouldGetListOfNodeIndexesWhenOneExist() throws JsonParseException
     {
         String indexName = "favorites";
         helper.createNodeIndex( indexName );
@@ -206,7 +205,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName, key,
                         URIHelper.encode( value ) ) );
         String entity = response.getEntity();
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 1, hits.size() );
     }
 
@@ -243,7 +242,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 .expectedStatus( 200 )
                 .get( functionalTestHelper.indexNodeUri( indexName, key, URIHelper.encode( value ) ) )
                 .entity();
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 1, hits.size() );
     }
 
@@ -268,7 +267,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
      */
     @Documented
     @Test
-    public void shouldAddToIndexAndRetrieveItByQuery() throws PropertyValueException
+    public void shouldAddToIndexAndRetrieveItByQuery() throws JsonParseException
     {
         String indexName = "bobTheIndex";
         String key = "Name";
@@ -282,7 +281,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 .get( functionalTestHelper.indexNodeUri( indexName ) + "?query=Name:Build~0.1%20AND%20Gender:Male" )
                 .entity();
 
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 1, hits.size() );
         LinkedHashMap<String, String> nodeMap = (LinkedHashMap) hits.iterator().next();
         assertNull( "score should not be present when not explicitly ordering",
@@ -304,7 +303,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName )
                         + "?query=Name:Build~0.1%20AND%20Gender:Male" ).entity();
 
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         LinkedHashMap<String, String> nodeMapUnordered = (LinkedHashMap) hits.iterator().next();
 
         // When
@@ -312,7 +311,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName )
                         + "?query=Name:Build~0.1%20AND%20Gender:Male&order=score" ).entity();
 
-        hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        hits = (Collection<?>) JsonHelper.readJson( entity );
         LinkedHashMap<String, String> nodeMapOrdered = (LinkedHashMap) hits.iterator().next();
 
         // Then
@@ -328,7 +327,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
 
     @Test
     public void shouldAddToIndexAndRetrieveItByQuerySorted()
-            throws PropertyValueException
+            throws JsonParseException
     {
         String indexName = "bobTheIndex";
         String key = "Name";
@@ -343,7 +342,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName )
                         + "?query=Name:Build~0.1%20AND%20Gender:Male&order=relevance" ).entity();
 
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 2, hits.size() );
         Iterator<LinkedHashMap<String, Object>> it = (Iterator<LinkedHashMap<String, Object>>) hits.iterator();
 
@@ -367,7 +366,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName )
                         + "?query=Name:Build~0.1%20AND%20Gender:Male&order=index" ).entity();
 
-        hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 2, hits.size() );
         it = (Iterator<LinkedHashMap<String, Object>>) hits.iterator();
 
@@ -390,7 +389,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
                 functionalTestHelper.indexNodeUri( indexName )
                         + "?query=Name:Build~0.1%20AND%20Gender:Male&order=score" ).entity();
 
-        hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 2, hits.size() );
         it = (Iterator<LinkedHashMap<String, Object>>) hits.iterator();
 
@@ -477,7 +476,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldGet200AndArrayOfNodeRepsWhenGettingFromIndex() throws PropertyValueException
+    public void shouldGet200AndArrayOfNodeRepsWhenGettingFromIndex() throws JsonParseException
     {
         String key = "myKey";
         String value = "myValue";
@@ -516,7 +515,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         JaxRsResponse response = RestRequest.req()
                 .get( functionalTestHelper.indexNodeUri( indexName, key, value ) );
         assertEquals( 200, response.getStatus() );
-        Collection<?> items = (Collection<?>) JsonHelper.jsonToSingleValue( response.getEntity() );
+        Collection<?> items = (Collection<?>) JsonHelper.readJson( response.getEntity() );
         int counter = 0;
         for ( Object item : items )
         {
@@ -676,14 +675,14 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         response.close();
         response = request.get( functionalTestHelper.indexNodeUri( indexName, key, URIHelper.encode( value ) ) );
         assertEquals( Status.OK.getStatusCode(), response.getStatus() );
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( response.getEntity() );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( response.getEntity() );
         assertEquals( 1, hits.size() );
         response.close();
 
         CLIENT.resource( location )
                 .delete();
         response = request.get( functionalTestHelper.indexNodeUri( indexName, key, URIHelper.encode( value ) ) );
-        hits = (Collection<?>) JsonHelper.jsonToSingleValue( response.getEntity() );
+        hits = (Collection<?>) JsonHelper.readJson( response.getEntity() );
         assertEquals( 0, hits.size() );
     }
 
@@ -904,7 +903,7 @@ public class IndexNodeDocIT extends AbstractRestFunctionalTestBase
         JaxRsResponse response = RestRequest.req()
                 .get( functionalTestHelper.indexNodeUri( indexName, key, URIHelper.encode( value ) ) );
         String entity = response.getEntity();
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( entity );
         assertEquals( 1, hits.size() );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/IndexRelationshipDocIT.java
@@ -176,7 +176,7 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
     }
 
     @Test
-    public void shouldGet200AndArrayOfRelationshipRepsWhenGettingFromIndex() throws PropertyValueException
+    public void shouldGet200AndArrayOfRelationshipRepsWhenGettingFromIndex() throws JsonParseException
     {
         final long startNode = helper.createNode();
         final long endNode = helper.createNode();
@@ -207,7 +207,7 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         JaxRsResponse response = RestRequest.req().get(
                 functionalTestHelper.indexRelationshipUri( indexName, key, value ) );
         assertEquals( 200, response.getStatus() );
-        Collection<?> items = (Collection<?>) JsonHelper.jsonToSingleValue( response.getEntity() );
+        Collection<?> items = (Collection<?>) JsonHelper.readJson( response.getEntity() );
         int counter = 0;
         for ( Object item : items )
         {
@@ -322,14 +322,14 @@ public class IndexRelationshipDocIT extends AbstractRestFunctionalTestBase
         response = httpGetIndexRelationshipNameKeyValue( indexName, key, URIHelper.encode( value ) );
         assertEquals( Status.OK.getStatusCode(), response.getStatus() );
         String responseEntity = response.getEntity();
-        Collection<?> hits = (Collection<?>) JsonHelper.jsonToSingleValue( responseEntity );
+        Collection<?> hits = (Collection<?>) JsonHelper.readJson( responseEntity );
         assertEquals( 1, hits.size() );
         response.close();
         CLIENT.resource( location ).delete();
         response = httpGetIndexRelationshipNameKeyValue( indexName, key, URIHelper.encode( value ) );
         assertEquals( 200, response.getStatus() );
         responseEntity = response.getEntity();
-        hits = (Collection<?>) JsonHelper.jsonToSingleValue( responseEntity );
+        hits = (Collection<?>) JsonHelper.readJson( responseEntity );
         assertEquals( 0, hits.size() );
         response.close();
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
@@ -145,7 +145,7 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = { @NODE( name = "Clint Eastwood", labels = { @LABEL( "Actor" ), @LABEL( "Director" ) }, setNameProperty = true ) } )
-    public void listing_node_labels() throws PropertyValueException
+    public void listing_node_labels() throws JsonParseException
     {
         Map<String, Node> nodes = data.get();
         String nodeUri = getNodeUri( nodes.get( "Clint Eastwood" ) );
@@ -239,7 +239,7 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
             @NODE( name = "Donald Sutherland",   labels={ @LABEL( "Person" )} ),
             @NODE( name = "Clint Eastwood", labels={ @LABEL( "Person" )}, properties = { @PROP( key = "name", value = "Clint Eastwood" )}),
             @NODE( name = "Steven Spielberg", labels={ @LABEL( "Person" )}, properties = { @PROP( key = "name", value = "Steven Spielberg" )})})
-    public void get_nodes_with_label_and_property() throws PropertyValueException, UnsupportedEncodingException
+    public void get_nodes_with_label_and_property() throws JsonParseException, UnsupportedEncodingException
     {
         data.get();
 
@@ -264,7 +264,7 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
                     {@PROP(key = "names", value = "Clint,Eastwood", type = ARRAY, componentType = STRING)}),
             @NODE(name = "Steven Spielberg", labels = {@LABEL("Person")}, properties =
                     {@PROP(key = "names", value = "Steven,Spielberg", type = ARRAY, componentType = STRING)})})
-    public void get_nodes_with_label_and_array_property() throws PropertyValueException, UnsupportedEncodingException
+    public void get_nodes_with_label_and_array_property() throws JsonParseException, UnsupportedEncodingException
     {
         data.get();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/PathsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/PathsDocIT.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
-import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphDescription.NODE;
@@ -53,7 +52,7 @@ public class PathsDocIT extends AbstractRestFunctionalTestBase
     "c to g" } )
     @Documented
     @Title( "Find all shortest paths" )
-    public void shouldBeAbleToFindAllShortestPaths() throws PropertyValueException
+    public void shouldBeAbleToFindAllShortestPaths() throws JsonParseException
     {
 
         // Get all shortest paths
@@ -64,7 +63,7 @@ public class PathsDocIT extends AbstractRestFunctionalTestBase
         .payload( getAllShortestPathPayLoad( g ) )
         .post( "http://localhost:7474/db/data/node/" + a + "/paths" )
         .entity();
-        Collection<?> result = (Collection<?>) JsonHelper.jsonToSingleValue( response );
+        Collection<?> result = (Collection<?>) JsonHelper.readJson( response );
         assertEquals( 2, result.size() );
         for ( Object representation : result )
         {

--- a/community/server/src/test/java/org/neo4j/server/rest/RestRequest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RestRequest.java
@@ -154,8 +154,8 @@ public class RestRequest {
     }
 
 
-    public Object toEntity( JaxRsResponse JaxRsResponse ) throws PropertyValueException {
-        return JsonHelper.jsonToSingleValue( entityString( JaxRsResponse ) );
+    public Object toEntity( JaxRsResponse JaxRsResponse ) throws JsonParseException {
+        return JsonHelper.readJson( entityString( JaxRsResponse ) );
     }
 
     public Map<?, ?> toMap( JaxRsResponse JaxRsResponse) throws JsonParseException {

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
@@ -30,7 +30,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.kernel.impl.annotations.Documented;
-import org.neo4j.server.rest.web.PropertyValueException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription;
 
 import static java.util.Arrays.asList;
@@ -57,7 +57,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void createPropertyUniquenessConstraint() throws PropertyValueException
+    public void createPropertyUniquenessConstraint() throws JsonParseException
     {
         data.get();
 
@@ -80,7 +80,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getLabelUniquenessPropertyConstraint() throws PropertyValueException
+    public void getLabelUniquenessPropertyConstraint() throws JsonParseException
     {
         data.get();
 
@@ -105,7 +105,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getLabelUniquenessPropertyConstraints() throws PropertyValueException
+    public void getLabelUniquenessPropertyConstraints() throws JsonParseException
     {
         data.get();
 
@@ -139,7 +139,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getLabelPropertyConstraints() throws PropertyValueException
+    public void getLabelPropertyConstraints() throws JsonParseException
     {
         data.get();
 
@@ -173,7 +173,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void get_constraints() throws PropertyValueException
+    public void get_constraints() throws JsonParseException
     {
         data.get();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaIndexDocIT.java
@@ -30,7 +30,7 @@ import org.neo4j.graphdb.Neo4jMatchers;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.impl.annotations.Documented;
-import org.neo4j.server.rest.web.PropertyValueException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription;
 
 import static java.util.Arrays.asList;
@@ -60,7 +60,7 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void create_index() throws PropertyValueException
+    public void create_index() throws JsonParseException
     {
         data.get();
         
@@ -85,7 +85,7 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void get_indexes_for_label() throws PropertyValueException
+    public void get_indexes_for_label() throws JsonParseException
     {
         data.get();
         
@@ -116,7 +116,7 @@ public class SchemaIndexDocIT extends AbstractRestFunctionalTestBase
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void get_indexes() throws PropertyValueException
+    public void get_indexes() throws JsonParseException
     {
         data.get();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/TraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/TraverserDocIT.java
@@ -33,8 +33,7 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.annotations.Documented;
-import org.neo4j.server.rest.domain.JsonHelper;
-import org.neo4j.server.rest.web.PropertyValueException;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphDescription.NODE;
 
@@ -108,7 +107,7 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
     @Test
     @Graph( "I know you" )
     public void shouldGetSomeHitsWhenTraversingWithDefaultDescription()
-            throws PropertyValueException
+            throws JsonParseException
     {
         String entity = gen().expectedStatus( Status.OK.getStatusCode() ).payload( "{}" ).post(
                 getTraverseUriNodes( getNode( "I" ) ) ).entity();
@@ -117,14 +116,14 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
     }
 
     private void expectNodes( String entity, Node... nodes )
-            throws PropertyValueException
+            throws JsonParseException
     {
         Set<String> expected = new HashSet<>();
         for ( Node node : nodes )
         {
             expected.add( getNodeUri( node ) );
         }
-        Collection<?> items = (Collection<?>) JsonHelper.jsonToSingleValue( entity );
+        Collection<?> items = (Collection<?>) readJson( entity );
         for ( Object item : items )
         {
             Map<?, ?> map = (Map<?, ?>) item;
@@ -146,7 +145,7 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
     @Graph( {"Root knows Mattias", "Root knows Johan", "Johan knows Emil", "Emil knows Peter", "Emil knows Tobias", "Tobias loves Sara"} )
     @Test
     public void shouldGetExpectedHitsWhenTraversingWithDescription()
-            throws PropertyValueException
+            throws JsonParseException
     {
         Node start = getNode( "Root" );
         List<Map<String, Object>> rels = new ArrayList<>();
@@ -177,7 +176,7 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
     @Graph( {"Root knows Mattias", "Root knows Johan", "Johan knows Emil", "Emil knows Peter", "Emil knows Tobias", "Tobias loves Sara"} )
     @Test
     public void shouldGetExpectedHitsWhenTraversingAtDepth()
-            throws PropertyValueException
+            throws JsonParseException
     {
         Node start = getNode( "Root" );
         String description = createJsonFrom( map(
@@ -206,7 +205,7 @@ public class TraverserDocIT extends AbstractRestFunctionalTestBase
              "Root eats Cork",    "Cork hates Root",
              "Root likes Banana", "Banana is_a Fruit"} )
     public void shouldAllowTypeOrderedTraversals()
-            throws PropertyValueException
+            throws JsonParseException
     {
         Node start = getNode( "Root" );
         String description = createJsonFrom( map(

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
@@ -38,7 +38,6 @@ import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.rest.RESTDocsGenerator;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
-import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 import org.neo4j.test.server.HTTP;
@@ -68,7 +67,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void missing_authorization() throws PropertyValueException, IOException
+    public void missing_authorization() throws JsonParseException, IOException
     {
         // Given
         startServerWithConfiguredUser();
@@ -96,7 +95,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void successful_authentication() throws PropertyValueException, IOException
+    public void successful_authentication() throws JsonParseException, IOException
     {
         // Given
         startServerWithConfiguredUser();
@@ -122,7 +121,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void incorrect_authentication() throws PropertyValueException, IOException
+    public void incorrect_authentication() throws JsonParseException, IOException
     {
         // Given
         startServerWithConfiguredUser();
@@ -152,7 +151,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void password_change_required() throws PropertyValueException, IOException
+    public void password_change_required() throws JsonParseException, IOException
     {
         // Given
         startServer( true );

--- a/community/server/src/test/java/org/neo4j/server/rest/security/UsersDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/UsersDocIT.java
@@ -37,6 +37,7 @@ import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.rest.RESTDocsGenerator;
 import org.neo4j.server.rest.domain.JsonHelper;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
@@ -65,7 +66,7 @@ public class UsersDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void user_status() throws PropertyValueException, IOException
+    public void user_status() throws JsonParseException, IOException
     {
         // Given
         startServerWithConfiguredUser();
@@ -91,7 +92,7 @@ public class UsersDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void user_status_first_access() throws PropertyValueException, IOException
+    public void user_status_first_access() throws JsonParseException, IOException
     {
         // Given
         startServer( true );
@@ -118,7 +119,7 @@ public class UsersDocIT extends ExclusiveServerTestBase
      */
     @Test
     @Documented
-    public void change_password() throws PropertyValueException, IOException
+    public void change_password() throws JsonParseException, IOException
     {
         // Given
         startServer( true );

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
@@ -359,7 +359,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
     @Test
     @Graph("Peter likes Jazz")
     public void shouldHandleEscapedStrings() throws ClientHandlerException,
-            UniformInterfaceException, JSONException, PropertyValueException {
+            UniformInterfaceException, JSONException, JsonParseException {
     	String string = "Jazz";
         Node gnode = getNode( string );
         assertThat( gnode, inTx(graphdb(), Neo4jMatchers.hasProperty( "name" ).withValue(string)) );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
+import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.util.RFC1123;
-import org.neo4j.server.rest.web.PropertyValueException;
 import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -54,7 +54,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void begin_a_transaction() throws PropertyValueException
+    public void begin_a_transaction() throws JsonParseException
     {
         // Document
         ResponseEntity response = gen.get()
@@ -79,7 +79,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void execute_statements_in_an_open_transaction() throws PropertyValueException
+    public void execute_statements_in_an_open_transaction() throws JsonParseException
     {
         // Given
         String location = POST( getDataUri() + "transaction" ).location();
@@ -105,7 +105,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void execute_statements_in_an_open_transaction_using_REST() throws PropertyValueException
+    public void execute_statements_in_an_open_transaction_using_REST() throws JsonParseException
     {
         // Given
         String location = POST( getDataUri() + "transaction" ).location();
@@ -138,7 +138,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
     @Test
     @Documented
     public void reset_transaction_timeout_of_an_open_transaction()
-            throws PropertyValueException, ParseException, InterruptedException
+            throws JsonParseException, ParseException, InterruptedException
     {
         // Given
         HTTP.Response initialResponse = POST( getDataUri() + "transaction" );
@@ -175,7 +175,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void commit_an_open_transaction() throws PropertyValueException
+    public void commit_an_open_transaction() throws JsonParseException
     {
         // Given
         String location = POST( getDataUri() + "transaction" ).location();
@@ -203,7 +203,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void begin_and_commit_a_transaction_in_one_request() throws PropertyValueException
+    public void begin_and_commit_a_transaction_in_one_request() throws JsonParseException
     {
         // Document
         ResponseEntity response = gen.get()
@@ -230,7 +230,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void return_results_in_graph_format() throws PropertyValueException
+    public void return_results_in_graph_format() throws JsonParseException
     {
         // Document
         ResponseEntity response = gen.get()
@@ -263,7 +263,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void rollback_an_open_transaction() throws PropertyValueException
+    public void rollback_an_open_transaction() throws JsonParseException
     {
         // Given
         HTTP.Response firstReq = POST( getDataUri() + "transaction",
@@ -303,7 +303,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
      */
     @Test
     @Documented
-    public void handling_errors() throws PropertyValueException
+    public void handling_errors() throws JsonParseException
     {
         // Given
         String location = POST( getDataUri() + "transaction" ).location();

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
@@ -33,6 +33,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Label;
@@ -271,7 +272,7 @@ public class DatabaseActionsTest
 
     @Test
     public void shouldRemoveNodeWithNoRelationsFromDBOnDelete() throws NodeNotFoundException,
-            OperationFailureException
+            ConstraintViolationException
     {
         long nodeId;
         Transaction tx = database.getGraph().beginTx();

--- a/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
@@ -22,6 +22,7 @@ package org.neo4j.server.rest.web;
 import java.util.Collection;
 import java.util.Map;
 
+import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -90,7 +91,7 @@ public class TransactionWrappedDatabaseActions extends DatabaseActions
     }
 
     @Override
-    public void deleteNode( long nodeId ) throws NodeNotFoundException, OperationFailureException
+    public void deleteNode( long nodeId ) throws NodeNotFoundException, ConstraintViolationException
     {
         Transaction transaction = graph.beginTx();
 


### PR DESCRIPTION
After these changes, response to the example request in #4145 ends like this:

```
"errors" : [ {
    "message" : "Cannot find node with id [-1] in database.",
    "code" : "Neo.ClientError.Statement.EntityNotFound"
} ]
```

instead of the previous behaviour which produced responses ending like this:

```
"errors": [ {
    "code": "Neo.DatabaseError.General.UnknownFailure",
    "message": "Cannot find node with id [-1] in database.",
    "stacktrace": "org.neo4j.server.rest.web.NodeNotFoundException: Cannot find node with id [-1] in database.\n\tat ...\n"
} ]
```
