### PR TITLE
Fix bugs related to MERGE following DELETE statements

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/Query.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/Query.scala
@@ -83,13 +83,18 @@ case class Query(returns: Return,
       case None            => acc :+ query
     }
 
+    def isMergeAction(action: UpdateAction) =
+      action.isInstanceOf[MergeNodeAction] || action.isInstanceOf[MergePatternAction]
+
     allTails(Vector.empty, this).reduceRight[Query] {
       case (head, remaining) =>
         if (head.compactableStart &&
-            remaining.compactableTail &&
-            // If we have updating actions, we can't merge with a tail part that has updating start items
-            // That would mess with the order of actions
-            !(head.updatedCommands.nonEmpty && remaining.start.exists(_.mutating))) {
+          remaining.compactableTail &&
+          // Merges are both reads and writes, and can't be compacted with something else
+          !remaining.updatedCommands.exists(isMergeAction) &&
+          // If we have updating actions, we can't merge with a tail part that has updating start items
+          // That would mess with the order of actions
+          !(head.updatedCommands.nonEmpty && remaining.start.exists(_.mutating))) {
           head.compactWith(remaining)
         } else
           head.copy(tail = Some(remaining))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/addEagernessIfNecessary.scala
@@ -26,7 +26,11 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     val nodesInterfere = from.contains(ReadsNodes) && to.contains(WritesNodes)
     val relsInterfere = from.contains(ReadsRelationships) && to.contains(WritesRelationships)
 
-    nodesInterfere || relsInterfere ||
+    val readWriteInterfereNodes = from.contains(WritesNodes) && to.contains(WritesNodes) && to.contains(ReadsNodes)
+    val readWriteInterfereRelationships = from.contains(WritesRelationships) && to.contains(WritesRelationships) &&
+                                          to.contains(ReadsRelationships)
+
+    nodesInterfere || relsInterfere || readWriteInterfereNodes || readWriteInterfereRelationships ||
       nodePropertiesInterfere(from, to) || relationshipPropertiesInterfere(from, to) || labelsInterfere(from, to)
   }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/UpdateAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/UpdateAction.scala
@@ -46,7 +46,7 @@ trait UpdateAction extends TypeSafe with AstNode[UpdateAction] {
     val collector = new EffectsCollector(localEffects(symbols), self, symbols)
     visitFirst {
       case (effectful: Effectful) => collector.register(effectful).withEffects(effectful.localEffects.toWriteEffects())
-      case (effectfulAst: EffectfulAstNode[_]) => collector.register(effectfulAst).withEffects(effectfulAst.localEffects(symbols).toWriteEffects())
+      case (effectfulAst: EffectfulAstNode[_]) => collector.register(effectfulAst).withEffects(effectfulAst.localEffects(updateSymbols(symbols)).toWriteEffects())
       case (update: UpdateAction) =>
         val oldSymbols = collector.symbols(update)
         collector

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
@@ -69,7 +69,7 @@ case class ExecuteUpdateCommandsPipe(source: Pipe, commands: Seq[UpdateAction])(
 
   def sourceSymbols: SymbolTable = source.symbols
 
-  override def localEffects = commands.effects(symbols)
+  override def localEffects = commands.effects(sourceSymbols)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -26,6 +26,30 @@ import scala.util.matching.Regex
 class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrivenPropertyChecks {
   val EagerRegEx: Regex = "Eager(?!A)".r
 
+  test("should introduce eagerness between DELETE and MERGE for node") {
+    val query =
+      """
+        |MATCH (b:B)
+        |DELETE b
+        |MERGE (b2:B { value: 1 })
+        |RETURN b2
+      """.stripMargin
+
+    assertNumberOfEagerness(query, 2)
+  }
+
+  test("should introduce eagerness between DELETE and MERGE for relationship") {
+    val query =
+      """
+        |MATCH (a)-[t:T]->(b)
+        |DELETE t
+        |MERGE (a)-[t2:T]->(b)
+        |RETURN t2
+      """.stripMargin
+
+    assertNumberOfEagerness(query, 2)
+  }
+
   test("should not introduce eagerness for MATCH nodes and CREATE relationships") {
     val query = "MATCH a, b CREATE (a)-[:KNOWS]->(b)"
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -21,10 +21,106 @@ package org.neo4j.cypher
 
 import org.neo4j.cypher.internal.PathImpl
 import org.neo4j.graphdb._
+import org.neo4j.graphdb.factory.GraphDatabaseFactory
 
 import scala.collection.JavaConverters._
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+
+  test("a merge following a delete of multiple rows should not match on a deleted entity") {
+    // GIVEN
+    val a = createLabeledNode("A")
+    val branches = 2
+    val b = (0 until branches).map(n => createLabeledNode(Map("value" -> n), "B"))
+    val c = (0 until branches).map(_ => createLabeledNode("C"))
+    (0 until branches).foreach(n => {
+      relate(a, b(n))
+      relate(b(n), c(n))
+    })
+
+    val query =
+      """
+        |MATCH (a:A) -[ab]-> (b:B) -[bc]-> (c:C)
+        |DELETE ab, bc, b, c
+        |MERGE (newB:B { value: 1 })
+        |MERGE (a) -[:REL]->  (newB)
+        |MERGE (newC:C)
+        |MERGE (newB) -[:REL]-> (newC)
+      """.stripMargin
+
+    // WHEN
+    executeWithRulePlannerOnly(query)
+
+    // THEN
+    assert(true)
+  }
+
+  test("identifiers of deleted nodes should not be able to cause errors in later merge actions that do not refer to them") {
+    // GIVEN
+    val a = createLabeledNode("A")
+    val b = createLabeledNode("B")
+    val c = createLabeledNode("C")
+    relate(a, b)
+    relate(b, c)
+
+    val query =
+      """
+        |MATCH (a:A) -[ab]-> (b:B) -[bc]-> (c:C)
+        |DELETE ab, bc, b, c
+        |MERGE (newB:B)
+        |MERGE (a) -[:REL]->  (newB)
+        |MERGE (newC:C)
+        |MERGE (newB) -[:REL]-> (newC)
+      """.stripMargin
+
+    // WHEN
+    executeWithRulePlannerOnly(query)
+
+    // THEN query should not crash
+    assert(true)
+  }
+
+  test("merges should not be able to match on deleted nodes") {
+    // GIVEN
+    val node1 = createLabeledNode(Map("value" -> 1), "A")
+    val node2 = createLabeledNode(Map("value" -> 2), "A")
+
+    val query = """
+      |MATCH (a:A)
+      |DELETE a
+      |MERGE (a2:A)
+      |RETURN a2
+    """.stripMargin
+
+    // WHEN
+    val result = executeWithRulePlannerOnly(query)
+
+    // THEN
+    result.toList should not contain Map("a2" -> node1)
+    result.toList should not contain Map("a2" -> node2)
+  }
+
+  test("merges should not be able to match on deleted relationships") {
+    // GIVEN
+    val a = createNode()
+    val b = createNode()
+    val rel1 = relate(a, b, "T")
+    val rel2 = relate(a, b, "T")
+
+    val query = """
+      |MATCH (a)-[t:T]->(b)
+      |DELETE t
+      |MERGE (a)-[t2:T]->(b)
+      |RETURN t2
+    """.stripMargin
+
+    // WHEN
+    val result = executeWithRulePlannerOnly(query)
+
+    // THEN
+    result.toList should not contain Map("t2" -> rel1)
+    result.toList should not contain Map("t2" -> rel2)
+  }
 
   test("path query should return results in written order") {
     val a = createLabeledNode("label1")


### PR DESCRIPTION
Several fixes combined to make this possible:
- MergePatternAction now lists its read effects properly.
- MergePatternAction will no longer lock all nodes in the execution context, but only those with identifiers in the current pattern
- Rule planner will no longer concatenate MERGE statements with anything
- Eagerness will be inserted between a write and a read/write (eg, merge)
- Consider both previous and introduced identifiers when cascading down the ast tree for merge actions, so the effects of the merge are the actual effects of the merge itself, not cascade effects.
