### PR TITLE
ShortestPath now interrupts if nodes belongs to disconnected graphs

### DIFF
--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
@@ -17,7 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.graphalgo.path;
+package org.neo4j.graphalgo.impl.path;
+
+import common.Neo4jAlgoTestCase;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,27 +30,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import common.Neo4jAlgoTestCase;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import org.neo4j.graphalgo.GraphAlgoFactory;
 import org.neo4j.graphalgo.PathFinder;
-import org.neo4j.graphalgo.impl.path.ShortestPath;
-import org.neo4j.graphalgo.impl.path.TraversalShortestPath;
+import org.neo4j.graphalgo.impl.path.ShortestPath.MutableInteger;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipExpander;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.kernel.StandardExpander;
 import org.neo4j.kernel.Traversal;
 
-import static java.util.Arrays.asList;
 import static common.Neo4jAlgoTestCase.MyRelTypes.R1;
 import static common.SimpleGraphBuilder.KEY_ID;
 import static org.hamcrest.CoreMatchers.is;
@@ -54,6 +57,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static java.util.Arrays.asList;
+
 import static org.neo4j.graphalgo.GraphAlgoFactory.shortestPath;
 import static org.neo4j.graphdb.Direction.BOTH;
 import static org.neo4j.graphdb.Direction.INCOMING;
@@ -63,17 +69,65 @@ import static org.neo4j.helpers.collection.IteratorUtil.count;
 
 public class TestShortestPath extends Neo4jAlgoTestCase
 {
-//    protected PathFinder<Path> instantiatePathFinder( int maxDepth )
-//    {
-//        return instantiatePathFinder( Traversal.expanderForTypes( MyRelTypes.R1,
-//                Direction.BOTH ), maxDepth );
-//    }
-//    
-//    protected PathFinder<Path> instantiatePathFinder( RelationshipExpander expander, int maxDepth )
-//    {
-////        return GraphAlgoFactory.shortestPath( expander, maxDepth );
-//        return new TraversalShortestPath( expander, maxDepth );
-//    }
+    // Attempt at recreating this issue without cypher
+    // https://github.com/neo4j/neo4j/issues/4160
+    @Test
+    public void shouldAbortAsSoonAsPossible()
+    {
+        Label A = DynamicLabel.label( "A" );
+        Label B = DynamicLabel.label( "B" );
+        Label C = DynamicLabel.label( "C" );
+        Label D = DynamicLabel.label( "D" );
+        Label E = DynamicLabel.label( "E" );
+        Label F = DynamicLabel.label( "F" );
+        final RelationshipType relType = DynamicRelationshipType.withName( "TO" );
+        recursiveSnowFlake( null, 0, 4, 5, new Label[] { A, B, C, D, E }, relType );
+        Node a = graphDb.findNodes( A ).next();
+        ResourceIterator<Node> allE = graphDb.findNodes( E );
+        while ( allE.hasNext() )
+        {
+            Node e = allE.next();
+            Node f = graphDb.createNode( F );
+            f.createRelationshipTo( e, relType );
+        }
+        CountingPathExpander countingPathExpander =
+                new CountingPathExpander( PathExpanders.forTypeAndDirection( relType, Direction.OUTGOING ) );
+        ShortestPath shortestPath =
+                new ShortestPath( Integer.MAX_VALUE, countingPathExpander, Integer.MAX_VALUE, false );
+        ResourceIterator<Node> allF = graphDb.findNodes( F );
+        long start = System.currentTimeMillis();
+        while ( allF.hasNext() )
+        {
+            Node f = allF.next();
+            shortestPath.findAllPaths( a, f );
+        }
+        long totalTime = System.currentTimeMillis() - start;
+        assertEquals(
+                "There are 625 different end nodes. The algorithm should start one traversal for each such node. "
+                        + "That is 625*2 visited nodes if traversal is interrupted correctly.", 1250,
+                countingPathExpander.nodesVisited.value );
+    }
+
+    private void recursiveSnowFlake( Node parent, int level, final int desiredLevel, final int branchingFactor,
+            final Label[] labels, final RelationshipType relType )
+    {
+        if ( level != 0 )
+        {
+            for ( int n = 0; n < branchingFactor; n++ )
+            {
+                Node node = graphDb.createNode( labels[level] );
+                if ( parent != null )
+                    parent.createRelationshipTo( node, relType );
+                if ( level < desiredLevel )
+                    recursiveSnowFlake( node, level + 1, desiredLevel, branchingFactor, labels, relType );
+            }
+        }
+        else
+        {
+            Node node = graphDb.createNode( labels[level] );
+            recursiveSnowFlake( node, level + 1, desiredLevel, branchingFactor, labels, relType );
+        }
+    }
 
     @Test
     public void testSimplestGraph()
@@ -85,7 +139,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //   \__/
         graph.makeEdge( "s", "t" );
         graph.makeEdge( "s", "t" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -115,7 +168,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "q", "t" );
         graph.makeEdge( "n", "o" );
         graph.makeEdge( "o", "t" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -147,14 +199,13 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "3", "4" );
         graph.makeEdge( "2", "t" );
         graph.makeEdge( "4", "t" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
             public void test( PathFinder<Path> finder )
             {
-                assertPaths( finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) ),
-                        "s,1,2,t", "s,1,4,t", "s,3,2,t", "s,3,4,t" );
+                assertPaths( finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) ), "s,1,2,t", "s,1,4,t",
+                        "s,3,2,t", "s,3,4,t" );
             }
         }, PathExpanders.forTypeAndDirection( R1, BOTH ), 3 );
     }
@@ -163,14 +214,13 @@ public class TestShortestPath extends Neo4jAlgoTestCase
     public void testDirectedFinder()
     {
         // Layout:
-        // 
+        //
         // (a)->(b)->(c)->(d)->(e)->(f)-------\
         //    \                                v
         //     >(g)->(h)->(i)->(j)->(k)->(l)->(m)
         //
         graph.makeEdgeChain( "a,b,c,d,e,f,m" );
         graph.makeEdgeChain( "a,g,h,i,j,k,l,m" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -191,12 +241,11 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //  (b)-----(d)------(j)
         //   |        \      /
         //  (e)--(f)--(h)--(i)
-        // 
+        //
         graph.makeEdgeChain( "a,c,g,k" );
         graph.makeEdgeChain( "a,b,d,j,k" );
         graph.makeEdgeChain( "b,e,f,h,i,j" );
         graph.makeEdgeChain( "d,h" );
-
         RelationshipExpander expander = Traversal.expanderForTypes( MyRelTypes.R1, Direction.OUTGOING );
         Node a = graph.getNode( "a" );
         Node k = graph.getNode( "k" );
@@ -219,7 +268,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //         (d)
         //
         graph.makeEdgeChain( "a,b,c,d,b,c,e" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -243,15 +291,16 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //         (d)
         //
         graph.makeEdgeChain( "a,b,c,d,b,c,e" );
-
         Node a = graph.getNode( "a" );
         Node e = graph.getNode( "e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ), "a,b,d,c,e" );
-        assertPaths( GraphAlgoFactory.pathsWithLength(
-                Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths( a, e ) );
+        assertPaths(
+                GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 3 ).findAllPaths( a, e ),
+                "a,b,c,e", "a,b,c,e" );
+        assertPaths(
+                GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 4 ).findAllPaths( a, e ),
+                "a,b,d,c,e" );
+        assertPaths( GraphAlgoFactory.pathsWithLength( Traversal.expanderForTypes( MyRelTypes.R1 ), 6 ).findAllPaths(
+                a, e ) );
     }
 
     @Test
@@ -265,7 +314,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //
         graph.makeEdgeChain( "a,b,c,d" );
         graph.makeEdgeChain( "a,g,h,d" );
-
         final Node a = graph.getNode( "a" );
         final Node d = graph.getNode( "d" );
         final Node b = graph.getNode( "b" );
@@ -279,7 +327,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 return !skip;
             }
         };
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -287,7 +334,7 @@ public class TestShortestPath extends Neo4jAlgoTestCase
             {
                 assertPaths( finder.findAllPaths( a, d ), "a,g,h,d" );
             }
-        }, ((StandardExpander)PathExpanders.allTypesAndDirections()).addNodeFilter( filter ), 10 );
+        }, ((StandardExpander) PathExpanders.allTypesAndDirections()).addNodeFilter( filter ), 10 );
     }
 
     @Test
@@ -298,7 +345,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         // (a)-->(b)-->(c)-->(d)-->(e)
         //
         graph.makeEdgeChain( "a,b,c,d,e" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -307,7 +353,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "b" ) ) );
             }
         }, PathExpanders.allTypesAndDirections(), 0 );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -317,7 +362,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "d" ) ) );
             }
         }, PathExpanders.allTypesAndDirections(), 1 );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -341,12 +385,10 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdgeChain( "a,b,c,d,e" );
         graph.makeEdgeChain( "a,b,c,d,e" );
         graph.makeEdgeChain( "a,f,g,h,i" );
-
         Node a = graph.getNode( "a" );
         Node b = graph.getNode( "b" );
         Node c = graph.getNode( "c" );
         final Set<Node> allowedNodes = new HashSet<Node>( Arrays.asList( a, b, c ) );
-
         PathFinder<Path> finder = new ShortestPath( 100, Traversal.expanderForAllTypes( Direction.OUTGOING ) )
         {
             @Override
@@ -379,10 +421,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
          */
         graph.makeEdgeChain( "i,g,f,e,d,c,b,a" );
         graph.makeEdgeChain( "i,h,f" );
-
         testShortestPathFinder( new PathFinderTester()
         {
-
             @Override
             public void test( PathFinder<Path> finder )
             {
@@ -411,7 +451,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdgeChain( "m,o,n" );
         graph.makeEdge( "o", "o" );
         graph.makeEdge( "n", "n" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -434,16 +473,14 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //   (i)-----------------(j)  |
         //    |                       |
         //   (k)----------------------
-        // 
+        //
         graph.makeEdgeChain( "a,b,c,d,e" );
         graph.makeEdgeChain( "a,f,g,h,e" );
         graph.makeEdgeChain( "f,i,j,e" );
         graph.makeEdgeChain( "i,k,e" );
-
         final Node a = graph.getNode( "a" );
         final Node e = graph.getNode( "e" );
         PathExpander expander = PathExpanders.forTypeAndDirection( R1, OUTGOING );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -452,7 +489,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 assertEquals( 4, count( finder.findAllPaths( a, e ) ) );
             }
         }, expander, 10, 10 );
-
         for ( int i = 4; i >= 1; i-- )
         {
             final int count = i;
@@ -483,7 +519,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdgeChain( "a,c" );
         final Node a = graph.getNode( "a" );
         final Node c = graph.getNode( "c" );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -492,7 +527,6 @@ public class TestShortestPath extends Neo4jAlgoTestCase
                 assertPathDef( finder.findSinglePath( a, c ), "a", "c" );
             }
         }, PathExpanders.forTypeAndDirection( R1, OUTGOING ), 2 );
-
         testShortestPathFinder( new PathFinderTester()
         {
             @Override
@@ -503,27 +537,24 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         }, PathExpanders.forTypeAndDirection( R1, INCOMING ), 2 );
     }
 
-    @Ignore("Exposes a problem where the expected path isn't returned")
+    @Ignore( "Exposes a problem where the expected path isn't returned" )
     @Test
     public void pathsWithLengthProblem() throws Exception
     {
         /*
-         * 
+         *
          *    (a)-->(b)-->(c)<--(f)
          *      \   ^      |
          *       v /       v
          *       (d)      (e)
-         * 
+         *
          */
-
         graph.makeEdgeChain( "f,c" );
         graph.makeEdgeChain( "c,e" );
         graph.makeEdgeChain( "a,b,c" );
         graph.makeEdgeChain( "a,d,b" );
-
         Node a = graph.getNode( "a" );
         Node c = graph.getNode( "c" );
-
         assertPaths( new ShortestPath( 3, PathExpanders.forType( R1 ), 10, true ).findAllPaths( a, c ), "a,d,b,c" );
     }
 
@@ -542,58 +573,56 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "c", "b" );
         graph.makeEdge( "e", "end" );
         graph.makeEdge( "a", "end" );
-
         Node start = graph.getNode( "start" );
         Node end = graph.getNode( "end" );
-
         assertThat( new ShortestPath( 2, allTypesAndDirections(), 42 ).findSinglePath( start, end ).length(), is( 2 ) );
         assertThat( new ShortestPath( 3, allTypesAndDirections(), 42 ).findSinglePath( start, end ).length(), is( 2 ) );
     }
-    
+
     private void testShortestPathFinder( PathFinderTester tester, PathExpander expander, int maxDepth )
     {
         testShortestPathFinder( tester, expander, maxDepth, null );
     }
 
     private void testShortestPathFinder( PathFinderTester tester, PathExpander expander, int maxDepth,
-                                         Integer maxResultCount )
+            Integer maxResultCount )
     {
         LengthCheckingExpanderWrapper lengthChecker = new LengthCheckingExpanderWrapper( expander );
-        
         List<PathFinder<Path>> finders = new ArrayList<>();
         finders.add( maxResultCount != null ? shortestPath( lengthChecker, maxDepth, maxResultCount ) : shortestPath(
                 lengthChecker, maxDepth ) );
-        finders.add( maxResultCount != null ? new TraversalShortestPath( lengthChecker, maxDepth,
-                maxResultCount ) : new TraversalShortestPath( lengthChecker, maxDepth ) );
+        finders.add( maxResultCount != null
+                ? new TraversalShortestPath( lengthChecker, maxDepth, maxResultCount )
+                : new TraversalShortestPath( lengthChecker, maxDepth ) );
         for ( PathFinder<Path> finder : finders )
         {
             tester.test( finder );
         }
     }
-    
+
     private interface PathFinderTester
     {
         void test( PathFinder<Path> finder );
     }
 
-    private static class LengthCheckingExpanderWrapper implements PathExpander<Object> {
+    private static class LengthCheckingExpanderWrapper implements PathExpander<Object>
+    {
+        private final PathExpander expander;
 
-        private PathExpander expander;
-        
         LengthCheckingExpanderWrapper( PathExpander expander )
         {
             this.expander = expander;
         }
-        
+
         @Override
-        @SuppressWarnings("unchecked")
-        public Iterable<Relationship> expand( Path path, BranchState<Object> state ) 
-        {           
-            if ( path.startNode().equals(path.endNode()) ) 
+        @SuppressWarnings( "unchecked" )
+        public Iterable<Relationship> expand( Path path, BranchState<Object> state )
+        {
+            if ( path.startNode().equals( path.endNode() ) )
             {
                 assertTrue( "Path length must be zero", path.length() == 0 );
-            } 
-            else 
+            }
+            else
             {
                 assertTrue( "Path length must be positive", path.length() > 0 );
             }
@@ -601,9 +630,41 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         }
 
         @Override
-        public PathExpander<Object> reverse() 
+        public PathExpander<Object> reverse()
         {
             return new LengthCheckingExpanderWrapper( expander.reverse() );
+        }
+    }
+
+    // Used to count how many nodes are visited
+    private class CountingPathExpander implements PathExpander
+    {
+        private MutableInteger nodesVisited;
+        private final PathExpander delegate;
+
+        public CountingPathExpander( PathExpander delegate )
+        {
+            nodesVisited = new MutableInteger( 0 );
+            this.delegate = delegate;
+        }
+
+        public CountingPathExpander( PathExpander delegate, MutableInteger nodesVisited )
+        {
+            this( delegate );
+            this.nodesVisited = nodesVisited;
+        }
+
+        @Override
+        public Iterable expand( Path path, BranchState state )
+        {
+            nodesVisited.value++;
+            return delegate.expand( path, state );
+        }
+
+        @Override
+        public PathExpander reverse()
+        {
+            return new CountingPathExpander( delegate.reverse(), nodesVisited );
         }
     }
 }


### PR DESCRIPTION
ShortestPath is bidirectional.
If one sides sees that other side is exhausted, that is, does not have any more nodes to traverse, it continues to search for hits in the current layer of nodes. Then it stops.
This improves efficiency alot when searching for shortest path between disconnected graphs where difference in graph size is large.

Moved TestShortestPath to matching package and changed visibility of MutableInteger private -> protected for usage in test.

(Lots of formatting)
