### PR TITLE
Documentation updates for NDP

### DIFF
--- a/community/ndp/v1-docs/pom.xml
+++ b/community/ndp/v1-docs/pom.xml
@@ -154,12 +154,13 @@
             </goals>
             <configuration>
               <backend>html</backend>
-              <outputDirectory>${basedir}/target/protocol-manual/pdf</outputDirectory>
+              <outputDirectory>${basedir}/target/protocol-manual/html</outputDirectory>
             </configuration>
           </execution>
         </executions>
         <configuration>
           <sourceDirectory>${basedir}/src/docs/dev</sourceDirectory>
+          <imagesDir>.</imagesDir>
           <attributes>
             <pagenums/>
             <toc/>

--- a/community/ndp/v1-docs/src/docs/dev/examples.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/examples.asciidoc
@@ -40,7 +40,7 @@ Server: SUCCESS {}
 
 === Pipelining
 
-This illustrates running two statements and retreiving their results, without waiting for the server to respond
+This illustrates running two statements and retrieving their results, without waiting for the server to respond
 in-between.
 
 Note that these two statements are executed in two individual transactions, implicitly created for each statement.
@@ -103,7 +103,7 @@ Server: SUCCESS {}
 === Error handling
 
 This illustrates how the server behaves when a request fails, and the server ignores incoming messages until an
-`ACK_FAILURE` message is recieved.
+`ACK_FAILURE` message is received.
 
 .Error handling
 [source,ndp_exchange]

--- a/community/ndp/v1-docs/src/docs/dev/index.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/index.asciidoc
@@ -4,17 +4,21 @@ Neo4j Data Protocol, Version 1
 
 WARNING: This component is in active development and *will* change.
 
+NOTE: Byte values within this document are represented in http://en.wikipedia.org/wiki/Hexadecimal[hexadecimal] notation unless otherwise specified.
+
+NOTE: Integers and floating point values are transmitted and stored using http://en.wikipedia.org/wiki/Endianness[big-endian] byte order unless otherwise specified.
+
 == Overview
 
 This section describes the Neo4j Data Protocol, version 1.
 It is written primarily for those implementing client drivers as well as those who want to understand the low-level communication details of such interactions.
 
-Neo4j supports a client-server protocol where messages are exchanged between a client who drives an interaction and a server which processes and responds to client requests.
+Neo4j supports a client-server protocol where messages are exchanged between a client who drives an interaction and a server that processes and responds to client requests.
 Every exchange of messages is initiated by the client with one or more request messages; in turn these requests are consumed by the server and corresponding response messages are returned.
 
 The diagram below illustrates a typical interaction including the order of messages sent and the life spans of the session and job (which are described in more detail in other chapters).
 
-image:typical-interaction.png[]
+image:images/typical-interaction.png[]
 
 The protocol is divided into two layers - <<ndp-transport,transport>> and <<ndp-messaging,messaging>>.
 

--- a/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
@@ -7,18 +7,18 @@ For details on how Neo4j types are represented in binary form, see <<ndp-seriali
 Clients may send request messages at any time.
 Clients may <<ndp-messaging-pipelining,pipeline>> requests, sending multiple requests together.
 
-Servers must fully respond to each request before the next request is processed and processing must be done in the same order requests arrived in for a given session.
+Servers must fully respond to each request before the next request is processed and processing of requests within a session must be done in the same order in which the requests.
 
 Servers must ignore messages sent by the client after a failure occurs on the server, until the client has acknowledged the failure. See Failure & Acknowledgement.
 
-For each request message sent, clients should expect to receive zero or more detail messages followed by exactly one summary message.
+For each request message sent, clients must anticipate receiving zero or more detail messages followed by exactly one summary message.
 The detail messages deliver the response content, while a summary message denotes the end of the response and any response metadata.
-Note that these are classifications of message, not specific message types.
+Note that "detail" and "summary" are classifications of message, not specific message types.
 For example, `RECORD` messages are classed as detail messages and `SUCCESS` messages as summary messages.
 
-The diagrams below illustrates a basic exchange wherein the client sends a fictional request message and receives a series of response messages.
+The diagrams below illustrates a basic exchange wherein the client sends a request message and receives a series of response messages.
 
-image:simple-exchange.png[]
+image:images/simple-exchange.png[]
 
 [[ndp-messaging-pipelining]]
 === Pipelining
@@ -26,7 +26,7 @@ image:simple-exchange.png[]
 The client is not required to wait for a response before sending more messages.
 Sending multiple messages together like this is called pipelining:
 
-image:pipelining.png[]
+image:images/pipelining.png[]
 
 For performance reasons, it is recommended that clients use pipelining as much as possible.
 Through pipelining, multiple messages can be transmitted together in the same network package, significantly reducing latency and increasing throughput.
@@ -39,22 +39,21 @@ commit is issued or a result is read by the application, and then sending all me
 Because the protocol leverages pipelining, the client and the server need to agree on what happens when a failure
 occurs, otherwise messages that were sent assuming no failure would occur might have unintended effects.
 
-When requests fail on the server, this is signalled to the client via a `FAILURE` message.
-After a failure, the server will not accept any messages it recieves until the client sends an `ACK_FAILURE` message.
-The server should issue an IGNORED message in response to any other kind of message sent by the client until an `ACK_FAILURE` has been received.
+When requests fail on the server, the server will send the client a `FAILURE` message.
+The client must acknowledge the `FAILURE` message by sending an `ACK_FAILURE` message to the server.
+Until the server receives the `ACK_FAILURE` message, it will send an `IGNORED` message in response to any other message from by the client, including messages that were sent in a pipeline.
 
 The diagram below illustrates a typical flow involving `ACK_FAILURE` messages:
 
-image:failure-ack.png[]
+image:images/failure-ack.png[]
 
 Here, the original failure is acknowledged immediately by the client, allowing the subsequent RUN to be actioned as expected.
 
 This second diagram shows a sequence where a pair of request messages are sent together:
 
-image:failure-optimistic.png[]
+image:images/failure-optimistic.png[]
 
-Here, the client optimistically sends a pair of messages. The first of these fails and the second is consequently
-`IGNORED`.
+Here, the client optimistically sends a pair of messages. The first of these fails and the second is consequently `IGNORED`.
 Once the client acknowledges the failure, it is then able to resend a corrected RUN message.
 
 
@@ -65,7 +64,7 @@ Protocol messages are represented as <<ndp-packstream-structures,serialized stru
 
 ==== RUN
 
-The `RUN` message is a client message that is used to start a new job on the server. It has the following structure:
+The `RUN` message is a client message used to start a new job on the server. It has the following structure:
 
 [source,ndp_message_struct]
 ----
@@ -75,15 +74,14 @@ RunMessage (signature=0x10) {
 }
 ----
 
-On receipt of a `RUN` message, a server should start a new job by executing the statement with the parameters supplied.
-If successful, the subsequent response should consist of a single `SUCCESS` message; if not, a `FAILURE` response should
- be sent instead.
+On receipt of a `RUN` message, the server will start a new job by executing the statement with the parameters supplied.
+If successful, the subsequent response will consist of a single `SUCCESS` message; if not, a `FAILURE` response will be sent instead.
 A successful job will always produce a result stream which must then be explicitly consumed, even if empty.
 
 In the case where a previous result stream has not yet been fully consumed (via `PULL_ALL` or `DISCARD_ALL`), an
-attempt to `RUN` a new job should trigger a `FAILURE` response.
+attempt to `RUN` a new job will trigger a `FAILURE` response.
 
-If an unacknowledged failure is pending from a previous exchange, the server must immediately respond with a single
+If an unacknowledged failure is pending from a previous exchange, the server will immediately respond with a single
 `IGNORED` message and take no further action.
 
 .Example
@@ -96,7 +94,7 @@ B2 10 8F 52  45 54 55 52  4E 20 31 20  41 53 20 6E  75 6D A0
 
 ==== DISCARD_ALL
 
-The `DISCARD_ALL` message is a client message that is used to discard all remaining items from the active result
+The `DISCARD_ALL` message is a client message used to discard all remaining items from the active result
 stream. It has the following structure:
 
 [source,ndp_message_struct]
@@ -105,10 +103,10 @@ DiscardAllMessage (signature=0x2F) {
 }
 ----
 
-On receipt of a `DISCARD_ALL` message, a server should dispose of all remaining items from the active result stream.
-If no result stream is currently active, the server should respond with a single FAILURE message.
+On receipt of a `DISCARD_ALL` message, the server will dispose of all remaining items from the active result stream, close the stream and send a single `SUCCESS` message to the client.
+If no result stream is currently active, the server will respond with a single `FAILURE` message.
 
-If an unacknowledged failure is pending from a previous exchange, the server must immediately respond with a single IGNORED message and take no further action.
+If an unacknowledged failure is pending from a previous exchange, the server will immediately respond with a single `IGNORED` message and take no further action.
 
 .Example
 [source,ndp_packstream_type]
@@ -119,7 +117,8 @@ B0 7E
 ----
 
 ==== PULL_ALL
-The `PULL_ALL` message is a client message that is used to retrieve all remaining items from the active result stream.
+
+The `PULL_ALL` message is a client message used to retrieve all remaining items from the active result stream.
 It has the following structure:
 
 [source,ndp_message_struct]
@@ -128,12 +127,11 @@ PullAllMessage (signature=0x3F) {
 }
 ----
 
-On receipt of a `PULL_ALL` message, a server should send all remaining result data items to the client, each in a
-single `RECORD` message, followed by a single `SUCCESS` message which may contain summary information on the data items
-sent.
-If an error is encountered, the server must instead send a `FAILURE` message and discard all remaining data items.
+On receipt of a `PULL_ALL` message, the server will send all remaining result data items to the client, each in a single `RECORD` message.
+The server will then close the stream and send a single `SUCCESS` message optionally containing summary information on the data items sent.
+If an error is encountered, the server must instead send a `FAILURE` message, discard all remaining data items and close the stream.
 
-If an unacknowledged failure is pending from a previous exchange, the server must immediately respond with a single IGNORED message and take no further action.
+If an unacknowledged failure is pending from a previous exchange, the server will immediately respond with a single `IGNORED` message and take no further action.
 
 .Example
 [source,ndp_packstream_type]
@@ -145,7 +143,7 @@ B0 3F
 
 ==== ACK_FAILURE
 
-The `ACK_FAILURE` message is a client message that is used to signal that a client has acknowledged a previous `FAILURE`
+The `ACK_FAILURE` message is a client message used to signal that a client has acknowledged a previous `FAILURE`
 . It has the following structure:
 
 [source,ndp_message_struct]
@@ -154,10 +152,10 @@ AcknowledgeFailureMessage (signature=0x0F) {
 }
 ----
 
-On receipt of an `ACK_FAILURE` message, a server should clear any pending failure state and respond with a single
-`SUCCESS` message. If no such failure state is pending, a FAILURE message should be sent instead.
+On receipt of an `ACK_FAILURE` message, the server will clear any pending failure state and respond with a single `SUCCESS` message.
+If no such failure state is pending, a FAILURE message will be sent instead.
 
-An `ACK_FAILURE` should never be ignored.
+An `ACK_FAILURE` will never be ignored by the server.
 
 .Example
 [source,ndp_packstream_type]
@@ -169,8 +167,9 @@ B0 0F
 
 ==== RECORD
 
-The `RECORD` message is a server detail message used to deliver data from the server to the client. Each record
-message contains a single List, which in turn contains the fields of the record in order. It has the following structure:
+The `RECORD` message is a server detail message used to deliver data from the server to the client.
+Each record message contains a single List, which in turn contains the fields of the record in order.
+It has the following structure:
 
 [source,ndp_message_struct]
 ----
@@ -189,8 +188,8 @@ B1 71 93 01  02 03
 
 ==== SUCCESS
 
-The `SUCCESS` message is a server summary message that is used to signal that a corresponding client message has been
-received and actioned as intended. It has the following structure:
+The `SUCCESS` message is a server summary message used to signal that a corresponding client message has been received and actioned as intended.
+It has the following structure:
 
 [source,ndp_message_struct]
 ----
@@ -210,8 +209,8 @@ B1 70 A1 86  66 69 65 6C  64 73 92 84  6E 61 6D 65
 
 ==== FAILURE
 
-The `FAILURE` message is a server summary message that is used to signal that a corresponding client message has
-encountered an error while being actioned. It has the following structure:
+The `FAILURE` message is a server summary message used to signal that a corresponding client message has encountered an error while being processed.
+It has the following structure:
 
 [source,ndp_message_struct]
 ----
@@ -220,8 +219,8 @@ FailureMessage (signature=0x7F) {
 }
 ----
 
-`FAILURE` messages contain metadata which describe the detail of the primary failure that has occurred. This metadata
-is a simple map containing a code and a message. These codes map to the standard Neo4j status codes.
+`FAILURE` messages contain metadata providing details regarding the primary failure that has occurred.
+This metadata is a simple map containing a code and a message. These codes map to the standard Neo4j status codes.
 
 .Example
 [source,ndp_packstream_type]
@@ -237,8 +236,8 @@ B1 7F A2 84  63 6F 64 65  D0 27 4E 65  6F 2E 43 6C
 
 ==== IGNORED
 
-The `IGNORED` message is a server summary message that is used to signal that a corresponding client message has been
-ignored and not actioned. It has the following structure:
+The `IGNORED` message is a server summary message used to signal that a corresponding client message has been ignored and not actioned.
+It has the following structure:
 
 [source,ndp_message_struct]
 ----
@@ -248,8 +247,9 @@ IgnoredMessage (signature=0x7E) {
 ----
 
 A client message will be ignored if an earlier failure has not yet been acknowledged by the client via an `ACK_FAILURE` message.
-This will occur if the client optimistically sends a group of messages, one of which fails during execution: all subsequent messages in that group will then be ignored.
-
+For example, this will occur if the client optimistically sends a group of messages, one of which fails during execution: all subsequent messages in that group will then be ignored.
+Note that the original `PULL_ALL` message was never processed by the server.
+
 .Example
 [source,ndp_packstream_type]
 ----

--- a/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
@@ -7,7 +7,7 @@ For details on the layout and meaning of specific messages, see <<ndp-messaging,
 
 [[ndp-type-system-mapping]]
 .Types overview
-[options="header",name="value-translation-table"]
+[cols="20,80",options="header",name="value-translation-table"]
 |=======================
 |Type                                  |Description
 |<<ndp-packstream-null,Null>>          |Represents the absence of a value
@@ -17,45 +17,35 @@ For details on the layout and meaning of specific messages, see <<ndp-messaging,
 |<<ndp-packstream-text,Text>>          |Unicode text string
 |<<ndp-packstream-lists,List>>         |Ordered collection of values
 |<<ndp-packstream-maps,Map>>           |Unordered, keyed collection of values
-|<<ndp-value-identitystruct,Identity>> |An opaque identifier that references a Node, a Relationship, or any other object Cypher wants to give the user a back-reference to.
-|<<ndp-value-nodestruct,Node>>         |The best place in the world to put your data
+|<<ndp-value-nodestruct,Node>>         |A node in the graph with optional properties and labels
 |<<ndp-value-relstruct,Relationship>>  |A directed, typed connection between two nodes. Each relationship may have properties and always has an identity
-|<<ndp-value-pathstruct,Path>>         |The record of a directed walk through the graph, a sequence of zro or more segments*. A path with zero segments consists of a single node.
+|<<ndp-value-pathstruct,Path>>         |The record of a directed walk through the graph, a sequence of zero or more segments*. A path with zero segments consists of a single node.
 |=======================
 
 NOTE: *A segment is the record of a single step traversal through a graph, encompassing a start node, a relationship
 traversed either forwards or backwards and an end node.
 
-==== Why a custom format?
-
-This format draws upon some of the best serialization formats available, but tailors it for the needs of Neo4j.
-
-Specifically, the Neo4j Serialization format has the following features:
-
-* Mixed unstructured and structured data, meaning we can easily represent self-describing data structures, while also leveraging schema-defined ones where a well-known structure exists.
-* No versioning, meaning lower overhead and lower complexity than formats with versioned messages.
-Versioning is instead handled by the wrapping transport protocol.
-* Efficient streaming serialization and deserialization of large (no size boundary) messages.
-
 === Markers
-Every value consists of at least one marker byte.
+
+Every value begins with a marker byte.
 The marker contains information on data type as well as direct or indirect size information for those types that require it.
 How that size information is encoded varies by marker type.
 
 Some values, such as `true`, can be encoded within a single marker byte and many small integers (specifically between -16 and +127) are also encoded within a single byte.
 
 A number of marker bytes are reserved for future expansion of the format itself.
-These bytes should not be used, and encountering them in a stream should cause an error.
+These bytes should not be used, and encountering them in a stream should treated as an error.
 
 === Sized Values
-Some value types require variable length representations and, as such, have their size encoded.
-These values generally consist of a single marker byte followed by a size followed by the data content itself.
+
+Some value types require variable length representations and, as such, have their size explicitly encoded.
+These values generally bgein with a single marker byte followed by a size followed by the data content itself.
 Here, the marker denotes both type and scale and therefore determines the number of bytes used to represent the size of the data.
 The size itself is either an 8-bit, 16-bit or 32-bit big-endian unsigned integer.
 
 The diagram below illustrates the general layout for a sized value, here with a 16-bit size:
 
-image:packstream-sized.png[]
+image:images/packstream-sized.png[]
 
 [[ndp-packstream-null]]
 === Null
@@ -124,7 +114,7 @@ These markers can be identified by a zero high-order bit or by a high-order nibb
 
 The available encodings are illustrated below and each shows a valid representation for the decimal value 42, with marker bytes in green:
 
-image:packstream-integers.png[]
+image:images/packstream-integers.png[]
 
 Note that while encoding small numbers in wider formats is supported, it is generally recommended to use the most compact representation possible.
 The following table shows the optimal representation for every possible integer:
@@ -154,7 +144,7 @@ CB 7F FF FF  FF FF FF FF  FF
 ----
 
 .Suggested integer representations
-[options="header",name="packstream-integer-range-table"]
+[cols=">,>,^",options="header",name="packstream-integer-range-table"]
 |=======================
 |Range Minimum               |Range Maximum              |Suggested representation
 |-9 223 372 036 854 775 808  |-2 147 483 649             |`INT_64`
@@ -173,7 +163,7 @@ Text data is represented as UTF-8 encoded binary data.
 Note that sizes used for text are the byte counts of the UTF-8 encoded data, not the character count of the original text.
 
 .Text markers
-[options="header",name="packstream-text-marker-table"]
+[cols="^20,<50,<30",options="header",name="packstream-text-marker-table"]
 |=======================
 |Marker         |Size                                        |Maximum data size
 |`0x80`..`0x8F` |contained within low-order nibble of marker |15 bytes
@@ -188,14 +178,14 @@ The encoded data then immediately follows the marker.
 The example below shows how the string "Hello" would be represented:
 
 // TODO: Convert this to a code-segment that can be tested
-image:packstream-tinytext.png[]
+image:images/packstream-tinytext.png[]
 
 ==== Regular Text Strings
 For encoded text containing 16 bytes or more, the marker `0xD0`, `0xD1` or `0xD2` should be used, depending on scale.
 This marker is followed by the size and the UTF-8 encoded data as in the example below:
 
 // TODO: Convert this to a code-segment that can be tested
-image:packstream-text.png[]
+image:images/packstream-text.png[]
 
 ==== Examples
 
@@ -227,12 +217,12 @@ D0 18 45 6E  20 C3 A5 20  66 6C C3 B6  74 20 C3 B6
 
 [[ndp-packstream-lists]]
 === Lists
-Lists are sized heterogeneous sequences of values and permit a mixture of types within the same list.
+Lists are heterogeneous sequences of values and permit a mixture of types within the same list.
 The size of a list denotes the number of items within that list, not the total packed byte size.
 The markers used to denote a list are described in the table below:
 
 .List markers
-[options="header",name="packstream-list-marker-table"]
+[cols="^20,<50,<30",options="header",name="packstream-list-marker-table"]
 |=======================
 |Marker         |Size                                        |Maximum list size
 |`0x90`..`0x9F` |contained within low-order nibble of marker |15 bytes
@@ -283,13 +273,13 @@ The size of a map denotes the number of pairs within that map, not the total pac
 The markers used to denote a map are described in the table below:
 
 .Map markers
-[options="header",name="packstream-map-marker-table"]
+[cols="^20,<50,<30",options="header",name="packstream-map-marker-table"]
 |=======================
 |Marker         |Size                                        |Maximum map size
-|`0xA0`..`0xAF` |contained within low-order nibble of marker |15 key-value pairs
-|`0xD8`         |8-bit  big-endian unsigned integer          |255 key-value pairs
-|`0xD9`         |16-bit big-endian unsigned integer          |65 535 key-value pairs
-|`0xDA`         |32-bit big-endian unsigned integer          |4 294 967 295 key-value pairs
+|`0xA0`..`0xAF` |contained within low-order nibble of marker |15 entries
+|`0xD8`         |8-bit  big-endian unsigned integer          |255 entries
+|`0xD9`         |16-bit big-endian unsigned integer          |65 535 entries
+|`0xDA`         |32-bit big-endian unsigned integer          |4 294 967 295 entries
 |=======================
 
 ==== Tiny Maps & Empty Maps
@@ -336,7 +326,7 @@ The size of a structure is measured as the number of fields, not the total packe
 The markers used to denote a structure are described in the table below:
 
 .Structure markers
-[options="header",name="packstream-structure-marker-table"]
+[cols="^20,<50,<30",options="header",name="packstream-structure-marker-table"]
 |=======================
 |Marker         |Size                                        |Maximum structure size
 |`0xB0`..`0xBF` |contained within low-order nibble of marker |15 fields
@@ -380,20 +370,10 @@ DC 10 01 01  02 03 04 05  06 07 08 09  00 01 02 03
 ----
 
 [[ndp-value-structs]]
-==== Neo4j value structs
+==== Graph Type Stuctures
 
-Neo4j values that are represented as <<ndp-packstream-structures,structures>>.
-
-[[ndp-value-identitystruct]]
-===== Identity
-An identity is an opaque unique handle that references a specific graph entity. The general serialised structure is as follows:
-
-[source,ndp_value_struct]
-----
-Identity (signature=0x49) {
-    Text              identityData
-}
-----
+A number of key Neo4j types are represented as <<ndp-packstream-structures,structures>>.
+These include _nodes_, _relationships_ and _paths_.
 
 [[ndp-value-nodestruct]]
 ===== Node
@@ -401,8 +381,8 @@ A Node represents a node from a Neo4j graph and consists of a unique identifier 
 
 [source,ndp_value_struct]
 ----
-Node (signature=0x4E) {
-    Identity          identity
+Node (signature=0x4E) {             /* signature: 'N' */
+    Text              identity
     List<Text>        labels
     Map<Text, Value>  properties
 }
@@ -414,11 +394,11 @@ A Relationship represents a relationship from a Neo4j graph and consists of a un
 
 [source,ndp_value_struct]
 ----
-Relationship (signature=0x52) {
-    Identity          identity
-    Identity          startNode
-    Identity          endNode
-    Identity          type
+Relationship (signature=0x52) {    /* signature: 'R' */
+    Text              identity
+    Text              startNode    /* identity of the start node */
+    Text              endNode      /* identity of the end node   */
+    Text              type
     Map<Text, Value>  properties
 }
 ----
@@ -429,7 +409,7 @@ A Path consists of a list of alternating nodes and relationships, always startin
 
 [source,ndp_value_struct]
 ----
-Path (signature=0x50) {
+Path (signature=0x50) {                  /* signature: 'P' */
     List<Node|Relationship> entities
 }
 ----
@@ -440,14 +420,14 @@ These are all the marker bytes:
 
 [[ndp-packstream-markers]]
 .Marker table
-[options="header",name="ndp-packstream-marker-table"]
+[cols="^15,^15,^15,<55",options="header",name="ndp-packstream-marker-table"]
 |=======================
 |Marker         |Binary     |Type          |Description
 |`0x00`..`0x7F` |`0xxxxxxx` |`+TINY_INT`   |Integer 0 to 127
-|`0x80`..`0x8F` |`1000xxxx` |`TINY_TEXT`   |UTF-8 encoded text string (fewer than 24 bytes)
-|`0x90`..`0x9F` |`1001xxxx` |`TINY_LIST`   |List (fewer than 24 items)
-|`0xA0`..`0xAF` |`1010xxxx` |`TINY_MAP`    |Map (fewer than 24 key-value pairs)
-|`0xB0`..`0xBF` |`1011xxxx` |`TINY_STRUCT` |Structure (fewer than 24 fields)
+|`0x80`..`0x8F` |`1000xxxx` |`TINY_TEXT`   |UTF-8 encoded text string (fewer than 2^4^ bytes)
+|`0x90`..`0x9F` |`1001xxxx` |`TINY_LIST`   |List (fewer than 2^4^ items)
+|`0xA0`..`0xAF` |`1010xxxx` |`TINY_MAP`    |Map (fewer than 2^4^ key-value pairs)
+|`0xB0`..`0xBF` |`1011xxxx` |`TINY_STRUCT` |Structure (fewer than 2^4^ fields)
 |`0xC0`         |`11000000` |`NULL`        |Null
 |`0xC1`         |`11000001` |`FLOAT_64`    |64-bit floating point number (double)
 |`0xC2`         |`11000010` |`FALSE`       |Boolean false
@@ -458,20 +438,20 @@ These are all the marker bytes:
 |`0xCA`         |`11001010` |`INT_32`      |32-bit signed integer
 |`0xCB`         |`11001011` |`INT_64`      |64-bit signed integer
 |`0xCC`..`0xCF` |`11001100` |              |Reserved
-|`0xD0`         |`11010000` |`TEXT_8`      |UTF-8 encoded text string (fewer than 28 bytes)
-|`0xD1`         |`11010001` |`TEXT_16`     |UTF-8 encoded text string (fewer than 216 bytes)
-|`0xD2`         |`11010010` |`TEXT_32`     |UTF-8 encoded text string (fewer than 232 bytes)
+|`0xD0`         |`11010000` |`TEXT_8`      |UTF-8 encoded text string (fewer than 2^8^ bytes)
+|`0xD1`         |`11010001` |`TEXT_16`     |UTF-8 encoded text string (fewer than 2^16^ bytes)
+|`0xD2`         |`11010010` |`TEXT_32`     |UTF-8 encoded text string (fewer than 2^32^ bytes)
 |`0xD3`         |`11010011` |              |Reserved
-|`0xD4`         |`11010100` |`LIST_8`      |List (fewer than 28 items)
-|`0xD5`         |`11010101` |`LIST_16`     |List (fewer than 216 items)
-|`0xD6`         |`11010110` |`LIST_32`     |List (fewer than 232 items)
+|`0xD4`         |`11010100` |`LIST_8`      |List (fewer than 2^8^ items)
+|`0xD5`         |`11010101` |`LIST_16`     |List (fewer than 2^16^ items)
+|`0xD6`         |`11010110` |`LIST_32`     |List (fewer than 2^32^ items)
 |`0xD7`         |`11010111` |              |Reserved
-|`0xD8`         |`11011000` |`MAP_8`       |Map (fewer than 28 key-value pairs)
-|`0xD9`         |`11011001` |`MAP_16`      |Map (fewer than 216 key-value pairs)
-|`0xDA`         |`11011010` |`MAP_32`      |Map (fewer than 232 key-value pairs)
+|`0xD8`         |`11011000` |`MAP_8`       |Map (fewer than 2^8^ key-value pairs)
+|`0xD9`         |`11011001` |`MAP_16`      |Map (fewer than 2^16^ key-value pairs)
+|`0xDA`         |`11011010` |`MAP_32`      |Map (fewer than 2^32^ key-value pairs)
 |`0xDB`         |`11011011` |              |Reserved
-|`0xDC`         |`11011100` |`STRUCT_8`    |Structure (fewer than 28 fields)
-|`0xDD`         |`11011101` |`STRUCT_16`   |Structure (fewer than 216 fields)
+|`0xDC`         |`11011100` |`STRUCT_8`    |Structure (fewer than 2^8^ fields)
+|`0xDD`         |`11011101` |`STRUCT_16`   |Structure (fewer than 2^16^ fields)
 |`0xDE`..`0xEF` |`1110xxxx` |              |Reserved
 |`0xF0`..`0xFF` |`1111xxxx` |`-TINY_INT`   |Integer -1 to -16
 |=======================

--- a/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
@@ -1,42 +1,40 @@
 [[ndp-transport]]
 == Transport layer
-The protocol supports a TCP and a WebSocket transport protocol for sending and receiving messages.
-A transport protocol is responsible for:
+The protocol supports both regular http://en.wikipedia.org/wiki/Network_socket[socket] and http://en.wikipedia.org/wiki/WebSocket[WebSocket] transport layers for sending and receiving messages.
+The transport layer is versioned along with the rest of the data protocol and is responsible for:
 
 * Negotiating Neo4j protocol version
 * Establishing and terminating sessions
 * Routing messages from clients to specific sessions and back
 
-The transport is versioned along with the rest of the data protocol - however, versioning applies only after a version negotiation handshake takes place.
-Before that handshake, the protocol will remain stable across versions to support backwards compatibility.
-
 === Sessions
 
-A connection to the server via a transport is called a session.
-Each session with the server is isolated and the server tracks the current state based on the requests and responses delivered within that session.
+Each connection to the server creates a new *session* that lives until that connection is closed.
+Each session is isolated and the server keep track of the current state, based on the requests and responses exchanged within that session.
 
-Neo4j uses 'sticky sessions', which means that, in a database cluster, each session is tied to one specific Neo4j instance.
+Neo4j uses _sticky sessions_, which means that, in a database cluster, each session is tied to one specific Neo4j instance.
 
 === Connecting
 
-To initialize a new session, the client connects either using a regular TCP socket, or using a websocket.
-Once connected, both connection methods behave identically.
+To begin a new session, the client connects using either a regular socket or a WebSocket.
+Once connected, both transport layers can be treated identically.
 
-The websocket connection should be made to the host and port Neo4j has been configured to use for its websocket listener.
-The URL by default is `ws://localhost:8776`.
-
-The TCP socket connection should be made to the host and port Neo4j has been configued to use for its TCP socket listener.
-The host and port by default is `localhost:7687`.
+A regular socket connection should be made to the host and port Neo4j has been configured to use for its regular socket listener.
+The default port for regular socket connections is *7687*.
+Similar configuration exists for the WebSocket listener.
+The default port for WebSocket connections is *8776*.
 
 === Handshake
 
-After connecting, a handshake to establish which protocol version to use takes place.
+After connecting, a handshake takes place to establish which protocol version should be used for that connection.
+This handshake is a _version-independent_ mini-protocol which is guaranteed to remain the same, regardless of preferred or available protocol versions.
 
 In the handshake, the client proposes up to four protocol versions it supports, in order of preference.
-The proposal is always represented as four 32-bit unsigned big-endian integers.
+The proposal is always represented as four 32-bit unsigned integers.
 Each integer represents a proposed protocol version to use, or zero (`00 00 00 00`) for "none".
 
-The server will respond with a single 32-bit unsigned big-endian integer representing the chosen protocol, this will always be the highest-priority protocol version the server supports.
+The server will respond with a single 32-bit unsigned integer representing the chosen protocol.
+This will always represent the highest-priority protocol version the server supports.
 If none of the proposed protocols are supported, the server responds with zero (`00 00 00 00`) and closes the connection.
 
 .Initial handshake
@@ -72,7 +70,7 @@ The transport protocol uses a framing layer to wrap messages.
 Each message is transferred as one or more `chunks` of data.
 Each chunk starts with a two-byte header, an unsigned big-endian 16-bit integer, representing the size of the chunk.
 The header is not counted towards this size.
-A message can be divided across multiple chunks, allowing client and server alike to efficiently transfer messages larger than their network buffers.
+A message can be divided across multiple chunks, allowing client and server alike to transfer large messages without having to determine the length of the entire message in advance.
 
 Each message ends with two bytes with the value `00 00`, these are not counted towards the chunk length.
 
@@ -116,4 +114,5 @@ header |         Data         |  Marker
 
 === Disconnecting
 
-To end a session, the client simply closes the TCP socket.
+A session ends when its communication socket is closed.
+Typically, this will be closed by the client.


### PR DESCRIPTION
- Include proposed edits from review
- Superscript fixes
- changed HTML output directory from `pdf` to `html`
- Added note regarding hex notation
- images relative to base, not 'images'
- remove Identities temporarily, to make docs be in sync with reality
