### PR TITLE
Add -Dfeature-ndp toggle to include NDP in packages built by packaging.

### DIFF
--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -159,7 +159,7 @@ terms of the relevant Commercial Agreement.
           <failIfMissing>true</failIfMissing>
           <plainTextReport>true</plainTextReport>
           <prependText>notice-agpl-prefix.txt</prependText>
-          <excludedGroups>^((org.neo4j){1}|(org.neo4j.app){1}|(org.neo4j.browser){1}|(org.neo4j.doc){1}|(org.neo4j.server.plugin){1}|(org.neo4j.assembly){1})$</excludedGroups>
+          <excludedGroups>^((org.neo4j){1}|(org.neo4j.app){1}|(org.neo4j.browser){1}|(org.neo4j.doc){1}|(org.neo4j.ndp){1}|(org.neo4j.server.plugin){1}|(org.neo4j.assembly){1})$</excludedGroups>
         </configuration>
         <executions>
           <execution>

--- a/packaging/standalone/standalone-advanced/pom.xml
+++ b/packaging/standalone/standalone-advanced/pom.xml
@@ -161,4 +161,22 @@ terms of the relevant Commercial Agreement.
     </dependency>
   </dependencies>
 
+  <profiles>
+    <!-- Temporary build-level feature toggle for Neo4j Data Protocol -->
+    <profile>
+      <id>feature-ndp</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property><name>feature-ndp</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.neo4j.ndp</groupId>
+          <artifactId>neo4j-ndp-kernelextension</artifactId>
+          <version>${neo4j.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -147,7 +147,6 @@ terms of the relevant Commercial Agreement.
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 
@@ -163,5 +162,23 @@ terms of the relevant Commercial Agreement.
       <version>${neo4j.version}</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- Temporary build-level feature toggle for Neo4j Data Protocol -->
+    <profile>
+      <id>feature-ndp</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property><name>feature-ndp</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.neo4j.ndp</groupId>
+          <artifactId>neo4j-ndp-kernelextension</artifactId>
+          <version>${neo4j.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -161,4 +161,22 @@ terms of the relevant Commercial Agreement.
     </dependency>
   </dependencies>
 
+  <profiles>
+    <!-- Temporary build-level feature toggle for Neo4j Data Protocol -->
+    <profile>
+      <id>feature-ndp</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property><name>feature-ndp</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.neo4j.ndp</groupId>
+          <artifactId>neo4j-ndp-kernelextension</artifactId>
+          <version>${neo4j.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Note that this is not for production usage, but pending a decision to include NDP proper in the built artifacts. This simply allows doing a build that automatically includes NDP with the build packages, such that it can be used for testing and for the driver integration tests.

Usage:

```
cd packaging 
mvn clean package -Dfeature-ndp -Doverwrite
```

`overwrite` is needed since the licenses include one more dependency. 
