### PR TITLE
Parallel relationship import in batch importer

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
@@ -21,7 +21,14 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+import org.neo4j.unsafe.impl.batchimport.staging.Step;
 
+/**
+ * Batch object flowing through several {@link Stage stages} in a {@link ParallelBatchImporter batch import}.
+ * Typically each {@link Step} populates or manipulates certain fields and passes the same {@link Batch} instance
+ * downstream.
+ */
 public class Batch<INPUT,RECORD extends PrimitiveRecord>
 {
     public final INPUT[] input;
@@ -32,8 +39,12 @@ public class Batch<INPUT,RECORD extends PrimitiveRecord>
     // using the same index as the record. So it's a collective size suitable for complete looping
     // over the batch.
     public PropertyBlock[] propertyBlocks;
+    // Used by ParallelizeByNodeIdStep to help determine any two batches have any id in common
+    public long[] sortedIds;
     // Used by relationship staged to query idMapper and store ids here
     public long[] ids;
+    public boolean parallelizableWithPrevious;
+    public long firstRecordId;
 
     public Batch( INPUT[] input )
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
@@ -40,7 +40,7 @@ public class CalculateDenseNodesStage extends Stage
             Collector<InputRelationship> badRelationshipsCollector,
             InputCache inputCache ) throws IOException
     {
-        super( "Calculate dense nodes", config, false );
+        super( "Calculate dense nodes", config );
         add( new InputIteratorBatcherStep<>( control(), config,
                 relationships.iterator(), InputRelationship.class ) );
         if ( !relationships.supportsMultiplePasses() )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
@@ -36,7 +36,7 @@ public class IdMapperPreparationStage extends Stage
     public IdMapperPreparationStage( Configuration config, IdMapper idMapper, InputIterable<InputNode> nodes,
             InputCache inputCache, StatsProvider memoryUsageStats )
     {
-        super( "Prepare node index", config, false );
+        super( "Prepare node index", config );
         add( new IdMapperPreparationStep( control(), config,
                 idMapper, idsOf( nodes.supportsMultiplePasses() ? nodes : inputCache.nodes() ), memoryUsageStats ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
@@ -35,7 +35,7 @@ public class NodeCountsStage extends Stage
     public NodeCountsStage( Configuration config, NodeLabelsCache cache, NodeStore nodeStore,
             int highLabelId, CountsAccessor.Updater countsUpdater, StatsProvider... additionalStatsProviders )
     {
-        super( "Node counts", config, false );
+        super( "Node counts", config );
         add( new ReadNodeRecordsStep( control(), config, nodeStore ) );
         add( new RecordProcessorStep<>( control(), "COUNT", config, new NodeCountsProcessor(
                 nodeStore, cache, highLabelId, countsUpdater ), true, additionalStatsProviders ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstRelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstRelationshipStage.java
@@ -33,7 +33,7 @@ public class NodeFirstRelationshipStage extends Stage
     public NodeFirstRelationshipStage( Configuration config, NodeStore nodeStore,
             RelationshipGroupStore relationshipGroupStore, NodeRelationshipCache cache )
     {
-        super( "Node --> Relationship", config, false );
+        super( "Node --> Relationship", config );
         add( new ReadNodeRecordsStep( control(), config, nodeStore ) );
         add( new RecordProcessorStep<>( control(), "LINK", config,
                 new NodeFirstRelationshipProcessor( relationshipGroupStore, cache ), false ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -34,6 +34,8 @@ import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStore;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingPageCache.WriterFactory;
 import org.neo4j.unsafe.impl.batchimport.store.io.IoMonitor;
 
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTREAM;
+
 /**
  * Imports nodes and their properties, everything except
  * {@link NodeRecord#setNextRel(long) first relationship id pointer} is set for every node in this stage.
@@ -44,7 +46,7 @@ public class NodeStage extends Stage
             InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
             BatchingNeoStore neoStore, InputCache inputCache, StatsProvider memoryUsage ) throws IOException
     {
-        super( "Nodes", config, true );
+        super( "Nodes", config, ORDER_SEND_DOWNSTREAM );
         add( new InputIteratorBatcherStep<>( control(), config, nodes.iterator(), InputNode.class ) );
         if ( !nodes.supportsMultiplePasses() )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelizationCoordinator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelizationCoordinator.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.neo4j.graphdb.Resource;
+
+/**
+ * Lock for coordinating concurrency of execution between stretches of parallelizable batches
+ * versus non-parallelizable batches. Usage is to
+ * {@link #coordinate(boolean) lock based on whether or not being parallelizable with the previous batch},
+ * put that {@link Resource} in a try-with-resource block, process and then exit that try-block.
+ */
+public class ParallelizationCoordinator
+{
+    private final ReadWriteLock lock = new ReentrantReadWriteLock( true );
+
+    public Resource coordinate( boolean parallelizableWithPrevious )
+    {
+        if ( !parallelizableWithPrevious )
+        {
+            // If this batch isn't parallelizable with previous batch then we need to wait for all previous
+            // batches (potentially many concurrent) to complete before this batch can run.
+            // Here that translates into acquiring the write lock.
+            lock.writeLock().lock();
+        }
+
+        // Now acquire the read lock, even if we have the write lock. Why? read right below.
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+
+        if ( !parallelizableWithPrevious )
+        {
+            // Alright, we've made our point above when we acquired the write lock, i.e. awaited previous
+            // batches to complete and blocking new batches from starting. We can now
+            // (after having acquired the read lock) release the write lock since:
+            // - if the next batch isn't parallelizable with this batch it will await this batch to complete
+            //   as a side effect of acquiring the write lock.
+            // - if the next batch is parallelizable with this batch it can go right ahead and process
+            //   since it'll only need to acquire the read lock.
+            lock.writeLock().unlock();
+        }
+
+        return new Resource()
+        {
+            @Override
+            public void close()
+            {
+                readLock.unlock();
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelizeByNodeIdStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelizeByNodeIdStep.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.neo4j.unsafe.impl.batchimport.Utils.anyIdCollides;
+import static org.neo4j.unsafe.impl.batchimport.Utils.mergeSortedInto;
+
+/**
+ * Enables {@link RelationshipEncoderStep} to safely process batches in parallel.
+ *
+ * Using actual node ids from {@link Batch#ids}, this step compares ids from consecutive batches and
+ * detects whether or not there are any overlap of ids between the batches. Batches that have no id overlap
+ * can be run in parallel. Batches that do have id overlap will not be run in parallel since that would
+ * introduce a chance for multiple threads updating the same cache entries of the {@link NodeRelationshipCache}
+ * concurrently.
+ *
+ * "Why not solve this with CAS in the {@link NodeRelationshipCache}, you say"... sure, that
+ * would solve the issue of updating the same cache entries concurrently, but may break a contract of
+ * the batch importer that relationship ids in any chain are ordered by id. Id ordering inside chains are
+ * fundamental for implementing the {@link RelationshipLinkbackStage "prev pointer" linking} in the
+ * efficient way it's done currently, upholding sequential I/O access properties correctly.
+ *
+ * This step will have an array, {@link #concurrentNodeIds}, containing all node ids that are potentially
+ * processed (by the downstream step) at any given point in time. In order to allow one more batch to be
+ * executed in parallel with any other concurrently executing batches no node id in the tentative batch
+ * can already exist in {@link #concurrentNodeIds}. This makes this array grow with consecutive parallelizable
+ * batches until a non-parallelizable batch is encountered, at which point the array can be reset and
+ * the comparison (and potential growth of it) can begin again. Implementation of this is garbage-free,
+ * but fact still remains that multiple consecutive parallelizable batches will keep increasing the
+ * time it takes to detect this property. Therefore there's an upper limit of 10 for the number of
+ * consecutive parallelizable batches, such that even if there would theoretically be 11 consecutive
+ * parallelizable batches, the 11:th will not be marked as parallelizable with the other previous 10.
+ */
+public class ParallelizeByNodeIdStep extends ProcessorStep<Batch<InputRelationship,RelationshipRecord>>
+{
+    private static final int MAX_PARALLELIZABLE_BATCHES = 10;
+
+    private final int idBatchSize;
+
+    // Since this step is single-threaded and currently RelationshipEncoderStep isn't then this is a perfect
+    // place for assigning actual relationship ids to batches, set in each Batch and used in RelationshipEncoderStep.
+    private long firstRecordId;
+
+    // Collection of all ids from batches (theoretically) concurrently processing. Ids in here are sorted.
+    private final long[] concurrentNodeIds;
+    private int concurrentBatches;
+
+    public ParallelizeByNodeIdStep( StageControl control, Configuration config )
+    {
+        super( control, "PARALLELIZE", config, 1 );
+        // x2 since ids array cover both start and end nodes
+        this.idBatchSize = config.batchSize()*2;
+        this.concurrentNodeIds = new long[idBatchSize * MAX_PARALLELIZABLE_BATCHES];
+    }
+
+    @Override
+    protected void process( Batch<InputRelationship,RelationshipRecord> batch, BatchSender sender ) throws Throwable
+    {
+        // Compare ids with concurrent ids
+        int concurrentNodeIdsRange = concurrentBatches*idBatchSize;
+        batch.parallelizableWithPrevious = concurrentBatches < MAX_PARALLELIZABLE_BATCHES && !anyIdCollides(
+                concurrentNodeIds, concurrentNodeIdsRange, batch.sortedIds, batch.ids.length );
+
+        // Assign first record id and send
+        batch.firstRecordId = firstRecordId;
+        sender.send( batch );
+
+        // Set state for the next batch
+        firstRecordId += batch.input.length;
+        if ( batch.parallelizableWithPrevious )
+        {
+            mergeSortedInto( batch.sortedIds, concurrentNodeIds, concurrentNodeIdsRange );
+            concurrentBatches++;
+        }
+        else
+        {
+            System.arraycopy( batch.sortedIds, 0, concurrentNodeIds, 0, batch.sortedIds.length );
+            concurrentBatches = 1;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
@@ -35,7 +35,7 @@ public class RelationshipCountsStage extends Stage
             int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater,
             NumberArrayFactory cacheFactory )
     {
-        super( "Relationship counts", config, false );
+        super( "Relationship counts", config );
         add( new ReadRelationshipCountsDataStep( control(), config, relationshipStore ) );
         add( new ProcessRelationshipCountsDataStep( control(), cache, config,
                 highLabelId, highRelationshipTypeId, countsUpdater, cacheFactory ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import org.neo4j.graphdb.Resource;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -44,6 +45,7 @@ public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationsh
     private final BatchingTokenRepository<?> relationshipTypeRepository;
     private final RelationshipStore relationshipStore;
     private final NodeRelationshipCache cache;
+    private final ParallelizationCoordinator parallelization = new ParallelizationCoordinator();
 
     // There are two "modes" in generating relationship ids
     // - ids are decided by InputRelationship#id() (f.ex. store migration, where ids should be kept intact).
@@ -51,7 +53,6 @@ public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationsh
     // - ids are incremented for each one, starting at a specific id (0 on empty db)
     //   nextRelationshipId is used and _no_ id from InputRelationship is used, rather no id is allowed to be specified.
     private final boolean specificIds;
-    private long nextRelationshipId;
 
     public RelationshipEncoderStep( StageControl control,
             Configuration config,
@@ -60,7 +61,7 @@ public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationsh
             NodeRelationshipCache cache,
             boolean specificIds )
     {
-        super( control, "RELATIONSHIP", config, 1 );
+        super( control, "RELATIONSHIP", config, 0 );
         this.relationshipTypeRepository = relationshipTypeRepository;
         this.relationshipStore = relationshipStore;
         this.cache = cache;
@@ -68,11 +69,18 @@ public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationsh
     }
 
     @Override
-    protected void process( Batch<InputRelationship,RelationshipRecord> batch, BatchSender sender )
+    protected Resource permit( Batch<InputRelationship,RelationshipRecord> batch )
+    {
+        return parallelization.coordinate( batch.parallelizableWithPrevious );
+    }
+
+    @Override
+    protected void process( Batch<InputRelationship,RelationshipRecord> batch, BatchSender sender ) throws Throwable
     {
         InputRelationship[] input = batch.input;
         batch.records = new RelationshipRecord[input.length];
         long[] ids = batch.ids;
+        long nextRelationshipId = batch.firstRecordId;
         for ( int i = 0; i < input.length; i++ )
         {
             InputRelationship batchRelationship = input[i];

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
@@ -32,7 +32,7 @@ public class RelationshipLinkbackStage extends Stage
 {
     public RelationshipLinkbackStage( Configuration config, RelationshipStore store, NodeRelationshipCache cache )
     {
-        super( "Relationship --> Relationship", config, false );
+        super( "Relationship --> Relationship", config );
         add( new ReadRelationshipRecordsBackwardsStep( control(), config, store ) );
         add( new RecordProcessorStep<>( control(), "LINK", config,
                 new RelationshipLinkbackProcessor( cache ), false ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipPreparationStep.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import java.util.Arrays;
+
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
@@ -52,6 +54,8 @@ public class RelationshipPreparationStep extends ProcessorStep<Batch<InputRelati
             ids[i*2] = idMapper.get( batchRelationship.startNode(), batchRelationship.startNodeGroup() );
             ids[i*2+1] = idMapper.get( batchRelationship.endNode(), batchRelationship.endNodeGroup() );
         }
+        batch.sortedIds = ids.clone();
+        Arrays.sort( batch.sortedIds );
         sender.send( batch );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
@@ -29,6 +29,9 @@ import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStore;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingPageCache.WriterFactory;
 import org.neo4j.unsafe.impl.batchimport.store.io.IoMonitor;
 
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_PROCESS;
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTREAM;
+
 /**
  * Imports the first part of relationships, namely the relationship record itself and its properties.
  * Only the "next" pointers are set at this stage. The "prev" pointers are set in a later stage.
@@ -39,13 +42,14 @@ public class RelationshipStage extends Stage
             InputIterable<InputRelationship> relationships, IdMapper idMapper,
             BatchingNeoStore neoStore, NodeRelationshipCache cache, boolean specificIds )
     {
-        super( "Relationships", config, false );
+        super( "Relationships", config, ORDER_SEND_DOWNSTREAM | ORDER_PROCESS );
         add( new InputIteratorBatcherStep<>( control(), config, relationships.iterator(), InputRelationship.class ) );
 
         RelationshipStore relationshipStore = neoStore.getRelationshipStore();
         PropertyStore propertyStore = neoStore.getPropertyStore();
         add( new RelationshipPreparationStep( control(), config, idMapper ) );
         add( new PropertyEncoderStep<>( control(), config, neoStore.getPropertyKeyRepository(), propertyStore ) );
+        add( new ParallelizeByNodeIdStep( control(), config ) );
         add( new RelationshipEncoderStep( control(), config,
                 neoStore.getRelationshipTypeRepository(), relationshipStore, cache, specificIds ) );
         add( new EntityStoreUpdaterStep<>( control(), config,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -131,6 +131,56 @@ public class Utils
         };
     }
 
+    // Values in the arrays are assumed to be sorted
+    public static boolean anyIdCollides( long[] first, int firstLength, long[] other, int otherLength )
+    {
+        int f = 0, o = 0;
+        while( f < firstLength && o < otherLength )
+        {
+            if ( first[f] == other[o] )
+            {
+                return true;
+            }
+
+            if ( first[f] < other[o] )
+            {
+                while ( ++f < firstLength && first[f] < other[o] );
+            }
+            else
+            {
+                while ( ++o < otherLength && first[f] > other[o] );
+            }
+        }
+
+        return false;
+    }
+
+    public static void mergeSortedInto( long[] values, long[] into, int intoLengthBefore )
+    {
+        int v = values.length-1;
+        int i = intoLengthBefore-1;
+        int t = i+values.length;
+        while ( v >= 0 || i >= 0 )
+        {
+            if ( i == -1 )
+            {
+                into[t--] = values[v--];
+            }
+            else if ( v == -1 )
+            {
+                into[t--] = into[i--];
+            }
+            else if ( values[v] >= into[i] )
+            {
+                into[t--] = values[v--];
+            }
+            else
+            {
+                into[t--] = into[i--];
+            }
+        }
+    }
+
     private Utils()
     {   // No instances allowed
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.neo4j.graphdb.Direction;
 
 /**
@@ -189,7 +191,7 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Home
         private static final int INDEX_LOOP = 3;
 
         private LongArray array;
-        private int nextFreeId = 0;
+        private final AtomicInteger nextFreeId = new AtomicInteger();
 
         RelGroupCache( NumberArrayFactory arrayFactory, long chunkSize )
         {
@@ -216,7 +218,7 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Home
 
         private int nextFreeId()
         {
-            return nextFreeId++;
+            return nextFreeId.getAndIncrement();
         }
 
         private void initializeGroup( long relGroupIndex, int type )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -48,8 +48,8 @@ public abstract class AbstractStep<T> implements Step<T>
     private volatile boolean endOfUpstream;
     protected volatile Throwable panic;
     private volatile boolean completed;
-    protected boolean orderedTickets;
-    protected final PrimitiveLongPredicate rightTicket = new PrimitiveLongPredicate()
+    protected int orderingGuarantees;
+    protected final PrimitiveLongPredicate rightDoneTicket = new PrimitiveLongPredicate()
     {
         @Override
         public boolean accept( long ticket )
@@ -83,10 +83,15 @@ public abstract class AbstractStep<T> implements Step<T>
     }
 
     @Override
-    public void start( boolean orderedTickets )
+    public void start( int orderingGuarantees )
     {
-        this.orderedTickets = orderedTickets;
+        this.orderingGuarantees = orderingGuarantees;
         resetStats();
+    }
+
+    protected boolean guarantees( int orderingGuaranteeFlag )
+    {
+        return (orderingGuarantees & orderingGuaranteeFlag) != 0;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.function.Factory;
 import org.neo4j.function.primitive.PrimitiveLongPredicate;
+import org.neo4j.graphdb.Resource;
 import org.neo4j.unsafe.impl.batchimport.executor.DynamicTaskExecutor;
 import org.neo4j.unsafe.impl.batchimport.executor.Task;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
@@ -53,6 +54,15 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
             return queuedBatches.get() <= queueSizeThreshold;
         }
     };
+    protected final AtomicLong begunBatches = new AtomicLong();
+    private final PrimitiveLongPredicate rightBeginTicket = new PrimitiveLongPredicate()
+    {
+        @Override
+        public boolean accept( long ticket )
+        {
+            return begunBatches.get() == ticket;
+        }
+    };
 
     // Time stamp for when we processed the last queued batch received from upstream.
     // Useful for tracking how much time we spend waiting for batches from upstream.
@@ -67,9 +77,9 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     }
 
     @Override
-    public void start( boolean orderedTickets )
+    public void start( int orderingGuarantees )
     {
-        super.start( orderedTickets );
+        super.start( orderingGuarantees );
         this.executor = new DynamicTaskExecutor<>( initialProcessorCount, maxProcessors, workAheadSize,
                 DEFAULT_PARK_STRATEGY, name(), new Factory<Sender>()
                 {
@@ -95,17 +105,28 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
             {
                 assertHealthy();
                 sender.initialize( ticket );
-                long startTime = currentTimeMillis();
                 try
                 {
-                    process( batch, sender );
-                    if ( downstream == null )
+                    // If we're ordering tickets we will force calls to #permit to be ordered by ticket
+                    // since grabbing a permit may include locking.
+                    if ( guarantees( ORDER_PROCESS ) )
                     {
-                        // No batches were emmitted so we couldn't track done batches in that way.
-                        // We can see that we're the last step so increment here instead
-                        doneBatches.incrementAndGet();
+                        await( rightBeginTicket, ticket );
                     }
-                    totalProcessingTime.add( currentTimeMillis()-startTime-sender.sendTime );
+                    try ( Resource precondition = permit( batch ) )
+                    {
+                        begunBatches.incrementAndGet();
+                        long startTime = currentTimeMillis();
+                        process( batch, sender );
+                        if ( downstream == null )
+                        {
+                            // No batches were emmitted so we couldn't track done batches in that way.
+                            // We can see that we're the last step so increment here instead
+                            doneBatches.incrementAndGet();
+                        }
+                        totalProcessingTime.add( currentTimeMillis()-startTime-sender.sendTime );
+                    }
+
                     decrementQueue();
                     checkNotifyEndDownstream();
                 }
@@ -117,6 +138,16 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
         } );
 
         return idleTime;
+    }
+
+    /**
+     * Called before {@link #process(Object, BatchSender) processing} and time measurement starts.
+     * Coordination with other processors should happen in here.
+     * If total ordering is enabled then calls will arrive in order of ticket.
+     */
+    protected Resource permit( T batch ) throws Throwable
+    {
+        return Resource.EMPTY;
     }
 
     private void decrementQueue()
@@ -186,9 +217,9 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     @SuppressWarnings( "unchecked" )
     private void sendDownstream( long ticket, Object batch )
     {
-        if ( orderedTickets )
+        if ( guarantees( ORDER_SEND_DOWNSTREAM ) )
         {
-            await( rightTicket, ticket );
+            await( rightDoneTicket, ticket );
         }
         downstreamIdleTime.addAndGet( downstream.receive( ticket, batch ) );
         doneBatches.incrementAndGet();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
@@ -33,9 +33,14 @@ public class Stage
     private final List<Step<?>> pipeline = new ArrayList<>();
     private final StageExecution execution;
 
-    public Stage( String name, Configuration config, boolean orderedTickets )
+    public Stage( String name, Configuration config )
     {
-        this.execution = new StageExecution( name, config, pipeline, orderedTickets );
+        this( name, config, 0 /*no ordering guarantees*/ );
+    }
+
+    public Stage( String name, Configuration config, int orderingGuarantees )
+    {
+        this.execution = new StageExecution( name, config, pipeline, orderingGuarantees );
     }
 
     protected StageControl control()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
@@ -43,14 +43,14 @@ public class StageExecution implements StageControl
     private final Collection<Step<?>> pipeline;
     private volatile Throwable panicCause;
     private long startTime;
-    private final boolean orderedTickets;
+    private final int orderingGuarantees;
 
-    public StageExecution( String stageName, Configuration config, Collection<Step<?>> pipeline, boolean orderedTickets )
+    public StageExecution( String stageName, Configuration config, Collection<Step<?>> pipeline, int orderingGuarantees )
     {
         this.stageName = stageName;
         this.config = config;
         this.pipeline = pipeline;
-        this.orderedTickets = orderedTickets;
+        this.orderingGuarantees = orderingGuarantees;
     }
 
     public boolean stillExecuting()
@@ -77,7 +77,7 @@ public class StageExecution implements StageControl
         this.startTime = currentTimeMillis();
         for ( Step<?> step : pipeline )
         {
-            step.start( orderedTickets );
+            step.start( orderingGuarantees );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
@@ -39,11 +39,21 @@ import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
 public interface Step<T> extends Parallelizable
 {
     /**
-     * Starts the processing in this step.
-     *
-     * @param orderedTickets whether or not tickets leave each step in order of ticket number.
+     * Whether or not tickets arrive in {@link #receive(long, Object)} ordered by ticket number.
      */
-    void start( boolean orderedTickets );
+    int ORDER_SEND_DOWNSTREAM = 0x1;
+
+    /**
+     * Whether or not actual processing of batches are ordered by ticket number.
+     */
+    int ORDER_PROCESS = 0x2;
+
+    /**
+     * Starts the processing in this step, such that calls to {@link #receive(long, Object)} can be accepted.
+     *
+     * @param orderingGuarantees which ordering guarantees that will be upheld.
+     */
+    void start( int orderingGuarantees );
 
     /**
      * @return name of this step.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
@@ -50,7 +50,7 @@ public class CalculateDenseNodesStepTest
         Configuration config = Configuration.DEFAULT;
         NodeRelationshipCache cache = new NodeRelationshipCache( NumberArrayFactory.HEAP, -1 );
         Step<long[]> step = new CalculateDenseNodesStep( control, config, cache );
-        step.start( false );
+        step.start( 0 );
         maxOutNumberOfProcessors( step );
 
         // WHEN sending many batches, all which "happens" to have ids of the same radix, in fact

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelizationCoordinatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelizationCoordinatorTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.graphdb.Resource;
+import org.neo4j.test.OtherThreadExecutor.WaitDetails;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
+import org.neo4j.test.OtherThreadRule;
+
+public class ParallelizationCoordinatorTest
+{
+    @Test
+    public void shouldSerializeNonParallelizableBatches() throws Exception
+    {
+        // GIVEN
+        ParallelizationCoordinator coordinator = new ParallelizationCoordinator();
+
+        // WHEN
+        Future<Resource> r2Future;
+        try ( Resource r1 = coordinator.coordinate( false ) )
+        {
+            r2Future = t2.execute( coordinate( coordinator, false ) );
+            waitUntilAwaitingLock( t2 );
+        }
+
+        // THEN
+        t2.execute( close( r2Future.get() ) ).get();
+    }
+
+    @Test
+    public void shouldParallelizeBatches() throws Exception
+    {
+        // GIVEN
+        ParallelizationCoordinator coordinator = new ParallelizationCoordinator();
+
+        // WHEN
+        Resource r1 = coordinator.coordinate( true );
+        Resource r2 = coordinator.coordinate( true );
+
+        // THEN
+        r1.close();
+        r2.close();
+    }
+
+    @Test
+    public void shouldHaveNonParallelizableBatchAwaitPreviousParallelizable() throws Exception
+    {
+        // GIVEN
+        ParallelizationCoordinator coordinator = new ParallelizationCoordinator();
+        Resource r1 = coordinator.coordinate( true );
+        Resource r2 = coordinator.coordinate( true );
+        Future<Resource> r3Future = t2.execute( coordinate( coordinator, false ) );
+        waitUntilAwaitingLock( t2 );
+
+        // WHEN the previous parallelizable batches are done
+        r2.close();
+        r1.close();
+
+        // THEN we should be able to continue
+        t2.execute( close( r3Future.get() ) ).get();
+    }
+
+    private void waitUntilAwaitingLock( OtherThreadRule<Void> thread ) throws TimeoutException
+    {
+        while ( true )
+        {
+            WaitDetails details = thread.get().waitUntilWaiting();
+            if ( details.isAt( ParallelizationCoordinator.class, "coordinate" ) )
+            {
+                break;
+            }
+        }
+    }
+
+    private WorkerCommand<Void,Resource> coordinate( final ParallelizationCoordinator coordinator,
+            final boolean parallelizable )
+    {
+        return new WorkerCommand<Void,Resource>()
+        {
+            @Override
+            public Resource doWork( Void state ) throws Exception
+            {
+                return coordinator.coordinate( parallelizable );
+            }
+        };
+    }
+
+    private WorkerCommand<Void,Void> close( final Resource resource )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                resource.close();
+                return null;
+            }
+        };
+    }
+
+    public final @Rule OtherThreadRule<Void> t2 = new OtherThreadRule<>();
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
@@ -85,7 +85,7 @@ public class PropertyEncoderStepTest
         step.setDownstream( downstream );
 
         // WHEN
-        step.start( false );
+        step.start( 0 );
         step.receive( 0, smallbatch() );
         step.endOfUpstream();
         awaitCompleted( step, control );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UtilsTest
+{
+    @Test
+    public void shouldDetectCollisions() throws Exception
+    {
+        // GIVEN
+        long[] first = new long[] {1, 4, 7, 10, 100, 101};
+        long[] other = new long[] {2, 3, 34, 75, 101};
+
+        // WHEN
+        boolean collides = Utils.anyIdCollides( first, first.length, other, other.length );
+
+        // THEN
+        assertTrue( collides );
+    }
+
+    @Test
+    public void shouldNotReportDisjointArraysAsCollision() throws Exception
+    {
+        // GIVEN
+        long[] first = new long[] {1, 4, 7, 10, 100, 101};
+        long[] other = new long[] {2, 3, 34, 75, 102};
+
+        // WHEN
+        boolean collides = Utils.anyIdCollides( first, first.length, other, other.length );
+
+        // THEN
+        assertFalse( collides );
+    }
+
+    @Test
+    public void shouldBeCorrectForSomeRandomBatches() throws Exception
+    {
+        // GIVEN
+        Random random = ThreadLocalRandom.current();
+        long[][] batches = new long[20][];
+        for ( int i = 0; i < batches.length; i++ )
+        {
+            batches[i] = randomBatch( 1_000, random, 5_000_000 );
+        }
+
+        // WHEN
+        for ( int i = 0; i < batches.length; i++ )
+        {
+            for ( int j = 0; j < batches.length; j++ )
+            {
+                // THEN
+                assertEquals(
+                        actuallyCollides( batches[i], batches[j] ),
+                        Utils.anyIdCollides( batches[i], batches[i].length, batches[j], batches[j].length ) );
+            }
+        }
+    }
+
+    @Test
+    public void shouldMergeIdsInto() throws Exception
+    {
+        // GIVEN
+        long[] values = new long[] { 2, 4, 10, 11, 14};
+        long[] into   = new long[] { 1, 5,  6, 11, 25};
+        int intoLengthBefore = into.length;
+        into = Arrays.copyOf( into, into.length+values.length );
+
+        // WHEN
+        Utils.mergeSortedInto( values, into, intoLengthBefore );
+
+        // THEN
+        assertArrayEquals( new long[] {1, 2, 4, 5, 6, 10, 11, 11, 14, 25}, into );
+    }
+
+    @Test
+    public void shouldMergeSomeRandomIdsInto() throws Exception
+    {
+        // GIVEN
+        Random random = ThreadLocalRandom.current();
+        int batchSize = 10_000;
+
+        // WHEN
+        for ( int i = 0; i < 100; i++ )
+        {
+            long[] values = randomBatch( batchSize, random, 100_000_000 );
+            long[] into = randomBatch( batchSize, random, 100_000_000 );
+            long[] expectedMergedArray = manuallyMerge( values, into );
+            into = Arrays.copyOf( into, batchSize*2 );
+            Utils.mergeSortedInto( values, into, batchSize );
+            assertArrayEquals( expectedMergedArray, into );
+        }
+    }
+
+    private long[] manuallyMerge( long[] values, long[] into )
+    {
+        long[] all = new long[values.length+into.length];
+        System.arraycopy( values, 0, all, 0, values.length );
+        System.arraycopy( into, 0, all, values.length, into.length );
+        Arrays.sort( all );
+        return all;
+    }
+
+    private boolean actuallyCollides( long[] b1, long[] b2 )
+    {
+        for ( int i = 0; i < b1.length; i++ )
+        {
+            for ( int j = 0; j < b2.length; j++ )
+            {
+                if ( b1[i] == b2[j] )
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private long[] randomBatch( int length, Random random, int max )
+    {
+        long[] result = new long[length];
+        randomBatchInto( result, length, random, max );
+        return result;
+    }
+
+    private void randomBatchInto( long[] into, int length, Random random, int max )
+    {
+        for ( int i = 0; i < length; i++ )
+        {
+            into[i] = random.nextInt( max );
+        }
+        Arrays.sort( into, 0, length );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ControlledStep.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ControlledStep.java
@@ -167,7 +167,7 @@ public class ControlledStep<T> implements Step<T>, StatsProvider
     }
 
     @Override
-    public void start( boolean orderedTickets )
+    public void start( int orderingGuarantees )
     {
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssignerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssignerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import static org.neo4j.unsafe.impl.batchimport.staging.ControlledStep.stepWithStats;
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTREAM;
 import static org.neo4j.unsafe.impl.batchimport.stats.Keys.avg_processing_time;
 import static org.neo4j.unsafe.impl.batchimport.stats.Keys.done_batches;
 
@@ -163,7 +164,7 @@ public class DynamicProcessorAssignerTest
 
     private StageExecution[] executionOf( Configuration config, Step<?>... steps )
     {
-        StageExecution execution = new StageExecution( "Test", config, Arrays.asList( steps ), true );
+        StageExecution execution = new StageExecution( "Test", config, Arrays.asList( steps ), ORDER_SEND_DOWNSTREAM );
         return new StageExecution[] {execution};
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ParallelizeByNodeIdStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ParallelizeByNodeIdStepTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.Batch;
+import org.neo4j.unsafe.impl.batchimport.ParallelizeByNodeIdStep;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class ParallelizeByNodeIdStepTest
+{
+    @Test
+    public void shouldDetectABA() throws Throwable
+    {
+        // GIVEN
+        StageControl control = mock( StageControl.class );
+        ProcessorStep<Batch<InputRelationship,RelationshipRecord>> step = new ParallelizeByNodeIdStep(
+                control, Configuration.DEFAULT );
+        int batchSize = Configuration.DEFAULT.batchSize();
+        Batch<InputRelationship,RelationshipRecord> a = new Batch<>( new InputRelationship[batchSize] );
+        setIds( a, 0, 2, batchSize*2 );
+        Batch<InputRelationship,RelationshipRecord> b = new Batch<>( new InputRelationship[batchSize] );
+        setIds( b, 1, 2, batchSize*2 );
+        Batch<InputRelationship,RelationshipRecord> aa = new Batch<>( new InputRelationship[batchSize] );
+        setIds( aa, 0, 2, batchSize*2 );
+        Batch<InputRelationship,RelationshipRecord> bb = new Batch<>( new InputRelationship[batchSize] );
+        setIds( bb, 1, 2, batchSize*2 );
+        BatchSender sender = mock( BatchSender.class );
+
+        // WHEN
+        step.process( a, sender );
+        step.process( b, sender );
+        step.process( aa, sender );
+        step.process( bb, sender );
+
+        // THEN
+        assertTrue( a.parallelizableWithPrevious ); // because it's the first batch
+        assertTrue( b.parallelizableWithPrevious ); // because no id here collides with the previous batch
+        assertFalse( aa.parallelizableWithPrevious ); // because there's one or more ids in this batch that collides
+                                                      // with the first batch
+        assertTrue( bb.parallelizableWithPrevious ); // because no id here collides with aa
+    }
+
+    private void setIds( Batch<?,?> batch, long first, long stride, int count )
+    {
+        batch.ids = new long[count];
+        long value = first;
+        for ( int i = 0; i < count; i++ )
+        {
+            batch.ids[i] = value;
+            value += stride;
+        }
+        batch.sortedIds = batch.ids.clone();
+        Arrays.sort( batch.sortedIds );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStepTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.graphdb.Resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_PROCESS;
+
+public class ProcessorStepTest
+{
+    @Test
+    public void shouldUpholdProcessOrderingGuarantee() throws Exception
+    {
+        // GIVEN
+        StageControl control = mock( StageControl.class );
+        MyProcessorStep step = new MyProcessorStep( control );
+        step.start( ORDER_PROCESS );
+        while ( step.numberOfProcessors() < 5 )
+        {
+            step.incrementNumberOfProcessors();
+        }
+
+        // WHEN
+        int batches = 10;
+        for ( int i = 0; i < batches; i++ )
+        {
+            step.receive( i, i );
+        }
+        step.endOfUpstream();
+        while ( !step.isCompleted() )
+        {
+            verifyNoMoreInteractions( control );
+        }
+
+        // THEN
+        assertEquals( batches, step.nextExpected.get() );
+        step.close();
+    }
+
+    public class MyProcessorStep extends ProcessorStep<Integer>
+    {
+        private final AtomicInteger nextExpected = new AtomicInteger();
+
+        private MyProcessorStep( StageControl control )
+        {
+            super( control, "test", Configuration.DEFAULT, 0 );
+        }
+
+        @Override
+        protected Resource permit( Integer batch ) throws Throwable
+        {
+            // Sleep a little to allow other processors much more easily to catch up and have
+            // a chance to race, if permit ordering guarantee isn't upheld, that is.
+            Thread.sleep( 10 );
+            assertEquals( nextExpected.getAndIncrement(), batch.intValue() );
+            return super.permit( batch );
+        }
+
+        @Override
+        protected void process( Integer batch, BatchSender sender ) throws Throwable
+        {   // No processing in this test
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecutionTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertFalse;
 
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
 import static org.neo4j.unsafe.impl.batchimport.staging.ControlledStep.stepWithAverageOf;
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTREAM;
 
 public class StageExecutionTest
 {
@@ -44,7 +45,7 @@ public class StageExecutionTest
         steps.add( stepWithAverageOf( "step1", 0, 10 ) );
         steps.add( stepWithAverageOf( "step2", 0, 5 ) );
         steps.add( stepWithAverageOf( "step3", 0, 30 ) );
-        StageExecution execution = new StageExecution( "Test", DEFAULT, steps, true );
+        StageExecution execution = new StageExecution( "Test", DEFAULT, steps, ORDER_SEND_DOWNSTREAM );
 
         // WHEN
         Iterator<Pair<Step<?>,Float>> ordered = execution.stepsOrderedBy( Keys.avg_processing_time, true ).iterator();
@@ -68,7 +69,7 @@ public class StageExecutionTest
         steps.add( stepWithAverageOf( "step2", 0, 5 ) );
         steps.add( stepWithAverageOf( "step3", 0, 30 ) );
         steps.add( stepWithAverageOf( "step4", 0, 5 ) );
-        StageExecution execution = new StageExecution( "Test", DEFAULT, steps, true );
+        StageExecution execution = new StageExecution( "Test", DEFAULT, steps, ORDER_SEND_DOWNSTREAM );
 
         // WHEN
         Iterator<Pair<Step<?>,Float>> ordered = execution.stepsOrderedBy( Keys.avg_processing_time, false ).iterator();


### PR DESCRIPTION
Batches of relationships to be imported are individually analyzed whether
or not they can be processed in parallel with its surrounding batches. The
deciding factor is whether or not there's any start/end node that is the
same as the previous batch. There can be stretches of batches that can be
run in parallel, batches that have completely disjoint sets of start/end
nodes. Then when there's a batch that has some same start/end node as any
in the current stretch of concurrently processing batches then it will
await all previous batches to complete before starting. Consecutive
batches will continue as described above.

There's a theoretical worst-case scenario where all batches have at least
one start/end node id in common, effectively removing the ability to
parallelize any batch. This scenario is not very likely and will still
have the performance of the relationship import as it was before this
commit.

Detection is done by comparing two sorted long[] in a new single-threaded
step. The actual sorting is done in an already existing preparation step
before ths detection step and since preparation is parallelizable it will
not become the bottleneck (given enough CPUs available of course).

Relationship import has been one of the most time consuming stages in the
batch importer, partly because it usually contains the most data of an
import, but also partly because there has been no parallelism in that stage.
This commit should (again, given enough available CPUs) ensure that the
bottleneck will be raw disk I/O.
