### PR TITLE
Fixes a simple mistake leading to wrong group comparison in IdMapper

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ControlledEncoder.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ControlledEncoder.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+public class ControlledEncoder implements Encoder
+{
+    private final Encoder actual;
+    private Object overrideId;
+
+    public ControlledEncoder( Encoder actual )
+    {
+        this.actual = actual;
+    }
+
+    /**
+     * Single use in {@link #encode(Object)}.
+     */
+    public void useThisIdToEncodeNoMatterWhatComesIn( Object id )
+    {
+        this.overrideId = id;
+    }
+
+    @Override
+    public long encode( Object value )
+    {
+        try
+        {
+            return actual.encode( overrideId != null ? overrideId : value );
+        }
+        finally
+        {
+            overrideId = null;
+        }
+    }
+}


### PR DESCRIPTION
When detecting duplicate input ids. This might have lead to false
duplicates being reported.
