### PR TITLE
Solves an issue when IDP is planning optional shortest paths

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -67,6 +67,12 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
 
+  test("returns null when no shortest path is found") {
+    val result = executeWithAllPlanners("MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
+
+    result should equal(List(Map("p" -> null)))
+  }
+
   test("finds shortest path rels") {
     /*
        a-b-c-d

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -67,16 +67,17 @@ case class QueryPlannerConfiguration(leafPlanners: LeafPlannerList,
                                      optionalSolvers: Seq[OptionalSolver],
                                      pickBestCandidate: LogicalPlanningFunction0[CandidateSelector]) {
 
-  def toKit(qg: QueryGraph)(implicit context: LogicalPlanningContext): QueryPlannerKit =
+  def toKit()(implicit context: LogicalPlanningContext): QueryPlannerKit =
     QueryPlannerKit(
-      qg = qg,
-      select = plan => applySelections(plan, qg),
+      select = (plan: LogicalPlan, qg: QueryGraph) => applySelections(plan, qg),
       projectAllEndpoints = (plan: LogicalPlan, qg: QueryGraph) => projectAllEndpoints(plan, qg),
       pickBest = pickBestCandidate(context)
     )
 }
 
-case class QueryPlannerKit(qg: QueryGraph,
-                           select: LogicalPlan => LogicalPlan,
+case class QueryPlannerKit(select: (LogicalPlan, QueryGraph) => LogicalPlan,
                            projectAllEndpoints: (LogicalPlan, QueryGraph) => LogicalPlan,
-                           pickBest: CandidateSelector)
+                           pickBest: CandidateSelector) {
+  def select(plans: Iterable[Seq[LogicalPlan]], qg: QueryGraph):Iterable[Seq[LogicalPlan]] =
+    plans.map(_.map( plan => select(plan, qg) ))
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -78,6 +78,6 @@ case class QueryPlannerConfiguration(leafPlanners: LeafPlannerList,
 case class QueryPlannerKit(select: (LogicalPlan, QueryGraph) => LogicalPlan,
                            projectAllEndpoints: (LogicalPlan, QueryGraph) => LogicalPlan,
                            pickBest: CandidateSelector) {
-  def select(plans: Iterable[Seq[LogicalPlan]], qg: QueryGraph):Iterable[Seq[LogicalPlan]] =
-    plans.map(_.map( plan => select(plan, qg) ))
+  def select(plans: Iterable[Seq[LogicalPlan]], qg: QueryGraph): Iterable[Seq[LogicalPlan]] =
+    plans.map(_.map(plan => select(plan, qg)))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyQueryGraphSolver.scala
@@ -33,12 +33,12 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[GreedyPlanTable],
 
     import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.CandidateGenerator._
 
-    val kit = config.toKit(queryGraph)
+    val kit = config.toKit()
     val optionalMatchesSolver = solveOptionalMatches(config.optionalSolvers, kit.pickBest)
 
     def generateLeafPlanTable(): GreedyPlanTable = {
       val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph, kit.projectAllEndpoints)
-      val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.iterator.map(_.map(kit.select))
+      val leafPlanCandidateListsWithSelections = kit.select(leafPlanCandidateLists, queryGraph).iterator
       val bestLeafPlans: Iterator[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(kit.pickBest(_))
       val startTable: GreedyPlanTable = leafPlan.foldLeft(GreedyPlanTable.empty)(_ + _)
       bestLeafPlans.foldLeft(startTable)(_ + _)
@@ -50,7 +50,7 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[GreedyPlanTable],
         val generated: Seq[LogicalPlan] = step(planTable, queryGraph)
 
         if (generated.nonEmpty) {
-          val selected: Seq[LogicalPlan] = generated.map(kit.select)
+          val selected: Seq[LogicalPlan] = generated.map(plan => kit.select(plan, queryGraph))
           //          println("Building on top of " + planTable.plans.map(_.availableSymbols).mkString(" | "))
           //          println("Produced: " + selected.map(_.availableSymbols).mkString(" | "))
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -68,9 +68,10 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
   }
 
   private def kitWithShortestPathSupport(kit: QueryPlannerKit)(implicit context: LogicalPlanningContext) =
-    kit.copy(select = (plan: LogicalPlan, qg: QueryGraph) => selectShortestPath(kit, plan, qg))
+    kit.copy(select = selectShortestPath(kit, _, _))
 
-  private def selectShortestPath(kit: QueryPlannerKit, initialPlan: LogicalPlan, qg: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan =
+  private def selectShortestPath(kit: QueryPlannerKit, initialPlan: LogicalPlan, qg: QueryGraph)
+                                (implicit context: LogicalPlanningContext): LogicalPlan =
     qg.shortestPathPatterns.foldLeft(kit.select(initialPlan, qg)) {
       case (plan, sp) if sp.isFindableFrom(plan.availableSymbols) =>
         val shortestPath = context.logicalPlanProducer.planShortestPaths(plan, sp)
@@ -98,10 +99,10 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
     // TODO: Investigate dropping leafPlanWeHopeToGetAwayWithIgnoring argument
     val leaves = leafPlanFinder(config, qg)
 
-    if (qg.patternRelationships.size > 0) {
+    if (qg.patternRelationships.nonEmpty) {
 
       val generators = solvers.map(_(qg))
-      val selectingGenerators = generators.map(_.map( plan => kit.select(plan, qg) ))
+      val selectingGenerators = generators.map(_.map(plan => kit.select(plan, qg)))
       val generator = selectingGenerators.foldLeft(IDPSolverStep.empty[PatternRelationship, LogicalPlan, LogicalPlanningContext])(_ ++ _)
 
       val solver = new IDPSolver[PatternRelationship, LogicalPlan, LogicalPlanningContext](
@@ -119,7 +120,9 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
       monitor.endIDPIterationFor(qg, component, result)
       result
     } else {
-      val solutionPlans = leaves.filter(plan => (qg.coveredIds -- plan.availableSymbols).isEmpty)
+      val solutionPlans = leaves collect {
+        case plan if (qg.coveredIds -- plan.availableSymbols).isEmpty => kit.select(plan, qg)
+      }
       val result = kit.pickBest(solutionPlans).getOrElse(throw new InternalException("Found no leaf plan for connected component.  This must not happen."))
       monitor.noIDPIterationFor(qg, component, result)
       result

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -56,39 +56,39 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
   extends QueryGraphSolver with PatternExpressionSolving {
 
   def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
-    implicit val kitFactory = (qg: QueryGraph) => kitWithShortestPathSupport(config.toKit(qg))
+    implicit val kit = kitWithShortestPathSupport(config.toKit())
     val components = queryGraph.connectedComponents
     val plans = if (components.isEmpty) planEmptyComponent(queryGraph) else planComponents(components)
 
-    implicit val kit = kitFactory.apply(queryGraph)
     val plansWithRemainingOptionalMatches = plans.map { (plan: LogicalPlan) => (plan, queryGraph.optionalMatches) }
     monitor.startConnectingComponents(queryGraph)
-    val result = connectComponents(plansWithRemainingOptionalMatches)
+    val result = connectComponents(plansWithRemainingOptionalMatches, queryGraph)
     monitor.endConnectingComponents(queryGraph, result)
     result
   }
 
   private def kitWithShortestPathSupport(kit: QueryPlannerKit)(implicit context: LogicalPlanningContext) =
-    kit.copy(select = selectShortestPath(kit, _))
+    kit.copy(select = (plan: LogicalPlan, qg: QueryGraph) => selectShortestPath(kit, plan, qg))
 
-  private def selectShortestPath(kit: QueryPlannerKit, initialPlan: LogicalPlan)(implicit context: LogicalPlanningContext): LogicalPlan =
-    kit.qg.shortestPathPatterns.foldLeft(kit.select(initialPlan)) {
-      case (plan, sp) if sp.isFindableFrom(plan.availableSymbols) => kit.select(context.logicalPlanProducer.planShortestPaths(plan, sp))
+  private def selectShortestPath(kit: QueryPlannerKit, initialPlan: LogicalPlan, qg: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan =
+    qg.shortestPathPatterns.foldLeft(kit.select(initialPlan, qg)) {
+      case (plan, sp) if sp.isFindableFrom(plan.availableSymbols) =>
+        val shortestPath = context.logicalPlanProducer.planShortestPaths(plan, sp)
+        kit.select(shortestPath, qg)
       case (plan, _) => plan
     }
 
-  private def planComponents(components: Seq[QueryGraph])(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kitFactory: (QueryGraph) => QueryPlannerKit): Seq[LogicalPlan] =
+  private def planComponents(components: Seq[QueryGraph])(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kit: QueryPlannerKit): Seq[LogicalPlan] =
     components.zipWithIndex.map { case (qg, component) =>
-      implicit val kit = kitFactory(qg)
       planComponent(qg, component)
     }
 
-  private def planEmptyComponent(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kitFactory: (QueryGraph) => QueryPlannerKit): Seq[LogicalPlan] = {
+  private def planEmptyComponent(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kit: QueryPlannerKit): Seq[LogicalPlan] = {
     val plan = if (queryGraph.argumentIds.isEmpty)
       context.logicalPlanProducer.planSingleRow()
     else
       context.logicalPlanProducer.planQueryArgumentRow(queryGraph)
-    val result: LogicalPlan = kitFactory(queryGraph).select(plan)
+    val result: LogicalPlan = kit.select(plan, queryGraph)
     monitor.emptyComponentPlanned(queryGraph, result)
     Seq(result)
   }
@@ -101,7 +101,7 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
     if (qg.patternRelationships.size > 0) {
 
       val generators = solvers.map(_(qg))
-      val selectingGenerators = generators.map(_.map(kit.select))
+      val selectingGenerators = generators.map(_.map( plan => kit.select(plan, qg) ))
       val generator = selectingGenerators.foldLeft(IDPSolverStep.empty[PatternRelationship, LogicalPlan, LogicalPlanningContext])(_ ++ _)
 
       val solver = new IDPSolver[PatternRelationship, LogicalPlan, LogicalPlanningContext](
@@ -129,7 +129,7 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
   private def initTable(qg: QueryGraph, kit: QueryPlannerKit, leaves: Set[LogicalPlan])(implicit context: LogicalPlanningContext) = {
     for (pattern <- qg.patternRelationships)
     yield {
-      val accessPlans = planSinglePattern(qg, pattern, leaves).map(kit.select)
+      val accessPlans = planSinglePattern(qg, pattern, leaves).map(plan => kit.select(plan, qg))
       val bestAccessor = kit.pickBest(accessPlans).getOrElse(throw new InternalException("Found no access plan for a pattern relationship in a connected component. This must not happen."))
       Set(pattern) -> bestAccessor
     }
@@ -152,7 +152,7 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
   }
 
   // TODO: Consider replacing with IDP loop
-  private def connectComponents(plans: Seq[(LogicalPlan, Seq[QueryGraph])])(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): LogicalPlan = {
+  private def connectComponents(plans: Seq[(LogicalPlan, Seq[QueryGraph])], queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): LogicalPlan = {
     @tailrec
     def recurse(plans: Seq[(LogicalPlan, Seq[QueryGraph])]): LogicalPlan = {
       if (plans.size == 1) {
@@ -162,14 +162,15 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
         resultPlan
       } else {
         val candidates = plans.map(applyApplicableOptionalMatches)
-        val cartesianProducts: Map[LogicalPlan, (Set[(LogicalPlan, Seq[QueryGraph])], Seq[QueryGraph])] = (for (
-          lhs @ (left, leftRemaining) <- candidates.iterator;
-          rhs @ (right, rightRemaining) <- candidates.iterator if left ne right;
-          remaining = if (leftRemaining.size < rightRemaining.size) leftRemaining else rightRemaining;
-          oldPlans = Set(lhs, rhs);
-          newPlan = kit.select(context.logicalPlanProducer.planCartesianProduct(left, right))
-        )
-        yield newPlan -> (oldPlans -> remaining)).toMap
+        val cartesianProducts: Map[LogicalPlan, (Set[(LogicalPlan, Seq[QueryGraph])], Seq[QueryGraph])] =
+          (for (
+            lhs@(left, leftRemaining) <- candidates.iterator;
+            rhs@(right, rightRemaining) <- candidates.iterator if left ne right;
+            remaining = if (leftRemaining.size < rightRemaining.size) leftRemaining else rightRemaining;
+            oldPlans = Set(lhs, rhs);
+            newPlan = kit.select(context.logicalPlanProducer.planCartesianProduct(left, right), queryGraph)
+          )
+            yield newPlan -> (oldPlans -> remaining)).toMap
         val bestCartesian = kit.pickBest(cartesianProducts.keys).get
         val (oldPlans, remaining) = cartesianProducts(bestCartesian)
         val newPlans = plans.filterNot(oldPlans.contains) :+ (bestCartesian -> remaining)
@@ -192,7 +193,10 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
 
     def withOptionalMatch(plan: LogicalPlan, optionalMatch: QueryGraph): Option[LogicalPlan] =
       if ((optionalMatch.argumentIds -- plan.availableSymbols).isEmpty) {
-        val candidates = config.optionalSolvers.flatMap { solver => solver(optionalMatch, plan) }
+        val candidates = config.optionalSolvers.flatMap {
+          solver =>
+            solver(optionalMatch, plan)
+        }
         val best = kit.pickBest(candidates)
         best
       } else {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -60,9 +60,8 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
     val components = queryGraph.connectedComponents
     val plans = if (components.isEmpty) planEmptyComponent(queryGraph) else planComponents(components)
 
-    val plansWithRemainingOptionalMatches = plans.map { (plan: LogicalPlan) => (plan, queryGraph.optionalMatches) }
     monitor.startConnectingComponents(queryGraph)
-    val result = connectComponents(plansWithRemainingOptionalMatches, queryGraph)
+    val result = connectComponentsAndSolveOptionalMatch(plans.toSet, queryGraph)
     monitor.endConnectingComponents(queryGraph, result)
     result
   }
@@ -154,58 +153,49 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
     }.flatten
   }
 
-  // TODO: Consider replacing with IDP loop
-  private def connectComponents(plans: Seq[(LogicalPlan, Seq[QueryGraph])], queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): LogicalPlan = {
-    @tailrec
-    def recurse(plans: Seq[(LogicalPlan, Seq[QueryGraph])]): LogicalPlan = {
-      if (plans.size == 1) {
-        val (resultPlan, leftOvers) = applyApplicableOptionalMatches(plans.head)
-        if (leftOvers.nonEmpty)
-          throw new InternalException(s"Failed to plan all optional matches:\n$leftOvers")
-        resultPlan
-      } else {
-        val candidates = plans.map(applyApplicableOptionalMatches)
-        val cartesianProducts: Map[LogicalPlan, (Set[(LogicalPlan, Seq[QueryGraph])], Seq[QueryGraph])] =
-          (for (
-            lhs@(left, leftRemaining) <- candidates.iterator;
-            rhs@(right, rightRemaining) <- candidates.iterator if left ne right;
-            remaining = if (leftRemaining.size < rightRemaining.size) leftRemaining else rightRemaining;
-            oldPlans = Set(lhs, rhs);
-            newPlan = kit.select(context.logicalPlanProducer.planCartesianProduct(left, right), queryGraph)
-          )
-            yield newPlan -> (oldPlans -> remaining)).toMap
-        val bestCartesian = kit.pickBest(cartesianProducts.keys).get
-        val (oldPlans, remaining) = cartesianProducts(bestCartesian)
-        val newPlans = plans.filterNot(oldPlans.contains) :+ (bestCartesian -> remaining)
-        recurse(newPlans)
-      }
+  private def connectComponentsAndSolveOptionalMatch(plans: Set[LogicalPlan], qg: QueryGraph)
+    (implicit context: LogicalPlanningContext, kit: QueryPlannerKit): LogicalPlan = {
+
+    def findBestCartesianProduct(plans: Set[LogicalPlan]): Set[LogicalPlan] = {
+
+      assert(plans.size > 1, "Can't build cartesian product with less than two input plans")
+
+      val allCrossProducts = (for (p1 <- plans; p2 <- plans if p1 != p2) yield {
+        val crossProduct = kit.select(context.logicalPlanProducer.planCartesianProduct(p1, p2), qg)
+        (crossProduct, (p1, p2))
+      }).toMap
+      val bestCartesian = kit.pickBest(allCrossProducts.keySet).get
+      val (p1, p2) = allCrossProducts(bestCartesian)
+
+      plans - p1 - p2 + bestCartesian
     }
 
     @tailrec
-    def applyApplicableOptionalMatches(todo: (LogicalPlan, Seq[QueryGraph])): (/* new plan*/ LogicalPlan, /* remaining */ Seq[QueryGraph]) = {
-      todo match {
-        case (plan, allRemaining @ Seq(nextOptional, nextRemaining@_*)) => withOptionalMatch(plan, nextOptional) match {
-          case Some(newPlan) => applyApplicableOptionalMatches(newPlan -> nextRemaining)
-          case None          => (plan, allRemaining)
-        }
+    def recurse(plans: Set[LogicalPlan], optionalMatches: Seq[QueryGraph]): (Set[LogicalPlan], Seq[QueryGraph]) = {
+      if (optionalMatches.nonEmpty) {
+        // If we have optional matches left to solve - start with that
+        val firstOptionalMatch = optionalMatches.head
+        val applicablePlan = plans.find(p => firstOptionalMatch.argumentIds subsetOf p.availableSymbols)
 
-        case done =>
-          done
-      }
+        applicablePlan match {
+          case Some(p) =>
+            val candidates = config.optionalSolvers.flatMap(solver => solver(firstOptionalMatch, p))
+            val best = kit.pickBest(candidates).get
+            recurse(plans - p + best, optionalMatches.tail)
+
+          case None =>
+            // If we couldn't find any optional match we can take on, produce the best cartesian product possible
+            recurse(findBestCartesianProduct(plans), optionalMatches)
+        }
+      } else if (plans.size > 1) {
+
+        recurse(findBestCartesianProduct(plans), optionalMatches)
+      } else (plans, optionalMatches)
     }
 
-    def withOptionalMatch(plan: LogicalPlan, optionalMatch: QueryGraph): Option[LogicalPlan] =
-      if ((optionalMatch.argumentIds -- plan.availableSymbols).isEmpty) {
-        val candidates = config.optionalSolvers.flatMap {
-          solver =>
-            solver(optionalMatch, plan)
-        }
-        val best = kit.pickBest(candidates)
-        best
-      } else {
-        None
-      }
-
-    recurse(plans)
+    val (resultingPlans, optionalMatches) = recurse(plans, qg.optionalMatches)
+    assert(resultingPlans.size == 1)
+    assert(optionalMatches.isEmpty)
+    resultingPlans.head
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/leafPlanOptions.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/leafPlanOptions.scala
@@ -26,11 +26,11 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{LogicalLea
 object leafPlanOptions extends LogicalLeafPlan.Finder {
 
   def apply(config: QueryPlannerConfiguration, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Set[LogicalPlan] = {
-    val kit = config.toKit(queryGraph)
+    val kit: QueryPlannerKit = config.toKit()
     val pickBest = config.pickBestCandidate(context)
 
     val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
-    val leafPlanCandidateListsWithSelections = leafPlanCandidateLists.map(_.map(kit.select))
+    val leafPlanCandidateListsWithSelections = kit.select(leafPlanCandidateLists, queryGraph)
     val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
     bestLeafPlans.toSet
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/leafPlanOptions.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/leafPlanOptions.scala
@@ -26,11 +26,11 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{LogicalLea
 object leafPlanOptions extends LogicalLeafPlan.Finder {
 
   def apply(config: QueryPlannerConfiguration, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Set[LogicalPlan] = {
-    val kit: QueryPlannerKit = config.toKit()
+    val queryPlannerKit = config.toKit()
     val pickBest = config.pickBestCandidate(context)
 
     val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
-    val leafPlanCandidateListsWithSelections = kit.select(leafPlanCandidateLists, queryGraph)
+    val leafPlanCandidateListsWithSelections = queryPlannerKit.select(leafPlanCandidateLists, queryGraph)
     val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
     bestLeafPlans.toSet
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -150,9 +150,11 @@ trait NewPlannerTestSupport extends CypherTestSupport {
 
   def executeWithAllPlanners(queryText: String, params: (String, Any)*): InternalExecutionResult = {
     val ruleResult = innerExecute(s"CYPHER planner=rule $queryText", params: _*)
+    val idpResult = innerExecute(s"CYPHER planner=idp $queryText", params: _*)
     val costResult = executeWithCostPlannerOnly(queryText, params: _*)
 
     assertResultsAreSame(ruleResult, costResult, queryText, "Diverging results between rule and cost planners")
+    assertResultsAreSame(idpResult, costResult, queryText, "Diverging results between IDP and greedy planner")
     ruleResult.close()
     costResult
   }


### PR DESCRIPTION
The query 

`MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p`

was making IDP blow up
