### PR TITLE
Make sure we don't generate NodeUniqueIndexSeeks for regular indices

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/IndexLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/steps/IndexLeafPlanner.scala
@@ -86,7 +86,6 @@ object uniqueIndexSeekLeafPlanner extends IndexLeafPlanner {
     (predicates: Seq[Expression]) =>
       context.logicalPlanProducer.planNodeIndexUniqueSeek(idName, label, propertyKey, valueExpr, predicates, hint, argumentIds)
 
-
   protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] =
     context.planContext.getUniqueIndexRule(label, property)
 }
@@ -102,9 +101,12 @@ object indexSeekLeafPlanner extends IndexLeafPlanner {
     (predicates: Seq[Expression]) =>
       context.logicalPlanProducer.planNodeIndexSeek(idName, label, propertyKey, valueExpr, predicates, hint, argumentIds)
 
-  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] =
-    context.planContext.getIndexRule(label, property)
+  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] = {
+    if (uniqueIndex(label, property).isDefined) None else anyIndex(label, property)
+  }
 
+  private def anyIndex(label: String, property: String)(implicit context: LogicalPlanningContext) = context.planContext.getIndexRule(label, property)
+  private def uniqueIndex(label: String, property: String)(implicit context: LogicalPlanningContext) = context.planContext.getUniqueIndexRule(label, property)
 }
 
 object legacyHintLeafPlanner extends LeafPlanner {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
@@ -107,7 +107,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       }
 
       def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] =
-        if (config.indexes((labelName, propertyKey)))
+        if (config.indexes((labelName, propertyKey)) || config.uniqueIndexes((labelName, propertyKey)))
           Some(new IndexDescriptor(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
@@ -51,6 +51,20 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     }
   }
 
+  test("does not plan index seek when there is a matching unique index") {
+    new given {
+      qg = queryGraph(inCollectionValue, hasLabels)
+
+      uniqueIndexOn("Awesome", "prop")
+    }.withLogicalPlanningContext { (cfg, ctx) =>
+      // when
+      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+
+      // then
+      resultPlans shouldBe empty
+    }
+  }
+
   test("does not plan index seek when no unique index exist") {
     new given {
       qg = queryGraph(inCollectionValue, hasLabels)
@@ -61,7 +75,6 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       // then
       resultPlans shouldBe empty
     }
-
   }
 
   test("index scan when there is an index on the property") {
@@ -78,7 +91,6 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
         case Seq(NodeIndexSeek(`idName`, _, _, ManyQueryExpression(Collection(Seq(`lit42`))), _)) =>  ()
       }
     }
-
   }
 
   test("plans index seeks when identifier exists as an argument") {
@@ -174,7 +186,6 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
         case (Seq(plannedQG: QueryGraph)) if plannedQG.hints == Set(hint) => ()
       }
     }
-
   }
 
   private def queryGraph(predicates: Expression*) =


### PR DESCRIPTION
o Also fixes a subtle issue where LPT2 would not report unique indices correctly in the mocked plan context
