### PR TITLE
Solve annoying leak warning from test code

### DIFF
--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedOutputTest.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedOutputTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -94,4 +95,11 @@ public class ChunkedOutputTest
 
         out.setTargetChannel( ch );
     }
+
+    @After
+    public void teardown()
+    {
+        out.close();
+    }
+
 }

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/ConcurrentAccessIT.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/integration/ConcurrentAccessIT.java
@@ -128,6 +128,7 @@ public class ConcurrentAccessIT
                 {
                     creaeteAndRollback( client );
                 }
+
                 return null;
             }
 


### PR DESCRIPTION
Just close the chunked output so that Netty is happy about its buffers getting returned. Gets rid of scary-looking `LEAK DETECTED` messages in the build output.
