### PR TITLE
Tiny logging fix for detecting server port during start

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
@@ -108,13 +108,11 @@ public abstract class Bootstrapper
 
         log = userLogProvider.getLog( getClass() );
 
-        serverPort = (configurator == null)
-                ? "unknown port"
-                : String.valueOf( configurator.configuration().get( ServerSettings.webserver_port ) );
-
+        serverPort = "unknown port";
         try
         {
             configurator = createConfigurationBuilder( log );
+            serverPort = String.valueOf( configurator.configuration().get( ServerSettings.webserver_port ) );
             dependencies = dependencies.userLogProvider( userLogProvider );
 
             life.start();


### PR DESCRIPTION
Should obtain server port from build-in configurator once the configurator is initialized
And as the configurator is initialized, we could definitely get a default port.
