### PR TITLE
Server should not close resources

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
@@ -106,5 +106,11 @@ class PipeExecutionResult(val result: ResultIterator,
   //notifications only present for EXPLAIN
   override val notifications = Iterable.empty[InternalNotification]
 
-  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = iteratorToVisitable.accept(self, visitor)
+  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = {
+    try {
+      iteratorToVisitable.accept(self, visitor)
+    } finally {
+      self.close()
+    }
+  }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -272,7 +272,13 @@ case class ExecutionResultWrapperFor2_2(inner: InternalExecutionResult, planner:
 
   def notifications = Seq.empty
 
-  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_2.runSafely {iteratorToVisitable.accept(self, visitor)}
+  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = {
+    try {
+      exceptionHandlerFor2_2.runSafely {iteratorToVisitable.accept(self, visitor)}
+    } finally {
+      self.close()
+    }
+  }
 }
 
 case class CompatibilityPlanDescription(inner: InternalPlanDescription, version: CypherVersion, planner: PlannerName)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LegacyExecutionResultWrapper.scala
@@ -108,7 +108,13 @@ case class LegacyExecutionResultWrapper(inner: ExecutionResult, planDescriptionR
     case _ => Iterable.empty
   }
 
-  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = iteratorToVisitable.accept(self, visitor)
+  def accept[EX <: Exception](visitor: ResultVisitor[EX]) = {
+    try {
+      iteratorToVisitable.accept(self, visitor)
+    } finally {
+      self.close()
+    }
+  }
 
   // since we can't introspect the query result returned by the legacy planners, this is the best we can do
   private def queryType = if (schemaQuery(queryStatistics()))

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -453,7 +453,6 @@ public class ExecutionResultSerializer
         finally
         {
             out.writeEndArray(); // </data>
-            data.close(); // free associated resources as early a possible
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/CypherQueriesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/CypherQueriesIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.annotations.Documented;
+import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
+import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.server.rest.repr.util.RFC1123;
+import org.neo4j.test.server.HTTP;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+import static org.neo4j.server.rest.RESTDocsGenerator.ResponseEntity;
+import static org.neo4j.server.rest.domain.JsonHelper.jsonToMap;
+import static org.neo4j.test.server.HTTP.GET;
+import static org.neo4j.test.server.HTTP.POST;
+
+public class CypherQueriesIT extends AbstractRestFunctionalTestBase
+{
+    @Test
+    public void runningInCompiledRuntime() throws JsonParseException
+    {
+        // Document
+        ResponseEntity response = gen.get()
+                .noGraph()
+                .expectedStatus( 200 )
+                .payload( quotedJson(
+                        "{ 'statements': [ { 'statement': 'CYPHER runtime=compiled MATCH (n) RETURN n' } ] }" ) )
+                .post( getDataUri() + "transaction/commit" );
+
+        // Then
+        Map<String, Object> result = jsonToMap( response.entity() );
+        assertNoErrors( result );
+    }
+
+
+    private void assertNoErrors( Map<String, Object> response )
+    {
+        @SuppressWarnings("unchecked")
+        Iterator<Map<String, Object>> errors = ((List<Map<String, Object>>) response.get( "errors" )).iterator();
+        assertFalse( errors.hasNext() );
+    }
+
+    private String quotedJson( String singleQuoted )
+    {
+        return singleQuoted.replaceAll( "'", "\"" );
+    }
+
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -778,41 +778,6 @@ public class ExecutionResultSerializerTest
         );
     }
 
-    @SuppressWarnings({"unchecked"})
-    @Test
-    public void shouldCloseResultIterator() throws Exception
-    {
-        // given
-        OutputStream output = mock( OutputStream.class );
-        ExecutionResultSerializer serializer = new ExecutionResultSerializer( output, null, NullLogProvider.getInstance() );
-        RuntimeException onCloseException = new IllegalStateException("Iterator closed");
-        Result result = mock( Result.class );
-        mockAccept( result );
-        when( result.hasNext() ).thenReturn( true );
-        when( result.next() ).thenThrow( onCloseException );
-
-        // when
-        try
-        {
-            serializer.statementResult( result, false );
-            fail("Expected IllegalStateException to be thrown when closing the iterator");
-        }
-        catch (IllegalStateException e)
-        {
-            // expected to be thrown by iterator access
-            assertEquals( onCloseException, e );
-        }
-
-        // then
-        verify( result, times( 1 ) ).columns();
-        verify( result, times( 1 ) ).accept(
-                (Result.ResultVisitor<RuntimeException>) any( Result.ResultVisitor.class ) );
-        verify( result, times( 1 ) ).hasNext();
-        verify( result, times( 1 ) ).next();
-        verify( result, times( 1 ) ).close();
-        verifyNoMoreInteractions(result);
-    }
-
     @Test
     public void shouldReturnNotifications() throws IOException
     {


### PR DESCRIPTION
The lifecycle of the statement should be handled by the `accept` method and server
should not close resources.
