### PR TITLE
JvmChecker accepts Java 8 as compatible version now.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/info/JvmChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/JvmChecker.java
@@ -24,9 +24,9 @@ import org.neo4j.kernel.impl.util.StringLogger;
 public class JvmChecker
 {
     public static final String INCOMPATIBLE_JVM_WARNING = "You are using an unsupported Java runtime. Please" +
-            " use Oracle(R) Java(TM) Runtime Environment 7 or OpenJDK(TM) 7.";
+            " use Oracle(R) Java(TM) Runtime Environment 7 or 8 or OpenJDK(TM) 7 or 8.";
     public static final String INCOMPATIBLE_JVM_VERSION_WARNING = "You are using an unsupported version of " +
-            "the Java runtime. Please use Oracle(R) Java(TM) Runtime Environment 7 or OpenJDK(TM) 7.";
+            "the Java runtime. Please use Oracle(R) Java(TM) Runtime Environment 7 or 8 or OpenJDK(TM) 7 or 8.";
 
     private final StringLogger stringLogger;
     private final JvmMetadataRepository jvmMetadataRepository;
@@ -46,7 +46,7 @@ public class JvmChecker
         {
             stringLogger.warn( INCOMPATIBLE_JVM_WARNING );
         }
-        else if ( !javaVersion.matches( "^1\\.7.*" ) )
+        else if ( !javaVersion.matches( "^1\\.[78].*" ) )
         {
             stringLogger.warn( INCOMPATIBLE_JVM_VERSION_WARNING );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/info/JVMCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/info/JVMCheckerTest.java
@@ -42,6 +42,17 @@ public class JVMCheckerTest
     }
 
     @Test
+    public void shouldNotIssueWarningWhenUsingHotspotServerVmVersion8() throws Exception
+    {
+        BufferingLogger bufferingLogger = new BufferingLogger();
+
+        new JvmChecker( bufferingLogger, new CannedJvmMetadataRepository( "Java HotSpot(TM) 64-Bit Server VM",
+                "1.8.0_45" ) ).checkJvmCompatibilityAndIssueWarning();
+
+        assertTrue( bufferingLogger.toString().isEmpty() );
+    }
+
+    @Test
     public void shouldNotIssueWarningWhenUsingHotspotServerVmVersion7InThe32BitVersion() throws Exception
     {
         BufferingLogger bufferingLogger = new BufferingLogger();


### PR DESCRIPTION
Updates the JvmChecker to accept Java 8 as a compatible version to align with docs update #4663.
