### PR TITLE
Improvements to neo4j-harness

### DIFF
--- a/community/neo4j-harness/CHANGES.txt
+++ b/community/neo4j-harness/CHANGES.txt
@@ -1,0 +1,5 @@
+2.3-SNAPSHOT
+------------------------
+o expose GraphDatabaseService to be used in assertions
+o support fixtures based on Function<GraphDatabaseService,Void>
+o support running Neo4jRule/TestServerBuilder with a existing databse 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
@@ -21,6 +21,8 @@ package org.neo4j.harness;
 
 import java.net.URI;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+
 /**
  * Control panel for a Neo4j test instance.
  */
@@ -38,4 +40,8 @@ public interface ServerControls extends AutoCloseable
     /** Stop the test instance and delete all files related to it on disk. */
     @Override
     void close();
+
+    /** Access the {@link org.neo4j.graphdb.GraphDatabaseService} used by the server */
+    GraphDatabaseService graph();
+
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -21,6 +21,8 @@ package org.neo4j.harness;
 
 import java.io.File;
 
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 
 /**
@@ -87,4 +89,19 @@ public interface TestServerBuilder
      * @return this builder instance
      */
     public TestServerBuilder withFixture( String fixtureStatement );
+
+    /**
+     * Data fixture to inject upon server start. This should be a user implemented fixture function
+     * operating on a {@link GraphDatabaseService} instance
+     * @param fixtureFunction a fixture function
+     * @return this builder instance
+     */
+    public TestServerBuilder withFixture( Function<GraphDatabaseService, Void> fixtureFunction );
+
+    /**
+     * Pre-populate the server with a database copied from the specified directory
+     * @param sourceDirectory
+     * @return this builder instance
+     */
+    public TestServerBuilder copyFrom( File sourceDirectory );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilders.java
@@ -34,15 +34,15 @@ public final class TestServerBuilders
      */
     public static TestServerBuilder newInProcessBuilder()
     {
-        return new InProcessServerBuilder(new File(System.getProperty("java.io.tmpdir")));
+        return new InProcessServerBuilder();
     }
 
     /**
-     * Create a builder capable of starting an in-process Neo4j instance, running in the specified directory.
+     * Create a builder capable of starting an in-process Neo4j instance, running in a subdirectory of the specified directory.
      */
     public static TestServerBuilder newInProcessBuilder(File workingDirectory)
     {
-        return new InProcessServerBuilder(workingDirectory );
+        return new InProcessServerBuilder( workingDirectory );
     }
 
     private TestServerBuilders(){}

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileUtils;
@@ -89,5 +90,10 @@ public class InProcessServerControls implements ServerControls
         // Pure paranoia, and a silly check - but this decreases the likelihood that we delete something that isn't
         // our randomly generated folder significantly.
         return name.length() == 32;
+    }
+
+    public GraphDatabaseService graph()
+    {
+        return server.getDatabase().getGraph();
     }
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -25,6 +25,9 @@ import java.net.URI;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilder;
@@ -117,6 +120,20 @@ public class Neo4jRule implements TestRule, TestServerBuilder
         return this;
     }
 
+    @Override
+    public Neo4jRule withFixture( Function<GraphDatabaseService, Void> fixtureFunction )
+    {
+        builder = builder.withFixture( fixtureFunction );
+        return this;
+    }
+
+    @Override
+    public Neo4jRule copyFrom( File sourceDirectory )
+    {
+        builder = builder.copyFrom( sourceDirectory );
+        return this;
+    }
+
     public URI httpURI()
     {
         if(controls == null)
@@ -133,5 +150,9 @@ public class Neo4jRule implements TestRule, TestServerBuilder
             throw new IllegalStateException( "Cannot access instance URI before or after the test runs." );
         }
         return controls.httpURI();
+    }
+
+    public GraphDatabaseService getGraphDatabaseService() {
+        return controls.graph();
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -19,11 +19,15 @@
  */
 package org.neo4j.harness;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.jackson.JsonNode;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -36,18 +40,29 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.server.HTTP;
+import org.neo4j.tooling.GlobalGraphOperations;
 
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import static org.neo4j.harness.TestServerBuilders.newInProcessBuilder;
 
 public class InProcessBuilderTest
@@ -106,7 +121,8 @@ public class InProcessBuilderTest
                 .newServer())
         {
             // Then
-            assertThat( HTTP.GET( server.httpURI().toString() + "path/to/my/extension/myExtension" ).status(), equalTo( 234 ) );
+            assertThat( HTTP.GET( server.httpURI().toString() + "path/to/my/extension/myExtension" ).status(),
+                    equalTo( 234 ) );
         }
     }
 
@@ -119,7 +135,8 @@ public class InProcessBuilderTest
                 .newServer())
         {
             // Then
-            assertThat( HTTP.GET( server.httpURI().toString() + "path/to/my/extension/myExtension" ).status(), equalTo( 234 ) );
+            assertThat( HTTP.GET( server.httpURI().toString() + "path/to/my/extension/myExtension" ).status(),
+                    equalTo( 234 ) );
         }
     }
 
@@ -136,6 +153,83 @@ public class InProcessBuilderTest
                 assertThat( secondServer.httpURI().getPort(), not( firstServer.httpURI().getPort() ) );
             }
         }
+    }
+
+    @Test
+    public void shouldRunBuilderOnExistingStoreDir() throws Exception
+    {
+        // When
+        // create graph db with one node upfront
+        Path dir = Files.createTempDirectory( getClass().getSimpleName() +
+                "_shouldRunBuilderOnExistingStorageDir" );
+        try
+        {
+
+            GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            try
+            {
+                db.execute( "create ()" );
+            }
+            finally
+            {
+                db.shutdown();
+            }
+
+            try ( ServerControls server = newInProcessBuilder( testDir.directory() ).copyFrom( dir.toFile() )
+                    .newServer() )
+            {
+                // Then
+                try ( Transaction tx = server.graph().beginTx() )
+                {
+                    ResourceIterable<Node> allNodes = GlobalGraphOperations.at(
+                            server.graph() ).getAllNodes();
+
+                    assertTrue( IteratorUtil.count( allNodes ) > 0 );
+
+                    // When: create another node
+                    server.graph().createNode();
+                    tx.success();
+                }
+            }
+
+            // Then: we still only have one node since the server is supposed to work on a copy
+            db = new GraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            try
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    assertEquals( 1, IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+                    tx.success();
+                }
+            }
+            finally
+            {
+                db.shutdown();
+            }
+        }
+        finally
+        {
+            FileUtils.forceDelete( dir.toFile() );
+        }
+    }
+
+    @Test
+    public void shouldFailWhenProvidingANonDirectoryAsSource() throws IOException
+    {
+
+        File notADirectory = File.createTempFile( "prefix", "suffix" );
+        assertFalse( notADirectory.isDirectory() );
+
+        try ( ServerControls server = newInProcessBuilder( ).copyFrom( notADirectory )
+                .newServer() )
+        {
+            fail("server should not start");
+        } catch (RuntimeException rte) {
+            Throwable cause = rte.getCause();
+            assertTrue( cause instanceof IOException);
+            assertTrue( cause.getMessage().contains( "exists but is not a directory" ));
+        }
+
     }
 
     private void assertDBConfig( ServerControls server, String expected, String key ) throws JsonParseException

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
@@ -19,27 +19,60 @@
  */
 package org.neo4j.harness;
 
+import java.util.List;
+
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runners.model.Statement;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.harness.junit.Neo4jRule;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.Mute;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.test.TargetDirectory.testDirForTest;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class JUnitRuleTest
 {
     @Rule
     public Neo4jRule neo4j = new Neo4jRule()
             .withFixture( "CREATE (u:User)" )
+            .withFixture( new Function<GraphDatabaseService, Void>()
+            {
+                @Override
+                public Void apply( GraphDatabaseService graphDatabaseService ) throws RuntimeException
+                {
+                    try ( Transaction tx = graphDatabaseService.beginTx() )
+                    {
+                        graphDatabaseService.createNode( DynamicLabel.label( "User" ));
+                        tx.success();
+                    }
+                    return null;
+                }
+            } )
             .withExtension( "/test", MyUnmanagedExtension.class );
+
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = testDirForTest( getClass() );
 
     @Rule public Mute mute = Mute.muteAll();
 
     @Test
-    public void shouldWork() throws Exception
+    public void shouldExtensionWork() throws Exception
     {
         // Given the rule in the beginning of this class
 
@@ -47,5 +80,62 @@ public class JUnitRuleTest
 
         // Then
         assertThat( HTTP.GET( neo4j.httpURI().resolve("test/myExtension").toString() ).status(), equalTo( 234 ) );
+    }
+
+    @Test
+    public void shouldFixturesWork() throws Exception
+    {
+        // Given the rule in the beginning of this class
+
+        // When I run this test
+
+        // Then
+        HTTP.Response response = HTTP.POST( neo4j.httpURI().toString() + "db/data/transaction/commit",
+                quotedJson( "{'statements':[{'statement':'MATCH (n:User) RETURN n'}]}" ) );
+
+        assertThat( response.get( "results" ).get(0).get("data").size(), equalTo(2));
+    }
+
+    @Test
+    public void shouldGraphDatabaseServiceBeAccessible()
+    {
+        // Given the rule in the beginning of this class
+
+        // When I run this test
+
+        // Then
+        assertEquals( 2, IteratorUtil.count(
+                neo4j.getGraphDatabaseService().execute( "MATCH (n:User) RETURN n" )
+        ) );
+    }
+
+    @Test
+    public void shouldRuleWorkWithExsitingDirectory()
+    {
+        // given
+
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( testDirectory.absolutePath() );
+        try {
+            db.execute( "create ()" );
+        } finally {
+            db.shutdown();
+        }
+
+        // When a rule with an pre-populated graph db directory is used
+        final Neo4jRule ruleWithDirectory = new Neo4jRule(testDirectory.directory()).copyFrom( testDirectory.directory());
+        ruleWithDirectory.apply( new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                // Then the database is not empty
+                Result result = ruleWithDirectory.getGraphDatabaseService().execute( "match (n) return count(n) as " +
+                        "count" );
+
+                List<Object> column = IteratorUtil.asList( result.columnAs( "count" ) );
+                assertEquals(1, column.size());
+                assertEquals(1, column.get(0));
+            }
+        }, null );
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/doc/ExtensionTestingDocTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/doc/ExtensionTestingDocTest.java
@@ -25,8 +25,15 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilders;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.Mute;
 import org.neo4j.test.server.HTTP;
 
@@ -34,7 +41,8 @@ import static org.junit.Assert.*;
 
 public class ExtensionTestingDocTest
 {
-    @Rule public Mute mute = Mute.muteAll();
+    @Rule
+    public Mute mute = Mute.muteAll();
 
     // START SNIPPET: testExtension
     @Path("")
@@ -60,6 +68,35 @@ public class ExtensionTestingDocTest
 
             // Then
             assertEquals( 200, response.status() );
+        }
+    }
+
+    @Test
+    public void testMyExtensionWithFunctionFixture() throws Exception
+    {
+        // Given
+        try ( ServerControls server = TestServerBuilders.newInProcessBuilder()
+                .withExtension( "/myExtension", MyUnmanagedExtension.class )
+                .withFixture( new Function<GraphDatabaseService, Void>()
+                {
+                    @Override
+                    public Void apply( GraphDatabaseService graphDatabaseService ) throws RuntimeException
+                    {
+                        try ( Transaction tx = graphDatabaseService.beginTx() )
+                        {
+                            graphDatabaseService.createNode( DynamicLabel.label( "User" ) );
+                            tx.success();
+                        }
+                        return null;
+                    }
+                } )
+                .newServer() )
+        {
+            // When
+            Result result = server.graph().execute( "MATCH (n:User) return n" );
+
+            // Then
+            assertEquals( 1, IteratorUtil.count( result ) );
         }
     }
     // END SNIPPET: testExtension


### PR DESCRIPTION
- expose GraphDatabaseService in ServerControls and Neo4jRule -> enables assertions based on GDB
- enable GDB based fixtures by using Function<GraphDatbaseService,Void>
- InProcessServerBuilder and Neo4jRule use a exisiting graph.db
- TestServerBuilder has a copyFrom(File) method that populates the server's graph db directory with the contents of an existing store.
