### PR TITLE
Better test coverage in ParallelBatchImporterTest

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -344,7 +344,7 @@ public class StoreMigrator implements StoreMigrationParticipant
                 parallel(), readAdditionalIds( storeDir, lastTxId, lastTxChecksum ) );
         InputIterable<InputNode> nodes = legacyNodesAsInput( legacyStore );
         InputIterable<InputRelationship> relationships = legacyRelationshipsAsInput( legacyStore );
-        importer.doImport( Inputs.input( nodes, relationships, IdMappers.actual(), IdGenerators.fromInput(), true ) );
+        importer.doImport( Inputs.input( nodes, relationships, IdMappers.actual(), IdGenerators.fromInput(), true, 0 ) );
 
         // During migration the batch importer only writes node, relationship, relationship group and counts stores.
         // Delete the property store files from the batch import migration so that even if we won't

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.io.IOException;
+
+import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipLink;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.InputCache;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.staging.InputIteratorBatcherStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+
+/**
+ * Counts number of relationships per node that is going to be imported by {@link RelationshipStage} later.
+ * Dense node threshold is calculated based on these counts, so that correct relationship representation can be written
+ * per node.
+ */
+public class CalculateDenseNodesStage extends Stage
+{
+    public CalculateDenseNodesStage( Configuration config, InputIterable<InputRelationship> relationships,
+            NodeRelationshipLink nodeRelationshipLink, IdMapper idMapper,
+            Collector<InputRelationship> badRelationshipsCollector,
+            InputCache inputCache ) throws IOException
+    {
+        super( "Calculate dense nodes", config, false );
+        add( new InputIteratorBatcherStep<>( control(), config.batchSize(), config.movingAverageSize(),
+                relationships.iterator(), InputRelationship.class ) );
+        if ( !relationships.supportsMultiplePasses() )
+        {
+            add( new InputEntityCacherStep<>( control(), config.workAheadSize(), config.movingAverageSize(),
+                    inputCache.cacheRelationships() ) );
+        }
+        add( new RelationshipPreparationStep( control(), config, idMapper ) );
+        add( new CalculateDenseNodesStep( control(), config, nodeRelationshipLink, badRelationshipsCollector ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
+import org.neo4j.unsafe.impl.batchimport.input.InputCache;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.staging.IdMapperPreparationStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
+
+import static org.neo4j.unsafe.impl.batchimport.Utils.idsOf;
+
+/**
+ * Performs {@link IdMapper#prepare(InputIterable, org.neo4j.helpers.progress.ProgressListener)}
+ * embedded in a {@link Stage} as to take advantage of statistics and monitoring provided by that framework.
+ */
+public class IdMapperPreparationStage extends Stage
+{
+    public IdMapperPreparationStage( Configuration config, IdMapper idMapper, InputIterable<InputNode> nodes,
+            InputCache inputCache, StatsProvider memoryUsageStats )
+    {
+        super( "Prepare node index", config, false );
+        add( new IdMapperPreparationStep( control(), config.batchSize(), config.movingAverageSize(),
+                idMapper, idsOf( nodes.supportsMultiplePasses() ? nodes : inputCache.nodes() ), memoryUsageStats ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -30,9 +30,6 @@ import org.neo4j.helpers.Format;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.api.CountsAccessor;
-import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.store.PropertyStore;
-import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -48,8 +45,6 @@ import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.staging.DynamicProcessorAssigner;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
-import org.neo4j.unsafe.impl.batchimport.staging.IdMapperPreparationStep;
-import org.neo4j.unsafe.impl.batchimport.staging.InputIteratorBatcherStep;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStore;
@@ -59,7 +54,6 @@ import org.neo4j.unsafe.impl.batchimport.store.io.IoMonitor;
 import static java.lang.System.currentTimeMillis;
 
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
-import static org.neo4j.unsafe.impl.batchimport.Utils.idsOf;
 import static org.neo4j.unsafe.impl.batchimport.WriterFactories.parallel;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseExecution;
@@ -151,10 +145,11 @@ public class ParallelBatchImporter implements BatchImporter
             InputIterable<InputRelationship> relationships = input.relationships();
 
             // Stage 1 -- nodes, properties, labels
-            NodeStage nodeStage = new NodeStage( nodes, idMapper, idGenerator, neoStore, inputCache, memoryUsageStats );
+            NodeStage nodeStage = new NodeStage( config, writeMonitor, writerFactory,
+                    nodes, idMapper, idGenerator, neoStore, inputCache, memoryUsageStats );
 
             // Stage 2 -- calculate dense node threshold
-            CalculateDenseNodesStage calculateDenseNodesStage = new CalculateDenseNodesStage( relationships,
+            CalculateDenseNodesStage calculateDenseNodesStage = new CalculateDenseNodesStage( config, relationships,
                     nodeRelationshipLink, idMapper, badRelationships, inputCache );
 
             // Execute stages 1 and 2 in parallel or sequentially?
@@ -173,7 +168,7 @@ public class ParallelBatchImporter implements BatchImporter
             }
 
             // Stage 3 -- relationships, properties
-            final RelationshipStage relationshipStage = new RelationshipStage(
+            final RelationshipStage relationshipStage = new RelationshipStage( config, writeMonitor, writerFactory,
                     relationships.supportsMultiplePasses() ? relationships : inputCache.relationships(),
                     idMapper, neoStore, nodeRelationshipLink, input.specificRelationshipIds() );
             executeStages( relationshipStage );
@@ -241,82 +236,5 @@ public class ParallelBatchImporter implements BatchImporter
     private void executeStages( Stage... stages )
     {
         superviseExecution( executionMonitor, config, stages );
-    }
-
-    public class NodeStage extends Stage
-    {
-        public NodeStage( InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
-                BatchingNeoStore neoStore, InputCache inputCache, StatsProvider memoryUsage ) throws IOException
-        {
-            super( "Nodes", config, true );
-            add( new InputIteratorBatcherStep<>( control(), config.batchSize(), config.movingAverageSize(),
-                    nodes.iterator(), InputNode.class ) );
-            if ( !nodes.supportsMultiplePasses() )
-            {
-                add( new InputEntityCacherStep<>( control(), config.workAheadSize(), config.movingAverageSize(),
-                        inputCache.cacheNodes() ) );
-            }
-
-            NodeStore nodeStore = neoStore.getNodeStore();
-            PropertyStore propertyStore = neoStore.getPropertyStore();
-            add( new PropertyEncoderStep<>( control(), config, 1, neoStore.getPropertyKeyRepository(),
-                    propertyStore ) );
-            add( new NodeEncoderStep( control(), config, idMapper, idGenerator,
-                    neoStore.getLabelRepository(), nodeStore, memoryUsage ) );
-            add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore,
-                    writeMonitor, writerFactory ) );
-        }
-    }
-
-    public class IdMapperPreparationStage extends Stage
-    {
-        public IdMapperPreparationStage( Configuration config, IdMapper idMapper, InputIterable<InputNode> nodes,
-                InputCache inputCache, StatsProvider memoryUsageStats )
-        {
-            super( "Prepare node index", config, false );
-            add( new IdMapperPreparationStep( control(), config.batchSize(), config.movingAverageSize(),
-                    idMapper, idsOf( nodes.supportsMultiplePasses() ? nodes : inputCache.nodes() ), memoryUsageStats ) );
-        }
-    }
-
-    public class CalculateDenseNodesStage extends Stage
-    {
-        public CalculateDenseNodesStage( InputIterable<InputRelationship> relationships,
-                NodeRelationshipLink nodeRelationshipLink, IdMapper idMapper,
-                Collector<InputRelationship> badRelationshipsCollector,
-                InputCache inputCache ) throws IOException
-        {
-            super( "Calculate dense nodes", config, false );
-            add( new InputIteratorBatcherStep<>( control(), config.batchSize(), config.movingAverageSize(),
-                    relationships.iterator(), InputRelationship.class ) );
-            if ( !relationships.supportsMultiplePasses() )
-            {
-                add( new InputEntityCacherStep<>( control(), config.workAheadSize(), config.movingAverageSize(),
-                        inputCache.cacheRelationships() ) );
-            }
-            add( new RelationshipPreparationStep( control(), config, idMapper ) );
-            add( new CalculateDenseNodesStep( control(), config, nodeRelationshipLink, badRelationshipsCollector ) );
-        }
-    }
-
-    public class RelationshipStage extends Stage
-    {
-        public RelationshipStage( InputIterable<InputRelationship> relationships, IdMapper idMapper,
-                BatchingNeoStore neoStore, NodeRelationshipLink nodeRelationshipLink, boolean specificIds )
-        {
-            super( "Relationships", config, false );
-            add( new InputIteratorBatcherStep<>( control(), config.batchSize(), config.movingAverageSize(),
-                    relationships.iterator(), InputRelationship.class ) );
-
-            RelationshipStore relationshipStore = neoStore.getRelationshipStore();
-            PropertyStore propertyStore = neoStore.getPropertyStore();
-            add( new RelationshipPreparationStep( control(), config, idMapper ) );
-            add( new PropertyEncoderStep<>( control(), config, 1, neoStore.getPropertyKeyRepository(),
-                    propertyStore ) );
-            add( new RelationshipEncoderStep( control(), config,
-                    neoStore.getRelationshipTypeRepository(), relationshipStore, nodeRelationshipLink, specificIds ) );
-            add( new EntityStoreUpdaterStep<>( control(), config,
-                    relationshipStore, propertyStore, writeMonitor, writerFactory ) );
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordProcessor.java
@@ -21,6 +21,11 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
+/**
+ * Generic processor of {@link AbstractBaseRecord} from a store.
+ *
+ * @param <T>
+ */
 public interface RecordProcessor<T extends AbstractBaseRecord>
 {
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -43,7 +43,8 @@ public class Inputs
 {
     public static Input input(
             final InputIterable<InputNode> nodes, final InputIterable<InputRelationship> relationships,
-            final IdMapper idMapper, final IdGenerator idGenerator, final boolean specificRelationshipIds )
+            final IdMapper idMapper, final IdGenerator idGenerator, final boolean specificRelationshipIds,
+            final int badTolerance )
     {
         return new Input()
         {
@@ -80,7 +81,7 @@ public class Inputs
             @Override
             public Collector<InputRelationship> badRelationshipsCollector( OutputStream out )
             {
-                return Collectors.badRelationshipsCollector( out, 0 );
+                return Collectors.badRelationshipsCollector( out, badTolerance );
             }
         };
     }


### PR DESCRIPTION
By carefully verifying all entities in the db after import to those from the (now even more randomized) input. Also introduces some bad relationships.
