### PR TITLE
Fixes IdMapper problem for anonymous nodes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -77,8 +77,7 @@ public class ParallelSort
             threadsNeeded++;
         }
         CountDownLatch waitSignal = new CountDownLatch( 1 );
-        CountDownLatch doneSignal = new CountDownLatch( threadsNeeded );
-        SortWorker[] sortWorker = new SortWorker[threadsNeeded];
+        Workers<SortWorker> sortWorkers = new Workers<>( "SortWorker" );
         progress.started( "SORT" );
         for ( int i = 0; i < threadsNeeded; i++ )
         {
@@ -86,13 +85,12 @@ public class ParallelSort
             {
                 break;
             }
-            sortWorker[i] = new SortWorker( i, sortParams[i][0], sortParams[i][1], waitSignal, doneSignal );
-            sortWorker[i].start();
+            sortWorkers.start( new SortWorker( sortParams[i][0], sortParams[i][1], waitSignal ) );
         }
         waitSignal.countDown();
         try
         {
-            doneSignal.await();
+            sortWorkers.awaitAndThrowOnError();
         }
         finally
         {
@@ -105,7 +103,7 @@ public class ParallelSort
     {
         int[][] rangeParams = new int[threads][2];
         int[] bucketRange = new int[threads];
-        TrackerInitializer[] initializers = new TrackerInitializer[threads];
+        Workers<TrackerInitializer> initializers = new Workers<>( "TrackerInitializer" );
         sortBuckets = new long[threads][2];
         int bucketSize = safeCastLongToInt( dataStats.size() / threads );
         int count = 0, fullCount = 0 + 0;
@@ -131,9 +129,9 @@ public class ParallelSort
                     fullCount += radixIndexCount[i];
                     progress.add( radixIndexCount[i] );
                 }
-                initializers[threadIndex] = new TrackerInitializer( threadIndex, rangeParams[threadIndex],
+                initializers.start( new TrackerInitializer( threadIndex, rangeParams[threadIndex],
                         threadIndex > 0 ? bucketRange[threadIndex-1] : -1, bucketRange[threadIndex],
-                        sortBuckets[threadIndex] );
+                        sortBuckets[threadIndex] ) );
                 threadIndex++;
             }
             else
@@ -145,9 +143,9 @@ public class ParallelSort
                 bucketRange[threadIndex] = radixIndexCount.length;
                 rangeParams[threadIndex][0] = fullCount;
                 rangeParams[threadIndex][1] = safeCastLongToInt( dataStats.size() - fullCount );
-                initializers[threadIndex] = new TrackerInitializer( threadIndex, rangeParams[threadIndex],
+                initializers.start( new TrackerInitializer( threadIndex, rangeParams[threadIndex],
                         threadIndex > 0 ? bucketRange[threadIndex-1] : -1, bucketRange[threadIndex],
-                        sortBuckets[threadIndex] );
+                        sortBuckets[threadIndex] ) );
                 break;
             }
         }
@@ -156,23 +154,15 @@ public class ParallelSort
         // In the loop above where we split up radixes into buckets, we start one thread per bucket whose
         // job is to populate trackerCache and sortBuckets where each thread will not touch the same
         // data indexes as any other thread. Here we wait for them all to finish.
+        Throwable error = initializers.await();
         int[] bucketIndex = new int[threads];
-        Throwable error = null;
         long highestIndex = -1, size = 0;
-        for ( int i = 0; i < initializers.length; i++ )
+        int i = 0;
+        for ( TrackerInitializer initializer : initializers )
         {
-            TrackerInitializer initializer = initializers[i];
-            if ( initializer != null )
-            {
-                Throwable initializerError = initializer.await();
-                if ( initializerError != null )
-                {
-                    error = initializerError;
-                }
-                bucketIndex[i] = initializer.bucketIndex;
-                highestIndex = max( highestIndex, initializer.highestIndex );
-                size += initializer.size;
-            }
+            bucketIndex[i++] = initializer.bucketIndex;
+            highestIndex = max( highestIndex, initializer.highestIndex );
+            size += initializer.size;
         }
         trackerStats.set( size, highestIndex );
         if ( error != null )
@@ -267,20 +257,17 @@ public class ParallelSort
      * instead trackerCache is updated to point to the right indexes. Only touches a designated part of trackerCache
      * so that many can run in parallel on their own part without synchronization.
      */
-    private class SortWorker extends Thread
+    private class SortWorker implements Runnable
     {
         private final int start, size;
-        private final CountDownLatch doneSignal, waitSignal;
-        private int workerId = -1;
+        private final CountDownLatch waitSignal;
         private int threadLocalProgress;
 
-        SortWorker( int workerId, int startRange, int size, CountDownLatch wait, CountDownLatch done )
+        SortWorker( int startRange, int size, CountDownLatch wait )
         {
             this.start = startRange;
             this.size = size;
-            this.doneSignal = done;
             this.waitSignal = wait;
-            this.workerId = workerId;
         }
 
         void incrementProgress( int diff )
@@ -302,7 +289,6 @@ public class ParallelSort
         public void run()
         {
             Random random = ThreadLocalRandom.current();
-            this.setName( "SortWorker-" + workerId );
             try
             {
                 waitSignal.await();
@@ -313,7 +299,6 @@ public class ParallelSort
             }
             recursiveQsort( start, start + size, random, this );
             reportProgress();
-            doneSignal.countDown();
         }
     }
 
@@ -321,7 +306,7 @@ public class ParallelSort
      * Sets the initial tracker indexes pointing to data indexes. Only touches a designated part of trackerCache
      * so that many can run in parallel on their own part without synchronization.
      */
-    private class TrackerInitializer extends Thread
+    private class TrackerInitializer implements Runnable
     {
         private final int[] rangeParams;
         private final int lowBucketRange;
@@ -329,7 +314,6 @@ public class ParallelSort
         private final int threadIndex;
         private int bucketIndex;
         private final long[] result;
-        private volatile Throwable error;
         private long highestIndex = -1;
         private long size;
 
@@ -340,46 +324,32 @@ public class ParallelSort
             this.lowBucketRange = lowBucketRange;
             this.highBucketRange = highBucketRange;
             this.result = result;
-            start();
         }
 
         @Override
         public void run()
         {
-            try
+            long max = dataStats.highestIndex();
+            for ( long i = 0; i <= max; i++ )
             {
-                long dataSize = dataStats.size();
-                for ( long i = 0; i < dataSize; i++ )
+                int rIndex = radixCalculator.radixOf( dataCache.get( i ) );
+                if ( rIndex > lowBucketRange && rIndex <= highBucketRange )
                 {
-                    int rIndex = radixCalculator.radixOf( dataCache.get( i ) );
-                    if ( rIndex > lowBucketRange && rIndex <= highBucketRange )
+                    long temp = (rangeParams[0] + bucketIndex++);
+                    assert tracker.get( temp ) == -1 : "Overlapping buckets i:" + i + ", k:" + threadIndex;
+                    tracker.set( temp, (int) i );
+                    if ( bucketIndex == rangeParams[1] )
                     {
-                        long temp = (rangeParams[0] + bucketIndex++);
-                        assert tracker.get( temp ) == -1 : "Overlapping buckets i:" + i + ", k:" + threadIndex;
-                        tracker.set( temp, (int) i );
-                        if ( bucketIndex == rangeParams[1] )
-                        {
-                            result[0] = highBucketRange;
-                            result[1] = rangeParams[0];
-                        }
+                        result[0] = highBucketRange;
+                        result[1] = rangeParams[0];
                     }
                 }
-                if ( bucketIndex > 0 )
-                {
-                    highestIndex = rangeParams[0] + bucketIndex - 1;
-                }
-                size = bucketIndex;
             }
-            catch ( Throwable t )
+            if ( bucketIndex > 0 )
             {
-                error = t;
+                highestIndex = rangeParams[0] + bucketIndex - 1;
             }
-        }
-
-        private synchronized Throwable await() throws InterruptedException
-        {
-            join();
-            return error;
+            size = bucketIndex;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.neo4j.function.Function;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.collection.Iterables;
+
+/**
+ * Utility for running a hand ful of {@link Runnable} in parallel, each in its own thread.
+ * {@link Runnable} instances are {@link #start(Runnable) added and started} and the caller can
+ * {@link #await()} them all to finish, returning a {@link Throwable error} if any thread encountered one so
+ * that the caller can decide how to handle that error. Or caller can use {@link #awaitAndThrowOnError()}
+ * where error from any worker would be thrown from that method.
+ *
+ * It's basically like using an {@link ExecutorService}, but without that "baggage" and an easier usage
+ * and less code in the scenario described above.
+ */
+public class Workers<R extends Runnable> implements Iterable<R>
+{
+    private final List<Worker> workers = new ArrayList<>();
+    private final String names;
+
+    public Workers( String names )
+    {
+        this.names = names;
+    }
+
+    /**
+     * Starts a thread to run {@code toRun}.
+     */
+    public void start( R toRun )
+    {
+        Worker worker = new Worker( names + "-" + workers.size(), toRun );
+        worker.start();
+        workers.add( worker );
+    }
+
+    public Throwable await() throws InterruptedException
+    {
+        Throwable error = null;
+        for ( Worker worker : workers )
+        {
+            Throwable anError = worker.await();
+            if ( error == null )
+            {
+                error = anError;
+            }
+        }
+        return error;
+    }
+
+    public <EXCEPTION extends Throwable> void awaitAndThrowOnError( Class<EXCEPTION> launderingException )
+            throws EXCEPTION, InterruptedException
+    {
+        Throwable error = await();
+        if ( error != null )
+        {
+            throw Exceptions.launderedException( launderingException, error );
+        }
+    }
+
+    public void awaitAndThrowOnError() throws InterruptedException
+    {
+        Throwable error = await();
+        if ( error != null )
+        {
+            throw Exceptions.launderedException( error );
+        }
+    }
+
+    @Override
+    public Iterator<R> iterator()
+    {
+        return Iterables.map( new Function<Worker,R>()
+        {
+            @Override
+            public R apply( Worker worker ) throws RuntimeException
+            {
+                return worker.toRun;
+            }
+        }, workers.iterator() );
+    }
+
+    private class Worker extends Thread
+    {
+        private volatile Throwable error;
+        private final R toRun;
+
+        Worker( String name, R toRun )
+        {
+            super( name );
+            this.toRun = toRun;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                toRun.run();
+            }
+            catch ( Throwable t )
+            {
+                error = t;
+                throw Exceptions.launderedException( t );
+            }
+        }
+
+        protected synchronized Throwable await() throws InterruptedException
+        {
+            join();
+            return error;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -435,6 +435,41 @@ public class EncodingIdMapperTest
         }
     }
 
+    @Test
+    public void shouldHandleHolesInIdSequence() throws Exception
+    {
+        // GIVEN
+        IdMapper mapper = new EncodingIdMapper( NumberArrayFactory.HEAP,
+                new LongEncoder(), new Radix.Long(), NO_MONITOR );
+        List<Object> ids = new ArrayList<>();
+        int skip = 1;
+        for ( int i = 0; i < 100; i += 2 )
+        {
+            if ( i > 0 && i%skip == 0 )
+            {
+                skip++;
+                if ( skip == 10 )
+                {
+                    skip = 1;
+                }
+            }
+            else
+            {
+                Long id = (long) i;
+                ids.add( id );
+                mapper.put( id, i, GLOBAL );
+            }
+        }
+        // WHEN
+        mapper.prepare( SimpleInputIteratorWrapper.wrap( "source", ids ), NONE );
+
+        // THEN
+        for ( Object id : ids )
+        {
+            assertEquals( ((Long)id).longValue(), mapper.get( id, GLOBAL ) );
+        }
+    }
+
     private class ValueGenerator implements InputIterable<Object>
     {
         private final int size;


### PR DESCRIPTION
i.e. nodes that doesn't have an :ID. This will leave holes in the index
which previously wasn't handled well and might fail at random, either in
prepare or in get.

Pulled out a little Workers utility for running both the sorting and
tracker initialization for less, more understandable code in ParallelSort
