### PR TITLE
Properly propagate exceptions and stack traces

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherException.scala
@@ -33,91 +33,93 @@ abstract class CypherException(message: String, cause: Throwable) extends Runtim
 }
 
 class UniquePathNotUniqueException(message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.uniquePathNotUniqueException(message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.uniquePathNotUniqueException(message, this)
 }
 
 class FailedIndexException(indexName: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.failedIndexException(indexName)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.failedIndexException(indexName, this)
 }
 
 class EntityNotFoundException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.entityNotFoundException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.entityNotFoundException(message, this)
 }
 
 class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.cypherTypeException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.cypherTypeException(message, this)
 }
 
 class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(cause) {
   def this(message: String) = this(message, null)
 
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterNotFoundException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterNotFoundException(message, this)
 }
 
 class ParameterWrongTypeException(message: String, cause: Throwable) extends CypherException(cause) {
   def this(message: String) = this(message, null)
 
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterWrongTypeException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterWrongTypeException(message, this)
 }
 
 class InvalidArgumentException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidArgumentException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidArgumentException(message, this)
 }
 
 class PatternException(message: String) extends CypherException(message) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.patternException(message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.patternException(message, this)
 }
 
 class InternalException(message: String, inner: Exception = null) extends CypherException(message, inner) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.internalException(message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.internalException(message, this)
 }
 
 class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.nodeStillHasRelationshipsException(nodeId, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.nodeStillHasRelationshipsException(nodeId, this)
 }
 
 class ProfilerStatisticsNotReadyException extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.profilerStatisticsNotReadyException()
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.profilerStatisticsNotReadyException(this)
 }
 
 class UnknownLabelException(labelName: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.unknownLabelException(labelName)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.unknownLabelException(labelName, this)
 }
 
 class IndexHintException(identifier: String, label: String, property: String, message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.indexHintException(identifier, label, property, message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.indexHintException(identifier, label, property, message, this)
 }
 
 class LabelScanHintException(identifier: String, label: String, message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.labelScanHintException(identifier, label, message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.labelScanHintException(identifier, label, message, this)
 }
 
 class InvalidSemanticsException(message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidSemanticException(message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidSemanticException(message, this)
 }
 
 class MergeConstraintConflictException(message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.mergeConstraintConflictException(message)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.mergeConstraintConflictException(message, this)
 }
 
 class ArithmeticException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.arithmeticException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.arithmeticException(message, this)
 }
 
 class IncomparableValuesException(lhs: String, rhs: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.incomparableValuesException(lhs, rhs)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.incomparableValuesException(lhs, rhs, this)
 }
 
 class PeriodicCommitInOpenTransactionException extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.periodicCommitInOpenTransactionException()
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.periodicCommitInOpenTransactionException(this)
 }
 
 class LoadExternalResourceException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.loadExternalResourceException(message, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.loadExternalResourceException(message, this)
 }
 
 class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException) extends CypherException(cause) {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.loadCsvStatusWrapCypherException(extraInfo, cause)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    // the mapper will map the cause here, so we cannot pass 'this' in as the cause...
+    mapper.loadCsvStatusWrapCypherException(extraInfo, cause)
 }
 
 class SyntaxException(message: String, val query: String, val offset: Option[Int]) extends CypherException(message) {
@@ -125,11 +127,11 @@ class SyntaxException(message: String, val query: String, val offset: Option[Int
 
   def this(message: String) = this(message, "", None)
 
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.syntaxException(message, query, offset)
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.syntaxException(message, query, offset, this)
 }
 
 class CypherExecutionException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.cypherExecutionException(message, cause)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.cypherExecutionException(message, this)
 }
 
 object IndexHintException {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ErrorReportingExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/ErrorReportingExecutablePlanBuilder.scala
@@ -29,6 +29,6 @@ case class ErrorReportingExecutablePlanBuilder(inner: ExecutablePlanBuilder) ext
       inner.producePlan(inputQuery, planContext)
     } catch {
       case e: CantHandleQueryException =>
-        throw new InvalidArgumentException("The given query is not supported at the moment in the selected cost-based planner")
+        throw new InvalidArgumentException("The given query is not supported at the moment in the selected cost-based planner", e)
     }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/MapToPublicExceptions.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/MapToPublicExceptions.scala
@@ -22,37 +22,37 @@ package org.neo4j.cypher.internal.compiler.v2_3.spi
 import org.neo4j.cypher.internal.compiler.v2_3.CypherException
 
 trait MapToPublicExceptions[T <: Throwable] {
-  def failedIndexException(indexName: String): T
+  def failedIndexException(indexName: String, cause: Throwable): T
 
-  def periodicCommitInOpenTransactionException(): T
+  def periodicCommitInOpenTransactionException(cause: Throwable): T
 
-  def syntaxException(message: String, query: String, offset: Option[Int]): T
+  def syntaxException(message: String, query: String, offset: Option[Int], cause: Throwable): T
 
   def loadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException): T
 
   def loadExternalResourceException(message: String, cause: Throwable): T
 
-  def incomparableValuesException(lhs: String, rhs: String): T
+  def incomparableValuesException(lhs: String, rhs: String, cause: Throwable): T
 
   def arithmeticException(message: String, cause: Throwable): T
 
-  def mergeConstraintConflictException(message: String): T
+  def mergeConstraintConflictException(message: String, cause: Throwable): T
 
-  def invalidSemanticException(message: String): T
+  def invalidSemanticException(message: String, cause: Throwable): T
 
-  def indexHintException(identifier: String, label: String, property: String, message: String): T
+  def indexHintException(identifier: String, label: String, property: String, message: String, cause: Throwable): T
 
-  def labelScanHintException(identifier: String, label: String, message: String): T
+  def labelScanHintException(identifier: String, label: String, message: String, cause: Throwable): T
 
-  def unknownLabelException(s: String): T
+  def unknownLabelException(s: String, cause: Throwable): T
 
-  def profilerStatisticsNotReadyException(): T
+  def profilerStatisticsNotReadyException(cause: Throwable): T
 
   def nodeStillHasRelationshipsException(nodeId: Long, cause: Throwable): T
 
-  def internalException(message: String): T
+  def internalException(message: String, cause: Exception): T
 
-  def patternException(message: String): T
+  def patternException(message: String, cause: Throwable): T
 
   def invalidArgumentException(message: String, cause: Throwable): T
 
@@ -60,7 +60,7 @@ trait MapToPublicExceptions[T <: Throwable] {
 
   def parameterNotFoundException(message: String, cause: Throwable): T
 
-  def uniquePathNotUniqueException(message: String): T
+  def uniquePathNotUniqueException(message: String, cause: Throwable): T
 
   def entityNotFoundException(message: String, cause: Throwable): T
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -24,7 +24,6 @@ import org.neo4j.kernel.api.exceptions.{KernelException, Status}
 abstract class CypherException(message: String, cause: Throwable) extends RuntimeException(message, cause)
 with Status.HasStatus {
   def status: Status
-  def this(message: String) = this(message, null)
 }
 
 class CypherExecutionException(message: String, cause: Throwable) extends CypherException(message, cause) {
@@ -35,7 +34,7 @@ class CypherExecutionException(message: String, cause: Throwable) extends Cypher
   }
 }
 
-class UniquePathNotUniqueException(message: String) extends CypherException(message) {
+class UniquePathNotUniqueException(message: String, cause:Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.ConstraintViolation
 }
 
@@ -48,14 +47,10 @@ class CypherTypeException(message: String, cause: Throwable = null) extends Cyph
 }
 
 class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  def this(message: String) = this(message, null)
-
   val status = Status.Statement.ParameterMissing
 }
 
 class ParameterWrongTypeException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  def this(message: String) = this(message, null)
-
   val status = Status.Statement.InvalidType
 }
 
@@ -63,23 +58,25 @@ class InvalidArgumentException(message: String, cause: Throwable = null) extends
   val status = Status.Statement.InvalidArguments
 }
 
-class PatternException(message: String) extends CypherException(message, null) {
+class PatternException(message: String, cause: Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.InvalidSemantics
+  def this(message: String) = this(message,null)
 }
 
 class InternalException(message: String, inner: Exception = null) extends CypherException(message, inner) {
   val status = Status.Statement.ExecutionFailure
 }
 
-class MissingIndexException(indexName: String) extends CypherException("Index `" + indexName + "` does not exist") {
+class MissingIndexException(indexName: String) extends CypherException("Index `" + indexName + "` does not exist", null) {
   val status = Status.Schema.NoSuchIndex
 }
 
-class FailedIndexException(indexName: String) extends CypherException("Index `" + indexName + "` has failed. Drop and recreate it to get it back online.") {
+class FailedIndexException(indexName: String, cause: Throwable) extends CypherException("Index `" + indexName + "` has failed. Drop and recreate it to get it back online.", cause) {
   val status = Status.General.FailedIndex
+  def this(indexName: String) = this(indexName, null)
 }
 
-class MissingConstraintException() extends CypherException("Constraint not found") {
+class MissingConstraintException(cause: Throwable) extends CypherException("Constraint not found", cause) {
   val status = Status.Schema.NoSuchConstraint
 }
 
@@ -88,51 +85,53 @@ class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable)
   val status = Status.Schema.ConstraintViolation
 }
 
-class ProfilerStatisticsNotReadyException() extends CypherException("This result has not been materialised yet. Iterate over it to get profiler stats.") {
+class ProfilerStatisticsNotReadyException(cause: Throwable) extends CypherException("This result has not been materialised yet. Iterate over it to get profiler stats.", cause) {
   val status = Status.Statement.ExecutionFailure
+  def this() = this(null)
 }
 
-class UnknownLabelException(labelName: String) extends CypherException(s"The provided label :`$labelName` does not exist in the store") {
+class UnknownLabelException(labelName: String, cause: Throwable) extends CypherException(s"The provided label :`$labelName` does not exist in the store", cause) {
   val status = Status.Statement.NoSuchLabel
+  def this(labelName: String) = this(labelName, null)
 }
 
-class IndexHintException(identifier: String, label: String, property: String, message: String)
-  extends CypherException(s"$message\nLabel: `$label`\nProperty name: `$property`") {
+class IndexHintException(identifier: String, label: String, property: String, message: String, cause: Throwable)
+  extends CypherException(s"$message\nLabel: `$label`\nProperty name: `$property`", cause) {
   val status = Status.Schema.NoSuchIndex
+  def this(identifier: String, label: String, property: String, message: String) = this(identifier, label, property, message, null)
 }
 
-class LabelScanHintException(identifier: String, label: String, message: String)
-  extends CypherException(s"$message\nLabel: `$label`") {
+class LabelScanHintException(identifier: String, label: String, message: String, cause: Throwable)
+  extends CypherException(s"$message\nLabel: `$label`", cause) {
   val status = Status.Statement.InvalidSemantics
+  def this(identifier: String, label: String, message: String) = this(identifier, label, message, null)
 }
 
-class UnableToPickStartPointException(message: String) extends CypherException(message) {
-  val status = Status.Statement.ExecutionFailure
-}
-
-class InvalidSemanticsException(message: String) extends CypherException(message) {
+class InvalidSemanticsException(message: String, cause: Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.InvalidSemantics
+  def this(message: String) = this(message,null)
 }
 
-class OutOfBoundsException(message: String) extends CypherException(message) {
-  val status = Status.Statement.InvalidArguments
-}
-
-class MergeConstraintConflictException(message: String) extends CypherException(message) {
+class MergeConstraintConflictException(message: String, cause: Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.ConstraintViolation
+  def this(message: String) = this(message, null)
 }
 
-class ArithmeticException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
+class ArithmeticException(message: String, cause: Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.ArithmeticError
 }
 
-class IncomparableValuesException(lhs: String, rhs: String)
-  extends SyntaxException(s"Don't know how to compare that. Left: ${lhs}; Right: ${rhs}")
+class IncomparableValuesException(lhs: String, rhs: String, cause: Throwable)
+  extends SyntaxException(s"Don't know how to compare that. Left: ${lhs}; Right: ${rhs}", cause) {
+  def this(lhs: String, rhs: String) = this(lhs, rhs, null)
+}
 
-class PeriodicCommitInOpenTransactionException
-  extends InvalidSemanticsException("Executing queries that use periodic commit in an open transaction is not possible.")
+class PeriodicCommitInOpenTransactionException(cause: Throwable)
+  extends InvalidSemanticsException("Executing queries that use periodic commit in an open transaction is not possible.", cause) {
+  def this() = this(null)
+}
 
-class LoadExternalResourceException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
+class LoadExternalResourceException(message: String, cause: Throwable) extends CypherException(message, cause) {
   val status = Status.Statement.ExternalResourceFailure
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/SyntaxException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/SyntaxException.scala
@@ -22,9 +22,11 @@ package org.neo4j.cypher
 import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.kernel.api.exceptions.Status
 
-class SyntaxException(message: String, val query:String,  val offset: Option[Int]) extends CypherException(message, null) {
-  def this(message: String, query:String, offset: Int) = this(message,query,Some(offset))
-  def this(message:String) = this(message,"",None)
+class SyntaxException(message: String, val query:String,  val offset: Option[Int], cause: Throwable) extends CypherException(message, cause) {
+  def this(message: String, query:String, offset: Option[Int]) = this(message,query,offset,null)
+  def this(message: String, query:String, offset: Int) = this(message,query,Some(offset),null)
+  def this(message:String, cause: Throwable) = this(message,"",None, cause)
+  def this(message:String) = this(message,"",None,null)
 
   override def toString = offset match {
     case Some(idx) =>message + "\n" + findErrorLine(idx, query.split('\n').toList)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -73,8 +73,6 @@ object exceptionHandlerFor2_2 extends MapToPublicExceptions[CypherException] {
 
   def internalException(message: String) = new InternalException(message)
 
-  def missingConstraintException() = new MissingConstraintException
-
   def loadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException_v2_2) =
     new LoadCsvStatusWrapCypherException(extraInfo, cause.mapToPublic(exceptionHandlerFor2_2))
 
@@ -82,7 +80,7 @@ object exceptionHandlerFor2_2 extends MapToPublicExceptions[CypherException] {
 
   def parameterNotFoundException(message: String, cause: Throwable) = throw new ParameterNotFoundException(message, cause)
 
-  def uniquePathNotUniqueException(message: String) = throw new UniquePathNotUniqueException(message)
+  def uniquePathNotUniqueException(message: String) = throw new UniquePathNotUniqueException(message, null)
 
   def entityNotFoundException(message: String, cause: Throwable) = throw new EntityNotFoundException(message, cause)
 
@@ -93,8 +91,6 @@ object exceptionHandlerFor2_2 extends MapToPublicExceptions[CypherException] {
   def invalidSemanticException(message: String) = throw new InvalidSemanticsException(message)
 
   def parameterWrongTypeException(message: String, cause: Throwable) = throw new ParameterWrongTypeException(message, cause)
-
-  def outOfBoundsException(message: String) = throw new OutOfBoundsException(message)
 
   def nodeStillHasRelationshipsException(nodeId: Long, cause: Throwable) = throw new NodeStillHasRelationshipsException(nodeId, cause)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -55,27 +55,25 @@ object helpersv2_3 {
 }
 
 object exceptionHandlerFor2_3 extends MapToPublicExceptions[CypherException] {
-  def syntaxException(message: String, query: String, offset: Option[Int]) = new SyntaxException(message, query, offset)
+  def syntaxException(message: String, query: String, offset: Option[Int], cause: Throwable) = new SyntaxException(message, query, offset, cause)
 
   def arithmeticException(message: String, cause: Throwable) = new ArithmeticException(message, cause)
 
-  def profilerStatisticsNotReadyException() = {
-    throw new ProfilerStatisticsNotReadyException()
+  def profilerStatisticsNotReadyException(cause: Throwable) = {
+    throw new ProfilerStatisticsNotReadyException(cause)
   }
 
-  def incomparableValuesException(lhs: String, rhs: String) = new IncomparableValuesException(lhs, rhs)
+  def incomparableValuesException(lhs: String, rhs: String, cause: Throwable) = new IncomparableValuesException(lhs, rhs, cause)
 
-  def unknownLabelException(s: String) = new UnknownLabelException(s)
+  def unknownLabelException(s: String, cause: Throwable) = new UnknownLabelException(s, cause)
 
-  def patternException(message: String) = new PatternException(message)
+  def patternException(message: String, cause: Throwable) = new PatternException(message, cause)
 
   def invalidArgumentException(message: String, cause: Throwable) = new InvalidArgumentException(message, cause)
 
-  def mergeConstraintConflictException(message: String) = new MergeConstraintConflictException(message)
+  def mergeConstraintConflictException(message: String, cause: Throwable) = new MergeConstraintConflictException(message, cause)
 
-  def internalException(message: String) = new InternalException(message)
-
-  def missingConstraintException() = new MissingConstraintException
+  def internalException(message: String, cause: Exception) = new InternalException(message, cause)
 
   def loadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException_v2_3) =
     new LoadCsvStatusWrapCypherException(extraInfo, cause.mapToPublic(exceptionHandlerFor2_3))
@@ -84,7 +82,7 @@ object exceptionHandlerFor2_3 extends MapToPublicExceptions[CypherException] {
 
   def parameterNotFoundException(message: String, cause: Throwable) = throw new ParameterNotFoundException(message, cause)
 
-  def uniquePathNotUniqueException(message: String) = throw new UniquePathNotUniqueException(message)
+  def uniquePathNotUniqueException(message: String, cause: Throwable) = throw new UniquePathNotUniqueException(message, cause)
 
   def entityNotFoundException(message: String, cause: Throwable) = throw new EntityNotFoundException(message, cause)
 
@@ -92,21 +90,19 @@ object exceptionHandlerFor2_3 extends MapToPublicExceptions[CypherException] {
 
   def cypherExecutionException(message: String, cause: Throwable) = throw new CypherExecutionException(message, cause)
 
-  def labelScanHintException(identifier: String, label: String, message: String) = throw new LabelScanHintException(identifier, label, message)
+  def labelScanHintException(identifier: String, label: String, message: String, cause: Throwable) = throw new LabelScanHintException(identifier, label, message, cause)
 
-  def invalidSemanticException(message: String) = throw new InvalidSemanticsException(message)
+  def invalidSemanticException(message: String, cause: Throwable) = throw new InvalidSemanticsException(message, cause)
 
   def parameterWrongTypeException(message: String, cause: Throwable) = throw new ParameterWrongTypeException(message, cause)
 
-  def outOfBoundsException(message: String) = throw new OutOfBoundsException(message)
-
   def nodeStillHasRelationshipsException(nodeId: Long, cause: Throwable) = throw new NodeStillHasRelationshipsException(nodeId, cause)
 
-  def indexHintException(identifier: String, label: String, property: String, message: String) = throw new IndexHintException(identifier, label, property, message)
+  def indexHintException(identifier: String, label: String, property: String, message: String, cause: Throwable) = throw new IndexHintException(identifier, label, property, message, cause)
 
-  def periodicCommitInOpenTransactionException() = throw new PeriodicCommitInOpenTransactionException
+  def periodicCommitInOpenTransactionException(cause: Throwable) = throw new PeriodicCommitInOpenTransactionException(cause)
 
-  def failedIndexException(indexName: String): CypherException = throw new FailedIndexException(indexName)
+  def failedIndexException(indexName: String, cause: Throwable): CypherException = throw new FailedIndexException(indexName, cause)
 
   def runSafely[T](body: => T)(implicit f: Throwable => Unit = (_) => ()) = {
     try {

--- a/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/CypherDocIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.server.rest;
 
+import org.junit.Test;
+
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.Map;
 import javax.ws.rs.core.Response.Status;
-
-import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -44,12 +44,12 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.server.rest.domain.JsonHelper.jsonToMap;
 
 public class CypherDocIT extends AbstractRestFunctionalTestBase {
@@ -391,7 +391,8 @@ public class CypherDocIT extends AbstractRestFunctionalTestBase {
         String response = cypherRestCall( script, Status.BAD_REQUEST, Pair.of( "startName", "I" ), Pair.of( "name", "you" ) );
 
         Map<String, Object> responseMap = jsonToMap( response );
-        assertEquals( 5, responseMap.size() );
+        assertThat( responseMap.keySet(), containsInAnyOrder(
+                "message", "exception", "fullname", "stackTrace", "cause", "errors" ) );
         assertThat( response, containsString( "message" ) );
         assertThat( ((String) responseMap.get( "message" )), containsString( "frien not defined" ) );
     }


### PR DESCRIPTION
The exception translation code would throw away intermediate exceptions, making it hard to follow the stack traces. This change resolves that, ensuring that all exceptions propagate, making it easier to find the root cause of exceptions.
