### PR TITLE
Throw descriptive exception when giving page cache fewer than 2 pages

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -219,6 +219,7 @@ public class MuninnPageCache implements PageCache
     {
         verifyHacks();
         verifyCachePageSizeIsPowerOfTwo( cachePageSize );
+        verifyMinimumPageCount( maxPages, cachePageSize );
 
         this.pageCacheId = pageCacheIdCounter.incrementAndGet();
         this.swapperFactory = swapperFactory;
@@ -273,6 +274,17 @@ public class MuninnPageCache implements PageCache
         {
             throw new IllegalArgumentException(
                     "Cache page size must be a power of two, but was " + cachePageSize );
+        }
+    }
+
+    private static void verifyMinimumPageCount( int maxPages, int cachePageSize )
+    {
+        int minimumPageCount = 2;
+        if ( maxPages < minimumPageCount )
+        {
+            throw new IllegalArgumentException( String.format(
+                    "Page cache must have at least %s pages (%s bytes of memory), but was given %s pages.",
+                    minimumPageCount, minimumPageCount * cachePageSize, maxPages ) );
         }
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -101,9 +101,8 @@ public abstract class PageCacheTest<T extends PageCache>
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
+    protected static final File file = new File( "a" );
     protected static ExecutorService executor;
-
-    protected final File file = new File( "a" );
 
     protected int recordSize = 9;
     protected int maxPages = 20;
@@ -326,6 +325,18 @@ public abstract class PageCacheTest<T extends PageCache>
     public void cachePageSizeMustBePowerOfTwo() throws IOException
     {
         getPageCache( fs, maxPages, 31, PageCacheTracer.NULL );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void mustHaveAtLeastTwoPages() throws Exception
+    {
+        getPageCache( fs, 1, pageCachePageSize, PageCacheTracer.NULL );
+    }
+
+    @Test
+    public void mustAcceptTwoPagesAsMinimumConfiguration() throws Exception
+    {
+        getPageCache( fs, 2, pageCachePageSize, PageCacheTracer.NULL );
     }
 
     @Test( timeout = 1000 )

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -210,6 +210,7 @@ public abstract class GraphDatabaseSettings
     @Internal
     public static final Setting<Long> mapped_memory_page_size = setting( "dbms.pagecache.pagesize", BYTES, "8192" );
 
+    @SuppressWarnings( "unchecked" )
     @Description( "The amount of memory to use for mapping the store files, in bytes (or kilobytes with the 'k' " +
                   "suffix, megabytes with 'm' and gigabytes with 'g'). If Neo4j is running on a dedicated server, " +
                   "then it is generally recommended to leave about 2-4 gigabytes for the operating system, give the " +
@@ -217,7 +218,7 @@ public abstract class GraphDatabaseSettings
                   "the page cache. The default page cache memory assumes the machine is dedicated to running " +
                   "Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size." )
     public static final Setting<Long> pagecache_memory =
-            setting( "dbms.pagecache.memory", BYTES, defaultPageCacheMemory() );
+            setting( "dbms.pagecache.memory", BYTES, defaultPageCacheMemory(), min( 8192 * 2L ) );
 
     private static String defaultPageCacheMemory()
     {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -21,6 +21,7 @@ package org.neo4j.graphdb.factory;
 
 import org.junit.Test;
 
+import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.configuration.Config;
 
@@ -48,7 +49,17 @@ public class GraphDatabaseSettingsTest
     {
         Setting<Long> setting = GraphDatabaseSettings.pagecache_memory;
         String name = setting.name();
-        assertThat( new Config( stringMap( name, "244" ) ).get( setting ), is( 244L ) );
+        assertThat( new Config( stringMap( name, "16384" ) ).get( setting ), is( 16 * KiB ) );
         assertThat( new Config( stringMap( name, "2244g" ) ).get( setting ), is( 2244 * GiB ) );
+    }
+
+    @Test( expected = InvalidSettingException.class )
+    public void pageCacheSettingMustRejectOverlyConstrainedMemorySetting() throws Exception
+    {
+        long pageSize = new Config().get( GraphDatabaseSettings.mapped_memory_page_size );
+        Setting<Long> setting = GraphDatabaseSettings.pagecache_memory;
+        String name = setting.name();
+        // We configure the page cache to have one byte less than two pages worth of memory. This must throw:
+        new Config( stringMap( name, "" + (pageSize * 2 - 1) ) ).get( setting );
     }
 }


### PR DESCRIPTION
This is useful for the case where people think they can disable memory mapping by setting the page cache size to 0.
