### PR TITLE
Add rpm to dependencies installation for Ubuntu

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -37,7 +37,7 @@ If you don't plan to build the browser (for example by using -DskipBrowser), the
 
 === With apt-get on Ubuntu ===
 
-  sudo apt-get install graphviz maven nodejs-legacy npm make openjdk-7-jdk devscripts debhelper
+  sudo apt-get install graphviz maven nodejs-legacy npm make openjdk-7-jdk devscripts debhelper rpm
 
 == Building Neo4j ==
 


### PR DESCRIPTION
While trying to run the full build on my ubuntu machine, I noticed that having RPM installed is required to build the linux installer packages. I added it to the Readme since it is not installed on Ubuntu by default.

Cheers,
Felix
