### PR TITLE
Regex file name matching in import tool input groups

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -326,7 +326,7 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
     @Override
     public String toString()
     {
-        return format( "%s[buffer:%s, seekPos:%d, line:%d]", getClass().getSimpleName(),
-                charBuffer, seekStartPos, lineNumber );
+        return format( "%s[source:%s, position:%d, line:%d]", getClass().getSimpleName(),
+                sourceDescription(), position(), lineNumber() );
     }
 }

--- a/community/import-tool/src/docs/ops/import-tool.asciidoc
+++ b/community/import-tool/src/docs/ops/import-tool.asciidoc
@@ -240,6 +240,9 @@ include::separate-header-example-command.adoc[]
 
 As well as using a separate header file you can also provide multiple nodes or relationships files.
 This may be useful when processing the output from a Hadoop pipeline for example.
+Files within such an input group can be specified with multiple match strings, delimited by +,+, where each match string can be either:
+* exact file name
+* regular expression matching one or more files. Multiple matching files will be sorted according to their characters _and_ their natural number sort order for file names containing numbers.
 
 .movies4-header.csv
 [source]

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -61,6 +61,7 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 
 import static java.lang.System.out;
 import static java.nio.charset.Charset.defaultCharset;
+
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -597,12 +598,12 @@ public class ImportTool
         public Collection<Option<File[]>> apply( Args args, String key )
         {
             return args.interpretOptionsWithMetadata( key, Converters.<File[]>optional(),
-                    Converters.toFiles( MULTI_FILE_DELIMITER ), FILES_EXISTS,
+                    Converters.toFiles( MULTI_FILE_DELIMITER, Converters.regexFiles( true ) ), FILES_EXISTS,
                     Validators.<File>atLeast( "--" + key, 1 ) );
         }
     };
 
-    private static final Validator<File[]> FILES_EXISTS = new Validator<File[]>()
+    static final Validator<File[]> FILES_EXISTS = new Validator<File[]>()
     {
         @Override
         public void validate( File[] files )
@@ -615,12 +616,12 @@ public class ImportTool
                             file.getName() + "). Please put such directly on the key, f.ex. " +
                             Options.NODE_DATA.argument() + ":MyLabel" );
                 }
-                Validators.FILE_EXISTS.validate( file );
+                Validators.REGEX_FILE_EXISTS.validate( file );
             }
         }
     };
 
-    private static void warn( String warning )
+    static void warn( String warning )
     {
         System.err.println( warning );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NumberAwareStringComparator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/NumberAwareStringComparator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.util.Comparator;
+import java.util.Iterator;
+
+import org.neo4j.helpers.collection.PrefetchingIterator;
+
+/**
+ * Comparator for strings that may, or may not, contain groups of digits representing numbers and where
+ * those numbers should be compared for what their numeric values are, not their string representations.
+ * This will solve a classic sorting issue that plain string sorting misses:
+ * <ol>
+ * <li>string-1</li>
+ * <li>string-2</li>
+ * <li>string-12</li>
+ * </ol>
+ * Where the above would be sorted as {@code string-1}, {@code string-12}, {@code string-2}, which may be
+ * undesirable in scenarios where the number matters. This comparator will sort the strings from the
+ * example above as {@code string-1}, {@code string-2}, {@code string-12}.
+ */
+public class NumberAwareStringComparator implements Comparator<String>
+{
+    public static final Comparator<String> INSTANCE = new NumberAwareStringComparator();
+
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    @Override
+    public int compare( String o1, String o2 )
+    {
+        Iterator<Comparable> c1 = comparables( o1 );
+        Iterator<Comparable> c2 = comparables( o2 );
+        // Single "|" to get both expressions always evaluated, you know, it's a good pattern to
+        // call hasNext before next on iterators.
+        boolean c1Has, c2Has;
+        while ( (c1Has = c1.hasNext()) | (c2Has = c2.hasNext()) )
+        {
+            if ( !c1Has )
+            {
+                return -1;
+            }
+            if ( !c2Has )
+            {
+                return 1;
+            }
+
+            int diff = c1.next().compareTo( c2.next() );
+            if ( diff != 0 )
+            {
+                return diff;
+            }
+            // else continue
+        }
+        // All elements are comparable with each other
+        return 0;
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private Iterator<Comparable> comparables( final String string )
+    {
+        return new PrefetchingIterator<Comparable>()
+        {
+            private int index;
+
+            @Override
+            protected Comparable fetchNextOrNull()
+            {
+                if ( index >= string.length() )
+                {   // End reached
+                    return null;
+                }
+
+                int startIndex = index;
+                char ch = string.charAt( index );
+                boolean isNumber = Character.isDigit( ch );
+                while ( Character.isDigit( ch ) == isNumber && ++index < string.length() )
+                {
+                    ch = string.charAt( index );
+                }
+                String substring = string.substring( startIndex, index );
+                return isNumber ? Long.valueOf( substring ) : substring;
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ConvertersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ConvertersTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.neo4j.kernel.impl.util.Converters.regexFiles;
+
+public class ConvertersTest
+{
+    public final @Rule TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldSortFilesByNumberCleverly() throws Exception
+    {
+        // GIVEN
+        File file1 = existenceOfFile( "file1" );
+        File file123 = existenceOfFile( "file123" );
+        File file12 = existenceOfFile( "file12" );
+        File file2 = existenceOfFile( "file2" );
+        File file32 = existenceOfFile( "file32" );
+
+        // WHEN
+        File[] files = regexFiles( true ).apply( directory.file( "file.*" ).getAbsolutePath() );
+
+        // THEN
+        assertArrayEquals( new File[] {file1, file2, file12, file32, file123}, files );
+    }
+
+    private File existenceOfFile( String name ) throws IOException
+    {
+        File file = directory.file( name );
+        file.createNewFile();
+        return file;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/NumberAwareStringComparatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/NumberAwareStringComparatorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NumberAwareStringComparatorTest
+{
+    @Test
+    public void shouldHandleSingleNumber() throws Exception
+    {
+        // LESSER
+        assertLesser( "123", "456" );
+        assertLesser( "123", "1234" );
+        assertLesser( "1", "12" );
+
+        // SAME
+        assertSame( "123", "123" );
+        assertSame( "001", "1" );
+
+        // GREATER
+        assertGreater( "555", "66" );
+    }
+
+    @Test
+    public void shouldHandleMixedAlthoughSimilarNumbersAndStrings() throws Exception
+    {
+        assertLesser( "same-1-thing-45", "same-12-thing-45" );
+        assertGreater( "same-2-thing-46", "same-2-thing-45" );
+    }
+
+    @Test
+    public void shouldHandleMixedAndDifferentNumbersAndStrings() throws Exception
+    {
+        assertLesser( "same123thing456", "same123thing456andmore" );
+        assertGreater( "same12", "same1thing456andmore" );
+    }
+
+    private void assertLesser( String first, String other )
+    {
+        assertTrue( compare( first, other ) < 0 );
+    }
+
+    private void assertSame( String first, String other )
+    {
+        assertEquals( 0, compare( first, other ) );
+    }
+
+    private void assertGreater( String first, String other )
+    {
+        assertTrue( compare( first, other ) > 0 );
+    }
+
+    private int compare( String first, String other )
+    {
+        return new NumberAwareStringComparator().compare( first, other );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ValidatorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/ValidatorsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+
+import static org.junit.Assert.fail;
+
+public class ValidatorsTest
+{
+    public final @Rule TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldFindFilesByRegex() throws Exception
+    {
+        // GIVEN
+        existenceOfFile( "abc" );
+        existenceOfFile( "bcd" );
+
+        // WHEN/THEN
+        assertValid( "abc" );
+        assertValid( "bcd" );
+        assertValid( "ab." );
+        assertValid( ".*bc" );
+        assertNotValid( "abcd" );
+        assertNotValid( ".*de.*" );
+    }
+
+    private void assertNotValid( String string )
+    {
+        try
+        {
+            validate( string );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {   // Good
+        }
+    }
+
+    private void assertValid( String fileByName )
+    {
+        validate( fileByName );
+    }
+
+    private void validate( String fileByName )
+    {
+        Validators.REGEX_FILE_EXISTS.validate( directory.file( fileByName ) );
+    }
+
+    private void existenceOfFile( String name ) throws IOException
+    {
+        directory.file( name ).createNewFile();
+    }
+}


### PR DESCRIPTION
Input files within an input group specified to the import tool
can be specified with regular expression instead of spelling
out each file. Matching files will be sorted as well, both by their
characters, but also by their numbers, if any, such that f.ex:
`nodes-1.csv, nodes-2.csv, nodes-10.csv` will be sorted in that order.

An example of this would be `--nodes nodes-.*`, or perhaps very
specifically: `--nodes nodes-[0-9]+\.csv`
