### PR TITLE
Extract PortRangeSocketBinder from Server.

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Connection.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Connection.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelException;
+
+import java.net.InetSocketAddress;
+
+public class Connection
+{
+    private Channel channel;
+    private InetSocketAddress socketAddress;
+
+    public Connection( InetSocketAddress socketAddress, Channel channel )
+    {
+        this.socketAddress = socketAddress;
+        this.channel = channel;
+    }
+
+    public Channel getChannel()
+    {
+        return channel;
+    }
+
+    public InetSocketAddress getSocketAddress()
+    {
+        return socketAddress;
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/PortIterator.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/PortIterator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import java.util.Iterator;
+
+public class PortIterator implements Iterator<Integer>
+{
+    private final int start;
+    private final int end;
+    private int next;
+
+    public PortIterator( int[] portRanges )
+    {
+        start = portRanges[0];
+        end = portRanges[1];
+        next = start;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return start < end ? next <= end : next >= end;
+    }
+
+    @Override
+    public Integer next()
+    {
+        return start < end ? next++ : next--;
+    }
+
+    @Override
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/PortRangeSocketBinder.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/PortRangeSocketBinder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelException;
+
+import java.net.InetSocketAddress;
+
+import org.neo4j.helpers.HostnamePort;
+
+public class PortRangeSocketBinder
+{
+    private ServerBootstrap bootstrap;
+    private static final String ALL_INTERFACES_ADDRESS = "0.0.0.0";
+
+    public PortRangeSocketBinder( ServerBootstrap bootstrap )
+    {
+        this.bootstrap = bootstrap;
+    }
+
+    public Connection bindToFirstAvailablePortInRange( HostnamePort serverAddress ) throws ChannelException
+    {
+        int[] ports = serverAddress.getPorts();
+        String host = serverAddress.getHost();
+
+        Channel channel;
+        InetSocketAddress socketAddress;
+        ChannelException lastException = null;
+
+        PortIterator portIterator = new PortIterator( ports );
+        while ( portIterator.hasNext() )
+        {
+            Integer port = portIterator.next();
+            if ( host == null || host.equals( ALL_INTERFACES_ADDRESS ) )
+            {
+                socketAddress = new InetSocketAddress( port );
+            }
+            else
+            {
+                socketAddress = new InetSocketAddress( host, port );
+            }
+            try
+            {
+                channel = bootstrap.bind( socketAddress );
+                return new Connection( socketAddress, channel );
+            }
+            catch ( ChannelException e )
+            {
+                if ( lastException != null )
+                {
+                    e.addSuppressed( lastException );
+                }
+                lastException = e;
+            }
+        }
+
+        throw lastException;
+    }
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/PortIteratorTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/PortIteratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class PortIteratorTest
+{
+    @Test
+    public void shouldCountUp()
+    {
+        PortIterator portIterator = new PortIterator( new int[]{6000, 6005} );
+
+        assertEquals( 6000, (int) portIterator.next() );
+        assertEquals( 6001, (int) portIterator.next() );
+        assertEquals( 6002, (int) portIterator.next() );
+        assertEquals( 6003, (int) portIterator.next() );
+        assertEquals( 6004, (int) portIterator.next() );
+        assertEquals( 6005, (int) portIterator.next() );
+        assertFalse( portIterator.hasNext() );
+    }
+
+    @Test
+    public void shouldCountDown()
+    {
+        PortIterator portIterator = new PortIterator( new int[]{6005, 6000} );
+
+        assertEquals( 6005, (int) portIterator.next() );
+        assertEquals( 6004, (int) portIterator.next() );
+        assertEquals( 6003, (int) portIterator.next() );
+        assertEquals( 6002, (int) portIterator.next() );
+        assertEquals( 6001, (int) portIterator.next() );
+        assertEquals( 6000, (int) portIterator.next() );
+        assertFalse( portIterator.hasNext() );
+    }
+
+    @Test
+    public void shouldNotSupportRemove()
+    {
+        try
+        {
+            new PortIterator( new int[]{6000, 6005} ).remove();
+            fail("Should have thrown exception");
+        }
+        catch ( UnsupportedOperationException e )
+        {
+            // expected
+        }
+    }
+}

--- a/enterprise/com/src/test/java/org/neo4j/com/PortRangeSocketBinderTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/PortRangeSocketBinderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelException;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import org.neo4j.helpers.HostnamePort;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class PortRangeSocketBinderTest
+{
+    @Test
+    public void shouldReThrowExceptionIfCannotBindToPort()
+    {
+        // given
+        HostnamePort localhost = new HostnamePort( "localhost", 9000 );
+        ServerBootstrap bootstrap = mock( ServerBootstrap.class );
+
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9000 ) ) ).thenThrow( new ChannelException() );
+
+        try
+        {
+            // when
+            new PortRangeSocketBinder( bootstrap ).bindToFirstAvailablePortInRange( localhost );
+            fail( "should have thrown ChannelException" );
+        }
+        catch ( ChannelException ignored )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldReThrowExceptionIfCannotBindToAnyOfThePortsInTheRange()
+    {
+        // given
+        HostnamePort localhost = new HostnamePort( "localhost", 9000, 9002 );
+        ServerBootstrap bootstrap = mock( ServerBootstrap.class );
+
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9000 ) ) ).thenThrow(
+                new ChannelException("Failed to bind to: 9000") );
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9001 ) ) ).thenThrow(
+                new ChannelException("Failed to bind to: 9001") );
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9002 ) ) ).thenThrow(
+                new ChannelException("Failed to bind to: 9002") );
+
+        try
+        {
+            // when
+            new PortRangeSocketBinder( bootstrap ).bindToFirstAvailablePortInRange( localhost );
+            fail( "should have thrown ChannelException" );
+        }
+        catch ( ChannelException ex )
+        {
+            // expected
+            assertEquals(2, suppressedExceptions( ex ));
+        }
+    }
+
+    private int suppressedExceptions( Throwable throwable ) {
+        int suppressed = 0;
+        for ( Throwable ignored : throwable.getSuppressed() )
+        {
+            suppressed++;
+            suppressed = suppressed + suppressedExceptions( ignored );
+
+        }
+        return suppressed;
+    }
+
+    @Test
+    public void shouldReturnChannelAndSocketIfPortIsFree()
+    {
+        // given
+        HostnamePort localhost = new HostnamePort( "localhost", 9000 );
+        ServerBootstrap bootstrap = mock( ServerBootstrap.class );
+        Channel channel = mock( Channel.class );
+
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9000 ) ) ).thenReturn( channel );
+
+        // when
+        Connection connection = new PortRangeSocketBinder( bootstrap ).bindToFirstAvailablePortInRange( localhost );
+
+        //then
+        assertEquals( channel, connection.getChannel() );
+        assertEquals( new InetSocketAddress( "localhost", 9000 ), connection.getSocketAddress() );
+    }
+
+    @Test
+    public void shouldReturnChannelAndSocketIfAnyPortsAreFree()
+    {
+        // given
+        HostnamePort localhost = new HostnamePort( "localhost", 9000, 9001 );
+        ServerBootstrap bootstrap = mock( ServerBootstrap.class );
+        Channel channel = mock( Channel.class );
+
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9000 ) ) ).thenThrow( new ChannelException() );
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9001 ) ) ).thenReturn( channel );
+
+        // when
+        Connection connection = new PortRangeSocketBinder( bootstrap ).bindToFirstAvailablePortInRange( localhost );
+
+        //then
+        assertEquals( channel, connection.getChannel() );
+        assertEquals( new InetSocketAddress( localhost.getHost(), 9001 ), connection.getSocketAddress() );
+    }
+
+    @Test
+    public void shouldReturnChannelAndSocketIfPortRangeIsInverted()
+    {
+        // given
+        HostnamePort localhost = new HostnamePort( "localhost", 9001, 9000 );
+        ServerBootstrap bootstrap = mock( ServerBootstrap.class );
+        Channel channel = mock( Channel.class );
+
+        when( bootstrap.bind( new InetSocketAddress( "localhost", 9001 ) ) ).thenReturn( channel );
+
+        // when
+        Connection connection = new PortRangeSocketBinder( bootstrap ).bindToFirstAvailablePortInRange( localhost );
+
+        //then
+        assertEquals( channel, connection.getChannel() );
+        assertEquals( new InetSocketAddress( localhost.getHost(), 9001 ), connection.getSocketAddress() );
+
+    }
+}


### PR DESCRIPTION
Implementation now also supports inverted port ranges;
e.g. localhost:6010-6000

Authors: me and @apcj 
