### PR TITLE
ImpermanentGraphDatabase uses JimFS file system instead of EFSA

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -195,4 +195,9 @@ public class DefaultFileSystemAbstraction
         }
         return clazz.cast( fileSystem );
     }
+
+    @Override
+    public void close() throws IOException
+    {   // Nothing to close
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.fs;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -30,46 +31,46 @@ import java.util.zip.ZipOutputStream;
 
 import org.neo4j.function.Function;
 
-public interface FileSystemAbstraction
+public interface FileSystemAbstraction extends Closeable
 {
     StoreChannel open( File fileName, String mode ) throws IOException;
-    
+
     OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException;
-    
+
     InputStream openAsInputStream( File fileName ) throws IOException;
-    
+
     Reader openAsReader( File fileName, String encoding ) throws IOException;
-    
+
     Writer openAsWriter( File fileName, String encoding, boolean append ) throws IOException;
-    
+
     FileLock tryLock( File fileName, StoreChannel channel ) throws IOException;
-    
+
     StoreChannel create( File fileName ) throws IOException;
-    
+
     boolean fileExists( File fileName );
-    
+
     boolean mkdir( File fileName );
-    
+
     void mkdirs( File fileName ) throws IOException;
-    
+
     long getFileSize( File fileName );
 
     boolean deleteFile( File fileName );
-    
+
     void deleteRecursively( File directory ) throws IOException;
-    
+
     boolean renameFile( File from, File to ) throws IOException;
-    
+
     File[] listFiles( File directory );
 
     File[] listFiles( File directory, FilenameFilter filter );
 
     boolean isDirectory( File file );
-    
+
     void moveToDirectory( File file, File toDirectory ) throws IOException;
-    
+
     void copyFile( File from, File to ) throws IOException;
-    
+
     void copyRecursively( File fromDirectory, File toDirectory ) throws IOException;
 
     <K extends ThirdPartyFileSystem> K getOrCreateThirdPartyFileSystem( Class<K> clazz, Function<Class<K>, K> creator );

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -61,48 +61,56 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         this.delegate = delegate;
     }
 
+    @Override
     public StoreChannel open( File fileName, String mode ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, IOException.class, SecurityException.class );
         return new AdversarialFileChannel( delegate.open( fileName, mode ), adversary );
     }
 
+    @Override
     public boolean renameFile( File from, File to ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, SecurityException.class );
         return delegate.renameFile( from, to );
     }
 
+    @Override
     public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, SecurityException.class );
         return new AdversarialOutputStream( delegate.openAsOutputStream( fileName, append ), adversary );
     }
 
+    @Override
     public StoreChannel create( File fileName ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, IOException.class, SecurityException.class );
         return new AdversarialFileChannel( delegate.create( fileName ), adversary );
     }
 
+    @Override
     public boolean mkdir( File fileName )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.mkdir( fileName );
     }
 
+    @Override
     public File[] listFiles( File directory )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.listFiles( directory );
     }
 
+    @Override
     public File[] listFiles( File directory, FilenameFilter filter )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.listFiles( directory, filter );
     }
 
+    @Override
     public Writer openAsWriter( File fileName, String encoding, boolean append ) throws IOException
     {
         adversary.injectFailure(
@@ -110,6 +118,7 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         return new AdversarialWriter( delegate.openAsWriter( fileName, encoding, append ), adversary );
     }
 
+    @Override
     public Reader openAsReader( File fileName, String encoding ) throws IOException
     {
         adversary.injectFailure(
@@ -117,36 +126,42 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         return new AdversarialReader( delegate.openAsReader( fileName, encoding ), adversary );
     }
 
+    @Override
     public long getFileSize( File fileName )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.getFileSize( fileName );
     }
 
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         adversary.injectFailure( SecurityException.class, FileNotFoundException.class, IOException.class );
         delegate.copyFile( from, to );
     }
 
+    @Override
     public void copyRecursively( File fromDirectory, File toDirectory ) throws IOException
     {
         adversary.injectFailure( SecurityException.class, IOException.class, NullPointerException.class );
         delegate.copyRecursively( fromDirectory, toDirectory );
     }
 
+    @Override
     public boolean deleteFile( File fileName )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.deleteFile( fileName );
     }
 
+    @Override
     public InputStream openAsInputStream( File fileName ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, SecurityException.class );
         return new AdversarialInputStream( delegate.openAsInputStream( fileName ), adversary );
     }
 
+    @Override
     public void moveToDirectory( File file, File toDirectory ) throws IOException
     {
         adversary.injectFailure(
@@ -155,30 +170,35 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         delegate.moveToDirectory( file, toDirectory );
     }
 
+    @Override
     public boolean isDirectory( File file )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.isDirectory( file );
     }
 
+    @Override
     public boolean fileExists( File fileName )
     {
         adversary.injectFailure( SecurityException.class );
         return delegate.fileExists( fileName );
     }
 
+    @Override
     public void mkdirs( File fileName ) throws IOException
     {
         adversary.injectFailure( SecurityException.class, IOException.class );
         delegate.mkdirs( fileName );
     }
 
+    @Override
     public void deleteRecursively( File directory ) throws IOException
     {
         adversary.injectFailure( SecurityException.class, NullPointerException.class, IOException.class );
         delegate.deleteRecursively( directory );
     }
 
+    @Override
     public FileLock tryLock( File fileName, StoreChannel channel ) throws IOException
     {
         adversary.injectFailure( SecurityException.class, IOException.class, FileNotFoundException.class );
@@ -218,5 +238,11 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         };
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         return (ThirdPartyFileSystem) Proxy.newProxyInstance( loader, new Class[] { clazz }, handler );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        delegate.close();
     }
 }

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -167,4 +167,10 @@ public class DelegatingFileSystemAbstraction implements FileSystemAbstraction
     {
         delegate.copyRecursively( fromDirectory, toDirectory );
     }
+
+    @Override
+    public void close() throws IOException
+    {
+        delegate.close();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -57,6 +57,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.neo4j.function.Function;
+import org.neo4j.io.fs.DelegateFileSystemAbstraction;
 import org.neo4j.io.fs.FileLock;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -68,6 +69,10 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Arrays.asList;
 
+/**
+ * @deprecated in favor of {@link DelegateFileSystemAbstraction} with something like JimFS.
+ */
+@Deprecated
 public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 {
     interface Positionable
@@ -93,7 +98,8 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         this.directories.addAll( directories );
     }
 
-    public synchronized void shutdown()
+    @Override
+    public synchronized void close()
     {
         for ( EphemeralFileData file : files.values() )
         {
@@ -112,8 +118,14 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     @Override
     protected void finalize() throws Throwable
     {
-        shutdown();
-        super.finalize();
+        try
+        {
+            close();
+        }
+        finally
+        {
+            super.finalize();
+        }
     }
 
     public void assertNoOpenFiles() throws Exception

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/NonClosingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/NonClosingFileSystemAbstraction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.mockfs;
+
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+/**
+ * {@link FileSystemAbstraction} that wraps another {@link FileSystemAbstraction} with the sole purpose
+ * of not calling {@link #close()}. The use case is where a custom FS is provided externally onto the
+ * GraphDatabaseFactory, at which point it isn't up to the database to close this file system.
+ * This wrapping is fine since it's only done in testing anyway.
+ */
+public class NonClosingFileSystemAbstraction extends DelegatingFileSystemAbstraction
+{
+    public NonClosingFileSystemAbstraction( FileSystemAbstraction delegate )
+    {
+        super( delegate );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        // Just don't delegate this call.
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -76,7 +76,6 @@ import org.neo4j.io.pagecache.tracing.PinEvent;
 import org.neo4j.test.LinearHistoryPageCacheTracer;
 import org.neo4j.test.RepeatRule;
 
-import static java.lang.Long.toHexString;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -89,6 +88,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static java.lang.Long.toHexString;
+
 import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_NO_FAULT;
 import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
@@ -182,7 +184,7 @@ public abstract class PageCacheTest<T extends PageCache>
         {
             tearDownPageCache( pageCache );
         }
-        fs.shutdown();
+        fs.close();
     }
 
     /**

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwappingTest.java
@@ -70,7 +70,7 @@ public abstract class PageSwappingTest
     @AfterClass
     public static void tearDown()
     {
-        fs.shutdown();
+        fs.close();
     }
 
     @Parameterized.Parameters

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.io.pagecache.impl;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -53,7 +53,7 @@ public class SingleFilePageSwapperTest
     @After
     public void tearDown()
     {
-        fs.shutdown();
+        fs.close();
     }
 
     @Test

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
@@ -67,7 +67,7 @@ public class RandomPageCacheTestHarness
     private int filePageSize;
     private PageCacheTracer tracer;
     private int commandCount;
-    private double[] commandProbabilityFactors;
+    private final double[] commandProbabilityFactors;
     private long randomSeed;
     private boolean fixedRandomSeed;
     private EphemeralFileSystemAbstraction fs;
@@ -414,7 +414,7 @@ public class RandomPageCacheTestHarness
             executor.awaitTermination( deadlineMillis - now, TimeUnit.MILLISECONDS );
             plan.close();
             cache.close();
-            this.fs.shutdown();
+            this.fs.close();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1235,7 +1235,6 @@ public class NeoStoreDataSource implements NeoStoreSupplier, Lifecycle, IndexPro
         kernelModule.kernelTransactions().disposeAll();
     }
 
-    @SuppressWarnings( "deprecation" )
     public static abstract class Configuration
     {
         public static final Setting<String> keep_logical_logs = GraphDatabaseSettings.keep_logical_logs;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -64,11 +64,9 @@ public abstract class EditionModule
         DiagnosticsManager diagnosticsManager = dependencyResolver.resolveDependency( DiagnosticsManager.class );
         NeoStoreDataSource neoStoreDataSource = dependencyResolver.resolveDependency( NeoStoreDataSource.class );
 
-        diagnosticsManager.prependProvider( new KernelDiagnostics.Versions( editionName, neoStoreDataSource.get().getStoreId() ) );
+        diagnosticsManager.prependProvider(
+                new KernelDiagnostics.Versions( editionName, neoStoreDataSource.get().getStoreId() ) );
         neoStoreDataSource.registerDiagnosticsWith( diagnosticsManager );
         diagnosticsManager.appendProvider( new KernelDiagnostics.StoreFiles( neoStoreDataSource.getStoreDir() ) );
-
     }
-
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -135,7 +135,7 @@ public class GraphDatabaseFacade
      * @param editionModule
      * @param dataSourceModule
      */
-    public void init(PlatformModule platformModule, EditionModule editionModule, DataSourceModule dataSourceModule)
+    public void init( PlatformModule platformModule, EditionModule editionModule, DataSourceModule dataSourceModule )
     {
         this.platformModule = platformModule;
         this.editionModule = editionModule;
@@ -269,7 +269,7 @@ public class GraphDatabaseFacade
     @Override
     public void shutdown()
     {
-        if (initialized)
+        if ( initialized )
         {
             try
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -126,8 +126,8 @@ public class PlatformModule
 
         // If no logging was passed in from the outside then create logging and register
         // with this life
-        logging = life.add(dependencies.satisfyDependency(createLogService(externalDependencies.userLogProvider())));
-
+        logging = life.add( dependencies.satisfyDependency(
+                createLogService( externalDependencies.userLogProvider() ) ) );
         config.setLogger( logging.getInternalLog( Config.class ) );
 
         StoreLockerLifecycleAdapter storeLocker = life.add( dependencies.satisfyDependency( new StoreLockerLifecycleAdapter(
@@ -214,7 +214,7 @@ public class PlatformModule
         {
             throw new RuntimeException( ex );
         }
-        return life.add( logService );
+        return logService;
     }
 
     protected Neo4jJobScheduler createJobScheduler()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
@@ -26,8 +26,8 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 
@@ -96,7 +96,7 @@ public class LabelRecoveryTest
         {
             database.shutdown();
         }
-        fs.shutdown();
+        fs.close();
     }
 
     public final EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -121,7 +121,7 @@ public abstract class KernelIntegrationTest
     public void cleanup() throws Exception
     {
         stopDb();
-        fs.shutdown();
+        fs.close();
     }
 
     protected void startDb(String cacheType)

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingFileSystemAbstraction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingFileSystemAbstraction.java
@@ -31,21 +31,22 @@ import java.nio.ByteBuffer;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.fs.StoreFileChannel;
 import org.neo4j.kernel.impl.store.AbstractDynamicStore;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RelationshipGroupStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.SchemaStore;
-import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.io.fs.StoreFileChannel;
 import org.neo4j.test.impl.ChannelInputStream;
 import org.neo4j.test.impl.ChannelOutputStream;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 
 public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstraction
 {
-    private final EphemeralFileSystemAbstraction ephemeralFileSystem;
+    private final FileSystemAbstraction ephemeralFileSystem;
     private final int sizePerJump;
 
     public JumpingFileSystemAbstraction( int sizePerJump )
@@ -53,13 +54,13 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
         this( new EphemeralFileSystemAbstraction(), sizePerJump );
     }
 
-    private JumpingFileSystemAbstraction( EphemeralFileSystemAbstraction ephemeralFileSystem, int sizePerJump )
+    private JumpingFileSystemAbstraction( FileSystemAbstraction ephemeralFileSystem, int sizePerJump )
     {
         super( ephemeralFileSystem );
         this.ephemeralFileSystem = ephemeralFileSystem;
         this.sizePerJump = sizePerJump;
     }
-    
+
     @Override
     public StoreChannel open( File fileName, String mode ) throws IOException
     {
@@ -72,18 +73,18 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
                 fileName.getName().equals( "neostore.propertystore.db.strings" ) ||
                 fileName.getName().equals( "neostore.propertystore.db.arrays" ) ||
                 fileName.getName().equals( "neostore.relationshipgroupstore.db" ) )
-        {        
+        {
             return new JumpingFileChannel( channel, recordSizeFor( fileName ) );
         }
         return channel;
     }
-    
+
     @Override
     public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException
     {
         return new ChannelOutputStream( open( fileName, "rw" ), append );
     }
-    
+
     @Override
     public InputStream openAsInputStream( File fileName ) throws IOException
     {
@@ -95,7 +96,7 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
     {
         return new InputStreamReader( openAsInputStream( fileName ), encoding );
     }
-    
+
     @Override
     public Writer openAsWriter( File fileName, String encoding, boolean append ) throws IOException
     {
@@ -107,7 +108,7 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
     {
         return open( fileName, "rw" );
     }
-    
+
     private int recordSizeFor( File fileName )
     {
         if ( fileName.getName().endsWith( "nodestore.db" ) )
@@ -142,17 +143,17 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
         }
         throw new IllegalArgumentException( fileName.getPath() );
     }
-    
+
     public class JumpingFileChannel extends StoreFileChannel
     {
         private final int recordSize;
-        
+
         public JumpingFileChannel( StoreFileChannel actual, int recordSize )
         {
             super( actual );
             this.recordSize = recordSize;
         }
-        
+
         private long translateIncoming( long position )
         {
             return translateIncoming( position, false );
@@ -174,7 +175,7 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
                 return offsettedRecord*recordSize;
             }
         }
-        
+
         private long translateOutgoing( long offsettedPosition )
         {
             long offsettedRecord = offsettedPosition/recordSize;
@@ -253,8 +254,9 @@ public class JumpingFileSystemAbstraction extends DelegatingFileSystemAbstractio
         }
     }
 
-    public void shutdown()
+    @Override
+    public void close() throws IOException
     {
-        ephemeralFileSystem.shutdown();
+        ephemeralFileSystem.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestJumpingIdGenerator.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import static org.junit.Assert.assertEquals;
-
-import static org.neo4j.kernel.impl.store.NodeStore.RECORD_SIZE;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.junit.Test;
-
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.core.JumpingFileSystemAbstraction.JumpingFileChannel;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.kernel.impl.store.NodeStore.RECORD_SIZE;
 
 public class TestJumpingIdGenerator
 {
@@ -46,7 +46,7 @@ public class TestJumpingIdGenerator
         {
             assertEquals( i, generator.nextId() );
         }
-        
+
         for ( int i = 0; i < sizePerJump-1; i++ )
         {
             long expected = 0x100000000L-sizePerJump/2+i;
@@ -67,7 +67,7 @@ public class TestJumpingIdGenerator
             assertEquals( 0x300000000L-sizePerJump/2+i, generator.nextId() );
         }
     }
-    
+
     @Test
     public void testOffsettedFileChannel() throws Exception
     {
@@ -77,23 +77,23 @@ public class TestJumpingIdGenerator
         offsettedFileSystem.mkdirs( fileName.getParentFile() );
         IdGenerator idGenerator = new JumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
         JumpingFileChannel channel = (JumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
-        
+
         for ( int i = 0; i < 16; i++ )
         {
             writeSomethingLikeNodeRecord( channel, idGenerator.nextId(), i );
         }
-        
+
         channel.close();
         channel = (JumpingFileChannel) offsettedFileSystem.open( fileName, "rw" );
         idGenerator = new JumpingIdGeneratorFactory( 10 ).get( IdType.NODE );
-        
+
         for ( int i = 0; i < 16; i++ )
         {
             assertEquals( i, readSomethingLikeNodeRecord( channel, idGenerator.nextId() ) );
         }
-        
+
         channel.close();
-        offsettedFileSystem.shutdown();
+        offsettedFileSystem.close();
     }
 
     private byte readSomethingLikeNodeRecord( JumpingFileChannel channel, long id ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,6 +27,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -224,11 +224,11 @@ public class IdGeneratorRebuildFailureEmulationTest
             //Collection<String> open = openFiles();
             //assertTrue( "Open files: " + open, open.isEmpty() );
             assertNoOpenFiles();
-            super.shutdown();
+            super.close();
         }
 
         @Override
-        public void shutdown()
+        public void close()
         {
             // no-op, it's pretty odd to have EphemeralFileSystemAbstraction implement Lifecycle by default
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -40,14 +40,16 @@ import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import static java.util.Arrays.asList;
+
 import static org.neo4j.kernel.impl.store.DynamicArrayStore.allocateFromNumbers;
 import static org.neo4j.kernel.impl.store.NodeStore.readOwnerFromDynamicLabelsRecord;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
@@ -131,7 +133,7 @@ public class NodeStoreTest
 
         // CLEANUP
         nodeStore.close();
-        fs.shutdown();
+        fs.close();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EphemeralFileSystemRule.java
@@ -33,7 +33,7 @@ public class EphemeralFileSystemRule extends ExternalResource implements Supplie
     @Override
     protected void after()
     {
-        fs.shutdown();
+        fs.close();
     }
 
     @Override
@@ -51,15 +51,15 @@ public class EphemeralFileSystemRule extends ExternalResource implements Supplie
         }
         finally
         {
-            fs.shutdown();
+            fs.close();
             fs = snapshot;
         }
         return fs;
     }
-    
+
     public void clear()
     {
-        fs.shutdown();
+        fs.close();
         fs = new EphemeralFileSystemAbstraction();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -19,15 +19,17 @@
  */
 package org.neo4j.test;
 
+import com.google.common.jimfs.Jimfs;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.fs.DelegateFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -200,7 +202,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
         @Override
         protected FileSystemAbstraction createFileSystemAbstraction()
         {
-            return new EphemeralFileSystemAbstraction();
+            return new DelegateFileSystemAbstraction( Jimfs.newFileSystem() );
         }
 
         @Override
@@ -210,7 +212,8 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
             try
             {
                 logService = new StoreLogService( NullLogProvider.getInstance(), fileSystem, storeDir, jobScheduler );
-            } catch ( IOException e )
+            }
+            catch ( IOException e )
             {
                 throw new RuntimeException( e );
             }

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
@@ -20,12 +20,13 @@
 package org.neo4j.test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
+import org.neo4j.helpers.Provider;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.LogProvider;
 
 public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
 {
-    private FileSystemAbstraction fileSystem;
+    private Provider<FileSystemAbstraction> fileSystem;
     private LogProvider internalLogProvider;
 
     public TestGraphDatabaseFactoryState()
@@ -41,17 +42,15 @@ public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
         internalLogProvider = previous.internalLogProvider;
     }
 
-    public FileSystemAbstraction getFileSystem()
+    public Provider<FileSystemAbstraction> getFileSystem()
     {
         return fileSystem;
     }
 
-
-    public void setFileSystem( FileSystemAbstraction fileSystem )
+    public void setFileSystem( Provider<FileSystemAbstraction> fileSystem )
     {
         this.fileSystem = fileSystem;
     }
-
 
     public LogProvider getInternalLogProvider()
     {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.api.impl.index;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -163,7 +163,7 @@ public class SchemaIndexAcceptanceTest
     {
         EphemeralFileSystemAbstraction snapshot = fs.snapshot();
         db.shutdown();
-        fs.shutdown();
+        fs.close();
         fs = snapshot;
         db = newDb();
     }


### PR DESCRIPTION
because of known problems with EFSA and knowing that JimFS is actively
developed and better already. jimFS is the default, but EFSA can still be
used if needed, it's just deptecated.

Part of this commit makes FileSystemAbstraction a Closeable, because
JimFS, which is a j.n.f.FileSystem, also is a Closeable. This changes the
responsibility that the GDS#shutdown() has, where the FSA should now also
be closed. EXCEPT from many test cases which uses a custom file
system, makes snapshots of it and uses the very same instance in the very
same GraphDatabaseFactory instance for producing multiple GDS instances.
For that scenario, and for the general sake of correctnes the
TestGraphDatabaseFactory#setFileSystem now accepts a
Provider<FileSystemAbstraction> instead, where both scenarios can be
implemented. The setFileSystem(FSA) method is still there and does what it
used to do, namely sets a custom file system that the database won't close
itself.
