### PR TITLE
Fix HPC array size heuristics bug on very large heaps

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HighPerformanceCache.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/cache/HighPerformanceCache.java
@@ -88,10 +88,11 @@ public class HighPerformanceCache<E extends EntityWithSizeObject> extends Cache.
                             + arrayHeapFraction + "%" );
         }
         long memToUse = (long)(((double)arrayHeapFraction) * Runtime.getRuntime().maxMemory() / 100);
-        long maxElementCount = (int) ( memToUse / 8 );
+        int bytesPerElementFactor = 8;
+        long maxElementCount = (int) (memToUse / bytesPerElementFactor);
         if ( memToUse > Integer.MAX_VALUE )
         {
-            maxElementCount = Integer.MAX_VALUE;
+            maxElementCount = Integer.MAX_VALUE / bytesPerElementFactor;
         }
         if ( maxSizeInBytes < MIN_SIZE )
         {


### PR DESCRIPTION
- Fixes an issue where a sufficiently large JVM heap size could cause the HPC
  heuristics to allocate an array for the cache that was 8 times larger than
  intended, running into JVM array allocation limitations.

Please review, @tinwelint 
