### PR TITLE
Use relative paths for cypher compatibility test data

### DIFF
--- a/community/cypher/compatibility-suite/src/test/resources/org/neo4j/cypher/db/cineast/params.json
+++ b/community/cypher/compatibility-suite/src/test/resources/org/neo4j/cypher/db/cineast/params.json
@@ -1,9 +1,9 @@
 {
-  "user_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/User.csv",
-  "person_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/Person.csv",
-  "movie_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/Movie.csv",
-  "acts_in_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/ACTS_IN.csv",
-  "directed_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/DIRECTED.csv",
-  "friend_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/FRIEND.csv",
-  "rated_csv" : "file:src/test/resources/org/neo4j/cypher/db/cineast/RATED.csv"
+  "user_csv" : "file:User.csv",
+  "person_csv" : "file:Person.csv",
+  "movie_csv" : "file:Movie.csv",
+  "acts_in_csv" : "file:ACTS_IN.csv",
+  "directed_csv" : "file:DIRECTED.csv",
+  "friend_csv" : "file:FRIEND.csv",
+  "rated_csv" : "file:RATED.csv"
 }


### PR DESCRIPTION
For finding the initial test data files (`import.cyp` and `params.json`) `getResource()` is used in order to find the path relative to the classpath, rather than relative to the current working directory of the JVM, since that will change depending on how the test is executed. The CWD is different when running through maven than when running through an IDE, whereas the classpath would contain the resource in the same way in both cases.

For finding files referenced from the test data, the paths are instead relative to the test data directory, i.e. the same directory that contains the `import.cyp` and `params.json` files.
