### PR TITLE
Optimizations in preparation stage of IdMapper

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -165,13 +165,14 @@ public class ParallelBatchImporter implements BatchImporter
                 // the node and calc dense node stages in parallel.
                 executeStages( nodeStage, calculateDenseNodesStage );
             }
+            nodeRelationshipCache.fixateNodes();
 
             // Stage 3 -- relationships, properties
             final RelationshipStage relationshipStage = new RelationshipStage( config, writeMonitor, writerFactory,
                     relationships.supportsMultiplePasses() ? relationships : inputCache.relationships(),
                     idMapper, neoStore, nodeRelationshipCache, input.specificRelationshipIds() );
             executeStages( relationshipStage );
-            nodeRelationshipCache.fixate();
+            nodeRelationshipCache.fixateGroups();
 
             // Prepare for updating
             neoStore.flush();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -86,6 +86,19 @@ public class Utils
         return false;
     }
 
+    /**
+     * Like {@link #unsignedCompare(long, long, CompareType)} but reversed in that you get {@link CompareType}
+     * from comparing data A and B, i.e. the difference between them.
+     */
+    public static CompareType unsignedDifference( long dataA, long dataB )
+    {
+        if ( dataA == dataB )
+        {
+            return CompareType.EQ;
+        }
+        return ((dataA < dataB) ^ ((dataA < 0) != (dataB < 0))) ? CompareType.LT : CompareType.GT;
+    }
+
     public static InputIterable<Object> idsOf( final InputIterable<InputNode> nodes )
     {
         return new InputIterable<Object>()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArray.java
@@ -39,38 +39,12 @@ abstract class ChunkedNumberArray<N extends NumberArray> implements NumberArray
     }
 
     @Override
-    public long size()
-    {
-        long size = 0;
-        for ( int i = 0; i < chunks.length; i++ )
-        {
-            size += chunks[i].size();
-        }
-        return size;
-    }
-
-    @Override
     public void clear()
     {
         for ( NumberArray chunk : chunks )
         {
             chunk.clear();
         }
-    }
-
-    @Override
-    public long highestSetIndex()
-    {
-        for ( int i = chunks.length-1; i >= 0; i-- )
-        {
-            NumberArray chunk = chunks[i];
-            long highestSetInChunk = chunk.highestSetIndex();
-            if ( highestSetInChunk > -1 )
-            {
-                return i*chunkSize + highestSetInChunk;
-            }
-        }
-        return -1;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
@@ -41,14 +41,17 @@ abstract class DynamicNumberArray<N extends NumberArray> extends ChunkedNumberAr
 
     protected N ensureChunkAt( long index )
     {
-        while ( index >= length() )
+        if ( index >= length() )
         {
             synchronized ( this )
             {
                 if ( index >= length() )
                 {
-                    NumberArray[] newChunks = Arrays.copyOf( chunks, chunks.length+1 );
-                    newChunks[chunks.length] = addChunk( chunkSize );
+                    NumberArray[] newChunks = Arrays.copyOf( chunks, chunkIndex( index )+1 );
+                    for ( int i = chunks.length; i < newChunks.length; i++ )
+                    {
+                        newChunks[i] = addChunk( chunkSize );
+                    }
                     chunks = newChunks;
                 }
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
@@ -54,23 +54,13 @@ public class HeapIntArray extends HeapNumberArray implements IntArray
     @Override
     public void set( long index, int value )
     {
-        int intIndex = safeCastLongToInt( index );
-        if ( array[intIndex] == defaultValue )
-        {
-            size++;
-        }
-        array[intIndex] = value;
-        if ( index > highestSetIndex )
-        {
-            highestSetIndex = index;
-        }
+        array[safeCastLongToInt( index )] = value;
     }
 
     @Override
     public void clear()
     {
         Arrays.fill( array, defaultValue );
-        super.clear();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
@@ -54,23 +54,13 @@ public class HeapLongArray extends HeapNumberArray implements LongArray
     @Override
     public void set( long index, long value )
     {
-        int intIndex = safeCastLongToInt( index );
-        if ( array[intIndex] == defaultValue )
-        {
-            size++;
-        }
-        array[intIndex] = value;
-        if ( index > highestSetIndex )
-        {
-            highestSetIndex = index;
-        }
+        array[safeCastLongToInt( index )] = value;
     }
 
     @Override
     public void clear()
     {
         Arrays.fill( array, defaultValue );
-        super.clear();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -151,9 +151,13 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Home
         return IdFieldManipulator.getCount( field );
     }
 
-    public void fixate()
+    public void fixateNodes()
     {
         array = array.fixate();
+    }
+
+    public void fixateGroups()
+    {
         relGroupCache.fixate();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -32,11 +32,6 @@ public interface NumberArray extends MemoryStatsVisitor.Home, AutoCloseable
     long length();
 
     /**
-     * @return number of indexes occupied, i.e. setting the same index multiple times doesn't increment size.
-     */
-    long size();
-
-    /**
      * Swaps {@code numberOfEntries} items from {@code fromIndex} to {@code toIndex}, such that
      * {@code fromIndex} and {@code toIndex}, {@code fromIndex+1} and {@code toIndex} a.s.o swaps places.
      *
@@ -50,11 +45,6 @@ public interface NumberArray extends MemoryStatsVisitor.Home, AutoCloseable
      * Sets all values to a default value.
      */
     void clear();
-
-    /**
-     * @return highest set index or -1 if no set.
-     */
-    long highestSetIndex();
 
     /**
      * Releases any resources that GC won't release automatically.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -198,13 +198,23 @@ public interface NumberArrayFactory
         @Override
         public LongArray newLongArray( long length, long defaultValue )
         {
-            return newDynamicLongArray( fractionOf( length ), defaultValue );
+            // Here we want to have the property of a dynamic array which makes some parts of the array
+            // live on heap, some off. At the same time we want a fixed size array. Therefore first create
+            // the array as a dynamic array, make it grow to the requested length and then fixate.
+            DynamicLongArray array = newDynamicLongArray( fractionOf( length ), defaultValue );
+            array.ensureChunkAt( length-1 );
+            return array.fixate();
         }
 
         @Override
         public IntArray newIntArray( long length, int defaultValue )
         {
-            return newDynamicIntArray( fractionOf( length ), defaultValue );
+            // Here we want to have the property of a dynamic array which makes some parts of the array
+            // live on heap, some off. At the same time we want a fixed size array. Therefore first create
+            // the array as a dynamic array, make it grow to the requested length and then fixate.
+            DynamicIntArray array = newDynamicIntArray( fractionOf( length ), defaultValue );
+            array.ensureChunkAt( length-1 );
+            return array.fixate();
         }
 
         private long fractionOf( long length )
@@ -213,13 +223,13 @@ public interface NumberArrayFactory
         }
 
         @Override
-        public IntArray newDynamicIntArray( long chunkSize, int defaultValue )
+        public DynamicIntArray newDynamicIntArray( long chunkSize, int defaultValue )
         {
             return new DynamicIntArray( delegate, chunkSize, defaultValue );
         }
 
         @Override
-        public LongArray newDynamicLongArray( long chunkSize, long defaultValue )
+        public DynamicLongArray newDynamicLongArray( long chunkSize, long defaultValue )
         {
             return new DynamicLongArray( delegate, chunkSize, defaultValue );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -28,8 +28,6 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
 {
     private final int defaultValue;
-    private long highestSetIndex = -1;
-    private long size;
 
     public OffHeapIntArray( long length, int defaultValue )
     {
@@ -47,28 +45,7 @@ public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
     @Override
     public void set( long index, int value )
     {
-        long address = addressOf( index );
-        if ( UnsafeUtil.getInt( address ) == defaultValue )
-        {
-            size++;
-        }
-        UnsafeUtil.putInt( address, value );
-        if ( index > highestSetIndex )
-        {
-            highestSetIndex = index;
-        }
-    }
-
-    @Override
-    public long highestSetIndex()
-    {
-        return highestSetIndex;
-    }
-
-    @Override
-    public long size()
-    {
-        return size;
+        UnsafeUtil.putInt( addressOf( index ), value );
     }
 
     @Override
@@ -85,8 +62,6 @@ public class OffHeapIntArray extends OffHeapNumberArray implements IntArray
                 UnsafeUtil.putInt( adr, defaultValue );
             }
         }
-        highestSetIndex = -1;
-        size = 0;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -28,8 +28,6 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
 {
     private final long defaultValue;
-    private long highestSetIndex = -1;
-    private long size;
 
     public OffHeapLongArray( long length, long defaultValue )
     {
@@ -47,28 +45,7 @@ public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
     @Override
     public void set( long index, long value )
     {
-        long address = addressOf( index );
-        if ( UnsafeUtil.getLong( address ) == defaultValue )
-        {
-            size++;
-        }
-        UnsafeUtil.putLong( address, value );
-        if ( index > highestSetIndex )
-        {
-            highestSetIndex = index;
-        }
-    }
-
-    @Override
-    public long highestSetIndex()
-    {
-        return highestSetIndex;
-    }
-
-    @Override
-    public long size()
-    {
-        return size;
+        UnsafeUtil.putLong( addressOf( index ), value );
     }
 
     @Override
@@ -85,8 +62,6 @@ public class OffHeapLongArray extends OffHeapNumberArray implements LongArray
                 UnsafeUtil.putLong( adr, defaultValue );
             }
         }
-        highestSetIndex = -1;
-        size = 0;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/NumberArrayStats.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/NumberArrayStats.java
@@ -17,28 +17,41 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.cache;
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArray;
 
 /**
- * Base class for common functionality for any {@link NumberArray} where the data lives inside heap.
+ * Keeps simple stats about f.ex a {@link NumberArray}. Keeps {@link #size()} and {@link #highestIndex()},
+ * either {@link #register(long) registered per value} or {@link #set(long, long)} specifically.
  */
-abstract class HeapNumberArray implements NumberArray
+public class NumberArrayStats
 {
-    private final int itemSize;
+    private long size;
+    private long highestIndex = -1;
 
-    protected HeapNumberArray( int itemSize )
+    public void register( long index )
     {
-        this.itemSize = itemSize;
+        size++;
+        if ( index > highestIndex )
+        {
+            highestIndex = index;
+        }
     }
 
-    @Override
-    public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+    public void set( long size, long highestIndex )
     {
-        visitor.heapUsage( length() * itemSize ); // roughly
+        this.size = size;
+        this.highestIndex = highestIndex;
     }
 
-    @Override
-    public void close()
-    {   // Nothing to close
+    public long size()
+    {
+        return size;
+    }
+
+    public long highestIndex()
+    {
+        return highestIndex;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -30,6 +30,9 @@ import org.neo4j.unsafe.impl.batchimport.Utils.CompareType;
 import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 
+import static java.lang.Math.max;
+
+import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.clearCollision;
 
 /**
@@ -41,22 +44,27 @@ public class ParallelSort
     private final int[] radixIndexCount;
     private final RadixCalculator radixCalculator;
     private final LongArray dataCache;
+    private final NumberArrayStats dataStats;
     private final IntArray tracker;
+    private final NumberArrayStats trackerStats;
     private final int threads;
     private long[][] sortBuckets;
     private final ProgressListener progress;
 
-    public ParallelSort( Radix radix, LongArray dataCache, IntArray tracker, int threads, ProgressListener progress )
+    public ParallelSort( Radix radix, LongArray dataCache, NumberArrayStats dataStats,
+            IntArray tracker, NumberArrayStats trackerStats, int threads, ProgressListener progress )
     {
         this.progress = progress;
         this.radixIndexCount = radix.getRadixIndexCounts();
         this.radixCalculator = radix.calculator();
         this.dataCache = dataCache;
+        this.dataStats = dataStats;
         this.tracker = tracker;
+        this.trackerStats = trackerStats;
         this.threads = threads;
     }
 
-    public long[][] run()
+    public long[][] run() throws InterruptedException
     {
         int[][] sortParams = sortRadix();
         int threadsNeeded = 0;
@@ -86,10 +94,6 @@ public class ParallelSort
         {
             doneSignal.await();
         }
-        catch ( InterruptedException e )
-        {
-            throw new RuntimeException( e );
-        }
         finally
         {
             progress.done();
@@ -97,12 +101,13 @@ public class ParallelSort
         return sortBuckets;
     }
 
-    private int[][] sortRadix()
+    private int[][] sortRadix() throws InterruptedException
     {
         int[][] rangeParams = new int[threads][2];
         int[] bucketRange = new int[threads];
+        TrackerInitializer[] initializers = new TrackerInitializer[threads];
         sortBuckets = new long[threads][2];
-        int bucketSize = (int) (dataCache.size() / threads);
+        int bucketSize = safeCastLongToInt( dataStats.size() / threads );
         int count = 0, fullCount = 0 + 0;
         rangeParams[0][0] = 0;
         bucketRange[0] = 0;
@@ -126,6 +131,9 @@ public class ParallelSort
                     fullCount += radixIndexCount[i];
                     progress.add( radixIndexCount[i] );
                 }
+                initializers[threadIndex] = new TrackerInitializer( threadIndex, rangeParams[threadIndex],
+                        threadIndex > 0 ? bucketRange[threadIndex-1] : -1, bucketRange[threadIndex],
+                        sortBuckets[threadIndex] );
                 threadIndex++;
             }
             else
@@ -136,36 +144,40 @@ public class ParallelSort
             {
                 bucketRange[threadIndex] = radixIndexCount.length;
                 rangeParams[threadIndex][0] = fullCount;
-                rangeParams[threadIndex][1] = (int) dataCache.size() - fullCount;
+                rangeParams[threadIndex][1] = safeCastLongToInt( dataStats.size() - fullCount );
+                initializers[threadIndex] = new TrackerInitializer( threadIndex, rangeParams[threadIndex],
+                        threadIndex > 0 ? bucketRange[threadIndex-1] : -1, bucketRange[threadIndex],
+                        sortBuckets[threadIndex] );
                 break;
             }
         }
         progress.done();
+
+        // In the loop above where we split up radixes into buckets, we start one thread per bucket whose
+        // job is to populate trackerCache and sortBuckets where each thread will not touch the same
+        // data indexes as any other thread. Here we wait for them all to finish.
         int[] bucketIndex = new int[threads];
-        for ( int i = 0; i < threads; i++ )
+        Throwable error = null;
+        long highestIndex = -1, size = 0;
+        for ( int i = 0; i < initializers.length; i++ )
         {
-            bucketIndex[i] = 0;
-        }
-        for ( long i = 0; i < dataCache.size(); i++ )
-        {
-            int rIndex = radixCalculator.radixOf( dataCache.get( i ) );
-            for ( int k = 0; k < threads; k++ )
+            TrackerInitializer initializer = initializers[i];
+            if ( initializer != null )
             {
-                //if ( rangeParams[k][0] >= rIndex )
-                if ( rIndex <= bucketRange[k] )
+                Throwable initializerError = initializer.await();
+                if ( initializerError != null )
                 {
-                    long temp = (rangeParams[k][0] + bucketIndex[k]++);
-                    assert tracker.get( temp ) == -1 : "Overlapping buckets i:" + i + ", k:" + k + "\n" +
-                            dumpBuckets( rangeParams, bucketRange, bucketIndex );
-                    tracker.set( temp, (int) i );
-                    if ( bucketIndex[k] == rangeParams[k][1] )
-                    {
-                        sortBuckets[k][0] = bucketRange[k];
-                        sortBuckets[k][1] = rangeParams[k][0];
-                    }
-                    break;
+                    error = initializerError;
                 }
+                bucketIndex[i] = initializer.bucketIndex;
+                highestIndex = max( highestIndex, initializer.highestIndex );
+                size += initializer.size;
             }
+        }
+        trackerStats.set( size, highestIndex );
+        if ( error != null )
+        {
+            throw new AssertionError( error.getMessage() + "\n" + dumpBuckets( rangeParams, bucketRange, bucketIndex ) );
         }
         return rangeParams;
     }
@@ -249,6 +261,11 @@ public class ParallelSort
         recursiveQsort( pivot + 1, end, random, workerProgress );
     }
 
+    /**
+     * Sorts a part of data in dataCache covered by trackerCache. Values in data cache doesn't change location,
+     * instead trackerCache is updated to point to the right indexes. Only touches a designated part of trackerCache
+     * so that many can run in parallel on their own part without synchronization.
+     */
     private class SortWorker extends Thread
     {
         private final int start, size;
@@ -296,6 +313,72 @@ public class ParallelSort
             recursiveQsort( start, start + size, random, this );
             reportProgress();
             doneSignal.countDown();
+        }
+    }
+
+    /**
+     * Sets the initial tracker indexes pointing to data indexes. Only touches a designated part of trackerCache
+     * so that many can run in parallel on their own part without synchronization.
+     */
+    private class TrackerInitializer extends Thread
+    {
+        private final int[] rangeParams;
+        private final int lowBucketRange;
+        private final int highBucketRange;
+        private final int threadIndex;
+        private int bucketIndex;
+        private final long[] result;
+        private volatile Throwable error;
+        private long highestIndex = -1;
+        private long size;
+
+        TrackerInitializer( int threadIndex, int[] rangeParams, int lowBucketRange, int highBucketRange, long[] result )
+        {
+            this.threadIndex = threadIndex;
+            this.rangeParams = rangeParams;
+            this.lowBucketRange = lowBucketRange;
+            this.highBucketRange = highBucketRange;
+            this.result = result;
+            start();
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                long dataSize = dataStats.size();
+                for ( long i = 0; i < dataSize; i++ )
+                {
+                    int rIndex = radixCalculator.radixOf( dataCache.get( i ) );
+                    if ( rIndex > lowBucketRange && rIndex <= highBucketRange )
+                    {
+                        long temp = (rangeParams[0] + bucketIndex++);
+                        assert tracker.get( temp ) == -1 : "Overlapping buckets i:" + i + ", k:" + threadIndex;
+                        tracker.set( temp, (int) i );
+                        if ( bucketIndex == rangeParams[1] )
+                        {
+                            result[0] = highBucketRange;
+                            result[1] = rangeParams[0];
+                        }
+                    }
+                }
+                if ( bucketIndex > 0 )
+                {
+                    highestIndex = rangeParams[0] + bucketIndex - 1;
+                }
+                size = bucketIndex;
+            }
+            catch ( Throwable t )
+            {
+                error = t;
+            }
+        }
+
+        private synchronized Throwable await() throws InterruptedException
+        {
+            join();
+            return error;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -209,29 +209,30 @@ public class ParallelSort
         long pivot = clearCollision( dataCache.get( tracker.get( pi ) ) );
         //save pivot in last index
         tracker.swap( pi, rightIndex - 1, 1 );
-        long left = 0, right = 0;
+        long left = clearCollision( dataCache.get( tracker.get( li ) ) );
+        long right = clearCollision( dataCache.get( tracker.get( ri ) ) );
         while ( li < ri )
         {
-            left = clearCollision( dataCache.get( tracker.get( li ) ) );
-            right = clearCollision( dataCache.get( tracker.get( ri ) ) );
             if ( Utils.unsignedCompare( left, pivot, CompareType.LT ) )
             {
                 //increment left to find the greater element than the pivot
-                li++;
+                left = clearCollision( dataCache.get( tracker.get( ++li ) ) );
             }
             else if ( Utils.unsignedCompare( right, pivot, CompareType.GE ) )
             {
                 //decrement right to find the smaller element than the pivot
-                ri--;
+                right = clearCollision( dataCache.get( tracker.get( --ri ) ) );
             }
             else
             {
                 //if right index is greater then only swap
                 tracker.swap( li, ri, 1 );
+                long temp = left;
+                left = right;
+                right = temp;
             }
         }
         int partingIndex = ri;
-        right = clearCollision( dataCache.get( tracker.get( ri ) ) );
         if ( Utils.unsignedCompare( right, pivot, CompareType.LT ) )
         {
             partingIndex++;


### PR DESCRIPTION
A previously costly initialization loop before sorting started now runs in parallel on all available CPUs. Also both collision detection and binarySearch algorithms does fewer data cache comparisons for a bit better performance.

Locally measured to cut the time spent in `Prepare node index` stage in half.
