### PR TITLE
Don't clear page memory during eviction

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/Page.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/Page.java
@@ -75,4 +75,9 @@ public interface Page
      *                     reopened and the swapIn operation must be retried.
      */
     void swapOut( StoreChannel channel, long offset, int length ) throws IOException;
+
+    /**
+     * Set the byte contents of this page to be all zeros.
+     */
+    void clear();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -95,6 +95,10 @@ public class SingleFilePageSwapper implements PageSwapper
             {
                 return page.swapIn( channel, offset, filePageSize );
             }
+            else
+            {
+                page.clear();
+            }
         }
         catch ( ClosedChannelException e )
         {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -326,10 +326,7 @@ final class MuninnPage extends StampedLock implements Page
             while ( read != -1 && (readTotal += read) < length );
 
             // Zero-fill the rest.
-            while ( bufferProxy.position() < bufferProxy.limit() )
-            {
-                bufferProxy.put( (byte) 0 );
-            }
+            UnsafeUtil.setMemory( pointer + readTotal, getCachePageSize() - readTotal, (byte) 0 );
             return readTotal;
         }
         catch ( ClosedChannelException e )
@@ -368,6 +365,12 @@ final class MuninnPage extends StampedLock implements Page
         {
             throw new IOException( e );
         }
+    }
+
+    @Override
+    public void clear()
+    {
+        UnsafeUtil.setMemory( pointer, getCachePageSize(), (byte) 0 );
     }
 
     /**
@@ -463,7 +466,6 @@ final class MuninnPage extends StampedLock implements Page
         evictionEvent.setSwapper( swapper );
 
         flush( evictionEvent.flushEventOpportunity() );
-        UnsafeUtil.setMemory( pointer, getCachePageSize(), (byte) 0 );
         this.filePageId = PageCursor.UNBOUND_PAGE_ID;
 
         this.swapper = null;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -68,6 +68,7 @@ import org.neo4j.io.pagecache.randomharness.Command;
 import org.neo4j.io.pagecache.randomharness.PageCountRecordFormat;
 import org.neo4j.io.pagecache.randomharness.Phase;
 import org.neo4j.io.pagecache.randomharness.RandomPageCacheTestHarness;
+import org.neo4j.io.pagecache.randomharness.Record;
 import org.neo4j.io.pagecache.randomharness.RecordFormat;
 import org.neo4j.io.pagecache.randomharness.StandardRecordFormat;
 import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
@@ -78,6 +79,7 @@ import org.neo4j.test.RepeatRule;
 
 import static java.lang.Long.toHexString;
 import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -3846,5 +3848,51 @@ public abstract class PageCacheTest<T extends PageCache>
             swapOutLatch.await();
             verifyRecordsInFile( file, recordsPerFilePage );
         }
+    }
+
+    @Test
+    public void mustReadZerosFromBeyondEndOfFile() throws Exception
+    {
+        StandardRecordFormat recordFormat = new StandardRecordFormat();
+        File[] files = {
+                new File( "1" ), new File( "2" ), new File( "3" ), new File( "4" ), new File( "5" ), new File( "6" ),
+                new File( "7" ), new File( "8" ), new File( "9" ), new File( "0" ), new File( "A" ), new File( "B" ),
+        };
+        for ( int fileId = 0; fileId < files.length; fileId++ )
+        {
+            File file = files[fileId];
+            StoreChannel channel = fs.open( file, "rw" );
+            for ( int recordId = 0; recordId < fileId + 1; recordId++ )
+            {
+                Record record = recordFormat.createRecord( file, recordId );
+                recordFormat.writeRecord( record, channel );
+            }
+            channel.close();
+        }
+
+        int pageSize = nextPowerOf2( recordFormat.getRecordSize() * (files.length + 1) );
+        getPageCache( fs, 2, pageSize, PageCacheTracer.NULL );
+
+        int fileId = files.length;
+        while ( fileId --> 0 )
+        {
+            File file = files[fileId];
+            try ( PagedFile pf = pageCache.map( file, pageSize );
+                  PageCursor cursor = pf.io( 0, PF_SHARED_LOCK ) )
+            {
+                int pageCount = 0;
+                while( cursor.next() )
+                {
+                    pageCount++;
+                    recordFormat.assertRecordsWrittenCorrectly( cursor );
+                }
+                assertThat( "pages in file " + file, pageCount, greaterThan( 0 ) );
+            }
+        }
+    }
+
+    private int nextPowerOf2( int i )
+    {
+        return 1 << (32 - Integer.numberOfLeadingZeros( i ) );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -44,6 +44,13 @@ public class StubPageCursor implements PageCursor
         this.page = new ByteBufferPage( ByteBuffer.allocate(pageSize) );
     }
 
+    public StubPageCursor( long initialPageId, ByteBuffer buffer )
+    {
+        this.pageId = initialPageId;
+        this.pageSize = buffer.capacity();
+        this.page = new ByteBufferPage( buffer );
+    }
+
     @Override
     public long getCurrentPageId()
     {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
@@ -122,4 +122,16 @@ public class ByteBufferPage implements Page
         duplicate.limit( length );
         channel.writeAll( duplicate, offset );
     }
+
+    @Override
+    public void clear()
+    {
+        ByteBuffer duplicate = buffer.duplicate();
+        duplicate.clear();
+        int length = duplicate.capacity();
+        for ( int i = 0; i < length; i++ )
+        {
+            duplicate.put( (byte) 0 );
+        }
+    }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
@@ -21,8 +21,11 @@ package org.neo4j.io.pagecache.randomharness;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
+import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.StubPageCursor;
 
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertThat;
@@ -43,6 +46,14 @@ public abstract class RecordFormat
     {
         int recordsPerPage = cursor.getCurrentPageSize() / getRecordSize();
         writeRecordToPage( cursor, cursor.getCurrentPageId(), recordsPerPage );
+    }
+
+    public final void writeRecord( Record record, StoreChannel channel ) throws IOException
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( getRecordSize() );
+        StubPageCursor cursor = new StubPageCursor( 0, buffer );
+        write( record, cursor );
+        channel.writeAll( buffer );
     }
 
     public final void fillWithRecords( PageCursor cursor )


### PR DESCRIPTION
- Instead only clear it in the page faulting threads that happen to actually
  need it. This speeds up eviction.
