### PR TITLE
Better error handling when failing to satisfy all hints.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherException.scala
@@ -84,6 +84,10 @@ class UnknownLabelException(labelName: String) extends CypherException {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.unknownLabelException(labelName)
 }
 
+class HintException(message: String) extends CypherException {
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.hintException(message)
+}
+
 class IndexHintException(identifier: String, label: String, property: String, message: String) extends CypherException {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.indexHintException(identifier, label, property, message)
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CompositeQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/CompositeQueryGraphSolver.scala
@@ -19,9 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
 
+import org.neo4j.cypher.internal.compiler.v2_2.HintException
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy.GreedyPlanTable
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.LogicalPlan
+
+import scala.util.{Failure, Success, Try}
 
 class CompositeQueryGraphSolver(solver1: TentativeQueryGraphSolver, solver2: TentativeQueryGraphSolver,
                                 val config: QueryPlannerConfiguration = QueryPlannerConfiguration.default)
@@ -35,7 +38,17 @@ class CompositeQueryGraphSolver(solver1: TentativeQueryGraphSolver, solver2: Ten
 
   def tryPlan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]) = {
     val pickBest = config.pickBestCandidate(context)
-    val availableSolutions = solver1.tryPlan(queryGraph).toSeq ++ solver2.tryPlan(queryGraph)
+
+    val solution1 = Try(solver1.tryPlan(queryGraph))
+    val solution2 = Try(solver2.tryPlan(queryGraph))
+
+    val availableSolutions = (solution1, solution2) match {
+      case (Success(s1), Success(s2)) => s1.toSeq ++ s2.toSeq
+      case (Failure(_:HintException), Success(s2)) => s2.toSeq
+      case (Success(s1), Failure(_:HintException)) => s1.toSeq
+      case (Failure(e), _) => throw e
+      case (_, Failure(e)) => throw e
+    }
 
     pickBest(availableSolutions)
   }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/greedy/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/greedy/GreedyQueryGraphSolver.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy
 
+import org.neo4j.cypher.internal.compiler.v2_2.{HintException, IndexHintException}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.{IdName, LogicalPlan}
@@ -83,9 +84,12 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[GreedyPlanTable],
     val leaves: GreedyPlanTable = generateLeafPlanTable()
     val afterCombiningPlans = iterateUntilConverged(findBestPlan(planCombiner))(leaves)
 
-    if (stillHasOverlappingPlans(afterCombiningPlans, leafPlan.map(_.availableSymbols).getOrElse(Set.empty)))
-      None
-    else {
+    if (stillHasOverlappingPlans(afterCombiningPlans, leafPlan.map(_.availableSymbols).getOrElse(Set.empty))) {
+      if (!afterCombiningPlans.m.keys.forall(_.allHints == queryGraph.allHints) )
+        throw new HintException("The current planner cannot satisfy all hints in the query, please try removing hints or try with another planner")
+      else
+        None
+    } else {
       val afterCartesianProduct = iterateUntilConverged(solveOptionalAndCartesianProducts)(afterCombiningPlans)
       Some(afterCartesianProduct.uniquePlan)
     }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/MapToPublicExceptions.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.spi
 import org.neo4j.cypher.internal.compiler.v2_2.CypherException
 
 trait MapToPublicExceptions[T <: Throwable] {
+
   def failedIndexException(indexName: String): T
 
   def periodicCommitInOpenTransactionException(): T
@@ -39,6 +40,8 @@ trait MapToPublicExceptions[T <: Throwable] {
   def mergeConstraintConflictException(message: String): T
 
   def invalidSemanticException(message: String): T
+
+  def hintException(s: String): T
 
   def indexHintException(identifier: String, label: String, property: String, message: String): T
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -96,9 +96,14 @@ class UnknownLabelException(labelName: String) extends CypherException(s"The pro
   val status = Status.Statement.NoSuchLabel
 }
 
+class HintException( message: String)
+  extends CypherException(message) {
+  val status = Status.Schema.NoSuchIndex
+}
+
 class IndexHintException(identifier: String, label: String, property: String, message: String)
   extends CypherException(s"$message\nLabel: `$label`\nProperty name: `$property`") {
-  val status = Status.Schema.NoSuchIndex
+  val status = Status.Statement.ExecutionFailure
 }
 
 class LabelScanHintException(identifier: String, label: String, message: String)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.RewriterStepSeq
 import org.neo4j.cypher.internal.compiler.v2_2.{CypherException => CypherException_v2_2, _}
 import org.neo4j.cypher.internal.spi.v2_2.{TransactionBoundGraphStatistics, TransactionBoundPlanContext, TransactionBoundQueryContext}
 import org.neo4j.cypher.javacompat.ProfilerStatistics
-import org.neo4j.cypher.{ArithmeticException, CypherTypeException, EntityNotFoundException, FailedIndexException, IncomparableValuesException, IndexHintException, InternalException, InvalidArgumentException, InvalidSemanticsException, LabelScanHintException, LoadCsvStatusWrapCypherException, LoadExternalResourceException, MergeConstraintConflictException, NodeStillHasRelationshipsException, ParameterNotFoundException, ParameterWrongTypeException, PatternException, PeriodicCommitInOpenTransactionException, ProfilerStatisticsNotReadyException, SyntaxException, UniquePathNotUniqueException, UnknownLabelException, _}
+import org.neo4j.cypher.{ArithmeticException, CypherTypeException, EntityNotFoundException, FailedIndexException, IncomparableValuesException, IndexHintException, InternalException, InvalidArgumentException, InvalidSemanticsException, LabelScanHintException, LoadCsvStatusWrapCypherException, LoadExternalResourceException, MergeConstraintConflictException, NodeStillHasRelationshipsException, ParameterNotFoundException, ParameterWrongTypeException, PatternException, PeriodicCommitInOpenTransactionException, ProfilerStatisticsNotReadyException, SyntaxException, UniquePathNotUniqueException, UnknownLabelException, HintException,  _}
 import org.neo4j.graphdb.{GraphDatabaseService, QueryExecutionType, ResourceIterator}
 import org.neo4j.helpers.{Assertion, Clock}
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -86,9 +86,12 @@ object exceptionHandlerFor2_2 extends MapToPublicExceptions[CypherException] {
 
   def cypherTypeException(message: String, cause: Throwable) = throw new CypherTypeException(message, cause)
 
+  def hintException(message: String): CypherException = throw new HintException(message)
+
   def labelScanHintException(identifier: String, label: String, message: String) = throw new LabelScanHintException(identifier, label, message)
 
   def invalidSemanticException(message: String) = throw new InvalidSemanticsException(message)
+
 
   def parameterWrongTypeException(message: String, cause: Throwable) = throw new ParameterWrongTypeException(message, cause)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingInAcceptanceTest.scala
@@ -74,4 +74,23 @@ class UsingInAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
     intercept[SyntaxException](
       executeWithAllPlanners("match n-->() using index n:Person(name) where n.name IN ['kabam'] OR n.name = 'kaboom' return n"))
   }
+
+  test("when failing to support all hints we should provide an understandable error message") {
+    // GIVEN
+    graph.createIndex("LocTag", "id")
+
+    // WHEN
+    val query = """MATCH (t1:LocTag {id:1642})-[:Child*0..]->(:LocTag)
+                  |     <-[:Tagged]-(s1:Startup)<-[r1:Role]-(u:User)
+                  |     -[r2:Role]->(s2:Startup)-[:Tagged]->(:LocTag)
+                  |     <-[:Child*0..]-(t2:LocTag {id:1642})
+                  |USING INDEX t1:LocTag(id)
+                  |USING INDEX t2:LocTag(id)
+                  |RETURN count(u)""".stripMargin
+
+
+    val error = intercept[HintException](executeWithAllPlanners(query))
+
+    error.getMessage should equal("The current planner cannot satisfy all hints in the query, please try removing hints or try with another planner")
+  }
 }


### PR DESCRIPTION
When the `greedy` planner ends up in a state where it fails to satisfy all hints, it
should provide a better error message instead of just saying
`Failed to create a plan for the given QueryGraph`.

Note that when merging this into 2.3 we must change the test to explicitly
use `greedy` (since it is no longer the default).
