### PR TITLE
Explicitly prevents CSV fields from having data after end quote

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -142,6 +142,16 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                     {   // Found a double quote, skip it and we're going down one more quote depth (quote-in-quote)
                         repositionChar( bufferPos++, ++skippedChars );
                     }
+                    else if ( nextCh != untilChar && !isNewLine( nextCh ) && nextCh != EOF_CHAR )
+                    {   // Found an ending quote of sorts, although the next char isn't a delimiter, newline, or EOF
+                        // so it looks like there's data characters after this end quote. We don't really support that.
+                        // So circle this back to the user saying there's something wrong with the field.
+                        throw new IllegalStateException( "At " + sourceDescription() + ":" + lineNumber() +
+                                " there's a field starting with a quote and whereas it ends that quote there seems " +
+                                " to be character in that field after that ending quote. That isn't supported." +
+                                " This is what I read: '" +
+                                new String( buffer, seekStartPos, bufferPos-seekStartPos ) + "'" );
+                    }
                     else
                     {   // Found an ending quote, skip it and switch mode
                         endOffset++;

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -33,9 +33,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -524,6 +526,28 @@ public class BufferedCharSeekerTest
         assertNextValue( seeker, mark, COMMA, "1992" );
         assertTrue( mark.isEndOfLine() );
         assertFalse( seeker.seek( mark, COMMA ) );
+    }
+
+    @Test
+    public void shouldFailOnCharactersAfterEndQuote() throws Exception
+    {
+        // GIVEN
+        String data = "abc,\"def\"ghi,jkl";
+        seeker = seeker( data );
+
+        // WHEN
+        assertNextValue( seeker, mark, COMMA, "abc" );
+        try
+        {
+            seeker.seek( mark, COMMA );
+            fail( "Should've failed" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN good
+            assertThat( e.getMessage(), containsString( ":0" ) );
+            assertThat( e.getMessage(), containsString( "after that ending quote" ) );
+        }
     }
 
     private String[][] randomWeirdValues( int cols, int rows, char... except )


### PR DESCRIPTION
CSV as a standard doesn't realsly support a field starting with a quote,
having a couple of characters then quote and then having even more
characters after that ending quote. It's considered bad input data. The
BufferedCharSeeker didn't really handle that case either, but instead of
throwing an explicit exception then bad data was extracted instead.

This commit makes that case explicit by throwing exception, providing
source information and line number about which field in the input data
contained the invalid field.
