### PR TITLE
Introduce session worker threads.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -45,7 +45,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexPopulation;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexPopulation;
 
 
 public class PopulatingIndexProxy implements IndexProxy

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode.BACKGROUND_REBUILD_UPDATED;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.indexSamplingController;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexSamplingController;
 
 public class IndexSamplingController
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTracker.java
@@ -69,7 +69,7 @@ public class IndexSamplingJobTracker
             }
 
             executingJobDescriptors.add( descriptor );
-            jobScheduler.schedule( JobScheduler.Group.indexSampling, new Runnable()
+            jobScheduler.schedule( JobScheduler.Groups.indexSampling, new Runnable()
             {
                 @Override
                 public void run()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -54,7 +54,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
                             JobScheduler jobScheduler, final Consumer<LogProvider> rotationListener ) throws IOException
     {
         this( userLogProvider, fileSystem, storeDirectory, internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives,
-                jobScheduler.executor( JobScheduler.Group.internalLogRotation ), rotationListener );
+                jobScheduler.executor( JobScheduler.Groups.internalLogRotation ), rotationListener );
     }
 
     public StoreLogService( LogProvider userLogProvider, FileSystemAbstraction fileSystem, File storeDirectory,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -19,16 +19,74 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.NEW_THREAD;
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * To be expanded, the idea here is to have a database-global service for running jobs, handling jobs crashing and so on.
  */
 public interface JobScheduler extends Lifecycle
 {
+    enum SchedulingStrategy
+    {
+        /** Create a new thread each time a job is scheduled */
+        NEW_THREAD,
+        /** Run the job from a pool of threads, shared among all groups with this strategy */
+        POOLED
+    }
+
+    /**
+     * Represents a common group of jobs, defining how they should be scheduled.
+     */
+    class Group
+    {
+        public static final String THREAD_ID = "thread-id";
+        public static final Map<String, String> NO_METADATA = Collections.EMPTY_MAP;
+
+        private final String name;
+        private final SchedulingStrategy strategy;
+        private final AtomicInteger threadCounter = new AtomicInteger( 0 );
+
+        public Group( String name, SchedulingStrategy strategy )
+        {
+            this.name = name;
+            this.strategy = strategy;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        public SchedulingStrategy strategy()
+        {
+            return strategy;
+        }
+
+        /**
+         * Name a new thread. This method may or may not be used, it is up to the scheduling strategy to decide
+         * to honor this.
+         * @param metadata comes from {@link #schedule(Group, Runnable, Map)}
+         */
+        public String threadName( Map<String, String> metadata )
+        {
+            if ( metadata.containsKey( THREAD_ID ) )
+            {
+                return "neo4j." + name() + "/" + metadata.get( THREAD_ID );
+            }
+            return "neo4j." + name() + "/" + threadCounter.incrementAndGet();
+        }
+
+    }
+
     /**
      * This is an exhaustive list of job types that run in the database. It should be expanded as needed for new groups
      * of jobs.
@@ -36,37 +94,43 @@ public interface JobScheduler extends Lifecycle
      * For now, this does naming only, but it will allow us to define per-group configuration, such as how to handle
      * failures, shared threads and (later on) affinity strategies.
      */
-    enum Group
+    class Groups
     {
-        indexPopulation,
-        masterTransactionPushing,
+        /** Session workers, these perform the work of actually executing client queries.  */
+        public static final Group sessionWorker = new Group( "Session", NEW_THREAD );
+
+        /** Background index population */
+        public static final Group indexPopulation = new Group( "IndexPopulation", POOLED );
+
+        /** Push transactions from master to slaves */
+        public static final Group masterTransactionPushing = new Group( "TransactionPushing", POOLED );
 
         /**
          * Rolls back idle transactions on the server.
          */
-        serverTransactionTimeout,
+        public static final Group serverTransactionTimeout = new Group( "ServerTransactionTimeout", POOLED );
 
         /**
          * Aborts idle slave lock sessions on the master.
          */
-        slaveLocksTimeout,
+        public static final Group slaveLocksTimeout = new Group( "SlaveLocksTimeout", POOLED );
 
         /**
          * Pulls updates from the master.
          */
-        pullUpdates,
+        public static final Group pullUpdates = new Group( "PullUpdates", POOLED );
 
         /**
          * Gathers approximated data about the underlying data store.
          */
-        indexSamplingController,
-        indexSampling,
-        pageCacheEviction,
+        public static final Group indexSamplingController = new Group( "IndexSamplingController", POOLED );
+        public static final Group indexSampling = new Group( "IndexSampling", POOLED );
+        public static final Group pageCacheEviction = new Group( "PageCacheEviction", POOLED );
 
         /**
          * Rotates internal diagnostic logs
          */
-        internalLogRotation,
+        public static final Group internalLogRotation = new Group( "InternalLogRotation", POOLED );
     }
 
     interface JobHandle
@@ -74,11 +138,18 @@ public interface JobScheduler extends Lifecycle
         void cancel( boolean mayInterruptIfRunning );
     }
 
+    /** Expose a group scheduler as an {@link Executor} */
     Executor executor( Group group );
 
+    /** Schedule a new job in the specified group. */
     JobHandle schedule( Group group, Runnable job );
 
+    /** Schedule a new job in the specified group, passing in metadata for the scheduling strategy to use. */
+    JobHandle schedule( Group group, Runnable job, Map<String, String> metadata );
+
+    /** Schedule a recurring job */
     JobHandle scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit );
 
+    /** Schedule a recurring job where the first invocation is delayed the specified time */
     JobHandle scheduleRecurring( Group group, Runnable runnable, long initialDelay, long period, TimeUnit timeUnit );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -28,15 +29,15 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
-
 import static org.neo4j.helpers.NamedThreadFactory.daemon;
 import static org.neo4j.kernel.impl.util.DebugUtil.trackTest;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.NO_METADATA;
 
 public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
 {
     private final String id;
 
-    private ExecutorService executor;
+    private ExecutorService globalPool;
     private ScheduledThreadPoolExecutor scheduledExecutor;
 
     public Neo4jJobScheduler()
@@ -52,8 +53,8 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     @Override
     public void init()
     {
-        this.executor = newCachedThreadPool( daemon( "Neo4j " + id + trackTest() ) );
-        this.scheduledExecutor = new ScheduledThreadPoolExecutor( 2, daemon( "Scheduled Neo4j " + id + trackTest() ) );
+        this.globalPool = newCachedThreadPool( daemon( "neo4j.pooled/" + id + trackTest() ) );
+        this.scheduledExecutor = new ScheduledThreadPoolExecutor( 2, daemon( "neo4j.scheduled/" + id + trackTest() ) );
     }
 
     @Override
@@ -72,7 +73,24 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     @Override
     public JobHandle schedule( Group group, Runnable job )
     {
-        return new Handle( this.executor.submit( job ) );
+        return schedule( group, job, NO_METADATA );
+    }
+
+    @Override
+    public JobHandle schedule( Group group, Runnable job, Map<String,String> metadata )
+    {
+        switch( group.strategy() )
+        {
+        case POOLED:
+            return new PooledJobHandle( this.globalPool.submit( job ) );
+        case NEW_THREAD:
+            Thread thread = new Thread( null, job, group.threadName( metadata ) );
+            thread.setDaemon( true );
+            thread.start();
+            return new SingleThreadHandle( thread );
+        default:
+            throw new IllegalArgumentException( "Unsupported strategy for scheduling job: " + group.strategy() );
+        }
     }
 
     @Override
@@ -85,7 +103,13 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     public JobHandle scheduleRecurring( Group group, final Runnable runnable, long initialDelay, long period,
                                         TimeUnit timeUnit )
     {
-        return new Handle( scheduledExecutor.scheduleAtFixedRate( runnable, initialDelay, period, timeUnit ) );
+        switch ( group.strategy() )
+        {
+        case POOLED:
+            return new PooledJobHandle( scheduledExecutor.scheduleAtFixedRate( runnable, initialDelay, period, timeUnit ) );
+        default:
+            throw new IllegalArgumentException( "Unsupported strategy to use for recurring jobs: " + group.strategy() );
+        }
     }
 
     @Override
@@ -94,11 +118,11 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
         RuntimeException exception = null;
         try
         {
-            if(executor != null)
+            if( globalPool != null)
             {
-                executor.shutdownNow();
-                executor.awaitTermination( 5, TimeUnit.SECONDS );
-                executor = null;
+                globalPool.shutdownNow();
+                globalPool.awaitTermination( 5, TimeUnit.SECONDS );
+                globalPool = null;
             }
         } catch(RuntimeException e)
         {
@@ -132,11 +156,11 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
         }
     }
 
-    private class Handle implements JobHandle
+    private static class PooledJobHandle implements JobHandle
     {
         private final Future<?> job;
 
-        public Handle( Future<?> job )
+        public PooledJobHandle( Future<?> job )
         {
             this.job = job;
         }
@@ -145,6 +169,25 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
         public void cancel( boolean mayInterruptIfRunning )
         {
             job.cancel( mayInterruptIfRunning );
+        }
+    }
+
+    private static class SingleThreadHandle implements JobHandle
+    {
+        private final Thread thread;
+
+        public SingleThreadHandle( Thread thread )
+        {
+            this.thread = thread;
+        }
+
+        @Override
+        public void cancel( boolean mayInterruptIfRunning )
+        {
+            if ( mayInterruptIfRunning )
+            {
+                thread.interrupt();
+            }
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
@@ -19,11 +19,14 @@
  */
 package org.neo4j.test;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.*;
 
 public class OnDemandJobScheduler extends LifecycleAdapter implements JobScheduler
 {
@@ -44,6 +47,12 @@ public class OnDemandJobScheduler extends LifecycleAdapter implements JobSchedul
 
     @Override
     public JobHandle schedule( Group group, Runnable job )
+    {
+        return this.schedule( group, job, NO_METADATA );
+    }
+
+    @Override
+    public JobHandle schedule( Group group, Runnable job, Map<String,String> metadata )
     {
         this.job = job;
         return new OnDemandJobHandle();

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorker.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorker.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.Log;
+import org.neo4j.ndp.runtime.Session;
+
+/**
+ * Executes incoming session commands on a specified session.
+ */
+public class SessionWorker implements Runnable
+{
+    /** Poison pill for closing the session and shutting down the worker */
+    public static final Consumer<Session> SHUTDOWN = new Consumer<Session>()
+    {
+        @Override
+        public void accept( Session session )
+        {
+
+        }
+    };
+
+    private final static int workQueueSize = Integer.getInteger( "org.neo4j.ndp.workQueueSize", 100 );
+
+    private final ArrayBlockingQueue<Consumer<Session>> workQueue = new ArrayBlockingQueue<>( workQueueSize );
+    private final Session session;
+    private final Log log;
+    private final Log userLog;
+    private boolean keepRunning;
+
+    public SessionWorker( Session session, LogService logging )
+    {
+        this.session = session;
+        this.log = logging.getInternalLog( getClass() );
+        this.userLog = logging.getUserLog( getClass() );
+    }
+
+    /**
+     * Accept a command to be executed at some point in the future. This will get queued and executed as soon as
+     * possible.
+     * @param command an operation to be performed on the session
+     */
+    public void handle( Consumer<Session> command ) throws InterruptedException
+    {
+        workQueue.put( command );
+    }
+
+    @Override
+    public void run()
+    {
+        keepRunning = true;
+        ArrayList<Consumer<Session>> batch = new ArrayList<>( workQueueSize );
+
+        try
+        {
+            while ( keepRunning )
+            {
+                Consumer<Session> work = workQueue.poll( 10, TimeUnit.SECONDS );
+                if ( work != null )
+                {
+                    execute( work );
+
+                    for ( int items = workQueue.drainTo( batch ); keepRunning && items > 0;
+                          items = workQueue.drainTo( batch ) )
+                    {
+                        executeBatch( batch );
+                    }
+                }
+            }
+        }
+        catch ( Throwable e )
+        {
+            log.error( "Worker for session '" + session.key() + "' crashed: " + e.getMessage(), e );
+            userLog.error( "Fatal, worker for session '" + session.key() + "' crashed. Please" +
+                           " contact your support representative if you are unable to resolve this error. Error " +
+                           "message was: " + e.getMessage() );
+
+            // Attempt to close the session, as an effort to release locks and other resources held by the session
+            session.close();
+        }
+    }
+
+    private void executeBatch( ArrayList<Consumer<Session>> batch )
+    {
+        for ( int i = 0; keepRunning && i < batch.size(); i++ )
+        {
+            execute( batch.get( i ) );
+        }
+        batch.clear();
+    }
+
+    private void execute( Consumer<Session> work )
+    {
+        if ( work == SHUTDOWN )
+        {
+            session.close();
+            keepRunning = false;
+        }
+        else
+        {
+            work.accept( session );
+        }
+    }
+}

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import java.util.Map;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.ndp.runtime.Session;
+import org.neo4j.ndp.runtime.StatementMetadata;
+import org.neo4j.stream.RecordStream;
+
+/**
+ * A session implementation that delegates work to a worker thread.
+ */
+public class SessionWorkerFacade implements Session
+{
+    private final String key;
+    private final SessionWorker worker;
+
+    public SessionWorkerFacade( String key, SessionWorker worker )
+    {
+        this.key = key;
+        this.worker = worker;
+    }
+
+    @Override
+    public String key()
+    {
+        return key;
+    }
+
+    @Override
+    public <A> void run( final String statement, final Map<String,Object> params, final A attachment,
+            final Callback<StatementMetadata,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.run( statement, params, attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void pullAll( final A attachment, final Callback<RecordStream,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.pullAll( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void discardAll( final A attachment, final Callback<Void,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.discardAll( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public <A> void acknowledgeFailure( final A attachment, final Callback<Void,A> callback )
+    {
+        queue( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.acknowledgeFailure( attachment, callback );
+            }
+        } );
+    }
+
+    @Override
+    public void close()
+    {
+        queue( SessionWorker.SHUTDOWN );
+    }
+
+    private void queue( Consumer<Session> action )
+    {
+        try
+        {
+            worker.handle( action );
+        }
+        catch ( InterruptedException e )
+        {
+            throw new RuntimeException( "Worker interrupted while queueing request, the session may have been " +
+                                        "forcibly closed, or the database may be shutting down." );
+        }
+    }
+}

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/ThreadedSessions.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/concurrent/ThreadedSessions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.ndp.runtime.Session;
+import org.neo4j.ndp.runtime.Sessions;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.JobScheduler.Group.THREAD_ID;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.sessionWorker;
+
+/**
+ * A {@link Sessions} implementation that creates one thread for every session started, requests are then executed
+ * in the session-specific thread.
+ *
+ * This resolves a tricky issue where sharing threads for multiple sessions can cause complex deadlocks. It does so
+ * at the expense of creating, potentially, many threads. However, this approach is much less complex than using
+ * a thread pool, and is the preferred approach of several highly scalable relational databases.
+ *
+ * If we find ourselves with tens of thousands of concurrent sessions per neo4j instance, we may want to introduce an
+ * alternate strategy.
+ */
+public class ThreadedSessions implements Sessions
+{
+    private Sessions delegate;
+    private JobScheduler scheduler;
+    private LogService logging;
+
+    public ThreadedSessions( Sessions delegate, JobScheduler scheduler, LogService logging )
+    {
+        this.delegate = delegate;
+        this.scheduler = scheduler;
+        this.logging = logging;
+    }
+
+    @Override
+    public Session newSession()
+    {
+        Session realSession = delegate.newSession();
+        SessionWorker worker = new SessionWorker( realSession, logging );
+
+        scheduler.schedule( sessionWorker, worker, stringMap( THREAD_ID, realSession.key() ) );
+
+        return new SessionWorkerFacade( realSession.key(), worker );
+    }
+}

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerTest.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/concurrent/SessionWorkerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.runtime.internal.concurrent;
+
+import org.junit.Test;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.ndp.runtime.Session;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class SessionWorkerTest
+{
+    @Test
+    public void shouldExecuteWorkWhenRun() throws Throwable
+    {
+        // Given
+        Session session = mock( Session.class );
+        SessionWorker worker = new SessionWorker( session, NullLogService.getInstance() );
+        worker.handle( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                session.run( "Hello, world!", null, null, null );
+            }
+        });
+        worker.handle( SessionWorker.SHUTDOWN );
+
+        // When
+        worker.run();
+
+        // Then
+        verify( session ).run( "Hello, world!", null, null, null );
+        verify( session ).close();
+        verifyNoMoreInteractions( session );
+    }
+
+    @Test
+    public void errorThrownDuringExecutionShouldCauseSessionClose() throws Throwable
+    {
+        // Given
+        Session session = mock( Session.class );
+        SessionWorker worker = new SessionWorker( session, NullLogService.getInstance() );
+        worker.handle( new Consumer<Session>()
+        {
+            @Override
+            public void accept( Session session )
+            {
+                throw new RuntimeException( "It didn't work out." );
+            }
+        });
+
+        // When
+        worker.run();
+
+        // Then
+        verify( session ).close();
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server;
 
+import org.apache.commons.configuration.Configuration;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -29,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.Filter;
 
-import org.apache.commons.configuration.Configuration;
-
 import org.neo4j.function.Function;
 import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.DependencyResolver;
@@ -38,9 +38,9 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.RunCarefully;
 import org.neo4j.helpers.Settings;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.guard.Guard;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -93,10 +93,9 @@ import org.neo4j.shell.ShellSettings;
 import static java.lang.Math.round;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.serverTransactionTimeout;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.serverTransactionTimeout;
 import static org.neo4j.server.database.InjectableProvider.providerForSingleton;
 
 /**
@@ -285,7 +284,8 @@ public abstract class AbstractNeoServer implements NeoServer
         // ensure that this is > 0
         long runEvery = round( timeoutMillis / 2.0 );
 
-        resolveDependency( JobScheduler.class ).scheduleRecurring( serverTransactionTimeout, new Runnable()
+        resolveDependency( JobScheduler.class ).scheduleRecurring( serverTransactionTimeout, new
+                Runnable()
         {
             @Override
             public void run()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePullerClient.java
@@ -28,6 +28,8 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.pullUpdates;
+
 public class UpdatePullerClient extends LifecycleAdapter
 {
     private final JobScheduler scheduler;
@@ -63,7 +65,7 @@ public class UpdatePullerClient extends LifecycleAdapter
     {
         if ( pullIntervalMillis > 0 )
         {
-            intervalJobHandle = scheduler.scheduleRecurring( JobScheduler.Group.pullUpdates, new Runnable()
+            intervalJobHandle = scheduler.scheduleRecurring( pullUpdates, new Runnable()
             {
                 @Override
                 public void run()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -54,7 +54,7 @@ import org.neo4j.kernel.impl.util.collection.NoSuchEntryException;
 import org.neo4j.kernel.impl.util.collection.TimedRepository;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.slaveLocksTimeout;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.slaveLocksTimeout;
 
 /**
  * This is the real master code that executes on a master. The actual
@@ -153,7 +153,9 @@ public class MasterImpl extends LifecycleAdapter implements Master
                     value.close();
                 }
             }, config.get( HaSettings.lock_read_timeout ) + TX_TIMEOUT_ADDITION, Clock.SYSTEM_CLOCK );
-        staleSlaveReaperJob = spi.scheduleRecurringJob( slaveLocksTimeout, unfinishedSessionsCheckInterval, slaveLockSessions );
+        staleSlaveReaperJob = spi.scheduleRecurringJob( slaveLocksTimeout,
+                unfinishedSessionsCheckInterval,
+                slaveLockSessions );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/CommitPusher.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-import static org.neo4j.kernel.impl.util.JobScheduler.Group.masterTransactionPushing;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.masterTransactionPushing;
 
 public class CommitPusher extends LifecycleAdapter
 {


### PR DESCRIPTION
This decouples request execution from IO threads, resolving several pesky NDP
deadlock issues, as well as opening up doors for performance improvements where
IO threads can focus on request deserialization, and worker threads focus on
query execution.

This design uses one thread per session started, under the assumption that the
average database will deal with <= 10 000 live sessions per database instance.

This should resolve deadlock issues seen on single-cpu systems.
