### PR TITLE
Less eager decrementing of processors

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
@@ -41,9 +41,9 @@ public class StageExecutionTest
     {
         // GIVEN
         Collection<Step<?>> steps = new ArrayList<>();
-        steps.add( stepWithAverageOf( 10 ) );
-        steps.add( stepWithAverageOf( 5 ) );
-        steps.add( stepWithAverageOf( 30 ) );
+        steps.add( stepWithAverageOf( "step1", 0, 10 ) );
+        steps.add( stepWithAverageOf( "step2", 0, 5 ) );
+        steps.add( stepWithAverageOf( "step3", 0, 30 ) );
         StageExecution execution = new StageExecution( "Test", DEFAULT, steps, true );
 
         // WHEN
@@ -64,10 +64,10 @@ public class StageExecutionTest
     {
         // GIVEN
         Collection<Step<?>> steps = new ArrayList<>();
-        steps.add( stepWithAverageOf( 10 ) );
-        steps.add( stepWithAverageOf( 5 ) );
-        steps.add( stepWithAverageOf( 30 ) );
-        steps.add( stepWithAverageOf( 5 ) );
+        steps.add( stepWithAverageOf( "step1", 0, 10 ) );
+        steps.add( stepWithAverageOf( "step2", 0, 5 ) );
+        steps.add( stepWithAverageOf( "step3", 0, 30 ) );
+        steps.add( stepWithAverageOf( "step4", 0, 5 ) );
         StageExecution execution = new StageExecution( "Test", DEFAULT, steps, true );
 
         // WHEN


### PR DESCRIPTION
so that a step will not decrement number of processors until it becomes
the bottleneck itself, instead possible just decrement until only slightly
ahead of the next slowest. This fixes an unnecessary behaviour where a
decrement would be followed by an immediate increment sometimes and it
could keep on flipping like that.
