### PR TITLE
Fixes lifecycle issue after multiple starting/stopping dbs

### DIFF
--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DatabaseActions.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DatabaseActions.java
@@ -44,7 +44,7 @@ public class DatabaseActions
     private final DesktopModel model;
     private AbstractNeoServer server;
     private Logging logging;
-    private LifeSupport life = new LifeSupport();
+    private LifeSupport life;
 
     public DatabaseActions( DesktopModel model )
     {
@@ -57,6 +57,7 @@ public class DatabaseActions
         {
             throw new UnableToStartServerException( "Already started" );
         }
+        life = new LifeSupport();
 
         DesktopConfigurator configurator = new DesktopConfigurator( model );
         logging = life.add( createDefaultLogging( configurator.getDatabaseTuningProperties() ) );


### PR DESCRIPTION
Issue was that starting/stopping a database multiple times in the same
neo4j desktop application instance had each logging line occur as number
of times as the database had been started. This was due to the same
LifeSupport instance being used, and an additional Logging instance added
to it every time the database started.

Solution is to instantiate a new LifeSupport for every started db.
