### PR TITLE
Bump git-commit-id-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@ public class ComponentVersion extends Version
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.1.5</version>
+          <version>2.1.13</version>
           <executions>
             <execution>
               <id>generate-git-hash</id>


### PR DESCRIPTION
Fixes this error:

```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.1.5:revision (generate-git-hash) on project neo4j-kernel: .git directory could not be found! Please specify a valid [dotGitDirectory] in your pom.xml -> [Help 1]
```

This makes it possible to build the individual modules again, because this newer version of the plugin will find the .git directory recursively:

```
cd community/kernel && mvn clean package
> SUCCESS!!one1
```
