### PR TITLE
Faster recovery for legacy indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -54,10 +54,11 @@ import org.neo4j.kernel.impl.api.GuardingStatementOperations;
 import org.neo4j.kernel.impl.api.Kernel;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.KernelTransactions;
-import org.neo4j.kernel.impl.api.LegacyIndexApplier;
-import org.neo4j.kernel.impl.api.LegacyIndexApplier.ProviderLookup;
+import org.neo4j.kernel.impl.api.LegacyIndexApplierLookup;
+import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
 import org.neo4j.kernel.impl.api.LockingStatementOperations;
+import org.neo4j.kernel.impl.api.RecoveryLegacyIndexApplierLookup;
 import org.neo4j.kernel.impl.api.SchemaStateConcern;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
@@ -313,7 +314,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
     private final AtomicInteger recoveredCount = new AtomicInteger();
     private final Guard guard;
     private final Map<String,IndexImplementation> indexProviders = new HashMap<>();
-    private final ProviderLookup legacyIndexProviderLookup;
+    private final LegacyIndexProviderLookup legacyIndexProviderLookup;
     private final IndexConfigStore indexConfigStore;
 
     private Dependencies dependencies;
@@ -395,10 +396,10 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
         msgLog = stringLogger;
         this.storeFactory = sf;
         this.lockService = new ReentrantLockService();
-        this.legacyIndexProviderLookup = new LegacyIndexApplier.ProviderLookup()
+        this.legacyIndexProviderLookup = new LegacyIndexProviderLookup()
         {
             @Override
-            public IndexImplementation lookup( String name )
+            public IndexImplementation apply( String name )
             {
                 assert name != null : "Null provider name supplied";
                 IndexImplementation provider = indexProviders.get( name );
@@ -413,7 +414,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
             }
 
             @Override
-            public Iterable<IndexImplementation> providers()
+            public Iterable<IndexImplementation> all()
             {
                 return indexProviders.values();
             }
@@ -787,8 +788,8 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
         final TransactionRepresentationStoreApplier storeApplier = dependencies.satisfyDependency(
                 new TransactionRepresentationStoreApplier(
                         indexingService, alwaysCreateNewWriter( labelScanStore ), neoStore,
-                        cacheAccess, lockService, legacyIndexProviderLookup, indexConfigStore,
-                        legacyIndexTransactionOrdering ) );
+                        cacheAccess, lockService, new LegacyIndexApplierLookup.Direct( legacyIndexProviderLookup ),
+                        indexConfigStore, legacyIndexTransactionOrdering ) );
 
         final PhysicalLogFile logFile = new PhysicalLogFile( fileSystemAbstraction, logFiles,
                 config.get( GraphDatabaseSettings.logical_log_rotation_threshold ), neoStore,
@@ -904,10 +905,12 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
     {
         final RecoveryLabelScanWriterProvider labelScanWriters =
                 new RecoveryLabelScanWriterProvider( labelScanStore, 1000 );
+        final RecoveryLegacyIndexApplierLookup legacyIndexApplierLookup = new RecoveryLegacyIndexApplierLookup(
+                new LegacyIndexApplierLookup.Direct( legacyIndexProviderLookup ), 1000 );
         final TransactionRepresentationStoreApplier storeRecoverer =
                 new TransactionRepresentationStoreApplier(
                         indexingService, labelScanWriters, neoStore, cacheAccess, lockService,
-                        legacyIndexProviderLookup, indexConfigStore, IdOrderingQueue.BYPASS );
+                        legacyIndexApplierLookup, indexConfigStore, IdOrderingQueue.BYPASS );
 
         RecoveryVisitor recoveryVisitor = new RecoveryVisitor( neoStore, storeRecoverer, indexUpdatesValidator,
                 recoveryVisitorMonitor );
@@ -924,6 +927,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 try
                 {
                     labelScanWriters.close();
+                    legacyIndexApplierLookup.close();
                 }
                 catch ( IOException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -81,7 +81,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
     private final StoreReadLayer storeLayer;
     private final TransactionCommitProcess transactionCommitProcess;
     private final IndexConfigStore indexConfigStore;
-    private final LegacyIndexApplier.ProviderLookup legacyIndexProviderLookup;
+    private final LegacyIndexProviderLookup legacyIndexProviderLookup;
     private final TransactionHooks hooks;
     private final TransactionMonitor transactionMonitor;
     private final LifeSupport dataSourceLife;
@@ -113,7 +113,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
                                PersistenceCache persistenceCache, StoreReadLayer storeLayer,
                                TransactionCommitProcess transactionCommitProcess,
                                IndexConfigStore indexConfigStore,
-                               LegacyIndexApplier.ProviderLookup legacyIndexProviderLookup,
+                               LegacyIndexProviderLookup legacyIndexProviderLookup,
                                TransactionHooks hooks, TransactionMonitor transactionMonitor,
                                LifeSupport dataSourceLife,
                                Tracers tracers )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplierLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplierLookup.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.index.IndexImplementation;
+import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+
+/**
+ * Looks up a {@link LegacyIndexApplier} given a provider name.
+ */
+public interface LegacyIndexApplierLookup
+{
+    NeoCommandHandler newApplier( String providerName, boolean recovery );
+
+    /**
+     * Looks up an {@link IndexImplementation} and calls {@link IndexImplementation#newApplier(boolean)} on it.
+     */
+    class Direct implements LegacyIndexApplierLookup
+    {
+        private final Function<String,IndexImplementation> providerLookup;
+
+        public Direct( Function<String,IndexImplementation> providerLookup )
+        {
+            this.providerLookup = providerLookup;
+        }
+
+        @Override
+        public NeoCommandHandler newApplier( String providerName, boolean recovery )
+        {
+            return providerLookup.apply( providerName ).newApplier( recovery );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexProviderLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexProviderLookup.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.index.IndexImplementation;
+
+/**
+ * Looks up an {@link IndexImplementation} given a name.
+ */
+public interface LegacyIndexProviderLookup extends Function<String,IndexImplementation>
+{
+    /**
+     * @return all known {@link IndexImplementation} instances in use.
+     */
+    Iterable<IndexImplementation> all();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+
+/**
+ * Batches updates to a legacy index. Used during recovery.
+ * After recovery has been completed {@link #close()} must be called.
+ */
+public class RecoveryLegacyIndexApplierLookup implements LegacyIndexApplierLookup, Closeable
+{
+    private final LegacyIndexApplierLookup lookup;
+    private final Map<String,RecoveryCommandHandler> appliers = new HashMap<>();
+    private final int batchSize;
+
+    public RecoveryLegacyIndexApplierLookup( LegacyIndexApplierLookup lookup, int batchSize )
+    {
+        this.lookup = lookup;
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public NeoCommandHandler newApplier( String name, boolean recovery )
+    {
+        RecoveryCommandHandler applier = appliers.get( name );
+        if ( applier == null )
+        {
+            NeoCommandHandler actualApplier = lookup.newApplier( name, recovery );
+            appliers.put( name, applier = new RecoveryCommandHandler( name, actualApplier ) );
+        }
+        return applier;
+    }
+
+    /**
+     * Called AFTER all transactions have been recovered, before forcing everything.
+     */
+    @Override
+    public void close() throws IOException
+    {
+        for ( RecoveryCommandHandler applier : appliers.values() )
+        {
+            applier.applyForReal();
+        }
+    }
+
+    private class RecoveryCommandHandler extends NeoCommandHandler.Delegator
+    {
+        private final String name;
+        private int applyCount;
+
+        RecoveryCommandHandler( String name, NeoCommandHandler applier )
+        {
+            super( applier );
+            this.name = name;
+        }
+
+        @Override
+        public void apply()
+        {
+            if ( ++applyCount % batchSize == 0 )
+            {
+                applyForReal();
+                appliers.remove( name );
+            }
+        }
+
+        /**
+         * Let close calls through since application of the changes is done in {@link #apply()},
+         * and it's the batching of those that we're interested in.
+         */
+        @Override
+        public void close()
+        {
+            super.close();
+        }
+
+        private void applyForReal()
+        {
+            super.apply();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api;
 import java.io.IOException;
 
 import org.neo4j.helpers.Provider;
-import org.neo4j.kernel.impl.api.LegacyIndexApplier.ProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
@@ -53,12 +52,12 @@ public class TransactionRepresentationStoreApplier
     private final LockService lockService;
     private final Provider<LabelScanWriter> labelScanWriters;
     private final IndexConfigStore indexConfigStore;
-    private final ProviderLookup legacyIndexProviderLookup;
+    private final LegacyIndexApplierLookup legacyIndexProviderLookup;
     private final IdOrderingQueue legacyIndexTransactionOrdering;
 
     public TransactionRepresentationStoreApplier(
             IndexingService indexingService, Provider<LabelScanWriter> labelScanWriters, NeoStore neoStore,
-            CacheAccessBackDoor cacheAccess, LockService lockService, ProviderLookup legacyIndexProviderLookup,
+            CacheAccessBackDoor cacheAccess, LockService lockService, LegacyIndexApplierLookup legacyIndexProviderLookup,
             IndexConfigStore indexConfigStore, IdOrderingQueue legacyIndexTransactionOrdering )
     {
         this.indexingService = indexingService;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.LegacyIndexApplier.ProviderLookup;
+import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -44,10 +44,10 @@ public class NeoStoreFileListing
     private final File storeDir;
     private final LabelScanStore labelScanStore;
     private final IndexingService indexingService;
-    private final ProviderLookup legacyIndexProviders;
+    private final LegacyIndexProviderLookup legacyIndexProviders;
 
     public NeoStoreFileListing( File storeDir, LabelScanStore labelScanStore,
-            IndexingService indexingService, ProviderLookup legacyIndexProviders )
+            IndexingService indexingService, LegacyIndexProviderLookup legacyIndexProviders )
     {
         this.storeDir = storeDir;
         this.labelScanStore = labelScanStore;
@@ -70,7 +70,7 @@ public class NeoStoreFileListing
     private Resource gatherLegacyIndexFiles( Collection<File> files ) throws IOException
     {
         final Collection<ResourceIterator<File>> snapshots = new ArrayList<>();
-        for ( IndexImplementation indexProvider : legacyIndexProviders.providers() )
+        for ( IndexImplementation indexProvider : legacyIndexProviders.all() )
         {
             ResourceIterator<File> snapshot = indexProvider.listStoreFiles();
             snapshots.add( snapshot );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
@@ -64,8 +64,8 @@ public class TransactionRepresentationStoreApplierTest
     private final NeoStore neoStore = mock( NeoStore.class );
     private final CacheAccessBackDoor cacheAccess = mock( CacheAccessBackDoor.class );
     private final LockService lockService = new ReentrantLockService();
-    private final LegacyIndexApplier.ProviderLookup legacyIndexProviderLookup =
-            mock( LegacyIndexApplier.ProviderLookup.class );
+    private final LegacyIndexApplierLookup legacyIndexProviderLookup =
+            mock( LegacyIndexApplierLookup.class );
     private final IndexConfigStore indexConfigStore = mock( IndexConfigStore.class );
     private final IdOrderingQueue queue = mock( IdOrderingQueue.class );
     private final int transactionId = 12;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.LegacyIndexApplier.ProviderLookup;
+import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
@@ -51,7 +52,7 @@ public class NeoStoreFileListingTest
     private LabelScanStore labelScanStore;
     private IndexingService indexingService;
     private File storeDir;
-    private ProviderLookup legacyIndexes;
+    private LegacyIndexProviderLookup legacyIndexes;
 
     private final static String[] STANDARD_STORE_DIR_FILES = new String[]{
             "lock",
@@ -99,8 +100,8 @@ public class NeoStoreFileListingTest
     {
         labelScanStore = mock( LabelScanStore.class );
         indexingService = mock( IndexingService.class );
-        legacyIndexes = mock( ProviderLookup.class );
-        when( legacyIndexes.providers() ).thenReturn( Collections.<IndexImplementation>emptyList() );
+        legacyIndexes = mock( LegacyIndexProviderLookup.class );
+        when( legacyIndexes.all() ).thenReturn( Collections.<IndexImplementation>emptyList() );
         storeDir = mock( File.class );
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.index.impl.lucene;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.IndexWriter;
 
 /**
  * This presents a context for each {@link LuceneCommand} when they are
@@ -105,12 +105,12 @@ class CommitContext implements Closeable
             }
         }
     }
-    
+
     @Override
     public void close() throws IOException
     {
         applyDocuments( writer, indexType, documents );
-        if ( writer != null )
+        if ( writer != null && !recovery )
         {
             dataSource.invalidateIndexSearcher( identifier );
         }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -205,6 +205,7 @@ public class LuceneDataSource implements Lifecycle
         {
             try
             {
+                index.setStale();
                 index.getWriter().commit();
             }
             catch ( IOException e )


### PR DESCRIPTION
by batching updates, in the lucene case avoiding refreshing the index
searcher after each recovered transaction.
