### PR TITLE
Introduce session worker threads.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -45,7 +45,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexPopulation;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexPopulation;
 
 
 public class PopulatingIndexProxy implements IndexProxy

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode.BACKGROUND_REBUILD_UPDATED;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexSamplingController;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexSamplingController;
 
 public class IndexSamplingController
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
@@ -69,7 +69,7 @@ public class IndexSamplingJobTracker
             }
 
             executingJobDescriptors.add( descriptor );
-            jobScheduler.schedule( JobScheduler.Group.indexSampling, new Runnable()
+            jobScheduler.schedule( JobScheduler.Groups.indexSampling, new Runnable()
             {
                 @Override
                 public void run()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -54,7 +54,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
                             JobScheduler jobScheduler, final Consumer<LogProvider> rotationListener ) throws IOException
     {
         this( userLogProvider, fileSystem, storeDirectory, internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives,
-                jobScheduler.executor( JobScheduler.Group.internalLogRotation ), rotationListener );
+                jobScheduler.executor( JobScheduler.Groups.internalLogRotation ), rotationListener );
     }
 
     public StoreLogService( LogProvider userLogProvider, FileSystemAbstraction fileSystem, File storeDirectory,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -19,16 +19,72 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.NEW_THREAD;
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * To be expanded, the idea here is to have a database-global service for running jobs, handling jobs crashing and so on.
  */
 public interface JobScheduler extends Lifecycle
 {
+    enum SchedulingStrategy
+    {
+        /** Create a new thread each time a job is scheduled */
+        NEW_THREAD,
+        /** Run the job from a pool of threads, shared among all groups with this strategy */
+        POOLED
+    }
+
+    /**
+     * Represents a common group of jobs, defining how they should be scheduled.
+     */
+    class Group
+    {
+        public static final String THREAD_ID = "thread-id";
+
+        private final String name;
+        private final SchedulingStrategy strategy;
+        private final AtomicInteger threadCounter = new AtomicInteger( 0 );
+
+        public Group( String name, SchedulingStrategy strategy )
+        {
+            this.name = name;
+            this.strategy = strategy;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        public SchedulingStrategy strategy()
+        {
+            return strategy;
+        }
+
+        /**
+         * Name a new thread. This method may or may not be used, it is up to the scheduling strategy to decide
+         * to honor this.
+         * @param metadata comes from {@link #schedule(Group, Runnable, Map)}
+         */
+        public String threadName( Map<String, String> metadata )
+        {
+            if(metadata.containsKey( THREAD_ID ))
+            {
+                return "neo4j." + name() + "/" + metadata.get( THREAD_ID );
+            }
+            return "neo4j." + name() + "/" + threadCounter.incrementAndGet();
+        }
+
+    }
+
     /**
      * This is an exhaustive list of job types that run in the database. It should be expanded as needed for new groups
      * of jobs.
@@ -36,37 +92,43 @@ public interface JobScheduler extends Lifecycle
      * For now, this does naming only, but it will allow us to define per-group configuration, such as how to handle
      * failures, shared threads and (later on) affinity strategies.
      */
-    enum Group
+    class Groups
     {
-        indexPopulation,
-        masterTransactionPushing,
+        /** Session workers, these perform the work of actually executing client queries.  */
+        public static final Group sessionWorker = new Group( "Session", NEW_THREAD );
+
+        /** Background index population */
+        public static final Group indexPopulation = new Group( "IndexPopulation", POOLED );
+
+        /** Push transactions from master to slaves */
+        public static final Group masterTransactionPushing = new Group( "TransactionPushing", POOLED );
 
         /**
          * Rolls back idle transactions on the server.
          */
-        serverTransactionTimeout,
+        public static final Group serverTransactionTimeout = new Group( "ServerTransactionTimeout", POOLED );
 
         /**
          * Aborts idle slave lock sessions on the master.
          */
-        slaveLocksTimeout,
+        public static final Group slaveLocksTimeout = new Group( "SlaveLocksTimeout", POOLED );
 
         /**
          * Pulls updates from the master.
          */
-        pullUpdates,
+        public static final Group pullUpdates = new Group( "PullUpdates", POOLED );
 
         /**
          * Gathers approximated data about the underlying data store.
          */
-        indexSamplingController,
-        indexSampling,
-        pageCacheEviction,
+        public static final Group indexSamplingController = new Group( "IndexSamplingController", POOLED );
+        public static final Group indexSampling = new Group( "IndexSampling", POOLED );
+        public static final Group pageCacheEviction = new Group( "PageCacheEviction", POOLED );
 
         /**
          * Rotates internal diagnostic logs
          */
-        internalLogRotation,
+        public static final Group internalLogRotation = new Group( "InternalLogRotation", POOLED );
     }
 
     interface JobHandle
@@ -74,11 +136,18 @@ public interface JobScheduler extends Lifecycle
         void cancel( boolean mayInterruptIfRunning );
     }
 
+    /** Expose a group scheduler as an {@link Executor} */
     Executor executor( Group group );
 
+    /** Schedule a new job in the specified group. */
     JobHandle schedule( Group group, Runnable job );
 
+    /** Schedule a new job in the specified group, passing in metadata for the scheduling strategy to use. */
+    JobHandle schedule( Group group, Runnable job, Map<String, String> metadata );
+
+    /** Schedule a recurring job */
     JobHandle scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit );
 
+    /** Schedule a recurring job where the first invocation is delayed the specified time */
     JobHandle scheduleRecurring( Group group, Runnable runnable, long initialDelay, long period, TimeUnit timeUnit );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
@@ -19,26 +19,33 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.kernel.lifecycle.LifeSupport;
+
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.Exceptions.launderedException;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexPopulation;
-
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.THREAD_ID;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexPopulation;
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.NEW_THREAD;
 
 public class Neo4jJobSchedulerTest
 {
-    private Neo4jJobScheduler scheduler;
-    private AtomicInteger invocations;
+    private final AtomicInteger invocations = new AtomicInteger();
+    private final LifeSupport life = new LifeSupport();
+    private Neo4jJobScheduler scheduler = life.add( new Neo4jJobScheduler(  ) );
 
     private Runnable countInvocationsJob = new Runnable()
     {
@@ -57,12 +64,6 @@ public class Neo4jJobSchedulerTest
         }
     };
 
-    @Before
-    public void initInvocation()
-    {
-        invocations = new AtomicInteger( 0 );
-    }
-
     @After
     public void stopScheduler() throws Throwable
     {
@@ -75,10 +76,9 @@ public class Neo4jJobSchedulerTest
         // Given
         long period = 1_000;
         int count = 2;
-        scheduler = new Neo4jJobScheduler();
+        life.start();
 
         // When
-        scheduler.init();
         scheduler.scheduleRecurring( indexPopulation, countInvocationsJob, period, MILLISECONDS );
         awaitFirstInvocation();
         sleep( period * count - period / 2 );
@@ -97,9 +97,7 @@ public class Neo4jJobSchedulerTest
     {
         // Given
         long period = 2;
-        scheduler = new Neo4jJobScheduler();
-
-        scheduler.init();
+        life.start();
         JobScheduler.JobHandle jobHandle = scheduler.scheduleRecurring(
                 indexPopulation,
                 countInvocationsJob,
@@ -112,8 +110,75 @@ public class Neo4jJobSchedulerTest
 
         // Then
         int recorded = invocations.get();
-        sleep( period*100 );
-        assertThat( invocations.get(), equalTo(recorded) );
+        sleep( period * 100 );
+        assertThat( invocations.get(), equalTo( recorded ) );
+    }
+
+    @Test
+    public void shouldRunJobInNewThread() throws Throwable
+    {
+        // Given
+        life.start();
+
+        // We start a thread that will signal when it's running, and remain running until we tell it to stop.
+        // This way we can check and make sure a thread with the name we expect is live and well
+        final CountDownLatch threadStarted = new CountDownLatch( 1 );
+        final CountDownLatch unblockThread = new CountDownLatch( 1 );
+
+        // When
+        scheduler.schedule( new JobScheduler.Group( "MyGroup", NEW_THREAD ),
+                            waitForLatch( threadStarted, unblockThread ),
+                            stringMap( THREAD_ID, "MyTestThread" ) );
+        threadStarted.await();
+
+        // Then
+        try
+        {
+            String threadName = "neo4j.MyGroup/MyTestThread";
+            for ( String name : threadNames() )
+            {
+                if(name.equals( threadName ))
+                {
+                    return;
+                }
+            }
+            fail("Expected a thread named '" + threadName + "' in " + threadNames() );
+
+        }
+        finally
+        {
+            unblockThread.countDown();
+        }
+    }
+
+    private List<String> threadNames()
+    {
+        List<String> names = new ArrayList<>();
+        for ( Thread thread : Thread.getAllStackTraces().keySet() )
+        {
+            names.add( thread.getName() );
+        }
+        return names;
+    }
+
+    private Runnable waitForLatch( final CountDownLatch threadStarted, final CountDownLatch runUntil )
+    {
+        return new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    threadStarted.countDown();
+                    runUntil.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+        };
     }
 
     private void awaitFirstInvocation()

--- a/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.test;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +48,12 @@ public class OnDemandJobScheduler extends LifecycleAdapter implements JobSchedul
     {
         this.job = job;
         return new OnDemandJobHandle();
+    }
+
+    @Override
+    public JobHandle schedule( Group group, Runnable job, Map<String,String> metadata )
+    {
+        return schedule( group, job );
     }
 
     @Override

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/ErrorTranslator.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/ErrorTranslator.java
@@ -40,6 +40,7 @@ public class ErrorTranslator
 
     public Neo4jError translate( Throwable any )
     {
+        any.printStackTrace();
         if ( any instanceof KernelException )
         {
             return new Neo4jError( ((KernelException) any).status(), any.getMessage() );

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorker.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorker.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.Log;
+import org.neo4j.ndp.runtime.Session;
+
+/**
+ * Executes incoming session commands on a specified session.
+ */
+public class SessionWorker implements Runnable
+{
+    /** Poison pill for closing the session and shutting down the worker */
+    public static final Consumer<Session> SHUTDOWN = new Consumer<Session>()
+    {
+        @Override
+        public void accept( Session session )
+        {
+
+        }
+    };
+
+    private final static int workQueueSize = Integer.getInteger( "org.neo4j.ndp.workQueueSize", 100 );
+
+    private final ArrayBlockingQueue<Consumer<Session>> workQueue = new ArrayBlockingQueue<>( workQueueSize );
+    private final Session session;
+    private final Log log;
+    private final Log userLog;
+    private boolean keepRunning;
+
+    public SessionWorker( Session session, LogService logging )
+    {
+        this.session = session;
+        this.log = logging.getInternalLog( getClass() );
+        this.userLog = logging.getUserLog( getClass() );
+    }
+
+    /**
+     * Accept a command to be executed at some point in the future. This will get queued and executd as soon as
+     * possible.
+     * @param command an operation to be performed on the session
+     */
+    public void handle( Consumer<Session> command ) throws InterruptedException
+    {
+        workQueue.put( command );
+    }
+
+    @Override
+    public void run()
+    {
+        keepRunning = true;
+        ArrayList<Consumer<Session>> batch = new ArrayList<>( workQueueSize );
+
+        try
+        {
+            while ( keepRunning )
+            {
+                Consumer<Session> work = workQueue.poll( 10, TimeUnit.SECONDS );
+                if ( work != null )
+                {
+                    execute( work );
+
+                    for ( int items = 1; keepRunning && items > 0;
+                          items = workQueue.drainTo( batch ) )
+                    {
+                        executeBatch( batch );
+                    }
+                }
+            }
+        }
+        catch(Throwable e)
+        {
+            log.error( "Worker for session '" + session.key() + "' crashed: " + e.getMessage(), e );
+            userLog.error( "Fatal, worker for session '" + session.key() + "' crashed. Please" +
+                           " contact your support representative if you are unable to resolve this error. Error " +
+                           "message was: " + e.getMessage() );
+
+            // Attempt to close the session, as an effort to release locks and other resources held by the session
+            session.close();
+        }
+    }
+
+    private void executeBatch( ArrayList<Consumer<Session>> batch )
+    {
+        for ( int i = 0; keepRunning && i < batch.size(); i++ )
+        {
+            execute( batch.get( i ) );
+        }
+        batch.clear();
+    }
+
+    private void execute( Consumer<Session> work )
+    {
+        if(work == SHUTDOWN)
+        {
+            session.close();
+            keepRunning = false;
+        }
+        else
+        {
+            work.accept( session );
+        }
+    }
+}

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import java.util.Map;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.ndp.runtime.Session;
+import org.neo4j.ndp.runtime.StatementMetadata;
+import org.neo4j.stream.RecordStream;
+
+/**
+ * A session implementation that delegates work to a worker thread.
+ */
+public class SessionWorkerFacade implements Session
+{
+    private final String key;
+    private final SessionWorker worker;
+
+    public SessionWorkerFacade( String key, SessionWorker worker )
+    {
+        this.key = key;
+        this.worker = worker;
+    }
+
+    @Override
+    public String key()
+    {
+        return key;
+    }
+
+    @Override
+    public <A> void run( final String statement, final Map<String,Object> params, final A attachment,
+            final Callback<StatementMetadata,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.run( statement, params, attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void pullAll( final A attachment, final Callback<RecordStream,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.pullAll( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void discardAll( final A attachment, final Callback<Void,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.discardAll( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void acknowledgeFailure( final A attachment, final Callback<Void,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.acknowledgeFailure( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public void close()
+    {
+        queue( SessionWorker.SHUTDOWN );
+    }
+
+    private void queue( Consumer<Session> action )
+    {
+        try
+        {
+            worker.handle( action );
+        }
+        catch ( InterruptedException e )
+        {
+            throw new RuntimeException( "Worker interrupted while queueing request, the session may have been " +
+                                        "forcibly closed, or the database may be shutting down." );
+        }
+    }
+}

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/ThreadedSessions.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/ThreadedSessions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.ndp.runtime.Session;
+import org.neo4j.ndp.runtime.Sessions;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.THREAD_ID;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.sessionWorker;
+
+/**
+ * A {@link Sessions} implementation that creates one thread for every session started, requests are then executed
+ * in the session-specific thread.
+ *
+ * This resolves a tricky issue where sharing threads for multiple sessions can cause complex deadlocks. It does so
+ * at the expense of creating, potentially, many threads. However, this approach is much less complex than using
+ * a thread pool, and is the preferred approach of several highly scalable relational databases.
+ *
+ * If we find ourselves with tens of thousands of concurrent sessions per neo4j instance, we may want to introduce an
+ * alternate strategy.
+ */
+public class ThreadedSessions implements Sessions
+{
+    private Sessions delegate;
+    private JobScheduler scheduler;
+    private LogService logging;
+
+    public ThreadedSessions(Sessions delegate, JobScheduler scheduler, LogService logging)
+    {
+        this.delegate = delegate;
+        this.scheduler = scheduler;
+        this.logging = logging;
+    }
+
+    @Override
+    public Session newSession()
+    {
+        Session realSession = delegate.newSession();
+        SessionWorker worker = new SessionWorker( realSession, logging );
+
+        scheduler.schedule( sessionWorker, worker, stringMap( THREAD_ID, realSession.key() ) );
+
+        return new SessionWorkerFacade( realSession.key(), worker );
+    }
+}

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TestSessions.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/TestSessions.java
@@ -27,11 +27,14 @@ import java.util.LinkedList;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.NullLog;
 import org.neo4j.ndp.runtime.Session;
 import org.neo4j.ndp.runtime.Sessions;
 import org.neo4j.ndp.runtime.internal.StandardSessions;
+import org.neo4j.ndp.runtime.internal.concurrent.ThreadedSessions;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class TestSessions implements TestRule, Sessions
@@ -50,7 +53,13 @@ public class TestSessions implements TestRule, Sessions
             public void evaluate() throws Throwable
             {
                 gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
-                actual = life.add( new StandardSessions( (GraphDatabaseAPI) gdb, NullLog.getInstance() ) );
+                Neo4jJobScheduler scheduler = life.add(new Neo4jJobScheduler());
+                StandardSessions sessions = life.add(
+                        new StandardSessions( (GraphDatabaseAPI) gdb, NullLog.getInstance() ));
+                actual = life.add( new ThreadedSessions(
+                        sessions,
+                        scheduler, NullLogService.getInstance() ) );
+
                 life.start();
                 try
                 {

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerTest.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import org.junit.Test;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.ndp.runtime.Session;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class SessionWorkerTest
+{
+    @Test
+    public void shouldExecuteWorkWhenRun() throws Throwable
+    {
+        // Given
+        Session session = mock( Session.class );
+        SessionWorker worker = new SessionWorker( session, NullLogService.getInstance() );
+        worker.handle( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.run( "Hello, world!", null, null, null );
+            }
+        });
+        worker.handle( SessionWorker.SHUTDOWN );
+
+        // When
+        worker.run();
+
+        // Then
+        verify( session ).run( "Hello, world!", null, null, null );
+        verify( session ).close();
+        verifyNoMoreInteractions( session );
+    }
+
+    @Test
+    public void errorThrownDuringExecutionShouldCauseSessionClose() throws Throwable
+    {
+        // Given
+        Session session = mock( Session.class );
+        SessionWorker worker = new SessionWorker( session, NullLogService.getInstance() );
+        worker.handle( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                throw new RuntimeException( "It didn't work out." );
+            }
+        });
+
+        // When
+        worker.run();
+
+        // Then
+        verify( session ).close();
+    }
+}


### PR DESCRIPTION
This decouples request execution from IO threads, resolving several pesky NDP
deadlock issues, as well as opening up doors for performance improvements where
IO threads can focus on request deserialization, and worker threads focus on
query execution.

This design uses one thread per session started, under the assumption that the
average database will deal with <= 10 000 live sessions per database instance.

This should resolve deadlock issues seen on single-cpu systems.

Also, modify JobScheduler to allow dynamically created thread groups, and per-group thread creation strategies.
