### PR TITLE
Builds label scan store in parallel with the node store during import

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import static java.lang.reflect.Modifier.isStatic;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+
 /**
  * Common implementations of {@link Extractor}. Since array values can have a delimiter of user choice this isn't
  * an enum, but a regular class with a constructor where that delimiter can be specified.
@@ -765,8 +767,6 @@ public class Extractors
 
     private static class LongArrayExtractor extends ArrayExtractor<long[]>
     {
-        private static final long[] EMPTY = new long[0];
-
         LongArrayExtractor( char arrayDelimiter )
         {
             super( arrayDelimiter, Long.TYPE );
@@ -776,7 +776,7 @@ public class Extractors
         protected void extract0( char[] data, int offset, int length )
         {
             int numberOfValues = numberOfValues( data, offset, length );
-            value = numberOfValues > 0 ? new long[numberOfValues] : EMPTY;
+            value = numberOfValues > 0 ? new long[numberOfValues] : EMPTY_LONG_ARRAY;
             for ( int arrayIndex = 0, charIndex = 0; arrayIndex < numberOfValues; arrayIndex++, charIndex++ )
             {
                 int numberOfChars = charsToNextDelimiter( data, offset+charIndex, length-charIndex );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -71,7 +71,7 @@ public class QuickImport
         String dir = args.get( ImportTool.Options.STORE_DIR.key() );
 
         Extractors extractors = new Extractors( COMMAS.arrayDelimiter() );
-        IdType idType = IdType.ACTUAL;
+        IdType idType = IdType.valueOf( args.get( "id-type", IdType.ACTUAL.name() ) );
 
         Header nodeHeader = parseNodeHeader( args, idType, extractors );
         Header relationshipHeader = parseRelationshipHeader( args, idType, extractors );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/NodePropertyUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/NodePropertyUpdate.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.api.index.UpdateMode;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.kernel.impl.api.index.UpdateMode.ADDED;
 import static org.neo4j.kernel.impl.api.index.UpdateMode.CHANGED;
 import static org.neo4j.kernel.impl.api.index.UpdateMode.REMOVED;
@@ -215,8 +216,6 @@ public class NodePropertyUpdate
         }
         return a.equals( b );
     }
-
-    public static final long[] EMPTY_LONG_ARRAY = new long[0];
 
     public static NodePropertyUpdate add( long nodeId, int propertyKeyId, Object value, long[] labels )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static java.lang.Integer.MAX_VALUE;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 import static org.neo4j.kernel.extension.KernelExtensionUtil.servicesClassPathEntryInformation;
 
@@ -126,7 +127,6 @@ public class LabelScanStoreProvider extends LifecycleAdapter implements Comparab
             {
                 return new PrefetchingIterator<NodeLabelUpdate>()
                 {
-                    private final long[] NO_LABELS = new long[0];
                     private final NodeStore nodeStore = neoStoreProvider.evaluate().getNodeStore();
                     private final long highId = nodeStore.getHighestPossibleIdInUse();
                     private long current;
@@ -142,7 +142,7 @@ public class LabelScanStoreProvider extends LifecycleAdapter implements Comparab
                                 long[] labels = NodeLabelsField.parseLabelsField( node ).get( nodeStore );
                                 if ( labels.length > 0 )
                                 {
-                                    return NodeLabelUpdate.labelChanges( node.getId(), NO_LABELS, labels );
+                                    return NodeLabelUpdate.labelChanges( node.getId(), EMPTY_LONG_ARRAY, labels );
                                 }
                             }
                         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.impl.util.Bits;
 import static java.lang.Long.highestOneBit;
 import static java.lang.String.format;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.kernel.impl.store.LabelIdArray.concatAndSort;
 import static org.neo4j.kernel.impl.store.LabelIdArray.filter;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsBody;
@@ -38,7 +39,6 @@ import static org.neo4j.kernel.impl.util.Bits.bitsFromLongs;
 
 public class InlineNodeLabels implements NodeLabels
 {
-    private static final long[] NO_LABELS = new long[0];
     private static final int LABEL_BITS = 36;
     private final long labelField;
     private final NodeRecord node;
@@ -144,7 +144,7 @@ public class InlineNodeLabels implements NodeLabels
         byte numberOfLabels = labelCount( labelField );
         if ( numberOfLabels == 0 )
         {
-            return NO_LABELS;
+            return EMPTY_LONG_ARRAY;
         }
 
         long existingLabelsField = parseLabelsBody( labelField );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/LabelChangeSummary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/LabelChangeSummary.java
@@ -22,10 +22,10 @@ package org.neo4j.kernel.impl.transaction.state;
 import static java.util.Arrays.binarySearch;
 import static java.util.Arrays.copyOf;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+
 public class LabelChangeSummary
 {
-    private static final long[] NO_LABELS = new long[0];
-
     private final long[] addedLabels;
     private final long[] removedLabels;
     private final long[] unchangedLabels;
@@ -66,7 +66,7 @@ public class LabelChangeSummary
     {
         if ( toLength == 0 )
         {
-            return NO_LABELS;
+            return EMPTY_LONG_ARRAY;
         }
         return array.length == toLength ? array : copyOf( array, toLength );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreIndexStoreView.java
@@ -51,7 +51,7 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.register.Register.DoubleLongRegister;
 
-import static org.neo4j.kernel.api.index.NodePropertyUpdate.EMPTY_LONG_ARRAY;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
@@ -45,6 +45,7 @@ public class Batch<INPUT,RECORD extends PrimitiveRecord>
     public long[] ids;
     public boolean parallelizableWithPrevious;
     public long firstRecordId;
+    public long[][] labels;
 
     public Batch( INPUT[] input )
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/LabelScanStorePopulationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/LabelScanStorePopulationStep.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.batchinsert.LabelScanWriter;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
+
+/**
+ * Populates a {@link LabelScanWriter} with all node labels from {@link Batch batches} passing by.
+ */
+public class LabelScanStorePopulationStep extends ProcessorStep<Batch<InputNode,NodeRecord>>
+{
+    private final LabelScanWriter writer;
+
+    public LabelScanStorePopulationStep( StageControl control, Configuration config, LabelScanStore labelScanStore )
+    {
+        super( control, "LABEL SCAN", config, 1 );
+        this.writer = labelScanStore.newWriter();
+    }
+
+    @Override
+    protected void process( Batch<InputNode,NodeRecord> batch, BatchSender sender ) throws Throwable
+    {
+        int length = batch.labels.length;
+        for ( int i = 0; i < length; i++ )
+        {
+            long[] labels = batch.labels[i];
+            NodeRecord node = batch.records[i];
+            if ( labels != null && node.inUse() )
+            {
+                writer.write( labelChanges( node.getId(), EMPTY_LONG_ARRAY, labels ) );
+            }
+        }
+        sender.send( batch );
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        super.close();
+        writer.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStep.java
@@ -65,6 +65,7 @@ public final class NodeEncoderStep extends ProcessorStep<Batch<InputNode,NodeRec
     {
         InputNode[] input = batch.input;
         batch.records = new NodeRecord[input.length];
+        batch.labels = new long[input.length][];
         for ( int i = 0; i < input.length; i++ )
         {
             InputNode batchNode = input[i];
@@ -86,7 +87,7 @@ public final class NodeEncoderStep extends ProcessorStep<Batch<InputNode,NodeRec
             }
             else
             {
-                long[] labels = labelHolder.getOrCreateIds( batchNode.labels() );
+                long[] labels = batch.labels[i] = labelHolder.getOrCreateIds( batchNode.labels() );
                 InlineNodeLabels.putSorted( nodeRecord, labels, null, nodeStore.getDynamicLabelStore() );
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -44,7 +45,8 @@ public class NodeStage extends Stage
 {
     public NodeStage( Configuration config, IoMonitor writeMonitor, WriterFactory writerFactory,
             InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
-            BatchingNeoStore neoStore, InputCache inputCache, StatsProvider memoryUsage ) throws IOException
+            BatchingNeoStore neoStore, InputCache inputCache, LabelScanStore labelScanStore,
+            StatsProvider memoryUsage ) throws IOException
     {
         super( "Nodes", config, ORDER_SEND_DOWNSTREAM );
         add( new InputIteratorBatcherStep<>( control(), config, nodes.iterator(), InputNode.class ) );
@@ -59,6 +61,7 @@ public class NodeStage extends Stage
                 propertyStore ) );
         add( new NodeEncoderStep( control(), config, idMapper, idGenerator,
                 neoStore.getLabelRepository(), nodeStore, memoryUsage ) );
+        add( new LabelScanStorePopulationStep( control(), config, labelScanStore ) );
         add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore,
                 writeMonitor, writerFactory ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -143,7 +143,7 @@ public class ParallelBatchImporter implements BatchImporter
 
             // Stage 1 -- nodes, properties, labels
             NodeStage nodeStage = new NodeStage( config, writeMonitor, writerFactory,
-                    nodes, idMapper, idGenerator, neoStore, inputCache, memoryUsageStats );
+                    nodes, idMapper, idGenerator, neoStore, inputCache, neoStore.getLabelScanStore(), memoryUsageStats );
 
             // Stage 2 -- calculate dense node threshold
             CalculateDenseNodesStage calculateDenseNodesStage = new CalculateDenseNodesStage( config, relationships,
@@ -179,7 +179,8 @@ public class ParallelBatchImporter implements BatchImporter
 
             // Stage 4 -- set node nextRel fields
             executeStages( new NodeFirstRelationshipStage( config, neoStore.getNodeStore(),
-                    neoStore.getRelationshipGroupStore(), nodeRelationshipCache, badCollector ) );
+                    neoStore.getRelationshipGroupStore(), nodeRelationshipCache, badCollector,
+                    neoStore.getLabelScanStore() ) );
             // Stage 5 -- link relationship chains together
             nodeRelationshipCache.clearRelationships();
             executeStages( new RelationshipLinkbackStage( config, neoStore.getRelationshipStore(),

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/UpdateNodeRecordsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/UpdateNodeRecordsStep.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.batchinsert.LabelScanWriter;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+
+/**
+ * Writes {@link NodeRecord} to store. Contains a {@link #accept(NodeRecord) predicate} to override
+ * for forcing some records to be set to {@link NodeRecord#setInUse(boolean) not in use}.
+ * Also deletes such unused records from {@link LabelScanStore}.
+ */
+public class UpdateNodeRecordsStep extends UpdateRecordsStep<NodeRecord>
+{
+    private final PrimitiveLongIterator ids;
+    private long current;
+    private boolean end;
+    private final LabelScanWriter labelScanWriter;
+
+    public UpdateNodeRecordsStep( StageControl control, Configuration config, RecordStore<NodeRecord> store,
+            Collector collector, LabelScanStore labelScanStore )
+    {
+        super( control, config, store );
+        this.ids = collector.leftOverDuplicateNodesIds();
+        goToNextId();
+        this.labelScanWriter = end ? LabelScanWriter.EMPTY : labelScanStore.newWriter();
+    }
+
+    private void goToNextId()
+    {
+        this.end = !ids.hasNext();
+        if ( !end )
+        {
+            this.current = ids.next();
+        }
+    }
+
+    @Override
+    protected boolean accept( NodeRecord node )
+    {
+        if ( !end && current == node.getId() )
+        {   // Found an id to exclude, exclude it and go to the next (they are sorted)
+            goToNextId();
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void update( NodeRecord node ) throws Throwable
+    {
+        super.update( node );
+        if ( !node.inUse() )
+        {
+            // Only the "labelsAfter" is considered
+            labelScanWriter.write( NodeLabelUpdate.labelChanges( current, EMPTY_LONG_ARRAY, EMPTY_LONG_ARRAY ) );
+        }
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        super.close();
+        labelScanWriter.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -436,7 +436,7 @@ public class EncodingIdMapper implements IdMapper
             Collector collector, ProgressListener progress )
             throws InterruptedException
     {
-        progress.started( "RESOLVE" );
+        progress.started( "RESOLVE (" + numberOfCollisions + " collisions)" );
         Radix radix = radixFactory.newInstance();
         List<String> sourceDescriptions = new ArrayList<>();
         String lastSourceDescription = null;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -261,7 +261,7 @@ public abstract class AbstractStep<T> implements Step<T>
     }
 
     @Override
-    public void close()
+    public void close() throws Exception
     {   // Do nothing by default
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -190,7 +190,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     protected abstract void process( T batch, BatchSender sender ) throws Throwable;
 
     @Override
-    public void close()
+    public void close() throws Exception
     {
         super.close();
         executor.shutdown( panic == null );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Step.java
@@ -36,7 +36,7 @@ import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
  *
  * @param <T> the type of batch objects received from upstream.
  */
-public interface Step<T> extends Parallelizable
+public interface Step<T> extends Parallelizable, AutoCloseable
 {
     /**
      * Whether or not tickets arrive in {@link #receive(long, Object)} ordered by ticket number.
@@ -102,5 +102,6 @@ public interface Step<T> extends Parallelizable
     /**
      * Closes any resources kept open by this step. Called after a {@link Stage} is executed, whether successful or not.
      */
-    void close();
+    @Override
+    void close() throws Exception;
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
@@ -23,9 +23,15 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.extension.KernelExtensions;
+import org.neo4j.kernel.extension.UnsatisfiedDependencyStrategies;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
@@ -34,7 +40,10 @@ import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreProvider;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds;
@@ -56,7 +65,7 @@ import static org.neo4j.kernel.impl.store.StoreFactory.configForStoreDir;
  * Creator and accessor of {@link NeoStore} with some logic to provide very batch friendly services to the
  * {@link NeoStore} when instantiating it. Different services for specific purposes.
  */
-public class BatchingNeoStore implements AutoCloseable
+public class BatchingNeoStore implements AutoCloseable, NeoStoreProvider
 {
     private final FileSystemAbstraction fileSystem;
     private final Monitors monitors;
@@ -68,6 +77,8 @@ public class BatchingNeoStore implements AutoCloseable
     private final BatchingPageCache pageCache;
     private final NeoStore neoStore;
     private final WriterFactory writerFactory;
+    private final LifeSupport life = new LifeSupport();
+    private final LabelScanStore labelScanStore;
 
     public BatchingNeoStore( FileSystemAbstraction fileSystem, File storeDir,
                              Configuration config, Monitor writeMonitor, Logging logging,
@@ -107,6 +118,20 @@ public class BatchingNeoStore implements AutoCloseable
                 neoStore.getLabelTokenStore(), initialIds.highLabelTokenId() );
         this.relationshipTypeRepository = new BatchingRelationshipTypeTokenRepository(
                 neoStore.getRelationshipTypeTokenStore(), initialIds.highRelationshipTypeTokenId() );
+
+        // Initialze kernel extensions
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependency( neo4jConfig );
+        dependencies.satisfyDependency( fileSystem );
+        dependencies.satisfyDependency( this );
+        dependencies.satisfyDependency( logging );
+        @SuppressWarnings( { "unchecked", "rawtypes" } )
+        KernelExtensions extensions = life.add( new KernelExtensions(
+                (Iterable) Service.load( KernelExtensionFactory.class ),
+                dependencies, UnsatisfiedDependencyStrategies.ignore() ) );
+        life.start();
+        labelScanStore = life.add( extensions.resolveDependency( LabelScanStoreProvider.class,
+                LabelScanStoreProvider.HIGHEST_PRIORITIZED ).getLabelScanStore() );
     }
 
     private boolean alreadyContainsData( NeoStore neoStore )
@@ -188,6 +213,7 @@ public class BatchingNeoStore implements AutoCloseable
         flushNeoStoreAndAwaitEverythingWritten();
 
         // Close the neo store
+        life.shutdown();
         neoStore.close();
     }
 
@@ -207,5 +233,16 @@ public class BatchingNeoStore implements AutoCloseable
     public long getLastCommittedTransactionId()
     {
         return neoStore.getLastCommittedTransactionId();
+    }
+
+    public LabelScanStore getLabelScanStore()
+    {
+        return labelScanStore;
+    }
+
+    @Override
+    public NeoStore evaluate()
+    {
+        return neoStore;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -44,8 +44,6 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
-import org.neo4j.unsafe.impl.batchimport.cache.GatheringMemoryStatsVisitor;
-import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.Monitor;
@@ -139,8 +137,6 @@ public class EncodingIdMapperTest
             idMapper.put( id, index++, GLOBAL );
         }
         idMapper.prepare( ids, mock( Collector.class ), NONE );
-        MemoryStatsVisitor memoryStats = new GatheringMemoryStatsVisitor();
-        idMapper.acceptMemoryStatsVisitor( memoryStats );
 
         // THEN
         for ( Object id : ids )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
@@ -25,17 +25,19 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import org.neo4j.com.Response;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdRange;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
+
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 
 public class HaIdGeneratorFactory implements IdGeneratorFactory
 {
@@ -63,7 +65,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
         {
             previous.close();
         }
-        
+
         IdGenerator initialIdGenerator;
         switch ( globalState )
         {
@@ -114,7 +116,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
 
         generators.get( IdType.RELATIONSHIP_GROUP ).switchToMaster();
     }
-    
+
     public void switchToSlave()
     {
         globalState = IdGeneratorState.SLAVE;
@@ -171,7 +173,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
                 {
                     fs.deleteFile( fileName );
                 }
-                    
+
                 localFactory.create( fs, fileName, highId );
                 delegate = localFactory.open( fs, fileName, grabSize, idType, highId );
                 logger.debug( "Instantiated master delegate " + delegate + " of type " + idType + " with highid " + highId );
@@ -209,7 +211,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
             {
                 throw new IllegalStateException( state.name() );
             }
-            
+
             long result = delegate.nextId();
             return result;
         }
@@ -221,7 +223,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
             {
                 throw new IllegalStateException( state.name() );
             }
-            
+
             return delegate.nextIdBatch( size );
         }
 
@@ -375,7 +377,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
         public void delete()
         {
         }
-        
+
         @Override
         public String toString()
         {
@@ -416,7 +418,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
                 ++position;
             }
         }
-        
+
         @Override
         public String toString()
         {
@@ -425,7 +427,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
     }
 
     private static IdRangeIterator EMPTY_ID_RANGE_ITERATOR =
-            new IdRangeIterator( new IdRange( new long[0], 0, 0 ) )
+            new IdRangeIterator( new IdRange( EMPTY_LONG_ARRAY, 0, 0 ) )
             {
                 @Override
                 long next()

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class MasterEpochTest
@@ -76,7 +77,7 @@ public class MasterEpochTest
 
     private IdAllocation idAllocation( long from, int length )
     {
-        return new IdAllocation( new IdRange( new long[0], from, length ), from+length, 0 );
+        return new IdAllocation( new IdRange( EMPTY_LONG_ARRAY, from, length ), from+length, 0 );
     }
 
     private RequestContext context( long epoch )


### PR DESCRIPTION
This to avoid the need to await a full build of it the next startup of the
database. For this the BatchingNeoStore now starts all kernel extensions
as well, because a LabelScanStore is a kernel extension.
