### PR TITLE
Initialize message for NDP

### DIFF
--- a/community/ndp/kernelextension/src/main/java/org/neo4j/ext/NDPKernelExtension.java
+++ b/community/ndp/kernelextension/src/main/java/org/neo4j/ext/NDPKernelExtension.java
@@ -44,6 +44,7 @@ import org.neo4j.ndp.transport.socket.SocketProtocol;
 import org.neo4j.ndp.transport.socket.SocketProtocolV1;
 import org.neo4j.ndp.transport.socket.SocketTransport;
 import org.neo4j.ndp.transport.socket.WebSocketTransport;
+import org.neo4j.udc.UsageData;
 
 import static java.util.Arrays.asList;
 import static org.neo4j.collection.primitive.Primitive.longObjectMap;
@@ -81,6 +82,8 @@ public class NDPKernelExtension extends KernelExtensionFactory<NDPKernelExtensio
         GraphDatabaseService db();
 
         JobScheduler scheduler();
+
+        UsageData usageData();
     }
 
     public NDPKernelExtension()
@@ -105,7 +108,7 @@ public class NDPKernelExtension extends KernelExtensionFactory<NDPKernelExtensio
         if ( config.get( Settings.ndp_enabled ) )
         {
             final Sessions sessions = life.add( new ThreadedSessions(
-                    life.add( new StandardSessions( api, logging ) ),
+                    life.add( new StandardSessions( api, dependencies.usageData(), logging ) ),
                     dependencies.scheduler(),
                     logging ) );
 

--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/MessageHandler.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/MessageHandler.java
@@ -42,6 +42,8 @@ public interface MessageHandler<E extends Exception>
 
     void handleIgnoredMessage() throws E;
 
+    void handleInitializeMessage( String clientName ) throws E;
+
     class Adapter<E extends Exception> implements MessageHandler<E>
     {
         @Override
@@ -88,6 +90,12 @@ public interface MessageHandler<E extends Exception>
 
         @Override
         public void handleIgnoredMessage() throws E
+        {
+
+        }
+
+        @Override
+        public void handleInitializeMessage( String clientName ) throws E
         {
 
         }

--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/message/InitializeMessage.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/message/InitializeMessage.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.messaging.v1.message;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.neo4j.ndp.messaging.v1.MessageHandler;
+
+public class InitializeMessage implements Message
+{
+    private final String clientName;
+
+    public InitializeMessage( String clientName )
+    {
+        this.clientName = clientName;
+    }
+
+    public String clientName()
+    {
+        return clientName;
+    }
+
+    @Override
+    public <E extends Exception> void dispatch( MessageHandler<E> consumer ) throws E
+    {
+        consumer.handleInitializeMessage( clientName );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        InitializeMessage that = (InitializeMessage) o;
+
+        return !(clientName != null ? !clientName.equals( that.clientName ) : that.clientName != null);
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return clientName != null ? clientName.hashCode() : 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "InitializeMessage{" +
+               "clientName='" + clientName + '\'' +
+               '}';
+    }
+}

--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/message/Messages.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/message/Messages.java
@@ -41,6 +41,11 @@ public class Messages
         return new RunMessage( statement, parameters );
     }
 
+    public static Message initialize( String clientName )
+    {
+        return new InitializeMessage( clientName );
+    }
+
     public static Message pullAll()
     {
         return PULL_ALL;

--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/msgprocess/TransportBridge.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/msgprocess/TransportBridge.java
@@ -61,6 +61,12 @@ public class TransportBridge extends MessageHandler.Adapter<RuntimeException>
     }
 
     @Override
+    public void handleInitializeMessage( String clientName ) throws RuntimeException
+    {
+        session.initialize( clientName, null, simpleCallback );
+    }
+
+    @Override
     public void handleRunMessage( String statement, Map<String,Object> params )
     {
         session.run( statement, params, null, runCallback );

--- a/community/ndp/messaging-v1/src/test/java/org/neo4j/ndp/messaging/v1/MessageFormatTest.java
+++ b/community/ndp/messaging-v1/src/test/java/org/neo4j/ndp/messaging/v1/MessageFormatTest.java
@@ -36,6 +36,7 @@ import org.neo4j.ndp.messaging.v1.message.AcknowledgeFailureMessage;
 import org.neo4j.ndp.messaging.v1.message.DiscardAllMessage;
 import org.neo4j.ndp.messaging.v1.message.FailureMessage;
 import org.neo4j.ndp.messaging.v1.message.IgnoredMessage;
+import org.neo4j.ndp.messaging.v1.message.InitializeMessage;
 import org.neo4j.ndp.messaging.v1.message.Message;
 import org.neo4j.ndp.messaging.v1.message.PullAllMessage;
 import org.neo4j.ndp.messaging.v1.message.RecordMessage;
@@ -67,6 +68,7 @@ public class MessageFormatTest
         assertSerializes( new FailureMessage( new Neo4jError( Status.General.UnknownFailure, "Err" ) ) );
         assertSerializes( new IgnoredMessage() );
         assertSerializes( new AcknowledgeFailureMessage() );
+        assertSerializes( new InitializeMessage("MyClient/1.0") );
     }
 
     @Test

--- a/community/ndp/messaging-v1/src/test/java/org/neo4j/ndp/messaging/v1/RecordingMessageHandler.java
+++ b/community/ndp/messaging-v1/src/test/java/org/neo4j/ndp/messaging/v1/RecordingMessageHandler.java
@@ -27,6 +27,7 @@ import org.neo4j.ndp.messaging.v1.message.AcknowledgeFailureMessage;
 import org.neo4j.ndp.messaging.v1.message.DiscardAllMessage;
 import org.neo4j.ndp.messaging.v1.message.FailureMessage;
 import org.neo4j.ndp.messaging.v1.message.IgnoredMessage;
+import org.neo4j.ndp.messaging.v1.message.InitializeMessage;
 import org.neo4j.ndp.messaging.v1.message.Message;
 import org.neo4j.ndp.messaging.v1.message.PullAllMessage;
 import org.neo4j.ndp.messaging.v1.message.RecordMessage;
@@ -85,6 +86,12 @@ public class RecordingMessageHandler implements MessageHandler<RuntimeException>
     public void handleIgnoredMessage() throws RuntimeException
     {
         messages.add( new IgnoredMessage() );
+    }
+
+    @Override
+    public void handleInitializeMessage( String clientName ) throws RuntimeException
+    {
+        messages.add( new InitializeMessage( clientName ) );
     }
 
     public List<Message> asList()

--- a/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
+++ b/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
@@ -326,19 +326,19 @@ public class PackStream
             }
         }
 
-        public void packStructHeader( int size, char signature ) throws IOException
+        public void packStructHeader( int size, byte signature ) throws IOException
         {
             if ( size < 0x10 )
             {
-                out.writeShort( (short) ((byte) (TINY_STRUCT | size) << 8 | (byte) signature) );
+                out.writeShort( (short) ((byte) (TINY_STRUCT | size) << 8 | signature) );
             }
             else if ( size <= Byte.MAX_VALUE )
             {
-                out.writeByte( STRUCT_8 ).writeByte( (byte) size ).writeByte( (byte) signature );
+                out.writeByte( STRUCT_8 ).writeByte( (byte) size ).writeByte( signature );
             }
             else if ( size <= Short.MAX_VALUE )
             {
-                out.writeByte( STRUCT_16 ).writeShort( (short) size ).writeByte( (byte) signature );
+                out.writeByte( STRUCT_16 ).writeShort( (short) size ).writeByte( signature );
             }
             else
             {

--- a/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
+++ b/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
@@ -483,7 +483,7 @@ public class PackStreamTest
 
         // When
         PackStream.Packer packer = machine.packer();
-        packer.packStructHeader( 3, 'N' );
+        packer.packStructHeader( 3, (byte)'N' );
         packer.pack( 12 );
         packer.packListHeader( 2 );
         packer.pack( "Person" );
@@ -521,7 +521,7 @@ public class PackStreamTest
 
         // When
         PackStream.Packer packer = machine.packer();
-        packer.packStructHeader( 3, 'N' );
+        packer.packStructHeader( 3,  (byte)'N' );
         packer.pack( 12 );
         packer.packListHeader( 2 );
         packer.pack( "Person" );
@@ -594,7 +594,7 @@ public class PackStreamTest
         // Given
         Machine machine = new Machine();
         PackStream.Packer packer = machine.packer();
-        packer.packStructHeader( 4, '~' );
+        packer.packStructHeader( 4,  (byte)'~' );
         packer.pack( 1 );
         packer.pack( 2 );
         packer.pack( 3 );

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/Session.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/Session.java
@@ -110,6 +110,11 @@ public interface Session extends AutoCloseable
     String key();
 
     /**
+     * Initialize the session.
+     */
+    <A> void initialize( String clientName, A attachment, Callback<Void,A> callback );
+
+    /**
      * Run a statement, yielding a result stream which can be retrieved through pulling it in a subsequent call.
      * <p/>
      * If there is a statement running already, all remaining items in its stream must be {@link #pullAll(Object,

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/StatementMetadata.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/StatementMetadata.java
@@ -21,8 +21,7 @@ package org.neo4j.ndp.runtime;
 
 /**
  * Metadata that becomes available as soon as a statement is started, and is sent to the client before the result
- * stream
- * is sent.
+ * stream is sent.
  */
 public interface StatementMetadata
 {

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/CypherStatementRunner.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/CypherStatementRunner.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.ndp.runtime.internal.session.SessionState;
 import org.neo4j.stream.RecordStream;
 
 public class CypherStatementRunner implements StatementRunner

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/SessionState.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/SessionState.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.ndp.runtime.internal.session;
+package org.neo4j.ndp.runtime.internal;
 
 import org.neo4j.kernel.api.Statement;
 

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/StandardSessions.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/StandardSessions.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.ndp.runtime.Session;
 import org.neo4j.ndp.runtime.Sessions;
-import org.neo4j.ndp.runtime.internal.session.SessionStateMachine;
+import org.neo4j.udc.UsageData;
 
 /**
  * The runtime environment in which user statements are executed. This is not a thread safe class, it is expected
@@ -36,14 +36,16 @@ public class StandardSessions extends LifecycleAdapter implements Sessions
 {
     private final GraphDatabaseAPI gds;
     private final LifeSupport life = new LifeSupport();
+    private final UsageData usageData;
     private final LogService logging;
 
     private CypherStatementRunner queryEngine;
     private ThreadToStatementContextBridge txBridge;
 
-    public StandardSessions( GraphDatabaseAPI gds, LogService logging )
+    public StandardSessions( GraphDatabaseAPI gds, UsageData usageData, LogService logging )
     {
         this.gds = gds;
+        this.usageData = usageData;
         this.logging = logging;
         // TODO: Introduce a clean SPI rather than use GDS
         this.txBridge = gds.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
@@ -77,6 +79,6 @@ public class StandardSessions extends LifecycleAdapter implements Sessions
     @Override
     public Session newSession()
     {
-        return new SessionStateMachine( gds, txBridge, queryEngine, logging );
+        return new SessionStateMachine( usageData, gds, txBridge, queryEngine, logging );
     }
 }

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/StatementRunner.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/StatementRunner.java
@@ -22,7 +22,6 @@ package org.neo4j.ndp.runtime.internal;
 import java.util.Map;
 
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.ndp.runtime.internal.session.SessionState;
 import org.neo4j.stream.RecordStream;
 
 /**

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -47,6 +47,19 @@ public class SessionWorkerFacade implements Session
     }
 
     @Override
+    public <A> void initialize( final String clientName, final A attachment, final Callback<Void,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.initialize( clientName, attachment, callback );
+            }
+        } );
+    }
+
+    @Override
     public <A> void run( final String statement, final Map<String,Object> params, final A attachment,
             final Callback<StatementMetadata,A> callback )
     {

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/SessionIT.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/SessionIT.java
@@ -58,6 +58,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // When
         session.run( "CREATE (n {k:'k'}) RETURN n.k", Collections.<String,Object>emptyMap(), null, responses );
@@ -78,6 +79,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -95,6 +97,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata,Object>noop() );
@@ -112,6 +115,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "BEGIN", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -131,6 +135,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran one statement
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -147,6 +152,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -164,6 +170,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -181,6 +188,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -198,6 +206,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And Given that I've ran and pulled one stream
         session.run( "RETURN 1", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
@@ -215,6 +224,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
         session.run( "CREATE (n:Victim)-[:REL]->()", EMPTY_PARAMS, null, Session.Callbacks.<StatementMetadata, Object>noop() );
         session.discardAll( null, Session.Callbacks.<Void,Object>noop() );
 
@@ -234,6 +244,8 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
+
         final CountDownLatch pullAllCallbackCalled = new CountDownLatch( 1 );
         final AtomicReference<Neo4jError> error = new AtomicReference<>();
 
@@ -272,7 +284,9 @@ public class SessionIT
     {
         // Given
         Session firstSession = env.newSession();
+        firstSession.initialize( "TestClient/1.0", null, null );
         Session secondSession = env.newSession();
+        secondSession.initialize( "TestClient/1.0", null, null );
 
         // And given I've started a transaction in one session
         runAndPull( firstSession, "BEGIN" );
@@ -295,6 +309,7 @@ public class SessionIT
     {
         // Given
         Session session = env.newSession();
+        session.initialize( "TestClient/1.0", null, null );
 
         // And given I've started a transaction that failed
         runAndPull( session, "BEGIN" );

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TestSessions.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TestSessions.java
@@ -35,6 +35,7 @@ import org.neo4j.ndp.runtime.Sessions;
 import org.neo4j.ndp.runtime.internal.StandardSessions;
 import org.neo4j.ndp.runtime.internal.concurrent.ThreadedSessions;
 import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.udc.UsageData;
 
 public class TestSessions implements TestRule, Sessions
 {
@@ -54,7 +55,7 @@ public class TestSessions implements TestRule, Sessions
                 gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
                 Neo4jJobScheduler scheduler = life.add( new Neo4jJobScheduler() );
                 StandardSessions sessions = life.add(
-                        new StandardSessions( (GraphDatabaseAPI) gdb, NullLogService.getInstance() ) );
+                        new StandardSessions( (GraphDatabaseAPI) gdb, new UsageData(), NullLogService.getInstance() ) );
                 actual = life.add( new ThreadedSessions(
                         sessions,
                         scheduler, NullLogService.getInstance() ) );

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TransactionIT.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TransactionIT.java
@@ -44,6 +44,7 @@ public class TransactionIT
         // Given
         RecordingCallback<StatementMetadata, ?> responses = new RecordingCallback<>();
         Session session = env.newSession();
+        session.initialize( "TestClient", null, null );
 
         // When
         session.run( "BEGIN", EMPTY_PARAMS, null, responses );
@@ -67,6 +68,7 @@ public class TransactionIT
         // Given
         RecordingCallback<StatementMetadata, ?> responses = new RecordingCallback<>();
         Session session = env.newSession();
+        session.initialize( "TestClient", null, null );
 
         // When
         session.run( "BEGIN", EMPTY_PARAMS, null, responses );

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/CypherStatementRunnerTest.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/CypherStatementRunnerTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
-import org.neo4j.ndp.runtime.internal.session.SessionStateMachine;
 
 import static java.util.Collections.EMPTY_MAP;
 import static org.mockito.Matchers.anyMap;

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketProtocolV1.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketProtocolV1.java
@@ -54,6 +54,7 @@ public class SocketProtocolV1 implements SocketProtocol
 
     private final TransportBridge bridge;
     private final Session session;
+
     private final Log log;
     private final AtomicInteger inFlight = new AtomicInteger( 0 );
     private final ErrorTranslator errorTranslator;

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/Neo4jWithSocket.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/Neo4jWithSocket.java
@@ -39,6 +39,7 @@ import org.neo4j.ndp.transport.socket.SocketProtocolV1;
 import org.neo4j.ndp.transport.socket.SocketTransport;
 import org.neo4j.ndp.transport.socket.WebSocketTransport;
 import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.udc.UsageData;
 
 import static java.util.Arrays.asList;
 import static org.neo4j.collection.primitive.Primitive.longObjectMap;
@@ -65,8 +66,9 @@ public class Neo4jWithSocket implements TestRule
                 final GraphDatabaseService gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
                 final GraphDatabaseAPI api = ((GraphDatabaseAPI) gdb);
                 final LogService logging = api.getDependencyResolver().resolveDependency( LogService.class );
+                final UsageData usageData = api.getDependencyResolver().resolveDependency( UsageData.class );
 
-                final Sessions sessions = life.add( new StandardSessions( api, logging ) );
+                final Sessions sessions = life.add( new StandardSessions( api, usageData, logging ) );
 
                 PrimitiveLongObjectMap<Function<Channel, SocketProtocol>> availableVersions = longObjectMap();
                 availableVersions.put( SocketProtocolV1.VERSION, new Function<Channel, SocketProtocol>()

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/TransportErrorIT.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/TransportErrorIT.java
@@ -119,7 +119,7 @@ public class TransportErrorIT
         final RecordingByteChannel rawData = new RecordingByteChannel();
         final PackStream.Packer packer = new PackStream.Packer( new BufferedChannelOutput( rawData ) );
 
-        packer.packStructHeader( 2, (char) PackStreamMessageFormatV1.MessageTypes.MSG_RUN );
+        packer.packStructHeader( 2, PackStreamMessageFormatV1.MessageTypes.MSG_RUN );
         packer.pack( "RETURN 1" );
         packer.pack( 1234 ); // Should've been a map
         packer.flush();
@@ -146,7 +146,7 @@ public class TransportErrorIT
         final RecordingByteChannel rawData = new RecordingByteChannel();
         final PackStream.Packer packer = new PackStream.Packer( new BufferedChannelOutput( rawData ) );
 
-        packer.packStructHeader( 1, (char) 0x66 ); // Invalid message type
+        packer.packStructHeader( 1, (byte)0x66 ); // Invalid message type
         packer.pack( 1234 );
         packer.flush();
 
@@ -171,7 +171,7 @@ public class TransportErrorIT
         final BufferedChannelOutput out = new BufferedChannelOutput( rawData );
         final PackStream.Packer packer = new PackStream.Packer( out );
 
-        packer.packStructHeader( 2, (char) PackStreamMessageFormatV1.MessageTypes.MSG_RUN );
+        packer.packStructHeader( 2, PackStreamMessageFormatV1.MessageTypes.MSG_RUN );
         out.writeByte( PackStream.RESERVED_C4 ); // Invalid marker byte
         out.flush();
 

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/TransportSessionIT.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/TransportSessionIT.java
@@ -38,6 +38,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.ndp.messaging.v1.message.Messages.initialize;
 import static org.neo4j.ndp.messaging.v1.message.Messages.pullAll;
 import static org.neo4j.ndp.messaging.v1.message.Messages.run;
 import static org.neo4j.ndp.messaging.v1.util.MessageMatchers.msgRecord;
@@ -118,12 +119,14 @@ public class TransportSessionIT
         client.connect( address )
                 .send( acceptedVersions( 1, 0, 0, 0 ) )
                 .send( chunk(
+                        initialize("TestClient/1.1"),
                         run( "UNWIND [1,2,3] AS a RETURN a, a * a AS a_squared" ),
                         pullAll() ) );
 
         // Then
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyRecieves(
+                msgSuccess(),
                 msgSuccess( map( "fields", asList( "a", "a_squared" ) ) ),
                 msgRecord( eqRecord( equalTo( 1l ), equalTo( 1l ) ) ),
                 msgRecord( eqRecord( equalTo( 2l ), equalTo( 4l ) ) ),

--- a/community/ndp/v1-docs/src/docs/dev/examples.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/examples.asciidoc
@@ -15,6 +15,14 @@ Client: <connect>
 Client: 00 00 00 01  00 00 00 00  00 00 00 00  00 00 00 00
 Server: 00 00 00 01
 
+Client: INITIALIZE "MyClient/1.0"
+
+  00 0F B1 01 8C 4D 79 43    6C 69 65 6E 74 2F 31 2E    30 00 00
+
+Server: SUCCESS {}
+
+  00 03 b1 70  a0 00 00
+
 Client: RUN "RETURN 1 AS num" {}
 
   00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53
@@ -52,6 +60,14 @@ Note that these two statements are executed in two individual transactions, impl
 Client: <connect>
 Client: 00 00 00 01  00 00 00 00  00 00 00 00  00 00 00 00
 Server: 00 00 00 01
+
+Client: INITIALIZE "MyClient/1.0"
+
+  00 0F B1 01 8C 4D 79 43    6C 69 65 6E 74 2F 31 2E    30 00 00
+
+Server: SUCCESS {}
+
+  00 03 b1 70  a0 00 00
 
 # Batch of messages
 Client: RUN "RETURN 1 AS num" {}
@@ -113,6 +129,13 @@ Client: <connect>
 Client: 00 00 00 01  00 00 00 00  00 00 00 00  00 00 00 00
 Server: 00 00 00 01
 
+Client: INITIALIZE "MyClient/1.0"
+
+  00 0F B1 01 8C 4D 79 43    6C 69 65 6E 74 2F 31 2E    30 00 00
+
+Server: SUCCESS {}
+
+  00 03 b1 70  a0 00 00
 
 # Message with syntax error
 Client: RUN "This will cause a syntax error" {}

--- a/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
@@ -4,7 +4,7 @@
 This section discusses the semantic meaning and layout of protocol messages.
 For details on how Neo4j types are represented in binary form, see <<ndp-serialization,serialization>>.
 
-Clients may send request messages at any time.
+Clients may send request messages at any time after a session is <<ndp-message-structs-initialize,initialized>>.
 Clients may <<ndp-messaging-pipelining,pipeline>> requests, sending multiple requests together.
 
 Servers must fully respond to each request before the next request is processed and processing of requests within a session must be done in the same order in which the requests.
@@ -19,6 +19,11 @@ For example, `RECORD` messages are classed as detail messages and `SUCCESS` mess
 The diagrams below illustrates a basic exchange wherein the client sends a request message and receives a series of response messages.
 
 image:images/simple-exchange.png[]
+
+=== Initialization
+
+Before a session can be used to <<ndp-message-structs-run,run>> queries, it must be <<ndp-message-structs-initialize,initialized>>.
+The `INITIALIZE` message message should be sent by the client as the first message it sends after <<ndp-handshake,negotiating protocol version>>.
 
 [[ndp-messaging-pipelining]]
 === Pipelining
@@ -62,6 +67,41 @@ Once the client acknowledges the failure, it is then able to resend a corrected 
 
 Protocol messages are represented as <<ndp-packstream-structures,serialized structures>>.
 
+[[ndp-message-structs-initialize]]
+==== INITIALIZE
+
+The `INITIALIZE` message is a client message used once to initalize the session.
+This message is always the first message the client sends after <<ndp-handshake,negotiating protocol version>>.
+Sending any message other than `INITIALIZE` as the first message to the server will result in a `FAILURE` and the
+server closing the connection.
+
+The server will reply with a `SUCCESS` message unless some parameter for initialization is malformed.
+
+All parameters in the `INITIALIZE` message are required.
+
+[source,ndp_message_struct]
+----
+InitializeMessage (signature=0x01) {
+    Text clientName
+}
+----
+
+.Example
+[source,ndp_packstream_type]
+----
+Value: INITIALIZE "MyClient/1.0"
+
+B1 01 8C 4D  79 43 6C 69  65 6E 74 2F  31 2E 30
+----
+
+.Initialize message parameters
+[cols="20,80",options="header"]
+|=======================
+|Parameter   |Description
+|clientName  |A name and version for the client, if the user has allowed usage data collection, this is used to track popular clients. Example: "MyClient/1.0"
+|=======================
+
+[[ndp-message-structs-run]]
 ==== RUN
 
 The `RUN` message is a client message used to start a new job on the server. It has the following structure:

--- a/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
@@ -24,6 +24,7 @@ The default port for regular socket connections is *7687*.
 Similar configuration exists for the WebSocket listener.
 The default port for WebSocket connections is *7688*.
 
+[[ndp-handshake]]
 === Handshake
 
 After connecting, a handshake takes place to establish which protocol version should be used for that connection.

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocSerialization.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocSerialization.java
@@ -136,7 +136,7 @@ public class DocSerialization
         else if ( value.startsWith( "Struct" ) )
         {
             DocStructExample struct = new DocStructExample( value );
-            packer.packStructHeader( struct.size(), (char) struct.signature() );
+            packer.packStructHeader( struct.size(), (byte)struct.signature() );
 
             for ( String s : struct )
             {
@@ -206,6 +206,10 @@ public class DocSerialization
                     "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n" +
                     "\"This will cause a syntax error\"\n" +
                     " ^" ) );
+        }
+        else if( value.equals( "INITIALIZE \"MyClient/1.0\"" ))
+        {
+            writer.handleInitializeMessage( "MyClient/1.0" );
         }
         else
         {

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocStruct.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocStruct.java
@@ -147,9 +147,9 @@ public class DocStruct implements Iterable<DocStruct.Field>
         return raw;
     }
 
-    public int signature()
+    public byte signature()
     {
-        return Integer.parseInt( attribute( "signature" ).substring( 2 ), 16 );
+        return (byte) Integer.parseInt( attribute( "signature" ).substring( 2 ), 16 );
     }
 
     public int size()

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPMessageStructsDocTest.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPMessageStructsDocTest.java
@@ -71,7 +71,7 @@ public class NDPMessageStructsDocTest
         PackStream.Packer packer = new PackStream.Packer( new BufferedChannelOutput( ch, 128 ) );
 
         // When I pack a message according to the documentation
-        packer.packStructHeader( struct.size(), (char) struct.signature() );
+        packer.packStructHeader( struct.size(), struct.signature() );
         for ( DocStruct.Field field : struct )
         {
             packValueOf( field.type(), packer );

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPPackStreamDocTest.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPPackStreamDocTest.java
@@ -68,7 +68,7 @@ public class NDPPackStreamDocTest
     public void serializingLeadsToSpecifiedOutput() throws Throwable
     {
         assertThat( "Serialized version of value should match documented data: " + example,
-                normalizedHex( pack( example.attribute( "Value" ) ) ),
-                equalTo( normalizedHex( example.serializedData() ) ) );
+                normalizedHex( example.serializedData() ),
+                equalTo( normalizedHex( pack( example.attribute( "Value" ) ) ) ) );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/modules/NDPModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/NDPModule.java
@@ -42,6 +42,7 @@ import org.neo4j.ndp.transport.socket.SocketTransport;
 import org.neo4j.ndp.transport.socket.WebSocketTransport;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.logging.Netty4LoggerFactory;
+import org.neo4j.udc.UsageData;
 
 import static java.util.Arrays.asList;
 import static org.neo4j.collection.primitive.Primitive.longObjectMap;
@@ -69,6 +70,7 @@ public class NDPModule implements ServerModule
         // organize this module life cycle better.
         final GraphDatabaseAPI api = dependencyResolver.resolveDependency( GraphDatabaseAPI.class );
         final LogService logging = dependencyResolver.resolveDependency( LogService.class );
+        final UsageData usageData = dependencyResolver.resolveDependency( UsageData.class );
         final JobScheduler scheduler = dependencyResolver.resolveDependency( JobScheduler.class );
 
         final Log internalLog = logging.getInternalLog( Sessions.class );
@@ -80,7 +82,7 @@ public class NDPModule implements ServerModule
         if ( config.get( ServerSettings.ndp_enabled ) )
         {
             final Sessions sessions = life.add( new ThreadedSessions(
-                    life.add( new StandardSessions( api, logging ) ),
+                    life.add( new StandardSessions( api, usageData, logging ) ),
                     scheduler,
                     logging ) );
 


### PR DESCRIPTION
First step, NDP now requires 'INITIALIZE' as first message sent.
Currently this simply asks for a client name, which will be plugged into UDC.
However, this can then be expanded to handle auth negotiation, compression,
buffer sizing and so on.
