### PR TITLE
Clarifying the difference between size and length

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LengthFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LengthFunction.scala
@@ -27,8 +27,8 @@ import org.neo4j.graphdb.Path
 
 case class LengthFunction(inner: Expression)
   extends NullInNullOutExpression(inner)
-  with CollectionSupport
-{
+  with CollectionSupport {
+  //NOTE all usage except for paths is deprecated
   def compute(value: Any, m: ExecutionContext)(implicit state: QueryState) = value match {
     case path: Path => path.length()
     case s: String  => s.length()
@@ -39,7 +39,7 @@ case class LengthFunction(inner: Expression)
 
   def arguments = Seq(inner)
 
-  def calculateType(symbols: SymbolTable): CypherType = CTInteger
+  def calculateType(symbols: SymbolTable) = CTInteger
 
   def symbolTableDependencies = inner.symbolTableDependencies
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
@@ -28,4 +28,6 @@ sealed trait InternalNotification
 
 case class CartesianProductNotification(position: InputPosition) extends InternalNotification
 
+case class LengthOnNonPathNotification(position: InputPosition) extends InternalNotification
+
 case object LegacyPlannerNotification extends InternalNotification

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LengthFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LengthFunctionTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.commands
+
+import org.neo4j.cypher.internal.compiler.v2_3._
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{LengthFunction, Identifier, PathImpl, SizeFunction}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryStateHelper
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.{Node, Relationship}
+
+class LengthFunctionTest extends CypherFunSuite {
+
+  test("length can be used on paths") {
+    //given
+    val p = new PathImpl(mock[Node], mock[Relationship], mock[Node])
+    val m = ExecutionContext.from("p" -> p)
+    val lengthFunction = LengthFunction(Identifier("p"))
+
+    //when
+    val result = lengthFunction.apply(m)(QueryStateHelper.empty)
+
+    //then
+    result should equal(1)
+  }
+
+  test("length can still be used on collections") {
+    //given
+    val l = Seq("it", "was", "the")
+    val m = ExecutionContext.from("l" -> l)
+    val lengthFunction = LengthFunction(Identifier("l"))
+
+    //when
+    val result = lengthFunction.apply(m)(QueryStateHelper.empty)
+
+    //then
+    result should equal(3)
+  }
+
+  test("length can still be used on strings") {
+    //given
+    val s = "it was the"
+    val m = ExecutionContext.from("s" -> s)
+    val lengthFunction = LengthFunction(Identifier("s"))
+
+    //when
+    val result = lengthFunction.apply(m)(QueryStateHelper.empty)
+
+    //then
+    result should equal(10)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/SizeFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/SizeFunctionTest.scala
@@ -20,19 +20,46 @@
 package org.neo4j.cypher.internal.compiler.v2_3.commands
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{SizeFunction, ExtractFunction, Identifier, LengthFunction}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{PathImpl, Identifier, SizeFunction}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.{Relationship, Node, Path}
 
-class ExtractTest extends CypherFunSuite {
-  test("canReturnSomethingFromAnIterable") {
-    val l = Seq("x", "xxx", "xx")
-    val expression = SizeFunction(Identifier("n"))
-    val collection = Identifier("l")
+class SizeFunctionTest extends CypherFunSuite {
+
+  test("size can be used on collections") {
+    //given
+    val l = Seq("it", "was", "the")
     val m = ExecutionContext.from("l" -> l)
+    val sizeFunction = SizeFunction(Identifier("l"))
 
-    val extract = ExtractFunction(collection, "n", expression)
+    //when
+    val result = sizeFunction.apply(m)(QueryStateHelper.empty)
 
-    extract.apply(m)(QueryStateHelper.empty) should equal(Seq(1, 3, 2))
+    //then
+    result should equal(3)
+  }
+
+  test("size can be used on strings") {
+    //given
+    val s = "it was the"
+    val m = ExecutionContext.from("s" -> s)
+    val sizeFunction = SizeFunction(Identifier("s"))
+
+    //when
+    val result = sizeFunction.apply(m)(QueryStateHelper.empty)
+
+    //then
+    result should equal(10)
+  }
+
+  test("size cannot be used on paths") {
+    //given
+    val p = new PathImpl(mock[Node], mock[Relationship], mock[Node])
+    val m = ExecutionContext.from("p" -> p)
+    val sizeFunction = SizeFunction(Identifier("p"))
+
+    //when/then
+    intercept[CypherTypeException](sizeFunction.apply(m)(QueryStateHelper.empty))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -832,12 +832,20 @@ class CypherParserTest extends CypherFunSuite {
         returns(ReturnItem(Equals(LengthFunction(Literal("foo")), Literal(10.0)), "n")))
   }
 
+  test("string size") {
+    expectQuery(
+      "return SIZE('foo') = 10 as n",
+      Query.
+        matches().
+        returns(ReturnItem(Equals(SizeFunction(Literal("foo")), Literal(10.0)), "n")))
+  }
+
   test("collectionSize") {
     expectQuery(
       "return SIZE([1, 2]) = 10 as n",
       Query.
         matches().
-        returns(ReturnItem(Equals(LengthFunction(Collection(Literal(1), Literal(2))), Literal(10.0)), "n")))
+        returns(ReturnItem(Equals(SizeFunction(Collection(Literal(1), Literal(2))), Literal(10.0)), "n")))
   }
 
   test("relationshipTypeOut") {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -25,7 +25,7 @@ import java.util
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.v2_3
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ExecutionPlan => ExecutionPlan_v2_3, InternalExecutionResult}
-import org.neo4j.cypher.internal.compiler.v2_3.notification.{CartesianProductNotification, InternalNotification, LegacyPlannerNotification}
+import org.neo4j.cypher.internal.compiler.v2_3.notification.{LengthOnNonPathNotification, CartesianProductNotification, InternalNotification, LegacyPlannerNotification}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.MapToPublicExceptions
@@ -280,6 +280,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
        NotificationCode.CARTESIAN_PRODUCT.notification(new InputPosition(pos.offset, pos.line, pos.column))
     case LegacyPlannerNotification =>
       NotificationCode.LEGACY_PLANNER.notification(InputPosition.empty)
+    case LengthOnNonPathNotification(pos) =>
+      NotificationCode.LENGTH_ON_NON_PATH.notification(new InputPosition(pos.offset, pos.line, pos.column))
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_3.runSafely {inner.accept(visitor)}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -154,7 +154,7 @@ trait NewPlannerTestSupport extends CypherTestSupport {
     val costResult = executeWithCostPlannerOnly(queryText, params: _*)
 
     assertResultsAreSame(ruleResult, costResult, queryText, "Diverging results between rule and cost planners")
-
+    ruleResult.close()
     costResult
   }
 
@@ -168,7 +168,8 @@ trait NewPlannerTestSupport extends CypherTestSupport {
 
     assertResultsAreSame(interpretedResult, compiledResult, queryText, "Diverging results between interpreted and compiled runtime")
     assertResultsAreSame(ruleResult, interpretedResult, queryText, "Diverging results between rule planner and interpreted runtime")
-
+    ruleResult.close()
+    interpretedResult.close()
     compiledResult
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -465,6 +465,11 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
       "integer, 10508455564958384115, is too large")
   }
 
+  test("Should fail when calling size on a path") {
+    executeAndEnsureError("match p=(a)-[*]->(b) return size(p)",
+      "Type mismatch: expected String or Collection<T> but was Path (line 1, column 34 (offset: 33))")
+  }
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.StringHelper._
 

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -42,9 +42,11 @@ include::includes/cypher-functions-graph.asciidoc[]
 
 :leveloffset: 2
 
-include::length.asciidoc[]
+include::size.asciidoc[]
 
-include::length-of-pattern-expression.asciidoc[]
+include::size-of-pattern-expression.asciidoc[]
+
+include::length.asciidoc[]
 
 include::type.asciidoc[]
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CollectionsAndMapsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CollectionsAndMapsTest.scala
@@ -76,10 +76,10 @@ RETURN range(0,10)[15]###
 ###
 RETURN range(0,10)[5..15]###
 
-You can get the length of a collection like this:
+You can get the size of a collection like this:
 
 ###
-RETURN length(range(0,10)[0..3])###
+RETURN size(range(0,10)[0..3])###
 
 == List comprehension ==
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -118,32 +118,44 @@ class FunctionsTest extends DocumentingTestBase {
       assertions = (p) => assertEquals("KNOWS", p.columnAs[String]("type(r)").toList.head))
   }
 
+  @Test def size() {
+    testThis(
+      title = "SIZE",
+      syntax = "SIZE( collection )",
+      arguments = List("collection" -> "An expression that returns a collection"),
+      text = """To return or filter on the size of a collection, use the `SIZE()` function.""",
+      queryText = """return size(['Alice', 'Bob']) as col""",
+      returns = """The number of items in the collection is returned by the query.""",
+      assertions = (col) => assertEquals(2, col.columnAs[Int]("col").toList.head))
+  }
+
+  @Test def size2() {
+    testThis(
+      title = "SIZE of pattern expression",
+      syntax = "SIZE( pattern expression )",
+      arguments = List("pattern expression" -> "A pattern expression that returns a collection"),
+      text = """
+               |This is the same `SIZE()` method described before,
+               |but instead of passing in a collection directly, you provide a pattern expression
+               |that can be used in a match query to provide a new set of results.
+               |The size of the result is calculated, not the length of the expression itself.
+               |""".stripMargin,
+      queryText = """match (a) where a.name='Alice' return size( (a)-->()-->() ) as fof""",
+      returns = """The number of sub-graphs matching the pattern expression is returned by the query.""",
+      assertions = (p) => assertEquals(3, p.columnAs[Int]("fof").toList.head))
+  }
+
   @Test def length() {
     testThis(
       title = "LENGTH",
-      syntax = "LENGTH( collection )",
-      arguments = List("collection" -> "An expression that returns a collection"),
-      text = """To return or filter on the length of a collection, use the `LENGTH()` function.""",
+      syntax = "LENGTH( path )",
+      arguments = List("path" -> "An expression that returns a path"),
+      text = """To return or filter on the length of a path, use the `LENGTH()` function.""",
       queryText = """match p=(a)-->(b)-->(c) where a.name='Alice' return length(p)""",
       returns = """The length of the path `p` is returned by the query.""",
       assertions = (p) => assertEquals(2, p.columnAs[Int]("length(p)").toList.head))
   }
 
-  @Test def length2() {
-    testThis(
-      title = "LENGTH of pattern expression",
-      syntax = "LENGTH( pattern expression )",
-      arguments = List("pattern expression" -> "A pattern expression that returns a collection"),
-      text = """
-          |This is the same `LENGTH()` method described before,
-          |but instead of passing in a collection directly, you provide a pattern expression
-          |that can be used in a match query to provide a new set of results.
-          |The length of the results is calculated, not the length of the expression itself.
-        |""".stripMargin,
-      queryText = """match (a) where a.name='Alice' return length( (a)-->()-->() ) as fof""",
-      returns = """The number of sub-graphs matching the pattern expression is returned by the query.""",
-      assertions = (p) => assertEquals(3, p.columnAs[Int]("fof").toList.head))
-  }
 
   @Test def labels() {
     testThis(
@@ -261,10 +273,10 @@ class FunctionsTest extends DocumentingTestBase {
       syntax = "FILTER(identifier in collection WHERE predicate)",
       arguments = common_arguments,
       text = "`FILTER` returns all the elements in a collection that comply to a predicate.",
-      queryText = """match (a) where a.name='Eskil' return a.array, filter(x in a.array WHERE length(x) = 3)""",
-      returns = "This returns the property named `array` and a list of values in it, which have the length `3`.",
+      queryText = """match (a) where a.name='Eskil' return a.array, filter(x in a.array WHERE size(x) = 3)""",
+      returns = "This returns the property named `array` and a list of values in it, which have size `3`.",
       assertions = (p) => {
-        val array = p.columnAs[Iterable[_]]("filter(x in a.array WHERE length(x) = 3)").toList.head
+        val array = p.columnAs[Iterable[_]]("filter(x in a.array WHERE size(x) = 3)").toList.head
         assert(List("one","two") === array.toList)
       })
   }

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionFunctionsTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionFunctionsTest.scala
@@ -65,10 +65,10 @@ class CollectionFunctionsTest extends RefcardTest with QueryStatisticsTestSuppor
 ###assertion=returns-one parameters=coll
 RETURN
 
-length({coll})
+size({coll})
 ###
 
-Length of the collection.
+Number of elements in the collection.
 
 ###assertion=returns-one parameters=coll
 RETURN

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
@@ -76,7 +76,7 @@ Literal collections are declared in square brackets.
 ###assertion=returns-one parameters=coll
 RETURN
 
-length({coll}) AS len, {coll}[0] AS value
+size({coll}) AS len, {coll}[0] AS value
 
 ###
 
@@ -106,7 +106,7 @@ Relationship identifiers of a variable length path contain a collection of relat
 MATCH (matchedNode)
 
 RETURN matchedNode.coll[0] AS value,
-       length(matchedNode.coll) AS len
+       size(matchedNode.coll) AS len
 
 ###
 

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
@@ -70,7 +70,7 @@ RETURN
 length(path)
 ###
 
-The length of the path.
+The number of relationships in the path.
 
 ###assertion=returns-one
 MATCH path=(n)-->(m)

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -39,7 +39,10 @@ public enum NotificationCode
                     "product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH" ),
     LEGACY_PLANNER( SeverityLevel.WARNING,
                     Status.Statement.DeprecationWarning,
-                    "Using PLANNER for switching between planners has been deprecated, please use CYPHER planner=[rule,cost] instead");
+                    "Using PLANNER for switching between planners has been deprecated, please use CYPHER planner=[rule,cost] instead"),
+    LENGTH_ON_NON_PATH( SeverityLevel.WARNING,
+                    Status.Statement.DeprecationWarning,
+                    "Using 'length' on anything that is not a path is deprecated, please use 'size' instead");
     private final Status status;
     private final String description;
     private final SeverityLevel severity;


### PR DESCRIPTION
Using `length` on anything other than a path is deprecated, `size` should be used instead. Using `length` still works but there is now a warning associated with invalid usages of `length`.
