### PR TITLE
Restructured Projection and ProduceResult

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGenerator.scala
@@ -23,18 +23,17 @@ import java.util
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.neo4j.cypher.internal.ExecutionMode
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.Eagerly
-import org.neo4j.cypher.internal.compiler.v2_3.{PropertyKeyId, CostPlannerName}
+import org.neo4j.cypher.internal.compiler.v2_3.CostPlannerName
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
-import org.neo4j.cypher.internal.compiler.v2_3.birk.CodeGenerator.JavaTypes.{INT, LONG, OBJECT, DOUBLE, STRING}
+import org.neo4j.cypher.internal.compiler.v2_3.birk.CodeGenerator.JavaTypes.{DOUBLE, INT, LONG, OBJECT, STRING}
 import org.neo4j.cypher.internal.compiler.v2_3.birk.il._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{PlanFingerprint, CompiledPlan}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{CompiledPlan, PlanFingerprint}
+import org.neo4j.cypher.internal.compiler.v2_3.helpers.Eagerly
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
-import org.neo4j.cypher.internal.compiler.v2_3.planner.{SemanticTable, CantCompileQueryException}
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LogicalPlanIdentificationBuilder,
-LogicalPlan2PlanDescription}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_3.spi.{PlanContext, InstrumentedGraphStatistics}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LogicalPlan2PlanDescription, LogicalPlanIdentificationBuilder}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{CantCompileQueryException, SemanticTable}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.{InstrumentedGraphStatistics, PlanContext}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.api.Statement
@@ -103,6 +102,7 @@ case class JavaSymbol(name: String, javaType: String)
 class CodeGenerator {
 
   import CodeGenerator.{n, nextClassName, packageName}
+
   import scala.collection.JavaConverters._
 
   def generate(plan: LogicalPlan, planContext: PlanContext, clock: Clock, semanticTable: SemanticTable) = {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProduceResultsPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProduceResultsPipe.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.Effects
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
+
+case class ProduceResultsPipe(source: Pipe, columns: Seq[String])(val estimatedCardinality: Option[Double] = None)
+                             (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    // do not register this pipe as parent as it does not do anything except filtering of already fetched
+    // key-value pairs and thus should not have any stats
+
+    input.map {
+      original =>
+        val m = MutableMaps.create(columns.size)
+        columns.foreach {
+          case (name) => m.put(name, original(name))
+        }
+
+        ExecutionContext(m)
+    }
+  }
+
+  def planDescriptionWithoutCardinality = source.planDescription
+    .andThen(this.id, "ProduceResults", identifiers, KeyNames(columns))
+
+  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+
+  def localEffects = Effects()
+
+  def symbols = source.symbols.filter(columns.contains)
+
+  def dup(sources: List[Pipe]): Pipe = {
+    val (source :: Nil) = sources
+    copy(source = source)(estimatedCardinality)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CostBasedExecutablePlanBuilder.scala
@@ -103,8 +103,8 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
         }
         val nodes = returnIdentifiers.filter(semanticTable.isNode).map(_.name)
         val relationships = returnIdentifiers.filter(semanticTable.isRelationship).map(_.name)
-        val other = returnIdentifiers.filterNot(semanticTable.isNode).filterNot(semanticTable.isRelationship).map(_.name)
-        val finalPlan = ProduceResult(nodes, relationships, other, logicalPlan)
+        val others = returnIdentifiers.map(_.name).filterNot(x => nodes.contains(x) || relationships.contains(x))
+        val finalPlan = ProduceResult(nodes, relationships, others, logicalPlan)
         val codeGen = new CodeGenerator
         Left(codeGen.generate(finalPlan, planContext, clock, semanticTable))
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/PlannerQuery.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/PlannerQuery.scala
@@ -42,6 +42,7 @@ case class PlannerQuery(graph: QueryGraph = QueryGraph.empty,
     horizon.preferredStrictness orElse tail.flatMap(_.preferredStrictness)
 
   def lastQueryGraph: QueryGraph = tail.map(_.lastQueryGraph).getOrElse(graph)
+  def lastQueryHorizon: QueryHorizon = tail.map(_.lastQueryHorizon).getOrElse(horizon)
 
   def withTail(newTail: PlannerQuery): PlannerQuery = tail match {
     case None => copy(tail = Some(newTail))

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.PatternConve
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.StatementConverters
 import org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters.projectNamedPaths
 import org.neo4j.cypher.internal.compiler.v2_3.ast.{Expression, Identifier, NodeStartItem, RelTypeName}
+import org.neo4j.cypher.internal.compiler.v2_3.birk.il.ProduceResults
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{AggregationExpression, Expression => CommandExpression}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{EntityProducerFactory, Predicate => CommandPredicate, True}
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.builders.prepare.KeyTokenResolver
@@ -51,12 +52,12 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
     implicit val table: SemanticTable = context.semanticTable
     val updating = false
 
-    def buildPipe(plan: LogicalPlan): Pipe = {
+    def buildPipe(plan: LogicalPlan): Pipe with RonjaPipe = {
       implicit val monitor = monitors.newMonitor[PipeMonitor]()
 
-      val result: Pipe with RonjaPipe = plan match {
+      val result = plan match {
         case Projection(left, expressions) =>
-          ProjectionNewPipe(buildPipe(left), Eagerly.immutableMapValues(expressions, buildExpression))()
+          ProjectionPipe(buildPipe(left), Eagerly.immutableMapValues(expressions, buildExpression))()
 
         case ProjectEndpoints(left, rel, start, startInScope, end, endInScope, types, directed, length) =>
           ProjectEndpointsPipe(buildPipe(left), rel.name,
@@ -211,6 +212,11 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
           val source = new SingleRowPipe()
           val ep = entityProducerFactory.nodeStartItems((planContext, StatementConverters.StartItemConverter(hint).asCommandStartItem))
           NodeStartPipe(source, id.name, ep)()
+
+        case ProduceResult(nodes, rels, others, lhs) =>
+          val source = buildPipe(lhs)
+          val columns = nodes ++ rels ++ others
+          ProduceResultsPipe(source, columns)()
 
         case x =>
           throw new CantHandleQueryException(x.toString)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizon.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.{projection, sortSkipAndLimit, aggregation}
+import org.neo4j.cypher.internal.compiler.v2_3.planner._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
+
+case class PlanEventHorizon(config: QueryPlannerConfiguration = QueryPlannerConfiguration.default)
+  extends LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] {
+
+  override def apply(query: PlannerQuery, plan: LogicalPlan)(implicit context: LogicalPlanningContext): LogicalPlan = {
+    val selectedPlan = config.applySelections(plan, query.graph)
+    val projectedPlan = query.horizon match {
+      case aggregatingProjection: AggregatingQueryProjection =>
+        val aggregationPlan = aggregation(selectedPlan, aggregatingProjection)
+        sortSkipAndLimit(aggregationPlan, query)
+
+      case queryProjection: RegularQueryProjection =>
+        val sortedAndLimited = sortSkipAndLimit(selectedPlan, query)
+        projection(sortedAndLimited, queryProjection.projections)
+
+      case UnwindProjection(identifier, expression) =>
+        context.logicalPlanProducer.planUnwind(plan, identifier, expression)
+
+      case _ =>
+        throw new CantHandleQueryException
+    }
+
+    projectedPlan
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanSingleQuery.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanSingleQuery.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v2_3.Rewriter
+import org.neo4j.cypher.internal.compiler.v2_3.planner.PlannerQuery
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.verifyBestPlan
+
+case class PlanSingleQuery(planPart: (PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan = planPart,
+                           planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = PlanEventHorizon(),
+                           expressionRewriterFactory: (LogicalPlanningContext => Rewriter) = ExpressionRewriterFactory,
+                           planWithTail: LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] = PlanWithTail()) extends LogicalPlanningFunction1[PlannerQuery, LogicalPlan] {
+
+  override def apply(in: PlannerQuery)(implicit context: LogicalPlanningContext): LogicalPlan = {
+    val partPlan = planPart(in, context, None)
+
+    val projectedPlan = planEventHorizon(in, partPlan)
+    val projectedContext = context.recurse(projectedPlan)
+    val expressionRewriter = expressionRewriterFactory(projectedContext)
+    val completePlan = projectedPlan.endoRewrite(expressionRewriter)
+
+    val finalPlan = planWithTail(completePlan, in.tail)(projectedContext)
+    verifyBestPlan(finalPlan, in)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanWithTail.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanWithTail.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v2_3.Rewriter
+import org.neo4j.cypher.internal.compiler.v2_3.planner.PlannerQuery
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
+
+case class PlanWithTail(expressionRewriterFactory: (LogicalPlanningContext => Rewriter) = ExpressionRewriterFactory,
+                        planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = PlanEventHorizon())
+  extends LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] {
+
+  override def apply(pred: LogicalPlan, remaining: Option[PlannerQuery])(implicit context: LogicalPlanningContext): LogicalPlan = {
+    remaining match {
+      case Some(query) =>
+        val lhs = pred
+        val lhsContext = context.recurse(lhs)
+        val rhs = planPart(query, lhsContext, Some(context.logicalPlanProducer.planQueryArgumentRow(query.graph)))
+        val applyPlan = context.logicalPlanProducer.planTailApply(lhs, rhs)
+
+        val applyContext = lhsContext.recurse(applyPlan)
+        val projectedPlan = planEventHorizon(query, applyPlan)(applyContext)
+
+        val projectedContext = applyContext.recurse(projectedPlan)
+        val expressionRewriter = expressionRewriterFactory(projectedContext)
+        val completePlan = projectedPlan.endoRewrite(expressionRewriter)
+
+        // planning nested expressions doesn't change outer cardinality
+        apply(completePlan, query.tail)(projectedContext)
+
+      case None =>
+        pred
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlanner.scala
@@ -21,10 +21,11 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{IdName, LogicalPlan, ProduceResult}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.{aggregation, projection, sortSkipAndLimit, verifyBestPlan}
+import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 
-import scala.annotation.tailrec
+import scala.collection.mutable
 
 trait QueryPlanner {
   def plan(plannerQuery: UnionQuery)(implicit context: LogicalPlanningContext): LogicalPlan
@@ -32,19 +33,42 @@ trait QueryPlanner {
 
 case class DefaultQueryPlanner(planRewriter: Rewriter,
                                config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
-                               planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = planSingleQueryX())
+                               planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = PlanSingleQuery())
   extends QueryPlanner {
 
   def plan(unionQuery: UnionQuery)(implicit context: LogicalPlanningContext): LogicalPlan = unionQuery match {
     case UnionQuery(queries, distinct) =>
-      val plan = planQuery(queries, distinct)
-      plan.endoRewrite(planRewriter)
+      val plan = planQueries(queries, distinct)
+      val rewrittenPlan = plan.endoRewrite(planRewriter)
+      createProduceResultOperator(rewrittenPlan, unionQuery)
 
     case _ =>
       throw new CantHandleQueryException
   }
 
-  private def planQuery(queries: Seq[PlannerQuery], distinct: Boolean)(implicit context: LogicalPlanningContext) = {
+  private def createProduceResultOperator(in: LogicalPlan, unionQuery: UnionQuery)
+                                         (implicit context: LogicalPlanningContext): LogicalPlan = {
+    val nodes = mutable.ListBuffer[String]()
+    val rels = mutable.ListBuffer[String]()
+    val others = mutable.ListBuffer[String]()
+
+    val lastQuery = unionQuery.queries.last
+    val columns = lastQuery.lastQueryHorizon.exposedSymbols(lastQuery.lastQueryGraph)
+
+    columns.foreach {
+      case IdName(name) =>
+        if (context.semanticTable.getTypeFor(name) == CTNode.invariant)
+          nodes += name
+        else if (context.semanticTable.getTypeFor(name) == CTRelationship.invariant)
+          rels += name
+        else
+          others += name
+    }
+
+    ProduceResult(nodes, rels, others, in)
+  }
+
+  private def planQueries(queries: Seq[PlannerQuery], distinct: Boolean)(implicit context: LogicalPlanningContext) = {
     val logicalPlans: Seq[LogicalPlan] = queries.map(p => planSingleQuery(p))
     val unionPlan = logicalPlans.reduce[LogicalPlan] {
       case (p1, p2) => context.logicalPlanProducer.planUnion(p1, p2)
@@ -57,60 +81,6 @@ case class DefaultQueryPlanner(planRewriter: Rewriter,
   }
 }
 
-case class planEventHorizonX(config: QueryPlannerConfiguration = QueryPlannerConfiguration.default)
-  extends LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] {
-
-  override def apply(query: PlannerQuery, plan: LogicalPlan)(implicit context: LogicalPlanningContext): LogicalPlan = {
-    val selectedPlan = config.applySelections(plan, query.graph)
-    val projectedPlan = query.horizon match {
-      case aggregatingProjection: AggregatingQueryProjection =>
-        val aggregationPlan = aggregation(selectedPlan, aggregatingProjection)
-        sortSkipAndLimit(aggregationPlan, query)
-
-      case queryProjection: RegularQueryProjection =>
-        val sortedAndLimited = sortSkipAndLimit(selectedPlan, query)
-        projection(sortedAndLimited, queryProjection.projections, intermediate = query.tail.isDefined)
-
-      case UnwindProjection(identifier, expression) =>
-        context.logicalPlanProducer.planUnwind(plan, identifier, expression)
-
-      case _ =>
-        throw new CantHandleQueryException
-    }
-
-    projectedPlan
-  }
-}
-
-case class planWithTailX(expressionRewriterFactory: (LogicalPlanningContext => Rewriter) = ExpressionRewriterFactory,
-                        planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = planEventHorizonX())
-  extends LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] {
-
-//  @tailrec
-  override def apply(pred: LogicalPlan, remaining: Option[PlannerQuery])(implicit context: LogicalPlanningContext): LogicalPlan = {
-    remaining match {
-      case Some(query) =>
-        val lhs = pred
-        val lhsContext = context.recurse(lhs)
-        val rhs = planPart(query, lhsContext, Some(context.logicalPlanProducer.planQueryArgumentRow(query.graph)))
-        val applyPlan = context.logicalPlanProducer.planTailApply(lhs, rhs)
-
-        val applyContext = lhsContext.recurse(applyPlan)
-        val projectedPlan = planEventHorizon(query, applyPlan)(applyContext)
-
-        val projectedContext = applyContext.recurse(projectedPlan)
-        val expressionRewriter = expressionRewriterFactory(projectedContext)
-        val completePlan = projectedPlan.endoRewrite(expressionRewriter)
-
-        // planning nested expressions doesn't change outer cardinality
-        apply(completePlan, query.tail)(projectedContext)
-
-      case None =>
-        pred
-    }
-  }
-}
-
 case object planPart extends ((PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan) {
 
   def apply(query: PlannerQuery, context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
@@ -119,23 +89,5 @@ case object planPart extends ((PlannerQuery, LogicalPlanningContext, Option[Logi
       case _ => context
     }
     ctx.strategy.plan(query.graph)(ctx, leafPlan)
-  }
-}
-
-case class planSingleQueryX(planPart: (PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan = planPart,
-                           planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = planEventHorizonX(),
-                           expressionRewriterFactory: (LogicalPlanningContext => Rewriter) = ExpressionRewriterFactory,
-                           planWithTail: LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] = planWithTailX()) extends LogicalPlanningFunction1[PlannerQuery, LogicalPlan] {
-
-  override def apply(in: PlannerQuery)(implicit context: LogicalPlanningContext): LogicalPlan = {
-    val partPlan = planPart(in, context, None)
-
-    val projectedPlan = planEventHorizon(in, partPlan)
-    val projectedContext = context.recurse(projectedPlan)
-    val expressionRewriter = expressionRewriterFactory(projectedContext)
-    val completePlan = projectedPlan.endoRewrite(expressionRewriter)
-
-    val finalPlan = planWithTail(completePlan, in.tail)(projectedContext)
-    verifyBestPlan(finalPlan, in)
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyPlanTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyPlanTable.scala
@@ -49,7 +49,7 @@ object GreedyPlanTable {
              !(newSolved.graph.covers(solved.graph) &&
                solved.isCoveredByHints(newSolved))
          }
-         DefaultGreedyPlanTable(oldPlansNotCoveredByNewPlan + (newPlan.solved.lastQueryGraph -> newPlan))
+         DefaultGreedyPlanTable(oldPlansNotCoveredByNewPlan + (newSolved.lastQueryGraph -> newPlan))
        }
      }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Projection.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Projection.scala
@@ -30,7 +30,7 @@ case class Projection(left: LogicalPlan, expressions: Map[String, Expression])
 
   def numExpressions = expressions.size
 
-  val availableSymbols = expressions.keySet.map(IdName(_))
+  val availableSymbols = left.availableSymbols ++ expressions.keySet.map(IdName(_))
 
   override def mapExpressions(f: (Set[IdName], Expression) => Expression): LogicalPlan =
     copy(expressions = Eagerly.immutableMapValues[String, Expression, Expression](expressions, f(left.availableSymbols, _)))(solved)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Union.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Union.scala
@@ -27,5 +27,5 @@ case class Union(left: LogicalPlan, right: LogicalPlan)(val solved: PlannerQuery
   val lhs = Some(left)
   val rhs = Some(right)
 
-  def availableSymbols: Set[IdName] = left.availableSymbols
+  def availableSymbols = left.availableSymbols intersect right.availableSymbols
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/aggregation.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/aggregation.scala
@@ -35,8 +35,9 @@ object aggregation {
       case id => id.name -> id
     }.toMap
 
-    //  TODO: we need to project here since the pipe does not do that, when moving to the new runtime the aggregation pipe MUST do the projection itself
-    val projectedPlan = projection(plan, groupingExpressions ++ identifiersToKeep, intermediate = true)
+    //  TODO: we need to project here since the pipe does not do that,
+    //  when moving to the new runtime the aggregation pipe MUST do the projection itself
+    val projectedPlan = projection(plan, groupingExpressions ++ identifiersToKeep)
     context.logicalPlanProducer.planAggregation(projectedPlan, groupingExpressions, aggregation.aggregationExpressions)
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/projection.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/projection.scala
@@ -26,14 +26,15 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 
 object projection {
 
-  def apply(plan: LogicalPlan, projectionsMap: Map[String, Expression], intermediate: Boolean)(implicit context: LogicalPlanningContext): LogicalPlan = {
+  def apply(plan: LogicalPlan, projectionsMap: Map[String, Expression])(implicit context: LogicalPlanningContext): LogicalPlan = {
     val ids = plan.availableSymbols
+
     val projectAllCoveredIds: Set[(String, Expression)] = ids.map {
       case IdName(id) => id -> ast.Identifier(id)(null)
     }
     val projections: Set[(String, Expression)] = projectionsMap.toSeq.toSet
 
-    if (intermediate && projections.subsetOf(projectAllCoveredIds) || projections == projectAllCoveredIds)
+    if (projections.subsetOf(projectAllCoveredIds) || projections == projectAllCoveredIds)
       context.logicalPlanProducer.planStarProjection(plan, projectionsMap)
     else
       context.logicalPlanProducer.planRegularProjection(plan, projectionsMap)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/symbols/SymbolTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/symbols/SymbolTable.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.symbols
 
-import org.neo4j.cypher.internal.compiler.v2_3.{CypherException, SyntaxException, CypherTypeException}
+import org.neo4j.cypher.internal.compiler.v2_3.{CypherException, CypherTypeException, SyntaxException}
 
 import scala.collection.Map
 
@@ -52,6 +52,16 @@ case class SymbolTable(identifiers: Map[String, CypherType] = Map.empty) {
     true
   } catch {
     case _: CypherException => false
+  }
+
+  def intersect(other: SymbolTable): SymbolTable = {
+    val overlap = identifiers.keySet intersect other.identifiers.keySet
+
+    val mergedIdentifiers = (overlap map {
+      key => key -> identifiers(key).leastUpperBound(other.identifiers(key))
+    }).toMap
+
+    new SymbolTable(mergedIdentifiers)
   }
 }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGeneratorTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGeneratorTest.scala
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v2_3.planner.{SemanticTable, LogicalPlanningTestSupport}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{LogicalPlanningTestSupport, SemanticTable}
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.graphdb.{Direction, GraphDatabaseService, Node}
 import org.neo4j.helpers.Clock
@@ -63,10 +63,10 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("label scan") {// MATCH (a:T1) RETURN a
     //given
-  val plan = ProduceResult(List("a"), List.empty, List.empty, NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved))
+    val plan = ProduceResult(List("a"), List.empty, List.empty, NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved))
 
     //when
-    val compiled = compile( plan)
+    val compiled = compile(plan)
 
     //then
     val result = getNodesFromResult(compiled, "a")

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProduceResultsPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProduceResultsPipeTest.scala
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.mockito.Mockito._
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.Effects
+
+class ProduceResultsPipeTest extends CypherFunSuite {
+
+  implicit val monitor = mock[PipeMonitor]
+
+  test("should project needed columns") {
+    val sourcePipe = mock[Pipe]
+    val queryState = mock[QueryState]
+
+    when(queryState.decorator).thenReturn(NullPipeDecorator)
+    when(sourcePipe.createResults(queryState)).thenReturn(
+      Iterator(
+        ctx("a" -> "foo", "b" -> 10, "c" -> true, "d" -> "d"),
+        ctx("a" -> "bar", "b" -> 20, "c" -> false, "d" -> "d")
+      ))
+
+    val pipe = ProduceResultsPipe(sourcePipe, Seq("a", "b", "c"))(Some(1.0))
+
+    val result = pipe.createResults(queryState).toList
+
+    result should equal(
+      List(
+        Map("a" -> "foo", "b" -> 10, "c" -> true),
+        Map("a" -> "bar", "b" -> 20, "c" -> false)
+      ))
+  }
+
+  test("should produce no results if child pipe produces no results") {
+    val sourcePipe = mock[Pipe]
+    val queryState = mock[QueryState]
+
+    when(queryState.decorator).thenReturn(NullPipeDecorator)
+    when(sourcePipe.createResults(queryState)).thenReturn(Iterator.empty)
+
+    val pipe = ProduceResultsPipe(sourcePipe, Seq("a", "b", "c"))(Some(1.0))
+
+    val result = pipe.createResults(queryState).toList
+
+    result shouldBe empty
+  }
+
+  test("should have no effects because it does not touch the store") {
+    val pipe = ProduceResultsPipe(mock[Pipe], Seq("a", "b", "c"))(Some(1.0))
+    assert(pipe.localEffects == Effects())
+  }
+
+  private def ctx(data: (String, Any)*): ExecutionContext = {
+    new ExecutionContext().newWith(Map(data: _*))
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UnionPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UnionPipeTest.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription._
+
+class UnionPipeTest extends CypherFunSuite {
+  test("union between three pipes produces expected an expected plan description") {
+    val pipeA = fakePipe("A")
+    val pipeB = fakePipe("B")
+    val pipeC = fakePipe("C")
+    val sources = List(pipeA, pipeB, pipeC)
+
+    val pipe = UnionPipe(sources, List("a"))(mock[PipeMonitor])
+    val A = PlanDescriptionImpl(pipeA.id, "A", NoChildren, Seq.empty, Set.empty)
+    val B = PlanDescriptionImpl(pipeB.id, "B", NoChildren, Seq.empty, Set.empty)
+    val C = PlanDescriptionImpl(pipeC.id, "C", NoChildren, Seq.empty, Set.empty)
+    val AuB = PlanDescriptionImpl(pipe.id, "Union", TwoChildren(A, B), Seq.empty, Set("a"))
+    val AuBuC = PlanDescriptionImpl(pipe.id, "Union", TwoChildren(AuB, C), Seq.empty, Set("a"))
+
+    val description = pipe.planDescription
+    description should equal(AuBuC)
+  }
+
+  private def fakePipe(name: String): Pipe = new Pipe {
+    def monitor = ???
+
+    def sources = ???
+
+    def localEffects = ???
+
+    def planDescription = new PlanDescriptionImpl(id, name, NoChildren, Seq.empty, Set.empty)
+
+    def symbols = ???
+
+    protected def internalCreateResults(state: QueryState) = ???
+
+    def dup(sources: List[Pipe]) = ???
+
+    def exists(pred: (Pipe) => Boolean) = ???
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/DbStructureLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/DbStructureLogicalPlanningConfiguration.scala
@@ -46,11 +46,12 @@ object DbStructureLogicalPlanningConfiguration {
 
     new RealLogicalPlanningConfiguration {
 
-      override val computeSemanticTable: SemanticTable = new SemanticTable(
-        resolvedLabelIds = resolvedLabels,
-        resolvedPropertyKeyNames = resolvedPropertyKeys,
-        resolvedRelTypeNames = resolvedRelTypeNames
-      )
+      override def updateSemanticTableWithTokens(table: SemanticTable) = {
+        resolvedPropertyKeys.foreach { case (keyName, keyId) => table.resolvedPropertyKeyNames.put(keyName, PropertyKeyId(keyId)) }
+        resolvedLabels.foreach{ case (keyName, keyId) => table.resolvedLabelIds.put(keyName, LabelId(keyId)) }
+        resolvedRelTypeNames.foreach{ case (keyName, keyId) => table.resolvedRelTypeNames.put(keyName, RelTypeId(keyId))}
+        table
+      }
 
       override val graphStatistics: GraphStatistics =
         new StatisticsCompletingGraphStatistics(underlyingStatistics)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningConfiguration.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{Cost, _}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.GraphStatistics
 
 trait LogicalPlanningConfiguration {
-  def computeSemanticTable: SemanticTable
+  def updateSemanticTableWithTokens(in: SemanticTable): SemanticTable
   def cardinalityModel(queryGraphCardinalityModel: QueryGraphCardinalityModel): CardinalityModel
   def costModel(): PartialFunction[(LogicalPlan, QueryGraphSolverInput), Cost]
   def graphStatistics: GraphStatistics
@@ -40,7 +40,7 @@ trait LogicalPlanningConfiguration {
 }
 
 class DelegatingLogicalPlanningConfiguration(val parent: LogicalPlanningConfiguration) extends LogicalPlanningConfiguration {
-  override def computeSemanticTable = parent.computeSemanticTable
+  override def updateSemanticTableWithTokens(in: SemanticTable): SemanticTable = parent.updateSemanticTableWithTokens(in)
   override def cardinalityModel(queryGraphCardinalityModel: QueryGraphCardinalityModel): CardinalityModel =
     parent.cardinalityModel(queryGraphCardinalityModel)
   override def costModel() = parent.costModel()
@@ -55,8 +55,7 @@ class DelegatingLogicalPlanningConfiguration(val parent: LogicalPlanningConfigur
 trait LogicalPlanningConfigurationAdHocSemanticTable {
   self: LogicalPlanningConfiguration =>
 
-  override def computeSemanticTable: SemanticTable = {
-    val table = SemanticTable()
+  override def updateSemanticTableWithTokens(table: SemanticTable): SemanticTable = {
     def addLabelIfUnknown(labelName: String) =
       if (!table.resolvedLabelIds.contains(labelName))
         table.resolvedLabelIds.put(labelName, LabelId(table.resolvedLabelIds.size))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilderTest.scala
@@ -51,7 +51,7 @@ class PipeExecutionPlanBuilderTest extends CypherFunSuite with LogicalPlanningTe
 
     pipeInfo should not be 'updating
     pipeInfo.periodicCommit should equal(None)
-    pipeInfo.pipe should equal(ProjectionNewPipe(SingleRowPipe(), Map("42" -> legacy.Literal(42)))())
+    pipeInfo.pipe should equal(ProjectionPipe(SingleRowPipe(), Map("42" -> legacy.Literal(42)))())
   }
 
   test("simple pattern query") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
@@ -22,59 +22,61 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_3.ast._
+import org.neo4j.cypher.internal.compiler.v2_3.ast.{ASTAnnotationMap, Expression}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{IdName, LazyMode, LogicalPlan, Projection}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{IdName, LazyMode, LogicalPlan, ProduceResult, Projection}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v2_3.planner.{CardinalityEstimation, LogicalPlanningTestSupport2, PlannerQuery, QueryGraph, RegularQueryProjection, SemanticTable, UnionQuery}
-import org.neo4j.cypher.internal.compiler.v2_3.{InputPosition, Rewriter}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v2_3.symbols._
+import org.neo4j.cypher.internal.compiler.v2_3.{ExpressionTypeInfo, Rewriter}
 
 class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
-  test("names unnamed patterns when planning pattern expressions") {
+  test("adds ProduceResult with a single node") {
+    val result = createProduceResultOperator(Set("a"), SemanticTable().addNode(ident("a")))
 
-    // given
-    val expectedPlan = mock[LogicalPlan]
-    val solver = new TentativeQueryGraphSolver {
-      override def config = ???
-      override def tryPlan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): Option[LogicalPlan] = ???
-      override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = expectedPlan
-    }
-
-    implicit val context = LogicalPlanningContext(null, LogicalPlanProducer(mock[Metrics.CardinalityModel]), null, SemanticTable(), solver)
-    val patExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN ()-[]->(b)")
-
-    // when
-    val (producedPlan, namedExpr) = solver.planPatternExpression(Set.empty, patExpr)
-
-    // then
-    val expectedExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN (`  UNNAMED50`)-[`  UNNAMED52`]->(b)")
-
-    expectedExpr should equal(namedExpr)
-    expectedPlan should equal(producedPlan)
+    result.nodes should equal(Seq("a"))
+    result.relationships shouldBe empty
+    result.other shouldBe empty
   }
 
-  test("build correct semantic table when planning pattern expressions") {
+  test("adds ProduceResult with a single relationship") {
+    val result = createProduceResultOperator(Set("r"), SemanticTable().addRelationship(ident("r")))
 
-    // given
-    val expectedPlan = mock[LogicalPlan]
-    val solver = new QueryGraphSolver with PatternExpressionSolving {
-      override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
-        val table = context.semanticTable
-        table.isNode(Identifier("  UNNAMED50")(InputPosition(49, 1, 50))) should be(true)
-        table.isRelationship(Identifier("  UNNAMED52")(InputPosition(51, 1, 52))) should be(true)
-        expectedPlan
-      }
-    }
+    result.relationships should equal(Seq("r"))
+    result.nodes shouldBe empty
+    result.other shouldBe empty
+  }
 
-    implicit val context = LogicalPlanningContext(null, LogicalPlanProducer(mock[Metrics.CardinalityModel]), null, SemanticTable(), solver)
-    val patExpr = parsePatternExpression("WITH {a} AS a, {r} AS r, {b} AS b LIMIT 1 RETURN ()-[]->(b)")
+  test("adds ProduceResult with a single value") {
+    val expr = ident("x")
+    val types = ASTAnnotationMap.empty[Expression, ExpressionTypeInfo].updated(expr, ExpressionTypeInfo(CTFloat, None))
 
-    // when
-    val (producedPlan, _) = solver.planPatternExpression(Set.empty, patExpr)
+    val result = createProduceResultOperator(Set("x"), semanticTable = SemanticTable(types = types))
 
-    // then
-    expectedPlan should equal(producedPlan)
+    result.other should equal(Seq("x"))
+    result.nodes shouldBe empty
+    result.relationships shouldBe empty
+  }
+
+  private def createProduceResultOperator(columns: Set[String], semanticTable: SemanticTable): ProduceResult = {
+    implicit val planningContext = mockLogicalPlanningContext(semanticTable)
+
+    val inputPlan = mock[LogicalPlan]
+    when(inputPlan.availableSymbols).thenReturn(columns.map(IdName.apply))
+
+    val queryPlanner = DefaultQueryPlanner(identity, planSingleQuery = new FakePlanner(inputPlan))
+
+    val pq = PlannerQuery(horizon = RegularQueryProjection(columns.map(c => c -> ident(c)).toMap))
+
+    val union = UnionQuery(Seq(pq), distinct = false)
+
+    val result = queryPlanner.plan(union)
+
+    result shouldBe a [ProduceResult]
+
+    result.asInstanceOf[ProduceResult]
   }
 
   test("should set strictness when needed") {
@@ -83,6 +85,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(plannerQuery.preferredStrictness).thenReturn(Some(LazyMode))
     when(plannerQuery.graph).thenReturn(QueryGraph.empty)
     when(plannerQuery.horizon).thenReturn(RegularQueryProjection())
+    when(plannerQuery.lastQueryHorizon).thenReturn(RegularQueryProjection())
     when(plannerQuery.tail).thenReturn(None)
 
     val lp = {
@@ -102,7 +105,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(producer.planStarProjection(any(), any())(any())).thenReturn(lp)
     when(context.logicalPlanProducer).thenReturn(producer)
     val queryPlanner = new DefaultQueryPlanner(planRewriter = Rewriter.noop,
-      planSingleQuery = planSingleQueryX(expressionRewriterFactory = (lpc) => Rewriter.noop ))
+      planSingleQuery = PlanSingleQuery(expressionRewriterFactory = (lpc) => Rewriter.noop ))
 
     // when
     val query = UnionQuery(Seq(plannerQuery), distinct = false)
@@ -112,12 +115,14 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     verify(context, times(1)).withStrictness(LazyMode)
   }
 
-  private def parsePatternExpression(query: String): PatternExpression = {
-    parser.parse(query) match {
-      case Query(_, SingleQuery(clauses)) =>
-        val ret = clauses.last.asInstanceOf[Return]
-        val patExpr = ret.returnItems.items.head.expression.asInstanceOf[PatternExpression]
-        patExpr
-    }
+  class FakePlanner(result: LogicalPlan) extends LogicalPlanningFunction1[PlannerQuery, LogicalPlan] {
+    def apply(input: PlannerQuery)(implicit context: LogicalPlanningContext): LogicalPlan = result
   }
+
+  private def mockLogicalPlanningContext(semanticTable: SemanticTable) = LogicalPlanningContext(
+    planContext = mock[PlanContext],
+    logicalPlanProducer = LogicalPlanProducer(mock[Metrics.CardinalityModel]),
+    metrics = mock[Metrics],
+    semanticTable = semanticTable,
+    strategy = mock[QueryGraphSolver])
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
@@ -32,13 +32,10 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
 
   test("Should build plans containing expand for single relationship pattern") {
     planFor("MATCH (a)-[r]->(b) RETURN r").plan should equal(
-      Projection(
         Expand(
           AllNodesScan("b", Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"
-        )(solved),
-        Map("r" -> Identifier("r") _)
-      )(solved)
+        )(solved)
     )
   }
 
@@ -53,15 +50,15 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
         case _ => 100.0
       }
     } planFor "MATCH (a)-[r1]->(b), (c)-[r2]->(d) RETURN r1, r2").plan should beLike {
-      case Projection(
-            Selection(_,
-              CartesianProduct(
-                Expand(
-                  AllNodesScan(IdName("c"), _), _, _, _, _, _, _),
-                Expand(
-                  AllNodesScan(IdName("a"), _), _, _, _, _, _, _)
-              )
-            ), _) => ()
+      case
+        Selection(_,
+          CartesianProduct(
+            Expand(
+              AllNodesScan(IdName("c"), _), _, _, _, _, _, _),
+            Expand(
+              AllNodesScan(IdName("a"), _), _, _, _, _, _, _)
+          )
+        ) => ()
     }
   }
 
@@ -69,12 +66,9 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
     val result = planFor("MATCH (a)-[r]->(a) RETURN r").plan
 
     result should equal(
-      Projection(
-        Expand(
-          AllNodesScan("a", Set.empty)(solved),
-          "a", Direction.OUTGOING, Seq.empty, "a", "r", ExpandInto)(solved),
-        Map("r" -> Identifier("r") _)
-      )(solved)
+      Expand(
+        AllNodesScan("a", Set.empty)(solved),
+        "a", Direction.OUTGOING, Seq.empty, "a", "r", ExpandInto)(solved)
     )
   }
 
@@ -87,15 +81,13 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
       }
 
     } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").plan should equal(
-    Projection(
       Selection(Seq(Not(Equals(Identifier("r1")_,Identifier("r2")_)_)_),
         Expand(
           Expand(
             AllNodesScan(IdName("b"),Set.empty)(solved),
             IdName("b"), Direction.INCOMING, Seq.empty, IdName("a"), IdName("r1"),ExpandAll)(solved),
           IdName("b"), Direction.INCOMING, Seq.empty, IdName("a"), IdName("r2"), ExpandInto)(solved)
-        )(solved),
-        Map("r1" -> Identifier("r1")_, "r2" -> Identifier("r2")_))(solved)
+        )(solved)
     )
   }
 
@@ -109,15 +101,12 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
     (new given {
       cardinality = PartialFunction(myCardinality)
     } planFor "MATCH (start)-[rel:x]-(a) WHERE a.name = 'Andres' return a").plan should equal(
-      Projection(
         Expand(
           Selection(
             Seq(In(Property(Identifier("a")_, PropertyKeyName("name")_)_, Collection(Seq(StringLiteral("Andres")_))_)_),
             AllNodesScan("a", Set.empty)(solved)
           )(solved),
           "a", Direction.BOTH, Seq(RelTypeName("x")_), "start", "rel"
-        )(solved),
-        Map("a" -> Identifier("a") _)
       )(solved)
     )
   }
@@ -131,13 +120,10 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
 
       indexOn("Person", "name")
     } planFor "MATCH (a)-[r]->(b) USING INDEX b:Person(name) WHERE b:Person AND b.name = 'Andres' return r").plan should equal(
-      Projection(
         Expand(
           NodeIndexSeek("b", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), ManyQueryExpression(Collection(Seq(StringLiteral("Andres") _)) _), Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"
-        )(solved),
-        Map("r" -> ident("r"))
-      )(solved)
+        )(solved)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -30,38 +30,32 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
 
   test("finds shortest paths") {
     planFor("MATCH a, b, shortestPath(a-[r]->b) RETURN b").plan should equal(
-      Projection(
-        FindShortestPaths(
-          CartesianProduct(
-            AllNodesScan("b", Set.empty)(solved),
-            AllNodesScan("a", Set.empty)(solved)
-          )(solved),
-          ShortestPathPattern(
-            None,
-            PatternRelationship("r", ("a", "b"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
-            single = true
-          )(null)
+      FindShortestPaths(
+        CartesianProduct(
+          AllNodesScan("b", Set.empty)(solved),
+          AllNodesScan("a", Set.empty)(solved)
         )(solved),
-        Map("b" -> ident("b"))
+        ShortestPathPattern(
+          None,
+          PatternRelationship("r", ("a", "b"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
+          single = true
+        )(null)
       )(solved)
     )
   }
 
   test("finds all shortest paths") {
     planFor("MATCH a, b, allShortestPaths(a-[r]->b) RETURN b").plan should equal(
-      Projection(
-        FindShortestPaths(
-          CartesianProduct(
-            AllNodesScan("b", Set.empty)(solved),
-            AllNodesScan("a", Set.empty)(solved)
-          )(solved),
-          ShortestPathPattern(
-            None,
-            PatternRelationship("r", ("a", "b"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
-            single = false
-          )(null)
+      FindShortestPaths(
+        CartesianProduct(
+          AllNodesScan("b", Set.empty)(solved),
+          AllNodesScan("a", Set.empty)(solved)
         )(solved),
-        Map("b" -> ident("b"))
+        ShortestPathPattern(
+          None,
+          PatternRelationship("r", ("a", "b"), Direction.OUTGOING, Seq.empty, SimplePatternLength),
+          single = false
+        )(null)
       )(solved)
     )
   }
@@ -80,22 +74,20 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
     } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").plan
 
     val expected =
-      Projection(
-        FindShortestPaths(
-          Selection(
-            Seq(Not(Equals(Identifier("r1") _, Identifier("r2") _) _) _),
-            NodeHashJoin(
-              Set(IdName("b")),
-              Expand(
-                NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved),
-                IdName("a"), Direction.INCOMING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved),
-              Expand(
-                NodeByLabelScan(IdName("c"), LazyLabel("X"), Set.empty)(solved),
-                IdName("c"), Direction.INCOMING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
-            )(solved)
-          )(solved),
-          ShortestPathPattern(Some(IdName("p")), PatternRelationship("r", ("a", "c"), Direction.OUTGOING, Seq.empty, SimplePatternLength), single = true)(null))(solved),
-        Map("p" -> Identifier("p") _))(solved)
+      FindShortestPaths(
+        Selection(
+          Seq(Not(Equals(Identifier("r1") _, Identifier("r2") _) _) _),
+          NodeHashJoin(
+            Set(IdName("b")),
+            Expand(
+              NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved),
+              IdName("a"), Direction.INCOMING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved),
+            Expand(
+              NodeByLabelScan(IdName("c"), LazyLabel("X"), Set.empty)(solved),
+              IdName("c"), Direction.INCOMING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
+          )(solved)
+        )(solved),
+        ShortestPathPattern(Some(IdName("p")), PatternRelationship("r", ("a", "c"), Direction.OUTGOING, Seq.empty, SimplePatternLength), single = true)(null))(solved)
 
     result should equal(expected)
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
@@ -43,15 +43,12 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val pathExpr = PathExpression(NodePathStep(Identifier("a")_,SingleRelationshipPathStep(Identifier("r")_, Direction.OUTGOING, NilPathStep)))_
 
     planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a RETURN b").plan should equal(
-      Projection(
-        Selection(
-          Seq(Equals(
-            FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
-            Identifier("a")_
-          )_),
-          Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
-        )(solved),
-        expressions = Map("b" -> Identifier("b") _)
+      Selection(
+        Seq(Equals(
+          FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
+          Identifier("a")_
+        )_),
+        Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
       )(solved)
     )
   }
@@ -60,21 +57,18 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val pathExpr = PathExpression(NodePathStep(Identifier("a")_,SingleRelationshipPathStep(Identifier("r")_, Direction.OUTGOING, NilPathStep)))_
 
     planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a AND length(p) > 10 RETURN b").plan should equal(
-      Projection(
-        Selection(
-          Seq(
-            GreaterThan(
-              FunctionInvocation(FunctionName("length")_, pathExpr)_,
-              SignedDecimalIntegerLiteral("10")_
-            )_,
-            Equals(
-              FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
-              Identifier("a")_
-            )_
-          ),
-          Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
-        )(solved),
-        expressions = Map("b" -> Identifier("b") _)
+      Selection(
+        Seq(
+          GreaterThan(
+            FunctionInvocation(FunctionName("length")_, pathExpr)_,
+            SignedDecimalIntegerLiteral("10")_
+          )_,
+          Equals(
+            FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
+            Identifier("a")_
+          )_
+        ),
+        Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -44,7 +44,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
 
     } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X) RETURN b").plan
 
-    val expected = Projection(
+    val expected =
       Selection(
         Seq(Not(Equals(Identifier("r1")_, Identifier("r2")_)_)_),
         NodeHashJoin(
@@ -56,8 +56,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
             NodeByLabelScan(IdName("c"), LazyLabel("X"), Set.empty)(solved),
             IdName("c"), Direction.INCOMING, Seq.empty, IdName("b"), IdName("r2"))(solved)
         )(solved)
-      )(solved),
-      Map("b" -> Identifier("b") _))(solved)
+      )(solved)
 
     result should equal(expected)
   }
@@ -76,19 +75,16 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
 
       indexOn("Person", "name")
     } planFor "MATCH (a)-[r]->(b) USING INDEX a:Person(name) USING INDEX b:Person(name) WHERE a:Person AND b:Person AND a.name = 'Jakub' AND b.name = 'Andres' return r").plan should equal(
-      Projection(
-        NodeHashJoin(
-          Set(IdName("b")),
-          Selection(
-            Seq(In(Property(ident("b"), PropertyKeyName("name")_)_, Collection(Seq(StringLiteral("Andres")_))_)_, HasLabels(ident("b"), Seq(LabelName("Person")_))_),
-            Expand(
-              NodeIndexSeek("a", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), ManyQueryExpression(Collection(Seq(StringLiteral("Jakub") _)) _), Set.empty)(solved),
-              "a", Direction.OUTGOING, Seq.empty, "b", "r"
-            )(solved)
-          )(solved),
-          NodeIndexSeek("b", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), ManyQueryExpression(Collection(Seq(StringLiteral("Andres") _)) _), Set.empty)(solved)
+      NodeHashJoin(
+        Set(IdName("b")),
+        Selection(
+          Seq(In(Property(ident("b"), PropertyKeyName("name")_)_, Collection(Seq(StringLiteral("Andres")_))_)_, HasLabels(ident("b"), Seq(LabelName("Person")_))_),
+          Expand(
+            NodeIndexSeek("a", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), ManyQueryExpression(Collection(Seq(StringLiteral("Jakub") _)) _), Set.empty)(solved),
+            "a", Direction.OUTGOING, Seq.empty, "b", "r"
+          )(solved)
         )(solved),
-        Map("r" -> ident("r"))
+        NodeIndexSeek("b", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), ManyQueryExpression(Collection(Seq(StringLiteral("Andres") _)) _), Set.empty)(solved)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
 
   test("should build plans containing joins") {
     (new given {
-      cost =  {
+      cost = {
         case (_: AllNodesScan, _) => 2000000.0
         case (_: NodeByLabelScan, _) => 20.0
         case (_: Expand, _) => 10.0
@@ -40,12 +40,9 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
         case _ => Double.MaxValue
       }
     } planFor "MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b").plan should equal(
-      Projection(
-        OuterHashJoin(Set("b"),
-          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq(), "b", "r1")(solved),
-          Expand(NodeByLabelScan("c", LazyLabel("Y"), Set.empty)(solved), "c", Direction.INCOMING, Seq(), "b", "r2")(solved)
-        )(solved),
-        expressions = Map("b" -> ident("b"))
+      OuterHashJoin(Set("b"),
+        Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq(), "b", "r1")(solved),
+        Expand(NodeByLabelScan("c", LazyLabel("Y"), Set.empty)(solved), "c", Direction.INCOMING, Seq(), "b", "r2")(solved)
       )(solved)
     )
   }
@@ -58,7 +55,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
 
   test("should build simple optional expand") {
     planFor("MATCH n OPTIONAL MATCH n-[:NOT_EXIST]->x RETURN n").plan.endoRewrite(unnestOptional) match {
-      case Projection(OptionalExpand(
+      case OptionalExpand(
       AllNodesScan(IdName("n"), _),
       IdName("n"),
       Direction.OUTGOING,
@@ -67,13 +64,13 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       _,
       _,
       _
-      ), _) => ()
+      ) => ()
     }
   }
 
   test("should build optional ProjectEndpoints") {
     planFor("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2) RETURN a1, r, b2").plan match {
-      case Projection(
+      case
       Apply(
       Limit(
       Expand(
@@ -83,14 +80,14 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       Argument(args), IdName("r"), IdName("b2"), false, IdName("a1"), true, None, true, SimplePatternLength
       )
       )
-      ), _) =>
+      ) =>
         args should equal(Set(IdName("r"), IdName("a1")))
     }
   }
 
   test("should build optional ProjectEndpoints with extra predicates") {
     planFor("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2").plan match {
-      case Projection(Apply(
+      case Apply(
       Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
       Selection(
@@ -101,7 +98,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       )
       )
       )
-      ), _) =>
+      ) =>
         args should equal(Set(IdName("r"), IdName("a1")))
         val predicate: Expression = Equals(Identifier("a1")_, Identifier("a2")_)_
         predicates should equal(Seq(predicate))
@@ -110,7 +107,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
 
   test("should build optional ProjectEndpoints with extra predicates 2") {
     planFor("MATCH (a1)-[r]->(b1) WITH r LIMIT 1 OPTIONAL MATCH (a2)-[r]->(b2) RETURN a2, r, b2").plan  match {
-      case Projection(Apply(
+      case Apply(
       Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
       ProjectEndpoints(
@@ -118,7 +115,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       IdName("r"), IdName("a2"), false, IdName("b2"), false, None, true, SimplePatternLength
       )
       )
-      ), _) =>
+      ) =>
         args should equal(Set(IdName("r")))
     }
   }
@@ -126,14 +123,11 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
   test("should solve multiple optional matches") {
     val plan = planFor("MATCH a OPTIONAL MATCH (a)-[:R1]->(x1) OPTIONAL MATCH (a)-[:R2]->(x2) RETURN a, x1, x2").plan.endoRewrite(unnestOptional)
     plan should equal(
-      Projection(
+      OptionalExpand(
         OptionalExpand(
-          OptionalExpand(
-            AllNodesScan(IdName("a"), Set.empty)(solved),
-            IdName("a"), Direction.OUTGOING, List(RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(solved),
-          IdName("a"), Direction.OUTGOING, List(RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(solved),
-        Map("a" -> ident("a"), "x1" -> ident("x1"), "x2" -> ident("x2"))
-      )(solved)
+          AllNodesScan(IdName("a"), Set.empty)(solved),
+          IdName("a"), Direction.OUTGOING, List(RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(solved),
+        IdName("a"), Direction.OUTGOING, List(RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(solved)
     )
   }
 
@@ -146,11 +140,8 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
     val allNodesN:LogicalPlan = AllNodesScan(IdName("n"),Set())(s)
     val predicate: Expression = In(Property(ident("m"), PropertyKeyName("prop") _) _, Collection(List(SignedDecimalIntegerLiteral("42") _)) _) _
     plan should equal(
-      Projection(
-        OptionalExpand( allNodesN, IdName( "n" ), Direction.BOTH, Seq.empty, IdName( "m" ), IdName( "r" ), ExpandAll,
-          Vector( predicate ) )( s ),
-        Map("m" -> ident("m"))
-      )(s)
+      OptionalExpand(allNodesN, IdName("n"), Direction.BOTH, Seq.empty, IdName("m"), IdName("r"), ExpandAll,
+        Vector(predicate))(s)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PatternPredicatePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PatternPredicatePlanningIntegrationTest.scala
@@ -141,7 +141,6 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
 
   test("should build plans containing let select or semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE a.prop = 9 OR (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
         SelectOrAntiSemiApply(
           LetSelectOrSemiApply(
             AllNodesScan("a", Set.empty)(solved),
@@ -157,15 +156,12 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
             "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED61", "  UNNAMED54"
           )(solved),
           ident("  FRESHID30")
-        )(solved),
-        Map("a" -> ident("a"))
-      )(solved)
+        )(solved)
     )
   }
 
   test("should build plans containing let semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
         SelectOrAntiSemiApply(
           LetSemiApply(
             AllNodesScan("a", Set.empty)(solved),
@@ -180,15 +176,12 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
             "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED47", "  UNNAMED40"
           )(solved),
           ident("  FRESHID16")
-        )(solved),
-        Map("a" -> ident("a"))
-      )(solved)
+        )(solved)
     )
   }
 
   test("should build plans containing let anti semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE NOT (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
         SelectOrAntiSemiApply(
           LetAntiSemiApply(
             AllNodesScan("a", Set.empty)(solved),
@@ -203,9 +196,7 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
             "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED51", "  UNNAMED44"
           )(solved),
           ident("  FRESHID20")
-        )(solved),
-        Map("a" -> ident("a"))
-      )(solved)
+        )(solved)
     )
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizonTest.scala
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.DummyPosition
+import org.neo4j.cypher.internal.compiler.v2_3.ast.{Identifier, SignedDecimalIntegerLiteral}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{IdName, AllNodesScan, Projection, SingleRow}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{CardinalityEstimation, PlannerQuery, RegularQueryProjection, SemanticTable}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
+
+class PlanEventHorizonTest extends CypherFunSuite {
+
+  val pos = DummyPosition(1)
+  implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[Metrics.CardinalityModel]), mock[Metrics], SemanticTable(), mock[QueryGraphSolver])
+
+  test("should not do projection if not necessary") {
+    // Given
+    val pq = PlannerQuery(horizon = RegularQueryProjection(Map("a" -> Identifier("a")(pos))))
+    val inputPlan = AllNodesScan(IdName("a"), Set.empty)(CardinalityEstimation.lift(PlannerQuery(), Cardinality(1)))
+
+    // When
+    val producedPlan = PlanEventHorizon()(pq, inputPlan)
+
+    // Then
+    inputPlan should equal(producedPlan)
+  }
+
+  test("should do projection if necessary") {
+    // Given
+    val literal: SignedDecimalIntegerLiteral = SignedDecimalIntegerLiteral("42")(pos)
+    val pq = PlannerQuery(horizon = RegularQueryProjection(Map("a" -> literal)))
+    val inputPlan = SingleRow()(CardinalityEstimation.lift(PlannerQuery(), Cardinality(1)))
+
+    // When
+    val producedPlan = PlanEventHorizon()(pq, inputPlan)
+
+    // Then
+    producedPlan should equal(Projection(inputPlan, Map("a" -> literal))(CardinalityEstimation.lift(PlannerQuery(), Cardinality(1))))
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/UnionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/UnionPlanningIntegrationTest.scala
@@ -29,46 +29,51 @@ class UnionPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTe
 
   test("MATCH (a:A) RETURN a AS a UNION ALL MATCH (a:B) RETURN a AS a") {
 
-    val setup: UnionPlanningIntegrationTest.this.type#given = new given {
+    val setup = new given {
       knownLabels = Set("A", "B")
     }
     implicit val (logicalPlan, semanticTable) = setup.getLogicalPlanFor("MATCH (a:A) RETURN a AS a UNION ALL MATCH (a:B) RETURN a AS a")
 
     logicalPlan should equal(
-      Union(
-        Projection(
-          NodeByLabelScan("  a@7", LazyLabel(LabelName("A")_), Set.empty)(solved),
-          Map("a" -> Identifier("  a@7")_)
-        )(solved),
-        Projection(
-          NodeByLabelScan("  a@43", LazyLabel(LabelName("B")_), Set.empty)(solved),
-          Map("a" -> Identifier("  a@43")_)
+      ProduceResult(Seq("a"), Seq.empty, Seq.empty,
+        Union(
+          Projection(
+            NodeByLabelScan("  a@7", LazyLabel(LabelName("A") _), Set.empty)(solved),
+            Map("a" -> Identifier("  a@7") _)
+          )(solved),
+          Projection(
+            NodeByLabelScan("  a@43", LazyLabel(LabelName("B") _), Set.empty)(solved),
+            Map("a" -> Identifier("  a@43") _)
+          )(solved)
         )(solved)
-      )(solved)
+      )
     )
   }
+
   test("MATCH (a:A) RETURN a AS a UNION MATCH (a:B) RETURN a AS a") {
 
-    val setup: UnionPlanningIntegrationTest.this.type#given = new given {
+    val setup = new given {
       knownLabels = Set("A", "B")
     }
     implicit val (logicalPlan, semanticTable) = setup.getLogicalPlanFor("MATCH (a:A) RETURN a AS a UNION MATCH (a:B) RETURN a AS a")
 
     logicalPlan should equal(
-      Aggregation(
-        left = Union(
-          Projection(
-            NodeByLabelScan("  a@7", LazyLabel(LabelName("A")_), Set.empty)(solved),
-            Map("a" -> Identifier("  a@7")_)
+      ProduceResult(Seq("a"), Seq.empty, Seq.empty,
+        Aggregation(
+          left = Union(
+            Projection(
+              NodeByLabelScan("  a@7", LazyLabel(LabelName("A") _), Set.empty)(solved),
+              Map("a" -> Identifier("  a@7") _)
+            )(solved),
+            Projection(
+              NodeByLabelScan("  a@39", LazyLabel(LabelName("B") _), Set.empty)(solved),
+              Map("a" -> Identifier("  a@39") _)
+            )(solved)
           )(solved),
-          Projection(
-            NodeByLabelScan("  a@39", LazyLabel(LabelName("B")_), Set.empty)(solved),
-            Map("a" -> Identifier("  a@39")_)
-          )(solved)
-        )(solved),
-        groupingExpressions = Map("a" -> ident("a")),
-        aggregationExpression = Map.empty
-      )(solved)
+          groupingExpressions = Map("a" -> ident("a")),
+          aggregationExpression = Map.empty
+        )(solved)
+      )
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
@@ -46,62 +46,62 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
     resultText should equal(
       // oh perty where art thou!?
-      "Projection(Limit(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(b -> Identifier(b)))")
+      "Limit(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),UnsignedDecimalIntegerLiteral(1))")
   }
 
   test("should build plans with WITH and selections") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r1]->(b) WHERE r1.prop = 42 RETURN r1").plan
 
     result.toString should equal(
-      "Projection(Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll))),Map(r1 -> Identifier(r1)))")
+      "Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll)))")
   }
 
   test("should build plans for two matches separated by WITH") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN b").plan
 
     result.toString should equal(
-      "Projection(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll),Map(b -> Identifier(b)))")
+      "Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll)")
   }
 
   test("should build plans that project endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r LIMIT 1 MATCH (u)-[r]->(v) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project endpoints of re-matched reversed directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r AS r, a AS a LIMIT 1 MATCH (b2)<-[r]-(a) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH * LIMIT 1 MATCH (a)-[r]->(b) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]->(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched undirected relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]-(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed var length relationship arguments") {
     val plan = planFor("MATCH (a)-[r*]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r*]->(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None))),Map(r -> Identifier(r)))")
+      "Apply(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None)))")
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
@@ -66,7 +66,7 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     aggregation(startPlan, projectionPlan)(context) should equal(
       Aggregation(
-        projection(startPlan, groupingMap + ("n" -> ident("n")), true),
+        projection(startPlan, groupingMap + ("n" -> ident("n"))),
         groupingMap, aggregatingMap2)(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
@@ -24,8 +24,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.ast
 import org.neo4j.cypher.internal.compiler.v2_3.ast.AscSortItem
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.{Ascending, SortDescription}
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{Cardinality, LogicalPlanningContext}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{IdName, LogicalPlan, Projection}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{Cardinality, LogicalPlanningContext}
 
 class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -41,7 +41,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, intermediate = true)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(Projection(startPlan, projections)(solved))
@@ -54,36 +54,23 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, intermediate = true)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(startPlan)
     result.solved.horizon should equal(RegularQueryProjection(projections))
   }
 
-  test("does add the final projection when needed") {
+  test("does projection when renaming columns") {
     // given
-    val projections: Map[String, ast.Expression] = Map("n" -> ast.Identifier("n") _)
+    val projections: Map[String, ast.Expression] = Map("  n@34" -> ast.Identifier("n") _)
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, intermediate = false)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(Projection(startPlan, projections)(solved))
-    result.solved.horizon should equal(RegularQueryProjection(projections))
-  }
-
-  test("does not add the final projection when not needed") {
-    // given
-    val projections: Map[String, ast.Expression] = Map("n" -> ast.Identifier("n") _, "m" -> ast.Identifier("m") _)
-    implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
-
-    // when
-    val result = projection(startPlan, projections, intermediate = false)
-
-    // then
-    result should equal(startPlan)
     result.solved.horizon should equal(RegularQueryProjection(projections))
   }
 
@@ -95,10 +82,10 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
       planContext = newMockedPlanContext
     )
 
-    val ids = Set(IdName("n"), IdName("m"))
+    val ids = projectionsMap.keys.map(IdName(_)).toSet
 
     val plan =
-      newMockedLogicalPlanWithSolved(ids, CardinalityEstimation.lift(PlannerQuery(QueryGraph.empty.addPatternNodes(IdName("n"), IdName("m"))), Cardinality(0)))
+      newMockedLogicalPlanWithSolved(ids, CardinalityEstimation.lift(PlannerQuery(QueryGraph.empty.addPatternNodes(ids.toList: _*)), Cardinality(0)))
 
     (context, plan)
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
@@ -105,7 +105,7 @@ class ProfilerTest extends CypherFunSuite {
     val projectedPath = mock[ProjectedPath]
     val DB_HITS = 100
     val innerPipe = NestedPipeExpression(new ProfilerTestPipe(SingleRowPipe(), "nested pipe", rows = 10, dbAccess = DB_HITS), projectedPath)
-    val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
+    val pipeUnderInspection = ProjectionPipe(SingleRowPipe(), Map("x" -> innerPipe))()
 
     val queryContext = mock[QueryContext]
     val profiler = new Profiler
@@ -125,9 +125,9 @@ class ProfilerTest extends CypherFunSuite {
     val projectedPath = mock[ProjectedPath]
     val DB_HITS = 100
     val nestedExpression = NestedPipeExpression(new ProfilerTestPipe(SingleRowPipe(), "nested pipe1", rows = 10, dbAccess = DB_HITS), projectedPath)
-    val innerInnerPipe = ProjectionNewPipe(SingleRowPipe(), Map("y"->nestedExpression))()
+    val innerInnerPipe = ProjectionPipe(SingleRowPipe(), Map("y"->nestedExpression))()
     val innerPipe = NestedPipeExpression(new ProfilerTestPipe(innerInnerPipe, "nested pipe2", rows = 10, dbAccess = DB_HITS), projectedPath)
-    val pipeUnderInspection = ProjectionNewPipe(SingleRowPipe(), Map("x" -> innerPipe))()
+    val pipeUnderInspection = ProjectionPipe(SingleRowPipe(), Map("x" -> innerPipe))()
 
     val queryContext = mock[QueryContext]
     val profiler = new Profiler

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternExpressionAcceptanceTest.scala
@@ -369,7 +369,8 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
       )
     }
 
-    val legacyExpression = result.executionPlanDescription().arguments.collect {case n: LegacyExpression => n}.head
+    val args = result.executionPlanDescription().children.head.arguments
+    val legacyExpression = args.collect {case n: LegacyExpression => n}.head
     val pipe = legacyExpression.value.asInstanceOf[NestedPipeExpression].pipe
 
     pipe should beLike {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnionAcceptanceTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher
 class UnionAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
   test("should be able to create text output from union queries") {
     // When
-    val result = executeWithRulePlanner("merge (a) return a union merge (a) return a")
+    val result = executeWithAllPlanners("MATCH (a:A) RETURN a AS a UNION MATCH (a:B) RETURN a AS a")
 
     // Then
     result.columns should not be empty

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -193,7 +193,7 @@ class QueryPlanTest extends DocumentingTestBase {
         """For each row from its input, projection executes a set of expressions and produces a row with the results of the expressions.
           |The following query will produce one row with the value "hello".""".stripMargin,
       queryText = """RETURN "hello" AS greeting""",
-      assertion = (p) => assertThat(p.executionPlanDescription().toString, startsWith("Projection"))
+      assertion = (p) => assertThat(p.executionPlanDescription().toString, containsString("Projection"))
     )
   }
 
@@ -522,7 +522,7 @@ class QueryPlanTest extends DocumentingTestBase {
         """Takes a collection of values and returns one row per item in the collection.
           |The following query will return one row for each of the numbers 1 to 5.""".stripMargin,
       queryText = """UNWIND range(1,5) as value return value;""",
-      assertion = (p) => assertThat(p.executionPlanDescription().toString, startsWith("UNWIND"))
+      assertion = (p) => assertThat(p.executionPlanDescription().toString, containsString("UNWIND"))
     )
   }
 


### PR DESCRIPTION
Before this change, Projection would both evaluate expressions and clean out
the contents of rows. Now Projection only means execution expressions and
storing their results. Cleaning of columns is now done by ProduceResult, which
is only introduced at the very last step in every plan.
