### PR TITLE
Close transaction after exhausting compiled results

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/birk/Javac.java
+++ b/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/birk/Javac.java
@@ -41,7 +41,10 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import sun.tools.java.CompilerError;
+
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionMode;
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.CompletionListener;
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult;
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription;
 import org.neo4j.cypher.internal.compiler.v2_3.planner.CantCompileQueryException;
@@ -96,13 +99,13 @@ public class Javac
         return clazz;
     }
 
-    public static InternalExecutionResult newInstance( Class<InternalExecutionResult> clazz, Statement statement,
+    public static InternalExecutionResult newInstance( Class<InternalExecutionResult> clazz, CompletionListener completion, Statement statement,
                                                        GraphDatabaseService db, ExecutionMode executionMode, InternalPlanDescription description, Map<String, Object> params)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException
     {
         Constructor<InternalExecutionResult> constructor =
-                clazz.getDeclaredConstructor( Statement.class, GraphDatabaseService.class, ExecutionMode.class, InternalPlanDescription.class , Map.class);
-        return constructor.newInstance( statement, db, executionMode, description, params );
+                clazz.getDeclaredConstructor( CompletionListener.class, Statement.class, GraphDatabaseService.class, ExecutionMode.class, InternalPlanDescription.class , Map.class);
+        return constructor.newInstance( completion, statement, db, executionMode, description, params );
     }
 
     private static class InMemSource extends SimpleJavaFileObject

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/birk/CodeGenerator.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.CostPlannerName
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.birk.CodeGenerator.JavaTypes.{DOUBLE, INT, LONG, OBJECT, STRING}
 import org.neo4j.cypher.internal.compiler.v2_3.birk.il._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{CompiledPlan, PlanFingerprint}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{CompletionListener, CompiledPlan, PlanFingerprint}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.Eagerly
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
@@ -122,8 +122,10 @@ object CodeGenerator {
        |import org.neo4j.graphdb.Result.ResultRow;
        |import org.neo4j.graphdb.Result.ResultVisitor;
        |import org.neo4j.graphdb.Result;
+       |import org.neo4j.graphdb.Transaction;
        |import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription;
        |import org.neo4j.cypher.internal.compiler.v2_3.ExecutionMode;
+       |import org.neo4j.cypher.internal.compiler.v2_3.executionplan.CompletionListener;
        |import java.util.Map;
        |
        |$imports
@@ -136,9 +138,10 @@ object CodeGenerator {
        |private final ExecutionMode executionMode;
        |private final Map<String, Object> params;
        |
-       |public $className( Statement statement, GraphDatabaseService db, ExecutionMode executionMode, InternalPlanDescription description, Map<String, Object> params )
+       |public $className( CompletionListener completion, Statement statement, GraphDatabaseService db, ExecutionMode executionMode, InternalPlanDescription description, Map<String, Object> params )
        |{
-       |  this.ro = statement.readOperations( );
+       |  super( completion, statement );
+       |  this.ro = statement.readOperations();
        |  this.db = db;
        |  this.executionMode = executionMode;
        |  this.description = description;
@@ -165,11 +168,16 @@ object CodeGenerator {
        |try
        |{
        |$methodBody
+       |success();
        |}
        |catch (Exception e)
        |{
        |//TODO proper error handling
        |throw new RuntimeException( e );
+       |}
+       |finally
+       |{
+       |close();
        |}
        |}
        |$privateMethodText
@@ -347,7 +355,7 @@ class CodeGenerator {
         val idMap = LogicalPlanIdentificationBuilder(plan)
         val description: InternalPlanDescription = LogicalPlan2PlanDescription(plan, idMap)
 
-        val builder = (st: Statement, db: GraphDatabaseService, mode: ExecutionMode, params: Map[String, Any]) => Javac.newInstance(clazz, st, db,  mode, description, asJavaHashMap(params))
+        val builder = (st: Statement, db: GraphDatabaseService, mode: ExecutionMode, params: Map[String, Any], completion:CompletionListener) => Javac.newInstance(clazz, completion, st, db,  mode, description, asJavaHashMap(params))
 
         CompiledPlan(updating = false, None, fp, CostPlannerName, builder)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompletionListener.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompletionListener.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.cypher.internal.compiler.v2_3.executionplan
+
+abstract class CompletionListener
+{
+  def complete( success: Boolean ): Unit
+}
+
+object CompletionListener{
+  val NOOP = new CompletionListener {
+    override def complete( success: Boolean ) = {}
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ExecutionPlanBuilder.scala
@@ -39,7 +39,7 @@ case class CompiledPlan(updating: Boolean,
                         periodicCommit: Option[PeriodicCommitInfo] = None,
                         fingerprint: Option[PlanFingerprint] = None,
                         plannerUsed: PlannerName,
-                        executionResultBuilder: (KernelStatement, GraphDatabaseService, ExecutionMode, Map[String, Any]) => InternalExecutionResult)
+                        executionResultBuilder: (KernelStatement, GraphDatabaseService, ExecutionMode, Map[String, Any], CompletionListener) => InternalExecutionResult)
 
 case class PipeInfo(pipe: Pipe,
                     updating: Boolean,
@@ -83,7 +83,9 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, statsDivergenceThreshold
 
       def run(queryContext: QueryContext, kernelStatement: KernelStatement,
                        planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult =
-        compiledPlan.executionResultBuilder(kernelStatement, graph, planType, params)
+        compiledPlan.executionResultBuilder(kernelStatement, graph, planType, params, new CompletionListener {
+          override def complete(success: Boolean) = queryContext.close(success)
+        })
 
       def plannerUsed: PlannerName = CostPlannerName
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher
 
-import java.util
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.PathImpl
 import org.neo4j.graphdb._
 

--- a/community/cypher/docs/graphgist/pom.xml
+++ b/community/cypher/docs/graphgist/pom.xml
@@ -54,6 +54,13 @@
       <artifactId>neo4j-graphviz</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-cypher</artifactId>
+      <version>${neo4j.version}</version>
+      <type>test-jar</type>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- other -->
     


### PR DESCRIPTION
Not only does this ensure correct behaviour, but it also brings the execution time of `MatchAcceptanceTest` back down from 195 seconds to 31 seconds.
