### PR TITLE
Solves problem with COST planner and ()-[*0..0]->() patterns

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
@@ -87,7 +87,8 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
                   }
               }
           val selectivityPerLength = selectivityPerLengthAndStep.flatMap(combiner.andTogetherSelectivities)
-          combiner.orTogetherSelectivities(selectivityPerLength).getOrElse(throw new InternalException("There is no spoon."))
+          combiner.orTogetherSelectivities(selectivityPerLength).
+            getOrElse(throw new InternalException("Unexpectedly tried to calculate cardinality of a [*0..0] relationship"))
       }
     }
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
@@ -112,6 +112,12 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
         A_T1_STAR + STAR_T1_A
       },
 
+      "MATCH (a:A)-[*0..0]-(b:A)"
+        -> N * Asel * Asel // This is a simplification, because *0..0 relationships mean something weird and icky
+                           // It's not really right, but should not be fixed by the cardinality model. It should have
+                           // been rewritten away before this stage
+      ,
+
       "MATCH (a:A:B)-->()"
         -> {
         val maxRelCount = N * N * Asel * Bsel

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -2,6 +2,7 @@
 -----
 o Fixes problem when using named paths and aggregation
 o Fixes #4462 - RULE planner inconsistent in order of path elements
+o Fixes problem with COST planner and ()-[*0..0]->() patterns
 
 2.2.1
 -----

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -2016,4 +2016,23 @@ return b
 
     result should equal(List(Map("a" -> node, "b" -> null, "c" -> null)))
   }
+
+  test("should handle varlength paths of size 0..0") {
+    val a = createNode()
+    val b = createNode()
+    val c = createNode()
+    relate(b, c)
+
+    val query =
+      """match (a)-[*0..0]->(b)
+        |return a, b""".stripMargin
+
+    val result = executeWithAllPlanners(query).toSet
+
+    result should equal(Set(
+      Map("a" -> a, "b" -> a),
+      Map("a" -> b, "b" -> b),
+      Map("a" -> c, "b" -> c)
+    ))
+  }
 }


### PR DESCRIPTION
This is here to handle the *0..0 case. It means that both end nodes of the relationship must be the same.
 Our solution to the problem is to keep count of how many of these we see, and decrease the number of pattern
 nodes accordingly. This workaround should work, but might not give the best numbers.

 The nice solution would have been to rewrite these relationships away at an earlier phase, but that is a much
 larger rewrite that we don't want to do in a patch release
