### PR TITLE
Reserve space for chunk header in ChunkedOutput

### DIFF
--- a/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/transport.asciidoc
@@ -88,12 +88,12 @@ header |                     Data                       |  Marker
 .A message split in two chunks
 [source,ndp_chunking_example]
 ----
-Chunk size: 8
-Message data: 00 01 02 03  04 05 06 07  08 09 0A 0B  0C  0D 0E 0F
+Chunk size: 16
+Message data: 00 01 02 03  04 05 06 07  08 09 0A 0B  0C 0D 0E 0F  01 02 03 04
 
-00 08  00 01 02 03  04 05 06 07  00 08  08 09 0A 0B  0C 0D 0E 0F  00 00
-chunk1 |        Message       |  chunk2 |         Message      |   End
-header |         Data         |  header |          Data        |  Marker
+00 10  00 01 02 03  04 05 06 07  08 09 0A 0B  0C 0D 0E 0F  00 04  01 02 03 04  00 00
+chunk1 |                    Message                     |  chunk2 | Message |   End
+header |                     Data                       |  header |  Data   |  Marker
 ----
 
 .Two messages


### PR DESCRIPTION
Fixed a bug where ChunkedOutput forgot to reserve space for chunk header. This bug arises if space left in current chunk is enough for data-to-write, but not header + data-to-write. The bug is fixed by ensuring space left is enough for header + data-to-write if data are to be written to a new chunk.
