### PR TITLE
CYPHER planner=cost instead of PLANNER COST

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOption.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOption.scala
@@ -28,5 +28,7 @@ case object CostPlannerOption extends CypherOption
 case object RulePlannerOption extends CypherOption
 case object IDPPlannerOption extends CypherOption
 case object DPPlannerOption extends CypherOption
+case class ConfigurationOptions(version: Option[VersionOption],
+                            options: Seq[CypherOption]) extends CypherOption
 
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOptionParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherOptionParser.scala
@@ -34,15 +34,25 @@ case class CypherOptionParser(monitor: ParserMonitor[CypherQueryWithOptions]) ex
 
   def AllOptions: Rule1[Seq[CypherOption]] = zeroOrMore(AnyCypherOption, WS)
 
-  def AnyCypherOption: Rule1[CypherOption] = Version | Explain | Profile | Planner
+  def AnyCypherOption: Rule1[CypherOption] = Cypher | Explain | Profile | PlannerDeprecated
 
   def AnySomething: Rule1[String] = rule("Query") { oneOrMore(org.parboiled.scala.ANY) ~> identity }
 
-  def Version: Rule1[VersionOption] = rule("CYPHER") {
-      keyword("CYPHER") ~ WS ~ VersionNumber
-    }
+  def Cypher = rule("CYPHER options") {
+    keyword("CYPHER") ~~
+      optional(VersionNumber) ~~
+      zeroOrMore(PlannerOption) ~~> ConfigurationOptions
+  }
 
-  def Planner = rule("PLANNER") (
+  def PlannerOption: Rule1[CypherOption] = rule("planner option") (
+    option("planner", "cost") ~ push(CostPlannerOption)
+  | option("planner", "rule") ~ push(RulePlannerOption)
+  | option("planner", "idp") ~ push(IDPPlannerOption)
+  | option("planner", "dp") ~ push(DPPlannerOption)
+  )
+
+  @deprecated
+  def PlannerDeprecated = rule("PLANNER") (
     keyword("PLANNER COST") ~ push(CostPlannerOption)
       | keyword("PLANNER IDP") ~ push(IDPPlannerOption)
       | keyword("PLANNER DP") ~ push(DPPlannerOption)
@@ -58,4 +68,8 @@ case class CypherOptionParser(monitor: ParserMonitor[CypherQueryWithOptions]) ex
   def Profile = keyword("PROFILE") ~ push(ProfileOption)
 
   def Explain = keyword("EXPLAIN") ~ push(ExplainOption)
+
+  def option(key: String, value: String): Rule0 = {
+    keyword(key) ~ WS ~ "=" ~ WS ~keyword(value)
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcAcceptanceTest.scala
@@ -34,7 +34,7 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
       ldbcQuery.constraintQueries.foreach(execute(_))
 
       //when
-      val result = executeWithNewPlanner(s"PLANNER COST ${ldbcQuery.query}", ldbcQuery.params.toSeq: _*).result
+      val result = executeWithNewPlanner(s"CYPHER planner=cost ${ldbcQuery.query}", ldbcQuery.params.toSeq: _*).result
 
       //then
       result should equal(ldbcQuery.expectedResult)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1896,7 +1896,7 @@ return b
     val node2 = createNode()
     val r = relate(node1, node2)
 
-    val query = """PLANNER COST WITH [{0}, {1}] AS x, count(*) as y
+    val query = """CYPHER planner=cost WITH [{0}, {1}] AS x, count(*) as y
                   |MATCH (n) WHERE ID(n) IN x
                   |MATCH (m) WHERE ID(m) IN x
                   |MATCH paths = allShortestPaths((n)-[*..1]-(m))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -34,7 +34,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     relate( createNode(), createNode(), "FOO")
 
     //WHEN
-    val result = profile("cypher 2.2 planner cost match n where n-[:FOO]->() return *")
+    val result = profile("CYPHER 2.2 planner=cost match n where n-[:FOO]->() return *")
 
     //THEN
     assertRows(1)(result)("SemiApply")
@@ -67,7 +67,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     relate( createNode(), createNode(), "FOO")
 
     //WHEN
-    val result = profile("cypher 2.2 planner cost match n where not n-[:FOO]->() return *")
+    val result = profile("CYPHER 2.2 planner=cost match n where not n-[:FOO]->() return *")
 
     //THEN
     assertRows(1)(result)("AntiSemiApply")
@@ -150,7 +150,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
   test("allows optional match to start a query") {
     //GIVEN
-    val result = profile("cypher 2.2 planner cost optional match (n) return n")
+    val result = profile("CYPHER 2.2 planner=cost optional match (n) return n")
 
     //WHEN THEN
     assertRows(1)(result)("Optional")
@@ -219,19 +219,19 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
   }
 
   test("should not have a problem profiling empty results") {
-    val result = super.profile("CYPHER 2.2 PLANNER COST MATCH n WHERE (n)-->() RETURN n")
+    val result = super.profile("CYPHER 2.2 planner=cost MATCH n WHERE (n)-->() RETURN n")
 
     result shouldBe empty
     result.executionPlanDescription().toString should include("AllNodes")
   }
 
   test("reports COST planner when showing plan description") {
-    val executionPlanDescription = eengine.execute("cypher 2.2 planner cost match n return n").executionPlanDescription()
+    val executionPlanDescription = eengine.execute("CYPHER 2.2 planner=cost match n return n").executionPlanDescription()
     executionPlanDescription.toString should include("Planner COST" + System.lineSeparator())
   }
 
   test("reports RULE planner when showing plan description") {
-    val executionPlanDescription = eengine.execute("cypher 2.2 planner cost create ()").executionPlanDescription()
+    val executionPlanDescription = eengine.execute("CYPHER 2.2 planner=cost create ()").executionPlanDescription()
 
     executionPlanDescription.toString should not include "Planner COST"
     executionPlanDescription.toString should include("Planner RULE" + System.lineSeparator())
@@ -253,7 +253,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.executionPlanDescription().toString should not include("EstimatedRows")
   }
 
-  test("planner cost match (p:Person {name:'Seymour'}) return (p)-[:RELATED_TO]->()") {
+  test("CYPHER planner=cost match (p:Person {name:'Seymour'}) return (p)-[:RELATED_TO]->()") {
     //GIVEN
     val seymour = createLabeledNode(Map("name" -> "Seymour"), "Person")
     relate(seymour, createLabeledNode(Map("name" -> "Buddy"), "Person"), "RELATED_TO")
@@ -266,7 +266,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     graph.createConstraint("Person", "name")
 
     //WHEN
-    val result = profile("planner cost match (p:Person {name:'Seymour'}) return (p)-[:RELATED_TO]->()")
+    val result = profile("CYPHER planner=cost match (p:Person {name:'Seymour'}) return (p)-[:RELATED_TO]->()")
 
     //THEN
     assertDbHits(7)(result)("Projection")
@@ -280,7 +280,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
   }
 
   test("should show expand with types in a simple form") {
-    val a = profile("planner cost match n-[r:T]->() return *")
+    val a = profile("CYPHER planner=cost match n-[r:T]->() return *")
 
     a.executionPlanDescription().toString should include("()<-[r:T]-(n)")
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniquenessAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniquenessAcceptanceTest.scala
@@ -83,7 +83,7 @@ class UniquenessAcceptanceTest extends ExecutionEngineFunSuite {
   }
 
 
-  val planners = Table(("Prefix"), ("PLANNER COST"), ("PLANNER RULE"), (""))
+  val planners = Table(("Prefix"), ("CYPHER planner=cost"), ("CYPHER planner=rule"), (""))
 
   test("should consider uniqueness when combining simple and variable length pattern in a match") {
     forAll(planners) { planner =>

--- a/community/cypher/docs/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -32,8 +32,8 @@ This planner uses the statistics service in Neo4j to assign cost to alternative 
 While this should lead to superior execution plans in most cases, it is still under development.
 
 By default, Neo4j 2.2 will use the cost planner for some queries, but not all.
-You can force it to use a specific planner by using the `query.planner.version` configuration setting (see <<config_dbms.cypher.planner>>), or by prepending your query with `PLANNER COST` or `PLANNER RULE`.
-Neo4j might still not use the planner you selected -- not all queries are solvable by the cost planner at this point.
+You can force it to use a specific planner by using the `query.planner.version` configuration setting (see <<config_dbms.cypher.planner>>), or by prepending your query with `CYPHER planner=cost` or `CYPHER planner=rule`.
+Neo4j might still not use the planner you selected -- not all queries are solvable by the cost planner at this point. Note that using `PLANNER COST` or `PLANNER RULE` in order to switch between planners has been deprecated and will stop working in future versions.
 
 You can see which planner was used by looking at the execution plan.
 

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -1153,26 +1153,26 @@ public class TestApps extends AbstractShellTest
     @Test
     public void shouldAllowPlannerAsStartForACypherQuery() throws Exception
     {
-        executeCommand( "PLANNER COST MATCH (n) RETURN n;");
+        executeCommand( "CYPHER planner=cost MATCH (n) RETURN n;");
     }
 
     @Test
     public void shouldBeAbleToSwitchBetweenPlanners() throws Exception
     {
-        executeCommand( "PROFILE PLANNER RULE MATCH (n)-[:T]-(n) RETURN n;", "Planner RULE");
-        executeCommand( "PROFILE PLANNER COST MATCH (n)-[:T]-(n) RETURN n;", "Planner COST");
+        executeCommand( "PROFILE CYPHER planner=rule MATCH (n)-[:T]-(n) RETURN n;", "Planner RULE");
+        executeCommand( "PROFILE CYPHER planner=cost MATCH (n)-[:T]-(n) RETURN n;", "Planner COST");
     }
 
     @Test
     public void shouldAllowCombiningPlannerAndProfile() throws Exception
     {
-        executeCommand( "PLANNER RULE PROFILE MATCH (n) RETURN n;", "Planner RULE");
+        executeCommand( "CYPHER planner=rule PROFILE MATCH (n) RETURN n;", "Planner RULE");
     }
 
     @Test
     public void shouldAllowCombiningProfileAndPlanner() throws Exception
     {
-        executeCommand( "PROFILE PLANNER RULE MATCH (n) RETURN n;", "Planner RULE");
+        executeCommand( "PROFILE CYPHER planner=rule MATCH (n) RETURN n;", "Planner RULE");
     }
 
     @Test


### PR DESCRIPTION
This adds a new way of specifiying the planner to use and slightly changes the effect of the CYPHER keyword
- CYPHER can be followed an optional version
- CYPHER [version] planner=[rule,cost] is now the way planners should be specified
- PLANNER RULE/COST still works but is deprecated.
