### PR TITLE
Handle finding server PID with lsof >= 4.88

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -143,9 +143,8 @@ detectrunning() {
       newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
       ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
-      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
-      newpid=${newpid:1}
+      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this text processing with perl below
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | perl -ne 'chomp; $pid = $1 if /^p(\d+)/; last if /TST=LISTEN/; END { print "$pid\n" }')
   fi
 }
 


### PR DESCRIPTION
lsof, as of 4.88, always prints the file descriptor number (prefixed
with an 'f') when using fields output (specified by the `-F`) option.
This can follow the PID in the field list, causing the `grep -B1 | head
-n1` expression to interpret the file descriptor number as the PID, which
makes starting a Neo4J server fail.

This change looks instead for the 'p' prefix that denotes the active
PID; perl is used instead of grep because I felt that it would be easier
to write a portable Perl invocation to extract the PID.
