### PR TITLE
Better ordering in generated dumps

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/SubGraphExporter.java
@@ -50,9 +50,9 @@ public class SubGraphExporter
 
     public void export( PrintWriter out )
     {
+        appendNodes( out );
         appendIndexes( out );
         appendConstraints( out );
-        appendNodes( out );
         appendRelationships( out );
     }
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/export/ExportTest.java
@@ -258,9 +258,9 @@ public class ExportTest
         Node n = gdb.createNode( label );
         final ExecutionResult result = result( "node", n );
         final SubGraph graph = CypherResultSubGraph.from( result, gdb, true );
-        assertEquals( "create index on :`Foo`(`bar2`)" + NL +
-                "create index on :`Foo`(`bar`)" + NL +
-                "create (_0:`Foo`)" + NL, doExportGraph( graph ) );
+        assertEquals( "create (_0:`Foo`)" + NL +
+                "create index on :`Foo`(`bar2`)" + NL +
+                "create index on :`Foo`(`bar`)" + NL, doExportGraph( graph ) );
     }
 
     @Test
@@ -273,9 +273,9 @@ public class ExportTest
         Node n = gdb.createNode( label );
         final ExecutionResult result = result( "node", n );
         final SubGraph graph = CypherResultSubGraph.from( result, gdb, true );
-        assertEquals( "create constraint on (n:`Foo`) assert n.`bar2` is unique" + NL +
-                "create constraint on (n:`Foo`) assert n.`bar` is unique" + NL +
-                "create (_0:`Foo`)" + NL, doExportGraph( graph ) );
+        assertEquals( "create (_0:`Foo`)" + NL +
+                "create constraint on (n:`Foo`) assert n.`bar2` is unique" + NL +
+                "create constraint on (n:`Foo`) assert n.`bar` is unique" + NL, doExportGraph( graph ) );
     }
 
     private void commitAndStartNewTransactionAfterSchemaChanges()


### PR DESCRIPTION
Would this order not be better for a dump file? Nodes are imported first, without constraints or indices slowing things down, then constraints and indices are added so the relationship creation can use them (maybe, if they're ready)?

The only downside I can think of is if someone is importing into an already populated database and one of the nodes conflicts with a constraint, you'll wait and see the error after a bit of work has already been done. That seems like a rare situation, though.
