### PR TITLE
Remove stray references to the Maven site plugin

### DIFF
--- a/community/io/pom.xml
+++ b/community/io/pom.xml
@@ -90,31 +90,6 @@ the relevant Commercial Agreement.
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <reportPlugins combine.children="append">
-            <plugin>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <detectJavaApiLink>true</detectJavaApiLink>
-                <detectLinks>true</detectLinks>
-                <quiet>true</quiet>
-                <excludePackageNames>*.impl.*</excludePackageNames>
-              </configuration>
-              <reports>
-                <report>javadoc</report>
-              </reports>
-            </plugin>
-          </reportPlugins>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-descriptor</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <!--
           Run mutation tests like this:
           mvn org.pitest:pitest-maven:mutationCoverage

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -159,48 +159,6 @@ the relevant Commercial Agreement.
         </dependencies>
       </plugin>
       <plugin>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <reportPlugins combine.children="append">
-            <plugin>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <detectJavaApiLink>true</detectJavaApiLink>
-                <detectLinks>true</detectLinks>
-                <quiet>true</quiet>
-                <excludePackageNames>org.neo4j.kernel,*.impl.*</excludePackageNames>
-                <groups>
-                  <group>
-                    <title>Graph database</title>
-                    <packages>org.neo4j.graphdb:org.neo4j.graphdb.*</packages>
-                  </group>
-                  <group>
-                    <title>Helpers</title>
-                    <packages>org.neo4j.helpers:org.neo4j.helpers.*</packages>
-                  </group>
-                  <group>
-                    <title>Tooling</title>
-                    <packages>org.neo4j.tooling:org.neo4j.tooling.*</packages>
-                  </group>
-                </groups>
-              </configuration>
-              <reports>
-                <report>javadoc</report>
-              </reports>
-            </plugin>
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>clirr-maven-plugin</artifactId>
-              <configuration>
-                <includes>
-                  <include>org/neo4j/graphdb/**</include>
-                </includes>
-              </configuration>
-            </plugin>
-          </reportPlugins>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <excludePackageNames>org.neo4j.kernel,*.impl.*</excludePackageNames>


### PR DESCRIPTION
We stopped using the plugin ages ago, but these references were somehow
missed.
