### PR TITLE
Fixes legacy index tx state issue where deleted entities might be visible

### DIFF
--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.graphalgo.path;
 
-import org.junit.Ignore;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.graphalgo.GraphAlgoFactory;
@@ -33,9 +31,7 @@ import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.RelationshipExpander;
 import org.neo4j.kernel.Traversal;
 
-import static org.junit.Assert.fail;
 import common.Neo4jAlgoTestCase;
-import common.Neo4jAlgoTestCase.MyRelTypes;
 import static org.junit.Assert.assertNotNull;
 
 public class TestExactDepthPathFinder extends Neo4jAlgoTestCase

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndex.java
@@ -49,4 +49,10 @@ public interface LegacyIndex
     LegacyIndexHits query( Object queryOrQueryObject, long startNode, long endNode );
 
     void addRelationship( long entity, String key, Object value, long startNode, long endNode );
+
+    void removeRelationship( long entity, String key, Object value, long startNode, long endNode );
+
+    void removeRelationship( long entity, String key, long startNode, long endNode );
+
+    void removeRelationship( long entity, long startNode, long endNode );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndexWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndexWrite.java
@@ -66,12 +66,13 @@ public interface LegacyIndexWrite
             throws EntityNotFoundException, LegacyIndexNotFoundKernelException;
 
     void relationshipRemoveFromLegacyIndex( String indexName, long relationship, String key, Object value )
-            throws LegacyIndexNotFoundKernelException;
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
     void relationshipRemoveFromLegacyIndex( String indexName, long relationship, String key )
-            throws LegacyIndexNotFoundKernelException;
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
-    void relationshipRemoveFromLegacyIndex( String indexName, long relationship ) throws LegacyIndexNotFoundKernelException;
+    void relationshipRemoveFromLegacyIndex( String indexName, long relationship )
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
     void nodeLegacyIndexDrop( String indexName ) throws LegacyIndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -883,7 +883,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
     @Override
     public void relationshipRemoveFromLegacyIndex( String indexName, long relationship, String key, Object value )
-            throws LegacyIndexNotFoundKernelException
+            throws EntityNotFoundException, LegacyIndexNotFoundKernelException
     {
         statement.assertOpen();
         legacyIndexWrite().relationshipRemoveFromLegacyIndex( statement, indexName, relationship, key, value );
@@ -891,7 +891,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
     @Override
     public void relationshipRemoveFromLegacyIndex( String indexName, long relationship, String key )
-            throws LegacyIndexNotFoundKernelException
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException
     {
         statement.assertOpen();
         legacyIndexWrite().relationshipRemoveFromLegacyIndex( statement, indexName, relationship, key );
@@ -899,7 +899,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
     @Override
     public void relationshipRemoveFromLegacyIndex( String indexName, long relationship )
-            throws LegacyIndexNotFoundKernelException
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException
     {
         statement.assertOpen();
         legacyIndexWrite().relationshipRemoveFromLegacyIndex( statement, indexName, relationship );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1383,24 +1383,64 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship,
-            String key, Object value ) throws LegacyIndexNotFoundKernelException
+    public void relationshipRemoveFromLegacyIndex( final KernelStatement statement, final String indexName, long relationship,
+            final String key, final Object value ) throws LegacyIndexNotFoundKernelException, EntityNotFoundException
     {
-        statement.legacyIndexTxState().relationshipChanges( indexName ).remove( relationship, key, value );
+        relationshipVisit( statement, relationship, new RelationshipVisitor<LegacyIndexNotFoundKernelException>()
+        {
+            @Override
+            public void visit( long relId, int type, long startNode, long endNode )
+                    throws LegacyIndexNotFoundKernelException
+            {
+                statement.legacyIndexTxState().relationshipChanges( indexName ).removeRelationship(
+                        relId, key, value, startNode, endNode );
+            }
+        } );
     }
 
     @Override
-    public void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship,
-            String key ) throws LegacyIndexNotFoundKernelException
+    public void relationshipRemoveFromLegacyIndex( final KernelStatement statement, final String indexName, long relationship,
+            final String key ) throws EntityNotFoundException, LegacyIndexNotFoundKernelException
     {
-        statement.legacyIndexTxState().relationshipChanges( indexName ).remove( relationship, key );
+        relationshipVisit( statement, relationship, new RelationshipVisitor<LegacyIndexNotFoundKernelException>()
+        {
+            @Override
+            public void visit( long relId, int type, long startNode, long endNode )
+                    throws LegacyIndexNotFoundKernelException
+            {
+                statement.legacyIndexTxState().relationshipChanges( indexName ).removeRelationship(
+                        relId, key, startNode, endNode );
+            }
+        } );
     }
 
     @Override
-    public void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship )
-            throws LegacyIndexNotFoundKernelException
+    public void relationshipRemoveFromLegacyIndex( final KernelStatement statement, final String indexName, long relationship )
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException
     {
-        statement.legacyIndexTxState().relationshipChanges( indexName ).remove( relationship );
+        try
+        {
+            relationshipVisit( statement, relationship, new RelationshipVisitor<LegacyIndexNotFoundKernelException>()
+            {
+                @Override
+                public void visit( long relId, int type, long startNode, long endNode )
+                        throws LegacyIndexNotFoundKernelException
+                {
+                    statement.legacyIndexTxState().relationshipChanges( indexName ).removeRelationship(
+                            relId, startNode, endNode );
+                }
+            } );
+        }
+        catch ( EntityNotFoundException e )
+        {
+            // This is a special case which is still OK. This method is called lazily where deleted relationships
+            // that still are referenced by a legacy index will be added for removal in this transaction.
+            // Ideally we'd want to include start/end node too, but we can't since the relationship doesn't exist.
+            // So we do the "normal" remove call on the legacy index transaction changes. The downside is that
+            // Some queries on this transaction state that include start/end nodes might produce invalid results.
+            statement.legacyIndexTxState().relationshipChanges( indexName ).remove( relationship );
+            throw e;
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/LegacyIndexWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/LegacyIndexWriteOperations.java
@@ -65,13 +65,13 @@ public interface LegacyIndexWriteOperations
             Object value ) throws EntityNotFoundException, LegacyIndexNotFoundKernelException;
 
     void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship, String key,
-            Object value ) throws LegacyIndexNotFoundKernelException;
+            Object value ) throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
     void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship, String key )
-            throws LegacyIndexNotFoundKernelException;
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
     void relationshipRemoveFromLegacyIndex( KernelStatement statement, String indexName, long relationship )
-            throws LegacyIndexNotFoundKernelException;
+            throws LegacyIndexNotFoundKernelException, EntityNotFoundException;
 
     void nodeLegacyIndexDrop( KernelStatement statement, String indexName ) throws LegacyIndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
@@ -171,21 +171,24 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
 
                     @Override
                     void remove( DataWriteOperations operations, String name, long id, String key, Object value )
-                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException
+                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                            EntityNotFoundException
                     {
                         operations.relationshipRemoveFromLegacyIndex( name, id, key, value );
                     }
 
                     @Override
                     void remove( DataWriteOperations operations, String name, long id, String key )
-                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException
+                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                            EntityNotFoundException
                     {
                         operations.relationshipRemoveFromLegacyIndex( name, id, key );
                     }
 
                     @Override
                     void remove( DataWriteOperations operations, String name, long id )
-                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException
+                            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                            EntityNotFoundException
                     {
                         operations.relationshipRemoveFromLegacyIndex( name, id );
                     }
@@ -223,13 +226,16 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
                 LegacyIndexNotFoundKernelException;
 
         abstract void remove( DataWriteOperations operations, String name, long id, String key, Object value )
-                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException;
+                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                EntityNotFoundException;
 
         abstract void remove( DataWriteOperations operations, String name, long id, String key )
-                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException;
+                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                EntityNotFoundException;
 
         abstract void remove( DataWriteOperations operations, String name, long id )
-                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException;
+                throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException,
+                EntityNotFoundException;
 
         abstract void drop( DataWriteOperations operations, String name )
                 throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException;
@@ -321,7 +327,8 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
                         {
                             internalRemove( statement, id );
                         }
-                        catch ( LegacyIndexNotFoundKernelException | InvalidTransactionTypeKernelException ignore )
+                        catch ( LegacyIndexNotFoundKernelException |
+                                InvalidTransactionTypeKernelException | EntityNotFoundException ignore )
                         {
                             // Ignore these failures because we are going to skip the entity anyway
                         }
@@ -411,6 +418,10 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
         {
             throw new NotFoundException( type + " index '" + name + "' doesn't exist" );
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new NotFoundException( entity + " doesn't exist" );
+        }
     }
 
     @Override
@@ -427,6 +438,10 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
         catch ( LegacyIndexNotFoundKernelException e )
         {
             throw new NotFoundException( type + " index '" + name + "' doesn't exist" );
+        }
+        catch ( EntityNotFoundException e )
+        {
+            throw new NotFoundException( entity + " doesn't exist" );
         }
     }
 
@@ -445,10 +460,14 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
         {
             throw new NotFoundException( type + " index '" + name + "' doesn't exist" );
         }
+        catch ( EntityNotFoundException e )
+        {
+            throw new NotFoundException( entity + " doesn't exist" );
+        }
     }
 
     private void internalRemove( Statement statement, long id )
-            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException
+            throws InvalidTransactionTypeKernelException, LegacyIndexNotFoundKernelException, EntityNotFoundException
     {
         type.remove( statement.dataWriteOperations(), name, id );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
@@ -81,7 +81,6 @@ public class DummyIndexImplementation implements IndexImplementation
 
     private static class EmptyLegacyIndex implements LegacyIndex
     {
-
         private final boolean failing;
 
         private EmptyLegacyIndex( boolean failing )
@@ -157,6 +156,24 @@ public class DummyIndexImplementation implements IndexImplementation
 
         @Override
         public void addNode( long entity, String key, Object value )
+        {
+            mutate();
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, Object value, long startNode, long endNode )
+        {
+            mutate();
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, long startNode, long endNode )
+        {
+            mutate();
+        }
+
+        @Override
+        public void removeRelationship( long entity, long startNode, long endNode )
         {
             mutate();
         }

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilderTestTools;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Provider;
@@ -117,6 +118,16 @@ public abstract class DatabaseRule extends ExternalResource
     public Node createNode( Label... labels )
     {
         return getGraphDatabaseAPI().createNode( labels );
+    }
+
+    public Node getNodeById( long id )
+    {
+        return getGraphDatabaseService().getNodeById( id );
+    }
+
+    public IndexManager index()
+    {
+        return getGraphDatabaseService().index();
     }
 
     public Schema schema()

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/ExactTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/ExactTxData.java
@@ -37,6 +37,7 @@ public class ExactTxData extends TxData
 {
     private Map<String, Map<Object, Set<Object>>> data;
     private boolean hasOrphans;
+    private boolean hasRelationshipIds;
 
     ExactTxData( LuceneIndex index )
     {
@@ -47,6 +48,10 @@ public class ExactTxData extends TxData
     void add( TxDataHolder holder, Object entityId, String key, Object value )
     {
         idCollection( key, value, true ).add( entityId );
+        if ( !hasRelationshipIds && entityId instanceof RelationshipId )
+        {
+            hasRelationshipIds = true;
+        }
     }
 
     private Set<Object> idCollection( String key, Object value, boolean create )
@@ -143,7 +148,7 @@ public class ExactTxData extends TxData
         {
             return;
         }
-        
+
         if ( key == null || value == null )
         {
             TxData fullData = toFullTxData();
@@ -171,7 +176,7 @@ public class ExactTxData extends TxData
         }
         return toLongs( ids );
     }
-    
+
     @Override
     Collection<Long> getOrphans( String key )
     {
@@ -192,7 +197,7 @@ public class ExactTxData extends TxData
     {
         if (ids.isEmpty()) return Collections.emptySet();
 
-        if ( ids.iterator().next() instanceof Long )
+        if ( !hasRelationshipIds )
         {
             return (Collection) ids;
         }
@@ -206,7 +211,7 @@ public class ExactTxData extends TxData
             return longs;
         }
     }
-    
+
     @Override
     IndexSearcher asSearcher( TxDataHolder holder, QueryContext context )
     {

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
@@ -406,25 +406,43 @@ public abstract class LuceneIndex implements LegacyIndex
         @Override
         public LegacyIndexHits get( String key, Object value, long startNode, long endNode )
         {
-            throw new UnsupportedOperationException( "Please implement" );
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public LegacyIndexHits query( String key, Object queryOrQueryObject, long startNode, long endNode )
         {
-            throw new UnsupportedOperationException( "Please implement" );
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public LegacyIndexHits query( Object queryOrQueryObject, long startNode, long endNode )
         {
-            throw new UnsupportedOperationException( "Please implement" );
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void addRelationship( long entity, String key, Object value, long startNode, long endNode )
         {
-            throw new UnsupportedOperationException( "Please implement" );
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, Object value, long startNode, long endNode )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, long startNode, long endNode )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeRelationship( long entity, long startNode, long endNode )
+        {
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -446,10 +464,11 @@ public abstract class LuceneIndex implements LegacyIndex
         public void addRelationship( long entity, String key, Object value, long startNode, long endNode )
         {
             assertValidKey( key );
+            RelationshipId id = RelationshipId.of( entity, startNode, endNode );
             for ( Object oneValue : IoPrimitiveUtils.asArray( value ) )
             {
                 oneValue = getCorrectValue( oneValue );
-                transaction.add( this, RelationshipId.of( entity, startNode, endNode ), key, oneValue );
+                transaction.add( this, id, key, oneValue );
                 commandFactory.addRelationship( identifier.indexName, entity, key, oneValue, startNode, endNode );
             }
         }
@@ -490,6 +509,36 @@ public abstract class LuceneIndex implements LegacyIndex
             addIfAssigned( query, startNode, KEY_START_NODE_ID );
             addIfAssigned( query, endNode, KEY_END_NODE_ID );
             return query( query, null, null, context );
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, Object value, long startNode, long endNode )
+        {
+            assertValidKey( key );
+            RelationshipId id = RelationshipId.of( entity, startNode, endNode );
+            for ( Object oneValue : IoPrimitiveUtils.asArray( value ) )
+            {
+                oneValue = getCorrectValue( oneValue );
+                transaction.remove( this, id, key, oneValue );
+                addRemoveCommand( entity, key, oneValue );
+            }
+        }
+
+        @Override
+        public void removeRelationship( long entity, String key, long startNode, long endNode )
+        {
+            assertValidKey( key );
+            RelationshipId id = RelationshipId.of( entity, startNode, endNode );
+            transaction.remove( this, id, key );
+            addRemoveCommand( entity, key, null );
+        }
+
+        @Override
+        public void removeRelationship( long entity, long startNode, long endNode )
+        {
+            RelationshipId id = RelationshipId.of( entity, startNode, endNode );
+            transaction.remove( this, id );
+            addRemoveCommand( entity, null, null );
         }
 
         private static void addIfAssigned( BooleanQuery query, long node, String field )

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneTransactionState.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneTransactionState.java
@@ -54,19 +54,19 @@ class LuceneTransactionState implements Closeable
         return data;
     }
 
-    void remove( LuceneIndex index, long entity, String key, Object value )
+    void remove( LuceneIndex index, Object entity, String key, Object value )
     {
         TxDataBoth data = getTxData( index, true );
         insert( entity, key, value, data.removed( true ), data.added( false ) );
     }
 
-    void remove( LuceneIndex index, long entity, String key )
+    void remove( LuceneIndex index, Object entity, String key )
     {
         TxDataBoth data = getTxData( index, true );
         insert( entity, key, null, data.removed( true ), data.added( false ) );
     }
 
-    void remove( LuceneIndex index, long entity )
+    void remove( LuceneIndex index, Object entity )
     {
         TxDataBoth data = getTxData( index, true );
         insert( entity, null, null, data.removed( true ), data.added( false ) );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AutoIndexerTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AutoIndexerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.index.IndexHits;
+import org.neo4j.graphdb.index.ReadableRelationshipIndex;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.EmbeddedDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+
+public class AutoIndexerTest
+{
+    public final @Rule DatabaseRule db = new EmbeddedDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            super.configure( builder );
+            builder.setConfig( GraphDatabaseSettings.relationship_keys_indexable, "Type" );
+            builder.setConfig( GraphDatabaseSettings.relationship_auto_indexing, "true" );
+        }
+    };
+
+    @Test
+    public void shouldNotSeeDeletedRelationshipWhenQueryingWithStartAndEndNode()
+    {
+        RelationshipType type = MyRelTypes.TEST;
+        long startId;
+        long endId;
+        Relationship rel;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node start = db.createNode();
+            Node end = db.createNode();
+            startId = start.getId();
+            endId = end.getId();
+            rel = start.createRelationshipTo( end, type );
+            rel.setProperty( "Type", type.name() );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            ReadableRelationshipIndex autoRelationshipIndex =
+                    db.index().getRelationshipAutoIndexer().getAutoIndex();
+            Node start = db.getNodeById( startId );
+            Node end = db.getNodeById( endId );
+            IndexHits<Relationship> hits = autoRelationshipIndex.get( "Type", type.name(), start, end );
+            assertEquals( 1, count( (Iterator<Relationship>)hits ) );
+            assertEquals( 1, hits.size() );
+            rel.delete();
+            autoRelationshipIndex = db.index().getRelationshipAutoIndexer().getAutoIndex();
+            hits = autoRelationshipIndex.get( "Type", type.name(), start, end );
+            assertEquals( 0, count( (Iterator<Relationship>)hits ) );
+            assertEquals( 0, hits.size() );
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
when querying. Problem was when querying w/ start/end node. As it was the
tx state didn't have the start/end node... something that a refactoring
between 2.1 and 2.2 introduced.
