### PR TITLE
Remove as many unnecessary usages of DependencyResolver as possible

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
@@ -21,6 +21,8 @@ package org.neo4j.graphdb;
 
 import java.util.Iterator;
 
+import org.neo4j.function.Supplier;
+
 /**
  * Find a dependency given a type. This can be the exact type or a super type of
  * the actual dependency.
@@ -48,6 +50,11 @@ public interface DependencyResolver
      * @throws IllegalArgumentException if no matching dependency was found.
      */
     <T> T resolveDependency( Class<T> type, SelectionStrategy selector ) throws IllegalArgumentException;
+
+    <T> Supplier<T> provideDependency( final Class<T> type, final SelectionStrategy selector);
+
+    <T> Supplier<T> provideDependency( final Class<T> type );
+
 
     /**
      * Responsible for making the choice between available candidates.
@@ -91,6 +98,30 @@ public interface DependencyResolver
         public <T> T resolveDependency( Class<T> type ) throws IllegalArgumentException
         {
             return resolveDependency( type, FIRST );
+        }
+
+        public <T> Supplier<T> provideDependency( final Class<T> type, final SelectionStrategy selector)
+        {
+            return new Supplier<T>()
+            {
+                @Override
+                public T get()
+                {
+                    return resolveDependency( type, selector );
+                }
+            };
+        }
+
+        public <T> Supplier<T> provideDependency( final Class<T> type )
+        {
+            return new Supplier<T>()
+            {
+                @Override
+                public T get()
+                {
+                    return resolveDependency( type );
+                }
+            };
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/KernelExtensions.java
@@ -19,10 +19,7 @@
  */
 package org.neo4j.kernel.extension;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -32,6 +29,7 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -121,8 +119,7 @@ public class KernelExtensions extends DependencyResolver.Adapter implements Life
     {
         Class configurationClass = (Class) ((ParameterizedType) factory.getClass().getGenericSuperclass())
                 .getActualTypeArguments()[0];
-        return Proxy.newProxyInstance( configurationClass.getClassLoader(), new Class[]{configurationClass},
-                new KernelExtensionHandler() );
+        return DependenciesProxy.dependencies(dependencies, configurationClass);
     }
 
     public Iterable<KernelExtensionFactory<?>> listFactories()
@@ -143,23 +140,6 @@ public class KernelExtensions extends DependencyResolver.Adapter implements Life
         public boolean test( Object extension )
         {
             return type.isInstance( extension );
-        }
-    }
-
-    private class KernelExtensionHandler
-            implements InvocationHandler
-    {
-        @Override
-        public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
-        {
-            try
-            {
-                return dependencies.resolveDependency( method.getReturnType() );
-            }
-            catch ( IllegalArgumentException e )
-            {
-                throw new UnsatisfiedDependencyException( e );
-            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -81,10 +81,8 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.execution_guard_enabled;
 
 /**
- * Datasource module for {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory}. This implements all the
- * remaining
- * services not yet created by either the {@link org.neo4j.kernel.impl.factory.PlatformModule} or {@link org.neo4j
- * .kernel.impl.factory.EditionModule}.
+ * Datasource module for {@link GraphDatabaseFacadeFactory}. This implements all the
+ * remaining services not yet created by either the {@link PlatformModule} or {@link EditionModule}.
  * <p/>
  * When creating new services, this would be the default place to put them, unless they need to go into the other
  * modules for any reason.
@@ -139,8 +137,7 @@ public class DataSourceModule
         transactionEventHandlers = new TransactionEventHandlers( nodeActions, relationshipActions,
                 threadToTransactionBridge );
 
-        IndexConfigStore indexStore = life.add(
-                deps.satisfyDependency( new IndexConfigStore( storeDir, fileSystem ) ) );
+        IndexConfigStore indexStore = life.add( deps.satisfyDependency( new IndexConfigStore( storeDir, fileSystem ) ) );
 
         diagnosticsManager.prependProvider( config );
 
@@ -274,13 +271,10 @@ public class DataSourceModule
         };
     }
 
-    protected RelationshipProxy.RelationshipActions createRelationshipActions( final GraphDatabaseService
-                                                                                       graphDatabaseService,
-                                                                               final ThreadToStatementContextBridge
-                                                                                       threadToStatementContextBridge,
+    protected RelationshipProxy.RelationshipActions createRelationshipActions( final GraphDatabaseService graphDatabaseService,
+                                                                               final ThreadToStatementContextBridge threadToStatementContextBridge,
                                                                                final NodeManager nodeManager,
-                                                                               final RelationshipTypeTokenHolder
-                                                                                       relationshipTypeTokenHolder )
+                                                                               final RelationshipTypeTokenHolder relationshipTypeTokenHolder )
     {
         return new RelationshipProxy.RelationshipActions()
         {
@@ -331,8 +325,7 @@ public class DataSourceModule
     }
 
     protected NodeProxy.NodeActions createNodeActions( final GraphDatabaseService graphDatabaseService,
-                                                       final ThreadToStatementContextBridge
-                                                               threadToStatementContextBridge,
+                                                       final ThreadToStatementContextBridge threadToStatementContextBridge,
                                                        final NodeManager nodeManager )
     {
         return new NodeProxy.NodeActions()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -128,9 +128,9 @@ public abstract class GraphDatabaseFacadeFactory
         Throwable error = null;
         try
         {
-            enableAvailabilityLogging( platform.availabilityGuard, platform.logging.getInternalLog( getClass() )
-                    .infoLogger() ); // Done after create to avoid a redundant
+            // Done after create to avoid a redundant
             // "database is now unavailable"
+            enableAvailabilityLogging( platform.availabilityGuard, platform.logging.getInternalLog( getClass() ).infoLogger() );
 
             platform.life.start();
         }
@@ -193,8 +193,8 @@ public abstract class GraphDatabaseFacadeFactory
      * @param editionModule
      * @return
      */
-    protected DataSourceModule createDataSource( final Dependencies dependencies, final PlatformModule
-            platformModule, EditionModule editionModule )
+    protected DataSourceModule createDataSource( final Dependencies dependencies,
+                                                 final PlatformModule platformModule, EditionModule editionModule )
     {
         return new DataSourceModule( dependencies, platformModule, editionModule );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -41,9 +41,8 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 /**
  * Not thread safe (since DiffRecordStore is not thread safe), intended for
@@ -79,7 +78,7 @@ public class StoreAccess
     @SuppressWarnings( "deprecation" )
     private static NeoStore getNeoStoreFrom( GraphDatabaseAPI graphdb )
     {
-        return graphdb.getDependencyResolver().resolveDependency( NeoStoreSupplier.class ).get();
+        return graphdb.getDependencyResolver().resolveDependency( NeoStore.class );
     }
 
     public StoreAccess( NeoStore store )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.DependencyResolver;
+
+/**
+ * Used to create dynamic proxies that implement dependency interfaces. Each method should have no arguments
+ * and return the type of the dependency desired. It will be mapped to a lookup in the provided {@link DependencyResolver}.
+ * Methods may also use a {@link Supplier} type for deferred lookups.
+ *
+ */
+public class DependenciesProxy
+{
+    /**
+     * Create a dynamic proxy that implements the given interface and backs invocation with lookups into the given
+     * dependency resolver.
+     *
+     * @param dependencyResolver
+     * @param dependenciesInterface
+     * @param <T>
+     * @return
+     */
+    public static <T> T dependencies(DependencyResolver dependencyResolver, Class<T> dependenciesInterface)
+    {
+        return (T) Proxy.newProxyInstance( dependenciesInterface.getClassLoader(), new Class[]{dependenciesInterface},
+                new ProxyHandler(dependencyResolver) );
+    }
+
+
+    private static class ProxyHandler
+            implements InvocationHandler
+    {
+        private DependencyResolver dependencyResolver;
+
+        public ProxyHandler( DependencyResolver dependencyResolver )
+        {
+            this.dependencyResolver = dependencyResolver;
+        }
+
+        @Override
+        public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
+        {
+            try
+            {
+                if (method.getReturnType().equals( Supplier.class ))
+                {
+                    return dependencyResolver.provideDependency( (Class)((ParameterizedType) method.getGenericReturnType()).getActualTypeArguments()[0] );
+                } else
+                {
+                    return dependencyResolver.resolveDependency( method.getReturnType() );
+                }
+            }
+            catch ( IllegalArgumentException e )
+            {
+                throw new UnsatisfiedDependencyException( e );
+            }
+        }
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -30,6 +31,8 @@ public class DummyExtensionFactory extends KernelExtensionFactory<DummyExtension
         Config getConfig();
 
         KernelData getKernel();
+
+        Supplier<NeoStoreDataSource> getNeoStoreDataSource();
     }
 
     static final String EXTENSION_ID = "dummy";

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
@@ -75,6 +75,9 @@ public final class TestKernelExtension extends KernelExtensionFactoryContractTes
             assertEquals( graphdb.getDependencyResolver().resolveDependency( Config.class ),
                     graphdb.getDependencyResolver().resolveDependency( KernelExtensions.class ).resolveDependency(
                             DummyExtension.class ).getDependencies().getConfig() );
+            assertEquals( graphdb.getDependencyResolver().resolveDependency( NeoStoreDataSource.class ),
+                    graphdb.getDependencyResolver().resolveDependency( KernelExtensions.class ).resolveDependency(
+                            DummyExtension.class ).getDependencies().getNeoStoreDataSource().get() );
         }
         finally
         {

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -191,8 +191,9 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
 
     protected static class ImpermanentPlatformModule extends PlatformModule
     {
-        public ImpermanentPlatformModule( Map<String, String> params, GraphDatabaseFacadeFactory.Dependencies
-                dependencies, GraphDatabaseFacade graphDatabaseFacade )
+        public ImpermanentPlatformModule( Map<String, String> params,
+                                          GraphDatabaseFacadeFactory.Dependencies dependencies,
+                                          GraphDatabaseFacade graphDatabaseFacade )
         {
             super( withForcedInMemoryConfiguration(params), dependencies, graphDatabaseFacade );
         }

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -299,7 +299,7 @@ public class DefaultUdcInformationCollectorTest
         }
     }
 
-    private static class StubDependencyResolver implements DependencyResolver
+    private static class StubDependencyResolver extends DependencyResolver.Adapter
     {
         private final IdGeneratorFactory idGeneratorFactory;
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -62,6 +62,7 @@ import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -313,7 +314,8 @@ class BackupService
         DependencyResolver resolver = targetDb.getDependencyResolver();
 
         ProgressTxHandler handler = new ProgressTxHandler();
-        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker( resolver );
+        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker(
+                DependenciesProxy.dependencies(resolver, TransactionCommittingResponseUnpacker.Dependencies.class) );
 
         Monitors monitors = resolver.resolveDependency( Monitors.class );
         LogProvider logProvider = resolver.resolveDependency( LogService.class ).getInternalLogProvider();

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -19,12 +19,18 @@
  */
 package org.neo4j.backup;
 
+import org.neo4j.function.Supplier;
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
+import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -37,14 +43,23 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
     {
         Config getConfig();
 
-
         GraphDatabaseAPI getGraphDatabaseAPI();
 
         LogService logService();
 
-        KernelPanicEventGenerator kpeg();
-
         Monitors monitors();
+
+        NeoStoreDataSource neoStoreDataSource();
+
+        Supplier<LogRotationControl> logRotationControlSupplier();
+
+        Supplier<TransactionIdStore> transactionIdStoreSupplier();
+
+        Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier();
+
+        Supplier<LogFileInformation> logFileInformationSupplier();
+
+        FileSystemAbstraction fileSystemAbstraction();
     }
 
     public OnlineBackupExtensionFactory()
@@ -62,6 +77,12 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
     public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
     {
         return new OnlineBackupKernelExtension( dependencies.getConfig(), dependencies.getGraphDatabaseAPI(),
-                dependencies.kpeg(), dependencies.logService().getInternalLogProvider(), dependencies.monitors() );
+                dependencies.logService().getInternalLogProvider(), dependencies.monitors(),
+                dependencies.neoStoreDataSource(),
+                dependencies.logRotationControlSupplier(),
+                dependencies.transactionIdStoreSupplier(),
+                dependencies.logicalTransactionStoreSupplier(),
+                dependencies.logFileInformationSupplier(),
+                dependencies.fileSystemAbstraction());
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.NeoStore.Position;
@@ -66,6 +65,8 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.FormattedLogProvider;
@@ -508,13 +509,11 @@ public class BackupServiceIT
         // This monitor is added server-side...
         monitors.addMonitorListener( new StoreSnoopingMonitor( barrier ) );
 
-        OnlineBackupKernelExtension backup = new OnlineBackupKernelExtension(
-                defaultConfig,
-                db,
-                db.getDependencyResolver().resolveDependency( KernelPanicEventGenerator.class ),
-                NullLogProvider.getInstance(),
-                // ... so that it's used by StoreCopyServer
-                monitors );
+        Dependencies dependencies = new Dependencies(db.getDependencyResolver());
+        dependencies.satisfyDependencies( defaultConfig, monitors, NullLogProvider.getInstance() );
+
+        OnlineBackupKernelExtension backup = (OnlineBackupKernelExtension) new OnlineBackupExtensionFactory().newKernelExtension(
+                DependenciesProxy.dependencies(dependencies, OnlineBackupExtensionFactory.Dependencies.class));
         backup.start();
 
         // when

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
@@ -41,13 +41,16 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.transaction.log.LogRotation;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.lang.System.currentTimeMillis;
+
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
@@ -152,14 +155,15 @@ public class BackupServiceStressTestingBuilder
                 final AtomicBoolean keepGoing = new AtomicBoolean( true );
 
                 // when
-                final OnlineBackupKernelExtension backup = new OnlineBackupKernelExtension(
-                        new Config(),
-                        db,
-                        db.getDependencyResolver().resolveDependency( KernelPanicEventGenerator.class ),
-                        NullLogProvider.getInstance(),
-                        new Monitors() );
+                Dependencies dependencies = new Dependencies(db.getDependencyResolver());
+                dependencies.satisfyDependencies( new Config(), NullLogProvider.getInstance(), new Monitors() );
+
+                OnlineBackupKernelExtension backup;
                 try
                 {
+                    backup = (OnlineBackupKernelExtension) new OnlineBackupExtensionFactory().newKernelExtension(
+                            DependenciesProxy.dependencies(dependencies, OnlineBackupExtensionFactory.Dependencies.class));
+
                     backup.init();
                     backup.start();
                 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -29,7 +29,6 @@ import org.neo4j.com.storecopy.ResponsePacker;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.function.Supplier;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdGeneratorFactory;
@@ -51,35 +50,62 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
 
-class DefaultMasterImplSPI implements MasterImpl.SPI
+public class DefaultMasterImplSPI implements MasterImpl.SPI
 {
     private static final int ID_GRAB_SIZE = 1000;
-    private final DependencyResolver dependencyResolver;
     private final GraphDatabaseAPI graphDb;
-    private final LogicalTransactionStore txStore;
-    private final TransactionIdStore transactionIdStore;
     private final TransactionChecksumLookup txChecksumLookup;
     private final FileSystemAbstraction fileSystem;
+    private final LabelTokenHolder labels;
+    private final PropertyKeyTokenHolder propertyKeyTokenHolder;
+    private final RelationshipTypeTokenHolder relationshipTypeTokenHolder;
+    private final IdGeneratorFactory idGeneratorFactory;
+    private final Locks locks;
+    private final NeoStoreDataSource neoStoreDataSource;
+    private final JobScheduler jobScheduler;
     private final File storeDir;
     private final ResponsePacker responsePacker;
     private final Monitors monitors;
 
-    public DefaultMasterImplSPI( final GraphDatabaseAPI graphDb )
+    private final TransactionCommitProcess transactionCommitProcess;
+    private final LogRotationControl logRotationControlSupplier;
+    private final LogicalTransactionStore txStore;
+    private final TransactionIdStore transactionIdStore;
+
+    public DefaultMasterImplSPI( final GraphDatabaseAPI graphDb,
+                                 FileSystemAbstraction fileSystemAbstraction,
+                                 Monitors monitors,
+                                 LabelTokenHolder labels, PropertyKeyTokenHolder propertyKeyTokenHolder,
+                                 RelationshipTypeTokenHolder relationshipTypeTokenHolder,
+                                 IdGeneratorFactory idGeneratorFactory, Locks locks,
+                                 TransactionCommitProcess transactionCommitProcess,
+                                 LogRotationControl logRotationControlSupplier,
+                                 TransactionIdStore transactionIdStore,
+                                 LogicalTransactionStore logicalTransactionStore,
+                                 NeoStoreDataSource neoStoreDataSource,
+                                 JobScheduler jobScheduler)
     {
         this.graphDb = graphDb;
-        this.dependencyResolver = graphDb.getDependencyResolver();
 
         // Hmm, fetching the dependencies here instead of handing them in the constructor directly feels bad,
         // but it seems like there's some intricate usage and need for the db's dependency resolver.
-        this.transactionIdStore = dependencyResolver.resolveDependency( TransactionIdStore.class );
-        this.fileSystem = dependencyResolver.resolveDependency( FileSystemAbstraction.class );
+        this.transactionIdStore = transactionIdStore;
+        this.fileSystem = fileSystemAbstraction;
+        this.labels = labels;
+        this.propertyKeyTokenHolder = propertyKeyTokenHolder;
+        this.relationshipTypeTokenHolder = relationshipTypeTokenHolder;
+        this.idGeneratorFactory = idGeneratorFactory;
+        this.locks = locks;
+        this.transactionCommitProcess = transactionCommitProcess;
+        this.logRotationControlSupplier = logRotationControlSupplier;
+        this.neoStoreDataSource = neoStoreDataSource;
+        this.jobScheduler = jobScheduler;
         this.storeDir = new File( graphDb.getStoreDir() );
-        this.txStore = dependencyResolver.resolveDependency( LogicalTransactionStore.class );
+        this.txStore = logicalTransactionStore;
         this.txChecksumLookup = new TransactionChecksumLookup( transactionIdStore, txStore );
         this.responsePacker = new ResponsePacker( txStore, transactionIdStore, new Supplier<StoreId>()
         {
@@ -89,7 +115,7 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
                 return graphDb.storeId();
             }
         } );
-        this.monitors = dependencyResolver.resolveDependency( Monitors.class );
+        this.monitors = monitors;
     }
 
     @Override
@@ -102,27 +128,25 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
     @Override
     public int getOrCreateLabel( String name )
     {
-        LabelTokenHolder labels = resolve( LabelTokenHolder.class );
         return labels.getOrCreateId( name );
     }
 
     @Override
     public int getOrCreateProperty( String name )
     {
-        PropertyKeyTokenHolder propertyKeyHolder = resolve( PropertyKeyTokenHolder.class );
-        return propertyKeyHolder.getOrCreateId( name );
+        return propertyKeyTokenHolder.getOrCreateId( name );
     }
 
     @Override
     public Locks.Client acquireClient()
     {
-        return resolve( Locks.class ).newClient();
+        return locks.newClient();
     }
 
     @Override
     public IdAllocation allocateIds( IdType idType )
     {
-        IdGenerator generator = resolve( IdGeneratorFactory.class ).get(idType);
+        IdGenerator generator = idGeneratorFactory.get( idType );
         return new IdAllocation( generator.nextIdBatch( ID_GRAB_SIZE ), generator.getHighId(),
                 generator.getDefragCount() );
     }
@@ -139,17 +163,14 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
     {
         try ( LockGroup locks = new LockGroup() )
         {
-            TransactionCommitProcess txCommitProcess = dependencyResolver
-                    .resolveDependency( NeoStoreDataSource.class )
-                    .getDependencyResolver().resolveDependency( TransactionCommitProcess.class );
-            return txCommitProcess.commit( preparedTransaction, locks, CommitEvent.NULL );
+            return transactionCommitProcess.commit( preparedTransaction, locks, CommitEvent.NULL );
         }
     }
 
     @Override
     public Integer createRelationshipType( String name )
     {
-        return resolve(RelationshipTypeTokenHolder.class).getOrCreateId( name );
+        return relationshipTypeTokenHolder.getOrCreateId( name );
     }
 
     @Override
@@ -161,9 +182,8 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
     @Override
     public RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer )
     {
-        NeoStoreDataSource dataSource = dependencyResolver.resolveDependency( DataSourceManager.class ).getDataSource();
-        StoreCopyServer streamer = new StoreCopyServer( transactionIdStore, dataSource,
-                dependencyResolver.resolveDependency( LogRotationControl.class ), fileSystem, storeDir,
+        StoreCopyServer streamer = new StoreCopyServer( transactionIdStore, neoStoreDataSource,
+                logRotationControlSupplier, fileSystem, storeDir,
                 monitors.newMonitor( StoreCopyServer.Monitor.class ) );
         return streamer.flushStoresAndStreamStoreFiles( writer, false );
     }
@@ -183,17 +203,12 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
     @Override
     public JobScheduler.JobHandle scheduleRecurringJob( JobScheduler.Group group, long interval, Runnable job )
     {
-        return resolve( JobScheduler.class ).scheduleRecurring( group, job, interval, TimeUnit.MILLISECONDS);
+        return jobScheduler.scheduleRecurring( group, job, interval, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public <T> Response<T> packEmptyResponse( T response )
     {
         return responsePacker.packEmptyResponse( response );
-    }
-
-    private <T> T resolve( Class<T> dependencyType )
-    {
-        return dependencyResolver.resolveDependency( dependencyType );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
@@ -20,8 +20,7 @@
 package org.neo4j.kernel.ha.com;
 
 import org.neo4j.com.RequestContext;
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
@@ -29,15 +28,15 @@ public class RequestContextFactory extends LifecycleAdapter
 {
     private long epoch;
     private final int serverId;
-    private final DependencyResolver resolver;
+    private final Supplier<TransactionIdStore> txIdStoreSupplier;
     private TransactionIdStore txIdStore;
 
     public static final int VOID_EVENT_IDENTIFIER = -3;
     public static final int DEFAULT_EVENT_IDENTIFIER = -1;
 
-    public RequestContextFactory( int serverId, DependencyResolver resolver )
+    public RequestContextFactory( int serverId, Supplier<TransactionIdStore> txIdStoreSupplier)
     {
-        this.resolver = resolver;
+        this.txIdStoreSupplier = txIdStoreSupplier;
         this.epoch = -1;
         this.serverId = serverId;
     }
@@ -45,7 +44,7 @@ public class RequestContextFactory extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        this.txIdStore = resolver.resolveDependency( NeoStoreDataSource.class ).getDependencyResolver().resolveDependency( TransactionIdStore.class );
+        this.txIdStore = txIdStoreSupplier.get();
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/EnterpriseEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/EnterpriseEditionModule.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.ha.factory;
 
-import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,13 +38,17 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
+import org.neo4j.com.Server;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
+import org.neo4j.com.storecopy.TransactionObligationFulfiller;
 import org.neo4j.function.Factory;
+import org.neo4j.function.Function;
 import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -56,6 +59,7 @@ import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.BranchDetectingTxVerifier;
 import org.neo4j.kernel.ha.BranchedDataMigrator;
 import org.neo4j.kernel.ha.CommitProcessSwitcher;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
@@ -67,10 +71,12 @@ import org.neo4j.kernel.ha.LabelTokenCreatorModeSwitcher;
 import org.neo4j.kernel.ha.LastUpdateTime;
 import org.neo4j.kernel.ha.PropertyKeyCreatorModeSwitcher;
 import org.neo4j.kernel.ha.RelationshipTypeCreatorModeSwitcher;
+import org.neo4j.kernel.ha.TransactionChecksumLookup;
 import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.kernel.ha.UpdatePullerClient;
 import org.neo4j.kernel.ha.UpdatePullingTransactionObligationFulfiller;
 import org.neo4j.kernel.ha.cluster.DefaultElectionCredentialsProvider;
+import org.neo4j.kernel.ha.cluster.DefaultMasterImplSPI;
 import org.neo4j.kernel.ha.cluster.HANewSnapshotFunction;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberChangeEvent;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberContext;
@@ -88,10 +94,12 @@ import org.neo4j.kernel.ha.com.master.DefaultSlaveFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.MasterImpl;
 import org.neo4j.kernel.ha.com.master.MasterServer;
+import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.ha.com.master.SlaveFactory;
 import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.com.slave.InvalidEpochExceptionHandler;
 import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
+import org.neo4j.kernel.ha.com.slave.SlaveImpl;
 import org.neo4j.kernel.ha.com.slave.SlaveServer;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.ha.lock.LockManagerModeSwitcher;
@@ -126,9 +134,12 @@ import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.storemigration.UpgradeConfiguration;
 import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByDatabaseModeException;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.log.LogRotationControl;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
 import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -136,6 +147,8 @@ import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+
+import static java.lang.reflect.Proxy.newProxyInstance;
 
 /**
  * This implementation of {@link org.neo4j.kernel.impl.factory.EditionModule} creates the implementations of services
@@ -159,17 +172,19 @@ public class EnterpriseEditionModule
         InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( logging.getInternalLogProvider() ) );
 
         life.add( new BranchedDataMigrator( platformModule.storeDir ) );
-        DelegateInvocationHandler<Master> masterDelegateInvocationHandler = new DelegateInvocationHandler<>( Master
-                .class );
-        Master master = (Master) Proxy.newProxyInstance( Master.class.getClassLoader(), new Class[]{Master.class},
+        DelegateInvocationHandler<Master> masterDelegateInvocationHandler =
+                new DelegateInvocationHandler<>( Master.class );
+        Master master = (Master) newProxyInstance( Master.class.getClassLoader(), new Class[]{Master.class},
                 masterDelegateInvocationHandler );
         InstanceId serverId = config.get( ClusterSettings.server_id );
+
         RequestContextFactory requestContextFactory = dependencies.satisfyDependency( new RequestContextFactory(
                 serverId.toIntegerIndex(),
-                dependencies ) );
+                dependencies.provideDependency( TransactionIdStore.class ) ) );
 
         TransactionCommittingResponseUnpacker responseUnpacker = dependencies.satisfyDependency(
-                new TransactionCommittingResponseUnpacker( dependencies ) );
+                new TransactionCommittingResponseUnpacker( DependenciesProxy.dependencies( dependencies,
+                        TransactionCommittingResponseUnpacker.Dependencies.class ) ) );
 
         Supplier<KernelAPI> kernelProvider = dependencies.provideDependency( KernelAPI.class );
 
@@ -183,31 +198,31 @@ public class EnterpriseEditionModule
                 new DelegateInvocationHandler<>( ClusterMemberAvailability.class );
 
         ClusterMemberEvents clusterEvents = dependencies.satisfyDependency(
-                (ClusterMemberEvents) Proxy.newProxyInstance(
+                (ClusterMemberEvents) newProxyInstance(
                         ClusterMemberEvents.class.getClassLoader(),
                         new Class[]{ClusterMemberEvents.class, Lifecycle.class},
                         clusterEventsDelegateInvocationHandler ) );
 
-        HighAvailabilityMemberContext memberContext = (HighAvailabilityMemberContext) Proxy.newProxyInstance(
+        HighAvailabilityMemberContext memberContext = (HighAvailabilityMemberContext) newProxyInstance(
                 HighAvailabilityMemberContext.class.getClassLoader(),
                 new Class[]{HighAvailabilityMemberContext.class}, memberContextDelegateInvocationHandler );
         ClusterMemberAvailability clusterMemberAvailability = dependencies.satisfyDependency(
-                (ClusterMemberAvailability) Proxy.newProxyInstance(
-                ClusterMemberAvailability.class.getClassLoader(),
-                new Class[]{ClusterMemberAvailability.class}, clusterMemberAvailabilityDelegateInvocationHandler ) );
+                (ClusterMemberAvailability) newProxyInstance(
+                        ClusterMemberAvailability.class.getClassLoader(),
+                        new Class[]{ClusterMemberAvailability.class},
+                        clusterMemberAvailabilityDelegateInvocationHandler ) );
 
         // TODO There's a cyclical dependency here that should be fixed
-        final AtomicReference<HighAvailabilityMemberStateMachine> electionProviderRef = new AtomicReference<>(  );
+        final AtomicReference<HighAvailabilityMemberStateMachine> electionProviderRef = new AtomicReference<>();
         ElectionCredentialsProvider electionCredentialsProvider = config.get( HaSettings.slave_only ) ?
                 new NotElectableElectionCredentialsProvider() :
                 new DefaultElectionCredentialsProvider(
                         config.get( ClusterSettings.server_id ),
-                        new OnDiskLastTxIdGetter( platformModule.graphDatabaseFacade ),
+                        new OnDiskLastTxIdGetter( platformModule.dependencies.provideDependency( NeoStore.class ) ),
                         new HighAvailabilityMemberInfoProvider()
                         {
                             @Override
-                            public HighAvailabilityMemberState
-                            getHighAvailabilityMemberState()
+                            public HighAvailabilityMemberState getHighAvailabilityMemberState()
                             {
                                 return electionProviderRef.get().getCurrentState();
                             }
@@ -224,32 +239,35 @@ public class EnterpriseEditionModule
                         electionCredentialsProvider,
                         objectStreamFactory, objectStreamFactory ) );
         PaxosClusterMemberEvents localClusterEvents = new PaxosClusterMemberEvents( clusterClient, clusterClient,
-                clusterClient, clusterClient, logging.getInternalLogProvider(), new org.neo4j.function.Predicate<PaxosClusterMemberEvents
-                .ClusterMembersSnapshot>()
-        {
-            @Override
-            public boolean test( PaxosClusterMemberEvents.ClusterMembersSnapshot item )
-            {
-                for ( MemberIsAvailable member : item.getCurrentAvailableMembers() )
+                clusterClient, clusterClient, logging.getInternalLogProvider(),
+                new org.neo4j.function.Predicate<PaxosClusterMemberEvents
+                        .ClusterMembersSnapshot>()
                 {
-                    if ( member.getRoleUri().getScheme().equals( "ha" ) )
+                    @Override
+                    public boolean test( PaxosClusterMemberEvents.ClusterMembersSnapshot item )
                     {
-                        if ( HighAvailabilityModeSwitcher.getServerId( member.getRoleUri() ).equals(
-                                platformModule.config.get( ClusterSettings.server_id ) ) )
+                        for ( MemberIsAvailable member : item.getCurrentAvailableMembers() )
                         {
-                            logging.getInternalLog( PaxosClusterMemberEvents.class ).error( String.format( "Instance " +
-                                            "%s has" +
-                                            " the same serverId as ours (%s) - will not " +
-                                            "join this cluster",
-                                    member.getRoleUri(), config.get( ClusterSettings.server_id ).toIntegerIndex()
-                            ) );
-                            return true;
+                            if ( member.getRoleUri().getScheme().equals( "ha" ) )
+                            {
+                                if ( HighAvailabilityModeSwitcher.getServerId( member.getRoleUri() ).equals(
+                                        platformModule.config.get( ClusterSettings.server_id ) ) )
+                                {
+                                    logging.getInternalLog( PaxosClusterMemberEvents.class ).error(
+                                            String.format( "Instance " +
+                                                            "%s has" +
+                                                            " the same serverId as ours (%s) - will not " +
+                                                            "join this cluster",
+                                                    member.getRoleUri(),
+                                                    config.get( ClusterSettings.server_id ).toIntegerIndex()
+                                            ) );
+                                    return true;
+                                }
+                            }
                         }
+                        return true;
                     }
-                }
-                return true;
-            }
-        }, new HANewSnapshotFunction(), objectStreamFactory, objectStreamFactory,
+                }, new HANewSnapshotFunction(), objectStreamFactory, objectStreamFactory,
                 platformModule.monitors.newMonitor( NamedThreadFactory.Monitor.class )
         );
 
@@ -279,7 +297,8 @@ public class EnterpriseEditionModule
         HighAvailabilityMemberContext localMemberContext = new SimpleHighAvailabilityMemberContext( clusterClient
                 .getServerId(), config.get( HaSettings.slave_only ) );
         PaxosClusterMemberAvailability localClusterMemberAvailability = new PaxosClusterMemberAvailability(
-                clusterClient.getServerId(), clusterClient, clusterClient, logging.getInternalLogProvider(), objectStreamFactory,
+                clusterClient.getServerId(), clusterClient, clusterClient, logging.getInternalLogProvider(),
+                objectStreamFactory,
                 objectStreamFactory );
 
         memberContextDelegateInvocationHandler.setDelegate( localMemberContext );
@@ -308,10 +327,12 @@ public class EnterpriseEditionModule
         paxosLife.add( clusterEvents );
         paxosLife.add( localClusterMemberAvailability );
 
-        idGeneratorFactory = dependencies.satisfyDependency(createIdGeneratorFactory( masterDelegateInvocationHandler, logging.getInternalLogProvider(), requestContextFactory ));
+        idGeneratorFactory = dependencies.satisfyDependency(
+                createIdGeneratorFactory( masterDelegateInvocationHandler, logging.getInternalLogProvider(),
+                        requestContextFactory ) );
 
         // TODO There's a cyclical dependency here that should be fixed
-        final AtomicReference<HighAvailabilityModeSwitcher> exceptionHandlerRef = new AtomicReference<>(  );
+        final AtomicReference<HighAvailabilityModeSwitcher> exceptionHandlerRef = new AtomicReference<>();
         InvalidEpochExceptionHandler invalidEpochHandler = new InvalidEpochExceptionHandler()
         {
             @Override
@@ -321,28 +342,110 @@ public class EnterpriseEditionModule
             }
         };
 
-        MasterClientResolver masterClientResolver = new MasterClientResolver( logging.getInternalLogProvider(), responseUnpacker,
+        MasterClientResolver masterClientResolver = new MasterClientResolver( logging.getInternalLogProvider(),
+                responseUnpacker,
                 invalidEpochHandler,
                 config.get( HaSettings.read_timeout ).intValue(),
                 config.get( HaSettings.lock_read_timeout ).intValue(),
                 config.get( HaSettings.max_concurrent_channels_per_slave ),
                 config.get( HaSettings.com_chunk_size ).intValue() );
 
-        SwitchToSlave switchToSlaveInstance = new SwitchToSlave( logging, config, dependencies,
-                (HaIdGeneratorFactory) idGeneratorFactory,
+        LastUpdateTime lastUpdateTime = new LastUpdateTime();
+
+        UpdatePuller updatePuller = dependencies.satisfyDependency( life.add(
+                new UpdatePuller( memberStateMachine, requestContextFactory, master, lastUpdateTime,
+                        logging.getInternalLogProvider(), serverId, invalidEpochHandler ) ) );
+        dependencies.satisfyDependency( life.add( new UpdatePullerClient( config.get( HaSettings.pull_interval ),
+                platformModule.jobScheduler, logging.getInternalLogProvider(), updatePuller,
+                platformModule.availabilityGuard ) ) );
+        dependencies.satisfyDependency( life.add( new UpdatePullingTransactionObligationFulfiller(
+                updatePuller, memberStateMachine, serverId,
+                dependencies.provideDependency( TransactionIdStore.class ) ) ) );
+
+
+        Factory<Slave> slaveFactory = new Factory<Slave>()
+        {
+            @Override
+            public Slave newInstance()
+            {
+                return new SlaveImpl( dependencies.resolveDependency( TransactionObligationFulfiller.class ) );
+            }
+        };
+
+        Function<Slave, SlaveServer> slaveServerFactory = new Function<Slave, SlaveServer>()
+        {
+            @Override
+            public SlaveServer apply( Slave slave ) throws RuntimeException
+            {
+                return new SlaveServer( slave, slaveServerConfig( config ), logging.getInternalLogProvider(),
+                        monitors.newMonitor( ByteCounterMonitor.class, SlaveServer.class ),
+                        monitors.newMonitor( RequestMonitor.class, SlaveServer.class ) );
+            }
+        };
+
+        SwitchToSlave switchToSlaveInstance = new SwitchToSlave( logging, platformModule.fileSystem, members,
+                config, dependencies, (HaIdGeneratorFactory) idGeneratorFactory,
                 masterDelegateInvocationHandler, clusterMemberAvailability,
                 requestContextFactory, platformModule.kernelExtensions.listFactories(), masterClientResolver,
-                monitors.newMonitor( ByteCounterMonitor.class, SlaveServer.class ),
-                monitors.newMonitor( RequestMonitor.class, SlaveServer.class ),
                 monitors.newMonitor( SwitchToSlave.Monitor.class ),
-                monitors.newMonitor( StoreCopyClient.Monitor.class ) );
+                monitors.newMonitor( StoreCopyClient.Monitor.class ),
+                dependencies.provideDependency( NeoStoreDataSource.class ),
+                dependencies.provideDependency( TransactionIdStore.class ),
+                slaveFactory, slaveServerFactory, updatePuller, platformModule.pageCache, monitors );
 
-        SwitchToMaster switchToMasterInstance = new SwitchToMaster( logging, platformModule.graphDatabaseFacade,
-                (HaIdGeneratorFactory) idGeneratorFactory, config, dependencies.provideDependency( SlaveFactory.class ),
-                masterDelegateInvocationHandler, clusterMemberAvailability, platformModule.dataSourceManager,
-                monitors.newMonitor( ByteCounterMonitor.class, MasterServer.class ),
-                monitors.newMonitor( RequestMonitor.class, MasterServer.class ),
-                monitors.newMonitor( MasterImpl.Monitor.class, MasterImpl.class ) );
+        final Factory<MasterImpl.SPI> masterSPIFactory = new Factory<MasterImpl.SPI>()
+        {
+            @Override
+            public MasterImpl.SPI newInstance()
+            {
+                return new DefaultMasterImplSPI( platformModule.graphDatabaseFacade, platformModule.fileSystem,
+                        platformModule.monitors,
+                        labelTokenHolder, propertyKeyTokenHolder, relationshipTypeTokenHolder, idGeneratorFactory,
+                        lockManager, platformModule.dependencies.resolveDependency( TransactionCommitProcess.class ),
+                        platformModule.dependencies.resolveDependency( LogRotationControl.class ),
+                        platformModule.dependencies.resolveDependency( TransactionIdStore.class ),
+                        platformModule.dependencies.resolveDependency( LogicalTransactionStore.class ),
+                        platformModule.dependencies.resolveDependency( NeoStoreDataSource.class ),
+                        platformModule.jobScheduler );
+            }
+        };
+
+        Factory<Master> masterFactory = new Factory<Master>()
+        {
+            @Override
+            public Master newInstance()
+            {
+                return new MasterImpl( masterSPIFactory.newInstance(),
+                        monitors.newMonitor( MasterImpl.Monitor.class, MasterImpl.class ), config );
+            }
+        };
+
+        Function<Master, MasterServer> masterServerFactory = new Function<Master, MasterServer>()
+        {
+            @Override
+            public MasterServer apply( Master master ) throws RuntimeException
+            {
+                TransactionChecksumLookup txChecksumLookup = new TransactionChecksumLookup(
+                        platformModule.dependencies.resolveDependency( TransactionIdStore.class ),
+                        platformModule.dependencies.resolveDependency( LogicalTransactionStore.class ) );
+
+                MasterServer masterServer = new MasterServer( master, logging.getInternalLogProvider(),
+                        masterServerConfig(
+                                config ),
+                        new BranchDetectingTxVerifier( logging.getInternalLogProvider(), txChecksumLookup ),
+                        monitors.newMonitor( ByteCounterMonitor.class, MasterServer.class ),
+                        monitors.newMonitor( RequestMonitor.class, MasterServer.class ) );
+                return masterServer;
+            }
+        };
+
+        SwitchToMaster switchToMasterInstance = new SwitchToMaster( logging, (HaIdGeneratorFactory) idGeneratorFactory,
+                config, dependencies.provideDependency( SlaveFactory.class ),
+                masterFactory,
+                masterServerFactory,
+                masterDelegateInvocationHandler, clusterMemberAvailability,
+                platformModule.dependencies.provideDependency(
+                        NeoStoreDataSource.class ) );
 
         final HighAvailabilityModeSwitcher highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher(
                 switchToSlaveInstance, switchToMasterInstance,
@@ -370,36 +473,31 @@ public class EnterpriseEditionModule
 
         life.add( responseUnpacker );
 
-        LastUpdateTime lastUpdateTime = new LastUpdateTime();
-
-        UpdatePuller updatePuller = dependencies.satisfyDependency( life.add(
-                new UpdatePuller( memberStateMachine, requestContextFactory, master, lastUpdateTime,
-                        logging.getInternalLogProvider(), serverId, invalidEpochHandler ) ) );
-        dependencies.satisfyDependency( life.add( new UpdatePullerClient( config.get( HaSettings.pull_interval ),
-                platformModule.jobScheduler, logging.getInternalLogProvider(), updatePuller, platformModule.availabilityGuard ) ) );
-        dependencies.satisfyDependency( life.add( new UpdatePullingTransactionObligationFulfiller(
-                updatePuller, memberStateMachine, serverId, dependencies ) ) );
-
         life.add( paxosLife );
 
         platformModule.diagnosticsManager.appendProvider( new HighAvailabilityDiagnostics( memberStateMachine,
                 clusterClient ) );
 
         // Create HA services
-        lockManager = dependencies.satisfyDependency(createLockManager( memberStateMachine, config, masterDelegateInvocationHandler, requestContextFactory, platformModule.availabilityGuard, logging ));
+        lockManager = dependencies.satisfyDependency(
+                createLockManager( memberStateMachine, config, masterDelegateInvocationHandler, requestContextFactory,
+                        platformModule.availabilityGuard, logging ) );
 
         propertyKeyTokenHolder = life.add( dependencies.satisfyDependency( new PropertyKeyTokenHolder(
-                createPropertyKeyCreator( config, memberStateMachine, masterDelegateInvocationHandler, requestContextFactory, kernelProvider ) )));
-        labelTokenHolder = life.add( dependencies.satisfyDependency(new LabelTokenHolder( createLabelIdCreator( config,
+                createPropertyKeyCreator( config, memberStateMachine, masterDelegateInvocationHandler,
+                        requestContextFactory, kernelProvider ) ) ) );
+        labelTokenHolder = life.add( dependencies.satisfyDependency( new LabelTokenHolder( createLabelIdCreator( config,
                 memberStateMachine, masterDelegateInvocationHandler, requestContextFactory, kernelProvider ) ) ) );
         relationshipTypeTokenHolder = life.add( dependencies.satisfyDependency( new RelationshipTypeTokenHolder(
                 createRelationshipTypeCreator( config, memberStateMachine, masterDelegateInvocationHandler,
                         requestContextFactory, kernelProvider ) ) ) );
 
-        life.add( dependencies.satisfyDependency(createKernelData( config, platformModule.graphDatabaseFacade, members, lastUpdateTime ) ));
+        life.add( dependencies.satisfyDependency( createKernelData( config, platformModule.graphDatabaseFacade, members,
+                lastUpdateTime, dependencies.provideDependency( NeoStore.class ) ) ) );
 
         commitProcessFactory = createCommitProcessFactory( dependencies, logging, monitors, config, life,
-                clusterClient, members, platformModule.jobScheduler, master, requestContextFactory, memberStateMachine );
+                clusterClient, members, platformModule.jobScheduler, master, requestContextFactory,
+                memberStateMachine );
 
         headerInformationFactory = createHeaderInformationFactory( memberContext );
 
@@ -424,8 +522,9 @@ public class EnterpriseEditionModule
         registerRecovery( config.get( GraphDatabaseFacadeFactory.Configuration.editionName ), dependencies, logging );
     }
 
-    protected TransactionHeaderInformationFactory createHeaderInformationFactory( final HighAvailabilityMemberContext
-                                                                                          memberContext )
+
+    protected TransactionHeaderInformationFactory createHeaderInformationFactory(
+            final HighAvailabilityMemberContext memberContext )
     {
         return new TransactionHeaderInformationFactory.WithRandomBytes()
         {
@@ -443,13 +542,15 @@ public class EnterpriseEditionModule
                                                                ClusterClient clusterClient, ClusterMembers members,
                                                                JobScheduler jobScheduler, final Master master,
                                                                final RequestContextFactory requestContextFactory,
-                                                               final HighAvailabilityMemberStateMachine memberStateMachine )
+                                                               final HighAvailabilityMemberStateMachine
+                                                                       memberStateMachine )
     {
         final DelegateInvocationHandler<TransactionCommitProcess> commitProcessDelegate =
                 new DelegateInvocationHandler<>( TransactionCommitProcess.class );
 
-        DefaultSlaveFactory slaveFactory = dependencies.satisfyDependency( new DefaultSlaveFactory( logging.getInternalLogProvider(), monitors,
-                config.get( HaSettings.com_chunk_size ).intValue() ) );
+        DefaultSlaveFactory slaveFactory = dependencies.satisfyDependency(
+                new DefaultSlaveFactory( logging.getInternalLogProvider(), monitors,
+                        config.get( HaSettings.com_chunk_size ).intValue() ) );
 
         Slaves slaves = dependencies.satisfyDependency(
                 life.add( new HighAvailabilitySlaves( members, clusterClient, slaveFactory ) ) );
@@ -474,20 +575,24 @@ public class EnterpriseEditionModule
                 else
                 {
 
-                    TransactionCommitProcess inner = new TransactionRepresentationCommitProcess( logicalTransactionStore, kernelHealth,
-                                                neoStore, storeApplier, indexUpdatesValidator, mode );
+                    TransactionCommitProcess inner = new TransactionRepresentationCommitProcess(
+                            logicalTransactionStore, kernelHealth,
+                            neoStore, storeApplier, indexUpdatesValidator, mode );
                     new CommitProcessSwitcher( pusher, master, commitProcessDelegate, requestContextFactory,
                             memberStateMachine, txValidator, inner );
 
-                    return (TransactionCommitProcess) Proxy
-                            .newProxyInstance( TransactionCommitProcess.class.getClassLoader(),
+                    return (TransactionCommitProcess)
+                            newProxyInstance( TransactionCommitProcess.class.getClassLoader(),
                                     new Class[]{TransactionCommitProcess.class}, commitProcessDelegate );
                 }
             }
         };
     }
 
-    protected IdGeneratorFactory createIdGeneratorFactory(DelegateInvocationHandler<Master> masterDelegateInvocationHandler, LogProvider logging, RequestContextFactory requestContextFactory)
+    protected IdGeneratorFactory createIdGeneratorFactory( DelegateInvocationHandler<Master>
+                                                                   masterDelegateInvocationHandler,
+                                                           LogProvider logging, RequestContextFactory
+            requestContextFactory )
     {
         idGeneratorFactory = new HaIdGeneratorFactory( masterDelegateInvocationHandler, logging,
                 requestContextFactory );
@@ -502,12 +607,15 @@ public class EnterpriseEditionModule
         return idGeneratorFactory;
     }
 
-    protected Locks createLockManager(HighAvailabilityMemberStateMachine memberStateMachine, final Config config, DelegateInvocationHandler<Master> masterDelegateInvocationHandler,
-                                      RequestContextFactory requestContextFactory, AvailabilityGuard availabilityGuard, final LogService logging)
+    protected Locks createLockManager( HighAvailabilityMemberStateMachine memberStateMachine, final Config config,
+                                       DelegateInvocationHandler<Master> masterDelegateInvocationHandler,
+                                       RequestContextFactory requestContextFactory,
+                                       AvailabilityGuard availabilityGuard, final LogService logging )
     {
         DelegateInvocationHandler<Locks> lockManagerDelegate = new DelegateInvocationHandler<>( Locks.class );
-        final Locks lockManager = (Locks) Proxy.newProxyInstance(
-                Locks.class.getClassLoader(), new Class[]{Locks.class}, lockManagerDelegate );
+        final Locks lockManager = (Locks) newProxyInstance( Locks.class.getClassLoader(),
+                new Class[]{Locks.class},
+                lockManagerDelegate );
         new LockManagerModeSwitcher( memberStateMachine, lockManagerDelegate, masterDelegateInvocationHandler,
                 requestContextFactory, availabilityGuard, config, new Factory<Locks>()
         {
@@ -520,9 +628,12 @@ public class EnterpriseEditionModule
         return lockManager;
     }
 
-    protected TokenCreator createRelationshipTypeCreator(Config config, HighAvailabilityMemberStateMachine memberStateMachine,
-                                                         DelegateInvocationHandler<Master> masterDelegateInvocationHandler, RequestContextFactory requestContextFactory,
-                                                         Supplier<KernelAPI> kernelProvider)
+    protected TokenCreator createRelationshipTypeCreator( Config config,
+                                                          HighAvailabilityMemberStateMachine memberStateMachine,
+                                                          DelegateInvocationHandler<Master>
+                                                                  masterDelegateInvocationHandler,
+                                                          RequestContextFactory requestContextFactory,
+                                                          Supplier<KernelAPI> kernelProvider )
     {
         if ( config.get( GraphDatabaseSettings.read_only ) )
         {
@@ -532,9 +643,8 @@ public class EnterpriseEditionModule
         {
             DelegateInvocationHandler<TokenCreator> relationshipTypeCreatorDelegate =
                     new DelegateInvocationHandler<>( TokenCreator.class );
-            TokenCreator relationshipTypeCreator =
-                    (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
-                            new Class[]{TokenCreator.class}, relationshipTypeCreatorDelegate );
+            TokenCreator relationshipTypeCreator = (TokenCreator) newProxyInstance( TokenCreator.class.getClassLoader(),
+                    new Class[]{TokenCreator.class}, relationshipTypeCreatorDelegate );
 
             new RelationshipTypeCreatorModeSwitcher( memberStateMachine, relationshipTypeCreatorDelegate,
                     masterDelegateInvocationHandler, requestContextFactory, kernelProvider, idGeneratorFactory );
@@ -543,9 +653,11 @@ public class EnterpriseEditionModule
         }
     }
 
-    protected TokenCreator createPropertyKeyCreator(Config config, HighAvailabilityMemberStateMachine memberStateMachine,
-                                                             DelegateInvocationHandler<Master> masterDelegateInvocationHandler, RequestContextFactory requestContextFactory,
-                                                             Supplier<KernelAPI> kernelProvider)
+    protected TokenCreator createPropertyKeyCreator( Config config,
+                                                     HighAvailabilityMemberStateMachine memberStateMachine,
+                                                     DelegateInvocationHandler<Master> masterDelegateInvocationHandler,
+                                                     RequestContextFactory requestContextFactory,
+                                                     Supplier<KernelAPI> kernelProvider )
     {
         if ( config.get( GraphDatabaseSettings.read_only ) )
         {
@@ -555,9 +667,8 @@ public class EnterpriseEditionModule
         {
             DelegateInvocationHandler<TokenCreator> propertyKeyCreatorDelegate =
                     new DelegateInvocationHandler<>( TokenCreator.class );
-            TokenCreator propertyTokenCreator =
-                    (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
-                            new Class[]{TokenCreator.class}, propertyKeyCreatorDelegate );
+            TokenCreator propertyTokenCreator = (TokenCreator) newProxyInstance( TokenCreator.class.getClassLoader(),
+                    new Class[]{TokenCreator.class}, propertyKeyCreatorDelegate );
             new PropertyKeyCreatorModeSwitcher( memberStateMachine, propertyKeyCreatorDelegate,
                     masterDelegateInvocationHandler, requestContextFactory, kernelProvider, idGeneratorFactory );
             return propertyTokenCreator;
@@ -565,8 +676,9 @@ public class EnterpriseEditionModule
     }
 
     protected TokenCreator createLabelIdCreator( Config config, HighAvailabilityMemberStateMachine memberStateMachine,
-                                                             DelegateInvocationHandler<Master> masterDelegateInvocationHandler, RequestContextFactory requestContextFactory,
-                                                             Supplier<KernelAPI> kernelProvider )
+                                                 DelegateInvocationHandler<Master> masterDelegateInvocationHandler,
+                                                 RequestContextFactory requestContextFactory,
+                                                 Supplier<KernelAPI> kernelProvider )
     {
         if ( config.get( GraphDatabaseSettings.read_only ) )
         {
@@ -576,24 +688,26 @@ public class EnterpriseEditionModule
         {
             DelegateInvocationHandler<TokenCreator> labelIdCreatorDelegate =
                     new DelegateInvocationHandler<>( TokenCreator.class );
-            TokenCreator labelIdCreator =
-                    (TokenCreator) Proxy.newProxyInstance( TokenCreator.class.getClassLoader(),
-                            new Class[]{TokenCreator.class}, labelIdCreatorDelegate );
+            TokenCreator labelIdCreator = (TokenCreator) newProxyInstance( TokenCreator.class.getClassLoader(),
+                    new Class[]{TokenCreator.class}, labelIdCreatorDelegate );
             new LabelTokenCreatorModeSwitcher( memberStateMachine, labelIdCreatorDelegate,
                     masterDelegateInvocationHandler, requestContextFactory, kernelProvider, idGeneratorFactory );
             return labelIdCreator;
         }
     }
 
-    protected KernelData createKernelData( Config config, GraphDatabaseAPI graphDb, ClusterMembers members, LastUpdateTime lastUpdateTime)
+    protected KernelData createKernelData( Config config, GraphDatabaseAPI graphDb, ClusterMembers members,
+                                           LastUpdateTime lastUpdateTime, Supplier<NeoStore> neoStoreSupplier )
     {
-        OnDiskLastTxIdGetter txIdGetter = new OnDiskLastTxIdGetter( graphDb );
-        ClusterDatabaseInfoProvider databaseInfo = new ClusterDatabaseInfoProvider(
-                members, txIdGetter, lastUpdateTime );
+        OnDiskLastTxIdGetter txIdGetter = new OnDiskLastTxIdGetter( neoStoreSupplier );
+        ClusterDatabaseInfoProvider databaseInfo = new ClusterDatabaseInfoProvider( members,
+                txIdGetter,
+                lastUpdateTime );
         return new HighlyAvailableKernelData( graphDb, members, databaseInfo, config );
     }
 
-    protected void registerRecovery( final String editionName, final DependencyResolver dependencyResolver, final LogService logging)
+    protected void registerRecovery( final String editionName, final DependencyResolver dependencyResolver,
+                                     final LogService logging )
     {
         memberStateMachine.addHighAvailabilityMemberListener( new HighAvailabilityMemberListener()
         {
@@ -605,8 +719,8 @@ public class EnterpriseEditionModule
             @Override
             public void masterIsAvailable( HighAvailabilityMemberChangeEvent event )
             {
-                if ( event.getOldState().equals( HighAvailabilityMemberState.TO_MASTER ) && event.getNewState().equals(
-                        HighAvailabilityMemberState.MASTER ) )
+                if ( event.getOldState().equals( HighAvailabilityMemberState.TO_MASTER ) &&
+                        event.getNewState().equals( HighAvailabilityMemberState.MASTER ) )
                 {
                     doAfterRecoveryAndStartup( true );
                 }
@@ -615,8 +729,8 @@ public class EnterpriseEditionModule
             @Override
             public void slaveIsAvailable( HighAvailabilityMemberChangeEvent event )
             {
-                if ( event.getOldState().equals( HighAvailabilityMemberState.TO_SLAVE ) && event.getNewState().equals(
-                        HighAvailabilityMemberState.SLAVE ) )
+                if ( event.getOldState().equals( HighAvailabilityMemberState.TO_SLAVE ) &&
+                        event.getNewState().equals( HighAvailabilityMemberState.SLAVE ) )
                 {
                     doAfterRecoveryAndStartup( false );
                 }
@@ -664,10 +778,71 @@ public class EnterpriseEditionModule
 
         if ( isMaster )
         {
-            new RemoveOrphanConstraintIndexesOnStartup( resolver.resolveDependency( NeoStoreDataSource.class )
-                    .getKernel(), resolver.resolveDependency( LogService.class ).getInternalLogProvider() ).perform();
+            new RemoveOrphanConstraintIndexesOnStartup( resolver.resolveDependency( KernelAPI.class ),
+                    resolver.resolveDependency( LogService.class ).getInternalLogProvider() ).perform();
         }
     }
+
+    private Server.Configuration masterServerConfig( final Config config )
+    {
+        return new Server.Configuration()
+        {
+            @Override
+            public long getOldChannelThreshold()
+            {
+                return config.get( HaSettings.lock_read_timeout );
+            }
+
+            @Override
+            public int getMaxConcurrentTransactions()
+            {
+                return config.get( HaSettings.max_concurrent_channels_per_slave );
+            }
+
+            @Override
+            public int getChunkSize()
+            {
+                return config.get( HaSettings.com_chunk_size ).intValue();
+            }
+
+            @Override
+            public HostnamePort getServerAddress()
+            {
+                return config.get( HaSettings.ha_server );
+            }
+        };
+    }
+
+    private Server.Configuration slaveServerConfig( final Config config )
+    {
+        return new Server.Configuration()
+        {
+            @Override
+            public long getOldChannelThreshold()
+            {
+                return config.get( HaSettings.lock_read_timeout );
+            }
+
+            @Override
+            public int getMaxConcurrentTransactions()
+            {
+                return config.get( HaSettings.max_concurrent_channels_per_slave );
+            }
+
+            @Override
+            public int getChunkSize()
+            {
+                return config.get( HaSettings.com_chunk_size ).intValue();
+            }
+
+            @Override
+            public HostnamePort getServerAddress()
+            {
+                return config.get( HaSettings.ha_server );
+            }
+        };
+    }
+
 
     private static final class HAUpgradeConfiguration implements UpgradeConfiguration
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
@@ -130,8 +130,7 @@ public final class HighAvailabilityBean extends ManagementBeanProvider
             long time = System.currentTimeMillis();
             try
             {
-                kernelData.graphDatabase().getDependencyResolver().resolveDependency(
-                        UpdatePullerClient.class ).pullUpdates();
+                kernelData.graphDatabase().getDependencyResolver().resolveDependency(UpdatePullerClient.class ).pullUpdates();
             }
             catch ( Exception e )
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
@@ -19,19 +19,18 @@
  */
 package org.neo4j.kernel.ha.transaction;
 
-import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.impl.core.LastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
 
 public class OnDiskLastTxIdGetter implements LastTxIdGetter
 {
-    private final GraphDatabaseAPI graphdb;
+    private final Supplier<NeoStore> neoStoreSupplier;
 
-    public OnDiskLastTxIdGetter( GraphDatabaseAPI graphdb )
+    public OnDiskLastTxIdGetter( Supplier<NeoStore> neoStoreSupplier )
     {
-        this.graphdb = graphdb;
+        this.neoStoreSupplier = neoStoreSupplier;
     }
 
     @Override
@@ -50,8 +49,6 @@ public class OnDiskLastTxIdGetter implements LastTxIdGetter
         // if we cache it.
         // We avoid this problem by simply not caching it, and instead looking it up
         // every time.
-        NeoStoreSupplier neoStoreSupplier =
-                graphdb.getDependencyResolver().resolveDependency( NeoStoreSupplier.class );
         return neoStoreSupplier.get();
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
@@ -21,8 +21,6 @@ package org.neo4j.kernel.ha;
 
 import org.junit.Test;
 
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
@@ -38,16 +36,12 @@ public class OnDiskLastTxIdGetterTest
     {
         // This is a sign that we have some bad coupling on our hands.
         // We currently have to do this because of our lifecycle and construction ordering.
-        GraphDatabaseAPI graphdb = mock( GraphDatabaseAPI.class );
-        DependencyResolver resolver = mock( DependencyResolver.class );
         NeoStoreSupplier supplier = mock( NeoStoreSupplier.class );
         NeoStore neoStore = mock( NeoStore.class );
-        when( graphdb.getDependencyResolver() ).thenReturn( resolver );
-        when( resolver.resolveDependency( NeoStoreSupplier.class ) ).thenReturn( supplier );
         when( supplier.get() ).thenReturn( neoStore );
         when( neoStore.getLastCommittedTransactionId() ).thenReturn( 13L );
 
-        OnDiskLastTxIdGetter getter = new OnDiskLastTxIdGetter( graphdb );
+        OnDiskLastTxIdGetter getter = new OnDiskLastTxIdGetter( supplier );
         assertEquals( 13L, getter.getLastTxId() );
     }
 }


### PR DESCRIPTION
With the new GraphDatabaseFacadeFactory in place it became easier to do proper constructor injection. This PR removes as many unnecessary uses of DependencyResolver as possible, making it more clear what the dependencies of a particular component is.
