### PR TITLE
Fixes problem when using named paths and aggregation

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/projectNamedPaths.scala
@@ -43,7 +43,7 @@ case object projectNamedPaths extends Rewriter {
     case expr: Expression =>
       replacer.stop(expr)
 
-    case clause@With(_, ri: ReturnItems, _, _, _, _) =>
+    case clause@With(_, ri: ReturnItems, _, _, _, _) if !ri.containsAggregate =>
       val pathDependencies = clause.treeFold(Set.empty[Identifier]) {
         case step:PathStep => (acc, children) => children(acc ++ step.dependencies)
         case _ => (acc, children) => children(acc)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectNamedPathsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectNamedPathsTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.AstRewritingTestSupport
-import org.neo4j.cypher.internal.compiler.v2_2.{SyntaxExceptionCreator, SemanticState, inSequence}
+import org.neo4j.cypher.internal.compiler.v2_2.{SemanticState, SyntaxExceptionCreator, inSequence}
 import org.neo4j.graphdb.Direction
 
 class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport {
@@ -77,6 +77,45 @@ class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport 
         ))(pos), None, None, None)(pos)
 
     val expected: Query = Query(None, SingleQuery(List(MATCH, WITH, RETURN))(pos))(pos)
+
+    rewritten should equal(expected)
+  }
+
+  test("Aggregating WITH downstreams" ) {
+    val rewritten = projectionInlinedAst("MATCH p = (a) WITH length(p) as l, count(*) as x WITH l, x RETURN l + x")
+    val a = ident("a")
+    val p = ident("p")
+    val l = ident("l")
+    val x = ident("x")
+    val MATCH =
+      Match(optional = false,
+        Pattern(List(
+          EveryPath(
+              NodePattern(Some(a), List(), None, naked = false)(pos))
+        ))(pos), List(), None)(pos)
+
+    val pathExpression = PathExpression(NodePathStep(a, NilPathStep))(pos)
+    val WITH1 =
+      With(distinct = false,
+        ReturnItems(includeExisting = false, Seq(
+          AliasedReturnItem(FunctionInvocation(FunctionName("length")(pos), pathExpression)(pos), l)(pos),
+          AliasedReturnItem(CountStar()(pos), x)(pos)
+        ))(pos), None, None, None, None)(pos)
+
+    val WITH2 =
+      With(distinct = false,
+        ReturnItems(includeExisting = false, Seq(
+          AliasedReturnItem(l, l)(pos),
+          AliasedReturnItem(x, x)(pos)
+        ))(pos), None, None, None, None)(pos)
+
+    val RETURN =
+      Return(distinct = false,
+        ReturnItems(includeExisting = false, Seq(
+          AliasedReturnItem(Add(l, x)(pos), ident("l + x"))(pos)
+        ))(pos), None, None, None)(pos)
+
+    val expected: Query = Query(None, SingleQuery(List(MATCH, WITH1, WITH2, RETURN))(pos))(pos)
 
     rewritten should equal(expected)
   }

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.2
+-----
+o Fixes problem when using named paths and aggregation
+
 2.2.1
 -----
 o NOTE: Support for Cypher version 2.0 and 2.1 will be removed in Neo4j 2.3

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
@@ -177,4 +177,30 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     //THEN
     result.toList should equal (List(Map("count(*)" -> 100)))
   }
+
+  test("aggregation around named paths works") {
+    val a = createNode()
+    val b = createNode()
+    val c = createNode()
+    val d = createNode()
+    val e = createNode()
+    val f = createNode()
+
+    relate(a, b)
+
+    relate(c, d)
+    relate(d, e)
+    relate(e, f)
+
+    val result = executeWithAllPlanners(
+      """match p = a-[*]->b
+        |return collect(nodes(p)) as paths, length(p) as l order by length(p)""".stripMargin)
+
+    val expected =
+      List(Map("l" -> 1, "paths" -> List(List(a, b), List(c, d), List(d, e), List(e, f))),
+           Map("l" -> 2, "paths" -> List(List(c, d, e), List(d, e, f))),
+           Map("l" -> 3, "paths" -> List(List(c, d, e, f))))
+
+    result.toList should be (expected)
+  }
 }


### PR DESCRIPTION
The projectNamedPaths rewriter added columns to intermediate WITH clauses,
and sometimes that changes the semantics of the aggregation. This commit
stops these rewrites in the presence of aggregation.
