### PR TITLE
Change test preparation handling to remove flakiness of test

### DIFF
--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregationTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregationTest.scala
@@ -23,7 +23,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class AggregationTest extends DocumentingTestBase {
+class AggregationTest extends DocumentingTestBase with SoftReset {
   override def graphDescription = List("A:Person KNOWS B:Person", "A KNOWS C:Person", "A KNOWS D:Person")
 
   override val properties: Map[String, Map[String, Any]] = Map(

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint
 
 import scala.collection.JavaConverters._
 
-class ConstraintsTest extends DocumentingTestBase {
+class ConstraintsTest extends DocumentingTestBase with SoftReset {
 
   def section: String = "Constraints"
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.QueryStatisticsTestSupport
 import org.neo4j.graphdb.{DynamicLabel, Node, Relationship}
 import org.neo4j.kernel.GraphDatabaseAPI
 
-class CreateTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class CreateTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
 
   def section = "Create"
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 import org.neo4j.visualization.graphviz.GraphStyle
 import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
 
-class CreateUniqueTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class CreateUniqueTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
 
   override protected def getGraphvizStyle: GraphStyle = 
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DeleteTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DeleteTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.graphdb.DynamicLabel
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class DeleteTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class DeleteTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
   override def graphDescription = List("Andres KNOWS Tobias", "Andres KNOWS Peter")
 
   override val properties = Map(
@@ -42,7 +42,7 @@ class DeleteTest extends DocumentingTestBase with QueryStatisticsTestSupport {
   @Test def delete_single_node() {
     val createLabeledNode = (db: GraphDatabaseAPI) => db.inTx {
       db.createNode(DynamicLabel.label("Useless"))
-    } : Unit
+    }
 
     prepareAndTestQuery(
       title = "Delete single node",

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.docgen
 
+import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.junit.Test
-import org.hamcrest.CoreMatchers._
 import org.neo4j.graphdb._
+import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.tooling.GlobalGraphOperations
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
@@ -49,6 +50,8 @@ class MatchTest extends DocumentingTestBase {
     "WallStreet" -> Map("title" -> "Wall Street"),
     "TheAmericanPresident" -> Map("title" -> "The American President")
   )
+
+  override val setupQueries = List("CREATE (r {name : 'Rob Reiner'})-[:`TYPE THAT HAS SPACE IN IT`]->(c {name : 'Charlie Sheen'})")
 
   override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()
@@ -203,12 +206,11 @@ This is not recommended practice. See <<match-node-by-id>> for more information 
   }
 
   @Test def relationshipsByTypeWithSpace() {
-    prepareAndTestQuery(
+    testQuery(
       title = "Relationship types with uncommon characters",
       text = "Sometime your database will have types with non-letter characters, or with spaces in them. Use +`+ (backtick) to quote these.",
       queryText = """match (n {name:'Rob Reiner'})-[r:`TYPE THAT HAS SPACE IN IT`]->() return r""",
       optionalResultExplanation = """Returns a relationship of a type with spaces in it.""",
-      prepare = executePreparationQueries(List("CREATE (r {name : 'Rob Reiner'})-[:`TYPE THAT HAS SPACE IN IT`]->(c {name : 'Charlie Sheen'})")),
       assertions = (p) => assertEquals(1, p.size)
     )
   }

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
@@ -23,7 +23,7 @@ import org.junit.Test
 import org.neo4j.cypher.{MergeConstraintConflictException, QueryStatisticsTestSupport}
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class MergeTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class MergeTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
 
   override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 import org.neo4j.cypher.QueryStatisticsTestSupport
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class SetTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class SetTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
 
   override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.docgen
 
 import org.junit.Test
+import org.neo4j.kernel.GraphDatabaseAPI
 
 class UsingTest extends DocumentingTestBase {
 
@@ -28,6 +29,8 @@ class UsingTest extends DocumentingTestBase {
     "Stefan:German KNOWS Andres",
     "Emil KNOWS Peter"
   )
+
+  override val setupConstraintQueries: List[String] = List("CREATE INDEX ON :Swedish(surname)", "CREATE INDEX ON :German(surname)")
 
   override val properties = Map(
     "Andres" -> Map("age" -> 36l, "awesome" -> true, "surname" -> "Taylor"),
@@ -38,25 +41,21 @@ class UsingTest extends DocumentingTestBase {
   def section = "Using"
 
   @Test def query_using_single_index_hint() {
-
     prepareAndTestQuery(
       title = "Query using an index hint",
       text = "To query using an index hint, use +USING+ +INDEX+.",
       queryText = "match (n:Swedish) using index n:Swedish(surname) where n.surname = 'Taylor' return n",
       optionalResultExplanation = "The query result is returned as usual.",
-      prepare = executePreparationQueries(List("CREATE INDEX ON :Swedish(surname)")),
       assertions = (p) => assert(p.toList === List(Map("n" -> node("Andres"))))
     )
   }
 
   @Test def query_using_multiple_index_hints() {
-
     prepareAndTestQuery(
       title = "Query using multiple index hints",
       text = "To query using multiple index hints, use +USING+ +INDEX+.",
       queryText = "match (m:German)-->(n:Swedish) using index m:German(surname) using index n:Swedish(surname) where m.surname = 'Plantikow' and n.surname = 'Taylor' return m",
       optionalResultExplanation = "The query result is returned as usual.",
-      prepare = executePreparationQueries(List("CREATE INDEX ON :Swedish(surname)", "CREATE INDEX ON :German(surname)")),
       assertions = (p) => assert(p.toList === List(Map("m" -> node("Stefan"))))
     )
   }

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsCompleteGraphTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsCompleteGraphTest.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.docgen.cookbook
 
 import org.junit.Test
-import org.neo4j.cypher.docgen.DocumentingTestBase
+import org.neo4j.cypher.docgen.{SoftReset, DocumentingTestBase}
 import org.neo4j.visualization.graphviz.GraphStyle
 import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
 import org.neo4j.cypher.QueryStatisticsTestSupport
 
-class PrettyGraphsCompleteGraphTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class PrettyGraphsCompleteGraphTest extends DocumentingTestBase with SoftReset with QueryStatisticsTestSupport {
   def section = "cookbook"
   generateInitialGraphForConsole = false
   override val graphvizOptions = "graph [layout=circo]"

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsFriendshipGraphTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsFriendshipGraphTest.scala
@@ -19,20 +19,19 @@
  */
 package org.neo4j.cypher.docgen.cookbook
 
-import org.junit.Test
 import org.junit.Assert._
-import org.neo4j.cypher.docgen.DocumentingTestBase
-import org.neo4j.visualization.graphviz.GraphStyle
-import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
+import org.junit.Test
 import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.cypher.docgen.{DocumentingTestBase, HardReset}
+import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class PrettyGraphsFriendshipGraphTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class PrettyGraphsFriendshipGraphTest extends DocumentingTestBase with HardReset with QueryStatisticsTestSupport {
   def section = "cookbook"
   generateInitialGraphForConsole = false
   override val graphvizOptions = "graph [layout=neato]"
   override val graphvizExecutedAfter = true
 
-  override protected def getGraphvizStyle: GraphStyle = 
+  override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()
 
   @Test def completeGraph() {

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsStarTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsStarTest.scala
@@ -19,14 +19,13 @@
  */
 package org.neo4j.cypher.docgen.cookbook
 
-import org.junit.Test
 import org.junit.Assert._
-import org.neo4j.cypher.docgen.DocumentingTestBase
-import org.neo4j.visualization.graphviz.GraphStyle
-import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
+import org.junit.Test
 import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.cypher.docgen.{DocumentingTestBase, HardReset}
+import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class PrettyGraphsStarTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class PrettyGraphsStarTest extends DocumentingTestBase with HardReset with QueryStatisticsTestSupport {
   def section = "cookbook"
   generateInitialGraphForConsole = false
   override val graphvizOptions = "graph [layout=neato]"

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsWheelTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsWheelTest.scala
@@ -19,14 +19,13 @@
  */
 package org.neo4j.cypher.docgen.cookbook
 
-import org.junit.Test
 import org.junit.Assert._
-import org.neo4j.cypher.docgen.DocumentingTestBase
-import org.neo4j.visualization.graphviz.GraphStyle
-import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
+import org.junit.Test
 import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.cypher.docgen.{DocumentingTestBase, HardReset}
+import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
-class PrettyGraphsWheelTest extends DocumentingTestBase with QueryStatisticsTestSupport {
+class PrettyGraphsWheelTest extends DocumentingTestBase with HardReset with QueryStatisticsTestSupport {
   def section = "cookbook"
   generateInitialGraphForConsole = false
   override val graphvizOptions = "graph [layout=neato]"


### PR DESCRIPTION
The test failures are likely caused by the indices not coming online in time.
The restructure changes also allows the database to be reused in most of the cases, reducing testing time.
