### PR TITLE
Order by rewriting in normalize return clause must be done topDown

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/normalizeReturnClauses.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.FreshIdNameGenerator
-import org.neo4j.cypher.internal.compiler.v2_2.{InputPosition, CypherException, Rewriter, bottomUp}
+import org.neo4j.cypher.internal.compiler.v2_2.{CypherException, InputPosition, Rewriter, bottomUp, topDown}
 
 /**
  * This rewriter makes sure that all return items in a RETURN clauses are aliased, and moves
@@ -74,7 +74,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
           (AliasedReturnItem(i.expression, newIdentifier)(i.position), AliasedReturnItem(newIdentifier.copyId, returnColumn)(i.position))
       }.unzip
 
-      val newOrderBy = orderBy.endoRewrite(bottomUp(Rewriter.lift {
+      val newOrderBy = orderBy.endoRewrite(topDown(Rewriter.lift {
         case exp: Expression if rewrites.contains(exp) => rewrites(exp).copyId
       }))
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -99,6 +99,15 @@ class NormalizeReturnClausesTest extends CypherFunSuite with RewriteTest with As
     )
   }
 
+  test("should replace the aggregation function in the order by") {
+    assertRewrite(
+      """MATCH n
+        |RETURN n as n, count(n) as count ORDER BY count(n)""".stripMargin,
+      """MATCH n
+        |WITH n AS `  FRESHID15`, count(n) AS `  FRESHID23` ORDER BY `  FRESHID23`
+        |RETURN `  FRESHID15` AS n, `  FRESHID23` as count""".stripMargin)
+  }
+
   protected override def assertRewrite(originalQuery: String, expectedQuery: String) {
     val original = parseForRewriting(originalQuery)
     val expected = parseForRewriting(expectedQuery)


### PR DESCRIPTION
In such a way we can ensure that we replace the biggest matching sub-expression
