### PR TITLE
Use index seek in rule planner when asked for

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
@@ -95,11 +95,16 @@ sealed abstract class SchemaIndexKind
 case object AnyIndex extends SchemaIndexKind
 case object UniqueIndex extends SchemaIndexKind
 
-trait QueryExpression[T] {
+trait QueryExpression[+T] {
   def expression: T
 
   def map[R](f: T => R): QueryExpression[R]
 }
+
+case class ScanQueryExpression[T](expression: T) extends QueryExpression[T] {
+  def map[R](f: (T) => R) = ScanQueryExpression(f(expression))
+}
+
 case class SingleQueryExpression[T](expression: T) extends QueryExpression[T] {
   def map[R](f: (T) => R) = SingleQueryExpression(f(expression))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/IndexLookupBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/IndexLookupBuilder.scala
@@ -69,7 +69,10 @@ class IndexLookupBuilder extends PlanBuilder {
 
       case predicate@QueryToken(AnyInCollection(expression, _, Equals(Property(Identifier(id), prop),Identifier(_))))
         if id == hint.identifier && prop.name == hint.property => (predicate, ManyQueryExpression(expression))
-    }
+
+      case predicate@QueryToken(PropertyExists(expr@Identifier(id), prop))
+        if id == hint.identifier && prop.name == hint.property => (predicate, ScanQueryExpression(expr))
+  }
 
   private def extractInterestingStartItem(plan: ExecutionPlanInProgress): QueryToken[SchemaIndex] =
     plan.query.start.filter(interestingFilter).head.asInstanceOf[QueryToken[SchemaIndex]]

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -1283,7 +1283,6 @@ return b
     val n = createLabeledNode(Map("email" -> "me@mine"), "User")
     val m = createLabeledNode(Map("email" -> "you@yours"), "User")
     val p = createLabeledNode(Map("emailx" -> "youtoo@yours"), "User")
-//    (1 to 100).foreach(e => createLabeledNode("User"))
     graph.createIndex("User", "email")
 
     // when
@@ -1292,6 +1291,36 @@ return b
     // then
     result.toList should equal(List(Map("n" -> n), Map("n" -> m)))
     result.executionPlanDescription().toString should include("NodeIndexScan")
+  }
+
+  test("should use the index for property existance queries for rule when asked for it") {
+    // given
+    val n = createLabeledNode(Map("email" -> "me@mine"), "User")
+    val m = createLabeledNode(Map("email" -> "you@yours"), "User")
+    val p = createLabeledNode(Map("emailx" -> "youtoo@yours"), "User")
+    graph.createIndex("User", "email")
+
+    // when
+    val result = eengine.execute("CYPHER planner=rule MATCH (n:User) USING INDEX n:User(email) WHERE has(n.email) RETURN n")
+
+    // then
+    result.toList should equal(List(Map("n" -> n), Map("n" -> m)))
+    result.executionPlanDescription().toString should include("SchemaIndex")
+  }
+
+  test("should not use the index for property existance queries for rule when not asking for it") {
+    // given
+    val n = createLabeledNode(Map("email" -> "me@mine"), "User")
+    val m = createLabeledNode(Map("email" -> "you@yours"), "User")
+    val p = createLabeledNode(Map("emailx" -> "youtoo@yours"), "User")
+    graph.createIndex("User", "email")
+
+    // when
+    val result = eengine.execute("CYPHER planner=rule MATCH (n:User) WHERE has(n.email) RETURN n")
+
+    // then
+    result.toList should equal(List(Map("n" -> n), Map("n" -> m)))
+    result.executionPlanDescription().toString should not include("SchemaIndex")
   }
 
   test("should handle cyclic patterns") {


### PR DESCRIPTION
Rule planner uses index seeks when explicitly asked for. For example
`MATCH (n:User) USING INDEX n:User(email) WHERE has(n.email) RETURN n'
will now not fail when using the rule planner.
