### PR TITLE
Use flat-combining for concurrent application of updates to the LabelScanStore

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplierTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import org.neo4j.concurrent.WorkSync;
+import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -34,7 +36,6 @@ import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates.NONE;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
@@ -48,8 +49,10 @@ public class IndexTransactionApplierTest
         // GIVEN
         IndexingService indexing = mock( IndexingService.class );
         LabelScanWriter writer = new OrderVerifyingLabelScanWriter( 10, 15, 20 );
+        WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanSync =
+                new WorkSync<>( singletonProvider( writer ) );
         try ( IndexTransactionApplier applier = new IndexTransactionApplier( indexing, NONE,
-                singletonProvider( writer ), mock( CacheAccessBackDoor.class ) ) )
+                labelScanSync, mock( CacheAccessBackDoor.class ) ) )
         {
             // WHEN
             applier.visitNodeCommand( node( 15 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.neo4j.concurrent.WorkSync;
 import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -100,6 +101,8 @@ public class NeoTransactionStoreApplierTest
     private final DynamicRecord one = DynamicRecord.dynamicRecord( 1, true );
     private final DynamicRecord two = DynamicRecord.dynamicRecord( 2, true );
     private final DynamicRecord three = DynamicRecord.dynamicRecord( 3, true );
+    private WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork>
+            labelScanStoreSynchronizer = new WorkSync<>( labelScanStore );
 
     @Before
     public void setup()
@@ -574,7 +577,7 @@ public class NeoTransactionStoreApplierTest
         // given
         final NeoCommandHandler applier = newApplier( false );
         final NeoCommandHandler indexApplier = new IndexTransactionApplier( indexingService,
-                ValidatedIndexUpdates.NONE, labelScanStore, cacheAccess );
+                ValidatedIndexUpdates.NONE, labelScanStoreSynchronizer, cacheAccess );
         final DynamicRecord record = DynamicRecord.dynamicRecord( 21, true );
         record.setCreated();
         final Collection<DynamicRecord> recordsAfter = Arrays.asList( record );
@@ -761,7 +764,8 @@ public class NeoTransactionStoreApplierTest
 
     private NeoCommandHandler newIndexApplier( TransactionApplicationMode mode )
     {
-        return new IndexTransactionApplier( indexingService, ValidatedIndexUpdates.NONE, labelScanStore, cacheAccess );
+        return new IndexTransactionApplier(
+                indexingService, ValidatedIndexUpdates.NONE, labelScanStoreSynchronizer, cacheAccess );
     }
 
     @Test

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+/**
+ * <p>
+ *     A unit of work that can be applied to the given type of material, or combined with other like-typed units of
+ *     work.
+ * </p>
+ * <p>
+ *     These types of work must exhibit a number of properties, for their use in the WorkSync to be correct:
+ * </p>
+ * <ul>
+ *     <li>
+ *         <strong>Commutativity</strong><br/>
+ *         The order of operands must not matter:
+ *         <code>a.combine(b)  =  b.combine(a)</code>
+ *     </li>
+ *     <li>
+ *         <strong>Associativity</strong><br/>
+ *         The order of operations must not matter:
+ *         <code>a.combine(b.combine(c))  =  a.combine(b).combine(c)</code>
+ *     </li>
+ *     <li>
+ *         <strong>Effect Transitivity</strong><br/>
+ *         Work-combining must not change work outcome:
+ *         <code>a.combine(b).apply(m)  =  { a.apply(m) ; b.apply(m) }</code>
+ *     </li>
+ * </ul>
+ * @see WorkSync
+ * @param <Material> The type of material to work with.
+ * @param <W> The concrete type of work being performed.
+ */
+public interface Work<Material, W extends Work<Material,W>>
+{
+    /**
+     * <p>
+     *     Combine this unit of work with the given unit of work, and produce a unit of work that represents the
+     *     aggregate of the work.
+     * </p>
+     * <p>
+     *     It is perfectly fine for a unit to build up internal state that aggregates the work it is combined with,
+     *     and then return itself. This is perhaps useful for reducing the allocation rate a little.
+     * </p>
+     */
+    W combine( W work );
+
+    /**
+     * Apply this unit of work to the given material.
+     */
+    void apply( Material material );
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Turns multi-threaded unary work into single-threaded stack work.
+ * <p>
+ *     The technique used here is inspired in part both by the Flat Combining
+ *     concept from Hendler, Incze, Shavit &amp; Tzafrir, and in part by the
+ *     wait-free linked queue design by Vyukov.
+ * </p>
+ * <p>
+ *     In a sense, this turns many small, presumably concurrent, pieces of work
+ *     into fewer, larger batches of work, that is then applied to the material
+ *     under synchronisation.
+ * </p>
+ * <p>
+ *     Obviously this only makes sense for that a) can be combined, and b)
+ *     where the performance improvements from batching effects is large enough
+ *     to overcome the overhead of collecting and batching up the work units.
+ * </p>
+ * @see Work
+ */
+public class WorkSync<Material, W extends Work<Material,W>>
+{
+    private final Material material;
+    private final AtomicReference<WorkUnit<Material,W>> stack;
+    private final WorkUnit<Material,W> stackEnd;
+    private final ReentrantLock lock;
+
+    /**
+     * Create a new WorkSync that will synchronize the application of work to
+     * the given material.
+     * @param material The material we want to apply work to, in a thread-safe
+     * way.
+     */
+    public WorkSync( Material material )
+    {
+        this.material = material;
+        this.stackEnd = new WorkUnit<>( null );
+        this.stack = new AtomicReference<>( stackEnd );
+        this.lock = new ReentrantLock();
+    }
+
+    /**
+     * Apply the given work to the material in a thread-safe way, possibly by
+     * combining it with other work.
+     * @param work The work to be done.
+     */
+    public void apply( W work )
+    {
+        // Schedule our work on the stack.
+        WorkUnit<Material,W> unit = new WorkUnit<>( work );
+        unit.next = stack.getAndSet( unit ); // benign race, see reverse()
+
+        // Try grabbing the lock to do all the work, until our work unit
+        // has been completed.
+        boolean wasInterrupted = false;
+        int tryCount = 0;
+        do
+        {
+            tryCount++;
+            try
+            {
+                if ( lock.tryLock( tryCount < 10? 0 : 10, TimeUnit.MILLISECONDS ) )
+                {
+                    try
+                    {
+                        doSynchronizedWork();
+                    }
+                    finally
+                    {
+                        lock.unlock();
+                    }
+                }
+            }
+            catch ( InterruptedException e )
+            {
+                // We can't stop now, because our work has already been
+                // scheduled. So instead we're just going to reset the
+                // interruption status when we're done.
+                wasInterrupted = true;
+            }
+        }
+        while ( !unit.done );
+
+        if ( wasInterrupted )
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void doSynchronizedWork()
+    {
+        WorkUnit<Material,W> batch = reverse( stack.getAndSet( stackEnd ) );
+        W combinedWork = combine( batch );
+
+        if ( combinedWork != null )
+        {
+            combinedWork.apply( material );
+        }
+
+        markAsDone( batch );
+    }
+
+    private WorkUnit<Material,W> reverse( WorkUnit<Material,W> batch )
+    {
+        WorkUnit<Material,W> result = stackEnd;
+        while ( batch != stackEnd )
+        {
+            WorkUnit<Material,W> tmp = batch.next;
+            while ( tmp == null )
+            {
+                // We may see 'null' via race, as work units are put on the
+                // stack before their 'next' pointers are updated. We just spin
+                // until we observe their volatile write to 'next'.
+                Thread.yield();
+                tmp = batch.next;
+            }
+            batch.next = result;
+            result = batch;
+            batch = tmp;
+        }
+        return result;
+    }
+
+    private W combine( WorkUnit<Material,W> batch )
+    {
+        W result = null;
+        while ( batch != stackEnd )
+        {
+            if ( result == null )
+            {
+                result = batch.work;
+            }
+            else
+            {
+                result = result.combine( batch.work );
+            }
+            batch = batch.next;
+        }
+        return result;
+    }
+
+    private void markAsDone( WorkUnit<Material,W> batch )
+    {
+        while ( batch != stackEnd )
+        {
+            batch.done = true;
+            batch = batch.next;
+        }
+    }
+
+    private static class WorkUnit<Material, W extends Work<Material,W>>
+    {
+        final W work;
+        volatile WorkUnit<Material,W> next;
+        volatile boolean done;
+
+        private WorkUnit( W work )
+        {
+            this.work = work;
+        }
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class WorkSyncTest
+{
+    private static void usleep( long micros )
+    {
+        long deadline = System.nanoTime() + TimeUnit.MICROSECONDS.toNanos( micros );
+        long now;
+        do
+        {
+            now = System.nanoTime();
+        }
+        while ( now < deadline );
+    }
+
+    private static class AddWork implements Work<Adder, AddWork>
+    {
+        private int delta;
+
+        private AddWork( int delta )
+        {
+            this.delta = delta;
+        }
+
+        @Override
+        public AddWork combine( AddWork work )
+        {
+            delta += work.delta;
+            return this;
+        }
+
+        @Override
+        public void apply( Adder adder )
+        {
+            usleep( 50 );
+            adder.add( delta );
+        }
+    }
+
+    private class Adder
+    {
+        public void add( int delta )
+        {
+            sum.getAndAdd( delta );
+            count.getAndIncrement();
+        }
+    }
+
+    private class RunnableWork implements Runnable
+    {
+        private final AddWork addWork;
+
+        public RunnableWork( AddWork addWork )
+        {
+            this.addWork = addWork;
+        }
+
+        @Override
+        public void run()
+        {
+            sync.apply( addWork );
+        }
+    }
+
+    private AtomicInteger sum = new AtomicInteger();
+    private AtomicInteger count = new AtomicInteger();
+    private Adder adder = new Adder();
+    private WorkSync<Adder,AddWork> sync = new WorkSync<>( adder );
+
+    @Test
+    public void mustApplyWork() throws Exception
+    {
+        sync.apply( new AddWork( 10 ) );
+        assertThat( sum.get(), is( 10 ) );
+
+        sync.apply( new AddWork( 20 ) );
+        assertThat( sum.get(), is( 30 ) );
+    }
+
+    @Test
+    public void mustCombineWork() throws Exception
+    {
+        ExecutorService executor = Executors.newFixedThreadPool( 64 );
+        for ( int i = 0; i < 1000; i++ )
+        {
+            executor.execute( new RunnableWork( new AddWork( 1 )) );
+        }
+        executor.shutdown();
+        assertTrue( executor.awaitTermination( 2, TimeUnit.SECONDS ) );
+
+        assertThat( count.get(), lessThan( sum.get() ) );
+    }
+
+    @Test
+    public void mustApplyWorkEvenWhenInterrupted() throws Exception
+    {
+        Thread.currentThread().interrupt();
+
+        sync.apply( new AddWork( 10 ) );
+
+        assertThat( sum.get(), is( 10 ) );
+        assertTrue( Thread.interrupted() );
+    }
+
+    @Test( timeout = 1000 )
+    public void mustRecoverFromExceptions() throws Exception
+    {
+        final AtomicBoolean broken = new AtomicBoolean( true );
+        Adder adder = new Adder()
+        {
+            @Override
+            public void add( int delta )
+            {
+                if ( broken.get() )
+                {
+                    throw new IllegalStateException( "boom!" );
+                }
+                super.add( delta );
+            }
+        };
+        sync = new WorkSync<>( adder );
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try
+        {
+            // Run this in a different thread to account for reentrant locks.
+            executor.submit( new RunnableWork( new AddWork( 10 ) ) ).get();
+            fail( "Should have thrown" );
+        }
+        catch ( ExecutionException exception )
+        {
+            assertThat( exception.getCause(), instanceOf( IllegalStateException.class ) );
+        }
+
+        broken.set( false );
+        sync.apply( new AddWork( 20 ) );
+
+        assertThat( sum.get(), is( 20 ) );
+        assertThat( count.get(), is( 1 ) );
+    }
+}

--- a/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.consistency.checking.full.FullCheck;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.progress.ProgressListener;
@@ -80,13 +81,14 @@ class RebuildFromLogs
 
     RebuildFromLogs( GraphDatabaseAPI graphdb )
     {
+        DependencyResolver resolver = graphdb.getDependencyResolver();
         this.stores = new StoreAccess( graphdb );
-        this.dataSource = graphdb.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource();
-        this.storeApplier = graphdb.getDependencyResolver().resolveDependency(
-                TransactionRepresentationStoreApplier.class ).withLegacyIndexTransactionOrdering( IdOrderingQueue.BYPASS);
+        this.dataSource = resolver.resolveDependency( DataSourceManager.class ).getDataSource();
+        this.storeApplier = resolver.resolveDependency( TransactionRepresentationStoreApplier.class )
+                                    .withLegacyIndexTransactionOrdering( IdOrderingQueue.BYPASS );
         PropertyLoader propertyLoader = new PropertyLoader( stores.getRawNeoStore() );
         this.indexUpdatesValidator = new IndexUpdatesValidator( stores.getRawNeoStore(), propertyLoader,
-                graphdb.getDependencyResolver().resolveDependency( IndexingService.class ) );
+                resolver.resolveDependency( IndexingService.class ) );
     }
 
     RebuildFromLogs applyTransactionsFrom( ProgressListener progress, File sourceDir ) throws IOException


### PR DESCRIPTION
This is similar to how we amortise the transaction log fsync cost.
When a transaction processing thread wants to write changes to the LabelScanStore (this is during commit, after they have written their commands to the transaction log), it starts out by adding a unit of work to a concurrent, wait-free batching stack.
Then it attempts to grab a lock (this happens inside the new WorkSync abstraction).
If it gets the lock, then it grabs the entire stack of work in one go, and combines all the units of work into a single unit.
This single unit of work is then applied to a single LabelScanWriter.
This amortises the creation and closure of LabelScanWriters, which are both very costly operations compared to just writing to a LabelScanWriter.
