### PR TITLE
Rename RUNTIME XYZ to runtime=XYZ

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
@@ -24,8 +24,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.InputPosition
 /**
  * Describes a notification
  */
-sealed trait InternalNotification {
-  def position: InputPosition
-}
+sealed trait InternalNotification
 
 case class CartesianProductNotification(position: InputPosition) extends InternalNotification
+
+case object LegacyPlannerNotification extends InternalNotification

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.CypherVersion._
 import org.neo4j.cypher.internal.compatibility._
 import org.neo4j.cypher.internal.compiler.v2_3.InputPosition
 import org.neo4j.cypher.internal.compiler.v2_2.{ConservativePlannerName => ConservativePlanner2_2, IDPPlannerName => IDPPlanner2_2, DPPlannerName => DPPlanner2_2,  CostPlannerName => CostPlanner2_2}
+import org.neo4j.cypher.internal.compiler.v2_3.notification.LegacyPlannerNotification
 import org.neo4j.cypher.internal.compiler.v2_3.{DPPlannerName, RulePlannerName, CostPlannerName, IDPPlannerName, ConservativePlannerName, PlannerName, InternalNotificationLogger, RecordingNotificationLogger, devNullLogger}
 import org.neo4j.cypher.internal.compiler.v2_2.{ConservativePlannerName => ConservativePlanner2_2, CostPlannerName => CostPlanner2_2, IDPPlannerName => IDPPlanner2_2}
 import org.neo4j.cypher.internal.compiler.v2_3.{ConservativePlannerName, CostPlannerName, DPPlannerName, IDPPlannerName, InputPosition, InternalNotificationLogger, PlannerName, RecordingNotificationLogger, RulePlannerName, devNullLogger, _}
@@ -47,7 +48,8 @@ object CypherCompiler {
     }
 }
 
-case class PreParsedQuery(statement: String, version: CypherVersion, executionMode: ExecutionMode, planner: PlannerName, runtime: RuntimeName)
+case class PreParsedQuery(statement: String, version: CypherVersion, executionMode: ExecutionMode, planner: PlannerName,
+                          runtime: RuntimeName, notificationLogger: InternalNotificationLogger)
                          (val offset: InputPosition) {
   val statementWithVersionAndPlanner = s"CYPHER ${version.name} planner=${planner.name} runtime=${runtime.name} $statement"
 }
@@ -78,16 +80,16 @@ class CypherCompiler(graph: GraphDatabaseService,
   private val compatibilityFor2_2DP = CompatibilityFor2_2Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, DPPlanner2_2)
   private val compatibilityFor2_2 = CompatibilityFor2_2Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, ConservativePlanner2_2)
 
-  private val compatibilityFor2_3Rule = CompatibilityFor2_3Rule(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, notificationLoggerBuilder)
-  private val compatibilityFor2_3CostInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, CostPlannerName, InterpretedRuntimeName)
-  private val compatibilityFor2_3IDPInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, IDPPlannerName, InterpretedRuntimeName)
-  private val compatibilityFor2_3DPInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, DPPlannerName, InterpretedRuntimeName)
-  private val compatibilityFor2_3CostCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, CostPlannerName, CompiledRuntimeName)
-  private val compatibilityFor2_3IDPCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, IDPPlannerName, CompiledRuntimeName)
-  private val compatibilityFor2_3DPCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, DPPlannerName, CompiledRuntimeName)
-  private val compatibilityFor2_3ConservativeCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, ConservativePlannerName, CompiledRuntimeName)
+  private val compatibilityFor2_3Rule = CompatibilityFor2_3Rule(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI)
+  private val compatibilityFor2_3CostInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, CostPlannerName, InterpretedRuntimeName)
+  private val compatibilityFor2_3IDPInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, IDPPlannerName, InterpretedRuntimeName)
+  private val compatibilityFor2_3DPInterpreted = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, DPPlannerName, InterpretedRuntimeName)
+  private val compatibilityFor2_3CostCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, CostPlannerName, CompiledRuntimeName)
+  private val compatibilityFor2_3IDPCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, IDPPlannerName, CompiledRuntimeName)
+  private val compatibilityFor2_3DPCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, DPPlannerName, CompiledRuntimeName)
+  private val compatibilityFor2_3ConservativeCompiled = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, ConservativePlannerName, CompiledRuntimeName)
 
-  private val compatibilityFor2_3 = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, notificationLoggerBuilder, ConservativePlannerName, InterpretedRuntimeName)
+  private val compatibilityFor2_3 = CompatibilityFor2_3Cost(graph, queryCacheSize, STATISTICS_DIVERGENCE_THRESHOLD, queryPlanTTL, CLOCK, kernelMonitors, kernelAPI, logger, ConservativePlannerName, InterpretedRuntimeName)
 
   private final val VERSIONS_WITH_FIXED_PLANNER: Set[CypherVersion] = Set(v1_9, v2_0, v2_1)
   private final val VERSIONS_WITH_FIXED_RUNTIME: Set[CypherVersion] = Set(v1_9, v2_0, v2_1, v2_2)
@@ -139,14 +141,14 @@ class CypherCompiler(graph: GraphDatabaseService,
     val cypherVersion = cypherOptions.flatMap(_.version)
       .map(v => CypherVersion(v.version))
       .getOrElse(defaultVersion)
-    val planner = calculatePlanner(cypherOptions, queryWithOption.options, cypherVersion)
     val executionMode: ExecutionMode = calculateExecutionMode(queryWithOption.options)
+    val logger = notificationLoggerBuilder(executionMode)
     if (executionMode == ExplainMode && VERSIONS_WITH_FIXED_PLANNER(cypherVersion)) {
       throw new InvalidArgumentException("EXPLAIN not supported in versions older than Neo4j v2.2")
     }
+    val planner = calculatePlanner(cypherOptions, queryWithOption.options, cypherVersion, logger)
     val runtime = calculateRuntime(cypherOptions, planner, cypherVersion)
-
-    PreParsedQuery(queryWithOption.statement, cypherVersion, executionMode, planner, runtime)(queryWithOption.offset)
+    PreParsedQuery(queryWithOption.statement, cypherVersion, executionMode, planner, runtime, logger)(queryWithOption.offset)
   }
 
   private def calculateExecutionMode(options: Seq[CypherOption]) = {
@@ -158,7 +160,8 @@ class CypherCompiler(graph: GraphDatabaseService,
     executionModes.reduceOption(_ combineWith _).getOrElse(NormalMode)
   }
 
-  private def calculatePlanner(options: Option[ConfigurationOptions], other: Seq[CypherOption], version: CypherVersion) = {
+  private def calculatePlanner(options: Option[ConfigurationOptions], other: Seq[CypherOption],
+                               version: CypherVersion, logger: InternalNotificationLogger) = {
     val planner = options.map(_.options.collect {
           case CostPlannerOption => CostPlannerName
           case RulePlannerOption => RulePlannerName
@@ -175,11 +178,11 @@ class CypherCompiler(graph: GraphDatabaseService,
     }
 
     //TODO once the we have removed PLANNER X syntax, change to defaultPlanner here
-    if (planner.isEmpty) calculatePlannerDeprecated(other, version) else planner.head
+    if (planner.isEmpty) calculatePlannerDeprecated(other, version, logger) else planner.head
   }
 
   @deprecated
-  private def calculatePlannerDeprecated( options: Seq[CypherOption], version: CypherVersion) = {
+  private def calculatePlannerDeprecated( options: Seq[CypherOption], version: CypherVersion, logger: InternalNotificationLogger) = {
     val planner = options.collect {
       case CostPlannerOption => CostPlannerName
       case RulePlannerOption => RulePlannerName
@@ -196,7 +199,12 @@ class CypherCompiler(graph: GraphDatabaseService,
       throw new InvalidSemanticsException("Can't use multiple planners")
     }
 
-    if (planner.isEmpty) defaultPlanner else planner.head
+    if (planner.isEmpty)
+      defaultPlanner
+    else {
+      logger += LegacyPlannerNotification
+      planner.head
+    }
   }
 
   private def calculateRuntime(options: Option[ConfigurationOptions], planner: PlannerName, version: CypherVersion) = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -126,7 +126,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
     engine.execute(query).toList
 
     // then
-    logger.assertAtLeastOnce(LogCall.info(s"Discarded stale query from the query cache: CYPHER 2.3 PLANNER CONSERVATIVE RUNTIME INTERPRETED $query"))
+    logger.assertAtLeastOnce(LogCall.info(s"Discarded stale query from the query cache: CYPHER 2.3 planner=CONSERVATIVE runtime=INTERPRETED $query"))
   }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LegacyPlannerNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LegacyPlannerNotificationAcceptanceTest.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import org.neo4j.graphdb.SeverityLevel
+
+class LegacyPlannerNotificationAcceptanceTest extends ExecutionEngineFunSuite {
+
+  test("should warn when using PLANNER X") {
+    val notifications = eengine.execute("EXPLAIN PLANNER RULE MATCH a RETURN a").notifications
+
+    notifications should have size 1
+
+    val notification = notifications.head
+    notification.getCode should equal("Neo.ClientNotification.Statement.DeprecationWarning")
+    notification.getDescription should equal("Using PLANNER for switching between planners has been deprecated, please use CYPHER planner=[rule,cost] instead")
+    notification.getSeverity should equal(SeverityLevel.WARNING)
+    notification.getTitle should equal("This feature is deprecated and will be removed in future versions.")
+  }
+
+  test("should not warn when using planner=x") {
+    val notifications = eengine.execute("EXPLAIN CYPHER planner=rule MATCH a RETURN a").notifications
+
+    notifications shouldBe empty
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -147,15 +147,15 @@ trait NewPlannerTestSupport extends CypherTestSupport {
     monitoringNewPlanner(innerExecute(queryText, params: _*))(failedToUseNewPlanner(queryText))(unexpectedlyUsedNewRuntime(queryText))
 
   def executeWithNewRuntime(queryText: String, params: (String, Any)*): InternalExecutionResult = {
-    val interpretedResult = innerExecute(s"RUNTIME INTERPRETED $queryText", params: _*)
-    val compiledResult = monitoringNewPlanner(innerExecute(s"RUNTIME COMPILED $queryText", params: _* ))(failedToUseNewPlanner(queryText))(failedToUseNewRuntime(queryText))
+    val interpretedResult = innerExecute(s"CYPHER runtime=interpreted $queryText", params: _*)
+    val compiledResult = monitoringNewPlanner(innerExecute(s"CYPHER runtime=compiled $queryText", params: _* ))(failedToUseNewPlanner(queryText))(failedToUseNewRuntime(queryText))
     assert(interpretedResult.toList === compiledResult.toList, "diverging results between compiled and interpreted runtime")
     compiledResult
   }
 
   def executeScalarWithNewRuntime[T](queryText: String, params: (String, Any)*) = {
-    val interpretedResult = self.executeScalar[T](s"RUNTIME INTERPRETED $queryText", params: _*)
-    val compiledResult = monitoringNewPlanner(self.executeScalar[T](s"RUNTIME COMPILED $queryText", params: _* ))(failedToUseNewPlanner(queryText))(failedToUseNewRuntime(queryText))
+    val interpretedResult = self.executeScalar[T](s"CYPHER runtime=interpreted $queryText", params: _*)
+    val compiledResult = monitoringNewPlanner(self.executeScalar[T](s"CYPHER runtime=compiled $queryText", params: _* ))(failedToUseNewPlanner(queryText))(failedToUseNewRuntime(queryText))
     assert(interpretedResult === compiledResult, "diverging results between compiled and interpreted runtime")
     compiledResult
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
@@ -66,9 +66,9 @@ class QueryCachingTest extends CypherFunSuite with GraphDatabaseTestSupport with
         val actual = cacheListener.trace
         val expected = List(
           s"cacheFlushDetected",
-          s"cacheMiss: CYPHER 2.3 PLANNER CONSERVATIVE RUNTIME INTERPRETED $query",
-          s"cacheHit: CYPHER 2.3 PLANNER CONSERVATIVE RUNTIME INTERPRETED $query",
-          s"cacheHit: CYPHER 2.3 PLANNER CONSERVATIVE RUNTIME INTERPRETED $query")
+          s"cacheMiss: CYPHER 2.3 planner=CONSERVATIVE runtime=INTERPRETED $query",
+          s"cacheHit: CYPHER 2.3 planner=CONSERVATIVE runtime=INTERPRETED $query",
+          s"cacheHit: CYPHER 2.3 planner=CONSERVATIVE runtime=INTERPRETED $query")
 
         actual should equal(expected)
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -153,7 +153,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
   def plan(query: String): (Double, Double) = {
     val compiler = createCurrentCompiler
-    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, NormalMode))
+    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, devNullLogger))
     val (planTime, _) = graph.inTx {
       measure(compiler.executionPlanBuilder.build(planContext, preparedQuery))
     }
@@ -176,7 +176,6 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
       clock = CLOCK,
       monitors = new WrappedMonitors2_3(kernelMonitors),
       logger = DEV_NULL,
-      notificationLoggerBuilder = _ => devNullLogger,
       plannerName = CostPlannerName,
       runtimeName = InterpretedRuntimeName
     )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherOptionParserTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherOptionParserTest.scala
@@ -51,23 +51,24 @@ class CypherOptionParserTest extends CypherFunSuite with TableDrivenPropertyChec
     ("CYPHER planner =dp RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(None, Seq(
       DPPlannerOption))), (1, 20, 19))),
 
-    ("RUNTIME INTERPRETED RETURN", CypherQueryWithOptions("RETURN", Seq(InterpretedRuntimeOption), (1, 21, 20))),
-    ("RUNTIME COMPILED RETURN", CypherQueryWithOptions("RETURN", Seq(CompiledRuntimeOption), (1, 18, 17))),
-    ("CYPHER 2.3 planner=cost RUNTIME INTERPRETED RETURN", CypherQueryWithOptions("RETURN", Seq(
-      ConfigurationOptions(Some(VersionOption("2.3")), Seq(CostPlannerOption)), InterpretedRuntimeOption), (1, 45, 44))),
-    ("CYPHER 2.3 planner=cost RUNTIME COMPILED RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
-      Some(VersionOption("2.3")), Seq(CostPlannerOption)), CompiledRuntimeOption), (1, 42, 41))),
-    ("CYPHER 2.3 planner=dp RUNTIME INTERPRETED RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
-      Some(VersionOption("2.3")), Seq(DPPlannerOption)), InterpretedRuntimeOption), (1, 43, 42))),
-    ("CYPHER 2.3 planner=dp RUNTIME COMPILED RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
-      Some(VersionOption("2.3")), Seq(DPPlannerOption)), CompiledRuntimeOption), (1, 40, 39))),
-    ("CYPHER 2.3 planner=idp RUNTIME INTERPRETED RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions
-      (Some(VersionOption("2.3")), Seq(IDPPlannerOption)), InterpretedRuntimeOption), (1, 44, 43))),
-    ("CYPHER 2.3 planner=idp RUNTIME COMPILED RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
-      Some(VersionOption("2.3")), Seq(IDPPlannerOption)), CompiledRuntimeOption), (1, 41, 40))),
-    ("CYPHER planner =dp RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(None, Seq(DPPlannerOption))), (1, 20, 19))),
-    ("explainmatch", CypherQueryWithOptions("explainmatch", Seq.empty, (1, 1, 0))),
-    ("""    CYPHER 2.2 PLANNER COST PROFILE PATTERN""", CypherQueryWithOptions("PATTERN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), CostPlannerOption, ProfileOption), (1, 37, 36)))
+    ("CYPHER runtime=interpreted RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(None, Seq(InterpretedRuntimeOption))), (1, 28, 27))),
+    ("CYPHER runtime=compiled RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(None, Seq(CompiledRuntimeOption))), (1, 25, 24))),
+
+    ("CYPHER 2.3 planner=cost runtime=interpreted RETURN", CypherQueryWithOptions("RETURN", Seq(
+      ConfigurationOptions(Some(VersionOption("2.3")), Seq(CostPlannerOption, InterpretedRuntimeOption))), (1, 45, 44))),
+    ("CYPHER 2.3 planner=cost runtime=compiled RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
+      Some(VersionOption("2.3")), Seq(CostPlannerOption, CompiledRuntimeOption))), (1, 42, 41))),
+    ("CYPHER 2.3 planner=dp runtime=interpreted RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
+      Some(VersionOption("2.3")), Seq(DPPlannerOption, InterpretedRuntimeOption))), (1, 43, 42))),
+    ("CYPHER 2.3 planner=dp runtime=compiled RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
+      Some(VersionOption("2.3")), Seq(DPPlannerOption, CompiledRuntimeOption))), (1, 40, 39))),
+    ("CYPHER 2.3 planner=idp runtime=interpreted RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions
+      (Some(VersionOption("2.3")), Seq(IDPPlannerOption, InterpretedRuntimeOption))), (1, 44, 43))),
+    ("CYPHER 2.3 planner=idp runtime=compiled RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
+      Some(VersionOption("2.3")), Seq(IDPPlannerOption, CompiledRuntimeOption))), (1, 41, 40))),
+    ("CYPHER 2.3  runtime=compiled  planner=idp   RETURN", CypherQueryWithOptions("RETURN", Seq(ConfigurationOptions(
+      Some(VersionOption("2.3")), Seq(CompiledRuntimeOption,IDPPlannerOption))), (1, 45, 44))),
+    ("explainmatch", CypherQueryWithOptions("explainmatch", Seq.empty, (1, 1, 0)))
     )
 
   test("run the tests") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CompilerComparisonTest.scala
@@ -297,7 +297,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val cacheFlushMonitor = monitors.newMonitor[CypherCacheFlushingMonitor[CacheAccessor[Statement, ExecutionPlan]]](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheHitMonitor)
 
-    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors, _ => devNullLogger)
+    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors)
   }
 
   private def legacyCompiler(graph: GraphDatabaseService): CypherCompiler = {
@@ -313,7 +313,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val cacheFlushMonitor = monitors.newMonitor[CypherCacheFlushingMonitor[CacheAccessor[Statement, ExecutionPlan]]](monitorTag)
     val cache = new MonitoringCacheAccessor[Statement, ExecutionPlan](cacheHitMonitor)
 
-    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors, _ => devNullLogger)
+    new CypherCompiler(parser, checker, execPlanBuilder, rewriter, cache, planCacheFactory, cacheFlushMonitor, monitors)
   }
 
   case class QueryExecutionResult(compiler: String, dbHits: Option[Long], plan: InternalPlanDescription) {
@@ -529,7 +529,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val (plan: ExecutionPlan, parameters) = db.withTx {
       tx =>
         val planContext = new TransactionBoundPlanContext(db.statement, db)
-        compiler.planQuery(query, planContext, NormalMode)
+        compiler.planQuery(query, planContext, devNullLogger)
     }
 
     db.withTx {

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -36,12 +36,14 @@ public enum NotificationCode
                     " query processing. " +
                     "While occasionally intended, it may often be possible to reformulate the query that avoids the " +
                     "use of this cross " +
-                    "product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH" );
-
+                    "product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH" ),
+    LEGACY_PLANNER( SeverityLevel.WARNING,
+                    Status.Statement.DeprecationWarning,
+                    "Using PLANNER for switching between planners has been deprecated, please use CYPHER planner=[rule,cost] instead");
     private final Status status;
     private final String description;
     private final SeverityLevel severity;
-    private NotificationCode( SeverityLevel severity, Status status, String description )
+    NotificationCode(SeverityLevel severity, Status status, String description)
     {
         this.severity = severity;
         this.status = status;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -159,6 +159,7 @@ public interface Status
         ExecutionFailure( DatabaseError, "The database was unable to execute the statement." ),
         ExternalResourceFailure( TransientError, "The external resource is not available"),
         CartesianProduct( ClientNotification, "This query builds a cartesian product between disconnected patterns." ),
+        DeprecationWarning( ClientNotification, "This feature is deprecated and will be removed in future versions." ),
         ;
 
         private final Code code;

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -1179,8 +1179,8 @@ public class TestApps extends AbstractShellTest
     @Test
     public void shouldBeAbleToSwitchBetweenRuntimes() throws Exception
     {
-        executeCommand( "RUNTIME COMPILED MATCH (n)-[:T]-(n) RETURN n;" );
-        executeCommand( "RUNTIME INTERPRETED MATCH (n)-[:T]-(n) RETURN n;" );
+        executeCommand( "CYPHER runtime=compiled MATCH (n)-[:T]-(n) RETURN n;" );
+        executeCommand( "CYPHER runtime=interpreted MATCH (n)-[:T]-(n) RETURN n;" );
     }
 
     @Test


### PR DESCRIPTION
- Only allow `CYPHER runtime=[interpreted,compiled]` syntax
- Warning when using `PLANNER [COST, RULE]`
