### PR TITLE
Reduced memory usage in LuceneLegacyIndex when querying

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.coreapi;
 
-import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -38,9 +37,8 @@ import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelExce
 import org.neo4j.kernel.impl.api.legacyindex.AbstractIndexHits;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 
-import static java.lang.Math.max;
 import static java.lang.String.format;
-import static org.neo4j.collection.primitive.Primitive.longSet;
+
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.single;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.LEGACY_INDEX;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.legacyIndexResourceId;
@@ -293,8 +291,6 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
     {
         return new AbstractIndexHits<T>()
         {
-            private final PrimitiveLongSet alreadyReturned = longSet( max( 16, ids.size() ) );
-
             @Override
             public int size()
             {
@@ -314,23 +310,20 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
                 while ( ids.hasNext() )
                 {
                     long id = ids.next();
-                    if ( alreadyReturned.add( id ) )
+                    try
                     {
-                        try
+                        return entityOf( id );
+                    }
+                    catch ( NotFoundException e )
+                    {   // By contract this is OK. So just skip it.
+                        // But first, let's try to repair the index so this doesn't happen again.
+                        try ( Statement statement = statementContextBridge.instance() )
                         {
-                            return entityOf( id );
+                            internalRemove( statement, id );
                         }
-                        catch ( NotFoundException e )
-                        {   // By contract this is OK. So just skip it.
-                            // But first, let's try to repair the index so this doesn't happen again.
-                            try ( Statement statement = statementContextBridge.instance() )
-                            {
-                                internalRemove( statement, id );
-                            }
-                            catch ( LegacyIndexNotFoundKernelException | InvalidTransactionTypeKernelException ignore )
-                            {
-                                // Ignore these failures because we are going to skip the entity anyway
-                            }
+                        catch ( LegacyIndexNotFoundKernelException | InvalidTransactionTypeKernelException ignore )
+                        {
+                            // Ignore these failures because we are going to skip the entity anyway
                         }
                     }
                 }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CombinedIndexHits.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CombinedIndexHits.java
@@ -59,7 +59,6 @@ public class CombinedIndexHits extends PrimitiveLongCollections.PrimitiveLongCon
         {
             hits.close();
         }
-        allIndexHits.clear();
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/DocToIdIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/DocToIdIterator.java
@@ -19,23 +19,27 @@
  */
 package org.neo4j.index.impl.lucene;
 
-import java.util.Collection;
-
 import org.apache.lucene.document.Document;
 
+import java.util.Collection;
+
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.index.IndexHits;
 
 public class DocToIdIterator extends AbstractLegacyIndexHits
 {
-    private final Collection<Long> exclude;
+    private final Collection<Long> removedInTransactionState;
     private IndexReference searcherOrNull;
     private final IndexHits<Document> source;
+    private final PrimitiveLongSet idsModifiedInTransactionState;
 
-    public DocToIdIterator( IndexHits<Document> source, Collection<Long> exclude, IndexReference searcherOrNull )
+    public DocToIdIterator( IndexHits<Document> source, Collection<Long> exclude, IndexReference searcherOrNull,
+            PrimitiveLongSet idsModifiedInTransactionState )
     {
         this.source = source;
-        this.exclude = exclude;
+        this.removedInTransactionState = exclude;
         this.searcherOrNull = searcherOrNull;
+        this.idsModifiedInTransactionState = idsModifiedInTransactionState;
         if ( source.size() == 0 )
         {
             close();
@@ -48,13 +52,23 @@ public class DocToIdIterator extends AbstractLegacyIndexHits
         while ( source.hasNext() )
         {
             Document doc = source.next();
-            long id = Long.parseLong( doc.get( LuceneIndex.KEY_DOC_ID ) );
-            if ( !exclude.contains( id ) )
+            long id = idFromDoc( doc );
+            boolean documentIsFromStore = doc.getFieldable( FullTxData.TX_STATE_KEY ) == null;
+            boolean idWillBeReturnedByTransactionStateInstead =
+                    documentIsFromStore && idsModifiedInTransactionState.contains( id );
+            if ( removedInTransactionState.contains( id ) || idWillBeReturnedByTransactionStateInstead )
             {
-                return next( id );
+                // Skip this one, continue to the next
+                continue;
             }
+            return next( id );
         }
         return endReached();
+    }
+
+    static long idFromDoc( Document doc )
+    {
+        return Long.parseLong( doc.get( LuceneIndex.KEY_DOC_ID ) );
     }
 
     protected boolean endReached()
@@ -81,7 +95,7 @@ public class DocToIdIterator extends AbstractLegacyIndexHits
          * issued, then it is possible to get negative size from the IndexHits result, if exclude is larger than source.
          * To avoid such weirdness, we return at least 0. Note that the iterator will return no results, as it should.
          */
-        return Math.max( 0, source.size() - exclude.size() );
+        return Math.max( 0, source.size() - removedInTransactionState.size() );
     }
 
     private boolean isClosed()

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/FullTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/FullTxData.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import org.neo4j.index.lucene.QueryContext;
 
 import static java.util.Collections.emptyList;
+
 import static org.neo4j.index.impl.lucene.LuceneDataSource.LUCENE_VERSION;
 import static org.neo4j.index.impl.lucene.LuceneIndex.KEY_DOC_ID;
 
@@ -77,6 +78,12 @@ class FullTxData extends TxData
      * well as any specific key which is pulled out from the incoming query.
      */
     private static final String ORPHANS_KEY = "__all__";
+    /**
+     * When querying we need to distinguish between documents coming from the store and documents
+     * coming from transaction state. A field with this key is put on all documents in transaction state.
+     */
+    public static final String TX_STATE_KEY = "__tx_state__";
+    private static final byte[] TX_STATE_VALUE = new byte[] {1};
     private static final String ORPHANS_VALUE = "1";
 
     private Directory directory;
@@ -104,6 +111,7 @@ class FullTxData extends TxData
             if ( document == null )
             {
                 document = IndexType.newDocument( entityId );
+                document.add( new Field( TX_STATE_KEY, TX_STATE_VALUE ) );
                 cachedDocuments.put( id, document );
                 add = true;
             }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneBatchInserterIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneBatchInserterIndex.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
 import org.neo4j.unsafe.batchinsert.BatchInserterIndex;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import static org.neo4j.index.impl.lucene.LuceneDataSource.LUCENE_VERSION;
 import static org.neo4j.index.impl.lucene.LuceneDataSource.getDirectory;
 
@@ -66,7 +67,7 @@ class LuceneBatchInserterIndex implements BatchInserterIndex
     private final boolean createdNow;
     private Map<String, LruCache<String, Collection<Long>>> cache;
     private int updateCount;
-    private int commitBatchSize = 500000;
+    private final int commitBatchSize = 500000;
     private final RelationshipLookup relationshipLookup;
 
     interface RelationshipLookup
@@ -284,7 +285,7 @@ class LuceneBatchInserterIndex implements BatchInserterIndex
             throw new RuntimeException( e );
         }
     }
-    
+
     private void closeSearcher()
     {
         try
@@ -331,11 +332,13 @@ class LuceneBatchInserterIndex implements BatchInserterIndex
             LegacyIndexHits primitiveHits = null;
             if ( key == null || this.cache == null || !this.cache.containsKey( key ) )
             {
-                primitiveHits = new DocToIdIterator( result, Collections.<Long>emptyList(), null );
+                primitiveHits = new DocToIdIterator( result, Collections.<Long>emptyList(), null,
+                        PrimitiveLongCollections.emptySet() );
             }
             else
             {
-                primitiveHits = new DocToIdIterator( result, Collections.<Long>emptyList(), null )
+                primitiveHits = new DocToIdIterator( result, Collections.<Long>emptyList(), null,
+                        PrimitiveLongCollections.emptySet() )
                 {
                     private final Collection<Long> ids = new ArrayList<>();
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
@@ -38,6 +38,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
@@ -50,6 +52,9 @@ import org.neo4j.kernel.api.LegacyIndex;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.impl.cache.LruCache;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
+
+import static org.neo4j.collection.primitive.Primitive.longSet;
+import static org.neo4j.index.impl.lucene.DocToIdIterator.idFromDoc;
 
 public abstract class LuceneIndex implements LegacyIndex
 {
@@ -211,20 +216,20 @@ public abstract class LuceneIndex implements LegacyIndex
     protected LegacyIndexHits query( Query query, String keyForDirectLookup,
             Object valueForDirectLookup, QueryContext additionalParametersOrNull )
     {
-        List<Long> ids = new ArrayList<>();
-        Collection<Long> removedIds = Collections.emptySet();
-        IndexSearcher additionsSearcher = null;
+        List<Long> simpleTransactionStateIds = new ArrayList<>();
+        Collection<Long> removedIdsFromTransactionState = Collections.emptySet();
+        IndexSearcher fulltextTransactionStateSearcher = null;
         if ( transaction != null )
         {
             if ( keyForDirectLookup != null )
             {
-                ids.addAll( transaction.getAddedIds( this, keyForDirectLookup, valueForDirectLookup ) );
+                simpleTransactionStateIds.addAll( transaction.getAddedIds( this, keyForDirectLookup, valueForDirectLookup ) );
             }
             else
             {
-                additionsSearcher = transaction.getAdditionsAsSearcher( this, additionalParametersOrNull );
+                fulltextTransactionStateSearcher = transaction.getAdditionsAsSearcher( this, additionalParametersOrNull );
             }
-            removedIds = keyForDirectLookup != null ?
+            removedIdsFromTransactionState = keyForDirectLookup != null ?
                     transaction.getRemovedIds( this, keyForDirectLookup, valueForDirectLookup ) :
                     transaction.getRemovedIds( this, query );
         }
@@ -248,30 +253,75 @@ public abstract class LuceneIndex implements LegacyIndex
             {
                 cachedIdsMap = dataSource.getFromCache(
                         identifier, keyForDirectLookup );
-                foundInCache = fillFromCache( cachedIdsMap, ids,
-                        valueForDirectLookup.toString(), removedIds );
+                foundInCache = fillFromCache( cachedIdsMap, simpleTransactionStateIds,
+                        valueForDirectLookup.toString(), removedIdsFromTransactionState );
             }
 
             if ( !foundInCache )
             {
-                DocToIdIterator searchedIds = new DocToIdIterator( search( searcher,
-                        query, additionalParametersOrNull, additionsSearcher, removedIds ), removedIds, searcher );
-                if ( ids.isEmpty() )
+                try
                 {
-                    idIterator = searchedIds;
+                    // Gather all added ids from fulltextTransactionStateSearcher and simpleTransactionStateIds.
+                    PrimitiveLongSet idsModifiedInTransactionState = gatherIdsModifiedInTransactionState(
+                            simpleTransactionStateIds, fulltextTransactionStateSearcher, query );
+
+                    // Do the combined search from store and fulltext tx state
+                    DocToIdIterator hits = new DocToIdIterator( search( searcher, fulltextTransactionStateSearcher,
+                            query, additionalParametersOrNull, removedIdsFromTransactionState ),
+                            removedIdsFromTransactionState, searcher, idsModifiedInTransactionState );
+
+                    idIterator = simpleTransactionStateIds.isEmpty() ? hits : new CombinedIndexHits(
+                            Arrays.<LegacyIndexHits>asList( hits,
+                                    new ConstantScoreIterator( simpleTransactionStateIds, Float.NaN ) ) );
                 }
-                else
+                catch ( IOException e )
                 {
-                    Collection<LegacyIndexHits> iterators = new ArrayList<>();
-                    iterators.add( searchedIds );
-                    iterators.add( new ConstantScoreIterator( ids, Float.NaN ) );
-                    idIterator = new CombinedIndexHits( iterators );
+                    throw new RuntimeException( "Unable to query " + this + " with " + query, e );
                 }
             }
         }
 
-        idIterator = idIterator == null ? new ConstantScoreIterator( ids, 0 ) : idIterator;
+        // We've only got transaction state
+        idIterator = idIterator == null ? new ConstantScoreIterator( simpleTransactionStateIds, 0 ) : idIterator;
         return idIterator;
+    }
+
+    private PrimitiveLongSet gatherIdsModifiedInTransactionState( List<Long> simpleTransactionStateIds,
+            IndexSearcher fulltextTransactionStateSearcher, Query query ) throws IOException
+    {
+        // If there's no state them don't bother gathering it
+        if ( simpleTransactionStateIds.isEmpty() && fulltextTransactionStateSearcher == null )
+        {
+            return PrimitiveLongCollections.emptySet();
+        }
+        // There's potentially some state
+        Hits hits = null;
+        int fulltextSize = 0;
+        if ( fulltextTransactionStateSearcher != null )
+        {
+            hits = new Hits( fulltextTransactionStateSearcher, query, null, null, false );
+            fulltextSize = hits.length();
+            // Nah, no state
+            if ( simpleTransactionStateIds.isEmpty() && fulltextSize == 0 )
+            {
+                return PrimitiveLongCollections.emptySet();
+            }
+        }
+
+        PrimitiveLongSet set = longSet( simpleTransactionStateIds.size() + fulltextSize );
+
+        // Add from simple tx state
+        for ( Long id : simpleTransactionStateIds )
+        {
+            set.add( id );
+        }
+
+        // Add from fulltext tx state
+        for ( int i = 0; i < fulltextSize; i++ )
+        {
+            set.add( idFromDoc( hits.doc( i ) ) );
+        }
+        return set;
     }
 
     private boolean fillFromCache(
@@ -298,40 +348,32 @@ public abstract class LuceneIndex implements LegacyIndex
         return found;
     }
 
-    private IndexHits<Document> search( IndexReference searcherRef, Query query,
-            QueryContext additionalParametersOrNull, IndexSearcher additionsSearcher, Collection<Long> removed )
+    private IndexHits<Document> search( IndexReference searcherRef, IndexSearcher fulltextTransactionStateSearcher,
+            Query query, QueryContext additionalParametersOrNull, Collection<Long> removed ) throws IOException
     {
-        try
+        if ( fulltextTransactionStateSearcher != null && !removed.isEmpty() )
         {
-            if ( additionsSearcher != null && !removed.isEmpty() )
-            {
-                letThroughAdditions( additionsSearcher, query, removed );
-            }
+            letThroughAdditions( fulltextTransactionStateSearcher, query, removed );
+        }
 
-            IndexSearcher searcher = additionsSearcher == null ? searcherRef.getSearcher() :
-                    new IndexSearcher( new MultiReader( searcherRef.getSearcher().getIndexReader(),
-                            additionsSearcher.getIndexReader() ) );
-            IndexHits<Document> result;
-            if ( additionalParametersOrNull != null && additionalParametersOrNull.getTop() > 0 )
-            {
-                result = new TopDocsIterator( query, additionalParametersOrNull, searcher );
-            }
-            else
-            {
-                Sort sorting = additionalParametersOrNull != null ?
-                        additionalParametersOrNull.getSorting() : null;
-                boolean forceScore = additionalParametersOrNull == null ||
-                        !additionalParametersOrNull.getTradeCorrectnessForSpeed();
-                Hits hits = new Hits( searcher, query, null, sorting, forceScore );
-                result = new HitsIterator( hits );
-            }
-            return result;
-        }
-        catch ( IOException e )
+        IndexSearcher searcher = fulltextTransactionStateSearcher == null ? searcherRef.getSearcher() :
+                new IndexSearcher( new MultiReader( searcherRef.getSearcher().getIndexReader(),
+                        fulltextTransactionStateSearcher.getIndexReader() ) );
+        IndexHits<Document> result;
+        if ( additionalParametersOrNull != null && additionalParametersOrNull.getTop() > 0 )
         {
-            throw new RuntimeException( "Unable to query " + this + " with "
-                                        + query, e );
+            result = new TopDocsIterator( query, additionalParametersOrNull, searcher );
         }
+        else
+        {
+            Sort sorting = additionalParametersOrNull != null ?
+                    additionalParametersOrNull.getSorting() : null;
+            boolean forceScore = additionalParametersOrNull == null ||
+                    !additionalParametersOrNull.getTradeCorrectnessForSpeed();
+            Hits hits = new Hits( searcher, query, null, sorting, forceScore );
+            result = new HitsIterator( hits );
+        }
+        return result;
     }
 
     private void letThroughAdditions( IndexSearcher additionsSearcher, Query query, Collection<Long> removed )


### PR DESCRIPTION
Previously stored all returned ids in set causing out of memory for
big queries. Now only stores ids for documents in transaction state << all
ids. When an id is in transaction state, this is the most up to date
version and this is what we want to return to the user.
We previously stored all returned ids in set to avoid returning same id multiple
times. This can only accure when id is in transaction state and thus we
only need to store those ids.

co-author: @burqen
