### PR TITLE
Make interpreted plans the default

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
@@ -79,7 +79,7 @@ object CypherCompilerFactory {
     val queryPlanner = new DefaultQueryPlanner(LogicalPlanRewriter(rewriterSequencer))
 
     val pickedPlannerName = plannerName.getOrElse(FallbackPlannerName)
-    val pickedRuntimeName = runtimeName.getOrElse(CompiledRuntimeName)
+    val pickedRuntimeName = runtimeName.getOrElse(RuntimeName.default)
     val planner = CostBasedPipeBuilderFactory(monitors, metricsFactory, planningMonitor, clock, queryPlanner = queryPlanner,
       rewriterSequencer = rewriterSequencer, plannerName = pickedPlannerName, runtimeName = pickedRuntimeName)
     // falling back to legacy planner is allowed only when no cost-based planner is picked explicitly (e.g., COST, IDP)


### PR DESCRIPTION
Compiled execution plans does not work in browser, so we'll disable it until we await a fix
