### PR TITLE
Only attempt to create auth file parent directory if missing

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
+++ b/community/server/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
@@ -187,7 +187,10 @@ public class FileUserRepository extends LifecycleAdapter implements UserReposito
     private void saveUsersToFile() throws IOException
     {
         Path directory = authFile.getParent();
-        Files.createDirectories( directory );
+        if ( !Files.exists( directory ) )
+        {
+            Files.createDirectories( directory );
+        }
 
         Path tempFile = Files.createTempFile( directory, authFile.getFileName().toString() + "-", ".tmp" );
         try


### PR DESCRIPTION
Fixes an odd issue where java.nio.file.Files.createDirectories() throws
an error, because the directory already exists but is a symlink.
