### PR TITLE
Fixes a race condition in HighAvailabilityModeSwitcher

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -216,11 +216,20 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
 
     private void stateChanged( HighAvailabilityMemberChangeEvent event ) throws ExecutionException, InterruptedException
     {
-        availableMasterId = event.getServerHaUri();
         if ( event.getNewState() == event.getOldState() )
         {
+            /*
+             * We get here if for example a new master becomes available while we are already switching. In that case
+             * we don't change state but we must update with the new availableMasterId, but only if it is not null.
+             */
+            if ( event.getServerHaUri() != null )
+            {
+                availableMasterId = event.getServerHaUri();
+            }
             return;
         }
+
+        availableMasterId = event.getServerHaUri();
 
         currentTargetState = event.getNewState();
         switch ( event.getNewState() )


### PR DESCRIPTION
Fixes a race between a SwitchToSlave rerunning because of
 either a NoSuchLogVersion or MismatchingStore Exception
 and a masterIsElected for the same or different master. That
 could lead to the availableMasterId being set to null and the
 second run of the SwitchToMaster failing with a NPE.
