### PR TITLE
Decouple version of fop-pom.xml from that of Neo4j

### DIFF
--- a/manual/fop-pom.xml
+++ b/manual/fop-pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-fop</artifactId>
-  <version>1.9-SNAPSHOT</version>
+  <version>100.0.0</version>
   <name>Neo4j - Reference Manual- FOP build</name>
   <description>Neo4j Reference Manual - FOP build.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>


### PR DESCRIPTION
This POM doesn't represent a published module. It's just used as a
convenience for invoking a third-party tool. Because it's not hooked
into the Neo4j parent module, updating the version number is a special
case that requires a workaround. Therefore we have decided to keep the
version number fixed and never change it. This change updates the
version number to something that clearly shows it's not related to the
Neo4j version number.
