### PR TITLE
CSV parser has ability to disallow multi-line fields

### DIFF
--- a/community/csv/CHANGES.txt
+++ b/community/csv/CHANGES.txt
@@ -1,6 +1,7 @@
 2.2.2
 -----
 o Fixes an issue in multi-line quotes values where a value ending with a newline could corrupt the next value.
+o BufferedCharSeeker has ability to allow/disallow multi-line fields
 
 2.2.1
 -----

--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -30,12 +30,8 @@ import static org.neo4j.csv.reader.Mark.END_OF_LINE_CHARACTER;
 /**
  * Much like a {@link BufferedReader} for a {@link Reader}.
  */
-public class BufferedCharSeeker implements CharSeeker, SourceTraceability
+public class BufferedCharSeeker implements CharSeeker
 {
-    private static final int KB = 1024, MB = KB * KB;
-    public static final int DEFAULT_BUFFER_SIZE = 4 * MB;
-    public static final char DEFAULT_QUOTE_CHAR = '"';
-
     private static final char EOL_CHAR = '\n';
     private static final char EOL_CHAR_2 = '\r';
     private static final char EOF_CHAR = (char) -1;
@@ -65,26 +61,18 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
     // this absolute position + bufferPos is the current position in the source we're reading
     private long absoluteBufferStartPosition;
     private String sourceDescription;
+    private final boolean multilineFields;
 
-    public BufferedCharSeeker( CharReadable reader )
-    {
-        this( reader, DEFAULT_BUFFER_SIZE, DEFAULT_QUOTE_CHAR );
-    }
-
-    public BufferedCharSeeker( CharReadable reader, int bufferSize )
-    {
-        this( reader, bufferSize, DEFAULT_QUOTE_CHAR );
-    }
-
-    public BufferedCharSeeker( CharReadable reader, int bufferSize, char quoteChar )
+    public BufferedCharSeeker( CharReadable reader, Configuration config )
     {
         this.reader = reader;
-        this.charBuffer = new SectionedCharBuffer( bufferSize );
+        this.charBuffer = new SectionedCharBuffer( config.bufferSize() );
         this.buffer = charBuffer.array();
         this.bufferPos = this.bufferEnd = charBuffer.pivot();
-        this.quoteChar = quoteChar;
+        this.quoteChar = config.quotationCharacter();
         this.lineStartPos = this.bufferPos;
         this.sourceDescription = reader.sourceDescription();
+        this.multilineFields = config.multilineFields();
     }
 
     @Override
@@ -146,11 +134,8 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                     {   // Found an ending quote of sorts, although the next char isn't a delimiter, newline, or EOF
                         // so it looks like there's data characters after this end quote. We don't really support that.
                         // So circle this back to the user saying there's something wrong with the field.
-                        throw new IllegalStateException( "At " + sourceDescription() + ":" + lineNumber() +
-                                " there's a field starting with a quote and whereas it ends that quote there seems " +
-                                " to be characters in that field after that ending quote. That isn't supported." +
-                                " This is what I read: '" +
-                                new String( buffer, seekStartPos, bufferPos-seekStartPos ) + "'" );
+                        throw new DataAfterQuoteException( this,
+                                new String( buffer, seekStartPos, bufferPos-seekStartPos ) );
                     }
                     else
                     {   // Found an ending quote, skip it and switch mode
@@ -159,7 +144,12 @@ public class BufferedCharSeeker implements CharSeeker, SourceTraceability
                     }
                 }
                 else if ( isNewLine( ch ) )
-                {   // Found a new line, just keep going
+                {   // Found a new line inside a quotation...
+                    if ( !multilineFields )
+                    {   // ...but we are configured to disallow it
+                        throw new IllegalMultilineFieldException( this );
+                    }
+                    // ... it's OK, just keep going
                     if ( ch == EOL_CHAR )
                     {
                         lineNumber++;

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
@@ -19,11 +19,8 @@
  */
 package org.neo4j.csv.reader;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 
-import static org.neo4j.csv.reader.BufferedCharSeeker.DEFAULT_BUFFER_SIZE;
 import static org.neo4j.csv.reader.ThreadAheadReadable.threadAhead;
 
 /**
@@ -42,28 +39,14 @@ public class CharSeekers
      * @param quotationCharacter character to interpret quotation character.
      * @return a {@link CharSeeker} with optional {@link ThreadAheadReadable read-ahead} capability.
      */
-    public static CharSeeker charSeeker( CharReadable reader, int bufferSize, boolean readAhead,
-            char quotationCharacter )
+    public static CharSeeker charSeeker( CharReadable reader, Configuration config, boolean readAhead )
     {
         if ( readAhead )
         {   // Thread that always has one buffer read ahead
-            reader = threadAhead( reader, bufferSize );
+            reader = threadAhead( reader, config.bufferSize() );
         }
 
         // Give the reader to the char seeker
-        return new BufferedCharSeeker( reader, bufferSize, quotationCharacter );
-    }
-
-    /**
-     * Instantiates a default {@link CharSeeker} capable of reading data in the specified {@code file}.
-     *
-     * @param file {@link File} to read data from.
-     * @return {@link CharSeeker} reading and parsing data from {@code file}.
-     * @throws FileNotFoundException if the specified {@code file} doesn't exist.
-     */
-    public static CharSeeker charSeeker( CharReadable reader, char quotationCharacter )
-            throws FileNotFoundException
-    {
-        return charSeeker( reader, DEFAULT_BUFFER_SIZE, true, quotationCharacter );
+        return new BufferedCharSeeker( reader, config );
     }
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+/**
+ * Configuration options around reading CSV data, or similar.
+ */
+public interface Configuration
+{
+    /**
+     * Character to regard as quotes. Quoted values can contain newline characters and even delimiters.
+     */
+    char quotationCharacter();
+
+    /**
+     * Data buffer size.
+     */
+    int bufferSize();
+
+    /**
+     * Whether or not fields are allowed to have newline characters in them, i.e. span multiple lines.
+     */
+    boolean multilineFields();
+
+    static int KB = 1024, MB = KB * KB;
+
+    class Default implements Configuration
+    {
+        @Override
+        public char quotationCharacter()
+        {
+            return '"';
+        }
+
+        @Override
+        public int bufferSize()
+        {
+            return 4 * MB;
+        }
+
+        @Override
+        public boolean multilineFields()
+        {
+            return false;
+        }
+    }
+
+    Configuration DEFAULT = new Default();
+
+    class Overridden implements Configuration
+    {
+        private final Configuration defaults;
+
+        public Overridden( Configuration defaults )
+        {
+            this.defaults = defaults;
+        }
+
+        @Override
+        public char quotationCharacter()
+        {
+            return defaults.quotationCharacter();
+        }
+
+        @Override
+        public int bufferSize()
+        {
+            return defaults.bufferSize();
+        }
+
+        @Override
+        public boolean multilineFields()
+        {
+            return defaults.multilineFields();
+        }
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/DataAfterQuoteException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/DataAfterQuoteException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+public class DataAfterQuoteException extends FormatException
+{
+    public DataAfterQuoteException( SourceTraceability source, String readValue )
+    {
+        super( source,
+                " there's a field starting with a quote and whereas it ends that quote there seems " +
+                " to be characters in that field after that ending quote. That isn't supported." +
+                " This is what I read: '" + readValue + "'" );
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/FormatException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/FormatException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+/**
+ * Super class for exceptions stemming from invalid format of a data source that is read.
+ */
+public abstract class FormatException extends IllegalStateException
+{
+    private final SourceTraceability source;
+
+    protected FormatException( SourceTraceability source, String description )
+    {
+        super( "At " + source.sourceDescription() + ":" + source.lineNumber() + " - " + description );
+        this.source = source;
+    }
+
+    public SourceTraceability source()
+    {
+        return this.source;
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/IllegalMultilineFieldException.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/IllegalMultilineFieldException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+public class IllegalMultilineFieldException extends FormatException
+{
+    public IllegalMultilineFieldException( SourceTraceability source )
+    {
+        super( source,
+                "Multi-line fields are illegal in this context and so this might suggest that " +
+                "there's a field with a start quote, but a missing end quote." );
+    }
+}

--- a/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/MultiReadableTest.java
@@ -43,7 +43,7 @@ public class MultiReadableTest
                 {"and here comes", "the third line"}
         };
         RawIterator<Reader,IOException> readers = readerIteratorFromStrings( data, null );
-        CharSeeker seeker = CharSeekers.charSeeker( new MultiReadable( readers ), 200, true, '"' );
+        CharSeeker seeker = CharSeekers.charSeeker( new MultiReadable( readers ), CONFIG, true );
 
         // WHEN/THEN
         for ( String[] line : data )
@@ -65,7 +65,7 @@ public class MultiReadableTest
 
         // WHEN
         RawIterator<Reader,IOException> readers = readerIteratorFromStrings( data, '\n' );
-        CharSeeker seeker = CharSeekers.charSeeker( Readables.sources( readers ), 200, true, '"' );
+        CharSeeker seeker = CharSeekers.charSeeker( Readables.sources( readers ), CONFIG, true );
 
         // WHEN/THEN
         for ( String[] line : data )
@@ -104,6 +104,15 @@ public class MultiReadableTest
         reader.read( buffer, buffer.front() );
         assertFalse( buffer.hasAvailable() );
     }
+
+    private static final Configuration CONFIG = new Configuration.Overridden( Configuration.DEFAULT )
+    {
+        @Override
+        public int bufferSize()
+        {
+            return 200;
+        }
+    };
 
     private void assertNextLine( String[] line, CharSeeker seeker, Mark mark, Extractors extractors ) throws IOException
     {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
@@ -43,7 +43,12 @@ class CSVResources(cleaner: TaskCloser) extends ExternalResource {
       override def toString = url.toString
     })
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
-    val seeker = CharSeekers.charSeeker(reader, CSVResources.DEFAULT_BUFFER_SIZE, true, CSVResources.DEFAULT_QUOTE_CHAR)
+    val config = new Configuration() {
+      def quotationCharacter(): Char = CSVResources.DEFAULT_QUOTE_CHAR
+      def bufferSize(): Int = CSVResources.DEFAULT_BUFFER_SIZE
+      def multilineFields(): Boolean = true
+    }
+    val seeker = CharSeekers.charSeeker(reader, config, true)
     val extractor = new Extractors(delimiter).string()
     val intDelimiter = delimiter.toInt
     val mark = new Mark

--- a/community/import-tool/CHANGES.txt
+++ b/community/import-tool/CHANGES.txt
@@ -11,6 +11,10 @@ o Removes the --bad option which previously could specify the location and file 
   <into>/bad.log
 o Input file names can now contain regular expressions and therefore match multiple files.
   Matching files will be correctly ordered according to any and all numbers found in their file names.
+o Ability to allow/disallow multi-line fields, i.e. fields containing new-line characters.
+  This to have a better default defense against missing end quotes.
+  Default is to disallow multi-line fields. While being a change in behavior, this option
+  will most likely result in less surprising handling of fields missing end quotes..
 
 2.2.1
 -----

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map.Entry;
 
+import org.neo4j.csv.reader.IllegalMultilineFieldException;
 import org.neo4j.function.Function;
 import org.neo4j.function.Function2;
 import org.neo4j.helpers.Args;
@@ -118,6 +119,9 @@ public class ImportTool
                         + "`\"\\\"Go away\\\", he said.\"` are supported. "
                         + "If you have set \"`'`\" to be used as the quotation character, "
                         + "you could write the previous example like this instead: " + "`'\"Go away\", he said.'`" ),
+        MULTILINE_FIELDS( "multiline-fields", org.neo4j.csv.reader.Configuration.DEFAULT.multilineFields(),
+                "<true/false>",
+                "Whether or not fields from input source can span multiple lines, i.e. contain newline characters." ),
         ID_TYPE( "id-type", IdType.STRING,
                 "<id-type>",
                 "One out of " + Arrays.toString( IdType.values() )
@@ -163,7 +167,6 @@ public class ImportTool
                         + "whereas consecutive such nodes will be skipped. "
                         + "Skipped nodes will be logged"
                         + ", containing at most number of entites specified by " + BAD_TOLERANCE.key() + "." );
-
 
         private final String key;
         private final Object defaultValue;
@@ -418,6 +421,11 @@ public class ImportTool
         };
     }
 
+    private static String manualReference( String page )
+    {
+        return " http://neo4j.com/docs/" + Version.getKernel().getVersion() + "/" + page;
+    }
+
     /**
      * Method name looks strange, but look at how it's used and you'll see why it's named like that.
      * @param stackTrace whether or not to also print the stack trace of the error.
@@ -426,10 +434,15 @@ public class ImportTool
     {
         if ( e.getClass().equals( DuplicateInputIdException.class ) )
         {
-            System.err.println( "Duplicate input ids that would otherwise clash can be put into separate id space,"
-                    + " read more about how to use id spaces in the manual:"
-                    + " http://neo4j.com/docs/" + Version.getKernel().getVersion() +
-                    "/import-tool-header-format.html#_id_spaces" );
+            System.err.println( "Duplicate input ids that would otherwise clash can be put into separate id space," +
+                    " read more about how to use id spaces in the manual:" +
+                    manualReference( "import-tool-header-format.html#_id_spaces" ) );
+        }
+        else if ( e.getClass().equals( IllegalMultilineFieldException.class ) )
+        {
+            System.err.println( "Detected field which spanned multiple lines for an import where " +
+                    Options.MULTILINE_FIELDS.argument() + "=false. If you know that your input data include " +
+                    "fields containing new-line characters then import with this option set to true." );
         }
 
         System.err.println( typeOfError + ": " + e.getMessage() );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.neo4j.csv.reader.IllegalMultilineFieldException;
 import org.neo4j.function.primitive.PrimitiveIntPredicate;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -595,6 +596,39 @@ public class ImportToolTest
             assertEquals( anonymousCount, count( filter( nodeFilter( "" ), allNodes.iterator() ) ) );
             tx.success();
         }
+    }
+
+    @Test
+    public void shouldDisallowMultilineFieldsByDefault() throws Exception
+    {
+        // GIVEN
+        File data = data( ":ID,name", "1,\"This is a line with\nnewlines in\"" );
+
+        // WHEN
+        try
+        {
+            importTool(
+                    "--into",  dbRule.getStoreDir().getAbsolutePath(),
+                    "--nodes", data.getAbsolutePath() );
+        }
+        catch ( Exception e )
+        {
+            // THEN
+            assertExceptionContains( e, "Multi-line", IllegalMultilineFieldException.class );
+        }
+    }
+
+    private File data( String... lines ) throws Exception
+    {
+        File file = file( fileName( "data.csv" ) );
+        try ( PrintStream writer = writer( file, Charset.defaultCharset() ) )
+        {
+            for ( String line : lines )
+            {
+                writer.println( line );
+            }
+        }
+        return file;
     }
 
     private Predicate<Node> nodeFilter( final String id )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -110,6 +110,13 @@ public class QuickImport
     private static CharSeeker seeker( String definition, Configuration config )
     {
         return CharSeekers.charSeeker( Readables.wrap( new StringReader( definition ) ),
-                10_000, false, config.quotationCharacter() );
+                new org.neo4j.csv.reader.Configuration.Overridden( config )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 10_000;
+            }
+        }, false );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
@@ -19,12 +19,10 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
-import org.neo4j.csv.reader.BufferedCharSeeker;
-
 /**
  * Configuration for {@link CsvInput}.
  */
-public interface Configuration
+public interface Configuration extends org.neo4j.csv.reader.Configuration
 {
     /**
      * Delimiting character between each values in a CSV input line.
@@ -37,29 +35,11 @@ public interface Configuration
      */
     char arrayDelimiter();
 
-    /**
-     * Character to regard as quotes. Quoted values can contain newline characters and even delimiters.
-     */
-    char quotationCharacter();
-
-    int bufferSize();
-
-    public static abstract class Default implements Configuration
+    abstract class Default extends org.neo4j.csv.reader.Configuration.Default implements Configuration
     {
-        @Override
-        public char quotationCharacter()
-        {
-            return BufferedCharSeeker.DEFAULT_QUOTE_CHAR;
-        }
-
-        @Override
-        public int bufferSize()
-        {
-            return BufferedCharSeeker.DEFAULT_BUFFER_SIZE;
-        }
     }
 
-    public static final Configuration COMMAS = new Default()
+    Configuration COMMAS = new Default()
     {
         @Override
         public char delimiter()
@@ -74,7 +54,7 @@ public interface Configuration
         }
     };
 
-    public static final Configuration TABS = new Default()
+    Configuration TABS = new Default()
     {
         @Override
         public char delimiter()
@@ -89,12 +69,13 @@ public interface Configuration
         }
     };
 
-    public static class OverrideFromConfig implements Configuration
+    class Overriden extends org.neo4j.csv.reader.Configuration.Overridden implements Configuration
     {
         private final Configuration defaults;
 
-        public OverrideFromConfig( Configuration defaults )
+        public Overriden( Configuration defaults )
         {
+            super( defaults );
             this.defaults = defaults;
         }
 
@@ -108,18 +89,6 @@ public interface Configuration
         public char arrayDelimiter()
         {
             return defaults.arrayDelimiter();
-        }
-
-        @Override
-        public char quotationCharacter()
-        {
-            return defaults.quotationCharacter();
-        }
-
-        @Override
-        public int bufferSize()
-        {
-            return defaults.bufferSize();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -78,8 +78,7 @@ public class DataFactories
                     {
                         try
                         {
-                            return charSeeker( files( charset, files ), config.bufferSize(),
-                                               true, config.quotationCharacter() );
+                            return charSeeker( files( charset, files ), config, true );
                         }
                         catch ( IOException e )
                         {
@@ -115,8 +114,7 @@ public class DataFactories
                     @Override
                     public CharSeeker stream()
                     {
-                        return charSeeker( readable.newInstance(), config.bufferSize(),
-                                           true, config.quotationCharacter() );
+                        return charSeeker( readable.newInstance(), config, true );
                     }
 
                     @Override
@@ -238,7 +236,7 @@ public class DataFactories
         @Override
         public CharSeeker open( CharSeeker seeker, Configuration config ) throws IOException
         {
-            return charSeeker( readable, config.bufferSize(), true, config.quotationCharacter() );
+            return charSeeker( readable, config, true );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -112,7 +112,7 @@ public class CsvInputBatchImportIT
     private org.neo4j.unsafe.impl.batchimport.input.csv.Configuration lowBufferSize(
             org.neo4j.unsafe.impl.batchimport.input.csv.Configuration actual )
     {
-        return new org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.OverrideFromConfig( actual )
+        return new org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overriden( actual )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -70,7 +70,6 @@ import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultF
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatRelationshipFileHeader;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.relationshipData;
 
-
 public class CsvInputTest
 {
     @Test
@@ -901,9 +900,19 @@ public class CsvInputTest
         };
     }
 
+    private static final org.neo4j.csv.reader.Configuration SEEKER_CONFIG =
+            new org.neo4j.csv.reader.Configuration.Overridden( new org.neo4j.csv.reader.Configuration.Default() )
+    {
+        @Override
+        public int bufferSize()
+        {
+            return 1_000;
+        }
+    };
+
     private static CharSeeker charSeeker( String data )
     {
-        return new BufferedCharSeeker( wrap( new StringReader( data ) ), 1_000 );
+        return new BufferedCharSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG );
     }
 
     @SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -297,14 +297,24 @@ public class DataFactoriesTest
         }
     }
 
+    private static final org.neo4j.csv.reader.Configuration SEEKER_CONFIG =
+            new org.neo4j.csv.reader.Configuration.Overridden( new org.neo4j.csv.reader.Configuration.Default() )
+    {
+        @Override
+        public int bufferSize()
+        {
+            return 1_000;
+        }
+    };
+
     private CharSeeker seeker( String data )
     {
-        return new BufferedCharSeeker( wrap( new StringReader( data ) ), BUFFER_SIZE );
+        return new BufferedCharSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG );
     }
 
     private static Configuration withBufferSize( Configuration config, final int bufferSize )
     {
-        return new Configuration.OverrideFromConfig( config )
+        return new Configuration.Overriden( config )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
@@ -31,7 +31,7 @@ import org.neo4j.function.Function;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
-import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.OverrideFromConfig;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overriden;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -136,9 +136,9 @@ public class ExternalPropertiesDecoratorTest
         };
     }
 
-    private OverrideFromConfig config()
+    private Overriden config()
     {
-        return new Configuration.OverrideFromConfig( Configuration.COMMAS )
+        return new Configuration.Overriden( Configuration.COMMAS )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -87,7 +87,7 @@ public class InputGroupsDeserializerTest
 
     private Configuration lowBufferSize( Configuration conf )
     {
-        return new Configuration.OverrideFromConfig( conf )
+        return new Configuration.Overriden( conf )
         {
             @Override
             public int bufferSize()


### PR DESCRIPTION
Being the default behaviour, it's a safer alternative compared to allowing
multi-line fields. The classic example is a field containing a start quote
and then for some reason missing the end quote and so all characters until
the next quote character, which might be several lines below, are
interpreted as being part of that same field. In the worst case, if data
happens to line up, this doesn't result in an exception, merely data
seemingly "just missing" from the reader.

BufferedCharSeeker now uses a Configuration interface for its config
options, where defaults and ability to override certain options are
centralized into one place.

The import tool has got an added `--multiline-fields` option which is used
to allow multiline fields, for input that needs it.
