### PR TITLE
Switch to scala 2.11

### DIFF
--- a/advanced/neo4j-advanced/LICENSES.txt
+++ b/advanced/neo4j-advanced/LICENSES.txt
@@ -259,6 +259,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/advanced/neo4j-advanced/NOTICE.txt
+++ b/advanced/neo4j-advanced/NOTICE.txt
@@ -38,4 +38,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/advanced/server-advanced/LICENSES.txt
+++ b/advanced/server-advanced/LICENSES.txt
@@ -279,6 +279,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/advanced/server-advanced/NOTICE.txt
+++ b/advanced/server-advanced/NOTICE.txt
@@ -58,6 +58,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/community/cypher/acceptance/pom.xml
+++ b/community/cypher/acceptance/pom.xml
@@ -44,8 +44,8 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <build>
@@ -89,7 +89,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -100,7 +100,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -111,7 +111,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_2.10</artifactId>
+      <artifactId>scalacheck_2.11</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -181,7 +181,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.parboiled</groupId>
-          <artifactId>parboiled-scala_2.10</artifactId>
+          <artifactId>parboiled-scala_2.11</artifactId>
         </exclusion>
         <exclusion>
           <groupId>net.sf.opencsv</groupId>
@@ -208,7 +208,7 @@
 
     <dependency>
       <groupId>com.novus</groupId>
-      <artifactId>salat-core_2.10</artifactId>
+      <artifactId>salat-core_2.11</artifactId>
       <version>1.9.8</version>
       <exclusions>
         <exclusion>

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -198,9 +198,9 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
         |return collect(nodes(p)) as paths, length(p) as l order by length(p)""".stripMargin)
 
     val expected =
-      List(Map("l" -> 1, "paths" -> List(List(a, b), List(c, d), List(d, e), List(e, f))),
-           Map("l" -> 2, "paths" -> List(List(c, d, e), List(d, e, f))),
-           Map("l" -> 3, "paths" -> List(List(c, d, e, f))))
+      List(Map[String, Any]("l" -> 1, "paths" -> List(List(a, b), List(c, d), List(d, e), List(e, f))),
+           Map[String, Any]("l" -> 2, "paths" -> List(List(c, d, e), List(d, e, f))),
+           Map[String, Any]("l" -> 3, "paths" -> List(List(c, d, e, f))))
 
     result.toList should be (expected)
   }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueAcceptanceTest.scala
@@ -165,8 +165,8 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
 
   test("should_be_able_to_handle_two_params") {
     createNode()
-    val props1 = Map("name"->"Andres", "position"->"Developer")
-    val props2 = Map("name"->"Lasse", "awesome"->true)
+    val props1 = Map[String, Any]("name"->"Andres", "position"->"Developer")
+    val props2 = Map[String, Any]("name"->"Lasse", "awesome"->true)
 
     val result = execute("match (n) where id(n) = 0 create unique n-[:REL]->(a {props1})-[:LER]->(b {props2}) return a,b", "props1"->props1, "props2"->props2)
 
@@ -184,8 +184,8 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
   test("should_be_able_to_handle_two_params_without_named_nodes") {
     createNode()
 
-    val props1 = Map("name"->"Andres", "position"->"Developer")
-    val props2 = Map("name"->"Lasse", "awesome"->true)
+    val props1 = Map[String, Any]("name"->"Andres", "position"->"Developer")
+    val props2 = Map[String, Any]("name"->"Lasse", "awesome"->true)
 
     val result = execute("match (n) where id(n) = 0 create unique p=n-[:REL]->({props1})-[:LER]->({props2}) return p", "props1"->props1, "props2"->props2)
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -2050,7 +2050,7 @@ return b
   }
 
   test("should return multiple property values for matched node") {
-    val props = Map(
+    val props = Map[String, Any](
       "name" -> "Philip J. Fry",
       "age" -> 2046,
       "seasons" -> Array(1, 2, 3, 4, 5, 6, 7))

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -44,8 +44,8 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <build>
@@ -75,7 +75,7 @@
 
     <dependency>
       <groupId>info.cukes</groupId>
-      <artifactId>cucumber-scala_2.10</artifactId>
+      <artifactId>cucumber-scala_2.11</artifactId>
       <version>1.2.2</version>
     </dependency>
     <dependency>
@@ -96,7 +96,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -107,7 +107,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -118,7 +118,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_2.10</artifactId>
+      <artifactId>scalacheck_2.11</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -186,7 +186,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.parboiled</groupId>
-          <artifactId>parboiled-scala_2.10</artifactId>
+          <artifactId>parboiled-scala_2.11</artifactId>
         </exclusion>
         <exclusion>
           <groupId>net.sf.opencsv</groupId>
@@ -203,7 +203,7 @@
 
     <dependency>
       <groupId>com.novus</groupId>
-      <artifactId>salat-core_2.10</artifactId>
+      <artifactId>salat-core_2.11</artifactId>
       <version>1.9.8</version>
       <scope>test</scope>
       <exclusions>

--- a/community/cypher/cypher-compiler-2.3/pom.xml
+++ b/community/cypher/cypher-compiler-2.3/pom.xml
@@ -22,8 +22,8 @@
 
   <properties>
     <version-package>cypher.internal.compiler.v2_3</version-package>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <licenses>
@@ -92,7 +92,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -114,7 +114,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_2.10</artifactId>
+      <artifactId>scalacheck_2.11</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -165,7 +165,7 @@
 
     <dependency>
       <groupId>org.parboiled</groupId>
-      <artifactId>parboiled-scala_2.10</artifactId>
+      <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
 
     <dependency>

--- a/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/executionplan/GeneratedQueryExecution.java
+++ b/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/executionplan/GeneratedQueryExecution.java
@@ -17,11 +17,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.planner.logical
+package org.neo4j.cypher.internal.compiler.v2_3.executionplan;
 
-import scala.collection.immutable.BitSet
+import java.util.List;
 
-package object idp {
-  type Goal = BitSet
-  type Seed[SolvableItem, Result] = Iterable[(Set[SolvableItem], Result)]
+import org.neo4j.cypher.internal.compiler.v2_3.ExecutionMode;
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription;
+import org.neo4j.graphdb.Result;
+
+public interface GeneratedQueryExecution
+{
+    List<String> javaColumns();
+
+    <E extends Exception> void accept( final Result.ResultVisitor<E> visitor ) throws E;
+
+    ExecutionMode executionMode();
+
+    InternalPlanDescription executionPlanDescription();
+
+    void setSuccessfulCloseable( SuccessfulCloseable closeable );
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/setStaticField.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/setStaticField.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen
 
-case object setStaticField {
+object setStaticField {
   def apply(clazz: Class[_], name: String, value: AnyRef) = {
     clazz.getDeclaredField(name).set(null, value)
   }

--- a/community/cypher/cypher/LICENSES.txt
+++ b/community/cypher/cypher/LICENSES.txt
@@ -258,6 +258,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -37,4 +37,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -43,8 +43,8 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <build>
@@ -88,7 +88,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -99,7 +99,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_2.10</artifactId>
+      <artifactId>scalacheck_2.11</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -169,8 +169,8 @@
     <!-- neo4j-cypher -->
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-compiler-1.9</artifactId>
-      <version>2.0.4</version>
+      <artifactId>neo4j-cypher-compiler-1.9_2.11</artifactId>
+      <version>2.0.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>
@@ -200,7 +200,7 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-compiler-2.2</artifactId>
+      <artifactId>neo4j-cypher-compiler-2.2_2.11</artifactId>
       <version>2.2.1</version>
       <exclusions>
         <exclusion>
@@ -295,7 +295,7 @@
 
     <dependency>
       <groupId>org.parboiled</groupId>
-      <artifactId>parboiled-scala_2.10</artifactId>
+      <artifactId>parboiled-scala_2.11</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.opencsv</groupId>
@@ -311,7 +311,7 @@
 
     <dependency>
         <groupId>com.novus</groupId>
-        <artifactId>salat-core_2.10</artifactId>
+        <artifactId>salat-core_2.11</artifactId>
         <version>1.9.8</version>
         <exclusions>
             <exclusion>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -84,6 +84,11 @@
       <version>${scala.version}</version>
     </dependency>
 
+    <dependency>
+      <artifactId>scala-parser-combinators_2.11</artifactId>
+      <groupId>org.scala-lang.modules</groupId>
+    </dependency>
+
     <!-- scala test dependencies -->
 
     <dependency>

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/Description.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/Description.java
@@ -69,7 +69,7 @@ class Description implements ExecutionPlanDescription
     @Override
     public Map<String, Object> getArguments()
     {
-        return JavaConversions.asJavaMap( description.arguments() );
+        return JavaConversions.mapAsJavaMap( description.arguments() );
     }
 
     @Override
@@ -77,7 +77,7 @@ class Description implements ExecutionPlanDescription
     {
         if ( description instanceof ExtendedPlanDescription )
         {
-            return JavaConversions.asJavaSet( ((ExtendedPlanDescription) description).identifiers() );
+            return JavaConversions.setAsJavaSet( ((ExtendedPlanDescription) description).identifiers() );
         }
         return Collections.emptySet();
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanDescription.scala
@@ -25,10 +25,15 @@ trait PlanDescription {
   self =>
 
   def name: String
-  def children: Seq[PlanDescription]
   def arguments: Map[String, AnyRef]
-  def hasProfilerStatistics: Boolean
+
+  // TODO: These two methods need default implementations in order to be useable from cypher-compiler-1.9
+  // TODO: Remove the implementation once we drop support for cypher-compiler-1.9
+  def children: Seq[PlanDescription] = throw new UnsupportedOperationException("This should not have been called")
+  def hasProfilerStatistics: Boolean = throw new UnsupportedOperationException("This should not have been called")
+
   def asJava: javacompat.PlanDescription
+
   def render(builder: StringBuilder) {}
   def render(builder: StringBuilder, separator: String, levelSuffix: String) {}
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/AmendedRootPlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/AmendedRootPlanDescription.scala
@@ -67,7 +67,7 @@ class AmendedRootPlanDescription(inner: ExtendedPlanDescription, version: Cypher
     s"Compiler $version \n\n$planner\n\n$runtime\n\n$innerToString"
   }
 
-  def children: Seq[PlanDescription] = inner.children
+  override def children: Seq[PlanDescription] = inner.children
 
   def extendedChildren: Seq[ExtendedPlanDescription] = inner.extendedChildren
 
@@ -75,5 +75,5 @@ class AmendedRootPlanDescription(inner: ExtendedPlanDescription, version: Cypher
 
   def identifiers: Set[String] = inner.identifiers
 
-  def hasProfilerStatistics: Boolean = inner.hasProfilerStatistics
+  override def hasProfilerStatistics: Boolean = inner.hasProfilerStatistics
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PathImpl.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PathImpl.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal
+
+import java.util.{Iterator => JavaIterator}
+import java.lang.{Iterable => JavaIterable}
+import collection.JavaConverters._
+import collection.mutable
+import org.neo4j.kernel.Traversal
+import org.neo4j.graphdb.{Path, Relationship, PropertyContainer, Node}
+
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+case class PathImpl(pathEntities: PropertyContainer*)
+  extends org.neo4j.graphdb.Path
+  with Traversable[PropertyContainer]
+  with CypherArray {
+
+  val (nodeList,relList) = {
+    if (pathEntities.size % 2 == 0) throw new IllegalArgumentException("Tried to construct a path that is not built like a path: even number of elements.");
+    var x = 0
+    val nodes = new Array[Node](pathEntities.size/2+1)
+    val rels = new Array[Relationship](pathEntities.size/2)
+    try {
+      pathEntities.foreach(e => {
+        if ((x % 2) == 0) nodes.update(x/2, e.asInstanceOf[Node])
+        else rels.update((x-1)/2, e.asInstanceOf[Relationship])
+        x+=1
+      })
+    } catch {
+      case e: ClassCastException => throw new IllegalArgumentException("Tried to construct a path that is not built like a path",e);
+    }
+    (new mutable.WrappedArray.ofRef(nodes),new mutable.WrappedArray.ofRef(rels))
+  }
+
+  require(isProperPath, "Tried to construct a path that is not built like a path")
+
+  def isProperPath: Boolean = {
+    val atLeastOneNode = nodeList.length > 0
+    val relsLengthEqualsToNodesLengthMinusOne = relList.length == nodeList.length - 1
+    atLeastOneNode && relsLengthEqualsToNodesLengthMinusOne
+  }
+
+  def startNode(): Node = nodeList.head
+
+  def endNode(): Node = nodeList.last
+
+  def lastRelationship(): Relationship = if (relList.isEmpty) null else relList.head
+
+  def relationships(): JavaIterable[Relationship] = relList.asJava
+
+  def nodes(): JavaIterable[Node] = nodeList.asJava
+
+  def length(): Int = relList.size
+
+  def iterator(): JavaIterator[PropertyContainer] = pathEntities.asJava.iterator()
+
+  def foreach[U](f: (PropertyContainer) => U) {
+    pathEntities.foreach(f(_))
+  }
+
+  override def toString(): String = Traversal.defaultPathToString(this)
+
+  override def canEqual(that: Any) = that != null && that.isInstanceOf[Path]
+
+  override def equals(p1: Any):Boolean = {
+    if (!canEqual(p1)) return false
+
+    val that = p1.asInstanceOf[Path]
+
+    that.asScala.toList == pathEntities.toList
+  }
+
+  def reverseNodes(): JavaIterable[Node] = nodeList.reverse.asJava
+
+  def reverseRelationships(): JavaIterable[Relationship] = relList.reverse.asJava
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -286,7 +286,8 @@ case class CompatibilityPlanDescription(inner: InternalPlanDescription, version:
   extends ExtendedPlanDescription {
 
   self =>
-  def children = extendedChildren
+
+  override def children = extendedChildren
 
   def extendedChildren = exceptionHandlerFor2_2.runSafely {
     inner.children.toSeq.map(CompatibilityPlanDescription.apply(_, version, planner))
@@ -298,7 +299,7 @@ case class CompatibilityPlanDescription(inner: InternalPlanDescription, version:
 
   def identifiers = exceptionHandlerFor2_2.runSafely { inner.orderedIdentifiers.toSet }
 
-  def hasProfilerStatistics = exceptionHandlerFor2_2.runSafely { inner.arguments.exists(_.isInstanceOf[DbHits]) }
+  override def hasProfilerStatistics = exceptionHandlerFor2_2.runSafely { inner.arguments.exists(_.isInstanceOf[DbHits]) }
 
   def name = exceptionHandlerFor2_2.runSafely { inner.name }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -298,7 +298,8 @@ case class CompatibilityPlanDescriptionFor2_3(inner: InternalPlanDescription, ve
   extends ExtendedPlanDescription {
 
   self =>
-  def children = extendedChildren
+
+  override def children = extendedChildren
 
   def extendedChildren = exceptionHandlerFor2_3.runSafely {
     inner.children.toSeq.map(CompatibilityPlanDescriptionFor2_3.apply(_, version, planner, runtime))
@@ -310,7 +311,7 @@ case class CompatibilityPlanDescriptionFor2_3(inner: InternalPlanDescription, ve
 
   def identifiers = exceptionHandlerFor2_3.runSafely { inner.orderedIdentifiers.toSet }
 
-  def hasProfilerStatistics = exceptionHandlerFor2_3.runSafely { inner.arguments.exists(_.isInstanceOf[DbHits]) }
+  override def hasProfilerStatistics = exceptionHandlerFor2_3.runSafely { inner.arguments.exists(_.isInstanceOf[DbHits]) }
 
   def name = exceptionHandlerFor2_3.runSafely { inner.name }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
@@ -20,15 +20,21 @@
 package org.neo4j.cypher.internal.compatibility
 
 import java.io.PrintWriter
+import java.util
 
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.AmendedRootPlanDescription
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.Argument
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{Rows, DbHits}
 import org.neo4j.cypher.internal.compiler.v2_3.{InterpretedRuntimeName, RulePlannerName}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.iteratorToVisitable
+import org.neo4j.cypher.javacompat.ProfilerStatistics
 import org.neo4j.graphdb.QueryExecutionType.{QueryType, profiled, query}
 import org.neo4j.graphdb.ResourceIterator
 import org.neo4j.graphdb.Result.ResultVisitor
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QuerySession}
+import org.neo4j.cypher.internal.compiler.v1_9.executionplan.{PlanDescription => PlanDescription_v1_9}
+import scala.collection.JavaConverters._
 
 case class LegacyExecutionResultWrapper(inner: ExecutionResult, planDescriptionRequested: Boolean, version: CypherVersion)
                                        (implicit monitor: QueryExecutionMonitor, session: QuerySession) extends ExtendedExecutionResult {
@@ -88,8 +94,14 @@ case class LegacyExecutionResultWrapper(inner: ExecutionResult, planDescriptionR
 
   def executionPlanDescription(): PlanDescription = {
     val description = inner.executionPlanDescription() match {
-      case extended: ExtendedPlanDescription => extended
-      case other => ExtendedPlanDescriptionWrapper(other)
+      case extended: ExtendedPlanDescription =>
+        extended
+
+      case legacy: org.neo4j.cypher.internal.compiler.v1_9.executionplan.PlanDescription =>
+        CompatibilityPlanDescriptionFor1_9(legacy, planDescriptionRequested)
+
+      case other =>
+        ExtendedPlanDescriptionWrapper(other)
     }
 
     new AmendedRootPlanDescription(description, version, RulePlannerName, InterpretedRuntimeName)
@@ -131,13 +143,40 @@ case class LegacyExecutionResultWrapper(inner: ExecutionResult, planDescriptionR
       stats.constraintsRemoved > 0)
 }
 
+case class CompatibilityPlanDescriptionFor1_9(legacy: PlanDescription_v1_9, planDescriptionRequested: Boolean) extends ExtendedPlanDescription {
+  self =>
+
+  def identifiers: Set[String] = Set.empty
+  def extendedChildren: Seq[ExtendedPlanDescription] = legacy.children.map(CompatibilityPlanDescriptionFor1_9(_, planDescriptionRequested))
+
+  override def asJava: javacompat.PlanDescription = new javacompat.PlanDescription {
+    def getProfilerStatistics: ProfilerStatistics = legacy.asJava.getProfilerStatistics
+
+    def getName: String = name
+    def getIdentifiers: util.Set[String] = identifiers.asJava
+    def getArguments: util.Map[String, AnyRef] = self.arguments.asJava
+    def getChildren: util.List[javacompat.PlanDescription] = extendedChildren.toList.map(_.asJava).asJava
+
+    def hasProfilerStatistics: Boolean = self.hasProfilerStatistics
+
+    override def toString: String = self.toString
+  }
+
+  def arguments: Map[String, AnyRef] = legacy.arguments
+  override def hasProfilerStatistics = planDescriptionRequested
+  def name: String = legacy.name
+
+  override def toString = legacy.toString
+}
+
 case class ExtendedPlanDescriptionWrapper(inner: PlanDescription) extends ExtendedPlanDescription {
   def extendedChildren = inner.children.map(ExtendedPlanDescriptionWrapper)
   def identifiers = Set.empty
   def asJava = inner.asJava
-  def children = inner.children
+  override def children = inner.children
   def arguments = inner.arguments
-  def hasProfilerStatistics = inner.hasProfilerStatistics
+  override def hasProfilerStatistics = inner.hasProfilerStatistics
   def name = inner.name
+
   override def toString = inner.toString
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/CastSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/CastSupport.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.helpers
+
+import org.neo4j.cypher.CypherTypeException
+
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+object CastSupport {
+
+  // TODO Switch to using ClassTag once we decide to depend on the reflection api
+
+  /**
+   * Filter sequence by type
+   */
+  def sift[A : Manifest](seq: Seq[Any]): Seq[A] = seq.collect(erasureCast)
+
+  /**
+   * Casts input to A if possible according to type erasure, discards input otherwise
+   */
+  def erasureCast[A : Manifest]: PartialFunction[Any, A] = { case value: A => value }
+
+  def castOrFail[A](value: Any)(implicit ev: Manifest[A]): A = value match {
+    case v: A => v
+    case _    => throw new CypherTypeException(
+      s"Expected $value to be a ${ev.runtimeClass.getName}, but it was a ${value.getClass.getName}")
+  }
+
+  /*
+  This method takes two values and finds the type both values could be represented in.
+
+  The produced value is strictly meant to be used as a type carrier
+   */
+  def merge(a: Any, b: Any): Any = {
+    (a, b) match {
+      case (_: String, _: String)   => a
+      case (_: Char, _: Char)       => a
+      case (_: Boolean, _: Boolean) => a
+
+      case (_: Byte, _: Byte)   => a
+      case (_: Byte, _: Short)  => b
+      case (_: Byte, _: Int)    => b
+      case (_: Byte, _: Long)   => b
+      case (_: Byte, _: Float)  => b
+      case (_: Byte, _: Double) => b
+
+      case (_: Short, _: Int)    => b
+      case (_: Short, _: Long)   => b
+      case (_: Short, _: Float)  => b
+      case (_: Short, _: Double) => b
+      case (_: Short, _: Number) => a
+
+      case (_: Int, _: Long)   => b
+      case (_: Int, _: Float)  => b
+      case (_: Int, _: Double) => b
+      case (_: Int, _: Number) => a
+
+      case (_: Long, _: Float)  => b
+      case (_: Long, _: Double) => b
+      case (_: Long, _: Number) => a
+
+      case (_: Float, _: Double) => b
+      case (_: Float, _: Number) => a
+
+      case (_: Double, _: Number) => a
+
+      case _ => throw new CypherTypeException("Collections containing mixed types can not be stored in properties.")
+    }
+  }
+
+  /*Instances of this class can be gotten from @CastSupport.getConverter*/
+  sealed case class Converter(valueConverter: Any => Any, arrayConverter: Seq[Any] => Array[_])
+
+  /*Returns a converter given a type value*/
+  def getConverter(x: Any): Converter = x match {
+    case _: String  => Converter(x => x.asInstanceOf[String], x => x.asInstanceOf[Seq[String]].toArray[String])
+    case _: Char    => Converter(x => x.asInstanceOf[Char], x => x.asInstanceOf[Seq[Char]].toArray[Char])
+    case _: Boolean => Converter(x => x.asInstanceOf[Boolean], x => x.asInstanceOf[Seq[Boolean]].toArray[Boolean])
+    case _: Byte    => Converter(x => x.asInstanceOf[Number].byteValue(), x => x.asInstanceOf[Seq[Byte]].toArray[Byte])
+    case _: Short   => Converter(x => x.asInstanceOf[Number].shortValue(), x => x.asInstanceOf[Seq[Short]].toArray[Short])
+    case _: Int     => Converter(x => x.asInstanceOf[Number].intValue(), x => x.asInstanceOf[Seq[Int]].toArray[Int])
+    case _: Long    => Converter(x => x.asInstanceOf[Number].longValue(), x => x.asInstanceOf[Seq[Long]].toArray[Long])
+    case _: Float   => Converter(x => x.asInstanceOf[Number].floatValue(), x => x.asInstanceOf[Seq[Float]].toArray[Float])
+    case _: Double  => Converter(x => x.asInstanceOf[Number].doubleValue(), x => x.asInstanceOf[Seq[Double]].toArray[Double])
+    case _          => throw new CypherTypeException("Properties containing arrays of non-primitive types are not supported")
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/CollectionSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/CollectionSupport.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.helpers
+
+import collection.Seq
+import collection.Map
+import java.lang.{Iterable => JavaIterable}
+import java.util.{Map => JavaMap}
+import collection.JavaConverters._
+
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+object IsCollection extends CollectionSupport {
+  def unapply(x: Any):Option[Iterable[Any]] = {
+    val collection = isCollection(x)
+    if (collection) {
+      Some(makeTraversable(x))
+    } else {
+      None
+    }
+  }
+}
+
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+trait CollectionSupport {
+
+  def singleOr[T](in:Iterator[T], or: => Exception):Iterator[T] = new Iterator[T] {
+    var used = false
+    def hasNext: Boolean = in.hasNext
+
+    def next(): T = {
+      if(used) {
+        throw or
+      }
+
+      used = true
+
+      in.next()
+    }
+  }
+
+  class NoValidValuesExceptions extends Exception
+
+  def isCollection(x: Any) = castToIterable.isDefinedAt(x)
+
+  def liftAsCollection[T](test: PartialFunction[Any, T])(input: Any): Option[Iterable[T]] = try {
+    input match {
+      case single if test.isDefinedAt(single) => Some(Seq(test(single)))
+
+      case IsCollection(coll) =>
+        val mappedCollection = coll map {
+          case elem if test.isDefinedAt(elem) => test(elem)
+          case _                              => throw new NoValidValuesExceptions
+        }
+
+        Some(mappedCollection)
+
+      case _ => None
+    }
+  } catch {
+    case _: NoValidValuesExceptions => None
+  }
+
+  def asCollectionOf[T](test: PartialFunction[Any, T])(input: Iterable[Any]): Option[Iterable[T]] =
+    Some(input map { (elem: Any) => if (test.isDefinedAt(elem)) test(elem) else return None })
+
+  def makeTraversable(z: Any): Iterable[Any] = if (castToIterable.isDefinedAt(z)) {
+    castToIterable(z)
+  } else {
+    if (z == null) Iterable() else Iterable(z)
+  }
+
+  protected def castToIterable: PartialFunction[Any, Iterable[Any]] = {
+    case x: Array[_]        => x
+    case x: Map[_, _]       => Iterable(x)
+    case x: JavaMap[_, _]   => Iterable(x.asScala)
+    case x: Traversable[_]  => x.toIterable
+    case x: JavaIterable[_] => x.asScala.map {
+      case y: JavaMap[_, _] => y.asScala
+      case y                => y
+    }
+  }
+
+  implicit class RichSeq[T](inner: Seq[T]) {
+    def foldMap[A](acc: A)(f: (A, T) => (A, T)): (A, Seq[T]) = {
+      val builder = Seq.newBuilder[T]
+      var current = acc
+
+      for (element <- inner) {
+        val (newAcc, newElement) = f(current, element)
+        current = newAcc
+        builder += newElement
+      }
+
+      (current, builder.result())
+    }
+
+    def asNonEmptyOption = if (inner.isEmpty) None else Some(inner)
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/StringRenderingSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/StringRenderingSupport.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.helpers
+
+/**
+ * Subclasses prefer to use StringBuilders to render themselves
+ */
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+trait StringRenderingSupport {
+  override def toString = {
+    val builder = new StringBuilder
+    render(builder)
+    builder.toString()
+  }
+
+  def render(builder: StringBuilder) {
+    builder ++= super.toString
+  }
+}
+

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/TypeSafeMathSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/TypeSafeMathSupport.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.helpers
+
+// TODO: This is only here for accomodating cypher-compiler-1.9. Do not touch, do not import, purge it with fire post 2.3
+trait TypeSafeMathSupport {
+  def plus(left: Any, right: Any): Any = {
+    (left, right) match {
+      case (null, _) => null
+      case (_, null) => null
+
+      case (l: Byte, r: Byte)   => l + r
+      case (l: Byte, r: Double) => l + r
+      case (l: Byte, r: Float)  => l + r
+      case (l: Byte, r: Int)    => l + r
+      case (l: Byte, r: Long)   => l + r
+      case (l: Byte, r: Short)  => l + r
+
+      case (l: Double, r: Byte)   => l + r
+      case (l: Double, r: Double) => l + r
+      case (l: Double, r: Float)  => l + r
+      case (l: Double, r: Int)    => l + r
+      case (l: Double, r: Long)   => l + r
+      case (l: Double, r: Short)  => l + r
+
+      case (l: Float, r: Byte)   => l + r
+      case (l: Float, r: Double) => l + r
+      case (l: Float, r: Float)  => l + r
+      case (l: Float, r: Int)    => l + r
+      case (l: Float, r: Long)   => l + r
+      case (l: Float, r: Short)  => l + r
+
+      case (l: Int, r: Byte)   => l + r
+      case (l: Int, r: Double) => l + r
+      case (l: Int, r: Float)  => l + r
+      case (l: Int, r: Int)    => l + r
+      case (l: Int, r: Long)   => l + r
+      case (l: Int, r: Short)  => l + r
+
+      case (l: Long, r: Byte)   => l + r
+      case (l: Long, r: Double) => l + r
+      case (l: Long, r: Float)  => l + r
+      case (l: Long, r: Int)    => l + r
+      case (l: Long, r: Long)   => l + r
+      case (l: Long, r: Short)  => l + r
+
+      case (l: Short, r: Byte)   => l + r
+      case (l: Short, r: Double) => l + r
+      case (l: Short, r: Float)  => l + r
+      case (l: Short, r: Int)    => l + r
+      case (l: Short, r: Long)   => l + r
+      case (l: Short, r: Short)  => l + r
+
+    }
+  }
+
+  def divide(left: Any, right: Any): Any = {
+    (left, right) match {
+      case (null, _) => null
+      case (_, null) => null
+
+      case (l: Byte, r: Byte)   => l / r
+      case (l: Byte, r: Double) => l / r
+      case (l: Byte, r: Float)  => l / r
+      case (l: Byte, r: Int)    => l / r
+      case (l: Byte, r: Long)   => l / r
+      case (l: Byte, r: Short)  => l / r
+
+      case (l: Double, r: Byte)   => l / r
+      case (l: Double, r: Double) => l / r
+      case (l: Double, r: Float)  => l / r
+      case (l: Double, r: Int)    => l / r
+      case (l: Double, r: Long)   => l / r
+      case (l: Double, r: Short)  => l / r
+
+      case (l: Float, r: Byte)   => l / r
+      case (l: Float, r: Double) => l / r
+      case (l: Float, r: Float)  => l / r
+      case (l: Float, r: Int)    => l / r
+      case (l: Float, r: Long)   => l / r
+      case (l: Float, r: Short)  => l / r
+
+      case (l: Int, r: Byte)   => l / r
+      case (l: Int, r: Double) => l / r
+      case (l: Int, r: Float)  => l / r
+      case (l: Int, r: Int)    => l / r
+      case (l: Int, r: Long)   => l / r
+      case (l: Int, r: Short)  => l / r
+
+      case (l: Long, r: Byte)   => l / r
+      case (l: Long, r: Double) => l / r
+      case (l: Long, r: Float)  => l / r
+      case (l: Long, r: Int)    => l / r
+      case (l: Long, r: Long)   => l / r
+      case (l: Long, r: Short)  => l / r
+
+      case (l: Short, r: Byte)   => l / r
+      case (l: Short, r: Double) => l / r
+      case (l: Short, r: Float)  => l / r
+      case (l: Short, r: Int)    => l / r
+      case (l: Short, r: Long)   => l / r
+      case (l: Short, r: Short)  => l / r
+
+    }
+  }
+
+  def minus(left: Any, right: Any): Any = {
+    (left, right) match {
+      case (null, _) => null
+      case (_, null) => null
+
+      case (l: Byte, r: Byte)   => l - r
+      case (l: Byte, r: Double) => l - r
+      case (l: Byte, r: Float)  => l - r
+      case (l: Byte, r: Int)    => l - r
+      case (l: Byte, r: Long)   => l - r
+      case (l: Byte, r: Short)  => l - r
+
+      case (l: Double, r: Byte)   => l - r
+      case (l: Double, r: Double) => l - r
+      case (l: Double, r: Float)  => l - r
+      case (l: Double, r: Int)    => l - r
+      case (l: Double, r: Long)   => l - r
+      case (l: Double, r: Short)  => l - r
+
+      case (l: Float, r: Byte)   => l - r
+      case (l: Float, r: Double) => l - r
+      case (l: Float, r: Float)  => l - r
+      case (l: Float, r: Int)    => l - r
+      case (l: Float, r: Long)   => l - r
+      case (l: Float, r: Short)  => l - r
+
+      case (l: Int, r: Byte)   => l - r
+      case (l: Int, r: Double) => l - r
+      case (l: Int, r: Float)  => l - r
+      case (l: Int, r: Int)    => l - r
+      case (l: Int, r: Long)   => l - r
+      case (l: Int, r: Short)  => l - r
+
+      case (l: Long, r: Byte)   => l - r
+      case (l: Long, r: Double) => l - r
+      case (l: Long, r: Float)  => l - r
+      case (l: Long, r: Int)    => l - r
+      case (l: Long, r: Long)   => l - r
+      case (l: Long, r: Short)  => l - r
+
+      case (l: Short, r: Byte)   => l - r
+      case (l: Short, r: Double) => l - r
+      case (l: Short, r: Float)  => l - r
+      case (l: Short, r: Int)    => l - r
+      case (l: Short, r: Long)   => l - r
+      case (l: Short, r: Short)  => l - r
+
+    }
+  }
+
+  def multiply(left: Any, right: Any): Any = {
+    (left, right) match {
+      case (null, _) => null
+      case (_, null) => null
+
+      case (l: Byte, r: Byte)   => l * r
+      case (l: Byte, r: Double) => l * r
+      case (l: Byte, r: Float)  => l * r
+      case (l: Byte, r: Int)    => l * r
+      case (l: Byte, r: Long)   => l * r
+      case (l: Byte, r: Short)  => l * r
+
+      case (l: Double, r: Byte)   => l * r
+      case (l: Double, r: Double) => l * r
+      case (l: Double, r: Float)  => l * r
+      case (l: Double, r: Int)    => l * r
+      case (l: Double, r: Long)   => l * r
+      case (l: Double, r: Short)  => l * r
+
+      case (l: Float, r: Byte)   => l * r
+      case (l: Float, r: Double) => l * r
+      case (l: Float, r: Float)  => l * r
+      case (l: Float, r: Int)    => l * r
+      case (l: Float, r: Long)   => l * r
+      case (l: Float, r: Short)  => l * r
+
+      case (l: Int, r: Byte)   => l * r
+      case (l: Int, r: Double) => l * r
+      case (l: Int, r: Float)  => l * r
+      case (l: Int, r: Int)    => l * r
+      case (l: Int, r: Long)   => l * r
+      case (l: Int, r: Short)  => l * r
+
+      case (l: Long, r: Byte)   => l * r
+      case (l: Long, r: Double) => l * r
+      case (l: Long, r: Float)  => l * r
+      case (l: Long, r: Int)    => l * r
+      case (l: Long, r: Long)   => l * r
+      case (l: Long, r: Short)  => l * r
+
+      case (l: Short, r: Byte)   => l * r
+      case (l: Short, r: Double) => l * r
+      case (l: Short, r: Float)  => l * r
+      case (l: Short, r: Int)    => l * r
+      case (l: Short, r: Long)   => l * r
+      case (l: Short, r: Short)  => l * r
+
+    }
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -30,8 +30,8 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
-class TransactionBoundPlanContext(statement: Statement, val gdb: GraphDatabaseService)
-  extends TransactionBoundTokenContext(statement) with PlanContext {
+class TransactionBoundPlanContext(initialStatement: Statement, val gdb: GraphDatabaseService)
+  extends TransactionBoundTokenContext(initialStatement) with PlanContext {
 
   @Deprecated
   def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] = evalOrNone {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/Cypher1_9BinaryCompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/Cypher1_9BinaryCompatibilityTest.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import java.io.PrintWriter
+
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.{ExecutionPlanDescription, Result}
+
+import scala.collection.Map
+
+class Cypher1_9BinaryCompatibilityTest extends CypherFunSuite with GraphDatabaseTestSupport {
+
+  override def databaseConfig(): Map[String, String] = super.databaseConfig() + ("cypher_parser_version" -> "1.9")
+
+  test("Can call all methods on returned result when running via graph.execute") {
+    def withResult(f: Result => Unit) = {
+      graph.inTx {
+        val n0 = createNode()
+        val n1 = createNode()
+        val result = graph.execute(s"START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+        f(result)
+      }
+    }
+
+    verifyJavaResult(withResult)
+  }
+
+  test("Can call all methods on returned result when running via javacompat engine.execute") {
+    val engine = new javacompat.ExecutionEngine(graph)
+
+    def withResult(f: Result => Unit) = {
+      graph.inTx {
+        val n0 = createNode()
+        val n1 = createNode()
+        val result = engine.execute(s"START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+        f(result)
+      }
+    }
+
+    verifyJavaResult(withResult)
+  }
+
+  test("Can call all methods on returned result when running via scala engine.execute") {
+    val engine = new ExecutionEngine(graph)
+
+    def withResult(f: ExtendedExecutionResult => Unit) = {
+      graph.inTx {
+        val n0 = createNode()
+        val n1 = createNode()
+        val result = engine.execute(s"START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+        f(result)
+      }
+    }
+
+    withResult { result => result.accept(mock[Result.ResultVisitor[RuntimeException]]) }
+    withResult { result => result.columns }
+    withResult { result => result.columnAs("b") }
+    withResult { result => result.executionType }
+    withResult { result => result.notifications should be(empty) }
+    withResult { result => result.planDescriptionRequested }
+    withResult { result => result.dumpToString() }
+    withResult { result => result.dumpToString(mock[PrintWriter]) }
+    withResult { result => result.javaColumns }
+    withResult { result => result.javaColumnAs[Any]("b").hasNext }
+    withResult { result => result.javaIterator.hasNext }
+    withResult { result => result.javaIterator.hasNext }
+    withResult { result => result.close() }
+  }
+
+
+  test("Can call all methods on returned PlanDescription when using graph.execute together with PROFILE") {
+    val plan = graph.inTx {
+      val n0 = createNode()
+      val n1 = createNode()
+      val result = graph.execute(s"PROFILE START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+      result.getExecutionPlanDescription
+    }
+
+    verifyJavaPlan(plan)
+  }
+
+  test("Can call all methods on returned PlanDescription when using javacompat engine.execute together with PROFILE") {
+    val engine = new javacompat.ExecutionEngine(graph)
+
+    val plan = graph.inTx {
+      val n0 = createNode()
+      val n1 = createNode()
+      val result = engine.execute(s"PROFILE START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+      result.getExecutionPlanDescription
+    }
+
+    verifyJavaPlan(plan)
+  }
+
+  test("Can call all methods on returned PlanDescription when using scala engine.profile") {
+    val plan = graph.inTx {
+      val n0 = createNode()
+      val n1 = createNode()
+      val engine = new ExecutionEngine(graph)
+      val result = engine.profile(s"START a=node(${n0.getId}), b=node(${n1.getId}) MATCH (a)-[r1:INTRODUCED]->(b)<-[r2:INTRODUCED]-(c) WHERE r1.year = r2.year RETURN b")
+      result.executionPlanDescription()
+    }
+
+    verifyScalaPlan(plan)
+  }
+
+  private def verifyJavaResult(withResult: ((Result => Unit) => Unit)): Unit = {
+    withResult { result => result.columns() }
+    withResult { result => result.columnAs("b") }
+    withResult { result => result.getNotifications.iterator().hasNext should be(right = false) }
+    withResult { result => result.getQueryStatistics.getConstraintsRemoved }
+    withResult { result => result.accept(mock[Result.ResultVisitor[RuntimeException]]) }
+
+  }
+  private def verifyJavaPlan(plan: ExecutionPlanDescription): Unit = {
+    plan.getName
+    val args = plan.getArguments
+    val argsIter = args.entrySet().iterator()
+    while(argsIter.hasNext) {
+      val elem = argsIter.next()
+      elem.getKey.toString
+      elem.getValue.toString
+    }
+    plan.getIdentifiers.toArray.map(_.toString)
+    if (plan.hasProfilerStatistics) {
+      val stats = plan.getProfilerStatistics
+      stats.getDbHits
+      stats.getRows
+    }
+    val iter = plan.getChildren.iterator()
+    while (iter.hasNext) {
+      val next = iter.next()
+      verifyJavaPlan(next)
+    }
+  }
+
+  private def verifyScalaPlan(plan: PlanDescription): Unit = {
+    plan.name
+    plan.arguments.map(_.toString())
+    plan.hasProfilerStatistics
+    plan.children.foreach(verifyScalaPlan)
+    verifyLegacyJavaPlan(plan.asJava)
+  }
+
+  private def verifyLegacyJavaPlan(plan: javacompat.PlanDescription): Unit = {
+    plan.getName
+    plan.getArguments.values().toArray.map(_.toString)
+    if (plan.hasProfilerStatistics) {
+      val stats = plan.getProfilerStatistics
+      stats.getDbHits
+      stats.getRows
+    }
+    val iter = plan.getChildren.iterator()
+    while (iter.hasNext) verifyLegacyJavaPlan(iter.next())
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
@@ -221,6 +221,5 @@ class CypherCompatibilityTest extends CypherFunSuite {
     } finally {
       graph.shutdown()
     }
-
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
@@ -174,24 +174,27 @@ object LdbcQueries {
 
     def params = Map("1" -> 0, "2" -> "name0", "3" -> 6)
 
-    def expectedResult = List(
-      Map("creationDate" -> 2, "gender" -> "gender2", "distance" -> 1, "unis" -> List(List("uni2", 3, "city0")), "locationIp" -> "ip2",
-        "languages" -> List("friend2language0", "friend2language1"), "birthday" -> 2, "cityName" -> "city1",
-        "lastName" -> "last0-ᚠさ丵פش", "id" -> 2, "emails" -> Seq.empty, "browser" -> "browser2", "companies" -> Seq.empty),
-      Map("creationDate" -> 3, "gender" -> "gender3", "distance" -> 1, "unis" -> Seq.empty, "locationIp" -> "ip3",
-        "languages" -> List("friend3language0"), "birthday" -> 3, "cityName" -> "city1", "lastName" -> "last0-ᚠさ丵פش",
-        "id" -> 3, "emails" -> List("friend3email1", "friend3email2"), "browser" -> "browser3",
-        "companies" -> List(List("company0", 1, "country0"))),
-      Map("creationDate" -> 1, "gender" -> "gender1", "distance" -> 1,
-        "unis" -> List(List("uni0", 0, "city1")), "locationIp" -> "ip1", "languages" -> List("friend1language0"),
-        "birthday" -> 1, "cityName" -> "city0", "lastName" -> "last1-ᚠさ丵פش", "id" -> 1,
-        "emails" -> List("friend1email1", "friend1email2"), "browser" -> "browser1", "companies" -> List(List("company0", 0, "country0"))),
-      Map("creationDate" -> 11, "gender" -> "gender11", "distance" -> 2, "unis" -> List(List("uni2", 2, "city0"),
-        List("uni1", 1, "city0")), "locationIp" -> "ip11", "languages" -> Seq.empty, "birthday" -> 11, "cityName" -> "city0",
-        "lastName" -> "last11-ᚠさ丵פش", "id" -> 11, "emails" -> Seq.empty, "browser" -> "browser11", "companies" -> Seq.empty),
-      Map("creationDate" -> 31, "gender" -> "gender31", "distance" -> 2, "unis" -> Seq.empty, "locationIp" -> "ip31",
-        "languages" -> Seq.empty, "birthday" -> 31, "cityName" -> "city1", "lastName" -> "last31-ᚠさ丵פش", "id" -> 31,
-        "emails" -> Seq.empty, "browser" -> "browser31", "companies" -> Seq.empty))
+    def expectedResult: List[Map[String, Any]] = {
+      List(
+        Map("creationDate" -> 2, "gender" -> "gender2", "distance" -> 1, "unis" -> List(List[Any]("uni2", 3, "city0")), "locationIp" -> "ip2",
+          "languages" -> List("friend2language0", "friend2language1"), "birthday" -> 2, "cityName" -> "city1",
+          "lastName" -> "last0-ᚠさ丵פش", "id" -> 2, "emails" -> Seq.empty, "browser" -> "browser2", "companies" -> Seq.empty),
+        Map("creationDate" -> 3, "gender" -> "gender3", "distance" -> 1, "unis" -> Seq.empty, "locationIp" -> "ip3",
+          "languages" -> List("friend3language0"), "birthday" -> 3, "cityName" -> "city1", "lastName" -> "last0-ᚠさ丵פش",
+          "id" -> 3, "emails" -> List("friend3email1", "friend3email2"), "browser" -> "browser3",
+          "companies" -> List(List[Any]("company0", 1, "country0"))),
+        Map("creationDate" -> 1, "gender" -> "gender1", "distance" -> 1,
+          "unis" -> List(List[Any]("uni0", 0, "city1")), "locationIp" -> "ip1", "languages" -> List("friend1language0"),
+          "birthday" -> 1, "cityName" -> "city0", "lastName" -> "last1-ᚠさ丵פش", "id" -> 1,
+          "emails" -> List("friend1email1", "friend1email2"), "browser" -> "browser1", "companies" -> List(List[Any]("company0", 0, "country0"))),
+        Map("creationDate" -> 11, "gender" -> "gender11", "distance" -> 2, "unis" -> List(List[Any]("uni2", 2, "city0"),
+          List[Any]("uni1", 1, "city0")), "locationIp" -> "ip11", "languages" -> Seq.empty, "birthday" -> 11, "cityName" -> "city0",
+          "lastName" -> "last11-ᚠさ丵פش", "id" -> 11, "emails" -> Seq.empty, "browser" -> "browser11", "companies" -> Seq.empty),
+        Map("creationDate" -> 31, "gender" -> "gender31", "distance" -> 2, "unis" -> Seq.empty, "locationIp" -> "ip31",
+          "languages" -> Seq.empty, "birthday" -> 31, "cityName" -> "city1", "lastName" -> "last31-ᚠさ丵פش", "id" -> 31,
+          "emails" -> Seq.empty, "browser" -> "browser31", "companies" -> Seq.empty)
+      )
+    }
   }
 
   object Query2 extends LdbcQuery {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupportTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SystemPropertyTestSupportTest.scala
@@ -53,7 +53,7 @@ class SystemPropertyTestSupportTest extends CypherFunSuite
     {
       def apply( )
       {
-        setSystemProperty( "os.name", "Linux" )
+        setSystemProperty( "os.name" -> "Linux" )
         getSystemProperty( "os.name" ) should equal( ("os.name", "Linux") )
       }
     })( )
@@ -65,8 +65,8 @@ class SystemPropertyTestSupportTest extends CypherFunSuite
     {
       def apply( )
       {
-        setSystemProperty( "os.name", "Linux" )
-        setSystemProperty( "os.name", "Mac OS" ) should equal( ("os.name", "Linux") )
+        setSystemProperty( "os.name" -> "Linux" )
+        setSystemProperty( "os.name" -> "Mac OS" ) should equal( ("os.name", "Linux") )
       }
     })( )
   }
@@ -77,7 +77,7 @@ class SystemPropertyTestSupportTest extends CypherFunSuite
     {
       def apply( )
       {
-        setSystemProperty( "os.name", "Linux" )
+        setSystemProperty( "os.name" -> "Linux" )
         withSystemProperties( "os.name" -> "Windows" )
         {
           getSystemProperty( "os.name" ) should equal( ("os.name", "Windows") )
@@ -92,10 +92,10 @@ class SystemPropertyTestSupportTest extends CypherFunSuite
     {
       def apply( )
       {
-        setSystemProperty( "os.name", "Linux" )
+        setSystemProperty( "os.name" -> "Linux" )
         withSystemProperties( "os.name" -> "Windows" )
         {
-          setSystemProperty( "os.name", "Mac OS" )
+          setSystemProperty( "os.name" -> "Mac OS" )
         }
         getSystemProperty( "os.name" ) should equal( ("os.name", "Linux") )
       }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -19,20 +19,13 @@
  */
 package org.neo4j.cypher.internal
 
-import java.util
-
-import org.mockito.Mockito.mock
 import org.neo4j.cypher.internal.compatibility.{ExecutionResultWrapperFor2_3, exceptionHandlerFor2_3}
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{CompiledExecutionResult, InternalExecutionResult}
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.iteratorToVisitable
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Planner, Runtime}
-import org.neo4j.cypher.internal.compiler.v2_3.{ExecutionMode => ExecutionModev2_3, PipeExecutionResult, PlannerName, RuntimeName, TaskCloser}
+import org.neo4j.cypher.internal.compiler.v2_3.{PipeExecutionResult, PlannerName, RuntimeName}
 import org.neo4j.cypher.{ExecutionResult, InternalException}
-import org.neo4j.function.Suppliers.singleton
 import org.neo4j.graphdb.QueryExecutionType.QueryType
-import org.neo4j.graphdb.Result.ResultVisitor
-import org.neo4j.kernel.api.Statement
 
 object RewindableExecutionResult {
   self =>
@@ -45,14 +38,16 @@ object RewindableExecutionResult {
         }
       }
     case other: CompiledExecutionResult  =>
-      exceptionHandlerFor2_3.runSafely {other.toEagerIterableResult(planner, runtime)}
+      exceptionHandlerFor2_3.runSafely {
+        other.toEagerIterableResult(planner, runtime)
+      }
+
     case _ =>
       inner
   }
 
   def apply(in: ExecutionResult): InternalExecutionResult = in match {
     case e@ExecutionResultWrapperFor2_3(inner, _, _) => exceptionHandlerFor2_3.runSafely(apply(inner, e.planner, e.runtime))
-
-    case _                                      => throw new InternalException("Can't get the internal execution result of an older compiler")
+    case _                                           => throw new InternalException("Can't get the internal execution result of an older compiler")
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/MapPropertySetActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/MapPropertySetActionTest.scala
@@ -120,7 +120,7 @@ class MapPropertySetActionTest extends GraphDatabaseFunSuite with QueryStateTest
   }
 
   test("explicit null removes values") {
-    val from = Map("a" -> 1, "b" -> null)
+    val from = Map[String, Any]("a" -> 1, "b" -> null)
     val to = createNode("a" -> "A", "b" -> "B", "c" -> "C")
 
     withCountsQueryState { queryState =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/CastSupportTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/CastSupportTest.scala
@@ -25,13 +25,13 @@ import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 class CastSupportTest extends CypherFunSuite {
 
   test("siftTest") {
-    val given = Seq(1, 2, "a", 3, "b", 42, "z")
+    val given = Seq[Any](1, 2, "a", 3, "b", 42, "z")
     val then  = helpers.CastSupport.sift[String](given)
     then should equal(Seq("a", "b", "z"))
   }
 
   test("siftComplexTest") {
-    val given = Seq(1, 2, List("a"), 3, "b", 42, List("z"))
+    val given = Seq[Any](1, 2, List("a"), 3, "b", 42, List("z"))
     val then  = helpers.CastSupport.sift[List[String]](given)
     then should equal(Seq(List("a"), List("z")))
   }

--- a/community/cypher/docs/cypher-docs/pom.xml
+++ b/community/cypher/docs/cypher-docs/pom.xml
@@ -45,8 +45,8 @@
     <docs-plugin.skip>false</docs-plugin.skip>
     <attach-docs-phase>verify</attach-docs-phase>
     <remote-csv-upload>http://neo4j.com/docs/${project.version}/csv</remote-csv-upload>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <dependencies>
@@ -65,7 +65,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DeleteTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DeleteTest.scala
@@ -29,9 +29,9 @@ class DeleteTest extends DocumentingTestBase with QueryStatisticsTestSupport wit
   override def graphDescription = List("Andres KNOWS Tobias", "Andres KNOWS Peter")
 
   override val properties = Map(
-    "Andres" -> Map("name"->"Andres", "age" -> 36l),
-    "Tobias" -> Map("name"->"Tobias", "age" -> 25l),
-    "Peter"  -> Map("name"->"Peter",  "age" -> 34l)
+    "Andres" -> Map[String, Any]("name"->"Andres", "age" -> 36l),
+    "Tobias" -> Map[String, Any]("name"->"Tobias", "age" -> 25l),
+    "Peter"  -> Map[String, Any]("name"->"Peter",  "age" -> 34l)
   )
 
   override protected def getGraphvizStyle: GraphStyle =

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -525,8 +525,8 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
 
 trait ResetStrategy {
   def reset() {}
-  def hardReset()
-  def softReset()
+  def hardReset() {}
+  def softReset() {}
 }
 
 trait HardReset extends ResetStrategy {

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/FunctionsTest.scala
@@ -34,11 +34,11 @@ class FunctionsTest extends DocumentingTestBase {
     "B MARRIED E:Spouse")
 
   override val properties = Map(
-    "A" -> Map("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
-    "B" -> Map("name" -> "Bob", "age" -> 25, "eyes" -> "blue"),
-    "C" -> Map("name" -> "Charlie", "age" -> 53, "eyes" -> "green"),
-    "D" -> Map("name" -> "Daniel", "age" -> 54, "eyes" -> "brown"),
-    "E" -> Map("name" -> "Eskil", "age" -> 41, "eyes" -> "blue", "array" -> Array("one", "two", "three"))
+    "A" -> Map[String, Any]("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
+    "B" -> Map[String, Any]("name" -> "Bob", "age" -> 25, "eyes" -> "blue"),
+    "C" -> Map[String, Any]("name" -> "Charlie", "age" -> 53, "eyes" -> "green"),
+    "D" -> Map[String, Any]("name" -> "Daniel", "age" -> 54, "eyes" -> "brown"),
+    "E" -> Map[String, Any]("name" -> "Eskil", "age" -> 41, "eyes" -> "blue", "array" -> Array("one", "two", "three"))
   )
 
   override protected def getGraphvizStyle: GraphStyle =

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
@@ -28,13 +28,13 @@ import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
 class ReturnTest extends DocumentingTestBase {
   override def graphDescription = List("A KNOWS B", "A BLOCKS B")
 
-  override protected def getGraphvizStyle: GraphStyle = 
+  override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()
-  
+
   def section = "Return"
 
   override val properties =
-    Map("A" -> Map("happy" -> "Yes!", "age" -> 55))
+    Map("A" -> Map[String, Any]("happy" -> "Yes!", "age" -> 55))
 
   @Test def returnNode() {
     testQuery(

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
@@ -35,8 +35,8 @@ class SetTest extends DocumentingTestBase with QueryStatisticsTestSupport with S
     "Emil KNOWS Peter")
 
   override val properties = Map(
-    "Andres" -> Map("age" -> 36l, "hungry" -> true),
-    "Peter" -> Map("age" -> 34l))
+    "Andres" -> Map[String, Any]("age" -> 36l, "hungry" -> true),
+    "Peter" -> Map[String, Any]("age" -> 34l))
 
   def section = "Set"
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
@@ -31,11 +31,11 @@ class SyntaxTest extends DocumentingTestBase {
     "B MARRIED E:Spouse")
 
   override val properties = Map(
-    "A" -> Map("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
-    "B" -> Map("name" -> "Bob", "age" -> 25, "eyes" -> "blue"),
-    "C" -> Map("name" -> "Charlie", "age" -> 53, "eyes" -> "green"),
-    "D" -> Map("name" -> "Daniel", "age" -> 54, "eyes" -> "brown"),
-    "E" -> Map("name" -> "Eskil", "age" -> 41, "eyes" -> "blue", "array" -> Array("one", "two", "three"))
+    "A" -> Map[String, Any]("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
+    "B" -> Map[String, Any]("name" -> "Bob", "age" -> 25, "eyes" -> "blue"),
+    "C" -> Map[String, Any]("name" -> "Charlie", "age" -> 53, "eyes" -> "green"),
+    "D" -> Map[String, Any]("name" -> "Daniel", "age" -> 54, "eyes" -> "brown"),
+    "E" -> Map[String, Any]("name" -> "Eskil", "age" -> 41, "eyes" -> "blue", "array" -> Array("one", "two", "three"))
   )
 
   def section = "syntax"

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -33,9 +33,9 @@ class UsingTest extends DocumentingTestBase {
   override val setupConstraintQueries: List[String] = List("CREATE INDEX ON :Swedish(surname)", "CREATE INDEX ON :German(surname)")
 
   override val properties = Map(
-    "Andres" -> Map("age" -> 36l, "awesome" -> true, "surname" -> "Taylor"),
-    "Peter" -> Map("age" -> 34l),
-    "Stefan" -> Map("surname" -> "Plantikow")
+    "Andres" -> Map[String, Any]("age" -> 36l, "awesome" -> true, "surname" -> "Taylor"),
+    "Peter" -> Map[String, Any]("age" -> 34l),
+    "Stefan" -> Map[String, Any]("surname" -> "Plantikow")
   )
 
   def section = "Using"

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -31,12 +31,12 @@ class WhereTest extends DocumentingTestBase {
     "Andres:Swedish KNOWS Peter")
 
   override val properties = Map(
-    "Andres" -> Map("age" -> 36l, "belt" -> "white"),
-    "Tobias" -> Map("age" -> 25l),
-    "Peter" -> Map("age" -> 34l)
+    "Andres" -> Map[String, Any]("age" -> 36l, "belt" -> "white"),
+    "Tobias" -> Map[String, Any]("age" -> 25l),
+    "Peter"  -> Map[String, Any]("age" -> 34l)
   )
 
-  override protected def getGraphvizStyle: GraphStyle = 
+  override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()
 
   def section = "Where"

--- a/community/cypher/docs/graphgist/LICENSES.txt
+++ b/community/cypher/docs/graphgist/LICENSES.txt
@@ -262,6 +262,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/cypher/docs/graphgist/NOTICE.txt
+++ b/community/cypher/docs/graphgist/NOTICE.txt
@@ -41,6 +41,7 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 
 HSQLDB License, a BSD open source license
   HyperSQL Database

--- a/community/cypher/docs/graphgist/pom.xml
+++ b/community/cypher/docs/graphgist/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <neo4j.version>${project.version}</neo4j.version>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <dependencies>
@@ -63,7 +63,7 @@
     </dependency>
 
     <!-- other -->
-    
+
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>

--- a/community/cypher/docs/graphgist/src/main/scala/org/neo4j/cypher/internal/DocsExecutionEngine.scala
+++ b/community/cypher/docs/graphgist/src/main/scala/org/neo4j/cypher/internal/DocsExecutionEngine.scala
@@ -25,19 +25,19 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 import org.neo4j.cypher.{ExecutionEngine, SyntaxException}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QuerySession}
-import org.neo4j.logging.{NullLogProvider, LogProvider}
+import org.neo4j.logging.{LogProvider, NullLogProvider}
 
 import scala.collection.JavaConverters._
 
 class DocsExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = NullLogProvider.getInstance)
-  (implicit monitor: QueryExecutionMonitor, session: QuerySession)
+                         (implicit monitor: QueryExecutionMonitor, session: QuerySession)
   extends ExecutionEngine(graph, logProvider) {
 
   @throws(classOf[SyntaxException])
-  def internalProfile(query: String, params: JavaMap[String, Any]): InternalExecutionResult =
-    RewindableExecutionResult(super.profile(query, params.asScala.toMap))
+  def internalExecute(query: String, params: JavaMap[String, Any]): InternalExecutionResult =
+    RewindableExecutionResult(execute(query, params.asScala.toMap))
 
   @throws(classOf[SyntaxException])
-  def internalExecute(query: String, params: JavaMap[String, Any]): InternalExecutionResult =
-    RewindableExecutionResult(super.execute(query, params.asScala.toMap))
+  def internalProfile(query: String, params: JavaMap[String, Any]): InternalExecutionResult =
+    RewindableExecutionResult(profile(query, params.asScala.toMap))
 }

--- a/community/cypher/docs/refcard-tests/pom.xml
+++ b/community/cypher/docs/refcard-tests/pom.xml
@@ -22,8 +22,8 @@
     <docs-plugin.skip>false</docs-plugin.skip>
     <attach-docs-phase>prepare-package</attach-docs-phase>
     <remote-csv-upload>http://neo4j.com/docs/${project.version}/cypher-refcard/csv</remote-csv-upload>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.6</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
   <licenses>
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
+      <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalautils</groupId>
-      <artifactId>scalautils_2.10</artifactId>
+      <artifactId>scalautils_2.11</artifactId>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -107,7 +107,7 @@
     </dependency>
 
     <!-- neo4j -->
-    
+
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
@@ -42,8 +42,8 @@ class CaseTest extends RefcardTest with QueryStatisticsTestSupport {
   }
 
   override val properties = Map(
-    "A" -> Map("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
-    "B" -> Map("name" -> "Beth", "age" -> 38, "eyes" -> "blue"))
+    "A" -> Map[String, Any]("name" -> "Alice", "age" -> 38, "eyes" -> "brown"),
+    "B" -> Map[String, Any]("name" -> "Beth", "age" -> 38, "eyes" -> "blue"))
 
   def text = """
 ###assertion=simple

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -235,7 +235,7 @@
 
       <dependency>
         <groupId>org.scalatest</groupId>
-        <artifactId>scalatest_2.10</artifactId>
+        <artifactId>scalatest_2.11</artifactId>
         <version>2.2.4</version>
         <scope>test</scope>
         <exclusions>
@@ -251,7 +251,7 @@
       </dependency>
       <dependency>
         <groupId>org.scalautils</groupId>
-        <artifactId>scalautils_2.10</artifactId>
+        <artifactId>scalautils_2.11</artifactId>
         <version>2.1.7</version>
         <scope>test</scope>
         <exclusions>
@@ -267,7 +267,7 @@
       </dependency>
       <dependency>
         <groupId>org.scalacheck</groupId>
-        <artifactId>scalacheck_2.10</artifactId>
+        <artifactId>scalacheck_2.11</artifactId>
         <version>1.12.2</version>
         <scope>test</scope>
       </dependency>
@@ -319,7 +319,7 @@
 
       <dependency>
         <groupId>org.parboiled</groupId>
-        <artifactId>parboiled-scala_2.10</artifactId>
+        <artifactId>parboiled-scala_2.11</artifactId>
         <version>1.1.7</version>
         <exclusions>
           <exclusion>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -318,6 +318,12 @@
       <!-- other -->
 
       <dependency>
+        <artifactId>scala-parser-combinators_2.11</artifactId>
+        <groupId>org.scala-lang.modules</groupId>
+        <version>1.0.3</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.parboiled</groupId>
         <artifactId>parboiled-scala_2.11</artifactId>
         <version>1.1.7</version>

--- a/community/embedded-examples/LICENSES.txt
+++ b/community/embedded-examples/LICENSES.txt
@@ -260,6 +260,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/embedded-examples/NOTICE.txt
+++ b/community/embedded-examples/NOTICE.txt
@@ -39,6 +39,7 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 
 MIT License
   SLF4J API Module

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/AbstractJavaDocTestBase.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/AbstractJavaDocTestBase.java
@@ -66,7 +66,7 @@ public abstract class AbstractJavaDocTestBase implements GraphHolder
 
     protected String createCypherSnippet( String cypherQuery )
     {
-        String snippet = org.neo4j.cypher.internal.compiler.v2_3.prettifier.Prettifier$.MODULE$.apply( cypherQuery );
+        String snippet = org.neo4j.cypher.internal.compiler.v2_3.prettifier.Prettifier.apply( cypherQuery );
         return AsciidocHelper.createAsciiDocSnippet( "cypher", snippet );
     }
 

--- a/community/ndp/messaging-v1/LICENSES.txt
+++ b/community/ndp/messaging-v1/LICENSES.txt
@@ -259,6 +259,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/ndp/messaging-v1/NOTICE.txt
+++ b/community/ndp/messaging-v1/NOTICE.txt
@@ -38,4 +38,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/community/ndp/runtime/LICENSES.txt
+++ b/community/ndp/runtime/LICENSES.txt
@@ -259,6 +259,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/ndp/runtime/NOTICE.txt
+++ b/community/ndp/runtime/NOTICE.txt
@@ -38,4 +38,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/community/ndp/transport-socket/LICENSES.txt
+++ b/community/ndp/transport-socket/LICENSES.txt
@@ -265,6 +265,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/ndp/transport-socket/NOTICE.txt
+++ b/community/ndp/transport-socket/NOTICE.txt
@@ -44,4 +44,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -280,6 +280,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -59,6 +59,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/community/neo4j/LICENSES.txt
+++ b/community/neo4j/LICENSES.txt
@@ -259,6 +259,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -38,4 +38,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/community/server-examples/LICENSES.txt
+++ b/community/server-examples/LICENSES.txt
@@ -266,6 +266,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/server-examples/NOTICE.txt
+++ b/community/server-examples/NOTICE.txt
@@ -45,6 +45,7 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 
 Common Development and Distribution License Version 1.1
   jersey-client

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -280,6 +280,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -59,6 +59,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/enterprise/enterprise-performance-tests/LICENSES.txt
+++ b/enterprise/enterprise-performance-tests/LICENSES.txt
@@ -261,6 +261,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/enterprise/enterprise-performance-tests/NOTICE.txt
+++ b/enterprise/enterprise-performance-tests/NOTICE.txt
@@ -40,4 +40,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -260,6 +260,7 @@ SUCH DAMAGE.
 ------------------------------------------------------------------------------
 BSD License
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -39,4 +39,5 @@ BSD - Scala License
 
 BSD License
   Scala Compiler
+  scala-parser-combinators
 

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -280,6 +280,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -59,6 +59,7 @@ BSD License
   Commons Compiler
   Janino
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -321,6 +321,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -67,6 +67,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
@@ -321,6 +321,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
@@ -67,6 +67,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -321,6 +321,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -67,6 +67,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -322,6 +322,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 ------------------------------------------------------------------------------
 
 Copyright (c) <year>, <copyright holder>

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -68,6 +68,7 @@ BSD License
   Janino
   JQuery Easing Plugin
   Scala Compiler
+  scala-parser-combinators
 
 Bouncy Castle License
   Legion of the Bouncy Castle Java Cryptography APIs


### PR DESCRIPTION
Refactor the code generation part of the new runtime in order to avoid inheritance across Java and Scala which causes compilation errors.
