### PR TITLE
Removed option to find path with exact depth from ShortestPath

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
@@ -19,11 +19,7 @@
  */
 package org.neo4j.graphalgo;
 
-import org.neo4j.graphalgo.impl.path.AStar;
-import org.neo4j.graphalgo.impl.path.AllPaths;
-import org.neo4j.graphalgo.impl.path.AllSimplePaths;
-import org.neo4j.graphalgo.impl.path.Dijkstra;
-import org.neo4j.graphalgo.impl.path.ShortestPath;
+import org.neo4j.graphalgo.impl.path.*;
 import org.neo4j.graphalgo.impl.util.DoubleEvaluator;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -179,7 +175,7 @@ public abstract class GraphAlgoFactory
     {
         return new ShortestPath( maxDepth, expander, maxHitCount );
     }
-    
+
     /**
      * Returns an algorithm which can find simple all paths of a certain length
      * between two nodes. These returned paths cannot contain loops (i.e. a node
@@ -193,14 +189,14 @@ public abstract class GraphAlgoFactory
      */
     public static PathFinder<Path> pathsWithLength( RelationshipExpander expander, int length )
     {
-        return new ShortestPath( length, expander, Integer.MAX_VALUE, true );
+        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE );
     }
-    
+
     /**
      * Returns an algorithm which can find simple all paths of a certain length
      * between two nodes. These returned paths cannot contain loops (i.e. a node
      * could not occur more than once in any returned path).
-     * 
+     *
      * @param expander the {@link PathExpander} to use for expanding
      * {@link Relationship}s for each {@link Node}.
      * @param length the {@link Path#length()} returned paths will have, if any
@@ -209,7 +205,7 @@ public abstract class GraphAlgoFactory
      */
     public static PathFinder<Path> pathsWithLength( PathExpander expander, int length )
     {
-        return new ShortestPath( length, expander, Integer.MAX_VALUE, true );
+        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE );
     }
     
     /**

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
@@ -189,7 +189,7 @@ public abstract class GraphAlgoFactory
      */
     public static PathFinder<Path> pathsWithLength( RelationshipExpander expander, int length )
     {
-        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE );
+        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE, false );
     }
 
     /**
@@ -205,7 +205,7 @@ public abstract class GraphAlgoFactory
      */
     public static PathFinder<Path> pathsWithLength( PathExpander expander, int length )
     {
-        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE );
+        return new ExactDepthPathFinder( expander, length, Integer.MAX_VALUE, false );
     }
     
     /**

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -57,7 +57,6 @@ public class ShortestPath implements PathFinder<Path>
     private final int maxDepth;
     private final int maxResultCount;
     private final PathExpander expander;
-    private final HitDecider hitDecider;
     private Metadata lastMetadata;
 
     /**
@@ -69,27 +68,14 @@ public class ShortestPath implements PathFinder<Path>
      */
     public ShortestPath( int maxDepth, PathExpander expander )
     {
-        this( maxDepth, expander, Integer.MAX_VALUE, false );
+        this( maxDepth, expander, Integer.MAX_VALUE );
     }
     
     public ShortestPath( int maxDepth, RelationshipExpander expander )
     {
-        this( maxDepth, toPathExpander( expander ), Integer.MAX_VALUE, false );
+        this( maxDepth, toPathExpander( expander ), Integer.MAX_VALUE );
     }
-    
-    /**
-     * Constructs a new shortest path algorithm.
-     * @param maxDepth the maximum depth for the traversal. Returned paths
-     * will never have a greater {@link Path#length()} than {@code maxDepth}.
-     * @param expander the {@link RelationshipExpander} to use for deciding
-     * which relationships to expand for each {@link Node}.
-     * @param maxResultCount the maximum number of hits to return. If this number
-     * of hits are encountered the traversal will stop.
-     */
-    public ShortestPath( int maxDepth, PathExpander expander, int maxResultCount )
-    {
-        this( maxDepth, expander, maxResultCount, false );
-    }
+
     
     public ShortestPath( int maxDepth, RelationshipExpander expander, int maxResultCount )
     {
@@ -104,22 +90,12 @@ public class ShortestPath implements PathFinder<Path>
      * which relationships to expand for each {@link Node}.
      * @param maxResultCount the maximum number of hits to return. If this number
      * of hits are encountered the traversal will stop.
-     * @param findPathsOnMaxDepthOnly if {@code true} then it will only try to
-     * find paths on that particular depth ({@code maxDepth}).
      */
-    public ShortestPath( int maxDepth, PathExpander expander, int maxResultCount,
-            boolean findPathsOnMaxDepthOnly )
+    public ShortestPath( int maxDepth, PathExpander expander, int maxResultCount )
     {
         this.maxDepth = maxDepth;
         this.expander = expander;
         this.maxResultCount = maxResultCount;
-        this.hitDecider = findPathsOnMaxDepthOnly ? new DepthHitDecider( maxDepth ) : YES_HIT_DECIDER;
-    }
-    
-    public ShortestPath( int maxDepth, RelationshipExpander relExpander, int maxResultCount,
-            boolean findPathsOnMaxDepthOnly )
-    {
-        this( maxDepth, toPathExpander( relExpander ), maxResultCount, findPathsOnMaxDepthOnly );
     }
     
     public Iterable<Path> findAllPaths( Node start, Node end )
@@ -211,10 +187,6 @@ public class ShortestPath implements PathFinder<Path>
         {
             // This is a hit
             int depth = directionData.currentDepth + otherSideHit.depth;
-            if ( !hitDecider.isHit( depth ) )
-            {
-                return;
-            }
             
             if ( directionData.sharedFrozenDepth.value == MutableInteger.NULL )
             {
@@ -328,10 +300,10 @@ public class ShortestPath implements PathFinder<Path>
                     return null;
                 }
                 lastMetadata.rels++;
-                if ( !hitDecider.canVisitRelationship( sharedVisitedRels, nextRel ) )
-                {
-                    continue;
-                }
+//                if ( !hitDecider.canVisitRelationship( sharedVisitedRels, nextRel ) )
+//                {
+//                    continue;
+//                }
                 
                 Node result = nextRel.getOtherNode( this.lastPath.endNode() );
                 LevelData levelData = this.visitedNodes.get( result );

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -300,10 +300,6 @@ public class ShortestPath implements PathFinder<Path>
                     return null;
                 }
                 lastMetadata.rels++;
-//                if ( !hitDecider.canVisitRelationship( sharedVisitedRels, nextRel ) )
-//                {
-//                    continue;
-//                }
                 
                 Node result = nextRel.getOtherNode( this.lastPath.endNode() );
                 LevelData levelData = this.visitedNodes.get( result );
@@ -627,46 +623,6 @@ public class ShortestPath implements PathFinder<Path>
             builder = builder.push( rel );
         }
         return builder;
-    }
-    
-    private static interface HitDecider
-    {
-        boolean isHit( int depth );
-        
-        boolean canVisitRelationship( Collection<Long> rels, Relationship rel );
-    }
-    
-    private static final HitDecider YES_HIT_DECIDER = new HitDecider()
-    {
-        public boolean isHit( int depth )
-        {
-            return true;
-        }
-        
-        public boolean canVisitRelationship( Collection<Long> rels, Relationship rel )
-        {
-            return true;
-        }
-    };
-    
-    private static class DepthHitDecider implements HitDecider
-    {
-        private final int depth;
-
-        DepthHitDecider( int depth )
-        {
-            this.depth = depth;
-        }
-        
-        public boolean isHit( int depth )
-        {
-            return this.depth == depth;
-        }
-        
-        public boolean canVisitRelationship( Collection<Long> rels, Relationship rel )
-        {
-            return rels.add( rel.getId() );
-        }
     }
     
     private static class Metadata implements TraversalMetadata

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -65,8 +65,7 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
     @Test
     public void testSingle()
     {
-    	createGraph();
-    	
+        createGraph();
         PathFinder<Path> finder = newFinder();
         Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) );
         assertNotNull( path );
@@ -76,60 +75,57 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
     @Test
     public void testAll()
     {
-    	createGraph();
-    	
+        createGraph();
         assertPaths( newFinder().findAllPaths( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) ),
                 "SOURCE,z,9,0,TARGET", "SOURCE,SUPER,r,SPIDER,TARGET" );
     }
 
-	@Test
-	public void testExactDepthFinder()
-	{
+    @Test
+    public void testExactDepthFinder()
+    {
+        // Layout (a to k):
+        //
+        //     (a)--(c)--(g)--(k)
+        //    /                /
+        //  (b)-----(d)------(j)
+        //   |        \      /
+        //  (e)--(f)--(h)--(i)
+        // 
+        graph.makeEdgeChain( "a,c,g,k" );
+        graph.makeEdgeChain( "a,b,d,j,k" );
+        graph.makeEdgeChain( "b,e,f,h,i,j" );
+        graph.makeEdgeChain( "d,h" );
+        RelationshipExpander expander = Traversal.expanderForTypes( MyRelTypes.R1, Direction.OUTGOING );
+        Node a = graph.getNode( "a" );
+        Node k = graph.getNode( "k" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 3 ).findAllPaths( a, k ), "a,c,g,k" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 4 ).findAllPaths( a, k ), "a,b,d,j,k" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 5 ).findAllPaths( a, k ) );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 6 ).findAllPaths( a, k ), "a,b,d,h,i,j,k" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 7 ).findAllPaths( a, k ), "a,b,e,f,h,i,j,k" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 8 ).findAllPaths( a, k ) );
+    }
 
-		// Layout (a to k):
-		//
-		//     (a)--(c)--(g)--(k)
-		//    /                /
-		//  (b)-----(d)------(j)
-		//   |        \      /
-		//  (e)--(f)--(h)--(i)
-		// 
-		graph.makeEdgeChain( "a,c,g,k" );
-		graph.makeEdgeChain( "a,b,d,j,k" );
-		graph.makeEdgeChain( "b,e,f,h,i,j" );
-		graph.makeEdgeChain( "d,h" );
-
-		RelationshipExpander expander = Traversal.expanderForTypes( MyRelTypes.R1, Direction.OUTGOING );
-		Node a = graph.getNode( "a" );
-		Node k = graph.getNode( "k" );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 3 ).findAllPaths( a, k ), "a,c,g,k" );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 4 ).findAllPaths( a, k ), "a,b,d,j,k" );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 5 ).findAllPaths( a, k ) );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 6 ).findAllPaths( a, k ), "a,b,d,h,i,j,k" );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 7 ).findAllPaths( a, k ), "a,b,e,f,h,i,j,k" );
-		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 8 ).findAllPaths( a, k ) );
-	}
-
-	@Test
-	public void testExactDepthPathsReturnsNoLoops()
-	{
-		// Layout:
-		//
-		// (a)-->(b)==>(c)-->(e)
-		//        ^    /
-		//         \  v
-		//         (d)
-		//
-		graph.makeEdgeChain( "a,b,c,d,b,c,e" );
-
-		Node a = graph.getNode( "a" );
-		Node e = graph.getNode( "e" );
-		assertPaths( GraphAlgoFactory.pathsWithLength(
-				Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
-		assertPaths( GraphAlgoFactory.pathsWithLength(
-				Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ), "a,b,d,c,e" );
-		assertPaths( GraphAlgoFactory.pathsWithLength(
-				Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths( a, e ) );
-	}
-
+    @Test
+    public void testExactDepthPathsReturnsNoLoops()
+    {
+        // Layout:
+        //
+        // (a)-->(b)==>(c)-->(e)
+        //        ^    /
+        //         \  v
+        //         (d)
+        //
+        graph.makeEdgeChain( "a,b,c,d,b,c,e" );
+        Node a = graph.getNode( "a" );
+        Node e = graph.getNode( "e" );
+        assertPaths(
+                GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ),
+                "a,b,c,e", "a,b,c,e" );
+        assertPaths(
+                GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ),
+                "a,b,d,c,e" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths(
+                a, e ) );
+    }
 }

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -21,18 +21,22 @@ package org.neo4j.graphalgo.path;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.neo4j.graphalgo.GraphAlgoFactory;
 import org.neo4j.graphalgo.PathFinder;
 import org.neo4j.graphalgo.impl.path.ExactDepthPathFinder;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpanders;
+import org.neo4j.graphdb.RelationshipExpander;
+import org.neo4j.kernel.Traversal;
 
 import common.Neo4jAlgoTestCase;
+import common.Neo4jAlgoTestCase.MyRelTypes;
 import static org.junit.Assert.assertNotNull;
 
 public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
 {
-    @Before
     public void createGraph()
     {
         graph.makeEdgeChain( "SOURCE,a,b,TARGET" );
@@ -55,12 +59,14 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
 
     private PathFinder<Path> newFinder()
     {
-        return new ExactDepthPathFinder( PathExpanders.allTypesAndDirections(), 4, 4 );
+        return new ExactDepthPathFinder( PathExpanders.allTypesAndDirections(), 4, 4, true );
     }
 
     @Test
     public void testSingle()
     {
+    	createGraph();
+    	
         PathFinder<Path> finder = newFinder();
         Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) );
         assertNotNull( path );
@@ -70,7 +76,60 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
     @Test
     public void testAll()
     {
+    	createGraph();
+    	
         assertPaths( newFinder().findAllPaths( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) ),
                 "SOURCE,z,9,0,TARGET", "SOURCE,SUPER,r,SPIDER,TARGET" );
     }
+
+	@Test
+	public void testExactDepthFinder()
+	{
+
+		// Layout (a to k):
+		//
+		//     (a)--(c)--(g)--(k)
+		//    /                /
+		//  (b)-----(d)------(j)
+		//   |        \      /
+		//  (e)--(f)--(h)--(i)
+		// 
+		graph.makeEdgeChain( "a,c,g,k" );
+		graph.makeEdgeChain( "a,b,d,j,k" );
+		graph.makeEdgeChain( "b,e,f,h,i,j" );
+		graph.makeEdgeChain( "d,h" );
+
+		RelationshipExpander expander = Traversal.expanderForTypes( MyRelTypes.R1, Direction.OUTGOING );
+		Node a = graph.getNode( "a" );
+		Node k = graph.getNode( "k" );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 3 ).findAllPaths( a, k ), "a,c,g,k" );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 4 ).findAllPaths( a, k ), "a,b,d,j,k" );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 5 ).findAllPaths( a, k ) );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 6 ).findAllPaths( a, k ), "a,b,d,h,i,j,k" );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 7 ).findAllPaths( a, k ), "a,b,e,f,h,i,j,k" );
+		assertPaths( GraphAlgoFactory.pathsWithLength( expander, 8 ).findAllPaths( a, k ) );
+	}
+
+	@Test
+	public void testExactDepthPathsReturnsNoLoops()
+	{
+		// Layout:
+		//
+		// (a)-->(b)==>(c)-->(e)
+		//        ^    /
+		//         \  v
+		//         (d)
+		//
+		graph.makeEdgeChain( "a,b,c,d,b,c,e" );
+
+		Node a = graph.getNode( "a" );
+		Node e = graph.getNode( "e" );
+		assertPaths( GraphAlgoFactory.pathsWithLength(
+				Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
+		assertPaths( GraphAlgoFactory.pathsWithLength(
+				Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ), "a,b,d,c,e" );
+		assertPaths( GraphAlgoFactory.pathsWithLength(
+				Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths( a, e ) );
+	}
+
 }

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
@@ -503,7 +503,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         }, PathExpanders.forTypeAndDirection( R1, INCOMING ), 2 );
     }
 
-    @Ignore("Exposes a problem where the expected path isn't returned")
     @Test
     public void pathsWithLengthProblem() throws Exception
     {
@@ -524,7 +523,7 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         Node a = graph.getNode( "a" );
         Node c = graph.getNode( "c" );
 
-        assertPaths( new ShortestPath( 3, PathExpanders.forType( R1 ), 10, true ).findAllPaths( a, c ), "a,d,b,c" );
+        assertPaths( new ShortestPath( 3, PathExpanders.forType( R1 ), 10 ).findAllPaths( a, c ), "a,d,c" );
     }
 
     @Test

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
@@ -523,7 +523,7 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         Node a = graph.getNode( "a" );
         Node c = graph.getNode( "c" );
 
-        assertPaths( new ShortestPath( 3, PathExpanders.forType( R1 ), 10 ).findAllPaths( a, c ), "a,d,c" );
+        assertPaths( new ShortestPath( 3, PathExpanders.forType( R1 ), 10 ).findAllPaths( a, c ), "a,b,c" );
     }
 
     @Test

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestShortestPath.java
@@ -181,32 +181,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         }, PathExpanders.forTypeAndDirection( R1, OUTGOING ), 4 );
     }
 
-    @Test
-    public void testExactDepthFinder()
-    {
-        // Layout (a to k):
-        //
-        //     (a)--(c)--(g)--(k)
-        //    /                /
-        //  (b)-----(d)------(j)
-        //   |        \      /
-        //  (e)--(f)--(h)--(i)
-        // 
-        graph.makeEdgeChain( "a,c,g,k" );
-        graph.makeEdgeChain( "a,b,d,j,k" );
-        graph.makeEdgeChain( "b,e,f,h,i,j" );
-        graph.makeEdgeChain( "d,h" );
-
-        RelationshipExpander expander = Traversal.expanderForTypes( MyRelTypes.R1, Direction.OUTGOING );
-        Node a = graph.getNode( "a" );
-        Node k = graph.getNode( "k" );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 3 ).findAllPaths( a, k ), "a,c,g,k" );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 4 ).findAllPaths( a, k ), "a,b,d,j,k" );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 5 ).findAllPaths( a, k ) );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 6 ).findAllPaths( a, k ), "a,b,d,h,i,j,k" );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 7 ).findAllPaths( a, k ), "a,b,e,f,h,i,j,k" );
-        assertPaths( GraphAlgoFactory.pathsWithLength( expander, 8 ).findAllPaths( a, k ) );
-    }
 
     @Test
     public void makeSureShortestPathsReturnsNoLoops()
@@ -230,28 +204,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 assertPaths( finder.findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
             }
         }, PathExpanders.forTypeAndDirection( R1, BOTH ), 6 );
-    }
-
-    @Test
-    public void testExactDepthPathsReturnsNoLoops()
-    {
-        // Layout:
-        //
-        // (a)-->(b)==>(c)-->(e)
-        //        ^    /
-        //         \  v
-        //         (d)
-        //
-        graph.makeEdgeChain( "a,b,c,d,b,c,e" );
-
-        Node a = graph.getNode( "a" );
-        Node e = graph.getNode( "e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ), "a,b,d,c,e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths( a, e ) );
     }
 
     @Test


### PR DESCRIPTION
It does not make sense to find a shortest path with specified length and ExactDepthPathFinder already provides that functionality.

Tests for both ExactDepthPathFinder and ShortestPath runs.
