### PR TITLE
More fixes from NDP feedback sessions

### DIFF
--- a/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/BufferedChannelOutput.java
+++ b/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/BufferedChannelOutput.java
@@ -62,6 +62,12 @@ public class BufferedChannelOutput implements PackOutput
     @Override
     public PackOutput writeBytes( byte[] data, int offset, int length ) throws IOException
     {
+        if( offset + length > data.length )
+        {
+            throw new IOException( "Asked to write " + length + " bytes, but there is only " +
+                                   ( data.length - offset ) + " bytes available in data provided." );
+        }
+
         int index = 0;
         while ( index < length )
         {

--- a/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
+++ b/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
@@ -21,7 +21,6 @@ package org.neo4j.packstream;
 
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 
 import static java.lang.Integer.toHexString;
@@ -172,16 +171,6 @@ public class PackStream
         public Packer( PackOutput out )
         {
             this.out = out;
-        }
-
-        public void reset( PackOutput out )
-        {
-            this.out = out;
-        }
-
-        public void reset( WritableByteChannel channel )
-        {
-            ((BufferedChannelOutput) out).reset( channel );
         }
 
         public void flush() throws IOException
@@ -369,27 +358,9 @@ public class PackStream
 
         private PackInput in;
 
-        public Unpacker( ReadableByteChannel channel )
-        {
-            this( DEFAULT_BUFFER_CAPACITY );
-            reset( channel );
-        }
-
-        public Unpacker( int bufferCapacity )
-        {
-            assert bufferCapacity >= 8 : "Buffer must be at least 8 bytes.";
-            this.in = new BufferedChannelInput( bufferCapacity );
-        }
-
         public Unpacker( PackInput in )
         {
             this.in = in;
-        }
-
-        public Unpacker reset( ReadableByteChannel ch )
-        {
-            ((BufferedChannelInput) in).reset( ch );
-            return this;
         }
 
         public boolean hasNext() throws IOException

--- a/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackType.java
+++ b/community/ndp/packstream-v1/src/main/java/org/neo4j/packstream/PackType.java
@@ -19,15 +19,28 @@
  */
 package org.neo4j.packstream;
 
+/**
+ * These are the primitive types that PackStream can represent. They map to the non-graph primitives of the Neo4j
+ * type system. Graph primitives and rich composite types are represented as {@link #STRUCT}.
+ */
 public enum PackType
 {
+    /** The absence of a value */
     NULL,
+    /** You know what this is */
     BOOLEAN,
+    /** 64-bit signed integer */
     INTEGER,
+    /** 64-bit floating point number */
     FLOAT,
+    /** Binary data */
     BYTES,
+    /** Unicode text */
     TEXT,
+    /** Sequence of zero or more values */
     LIST,
+    /** Sequence of zero or more key/value pairs, keys are unique */
     MAP,
+    /** A composite data structure, made up of zero or more packstream values and a type signature. */
     STRUCT
 }

--- a/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/BufferedChannelOutputTest.java
+++ b/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/BufferedChannelOutputTest.java
@@ -17,31 +17,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.ndp.messaging.v1;
+package org.neo4j.packstream;
+
+import junit.framework.TestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
 
-import org.neo4j.ndp.messaging.v1.message.Message;
-
-public interface MessageFormat
+public class BufferedChannelOutputTest
 {
-    int version();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
-    interface Writer extends MessageHandler<IOException>
+    @Test
+    public void shouldThrowWhenAskedToWriteMoreThanGiven() throws Throwable
     {
-        Writer write( Message msg ) throws IOException;
+        // Given
+        BufferedChannelOutput out = new BufferedChannelOutput( 12 );
 
-        void flush() throws IOException;
-    }
+        // Expect
+        exception.expect( IOException.class );
+        exception.expectMessage( "Asked to write 2 bytes, but there is only 1 bytes available in data provided." );
 
-    interface Reader
-    {
-        /** Return true if there is another message in the underlying buffer */
-        boolean hasNext() throws IOException;
-
-        <E extends Exception> void read( MessageHandler<E> consumer ) throws IOException, E;
-
+        // When
+        out.writeBytes( new byte[]{1}, 0, 2 );
     }
 }

--- a/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
+++ b/community/ndp/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
@@ -100,7 +100,7 @@ public class PackStreamTest
     private PackStream.Unpacker newUnpacker( byte[] bytes )
     {
         ByteArrayInputStream input = new ByteArrayInputStream( bytes );
-        return new PackStream.Unpacker( Channels.newChannel( input ) );
+        return new PackStream.Unpacker( new BufferedChannelInput( 16 ).reset( Channels.newChannel( input ) ) );
     }
 
     @Test
@@ -677,8 +677,7 @@ public class PackStreamTest
         packer.flush();
 
         ReadableByteChannel ch = Channels.newChannel( new ByteArrayInputStream( machine.output() ) );
-        PackStream.Unpacker unpacker = new PackStream.Unpacker( 11 );
-        unpacker.reset( ch );
+        PackStream.Unpacker unpacker = new PackStream.Unpacker( new BufferedChannelInput( 11 ).reset( ch ) );
 
         // Serialized ch will look like, and misalign with the 11-byte unpack buffer:
 

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketProtocolV1.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketProtocolV1.java
@@ -76,7 +76,7 @@ public class SocketProtocolV1 implements SocketProtocol
         this.output = new ChunkedOutput( channel, DEFAULT_BUFFER_SIZE );
         this.input = new ChunkedInput();
         this.packer = new PackStreamMessageFormatV1.Writer( new PackStream.Packer( output ), output.messageBoundaryHook() );
-        this.unpacker = new PackStreamMessageFormatV1.Reader( input );
+        this.unpacker = new PackStreamMessageFormatV1.Reader( new PackStream.Unpacker( input ) );
         this.bridge = new TransportBridge( log ).reset( session, packer, new Runnable()
         {
             @Override

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocSerialization.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/DocSerialization.java
@@ -216,7 +216,8 @@ public class DocSerialization
     public static List<Message> unpackChunked( byte[] data ) throws Exception
     {
         ChunkedInput input = new ChunkedInput();
-        PackStreamMessageFormatV1.Reader reader = new PackStreamMessageFormatV1.Reader( input );
+        PackStreamMessageFormatV1.Reader reader =
+                new PackStreamMessageFormatV1.Reader( new PackStream.Unpacker(  input ) );
         RecordingMessageHandler messages = new RecordingMessageHandler();
 
         ByteBuf buf = Unpooled.wrappedBuffer( data );

--- a/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPMessageStructsDocTest.java
+++ b/community/ndp/v1-docs/src/test/java/org/neo4j/ndp/docs/v1/NDPMessageStructsDocTest.java
@@ -31,6 +31,7 @@ import org.neo4j.ndp.messaging.v1.PackStreamMessageFormatV1;
 import org.neo4j.ndp.messaging.v1.RecordingByteChannel;
 import org.neo4j.ndp.messaging.v1.RecordingMessageHandler;
 import org.neo4j.ndp.messaging.v1.util.ArrayByteChannel;
+import org.neo4j.packstream.BufferedChannelInput;
 import org.neo4j.packstream.BufferedChannelOutput;
 import org.neo4j.packstream.PackStream;
 
@@ -79,8 +80,9 @@ public class NDPMessageStructsDocTest
 
         // Then it should get interpreted as the documented message
         RecordingMessageHandler messages = new RecordingMessageHandler();
-        PackStreamMessageFormatV1.Reader reader = new PackStreamMessageFormatV1.Reader();
-        reader.reset( new ArrayByteChannel( ch.getBytes() ) );
+        PackStreamMessageFormatV1.Reader reader = new PackStreamMessageFormatV1.Reader(
+                new PackStream.Unpacker(
+                        new BufferedChannelInput( 128 ).reset( new ArrayByteChannel( ch.getBytes() ) ) ) );
         reader.read( messages );
 
         // Hello, future traveler. The assertion below is not strictly necessary. What we're trying to do here


### PR DESCRIPTION
- Clean up packstream constructors
- Remove newWriter/newReader from Format
- remove packinput reset methods
- Add bounds check to BufferedPackOutput
- Javadocs for PackType
