### PR TITLE
Fixes a recovery issue with legacy indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ community/neo4j-harness/data
 community/server-plugin-test/neo4j-home
 enterprise/server-enterprise/neo4j-home
 integrationtests/data
+Thumbs.db

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
@@ -70,6 +70,7 @@ public class RecoveryLegacyIndexApplierLookup implements LegacyIndexApplierLooku
     {
         private final String name;
         private int applyCount;
+        private boolean applied;
 
         RecoveryCommandHandler( String name, NeoCommandHandler applier )
         {
@@ -80,10 +81,10 @@ public class RecoveryLegacyIndexApplierLookup implements LegacyIndexApplierLooku
         @Override
         public void apply()
         {
+            assert !applied;
             if ( ++applyCount % batchSize == 0 )
             {
                 applyForReal();
-                appliers.remove( name );
             }
         }
 
@@ -94,12 +95,17 @@ public class RecoveryLegacyIndexApplierLookup implements LegacyIndexApplierLooku
         @Override
         public void close()
         {
-            super.close();
+            if ( applied )
+            {
+                super.close();
+            }
         }
 
         private void applyForReal()
         {
             super.apply();
+            appliers.remove( name );
+            applied = true;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
@@ -516,4 +516,10 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
     {
         type.add( statement.dataWriteOperations(), name, type.id( entity ), key, value );
     }
+
+    @Override
+    public String toString()
+    {
+        return "Index[" + type + ", " + name + "]";
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;
+import org.neo4j.kernel.impl.index.IndexCommand.AddRelationshipCommand;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
+import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
+import static org.neo4j.kernel.impl.util.IdOrderingQueue.BYPASS;
+
+public class LegacyIndexApplierTest
+{
+    public final @Rule LifeRule life = new LifeRule( true );
+    public final @Rule EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldOnlyCreateOneApplierPerProvider() throws Exception
+    {
+        // GIVEN
+        Map<String,Byte> names = MapUtil.<String,Byte> genericMap( "first", (byte) 0, "second", (byte) 1 );
+        Map<String,Byte> keys = MapUtil.<String,Byte> genericMap( "key", (byte) 0 );
+        String applierName = "test-applier";
+        IndexConfigStore config = newIndexConfigStore( names, applierName );
+        LegacyIndexApplierLookup applierLookup = mock( LegacyIndexApplierLookup.class );
+        when( applierLookup.newApplier( anyString(), anyBoolean() ) ).thenReturn( mock( NeoCommandHandler.class ) );
+        try ( LegacyIndexApplier applier = new LegacyIndexApplier( config, applierLookup, BYPASS, BASE_TX_ID, INTERNAL ) )
+        {
+            // WHEN
+            IndexDefineCommand definitions = definitions( names, keys );
+            applier.visitIndexDefineCommand( definitions );
+            applier.visitIndexAddNodeCommand( addNodeToIndex( definitions, "first" ) );
+            applier.visitIndexAddNodeCommand( addNodeToIndex( definitions, "second" ) );
+            applier.visitIndexAddRelationshipCommand( addRelationshipToIndex( definitions, "second" ) );
+            applier.apply();
+        }
+
+        // THEN
+        verify( applierLookup, times( 1 ) ).newApplier( eq( applierName ), anyBoolean() );
+    }
+
+    private static AddRelationshipCommand addRelationshipToIndex( IndexDefineCommand definitions, String indexName )
+    {
+        AddRelationshipCommand command = new AddRelationshipCommand();
+        command.init( definitions.getOrAssignIndexNameId( indexName ), 0L, (byte) 0, null, 1, 2 );
+        return command;
+    }
+
+    private static AddNodeCommand addNodeToIndex( IndexDefineCommand definitions, String indexName )
+    {
+        AddNodeCommand command = new AddNodeCommand();
+        command.init( definitions.getOrAssignIndexNameId( indexName ), 0L, (byte) 0, null );
+        return command;
+    }
+
+    private static IndexDefineCommand definitions( Map<String,Byte> names, Map<String,Byte> keys )
+    {
+        IndexDefineCommand definitions = new IndexDefineCommand();
+        definitions.init( names, keys );
+        return definitions;
+    }
+
+    private IndexConfigStore newIndexConfigStore( Map<String,Byte> names, String providerName )
+    {
+        File dir = new File( "conf" );
+        EphemeralFileSystemAbstraction fileSystem = fs.get();
+        fileSystem.mkdirs( dir );
+        IndexConfigStore store = life.add( new IndexConfigStore( dir, fileSystem ) );
+        for ( Map.Entry<String,Byte> name : names.entrySet() )
+        {
+            store.set( Node.class, name.getKey(), stringMap( IndexManager.PROVIDER, providerName ) );
+            store.set( Relationship.class, name.getKey(), stringMap( IndexManager.PROVIDER, providerName ) );
+        }
+        return store;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/LifeRule.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/lifecycle/LifeRule.java
@@ -25,6 +25,18 @@ import org.junit.runners.model.Statement;
 
 public class LifeRule extends LifeSupport implements TestRule
 {
+    private final boolean autoStart;
+
+    public LifeRule()
+    {
+        this( false );
+    }
+
+    public LifeRule( boolean autoStart )
+    {
+        this.autoStart = autoStart;
+    }
+
     @Override
     public Statement apply( final Statement base, Description description )
     {
@@ -35,6 +47,10 @@ public class LifeRule extends LifeSupport implements TestRule
             {
                 try
                 {
+                    if ( autoStart )
+                    {
+                        start();
+                    }
                     base.evaluate();
                 }
                 catch ( Throwable failure )

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/CommitContext.java
@@ -110,7 +110,7 @@ class CommitContext implements Closeable
     public void close() throws IOException
     {
         applyDocuments( writer, indexType, documents );
-        if ( writer != null && !recovery )
+        if ( writer != null )
         {
             dataSource.invalidateIndexSearcher( identifier );
         }
@@ -131,6 +131,12 @@ class CommitContext implements Closeable
             this.document = document;
             this.exists = exists;
             this.entityId = entityId;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "DocumentContext[document=" + document + ", exists=" + exists + ", entityId=" + entityId + "]";
         }
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -205,7 +205,6 @@ public class LuceneDataSource implements Lifecycle
         {
             try
             {
-                index.setStale();
                 index.getWriter().commit();
             }
             catch ( IOException e )

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneCommandApplierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneCommandApplierTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.helpers.Settings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.index.impl.lucene.LuceneIndexImplementation.EXACT_CONFIG;
+
+public class LuceneCommandApplierTest
+{
+    public final @Rule EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    public final @Rule LifeRule life = new LifeRule( true );
+    private final File dir = new File( "dir" );
+
+    @Test
+    public void shouldHandleMultipleIdSpaces() throws Exception
+    {
+        // GIVEN
+        fs.get().mkdirs( dir );
+        String indexName = "name", key = "key";
+        IndexConfigStore configStore = new IndexConfigStore( dir, fs.get() );
+        configStore.set( Node.class, indexName, EXACT_CONFIG );
+        LuceneDataSource dataSource = life.add( spy( new LuceneDataSource( new Config( stringMap(
+                LuceneDataSource.Configuration.store_dir.name(), dir.getAbsolutePath(),
+                LuceneDataSource.Configuration.ephemeral.name(), Settings.TRUE ) ),
+                configStore, fs.get() ) ) );
+
+        try ( LuceneCommandApplier applier = new LuceneCommandApplier( dataSource, false ) )
+        {
+            // WHEN issuing a command where the index name is mapped to a certain id
+            IndexDefineCommand definitions = definitions(
+                    MapUtil.<String,Byte>genericMap( indexName, (byte) 0 ),
+                    MapUtil.<String,Byte>genericMap( key, (byte) 0 ) );
+            applier.visitIndexDefineCommand( definitions );
+            applier.visitIndexAddNodeCommand( addNodeToIndex( definitions, indexName, 0L ) );
+            // and then later issuing a command for that same index, but in another transaction where
+            // the local index name id is a different one
+            definitions = definitions(
+                    MapUtil.<String,Byte>genericMap( indexName, (byte) 1 ),
+                    MapUtil.<String,Byte>genericMap( key, (byte) 0 ) );
+            applier.visitIndexDefineCommand( definitions );
+            applier.visitIndexAddNodeCommand( addNodeToIndex( definitions, indexName, 1L ) );
+            applier.apply();
+        }
+
+        // THEN both those updates should have been directed to the same index
+        verify( dataSource, times( 1 ) ).getIndexSearcher( any( IndexIdentifier.class ) );
+    }
+
+    private static AddNodeCommand addNodeToIndex( IndexDefineCommand definitions, String indexName, long nodeId )
+    {
+        AddNodeCommand command = new AddNodeCommand();
+        command.init( definitions.getOrAssignIndexNameId( indexName ), nodeId, (byte) 0, "some value" );
+        return command;
+    }
+
+    private static IndexDefineCommand definitions( Map<String,Byte> names, Map<String,Byte> keys )
+    {
+        IndexDefineCommand definitions = new IndexDefineCommand();
+        definitions.init( names, keys );
+        return definitions;
+    }
+}


### PR DESCRIPTION
Where updates could go to the wrong index. This was introduced by a recent
change where commits were batched during recovery. The core of the problem
was that index name ids are transaction-local, but was treated as global,
which became a problem for appliers that used the index name id as key to
redirect updates to the right indexes.

Also previously there were one applier created for every index, even
though legacy index appliers are designed to handle multiple indexes each.
This has been fixed.
