### PR TITLE
Added ability to run cypher acceptance tests with all planners

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
@@ -26,7 +26,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     given()
 
     // When
-    val result = executeWithNewPlanner("MATCH (n:Crew) WHERE n.name = 'Neo' RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Crew) WHERE n.name = 'Neo' RETURN n")
 
     // Then
     result.executionPlanDescription().toString should include("NodeIndexSeek")
@@ -36,7 +36,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     given()
 
     // When
-    val result = executeWithNewPlanner("MATCH (n:Crew) WHERE n.name = 'Neo' AND n.name = 'Morpheus' RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Crew) WHERE n.name = 'Neo' AND n.name = 'Morpheus' RETURN n")
 
     // Then
     result shouldBe empty
@@ -47,7 +47,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     given()
 
     // When
-    val result = executeWithNewPlanner("MATCH (n:Matrix:Crew) WHERE n.name = 'Neo' RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Matrix:Crew) WHERE n.name = 'Neo' RETURN n")
 
     // Then
     result.executionPlanDescription().toString should include("NodeIndexSeek")
@@ -62,7 +62,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     for (i <- 4 to 30) createLabeledNode(Map("id" -> i), "Prop")
 
     // When
-    val result = executeWithNewPlanner("unwind [1,2,3] as x match (n:Prop) where n.id = x return n;")
+    val result = executeWithAllPlanners("unwind [1,2,3] as x match (n:Prop) where n.id = x return n;")
 
     // Then
     result.toList should equal(List(Map("n" -> n1), Map("n" -> n2), Map("n" -> n3)))
@@ -89,7 +89,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     graph.createIndex("L", "l")
     graph.createIndex("R", "r")
 
-    val result = executeWithNewPlanner("MATCH (l:L {l: 9})-[:REL]->(r:R {r: 23}) RETURN l, r")
+    val result = executeWithAllPlanners("MATCH (l:L {l: 9})-[:REL]->(r:R {r: 23}) RETURN l, r")
     result.toList should have size 100
     val found = result.executionPlanDescription().pipe.exists {
       case p: NodeIndexSeekPipe =>
@@ -101,7 +101,7 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
   }
 
   private def given() {
-    execute(
+    executeWithRulePlannerOnly(
       """CREATE (architect:Matrix { name:'The Architect' }),
         |       (smith:Matrix { name:'Agent Smith' }),
         |       (cypher:Matrix:Crew { name:'Cypher' }),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/OrderByAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/OrderByAcceptanceTest.scala
@@ -26,7 +26,7 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
     createNode("prop" -> 1)
     createNode("prop" -> 3)
     createNode("prop" -> -5)
-    val result = executeWithNewPlanner("match (n) return n.prop AS prop ORDER BY n.prop")
+    val result = executeWithAllPlanners("match (n) return n.prop AS prop ORDER BY n.prop")
     result.toList should equal(List(
       Map("prop" -> -5),
       Map("prop" -> 1),
@@ -38,7 +38,7 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
     createNode("prop" -> 1)
     createNode("prop" -> 3)
     createNode("prop" -> -5)
-    val result = executeWithNewPlanner("match (n) return n.prop AS prop ORDER BY n.prop DESC")
+    val result = executeWithAllPlanners("match (n) return n.prop AS prop ORDER BY n.prop DESC")
     result.toList should equal(List(
       Map("prop" -> 3),
       Map("prop" -> 1),
@@ -47,7 +47,7 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
   }
 
   test("ORDER BY of an column introduced in RETURN should work well") {
-    executeWithNewPlanner("WITH 1 AS p, rand() AS rng RETURN p ORDER BY rng").toList should
+    executeWithAllPlanners("WITH 1 AS p, count(*) AS rng RETURN p ORDER BY rng").toList should
       equal(List(Map("p" -> 1)))
  }
 
@@ -56,7 +56,7 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
     createNode("prop" -> 3)
     createNode("prop" -> -5)
 
-    executeWithNewPlanner("MATCH n RETURN n.prop AS n ORDER BY n + 2").toList should
+    executeWithAllPlanners("MATCH n RETURN n.prop AS n ORDER BY n + 2").toList should
       equal(List(
         Map("n" -> -5),
         Map("n" -> 1),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
@@ -36,7 +36,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) return (n)-->() as p").toList
+    val result = executeWithAllPlanners("match (n) return (n)-->() as p").toList
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should have size 2
@@ -55,7 +55,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(a, b3)
 
     // WHEN
-    val result = executeWithNewPlanner("MATCH (n:Start) RETURN n-->(:A)")
+    val result = executeWithAllPlanners("MATCH (n:Start) RETURN n-->(:A)")
       .toList.head("n-->(:A)").asInstanceOf[Seq[_]]
 
     result should have size 1
@@ -66,7 +66,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val b = createLabeledNode("End")
     relate(a, b)
 
-    val resultPath = executeWithNewPlanner("match (a:Start), (b:End) RETURN a-[*]->b as path")
+    val resultPath = executeWithAllPlanners("match (a:Start), (b:End) RETURN a-[*]->b as path")
       .toList.head("path").asInstanceOf[Seq[_]]
 
     resultPath should have size 1
@@ -77,7 +77,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) return case when id(n) >= 0 then (n)-->() else 42 end as p")
+    val result = executeWithAllPlanners("match (n) return case when id(n) >= 0 then (n)-->() else 42 end as p")
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should have size 2
@@ -88,7 +88,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) return case when id(n) < 0 then (n)-->() else 42 end as p")
+    val result = executeWithAllPlanners("match (n) return case when id(n) < 0 then (n)-->() else 42 end as p")
       .toList.head("p").asInstanceOf[Long]
 
     result should equal(42)
@@ -99,7 +99,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) return extract(x IN (n)-->() | head(nodes(x)) )  as p")
+    val result = executeWithAllPlanners("match (n) return extract(x IN (n)-->() | head(nodes(x)) )  as p")
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should equal(List(start, start))
@@ -116,7 +116,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val rel4 = relate(start2, d)
 
     graph.inTx {
-      val result = executeWithNewPlanner("match (n) return case when n:A then (n)-->(:C) when n:B then (n)-->(:D) else 42 end as p")
+      val result = executeWithAllPlanners("match (n) return case when n:A then (n)-->(:C) when n:B then (n)-->(:D) else 42 end as p")
         .map(_.mapValues {
         case l: List[Any] => l.toSet
         case x => x
@@ -136,7 +136,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n)-->(b) with (n)-->() as p, count(b) as c return p, c").toList
+    val result = executeWithAllPlanners("match (n)-->(b) with (n)-->() as p, count(b) as c return p, c").toList
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should have size 2
@@ -147,7 +147,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val b = createLabeledNode("End")
     relate(a, b)
 
-    val resultPath = executeWithNewPlanner("match (a:Start), (b:End) with a-[*]->b as path, count(a) as c return path, c")
+    val resultPath = executeWithAllPlanners("match (a:Start), (b:End) with a-[*]->b as path, count(a) as c return path, c")
       .toList.head("path").asInstanceOf[Seq[_]]
 
     resultPath should have size 1
@@ -158,7 +158,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) with case when id(n) >= 0 then (n)-->() else 42 end as p, count(n) as c return p, c")
+    val result = executeWithAllPlanners("match (n) with case when id(n) >= 0 then (n)-->() else 42 end as p, count(n) as c return p, c")
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should have size 2
@@ -169,7 +169,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) with case when id(n) < 0 then (n)-->() else 42 end as p, count(n) as c return p, c")
+    val result = executeWithAllPlanners("match (n) with case when id(n) < 0 then (n)-->() else 42 end as p, count(n) as c return p, c")
       .toList.head("p").asInstanceOf[Long]
 
     result should equal(42)
@@ -180,7 +180,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n:A) with extract(x IN (n)-->() | head(nodes(x)) ) as p, count(n) as c return p, c")
+    val result = executeWithAllPlanners("match (n:A) with extract(x IN (n)-->() | head(nodes(x)) ) as p, count(n) as c return p, c")
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should equal(List(start, start))
@@ -197,7 +197,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val rel4 = relate(start2, d)
 
     graph.inTx {
-      val result = executeWithNewPlanner("match (n) with case when n:A then (n)-->(:C) when n:B then (n)-->(:D) else 42 end as p, count(n) as c return p, c")
+      val result = executeWithAllPlanners("match (n) with case when n:A then (n)-->(:C) when n:B then (n)-->(:D) else 42 end as p, count(n) as c return p, c")
         .map(_.mapValues {
         case l: List[Any] => l.toSet
         case x => x
@@ -216,7 +216,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) where (case when id(n) >= 0 then length((n)-->()) else 42 end) > 0 return n")
+    val result = executeWithAllPlanners("match (n) where (case when id(n) >= 0 then length((n)-->()) else 42 end) > 0 return n")
       .toList
 
     result should equal(List(
@@ -230,7 +230,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) where (case when id(n) < 0 then length((n)-->()) else 42 end) > 0 return n")
+    val result = executeWithAllPlanners("match (n) where (case when id(n) < 0 then length((n)-->()) else 42 end) > 0 return n")
       .toList
 
     result should have size 3
@@ -241,7 +241,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWithNewPlanner("match (n) where n IN extract(x IN (n)-->() | head(nodes(x)) ) return n")
+    val result = executeWithAllPlanners("match (n) where n IN extract(x IN (n)-->() | head(nodes(x)) ) return n")
       .toList
 
     result should equal(List(
@@ -259,7 +259,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(start3, createNode())
 
     graph.inTx {
-      val result = executeWithNewPlanner("match (n) where (n)-->() AND (case when n:A then length((n)-->(:C)) when n:B then length((n)-->(:D)) else 42 end) > 1 return n")
+      val result = executeWithAllPlanners("match (n) where (n)-->() AND (case when n:A then length((n)-->(:C)) when n:B then length((n)-->(:D)) else 42 end) > 1 return n")
         .toList
 
       result should equal(List(
@@ -273,7 +273,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val a = createNode()
     relate(a, createNode())
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       """MATCH (owner)
         |WITH owner, COUNT(*) > 0 AS collected
         |WHERE (owner)-->()
@@ -289,7 +289,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val a = createNode()
     relate(a, createNode())
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       """MATCH (owner)
         |WITH owner, COUNT(*) AS collected
         |WHERE (owner)-->()
@@ -311,7 +311,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
 
     val r = relate(createNode(), createLabeledNode("A"), "T")
 
-    val result = executeWithNewPlanner("PROFILE MATCH ()-[r]->() WHERE ()-[r]-(:A) RETURN r")
+    val result = executeWithAllPlanners("PROFILE MATCH ()-[r]->() WHERE ()-[r]-(:A) RETURN r")
 
     result.columnAs[Relationship]("r").toList should equal(List(r))
     result.executionPlanDescription().toString should not include "NodeByLabelScan"
@@ -329,14 +329,14 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     relate(nodeC, nodeB, "HAS")
     relate(nodeD, nodeE, "HAS")
 
-    val result = executeWithNewPlanner("MATCH (a:Foo) OPTIONAL MATCH a--(b:Bar) WHERE a--(b:Bar)--() RETURN a, b")
+    val result = executeWithAllPlanners("MATCH (a:Foo) OPTIONAL MATCH a--(b:Bar) WHERE a--(b:Bar)--() RETURN a, b")
     result.toList should equal(List(
       Map("a" -> nodeA, "b" -> nodeB),
       Map("a" -> nodeC, "b" -> nodeB),
       Map("a" -> nodeD, "b" -> null)
     ))
 
-    val resultNot = executeWithNewPlanner("MATCH (a:Foo) OPTIONAL MATCH a--(b:Bar) WHERE NOT(a--(b:Bar)--()) RETURN a, b")
+    val resultNot = executeWithAllPlanners("MATCH (a:Foo) OPTIONAL MATCH a--(b:Bar) WHERE NOT(a--(b:Bar)--()) RETURN a, b")
     resultNot.toList should equal(List(
       Map("a" -> nodeA, "b" -> null),
       Map("a" -> nodeC, "b" -> null),
@@ -351,7 +351,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     createLabeledNode("A")
     relate(node, createNode(), "HAS")
 
-    val result = executeWithNewPlanner("MATCH (n:A) WHERE (n)-[:HAS]->() RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:A) WHERE (n)-[:HAS]->() RETURN n")
 
     result.toList should equal(Seq(Map("n" -> node)))
     val argumentPLan = result.executionPlanDescription().cd("Argument")
@@ -367,7 +367,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     val endNode = createNode()
     val rel = relate(node, endNode, "HAS")
 
-    val result = executeWithNewPlanner("MATCH (n:A) RETURN (n)-[:HAS]->() as p")
+    val result = executeWithAllPlanners("MATCH (n:A) RETURN (n)-[:HAS]->() as p")
 
     graph.inTx {
       result.toList should equal(Seq(
@@ -394,7 +394,7 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     createLabeledNode("A")
     relate(node, createNode(), "HAS")
 
-    val result = executeWithNewPlanner("MATCH (n:A) RETURN count((n)-[:HAS]->()) as c").toList
+    val result = executeWithAllPlanners("MATCH (n:A) RETURN count((n)-[:HAS]->()) as c").toList
 
     result should equal(List(Map("c" -> 3)))
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternPredicateAcceptanceTest.scala
@@ -31,7 +31,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     relate(createNode(), createNode(), "id" -> 2)
 
     // when
-    val result = executeScalarWithNewPlanner[Node]("match (n) where (n)-[{id: 1}]->() return n")
+    val result = executeScalarWithAllPlanners[Node]("match (n) where (n)-[{id: 1}]->() return n")
 
     // then
     result should equal(node)
@@ -44,7 +44,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     relate(createNode(), createNode(), "id" -> 2)
 
     // when
-    val result = executeWithNewPlanner("match (n) where NOT (n)-[{id: 1}]->() return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n) where NOT (n)-[{id: 1}]->() return n").columnAs[Node]("n").toList
 
     // then
     result.size should be(3)
@@ -57,7 +57,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(324234,666)
 
     // when
-    val result = executeScalarWithNewPlanner[Node]("match (n:Start) where (n)-[*2 {prop: 42}]->() return n")
+    val result = executeScalarWithAllPlanners[Node]("match (n:Start) where (n)-[*2 {prop: 42}]->() return n")
 
     // then
     assert(start1 == result)
@@ -70,7 +70,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(55555, 7777)
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2) == result)
@@ -84,7 +84,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(55555, 7777)
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() OR n.p = 25 return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.p = 12 OR (n)-[*2 {prop: 42}]->() OR n.p = 25 return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2, start3) == result)
@@ -97,7 +97,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createPath(nodePropertyValue = 25, relPropertyValue = 42)
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.p = 12 OR NOT (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.p = 12 OR NOT (n)-[*2 {prop: 42}]->() return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2) == result)
@@ -112,7 +112,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     val start3 = createLabeledNode("Start")
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where (n)-->({prop: 42}) OR NOT (n)-->() return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where (n)-->({prop: 42}) OR NOT (n)-->() return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start3) == result)
@@ -127,7 +127,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createLabeledNode("Start")
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where (n)-->({prop: 42}) OR (n)-->({prop: 411}) return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where (n)-->({prop: 42}) OR (n)-->({prop: 411}) return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start2) == result)
@@ -142,7 +142,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     val start3 = createLabeledNode("Start")
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where NOT (n)-->() OR (n)-->({prop: 42}) return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where NOT (n)-->() OR (n)-->({prop: 42}) return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start3) == result)
@@ -158,7 +158,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     createNode()
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.prop = 21 OR NOT (n)-->() OR (n)-->({prop: 42}) return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.prop = 21 OR NOT (n)-->() OR (n)-->({prop: 42}) return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start3) == result)
@@ -175,7 +175,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     relate(start4, createNode(Map("prop" -> 1)))
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.prop = 21 OR NOT (n)-->() OR (n)-->({prop: 42}) OR (n)-->({prop: 1}) return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.prop = 21 OR NOT (n)-->() OR (n)-->({prop: 42}) OR (n)-->({prop: 1}) return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start3, start4) == result)
@@ -192,7 +192,7 @@ class PatternPredicateAcceptanceTest extends ExecutionEngineFunSuite with Matche
     relate(start4, createNode(Map("prop" -> 1)))
 
     // when
-    val result = executeWithNewPlanner("match (n:Start) where n.prop = 21 OR (n)-->({prop: 42}) OR NOT (n)-->() OR (n)-->({prop: 1}) return n").columnAs[Node]("n").toList
+    val result = executeWithAllPlanners("match (n:Start) where n.prop = 21 OR (n)-->({prop: 42}) OR NOT (n)-->() OR (n)-->({prop: 1}) return n").columnAs[Node]("n").toList
 
     // then
     assert(Seq(start1, start3, start4) == result)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -202,7 +202,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val query = s"USING PERIODIC COMMIT 10 LOAD CSV FROM '$url' AS line CREATE()"
 
     // given
-    execute(query).toList
+    executeWithRulePlannerOnly(query).toList
     deleteAllEntities()
     val initialTxCounts = graph.txCounts
 
@@ -313,7 +313,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result
   }
 
-  override def profile(q: String, params: (String, Any)*): InternalExecutionResult = profileWithPlanner(executeWithNewPlanner(_,_:_*), q, params:_*)
+  override def profile(q: String, params: (String, Any)*): InternalExecutionResult = profileWithPlanner(executeWithAllPlanners(_,_:_*), q, params:_*)
 
   def legacyProfile(q: String, params: (String, Any)*): InternalExecutionResult = profileWithPlanner(innerExecute(_,_:_*), q, params:_*)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
@@ -46,7 +46,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWithNewPlanner("MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWithAllPlanners("MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
@@ -61,7 +61,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWithNewPlanner("OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWithAllPlanners("OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
@@ -76,7 +76,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeC, nodeD)
     val r4 = relate(nodeB, nodeD)
 
-    val result = executeWithNewPlanner("MATCH shortestPath((src:A)-[r*]->(dst:D)) RETURN r AS rels").columnAs[List[Node]]("rels").toList
+    val result = executeWithAllPlanners("MATCH shortestPath((src:A)-[r*]->(dst:D)) RETURN r AS rels").columnAs[List[Node]]("rels").toList
 
     result should equal(List(List(r1, r4)))
   }
@@ -87,18 +87,19 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeB, nodeC)
     relate(nodeC, nodeD)
 
-    val result = executeWithNewPlanner("MATCH p = shortestPath((src:A)-[*..1]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWithAllPlanners("MATCH p = shortestPath((src:A)-[*..1]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should be(empty)
   }
 
+  // todo: broken for rule planner
   test("finds no shortest path due to start node being null") {
     // a-b-c-d
     relate(nodeA, nodeB)
     relate(nodeB, nodeC)
     relate(nodeC, nodeD)
 
-    val result = executeWithNewPlanner("OPTIONAL MATCH (src:Y) WITH src MATCH p = shortestPath(src-[*..1]->dst) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWithCostPlannerOnly("OPTIONAL MATCH (src:Y) WITH src MATCH p = shortestPath(src-[*..1]->dst) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should equal(List())
   }
@@ -110,7 +111,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeC, nodeD)
 
     evaluating {
-      executeWithNewPlanner("MATCH p = shortestPath((src:A)-[*2..3]->(dst:D)) RETURN nodes(p) AS nodes").toList
+      executeWithAllPlanners("MATCH p = shortestPath((src:A)-[*2..3]->(dst:D)) RETURN nodes(p) AS nodes").toList
     } should produce[SyntaxException]
   }
 
@@ -124,7 +125,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeA, nodeD)
     relate(nodeD, nodeC)
 
-    val result = executeWithNewPlanner("MATCH p = allShortestPaths((src:A)-[*]->(dst:C)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toSet
+    val result = executeWithAllPlanners("MATCH p = allShortestPaths((src:A)-[*]->(dst:C)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toSet
     result should equal(Set(List(nodeA, nodeB, nodeC), List(nodeA, nodeD, nodeC)))
   }
 
@@ -135,7 +136,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeA, nodeB)
     relate(nodeB, nodeC)
 
-    val result = executeWithNewPlanner("match p = shortestpath((a:A)-[r*..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    val result = executeWithAllPlanners("match p = shortestpath((a:A)-[r*..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
     result should equal(Set(List(nodeA, nodeB)))
   }
 
@@ -146,7 +147,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeA, nodeB)
     relate(nodeB, nodeC)
 
-    val result = executeWithNewPlanner("match p = shortestpath((a:A)-[r*0..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    val result = executeWithAllPlanners("match p = shortestpath((a:A)-[r*0..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
     result should equal(Set(List(nodeA), List(nodeA, nodeB)))
   }
 
@@ -157,7 +158,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeA, nodeB)
     relate(nodeB, nodeC)
 
-    val result = executeWithNewPlanner("match p = shortestpath((a:A)-[r*1..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    val result = executeWithAllPlanners("match p = shortestpath((a:A)-[r*1..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
     result should equal(Set(List(nodeA, nodeB)))
   }
 
@@ -168,7 +169,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     relate(nodeA, nodeB)
     relate(nodeB, nodeC)
 
-    val result = executeWithNewPlanner("match p = shortestpath((a:A)-[r]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
+    val result = executeWithAllPlanners("match p = shortestpath((a:A)-[r]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
     result should equal(Set(List(nodeA, nodeB)))
   }
 
@@ -186,6 +187,6 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
                   |WITH pathNodes[0] AS p, pathNodes[3] as c
                   |RETURN length((c)-[:R]-(:B)-[:R]-(:B)-[:R]-(p)) AS res""".stripMargin
 
-    executeWithNewPlanner(query).toList should equal(List(Map("res" -> 1)))
+    executeWithAllPlanners(query).toList should equal(List(Map("res" -> 1)))
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/StartAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/StartAcceptanceTest.scala
@@ -23,7 +23,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   test("START r=rel(0) RETURN r") {
     val rel = relate(createNode(), createNode())
-    val result = execute("START r=rel(0) RETURN r").toList
+    val result = executeWithRulePlannerOnly("START r=rel(0) RETURN r").toList
 
     result should equal(List(Map("r"-> rel)))
   }
@@ -34,14 +34,14 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forRelationships("index").add(rel, "key", "value")
     }
 
-    val result = execute("""START r=rel:index(key = "value") RETURN r""").toList
+    val result = executeWithRulePlannerOnly("""START r=rel:index(key = "value") RETURN r""").toList
 
     result should equal(List(Map("r"-> rel)))
   }
 
   test("START n=node(0) RETURN n") {
     val node = createNode()
-    val result = execute("START n=node(0) RETURN n").toList
+    val result = executeWithRulePlannerOnly("START n=node(0) RETURN n").toList
 
     result should equal(List(Map("n"-> node)))
   }
@@ -52,7 +52,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forNodes("index").add(node, "key", "value")
     }
 
-    val result = executeWithNewPlanner("""START n=node:index(key = "value") RETURN n""").toList
+    val result = executeWithAllPlanners("""START n=node:index(key = "value") RETURN n""").toList
 
     result should equal(List(Map("n"-> node)))
   }
@@ -63,7 +63,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forRelationships("index").add(rel, "key", "value")
     }
 
-    val result = execute("""START r=rel:index("key:value") RETURN r""").toList
+    val result = executeWithRulePlannerOnly("""START r=rel:index("key:value") RETURN r""").toList
 
     result should equal(List(Map("r"-> rel)))
   }
@@ -74,7 +74,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forNodes("index").add(node, "key", "value")
     }
 
-    val result = executeWithNewPlanner("""START n=node:index("key:value") RETURN n""").toList
+    val result = executeWithAllPlanners("""START n=node:index("key:value") RETURN n""").toList
 
     result should equal(List(Map("n"-> node)))
   }
@@ -88,7 +88,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forNodes("index").add(otherNode, "key", "value")
     }
 
-    val result = executeWithNewPlanner("""START n=node:index("key:value") WHERE n.prop = 42 RETURN n""").toList
+    val result = executeWithAllPlanners("""START n=node:index("key:value") WHERE n.prop = 42 RETURN n""").toList
 
     result should equal(List(Map("n"-> node)))
   }
@@ -99,7 +99,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val c = createNode()
     val ab = relate(a, b)
     val ac = relate(a, c)
-    val result = execute(
+    val result = executeWithRulePlannerOnly(
       """start a=node(0), ab=relationship(0)
         |match (a)-[ab]->(b)
         |return b
@@ -114,7 +114,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val c = createNode()
     val ab = relate(a, b)
     val ac = relate(a, c)
-    val result = execute(
+    val result = executeWithRulePlannerOnly(
       """start a=node(0), b=node(1)
         |match (a)-[ab]->(b)
         |return b
@@ -133,7 +133,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val ac = relate(a, c)
     val bd = relate(b, d)
     val ce = relate(c, e)
-    val result = execute(
+    val result = executeWithRulePlannerOnly(
       """start a=node(0), ab=relationship(0), bd=relationship(2)
         |match (a)-[ab]->(b)-[bd]->(d)
         |return b, d
@@ -150,7 +150,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val ab = relate(a, b)
     val ac = relate(a, c)
     val ad = relate(a, d)
-    val result = execute(
+    val result = executeWithRulePlannerOnly(
       """start a=node(0), ab=relationship(0, 1)
         |match (a)-[ab]->(b)
         |return b
@@ -170,7 +170,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       graph.index.forRelationships("rels").add(rel, "key", "B")
     }
 
-    val result = execute("START n=node:nodes(key = 'A'), r=rel:rels(key = 'B') MATCH (n)-[r]->(b) RETURN b")
+    val result = executeWithRulePlannerOnly("START n=node:nodes(key = 'A'), r=rel:rels(key = 'B') MATCH (n)-[r]->(b) RETURN b")
     result.toList should equal(List(Map("b" -> resultNode)))
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/StartPointFindingAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/StartPointFindingAcceptanceTest.scala
@@ -26,7 +26,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
   test("Scan all nodes") {
     val nodes = Set(createNode("a"), createNode("b"), createNode("c"))
 
-    executeWithNewPlanner("match n return n").columnAs[Node]("n").toSet should equal(nodes)
+    executeWithAllPlanners("match n return n").columnAs[Node]("n").toSet should equal(nodes)
   }
 
   test("Scan labeled node") {
@@ -34,21 +34,21 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     createLabeledNode("Person")
     val animals = Set(createLabeledNode("Animal"), createLabeledNode("Animal"))
 
-    executeWithNewPlanner("match (n:Animal) return n").columnAs[Node]("n").toSet should equal(animals)
+    executeWithAllPlanners("match (n:Animal) return n").columnAs[Node]("n").toSet should equal(animals)
   }
 
   test("Seek node by id given on the left") {
     createNode("a")
     val node = createNode("b")
 
-    executeScalarWithNewPlanner[Node](s"match n where ${node.getId} = id(n) return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match n where ${node.getId} = id(n) return n") should equal(node)
   }
 
   test("Seek node by id given on the right") {
     createNode("a")
     val node = createNode("b")
 
-    executeScalarWithNewPlanner[Node](s"match n where id(n) = ${node.getId} return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match n where id(n) = ${node.getId} return n") should equal(node)
   }
 
   test("Seek node by id with multiple values") {
@@ -56,7 +56,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val n1= createNode("b")
     val n2 = createNode("c")
 
-    val result = executeWithNewPlanner(s"match n where id(n) IN [${n1.getId}, ${n2.getId}] return n")
+    val result = executeWithAllPlanners(s"match n where id(n) IN [${n1.getId}, ${n2.getId}] return n")
     result.columnAs("n").toList should equal(Seq(n1, n2))
   }
 
@@ -64,32 +64,32 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     createLabeledNode("Person")
     val node = createLabeledNode("Person")
 
-    executeScalarWithNewPlanner[Node](s"match n where n:Person and ${node.getId} = id(n) return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match n where n:Person and ${node.getId} = id(n) return n") should equal(node)
   }
 
   test("Can use both label scan (right) and node by id (left) when there are no indices") {
     createLabeledNode("Person")
     val node = createLabeledNode("Person")
 
-    executeScalarWithNewPlanner[Node](s"match n where ${node.getId} = id(n) and n:Person return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match n where ${node.getId} = id(n) and n:Person return n") should equal(node)
   }
 
   test("Can find nodes by id and apply a predicate on it") {
     createNode("prop"->1)
     val n = createNode("prop"->2)
-    executeScalarWithNewPlanner[Node](s"match n where n.prop = 2 return n") should equal(n)
+    executeScalarWithAllPlanners[Node](s"match n where n.prop = 2 return n") should equal(n)
   }
 
   test("Seek relationship by id given on the left") {
     val rel = relate(createNode("a"), createNode("b"))
 
-    executeScalarWithNewPlanner[Node](s"match ()-[r]->() where ${rel.getId} = id(r) return r") should equal(rel)
+    executeScalarWithAllPlanners[Node](s"match ()-[r]->() where ${rel.getId} = id(r) return r") should equal(rel)
   }
 
   test("Seek relationship by id given on the right") {
     val rel = relate(createNode("a"), createNode("b"))
 
-    executeScalarWithNewPlanner[Node](s"match ()-[r]->() where id(r) = ${rel.getId} return r") should equal(rel)
+    executeScalarWithAllPlanners[Node](s"match ()-[r]->() where id(r) = ${rel.getId} return r") should equal(rel)
   }
 
   test("Seek relationship by id with multiple values") {
@@ -97,7 +97,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val rel1 = relate(createNode("a"), createNode("b"))
     val rel2 = relate(createNode("c"), createNode("d"))
 
-    val result = executeWithNewPlanner(s"match ()-[r]->() where id(r) IN [${rel1.getId}, ${rel2.getId}] return r")
+    val result = executeWithAllPlanners(s"match ()-[r]->() where id(r) IN [${rel1.getId}, ${rel2.getId}] return r")
     result.columnAs("r").toList should equal(Seq(rel1, rel2))
   }
 
@@ -106,7 +106,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val b = createNode("x")
     val r = relate(a, b)
 
-    val result = executeWithNewPlanner(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
+    val result = executeWithAllPlanners(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
     result.toList should equal(List(
       Map("r" -> r, "a" -> a, "b" -> b),
       Map("r" -> r, "a" -> b, "b" -> a)))
@@ -115,7 +115,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
   test("Seek relationship by id with type that is not matching") {
     val r = relate(createNode("x"), createNode("y"), "FOO")
 
-    val result = executeWithNewPlanner(s"match ()-[r:BAR]-() where id(r) = ${r.getId} return r")
+    val result = executeWithAllPlanners(s"match ()-[r:BAR]-() where id(r) = ${r.getId} return r")
     result.toList shouldBe empty
   }
 
@@ -124,7 +124,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     graph.createIndex("Person", "prop")
 
     val node = createLabeledNode(Map("prop" -> 42), "Person")
-    executeScalarWithNewPlanner[Node](s"match (n:Person) where n.prop = 42 return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match (n:Person) where n.prop = 42 return n") should equal(node)
   }
 
   test("Scan index with property given in node pattern") {
@@ -132,7 +132,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     graph.createIndex("Person", "prop")
 
     val node = createLabeledNode(Map("prop" -> 42), "Person")
-    executeScalarWithNewPlanner[Node](s"match (n:Person {prop: 42}) return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match (n:Person {prop: 42}) return n") should equal(node)
   }
 
   test("Seek index with property given in where") {
@@ -140,7 +140,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     graph.createConstraint("Person", "prop")
 
     val node = createLabeledNode(Map("prop" -> 42), "Person")
-    executeScalarWithNewPlanner[Node](s"match (n:Person) where n.prop = 42 return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match (n:Person) where n.prop = 42 return n") should equal(node)
   }
 
   test("Seek index with property given in node pattern") {
@@ -148,7 +148,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     graph.createConstraint("Person", "prop")
 
     val node = createLabeledNode(Map("prop" -> 42), "Person")
-    executeScalarWithNewPlanner[Node](s"match (n:Person {prop: 42}) return n") should equal(node)
+    executeScalarWithAllPlanners[Node](s"match (n:Person {prop: 42}) return n") should equal(node)
   }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher
 class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
   test("should be able to create text output from union queries") {
     // When
-    val result = execute("merge (a) return a union merge (a) return a")
+    val result = executeWithRulePlannerOnly("merge (a) return a union merge (a) return a")
 
     // Then
     result.columns should not be empty
@@ -30,7 +30,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("two elements, both unique, not distinct") {
     // When
-    val result = executeWithNewPlanner("return 1 as x union all return 2 as x")
+    val result = executeWithAllPlanners("return 1 as x union all return 2 as x")
 
     // Then
     result.columns should not be empty
@@ -39,7 +39,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("two elements, both unique, distinct") {
     // When
-    val result = executeWithNewPlanner("return 1 as x union return 2 as x")
+    val result = executeWithAllPlanners("return 1 as x union return 2 as x")
 
     // Then
     result.columns should not be empty
@@ -51,7 +51,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("three elements, two unique, distinct") {
     // When
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       """return 2 as x
         |union
         |return 1 as x
@@ -67,7 +67,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("three elements, two unique, not distinct") {
     // When
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       """return 2 as x
         |union all
         |return 1 as x

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnwindAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnwindAcceptanceTest.scala
@@ -26,7 +26,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
 
   test("unwind collection returns individual values") {
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND [1,2,3] as x return x"
     )
     result.columnAs[Int]("x").toList should equal(List(1, 2, 3))
@@ -34,14 +34,14 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
 
   test("unwind a range") {
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND RANGE(1,3) as x return x"
     )
     result.columnAs[Int]("x").toList should equal(List(1, 2, 3))
   }
   test("unwind a concatenation of collections") {
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "WITH [1,2,3] AS first, [4,5,6] AS second UNWIND (first + second) as x return x"
     )
     result.columnAs[Int]("x").toList should equal(List(1, 2, 3, 4, 5, 6))
@@ -49,7 +49,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
 
   test("unwind a collected unwound expression") {
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND RANGE(1,2) AS row WITH collect(row) as rows UNWIND rows as x return x"
     )
     result.columnAs[Int]("x").toList should equal(List(1, 2))
@@ -59,7 +59,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
     val a = createLabeledNode(Map("id" -> 1))
     val b = createLabeledNode(Map("id" -> 2))
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (row) WITH collect(row) AS rows UNWIND rows AS node RETURN node"
     )
     result.columnAs[Node]("node").toList should equal(List(a, b))
@@ -68,7 +68,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
   test("create nodes from a collection parameter") {
     createLabeledNode(Map("year" -> 2014), "Year")
 
-    val result = execute(
+    val result = executeWithRulePlannerOnly(
       "UNWIND {events} as event MATCH (y:Year {year:event.year}) MERGE (y)<-[:IN]-(e:Event {id:event.id}) RETURN e.id as x order by x",
       "events" -> List(Map("year" -> 2014, "id" -> 1), Map("year" -> 2014, "id" -> 2))
     )
@@ -76,35 +76,35 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
   }
 
   test("double unwinding a collection of collections returns one row per item") {
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "WITH [[1,2,3], [4,5,6]] AS coc UNWIND coc AS x UNWIND x AS y RETURN y"
     )
     result.columnAs[Int]("y").toList should equal(List(1, 2, 3, 4, 5, 6))
   }
 
   test("no rows for unwinding an empty collection") {
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND [] AS empty RETURN empty"
     )
     result.columnAs[Int]("empty").toList should equal(List())
   }
 
   test("no rows for unwinding null") {
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND null AS empty RETURN empty"
     )
     result.columnAs[Int]("empty").toList should equal(List())
   }
 
   test("one row per item of a collection even with duplicates") {
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "UNWIND [1,1,2,2,3,3,4,4,5,5] AS duplicate RETURN duplicate"
     )
     result.columnAs[Int]("duplicate").toList should equal(List(1, 1, 2, 2, 3, 3, 4, 4, 5, 5))
   }
 
   test("unwind does not remove anything from the context") {
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "WITH [1,2,3] as collection UNWIND collection AS x RETURN *"
     )
     result.toList should equal(List(
@@ -121,7 +121,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
     relate(s1, n2, "Y")
     relate(createNode(), n2, "Y")
 
-    val result = executeWithNewPlanner("""MATCH (a:Start)-[:X]->(b1)
+    val result = executeWithAllPlanners("""MATCH (a:Start)-[:X]->(b1)
                                          |WITH a, COLLECT(b1) AS bees
                                          |UNWIND bees as b2
                                          |MATCH (a)-[:Y]->(b2)
@@ -131,7 +131,7 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
 
   test("multiple unwinds after each other work like expected") {
     val result =
-      executeWithNewPlanner( """WITH [1,2] as XS, [3,4] as YS, [5,6] as ZS
+      executeWithAllPlanners( """WITH [1,2] as XS, [3,4] as YS, [5,6] as ZS
                              |UNWIND XS as X
                              |UNWIND YS as Y
                              |UNWIND ZS as Z

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UpdateReportingAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UpdateReportingAcceptanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher
 
 class UpdateReportingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
   test("creating a node gets reported as such") {
-    val output = execute("create (:A)").dumpToString()
+    val output = executeWithRulePlannerOnly("create (:A)").dumpToString()
 
     output should include ("Nodes created: 1")
     output should include ("Labels added: 1")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
@@ -28,7 +28,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN & THEN
     intercept[SyntaxException](
-      executeWithNewPlanner("start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n"))
+      executeWithAllPlanners("start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n"))
   }
 
   test("fail if using an identifier with label not used in match") {
@@ -37,7 +37,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match n-->() using index n:Person(name) where n.name = 'kabam' return n"))
+      executeWithAllPlanners("match n-->() using index n:Person(name) where n.name = 'kabam' return n"))
   }
 
   test("fail if using an hint for a non existing index") {
@@ -45,7 +45,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN
     intercept[IndexHintException](
-      executeWithNewPlanner("match (n:Person)-->() using index n:Person(name) where n.name = 'kabam' return n"))
+      executeWithAllPlanners("match (n:Person)-->() using index n:Person(name) where n.name = 'kabam' return n"))
   }
 
   test("fail if using hints with unusable equality predicate") {
@@ -54,7 +54,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match (n:Person)-->() using index n:Person(name) where n.name <> 'kabam' return n"))
+      executeWithAllPlanners("match (n:Person)-->() using index n:Person(name) where n.name <> 'kabam' return n"))
   }
 
   test("fail if joining index hints in equality predicates") {
@@ -64,11 +64,11 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name = m.name return n"))
+      executeWithAllPlanners("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name = m.name return n"))
   }
 
   test("scan hints are handled by ronja") {
-    executeWithNewPlanner("match (n:Person) using scan n:Person return n").toList
+    executeWithAllPlanners("match (n:Person) using scan n:Person return n").toList
   }
 
   test("fail when equality checks are done with OR") {
@@ -77,7 +77,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match n-->() using index n:Person(name) where n.name = 'kabam' OR n.name = 'kaboom' return n"))
+      executeWithAllPlanners("match n-->() using index n:Person(name) where n.name = 'kabam' OR n.name = 'kaboom' return n"))
   }
 
   test("should be able to use index hints on IN expressions") {
@@ -90,7 +90,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWithNewPlanner("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob'] RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob'] RETURN n")
 
     //THEN
     result.toList should equal (List(Map("n" -> jake)))
@@ -106,7 +106,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWithNewPlanner("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob','Jacob'] RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob','Jacob'] RETURN n")
 
     //THEN
     result.toList should equal (List(Map("n" -> jake)))
@@ -122,7 +122,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWithNewPlanner("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN [] RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN [] RETURN n")
 
     //THEN
     result.toList should equal (List())
@@ -138,7 +138,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWithNewPlanner("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN null RETURN n")
+    val result = executeWithAllPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN null RETURN n")
 
     //THEN
     result.toList should equal (List())
@@ -154,7 +154,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWithNewPlanner("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} RETURN n","coll"->List("Jacob"))
+    val result = executeWithAllPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} RETURN n","coll"->List("Jacob"))
 
     //THEN
     result.toList should equal (List(Map("n" -> jake)))
@@ -169,7 +169,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     // WHEN THEN
     val e = intercept[SyntaxException] {
-      executeWithNewPlanner(
+      executeWithAllPlanners(
         "MATCH (n:Entity:Person) " +
           "USING INDEX n:Person(first_name) " +
           "USING INDEX n:Entity(source) " +
@@ -183,7 +183,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("does not accept multiple scan hints for the same identifier") {
     val e = intercept[SyntaxException] {
-      executeWithNewPlanner(
+      executeWithAllPlanners(
         "MATCH (n:Entity:Person) " +
           "USING SCAN n:Person " +
           "USING SCAN n:Entity " +
@@ -197,7 +197,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
   test("does not accept multiple mixed hints for the same identifier") {
     val e = intercept[SyntaxException] {
-      executeWithNewPlanner(
+      executeWithAllPlanners(
         "MATCH (n:Entity:Person) " +
           "USING SCAN n:Person " +
           "USING INDEX n:Entity(first_name) " +

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
@@ -27,7 +27,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN & THEN
     intercept[SyntaxException](
-      executeWithNewPlanner("start n=node(*) using index n:Person(name) where n:Person and n.name IN ['kabam'] return n"))
+      executeWithAllPlanners("start n=node(*) using index n:Person(name) where n:Person and n.name IN ['kabam'] return n"))
   }
 
   test("fail if using an identifier with label not used in match") {
@@ -36,7 +36,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match n-->() using index n:Person(name) where n.name IN ['kabam'] return n"))
+      executeWithAllPlanners("match n-->() using index n:Person(name) where n.name IN ['kabam'] return n"))
   }
 
   test("fail if using an hint for a non existing index") {
@@ -44,7 +44,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN
     intercept[IndexHintException](
-      executeWithNewPlanner("match (n:Person)-->() using index n:Person(name) where n.name IN ['kabam'] return n"))
+      executeWithAllPlanners("match (n:Person)-->() using index n:Person(name) where n.name IN ['kabam'] return n"))
   }
 
   test("fail if using hints with unusable equality predicate") {
@@ -53,7 +53,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match (n:Person)-->() using index n:Person(name) where NOT (n.name IN ['kabam']) return n"))
+      executeWithAllPlanners("match (n:Person)-->() using index n:Person(name) where NOT (n.name IN ['kabam']) return n"))
   }
 
   test("fail if joining index hints in equality predicates") {
@@ -63,7 +63,7 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name IN [m.name] return n"))
+      executeWithAllPlanners("match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name IN [m.name] return n"))
   }
 
   test("fail when equality checks are done with OR") {
@@ -72,6 +72,6 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
 
     // WHEN
     intercept[SyntaxException](
-      executeWithNewPlanner("match n-->() using index n:Person(name) where n.name IN ['kabam'] OR n.name = 'kaboom' return n"))
+      executeWithAllPlanners("match n-->() using index n:Person(name) where n.name IN ['kabam'] OR n.name = 'kaboom' return n"))
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/WithAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/WithAcceptanceTest.scala
@@ -26,7 +26,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     val b = createNode()
     relate(a, b)
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH a WITH a MATCH a-->b RETURN *"
     )
     result.toList should equal(List(Map("a" -> a, "b" -> b)))
@@ -39,7 +39,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
 
     relate(a,createNode())
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH a WITH a ORDER BY a.name LIMIT 1 MATCH a-->b RETURN a"
     )
     result.toList should equal(List(Map("a" -> a)))
@@ -49,7 +49,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     val a = createNode()
     val b = createNode()
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH a WITH a MATCH b RETURN *"
     )
     result.toSet should equal(Set(
@@ -65,7 +65,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     val b = createLabeledNode(Map("prop"->42), "End")
     createLabeledNode(Map("prop"->3), "End")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a:Start) WITH a.prop AS property MATCH (b:End) WHERE property = b.prop RETURN b"
     )
     result.toSet should equal(Set(Map("b" -> b)))
@@ -76,7 +76,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     createLabeledNode(Map("prop" -> 3), "End")
     createLabeledNode(Map("prop" -> b.getId), "Start")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a:Start) WITH a.prop AS property LIMIT 1 MATCH (b) WHERE id(b) = property RETURN b"
     )
     result.toSet should equal(Set(Map("b" -> b)))
@@ -87,7 +87,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     createNode("prop" -> "B", "id" -> a.getId)
     createNode("prop" -> "C", "id" -> 0)
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       """MATCH (a)
         |WITH a.prop AS property, a.id as idToUse
         |ORDER BY property
@@ -104,7 +104,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     val b = createNode("B")
     createNode("C")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a) WITH a WHERE a.name = 'B' RETURN a"
     )
     result.toSet should equal(Set(Map("a" -> b)))
@@ -119,7 +119,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     relate(a, createNode())
     relate(b, createNode())
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a)-->() WITH a, count(*) as relCount WHERE relCount > 1 RETURN a"
     )
     result.toSet should equal(Set(Map("a" -> a)))
@@ -130,7 +130,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     createNode("bar" -> "A")
     createNode("bar" -> "B")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a) WITH a.bar as bars, count(*) as relCount ORDER BY a.bar RETURN *"
     )
 
@@ -142,7 +142,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     createNode("bar" -> "A")
     createNode("bar" -> "B")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a) WITH DISTINCT a.bar as bars ORDER BY a.bar RETURN *"
     )
 
@@ -154,7 +154,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     createNode("bar" -> "A")
     createNode("bar" -> "B")
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "MATCH (a) WITH DISTINCT a.bar as bars WHERE a.bar = 'B' RETURN *"
     )
 
@@ -166,7 +166,7 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     val node2 = createNode()
     val rel = relate(node1, node2)
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "WITH {a} AS b, {b} AS tmp, {r} AS r WITH b AS a, r LIMIT 1 MATCH (a)-[r]->(b) RETURN a, r, b",
       "a" -> node1, "b" -> node2, "r" -> rel
     )
@@ -177,12 +177,12 @@ class WithAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
   }
 
   test("nulls passing through WITH") {
-    executeWithNewPlanner("optional match (a:Start) with a match a-->b return *") should be (empty)
+    executeWithAllPlanners("optional match (a:Start) with a match a-->b return *") should be (empty)
   }
 
   test("WITH {foo: {bar: 'baz'}} AS nestedMap RETURN nestedMap.foo.bar") {
 
-    val result = executeWithNewPlanner(
+    val result = executeWithAllPlanners(
       "WITH {foo: {bar: 'baz'}} AS nestedMap RETURN nestedMap.foo.bar"
     )
     result.toSet should equal(Set(Map("nestedMap.foo.bar" -> "baz")))


### PR DESCRIPTION
This is pretty much a backport of https://github.com/neo4j/neo4j/pull/4388 except it does not include compiled runtime.
Forward merge should be a null-merge.
