### PR TITLE
Fix bug in CC: not checking all relationship records on multipass

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
@@ -293,9 +293,8 @@ class CountsBuilderDecorator extends CheckDecorator.Adapter
                         }
                     }
                 }
-
-                inner.check( record, engine, records );
             }
+            inner.check( record, engine, records );
         }
 
         @Override


### PR DESCRIPTION
The CountsBuilderDecorator should always call the inner.check(...) on
relationship record and not skip it as part of counting relationships.
