### PR TITLE
Properly handle all projections in compiled plans.

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -2216,6 +2216,24 @@ return b
     ))
   }
 
+  test("properly handle collections of nodes and relationships") {
+    val node1 = createNode()
+    val node2 = createNode()
+    val rel = relate(node1, node2)
+    val result = executeWithAllPlannersAndRuntimes("match (n)-[r]->(m) return [n, r, m] as r").toComparableResult
+
+    result should equal(Seq(Map("r" -> Seq(node1, rel, node2))))
+  }
+
+  test("properly handle maps of nodes and relationships") {
+    val node1 = createNode()
+    val node2 = createNode()
+    val rel = relate(node1, node2)
+    val result = executeWithAllPlannersAndRuntimes("match (n)-[r]->(m) return {node1: n, rel: r, node2: m} as m").toComparableResult
+
+    result should equal(Seq(Map("m" -> Map("node1" -> node1, "rel" -> rel, "node2" -> node2))))
+  }
+
   /**
    * Append identifier to keys and transform value arrays to lists
    */

--- a/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/codegen/ResultRowImpl.java
+++ b/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/codegen/ResultRowImpl.java
@@ -27,22 +27,10 @@ import org.neo4j.graphdb.*;
 
 public class ResultRowImpl implements Result.ResultRow
 {
-    private final GraphDatabaseService db;
     private Map<String, Object> results = new HashMap<>();
 
-    public ResultRowImpl( GraphDatabaseService db )
+    public ResultRowImpl( )
     {
-        this.db = db;
-    }
-
-    public void setNode( String k, long id )
-    {
-        results.put( k, db.getNodeById(id) );
-    }
-
-    public void setRelationship( String k, long id )
-    {
-        results.put( k, db.getRelationshipById(id) );
     }
 
     public void set( String k, Object value)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen
 
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ir.CodeThunk
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v2_3.planner.SemanticTable

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenPlan.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenPlan.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen
 
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ir.Instruction
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenerator.scala
@@ -23,6 +23,7 @@ import java.util
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.commons.lang3.StringEscapeUtils
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.{JavaSymbol, JavaTypes}
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ir._
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{CompiledPlan, PlanFingerprint, _}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.Eagerly
@@ -47,22 +48,12 @@ object CodeGenerator {
     (Javac.compile(s"$packageName.$className", source), source)
   }
 
-  implicit class JavaString(name: String) {
-    def toJava = s"""${StringEscapeUtils.escapeJava(name)}"""
-  }
-
-  object JavaTypes {
-    val LONG = "long"
-    val INT = "int"
-    val OBJECT = "Object"
-    val LIST = "java.util.List"
-    val MAP = "java.util.Map"
-    val DOUBLE = "double"
-    val STRING = "String"
-    val NUMBER = "Number"
-  }
-
   private val packageName = "org.neo4j.cypher.internal.compiler.v2_3.generated"
+
+  //TODO these methods should be move out of 2.3 together with everyting that touches Statement
+  def getNodeById(v: String) = JavaSymbol(s"""db.getNodeById( $v )""", JavaTypes.NODE)
+  def getRelationshipById(v: String) = JavaSymbol(s"""db.getRelationshipById( $v )""", JavaTypes.RELATIONSHIP)
+
   private val nameCounter = new AtomicInteger(0)
 
   def indentNicely(in: String): String = {
@@ -160,7 +151,8 @@ object CodeGenerator {
        |@Override
        |public <E extends Exception> void accept(final ResultVisitor<E> visitor) throws E
        |{
-       |final ResultRowImpl row = new ResultRowImpl(db);
+       |final ResultRowImpl row = new ResultRowImpl();
+       |$init
        |try
        |{
        |$init
@@ -186,7 +178,7 @@ object CodeGenerator {
   }
 }
 
-case class JavaSymbol(name: String, javaType: String)
+
 
 class CodeGenerator {
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/JavaUtils.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/JavaUtils.scala
@@ -19,41 +19,32 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen
 
-import java.util.concurrent.atomic.AtomicInteger
+import org.apache.commons.lang3.StringEscapeUtils
 
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
+object JavaUtils {
 
-class Namer(classNameCounter: AtomicInteger) {
-
-  private var methodNameCounter = 0
-  private var varNameCounter = 0
-  private var opNameCounter = 0
-
-  def newMethodName(): String = {
-    methodNameCounter += 1
-    s"m$methodNameCounter"
+  implicit class JavaString(name: String) {
+    def toJava = s"""${StringEscapeUtils.escapeJava(name)}"""
   }
 
-  def newVarName(): String = {
-    varNameCounter += 1
-    s"v$varNameCounter"
+  object JavaTypes {
+    val LONG = "long"
+    val INT = "int"
+    val OBJECT = "Object"
+    val LIST = "java.util.List"
+    val MAP = "java.util.Map"
+    val DOUBLE = "double"
+    val STRING = "String"
+    val NUMBER = "Number"
+    val NODE = "org.neo4j.graph.Node"
+    val RELATIONSHIP = "org.neo4j.graph.Relationship"
   }
 
-  def newOpName(planName: String): String = {
-    opNameCounter += 1
-    s"OP${opNameCounter}_$planName"
-  }
+  case class JavaSymbol(name: String, javaType: String, materializedSymbol: Option[JavaSymbol] = None) {
+    self =>
 
-  def newVarName(typ: String): JavaSymbol = JavaSymbol(newVarName(), typ)
-}
+    def materialize = materializedSymbol.getOrElse(self)
 
-object Namer {
-
-  private val classNameCounter = new AtomicInteger()
-
-  def apply(): Namer = new Namer(classNameCounter)
-
-  def newClassName() = {
-    s"GeneratedExecutionPlan${classNameCounter.incrementAndGet()}"
+    def withProjectedSymbol(symbol: JavaSymbol) = copy(materializedSymbol = Some(symbol))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTable.scala
@@ -20,7 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
 
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.CodeGenerator.n
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.{Namer, CodeGenerator, JavaSymbol}
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils._
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.Namer
 
 sealed trait BuildProbeTable extends Instruction {
   def producedType: String

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/MethodInvocation.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/MethodInvocation.scala
@@ -64,7 +64,7 @@ case class MethodInvocation(override val operatorId: Option[String],
     def name = methodName
   })
 
-  override def exceptions(): Set[ExceptionCodeGen] = Set(KernelExceptionCodeGen)
+  override def exceptions: Set[ExceptionCodeGen] = Set(KernelExceptionCodeGen)
 
   def members() = statements.map(_.members()).reduce(_ + n + _)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/ScanForLabel.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/ScanForLabel.scala
@@ -19,8 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
 
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.CodeGenerator.JavaString
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaSymbol
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaString
+
 
 case class ScanForLabel(id: String, labelName: String, labelVar: JavaSymbol) extends Instruction with LoopDataGenerator {
   def generateCode() = s"""ro.nodesGetForLabel( ${labelVar.name} )"""

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/WhileLoop.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/WhileLoop.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
 
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.CodeGenerator.n
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaSymbol
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
 
 case class WhileLoop(id: JavaSymbol, producer: LoopDataGenerator, action: Instruction) extends Instruction {
   def generateCode(): String = {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CostBasedExecutablePlanBuilder.scala
@@ -94,6 +94,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
       case InterpretedRuntimeName => Right(executionPlanBuilder.build(logicalPlan)(pipeBuildContext, planContext))
       case CompiledRuntimeName =>
         monitor.newPlanSeen(logicalPlan)
+
         val codeGen = new CodeGenerator
         Left(codeGen.generate(logicalPlan, planContext, clock, semanticTable))
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -320,10 +320,6 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
   def planSingleRow()(implicit context: LogicalPlanningContext) =
     SingleRow()(PlannerQuery.empty)
 
-  def planStarProjection(inner: LogicalPlan, expressions: Map[String, Expression])
-                        (implicit context: LogicalPlanningContext) =
-    inner.updateSolved(_.updateTailOrSelf(_.updateQueryProjection(_.withProjections(expressions))))
-
   def planRegularProjection(inner: LogicalPlan, expressions: Map[String, Expression])
                            (implicit context: LogicalPlanningContext) = {
     val solved = inner.solved.updateTailOrSelf(_.updateQueryProjection(_.withProjections(expressions)))

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/projection.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/projection.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v2_3.ast
 import org.neo4j.cypher.internal.compiler.v2_3.ast.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
@@ -28,15 +27,6 @@ object projection {
 
   def apply(plan: LogicalPlan, projectionsMap: Map[String, Expression])(implicit context: LogicalPlanningContext): LogicalPlan = {
     val ids = plan.availableSymbols
-
-    val projectAllCoveredIds: Set[(String, Expression)] = ids.map {
-      case IdName(id) => id -> ast.Identifier(id)(null)
-    }
-    val projections: Set[(String, Expression)] = projectionsMap.toSeq.toSet
-
-    if (projections.subsetOf(projectAllCoveredIds) || projections == projectAllCoveredIds)
-      context.logicalPlanProducer.planStarProjection(plan, projectionsMap)
-    else
-      context.logicalPlanProducer.planRegularProjection(plan, projectionsMap)
+    context.logicalPlanProducer.planRegularProjection(plan, projectionsMap)
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CompiledProfilingTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CompiledProfilingTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
 import org.mockito.Mockito._
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compiler.v2_3.ProfileMode
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaSymbol
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.JavaUtils.JavaSymbol
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription._
@@ -42,7 +42,9 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     val id2 = new Id()
 
     val compiled = compile(WhileLoop(JavaSymbol("name", "Object"),
-      ScanAllNodes("OP1"), AcceptVisitor("OP2", Map.empty, Map.empty, Map.empty)))
+      ScanAllNodes("OP1"),
+      Project(List(ProjectNode(JavaSymbol("foo", "Node"))),
+      AcceptVisitor("OP2", Map("n" -> JavaSymbol("name", "Node"))))))
 
     val statement = mock[Statement]
     val readOps = mock[ReadOperations]
@@ -108,7 +110,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     // given
     val instruction = WhileLoop(JavaSymbol("name", "Object"),
       ScanAllNodes("foo"),
-      AcceptVisitor("bar", Map.empty, Map.empty, Map.empty))
+      AcceptVisitor("bar", Map.empty))
 
     // when
     val source = generateSource(instruction)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/ProjectionInstructionCompilationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/ProjectionInstructionCompilationTest.scala
@@ -20,15 +20,16 @@
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
 
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ir.ProjectionInstruction.{add, parameter, sub}
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 import org.scalatest._
 
-class ProjectionInstructionCompilationTest extends FunSuite with Matchers with CodeGenSugar {
+class ProjectionInstructionCompilationTest extends CypherFunSuite with Matchers with CodeGenSugar {
   // addition
 
   { // literal + literal
     def adding(lhs: ProjectionInstruction, rhs: ProjectionInstruction) = evaluate(
-      ProjectProperties(Seq.empty, AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> add(lhs, rhs).projectedVariable.name))))
+      Project(Seq.empty, AcceptVisitor("id", Map("result" -> add(lhs, rhs).projectedVariable))))
+
 
     verifyAddition(adding, new SimpleOperands[ProjectionInstruction]("literal") {
       override def value(value: Any) = literal(value)
@@ -37,8 +38,8 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
 
   { // parameter + parameter
     val addition: ProjectionInstruction = add(parameter("lhs"), parameter("rhs"))
-    val clazz = compile(ProjectProperties(Seq(addition), AcceptVisitor("id", Map.empty, Map.empty,
-      Map("result" -> addition.projectedVariable.name))))
+    val clazz = compile(Project(Seq(addition), AcceptVisitor("id", Map("result" -> addition.projectedVariable))))
+
     def adding(lhs: Any, rhs: Any) = evaluate(newInstance(clazz, params = Map("lhs" -> lhs, "rhs" -> rhs)))
 
     verifyAddition(adding, new SimpleOperands[Any]("parameter") {
@@ -49,8 +50,8 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
   { // literal + parameter
     def adding(lhs: ProjectionInstruction, rhs: Any) = {
       val addition: ProjectionInstruction = add(lhs, parameter("rhs"))
-      evaluate(newInstance(compile(ProjectProperties(Seq(addition), AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> addition.projectedVariable.name)))), params = Map("rhs" -> rhs)))
+      evaluate(newInstance(compile(Project(Seq(addition), AcceptVisitor("id", Map("result" -> addition.projectedVariable)))), params = Map("rhs" -> rhs)))
+
     }
 
     verifyAddition(adding, new Operands[ProjectionInstruction, Any]("literal", "parameter") {
@@ -63,8 +64,8 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
   { // parameter + literal
     def adding(lhs: Any, rhs: ProjectionInstruction) = {
       val addition: ProjectionInstruction = add(parameter("lhs"), rhs)
-      evaluate(newInstance(compile(ProjectProperties(Seq(addition), AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> addition.projectedVariable.name)))), params = Map("lhs" -> lhs)))
+      evaluate(newInstance(compile(Project(Seq(addition),
+        AcceptVisitor("id", Map("result" -> addition.projectedVariable)))), params = Map("lhs" -> lhs)))
     }
 
     verifyAddition(adding, new Operands[Any, ProjectionInstruction]("parameter", "literal") {
@@ -78,8 +79,7 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
 
   { // literal - literal
     def subtracting(lhs: ProjectionInstruction, rhs: ProjectionInstruction) = evaluate(
-      ProjectProperties(Seq.empty, AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> sub(lhs, rhs).projectedVariable.name))))
+      Project(Seq.empty, AcceptVisitor("id", Map("result" -> sub(lhs, rhs).projectedVariable))))
 
     verifySubtraction(subtracting, new SimpleOperands[ProjectionInstruction]("literal") {
       override def value(value: Any) = literal(value)
@@ -88,8 +88,7 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
 
   { // parameter - parameter
     val subtraction: ProjectionInstruction = sub(parameter("lhs"), parameter("rhs"))
-    val clazz = compile(ProjectProperties(Seq(subtraction), AcceptVisitor("id", Map.empty, Map.empty,
-      Map("result" -> subtraction.projectedVariable.name))))
+    val clazz = compile(Project(Seq(subtraction), AcceptVisitor("id", Map("result" -> subtraction.projectedVariable))))
     def subtracting(lhs: Any, rhs: Any) = evaluate(newInstance(clazz, params = Map("lhs" -> lhs, "rhs" -> rhs)))
 
     verifySubtraction(subtracting, new SimpleOperands[Any]("parameter") {
@@ -100,8 +99,9 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
   { // literal - parameter
     def subtracting(lhs: ProjectionInstruction, rhs: Any) = {
       val subtraction: ProjectionInstruction = sub(lhs, parameter("rhs"))
-      evaluate(newInstance(compile(ProjectProperties(Seq(subtraction), AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> subtraction.projectedVariable.name)))), params = Map("rhs" -> rhs)))
+      evaluate(newInstance(compile(Project(Seq(subtraction),
+        AcceptVisitor("id", Map("result" -> subtraction.projectedVariable)))), params = Map("rhs" -> rhs)))
+
     }
 
     verifySubtraction(subtracting, new Operands[ProjectionInstruction, Any]("literal", "parameter") {
@@ -114,8 +114,8 @@ class ProjectionInstructionCompilationTest extends FunSuite with Matchers with C
   { // parameter - literal
     def subtracting(lhs: Any, rhs: ProjectionInstruction) = {
       val subtraction: ProjectionInstruction = sub(parameter("lhs"), rhs)
-      evaluate(newInstance(compile(ProjectProperties(Seq(subtraction), AcceptVisitor("id", Map.empty, Map.empty,
-        Map("result" -> subtraction.projectedVariable.name)))), params = Map("lhs" -> lhs)))
+      evaluate(newInstance(compile(Project(Seq(subtraction),
+        AcceptVisitor("id", Map("result" -> subtraction.projectedVariable)))), params = Map("lhs" -> lhs)))
     }
 
     verifySubtraction(subtracting, new Operands[Any, ProjectionInstruction]("parameter", "literal") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/profiling/ProfilingTracerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/profiling/ProfilingTracerTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.profiling
 
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -222,4 +222,10 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
   implicit def propertyKeyId(label: String)(implicit plan: SemanticPlan): PropertyKeyId =
     plan.semanticTable.resolvedPropertyKeyNames(label)
+
+  implicit class RichPlan(plan: SemanticPlan) {
+    def innerPlan = plan.plan match {
+      case Projection(inner, _) => inner
+    }
+  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CartesianProductPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CartesianProductPlanningIntegrationTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 class CartesianProductPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("should build plans for simple cartesian product") {
-    planFor("MATCH n, m RETURN n, m").plan should equal(
+    planFor("MATCH n, m RETURN n, m").innerPlan should equal(
       CartesianProduct(
         AllNodesScan(IdName("n"), Set.empty)(solved),
         AllNodesScan(IdName("m"), Set.empty)(solved)
@@ -45,7 +45,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
       cardinality = mapCardinality {
         case PlannerQuery(queryGraph, _, _) if queryGraph.selections.predicates.size == 1 => 10
       }
-    } planFor "MATCH n, m WHERE n.prop = 12 AND m:Label RETURN n, m").plan should beLike {
+    } planFor "MATCH n, m WHERE n.prop = 12 AND m:Label RETURN n, m").innerPlan should beLike {
       case CartesianProduct(_: Selection, _: NodeByLabelScan) => ()
     }
   }
@@ -59,7 +59,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
       )
     } planFor "MATCH a, b, c WHERE a:A AND b:B AND c:C RETURN a, b, c"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       CartesianProduct(
         NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved),
         CartesianProduct(
@@ -81,7 +81,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
     // A x B = 30 * 2 + 30 * (20 * 2) => 1260
     // B x A = 20 * 2 + 20 * (30 * 2) => 1240
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       CartesianProduct(
         NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved),
         NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
@@ -102,7 +102,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     })
     when(context.withStrictness(any())).thenReturn(context)
     val producer = mock[LogicalPlanProducer]
-    when(producer.planStarProjection(any(), any())(any())).thenReturn(lp)
+    when(producer.planRegularProjection(any(), any())(any())).thenReturn(lp)
     when(context.logicalPlanProducer).thenReturn(producer)
     val queryPlanner = new DefaultQueryPlanner(planRewriter = Rewriter.noop,
       planSingleQuery = PlanSingleQuery(expressionRewriterFactory = (lpc) => Rewriter.noop ))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ import org.neo4j.graphdb.Direction
 class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("Should build plans containing expand for single relationship pattern") {
-    planFor("MATCH (a)-[r]->(b) RETURN r").plan should equal(
+    planFor("MATCH (a)-[r]->(b) RETURN r").innerPlan should equal(
         Expand(
           AllNodesScan("b", Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"
@@ -49,7 +49,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
         case PlannerQuery(queryGraph, _, _) if queryGraph.patternNodes == Set(IdName("d")) => 4000.0
         case _ => 100.0
       }
-    } planFor "MATCH (a)-[r1]->(b), (c)-[r2]->(d) RETURN r1, r2").plan should beLike {
+    } planFor "MATCH (a)-[r1]->(b), (c)-[r2]->(d) RETURN r1, r2").innerPlan should beLike {
       case
         Selection(_,
           CartesianProduct(
@@ -63,7 +63,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
   }
 
   test("Should build plans containing expand for self-referencing relationship patterns") {
-    val result = planFor("MATCH (a)-[r]->(a) RETURN r").plan
+    val result = planFor("MATCH (a)-[r]->(a) RETURN r").innerPlan
 
     result should equal(
       Expand(
@@ -80,7 +80,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
         case _                                                                   => 1.0
       }
 
-    } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").plan should equal(
+    } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").innerPlan should equal(
       Selection(Seq(Not(Equals(Identifier("r1")_,Identifier("r2")_)_)_),
         Expand(
           Expand(
@@ -100,7 +100,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
 
     (new given {
       cardinality = PartialFunction(myCardinality)
-    } planFor "MATCH (start)-[rel:x]-(a) WHERE a.name = 'Andres' return a").plan should equal(
+    } planFor "MATCH (start)-[rel:x]-(a) WHERE a.name = 'Andres' return a").innerPlan should equal(
         Expand(
           Selection(
             Seq(In(Property(Identifier("a")_, PropertyKeyName("name")_)_, Collection(Seq(StringLiteral("Andres")_))_)_),
@@ -119,7 +119,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
       }
 
       indexOn("Person", "name")
-    } planFor "MATCH (a)-[r]->(b) USING INDEX b:Person(name) WHERE b:Person AND b.name = 'Andres' return r").plan should equal(
+    } planFor "MATCH (a)-[r]->(b) USING INDEX b:Person(name) WHERE b:Person AND b.name = 'Andres' return r").innerPlan should equal(
         Expand(
           NodeIndexSeek("b", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), SingleQueryExpression(StringLiteral("Andres")_), Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.Direction
 class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("finds shortest paths") {
-    planFor("MATCH a, b, shortestPath(a-[r]->b) RETURN b").plan should equal(
+    planFor("MATCH a, b, shortestPath(a-[r]->b) RETURN b").innerPlan should equal(
       FindShortestPaths(
         CartesianProduct(
           AllNodesScan("b", Set.empty)(solved),
@@ -45,7 +45,7 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
   }
 
   test("finds all shortest paths") {
-    planFor("MATCH a, b, allShortestPaths(a-[r]->b) RETURN b").plan should equal(
+    planFor("MATCH a, b, allShortestPaths(a-[r]->b) RETURN b").innerPlan should equal(
       FindShortestPaths(
         CartesianProduct(
           AllNodesScan("b", Set.empty)(solved),
@@ -71,7 +71,7 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
         case PlannerQuery(queryGraph, _, _) if queryGraph.patternRelationships.size == 1 => 100.0
         case _                             => Double.MaxValue
       }
-    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").plan
+    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").innerPlan
 
     val expected =
       FindShortestPaths(

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
@@ -33,7 +33,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
   test("should build plans for all nodes scans") {
     (new given {
-    } planFor "MATCH (n) RETURN n").plan should equal(
+    } planFor "MATCH (n) RETURN n").innerPlan should equal(
       AllNodesScan("n", Set.empty)(solved)
     )
   }
@@ -46,7 +46,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         case (_: NodeByLabelScan, _) => 1.0
         case _ => Double.MaxValue
       }
-    } planFor "MATCH (n:Awesome) RETURN n").plan should equal(
+    } planFor "MATCH (n:Awesome) RETURN n").innerPlan should equal(
       NodeByLabelScan("n", LazyLabel("Awesome"), Set.empty)(solved)
     )
   }
@@ -62,7 +62,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       knownLabels = Set("Awesome")
     } planFor "MATCH (n:Awesome) RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeByLabelScan("n", lazyLabel("Awesome"), Set.empty)(solved)
     )
   }
@@ -82,7 +82,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -97,7 +97,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -113,7 +113,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -128,7 +128,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) AND n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       Selection(Seq(FunctionInvocation(FunctionName("has") _, Property(ident("n"), PropertyKeyName("prop") _) _) _),
         NodeIndexSeek(
           "n",
@@ -144,7 +144,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexSeek(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -159,7 +159,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexUniqueSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -170,7 +170,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexUniqueSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)),
         SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
@@ -179,7 +179,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID mixed with label scan when node by ID is cheaper") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) = 42 RETURN n").plan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) = 42 RETURN n").innerPlan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Collection(Seq(SignedDecimalIntegerLiteral("42")_))_), Set.empty)(solved)
@@ -190,7 +190,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID when the predicate is IN and rhs is a param") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) IN {param} RETURN n").plan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) IN {param} RETURN n").innerPlan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Parameter("param")_), Set.empty)(solved)
@@ -200,14 +200,14 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
   test("should build plans for directed rel by ID when the predicate is IN and rhs is a param") {
     (new given {
-    } planFor "MATCH (a)-[r]->(b) WHERE id(r) IN {param} RETURN a, r, b").plan should equal (
+    } planFor "MATCH (a)-[r]->(b) WHERE id(r) IN {param} RETURN a, r, b").innerPlan should equal (
       DirectedRelationshipByIdSeek("r", ManySeekableArgs(Parameter("param")_), "a", "b", Set.empty)(solved)
     )
   }
 
   test("should build plans for undirected rel by ID when the predicate is IN and rhs is a param") {
     (new given {
-    } planFor "MATCH (a)-[r]-(b) WHERE id(r) IN {param} RETURN a, r, b").plan should equal (
+    } planFor "MATCH (a)-[r]-(b) WHERE id(r) IN {param} RETURN a, r, b").innerPlan should equal (
       UndirectedRelationshipByIdSeek("r", ManySeekableArgs(Parameter("param")_), "a", "b", Set.empty)(solved)
     )
   }
@@ -215,7 +215,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID when the predicate is IN") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) IN [42, 64] RETURN n").plan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) IN [42, 64] RETURN n").innerPlan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Collection(Seq(SignedDecimalIntegerLiteral("42")_, SignedDecimalIntegerLiteral("64")_))_), Set.empty)(solved)
@@ -226,7 +226,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for index seek when there is an index on the property and an IN predicate") {
     (new given {
       indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [42] RETURN n").plan should beLike {
+    } planFor "MATCH (n:Awesome) WHERE n.prop IN [42] RETURN n").innerPlan should beLike {
       case NodeIndexSeek(
               IdName("n"),
               LabelToken("Awesome", _),
@@ -243,7 +243,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     // should not win
     (new given {
       indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] RETURN n").plan should beLike {
+    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] RETURN n").innerPlan should beLike {
       case _: Selection => ()
     }
   }
@@ -259,7 +259,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5] RETURN n"
 
-    result.plan should beLike {
+    result.innerPlan should beLike {
       case _: NodeIndexUniqueSeek => ()
     }
   }
@@ -267,7 +267,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for label scans when a hint is given") {
     implicit val plan = new given planFor "MATCH (n:Foo:Bar:Baz) USING SCAN n:Bar RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       Selection(
         Seq(HasLabels(ident("n"), Seq(LabelName("Foo")_))_, HasLabels(ident("n"), Seq(LabelName("Baz")_))_),
         NodeByLabelScan("n", LazyLabel("Bar"), Set.empty)(solved)
@@ -280,7 +280,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -290,7 +290,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN *"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -301,7 +301,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 = 3 RETURN n "
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -314,7 +314,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       NodeIndexUniqueSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -325,7 +325,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 = 3 RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeIndexUniqueSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -339,7 +339,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 IN [3] RETURN n"
 
-    plan.plan should equal(
+    plan.innerPlan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeIndexUniqueSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -359,11 +359,12 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
     plan.plan should equal(
       Aggregation(
+      Projection(
         Apply(
           Projection(SingleRow()(solved),Map("arr" -> Collection(List(SignedDecimalIntegerLiteral("0")_, SignedDecimalIntegerLiteral("1")_, SignedDecimalIntegerLiteral("3")_))_))(solved),
           NodeByIdSeek(IdName("n"), ManySeekableArgs(Identifier("arr")_),Set(IdName("arr")))(solved)
         )(solved),
-        Map(),Map("count(*)" -> CountStar()_)
+        Map())(solved), Map(), Map("count(*)" -> CountStar()_)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
@@ -43,13 +43,14 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val pathExpr = PathExpression(NodePathStep(Identifier("a")_,SingleRelationshipPathStep(Identifier("r")_, Direction.OUTGOING, NilPathStep)))_
 
     planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a RETURN b").plan should equal(
-      Selection(
-        Seq(Equals(
-          FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
-          Identifier("a")_
-        )_),
-        Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
-      )(solved)
+      Projection(
+        Selection(
+          Seq(Equals(
+            FunctionInvocation(FunctionName("head") _, FunctionInvocation(FunctionName("nodes") _, pathExpr) _) _,
+            Identifier("a") _
+          ) _),
+          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq.empty, "b", "r")(solved)
+        )(solved), Map("b" -> ident("b")))(solved)
     )
   }
 
@@ -57,19 +58,20 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val pathExpr = PathExpression(NodePathStep(Identifier("a")_,SingleRelationshipPathStep(Identifier("r")_, Direction.OUTGOING, NilPathStep)))_
 
     planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a AND length(p) > 10 RETURN b").plan should equal(
-      Selection(
-        Seq(
-          GreaterThan(
-            FunctionInvocation(FunctionName("length")_, pathExpr)_,
-            SignedDecimalIntegerLiteral("10")_
-          )_,
-          Equals(
-            FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, pathExpr)_)_,
-            Identifier("a")_
-          )_
-        ),
-        Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved)
-      )(solved)
+      Projection(
+        Selection(
+          Seq(
+            GreaterThan(
+              FunctionInvocation(FunctionName("length") _, pathExpr) _,
+              SignedDecimalIntegerLiteral("10") _
+            ) _,
+            Equals(
+              FunctionInvocation(FunctionName("head") _, FunctionInvocation(FunctionName("nodes") _, pathExpr) _) _,
+              Identifier("a") _
+            ) _
+          ),
+          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq.empty, "b", "r")(solved)
+        )(solved), Map("b" -> ident("b")))(solved)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -42,7 +42,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
         case _                             => Double.MaxValue
       }
 
-    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X) RETURN b").plan
+    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X) RETURN b").innerPlan
 
     val expected =
       Selection(
@@ -74,7 +74,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
       }
 
       indexOn("Person", "name")
-    } planFor "MATCH (a)-[r]->(b) USING INDEX a:Person(name) USING INDEX b:Person(name) WHERE a:Person AND b:Person AND a.name = 'Jakub' AND b.name = 'Andres' return r").plan should equal(
+    } planFor "MATCH (a)-[r]->(b) USING INDEX a:Person(name) USING INDEX b:Person(name) WHERE a:Person AND b:Person AND a.name = 'Jakub' AND b.name = 'Andres' return r").innerPlan should equal(
       NodeHashJoin(
         Set(IdName("b")),
         Selection(

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PlanEventHorizonTest.scala
@@ -32,18 +32,6 @@ class PlanEventHorizonTest extends CypherFunSuite {
   val pos = DummyPosition(1)
   implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[Metrics.CardinalityModel]), mock[Metrics], SemanticTable(), mock[QueryGraphSolver])
 
-  test("should not do projection if not necessary") {
-    // Given
-    val pq = PlannerQuery(horizon = RegularQueryProjection(Map("a" -> Identifier("a")(pos))))
-    val inputPlan = AllNodesScan(IdName("a"), Set.empty)(CardinalityEstimation.lift(PlannerQuery(), Cardinality(1)))
-
-    // When
-    val producedPlan = PlanEventHorizon()(pq, inputPlan)
-
-    // Then
-    inputPlan should equal(producedPlan)
-  }
-
   test("should do projection if necessary") {
     // Given
     val literal: SignedDecimalIntegerLiteral = SignedDecimalIntegerLiteral("42")(pos)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
@@ -44,10 +44,10 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
       planContext = newMockedPlanContext
     )
 
-    val startPlan = newMockedLogicalPlan()
+    val startPlan = Projection(newMockedLogicalPlan(), Map("count(*)" -> CountStar()_))(solved)
 
     aggregation(startPlan, projection)(context) should equal(
-      Aggregation(startPlan, Map(), aggregatingMap)(solved)
+      Aggregation(Projection(startPlan, Map.empty)(solved), Map(), aggregatingMap)(solved)
     )
   }
 
@@ -90,10 +90,9 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // When
     val result = aggregation(projectionPlan, projection)(context)
-
     // Then
     result should equal(
-      Aggregation(projectionPlan, groupingKeyMap, aggregatingMap)(solved)
+      Aggregation(Projection(projectionPlan, groupingKeyMap)(solved), groupingKeyMap, aggregatingMap)(solved)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
@@ -57,7 +57,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val result = projection(startPlan, projections)
 
     // then
-    result should equal(startPlan)
+    result should equal(Projection(startPlan, projections)(solved))
     result.solved.horizon should equal(RegularQueryProjection(projections))
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -197,7 +197,8 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
     val children = description.getChildren
     children should have size 1
     description.getArguments.get("DbHits") should equal(0) // ProduceResults has no hits
-    children.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
+    children.get(0).getArguments.get("DbHits") should equal(0) // Projection has no hits
+    children.get(0).getChildren.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
   }
 
   //TODO remove InterpretedRuntimeName when PROFILE is supported


### PR DESCRIPTION
In order to support projections such as `match n return [n]` we have changed so
that the responsibility of materializing things like `Node` and `Relationships` now live
in the Projection rather than in the `ResultsRow`. For this to work we also need to project
consistently in all LogicalPlans and not only when it was needed for the interpreted runtime.
