### PR TITLE
IdMapper collision detection is id space aware

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -31,6 +31,8 @@ import org.neo4j.unsafe.impl.batchimport.input.Group;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
+import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.NO_MONITOR;
+
 /**
  * Place to instantiate common {@link IdMapper} implementations.
  */
@@ -89,7 +91,7 @@ public class IdMappers
      */
     public static IdMapper strings( NumberArrayFactory cacheFactory )
     {
-        return new EncodingIdMapper( cacheFactory, new StringEncoder(), new Radix.String() );
+        return new EncodingIdMapper( cacheFactory, new StringEncoder(), new Radix.String(), NO_MONITOR );
     }
 
     /**
@@ -101,6 +103,6 @@ public class IdMappers
      */
     public static IdMapper longs( NumberArrayFactory cacheFactory )
     {
-        return new EncodingIdMapper( cacheFactory, new LongEncoder(), new Radix.Long() );
+        return new EncodingIdMapper( cacheFactory, new LongEncoder(), new Radix.Long(), NO_MONITOR );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -58,6 +58,19 @@ import static org.neo4j.unsafe.impl.batchimport.Utils.unsignedCompare;
  */
 public class EncodingIdMapper implements IdMapper
 {
+    public interface Monitor
+    {
+        void numberOfCollisions( int numberOfCollisions );
+    }
+
+    public static final Monitor NO_MONITOR = new Monitor()
+    {
+        @Override
+        public void numberOfCollisions( int numberOfCollisions )
+        {   // Do nothing.
+        }
+    };
+
     // Bit in encoded String --> long values that marks that the particular item has a collision,
     // i.e. that there's at least one other string that encodes into the same long value.
     // This bit is the least significant in the most significant byte of the encoded values,
@@ -88,15 +101,17 @@ public class EncodingIdMapper implements IdMapper
     private IdGroup[] idGroups = new IdGroup[10];
     private IdGroup currentIdGroup;
     private int idGroupsCursor;
+    private final Monitor monitor;
 
-    public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Radix radix )
+    public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Radix radix, Monitor monitor )
     {
-        this( cacheFactory, encoder, radix, CACHE_CHUNK_SIZE, Runtime.getRuntime().availableProcessors() - 1 );
+        this( cacheFactory, encoder, radix, monitor, CACHE_CHUNK_SIZE, Runtime.getRuntime().availableProcessors() - 1 );
     }
 
     public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Radix radix,
-            int chunkSize, int processorsForSorting )
+            Monitor monitor, int chunkSize, int processorsForSorting )
     {
+        this.monitor = monitor;
         this.processorsForSorting = max( processorsForSorting, 1 );
         this.dataCache = newLongArray( cacheFactory, chunkSize );
         this.trackerCache = newIntArray( cacheFactory, chunkSize );
@@ -115,6 +130,9 @@ public class EncodingIdMapper implements IdMapper
         return cacheFactory.newDynamicLongArray( chunkSize, -1 );
     }
 
+    /**
+     * Returns the data index if found, or {@code -1} if not found.
+     */
     @Override
     public long get( Object inputId, Group group )
     {
@@ -254,47 +272,87 @@ public class EncodingIdMapper implements IdMapper
         return COLLISION_BIT.get( value, 1 ) != 0;
     }
 
+    /**
+     * There are two types of collisions:
+     * - actual: collisions coming from equal input value. These might however not impose
+     *   keeping original input value since the colliding values might be for separate id groups,
+     *   just as long as there's at most one per id space.
+     * - accidental: collisions coming from different input values that happens to coerce into
+     *   the same encoded value internally.
+     *
+     * For any encoded value there might be a mix of actual and accidental collisions. As long as there's
+     * only one such value (accidental or actual) per id space the original input id doesn't need to be kept.
+     * For scenarios where there are multiple per for any given id space:
+     * - actual: there are two equal input values in the same id space
+     *     ==> fail, not allowed
+     * - accidental: there are two different input values coerced into the same encoded value
+     *   in the same id space
+     *     ==> original input values needs to be kept
+     */
     private int detectAndMarkCollisions( ProgressListener progress )
     {
         progress.started( "DETECT" );
         int numCollisions = 0;
         long max = trackerCache.size() - 1;
+        SameGroupDetector sameGroupDetector = new SameGroupDetector();
         for ( int i = 0; i < max; )
         {
             int batch = (int) min( max-i, 10_000 );
             for ( int j = 0; j < batch; j++, i++ )
             {
-                if ( compareDataCache( dataCache, trackerCache, i, i + 1, CompareType.GE ) )
+                int dataIndexA = trackerCache.get( i );
+                int dataIndexB = trackerCache.get( i+1 );
+                if ( dataIndexA == -1 || dataIndexB == -1 )
                 {
-                    if ( !compareDataCache( dataCache, trackerCache, i, i + 1, CompareType.EQ ) )
+                    sameGroupDetector.reset();
+                    continue;
+                }
+
+                long dataA = clearCollision( dataCache.get( dataIndexA ) );
+                long dataB = clearCollision( dataCache.get( dataIndexB ) );
+
+                if ( unsignedCompare( dataA, dataB, CompareType.GE ) )
+                {
+                    if ( !unsignedCompare( dataA, dataB, CompareType.EQ ) )
                     {
                         throw new IllegalStateException( "Failure:[" + i + "] " +
-                                Long.toHexString( dataCache.get( trackerCache.get( i ) ) ) + ":" +
-                                Long.toHexString( dataCache.get( trackerCache.get( i + 1 ) ) ) + " | " +
-                                radixOf( dataCache.get( trackerCache.get( i ) ) ) + ":" +
-                                radixOf( dataCache.get( trackerCache.get( i + 1 ) ) ) );
+                                Long.toHexString( dataA ) + ":" + Long.toHexString( dataB ) + " | " +
+                                radixOf( dataA ) + ":" + radixOf( dataB ) );
                     }
 
-                    if ( trackerCache.get( i ) > trackerCache.get( i + 1 ) )
-                    {   // swap
+                    // Here we have two equal encoded values. First let's check if they are in the same id space.
+                    int collision = sameGroupDetector.collisionWithinSameGroup(
+                            dataIndexA, groupOf( dataIndexA ).id(),
+                            dataIndexB, groupOf( dataIndexB ).id() );
+
+                    if ( dataIndexA > dataIndexB )
+                    {
+                        // Swap so that lower tracker index means lower data index. TODO Why do we do this?
                         trackerCache.swap( i, i+1, 1 );
                     }
 
-                    markAsCollision( i );
-                    markAsCollision( i+1 );
-                    numCollisions++;
+                    if ( collision != -1 )
+                    {
+                        markAsCollision( collision );
+                        markAsCollision( dataIndexB );
+                        numCollisions++;
+                    }
+                }
+                else
+                {
+                    sameGroupDetector.reset();
                 }
             }
             progress.add( batch );
         }
         progress.done();
+        monitor.numberOfCollisions( numCollisions );
         return numCollisions;
     }
 
-    private void markAsCollision( int trackerIndex )
+    private void markAsCollision( int dataIndex )
     {
-        int index = trackerCache.get( trackerIndex );
-        dataCache.set( index, setCollision( dataCache.get( index ) ) );
+        dataCache.set( dataIndex, setCollision( dataCache.get( dataIndex ) ) );
     }
 
     private void buildCollisionInfo( InputIterator<Object> ids, ProgressListener progress )
@@ -369,19 +427,28 @@ public class EncodingIdMapper implements IdMapper
         while ( low <= high )
         {
             long mid = low + (high - low)/2;//(low + high) / 2;
-            int index = trackerCache.get( mid );
-            if ( index == -1 )
+            int dataIndex = trackerCache.get( mid );
+            if ( dataIndex == -1 )
             {
                 return -1;
             }
-            long midValue = dataCache.get( index );
+            long midValue = dataCache.get( dataIndex );
             if ( unsignedCompare( clearCollision( midValue ), x, CompareType.EQ ) )
             {
-                if ( isCollision( midValue ) )
-                {
-                    return findFromCollisions( mid, inputId, groupId );
+                // We found the value we were looking for. Question now is whether or not it's the only
+                // of its kind. Not all values that there are duplicates of are considered collisions,
+                // read more in detectAndMarkCollisions(). So regardless we need to check previous/next
+                // if they are the same value.
+                if ( (mid > 0 && unsignedCompare( x, dataValue( mid - 1 ), CompareType.EQ )) ||
+                        (mid < trackerCache.highestSetIndex() && unsignedCompare( x, dataValue( mid + 1 ), CompareType.EQ ) ) )
+                {   // OK so there are actually multiple equal data values here, we need to go through them all
+                    // to be sure we find the correct one.
+                    return findFromCollisions( mid, midValue, inputId, groupId );
                 }
-                return groupOf( index ).id() == groupId ? index : -1;
+                else
+                {   // This is the only value here, let's do a simple comparison with correct group id and return
+                    return groupOf( dataIndex ).id() == groupId ? dataIndex : -1;
+                }
             }
             else if ( unsignedCompare( clearCollision( midValue ), x, CompareType.LT ) )
             {
@@ -393,6 +460,11 @@ public class EncodingIdMapper implements IdMapper
             }
         }
         return -1;
+    }
+
+    private long dataValue( long index )
+    {
+        return clearCollision( dataCache.get( trackerCache.get( index ) ) );
     }
 
     private long findIndex( LongArray array, long value )
@@ -420,19 +492,18 @@ public class EncodingIdMapper implements IdMapper
         return -1;
     }
 
-    private long findFromCollisions( long index, Object inputId, int groupId )
+    private long findFromCollisions( long index, long val, Object inputId , int groupId )
     {
-        long val = clearCollision( dataCache.get( trackerCache.get( index ) ) );
+        val = clearCollision( val );
         assert val == encoder.encode( inputId );
 
-        while ( index > 0 &&
-                unsignedCompare( val, clearCollision( dataCache.get( trackerCache.get( index - 1 ) ) ), CompareType.EQ ) )
+        while ( index > 0 && unsignedCompare( val, dataValue( index - 1 ), CompareType.EQ ) )
         {
             index--;
         }
+        long high = trackerCache.highestSetIndex();
         long fromIndex = index;
-        while ( index < trackerCache.highestSetIndex() &&
-                unsignedCompare( val, clearCollision( dataCache.get( trackerCache.get( index + 1 ) ) ), CompareType.EQ ) )
+        while ( index < high && unsignedCompare( val, dataValue( index + 1 ), CompareType.EQ ) )
         {
             index++;
         }
@@ -447,18 +518,32 @@ public class EncodingIdMapper implements IdMapper
         for ( long index = fromIndex; index <= toIndex; index++ )
         {
             int dataIndex = trackerCache.get( index );
+            long data = dataCache.get( dataIndex );
             IdGroup group = groupOf( dataIndex );
             if ( groupId == group.id() )
             {
-                // If we have more than Integer.MAX_VALUE collisions then I'd be darned.
-                int collisionIndex = safeCastLongToInt( findIndex( collisionCache, dataIndex ) );
-                Object value = collisionValues.get( collisionIndex );
-                if ( inputId.equals( value ) )
-                {
-                    lowestFound = lowestFound == -1 ? dataIndex : min( lowestFound, dataIndex );
-                    // continue checking so that we can find the lowest one. It's not up to us here to
-                    // consider multiple equal ids in this group an error or not. That should have been
-                    // decided in #prepare.
+                if ( isCollision( data ) )
+                {   // We found a data value for our group, but there are collisions within this group.
+                    // We need to consult the collision cache and original input id
+
+                    // If we have more than Integer.MAX_VALUE collisions then I'd be darned.
+                    int collisionIndex = safeCastLongToInt( findIndex( collisionCache, dataIndex ) );
+                    Object value = collisionValues.get( collisionIndex );
+                    if ( inputId.equals( value ) )
+                    {
+                        lowestFound = lowestFound == -1 ? dataIndex : min( lowestFound, dataIndex );
+                        // continue checking so that we can find the lowest one. It's not up to us here to
+                        // consider multiple equal ids in this group an error or not. That should have been
+                        // decided in #prepare.
+                    }
+                }
+                else
+                {   // We found a data value that is alone in its group. Just return it
+                    lowestFound = dataIndex;
+
+                    // We don't need to look no further because this value wasn't a collision,
+                    // i.e. there are more like it for this group
+                    break;
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import java.util.Arrays;
+
+/**
+ * Used by {@link EncodingIdMapper} to help detect collisions of encoded values within the same group.
+ * Same values for different groups are not considered collisions.
+ */
+class SameGroupDetector
+{
+    // Alternating data index, group id
+    private int[] seen = new int[100]; // grows on demand
+    private int cursor;
+
+    /**
+     * @return -1 if no collision within the same group, or an actual data index which collides with the
+     * supplied data index and group id. In the case of <strong>not</strong> {@code -1} both {@code dataIndexB}
+     * and the returned data index should be marked as collisions.
+     */
+    int collisionWithinSameGroup( int dataIndexA, int groupIdA, int dataIndexB, int groupIdB )
+    {
+        // The first call, add both the entries. For consecutive calls for this same collision stretch
+        // only add and compare the second. The reason it's done in here instead of having a method signature
+        // of one data index and group id and having the caller call two times is that we're better suited
+        // to decide if this is the first or consecutive call for this collision stretch.
+        if ( cursor == 0 )
+        {
+            add( dataIndexA, groupIdA );
+        }
+
+        int collision = -1;
+        for ( int i = 0; i < cursor; i++ )
+        {
+            int dataIndexAtCursor = seen[i++];
+            int groupIdAtCursor = seen[i];
+            if ( groupIdAtCursor == groupIdB )
+            {
+                collision = dataIndexAtCursor;
+                break;
+            }
+        }
+
+        add( dataIndexB, groupIdB );
+
+        return collision;
+    }
+
+    private void add( int dataIndex, int groupId )
+    {
+        if ( cursor == seen.length )
+        {
+            seen = Arrays.copyOf( seen, seen.length*2 );
+        }
+        seen[cursor++] = dataIndex;
+        seen[cursor++] = groupId;
+    }
+
+    void reset()
+    {
+        cursor = 0;
+    }
+}


### PR DESCRIPTION
There was a problem in the presence of multiple id spaces where many of the
ids in each id spaces were the same. This is all fine since an id is unique
within its id space only. The problem was that the collision detection code
wasn't id space aware and so treated all these same ids as collisions and
went through the hassle of going through the input and gathering up their
actual ids (e.g. the String/Long input node ids) and keeping them all in
memory. On top of that there is a temporary data structure which kept all
ids per group as well, to be able to detect duplicates within the same id
space. The code described above just wasn't supposed to handle that many
collisions since the Encoder is built to produce collisions very rarely.

This commit changes that so it's only multiple ids within the same'
id space that are treated as collisions and so should remove this
overhead completely
