### PR TITLE
No more most-derived-bootstrapper

### DIFF
--- a/advanced/server-advanced/src/main/java/org/neo4j/server/advanced/AdvancedBootstrapper.java
+++ b/advanced/server-advanced/src/main/java/org/neo4j/server/advanced/AdvancedBootstrapper.java
@@ -27,6 +27,15 @@ import org.neo4j.server.configuration.ConfigurationBuilder;
 
 public class AdvancedBootstrapper extends CommunityBootstrapper
 {
+	public static void main( String[] args )
+	{
+		Integer exit = new AdvancedBootstrapper().start();
+		if ( exit != 0 )
+		{
+			System.exit( exit );
+		}
+	}
+
 	@Override
 	protected NeoServer createNeoServer( ConfigurationBuilder configurator, GraphDatabaseDependencies dependencies, LogProvider userLogProvider )
 	{

--- a/advanced/server-advanced/src/test/java/org/neo4j/server/advanced/AdvancedBootstrapperTest.java
+++ b/advanced/server-advanced/src/test/java/org/neo4j/server/advanced/AdvancedBootstrapperTest.java
@@ -25,12 +25,6 @@ import org.neo4j.server.Bootstrapper;
 public class AdvancedBootstrapperTest extends BaseBootstrapperTest
 {
     @Override
-    protected Class<? extends Bootstrapper> bootstrapperClass()
-    {
-        return AdvancedBootstrapper.class;
-    }
-
-    @Override
     protected Bootstrapper newBootstrapper()
     {
         return new AdvancedBootstrapper();

--- a/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
@@ -24,7 +24,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.helpers.Service;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.kernel.info.JvmChecker;
@@ -64,37 +63,9 @@ public abstract class Bootstrapper
 
     public static void main( String[] args )
     {
-        Bootstrapper bootstrapper = loadMostDerivedBootstrapper();
-        Integer exit = bootstrapper.start();
-        if ( exit != 0 )
-        {
-            System.exit( exit );
-        }
-    }
-
-    public static Bootstrapper loadMostDerivedBootstrapper()
-    {
-        Bootstrapper winner = new CommunityBootstrapper();
-        for ( Bootstrapper candidate : Service.load( Bootstrapper.class ) )
-        {
-            if ( candidate.isMoreDerivedThan( winner ) )
-            {
-                winner = candidate;
-            }
-        }
-        return winner;
-    }
-
-    // TODO: method not used and WrapperListener interface does no exist. Check if it is safe to remove it
-    public void controlEvent( int arg )
-    {
-        // Do nothing, required by the WrapperListener interface
-    }
-
-    // TODO: args are not used, check if it is safe to remove this method
-    public Integer start( String[] args )
-    {
-        return start();
+        throw new UnsupportedOperationException(
+                "Invoking Bootstrapper#main() is no longer supported. If you see this error, please contact Neo4j " +
+                "support." );
     }
 
     public Integer start()
@@ -151,12 +122,6 @@ public abstract class Bootstrapper
     }
 
     protected abstract NeoServer createNeoServer( ConfigurationBuilder configurator, GraphDatabaseDependencies dependencies, LogProvider userLogProvider );
-
-    // TODO: stopArg is not used, check if it is safe to remove this method
-    public void stop( int stopArg )
-    {
-        stop();
-    }
 
     public int stop()
     {
@@ -229,10 +194,4 @@ public abstract class Bootstrapper
         return new PropertyFileConfigurator( configFile, log );
     }
 
-    protected boolean isMoreDerivedThan( Bootstrapper other )
-    {
-        // Default implementation just checks if this is a subclass of other
-        return other.getClass()
-                .isAssignableFrom( getClass() );
-    }
 }

--- a/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
@@ -29,6 +29,15 @@ import org.neo4j.server.configuration.ConfigurationBuilder;
 @Deprecated
 public class CommunityBootstrapper extends Bootstrapper
 {
+    public static void main( String[] args )
+    {
+        Integer exit = new CommunityBootstrapper().start();
+        if ( exit != 0 )
+        {
+            System.exit( exit );
+        }
+    }
+
     @Override
     protected NeoServer createNeoServer( ConfigurationBuilder configurator, GraphDatabaseDependencies dependencies, LogProvider logProvider )
     {

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
@@ -30,11 +30,8 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.Mute;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
 {
@@ -55,15 +52,7 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         }
     }
 
-    protected abstract Class<? extends Bootstrapper> bootstrapperClass();
-
     protected abstract Bootstrapper newBootstrapper();
-
-    @Test
-    public void shouldLoadAppropriateBootstrapper()
-    {
-        assertThat( Bootstrapper.loadMostDerivedBootstrapper(), is( instanceOf( bootstrapperClass() ) ) );
-    }
 
     @Test
     public void shouldStartStopNeoServerWithoutAnyConfigFiles()

--- a/community/server/src/test/java/org/neo4j/server/CommunityBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/CommunityBootstrapperTest.java
@@ -19,35 +19,11 @@
  */
 package org.neo4j.server;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 public class CommunityBootstrapperTest extends BaseBootstrapperTest
 {
-    @Override
-    protected Class<? extends Bootstrapper> bootstrapperClass()
-    {
-        return CommunityBootstrapper.class;
-    }
-
     @Override
     protected Bootstrapper newBootstrapper()
     {
         return new CommunityBootstrapper();
-    }
-
-    @Test
-    public void shouldFindTheMostDerivedType() throws Exception
-    {
-        Bootstrapper bs = new CommunityBootstrapper();
-        Bootstrapper other = new MoreDerivedBootstrapper();
-        assertFalse( bs.isMoreDerivedThan( other ) );
-        assertTrue( other.isMoreDerivedThan( bs ) );
-    }
-
-    private static class MoreDerivedBootstrapper extends CommunityBootstrapper
-    {
     }
 }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -27,6 +27,15 @@ import org.neo4j.server.configuration.ConfigurationBuilder;
 
 public class EnterpriseBootstrapper extends AdvancedBootstrapper
 {
+	public static void main( String[] args )
+	{
+		Integer exit = new EnterpriseBootstrapper().start();
+		if ( exit != 0 )
+		{
+			System.exit( exit );
+		}
+	}
+
     @Override
 	protected NeoServer createNeoServer( ConfigurationBuilder configurator, GraphDatabaseDependencies dependencies, LogProvider userLogProvider )
 	{

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -25,12 +25,6 @@ import org.neo4j.server.Bootstrapper;
 public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
 {
     @Override
-    protected Class<? extends Bootstrapper> bootstrapperClass()
-    {
-        return EnterpriseBootstrapper.class;
-    }
-
-    @Override
     protected Bootstrapper newBootstrapper()
     {
         return new EnterpriseBootstrapper();

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.storeupgrade;
 
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -28,11 +33,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
-
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -56,6 +56,7 @@ import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UpgradingStoreVersionN
 import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
 import org.neo4j.server.Bootstrapper;
+import org.neo4j.server.CommunityBootstrapper;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.database.Database;
@@ -67,7 +68,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.helpers.collection.Iterables.concat;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -166,7 +166,7 @@ public class StoreUpgradeIntegrationTest
             {
                 System.setProperty( Configurator.NEO_SERVER_CONFIG_FILE_KEY, configFile.getAbsolutePath() );
 
-                Bootstrapper bootstrapper = Bootstrapper.loadMostDerivedBootstrapper();
+                Bootstrapper bootstrapper = new CommunityBootstrapper();
                 bootstrapper.start();
                 try
                 {

--- a/packaging/standalone/permalinks.properties
+++ b/packaging/standalone/permalinks.properties
@@ -1,19 +1,19 @@
 neo4j-home.url=http://neo4j.com/
 neo4j-home.url.title=Neo4j Home
-neo4j-manual.url=http://neo4j.com/docs/${project.version}/
+neo4j-manual.url=http://neo4j.com/docs/#{project.version}/
 neo4j-manual.title=The Neo4j Manual
 downloads.url=http://neo4j.com/download/
 downloads.url.title=Neo4j Downloads
-getting-started.url=http://neo4j.com/docs/${project.version}/introduction.html
+getting-started.url=http://neo4j.com/docs/#{project.version}/introduction.html
 getting-started.url.title=Getting Started
-getting-started-server.url=http://neo4j.com/docs/${project.version}/deployment.html
-getting-started-ha.url=http://neo4j.com/docs/${project.version}/ha-setup-tutorial.html
+getting-started-server.url=http://neo4j.com/docs/#{project.version}/deployment.html
+getting-started-ha.url=http://neo4j.com/docs/#{project.version}/ha-setup-tutorial.html
 getting-started-server.url.title=Getting Started Java With Neo4j Server
-getting-started-java.url=http://neo4j.com/docs/${project.version}/server-java-rest-client-example.html
+getting-started-java.url=http://neo4j.com/docs/#{project.version}/server-java-rest-client-example.html
 getting-started-java.url.title=Getting Started With Java
-getting-started-ruby.url=http://neo4j.com/docs/${project.version}/languages.html
+getting-started-ruby.url=http://neo4j.com/docs/#{project.version}/languages.html
 getting-started-ruby.url.title=Getting Started Java With Ruby
-getting-started-python.url=http://neo4j.com/docs/${project.version}/languages.html
+getting-started-python.url=http://neo4j.com/docs/#{project.version}/languages.html
 getting-started-python.url.title=Getting Started With Python
 
 wrapper-home.url=http://yajsw.sourceforge.net/

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j.bat
@@ -21,7 +21,7 @@ set serviceName=Neo4j-Server
 set serviceDisplayName=Neo4j-Server
 set serviceStartType=auto
 set classpath="-DserverClasspath=lib/*.jar;system/lib/*.jar;plugins/**/*.jar;./conf*"
-set mainclass="-DserverMainClass=org.neo4j.server.Bootstrapper"
+set mainclass="-DserverMainClass=#{neo4j.mainClass}"
 set configFile="conf\neo4j-wrapper.conf"
 
 call "%~dps0base.bat" %1 %2 %3 %4 %5

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/base.bat
@@ -54,7 +54,7 @@ goto:eof
       set javaPath=%%P
   )
 
-  set wrapperJarFilename=${windows-wrapper.filename}
+  set wrapperJarFilename=#{windows-wrapper.filename}
   set command=""
   call:parseConfig "%~dps0..\%configFile%"
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -190,14 +190,14 @@ startit() {
       su $NEO4J_USER -c "\"$JAVACMD\" -cp '$CLASSPATH' $JAVA_OPTS \
         -Dneo4j.home=\"${NEO4J_HOME}\" -Dneo4j.instance=\"${NEO4J_INSTANCE}\" \
         -Dfile.encoding=UTF-8 \
-        org.neo4j.server.Bootstrapper >> \"${CONSOLE_LOG}\" 2>&1 & echo \$! > \"$PID_FILE\" "
+        #{neo4j.mainClass} >> \"${CONSOLE_LOG}\" 2>&1 & echo \$! > \"$PID_FILE\" "
     else
       checkwriteaccess
       echo "WARNING: not changing user"
       "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS  \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
         -Dfile.encoding=UTF-8 \
-        org.neo4j.server.Bootstrapper >> "${CONSOLE_LOG}" 2>&1 & echo $! > "${PID_FILE}"
+        #{neo4j.mainClass} >> "${CONSOLE_LOG}" 2>&1 & echo $! > "${PID_FILE}"
     fi
 
     STARTED_PID=$( cat "$PID_FILE" )
@@ -269,12 +269,10 @@ console() {
     checkwriteaccess
     checkandrepairenv
 
-    echo "Using additional JVM arguments: " $JAVA_OPTS
-
     "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
         -Dfile.encoding=UTF-8 \
-        org.neo4j.server.Bootstrapper
+        #{neo4j.mainClass}
 
   else
     echo "$FRIENDLY_NAME already running with pid $NEO4J_PID"

--- a/packaging/standalone/standalone-advanced/pom.xml
+++ b/packaging/standalone/standalone-advanced/pom.xml
@@ -25,6 +25,9 @@
 	  <url>https://github.com/neo4j/neo4j/tree/master/packaging/standalone/standalone-advanced</url>
   </scm>
 
+  <properties>
+    <neo4j.mainClass>org.neo4j.server.advanced.AdvancedBootstrapper</neo4j.mainClass>
+  </properties>
 
   <licenses>
     <license>
@@ -69,11 +72,17 @@ terms of the relevant Commercial Agreement.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.4</version>
         <configuration>
           <attach>false</attach>
           <finalName>${product.shortname}-advanced-${project.version}</finalName>
           <appendAssemblyId>true</appendAssemblyId>
           <outputDirectory>${project.parent.build.directory}</outputDirectory>
+          <delimiters>
+            <!-- Because we are filtering shell scripts, which use '@' on windows and '${}' on *nix, change the
+                 parameter substitution pattern to not clash with those. -->
+            <delimiter>#{*}</delimiter>
+          </delimiters>
         </configuration>
         <executions>
           <execution>

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -66,24 +66,12 @@
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
-        <exclude>bin/neo4j</exclude>
         <exclude>**/*.bat</exclude>
         <exclude>**/neo4j-backup*</exclude>
         <exclude>**/neo4j-coord*</exclude>
         <exclude>**/*arbiter*</exclude>
       </excludes>
       <filtered>true</filtered>
-    </fileSet>
-    <!-- treat the neo4j script as special so we don't filter shell variables -->
-    <fileSet>
-      <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
-      <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
-      <includes>
-        <include>**/neo4j</include>
-      </includes>
-      <filtered>false</filtered>
     </fileSet>
     <!--add MacOS *.plist installer files -->
     <fileSet>

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -1,4 +1,4 @@
-For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
+For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
 2.3-M02
 -------

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/README.txt
@@ -1,14 +1,14 @@
-${product.fullname} ${neo4j.version}
+#{product.fullname} #{neo4j.version}
 =======================================
 
-Welcome to ${product.fullname} release ${neo4j.version}, a high-performance graph database.
-This is the advanced distribution of ${product.fullname}, including everything you need to
+Welcome to #{product.fullname} release #{neo4j.version}, a high-performance graph database.
+This is the advanced distribution of #{product.fullname}, including everything you need to
 start building applications that can model, persist and explore graph-like data.
 
 In the box
 ----------
 
-${product.fullname} runs as a server application, exposing a Web-based management
+#{product.fullname} runs as a server application, exposing a Web-based management
 interface and RESTful endpoints for data access, along with logging and JMX remote monitoring.
 
 Here in the installation directory, you'll find:
@@ -23,27 +23,27 @@ Here in the installation directory, you'll find:
 Make it go
 ----------
 
-For full instructions, see ${getting-started-server.url}
+For full instructions, see #{getting-started-server.url}
 
-To get started with ${product.fullname}, let's start the server and take a
+To get started with #{product.fullname}, let's start the server and take a
 look at the web interface ...
 
 1. Open a console and navigate to the install directory.
 2. Start the server:
    * Windows: use bin\Neo4j.bat
    * Linux/Mac: use ./bin/neo4j console
-3. In a browser, open http://localhost:${org.neo4j.webserver.port}/
-4. From any REST client or browser, open http://localhost:${org.neo4j.webserver.port}/db/data
+3. In a browser, open http://localhost:#{org.neo4j.webserver.port}/
+4. From any REST client or browser, open http://localhost:#{org.neo4j.webserver.port}/db/data
    in order to get a REST starting point, e.g.
-   curl -v http://localhost:${org.neo4j.webserver.port}/db/data
+   curl -v http://localhost:#{org.neo4j.webserver.port}/db/data
 5. Shutdown the server by typing Ctrl-C in the console.
 
 Learn more
 ----------
 
-* ${neo4j-home.url.title}: ${neo4j-home.url}
-* ${getting-started.url.title}: ${getting-started.url}
-* ${neo4j-manual.title}: ${neo4j-manual.url}
+* #{neo4j-home.url.title}: #{neo4j-home.url}
+* #{getting-started.url.title}: #{getting-started.url}
+* #{neo4j-manual.title}: #{neo4j-manual.url}
 
 License(s)
 ----------

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/bin/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/bin/README.txt
@@ -1,5 +1,5 @@
-${product.fullname} Binaries
+#{product.fullname} Binaries
 =======================================
 
 This directory has scripts for running the applications
-distributed with ${product.fullname}.
+distributed with #{product.fullname}.

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} Configuration
+#{product.fullname} Configuration
 =======================================
 
-${product.fullname} configuration files.
+#{product.fullname} configuration files.
 
 * neo4j-http-logging.xml             -- logging system configuration for the HTTP REST server
                                         using standard logback options

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j-server.properties - runtime operational settings
 #
@@ -10,7 +10,7 @@
 #***************************************************************
 
 # location of the database directory
-org.neo4j.server.database.location=${org.neo4j.database.location}
+org.neo4j.server.database.location=#{org.neo4j.database.location}
 
 # Low-level graph engine tuning file
 org.neo4j.server.db.tuning.properties=conf/neo4j.properties
@@ -21,34 +21,34 @@ org.neo4j.server.db.tuning.properties=conf/neo4j.properties
 #org.neo4j.server.webserver.address=0.0.0.0
 
 # Require (or disable the requirement of) auth to access Neo4j
-dbms.security.auth_enabled=${dbms.security.require_auth}
+dbms.security.auth_enabled=#{dbms.security.require_auth}
 
 #
 # HTTP Connector
 #
 
 # http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=${org.neo4j.webserver.port}
+org.neo4j.server.webserver.port=#{org.neo4j.webserver.port}
 
 #
 # HTTPS Connector
 #
 
 # Turn https-support on/off
-org.neo4j.server.webserver.https.enabled=${org.neo4j.server.webserver.https.enabled}
+org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enabled}
 
 # https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=${org.neo4j.webserver.https.port}
+org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=${org.neo4j.server.webserver.https.cert.location}
+org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=${org.neo4j.server.webserver.https.key.location}
+org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)
-org.neo4j.server.webserver.https.keystore.location=${org.neo4j.server.webserver.https.keystore.location}
+org.neo4j.server.webserver.https.keystore.location=#{org.neo4j.server.webserver.https.keystore.location}
 
 
 # Comma separated list of JAX-RS packages containing JAX-RS resources, one
@@ -56,7 +56,7 @@ org.neo4j.server.webserver.https.keystore.location=${org.neo4j.server.webserver.
 # under the mountpoints specified. Uncomment this line to mount the
 # org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
 # neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
-# http://localhost:${org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
+# http://localhost:#{org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
 #org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
 
 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -70,4 +70,4 @@ wrapper.user=
 #********************************************************************
 # Other Neo4j system properties
 #********************************************************************
-wrapper.java.additional=-Dneo4j.ext.udc.source=${neo4j.ext.udc.source}
+wrapper.java.additional=-Dneo4j.ext.udc.source=#{neo4j.ext.udc.source}

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j.properties - database tuning parameters
 #

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/README.txt
@@ -1,5 +1,5 @@
-${product.fullname} Data
+#{product.fullname} Data
 =======================================
 
-This directory contains all live data managed by ${product.fullname}, including
+This directory contains all live data managed by #{product.fullname}, including
 database files, logs, and other "live" files.

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/log/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/log/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} Logs
+#{product.fullname} Logs
 =======================================
 
 Server logs, including:

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/system/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/system/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} System
+#{product.fullname} System
 =======================================
 
 The system directory contains runtime libraries and resources
-required by ${product.fullname}.
+required by #{product.fullname}.
 
 These are not the droids you're looking for.

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/system/lib/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/system/lib/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} System Libraries
+#{product.fullname} System Libraries
 =======================================
 
 Nobody really knows what these things are for, but if anything

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -25,6 +25,9 @@
 	  <url>https://github.com/neo4j/neo4j/tree/master/packaging/standalone/standalone-community</url>
   </scm>
 
+  <properties>
+    <neo4j.mainClass>org.neo4j.server.CommunityBootstrapper</neo4j.mainClass>
+  </properties>
 
   <licenses>
     <license>
@@ -69,11 +72,17 @@ terms of the relevant Commercial Agreement.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.4</version>
         <configuration>
           <attach>false</attach>
           <finalName>${product.shortname}-community-${project.version}</finalName>
           <appendAssemblyId>true</appendAssemblyId>
           <outputDirectory>${project.parent.build.directory}</outputDirectory>
+          <delimiters>
+            <!-- Because we are filtering shell scripts, which use '@' on windows and '${}' on *nix, change the
+                 parameter substitution pattern to not clash with those. -->
+            <delimiter>#{*}</delimiter>
+          </delimiters>
         </configuration>
         <executions>
           <execution>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -53,24 +53,12 @@
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
-        <exclude>bin/neo4j</exclude>
         <exclude>**/*.bat</exclude>
         <exclude>**/neo4j-backup*</exclude>
         <exclude>**/neo4j-coord*</exclude>
         <exclude>**/*arbiter*</exclude>
       </excludes>
       <filtered>true</filtered>
-    </fileSet>
-    <!-- treat the neo4j script as special so we don't filter shell variables -->
-    <fileSet>
-      <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
-      <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
-      <includes>
-        <include>**/neo4j</include>
-      </includes>
-      <filtered>false</filtered>
     </fileSet>
     <!--add MacOS *.plist installer files -->
     <fileSet>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -1,4 +1,4 @@
-For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
+For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
 2.3-M02
 -------

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/README.txt
@@ -1,14 +1,14 @@
-${product.fullname} ${neo4j.version}
+#{product.fullname} #{neo4j.version}
 =======================================
 
-Welcome to ${product.fullname} release ${neo4j.version}, a high-performance graph database.
-This is the community distribution of ${product.fullname}, including everything you need to
+Welcome to #{product.fullname} release #{neo4j.version}, a high-performance graph database.
+This is the community distribution of #{product.fullname}, including everything you need to
 start building applications that can model, persist and explore graph-like data.
 
 In the box
 ----------
 
-${product.fullname} runs as a server application, exposing a Web-based management
+#{product.fullname} runs as a server application, exposing a Web-based management
 interface and RESTful endpoints for data access.
 
 Here in the installation directory, you'll find:
@@ -23,27 +23,27 @@ Here in the installation directory, you'll find:
 Make it go
 ----------
 
-For full instructions, see ${getting-started-server.url}
+For full instructions, see #{getting-started-server.url}
 
-To get started with ${product.fullname}, let's start the server and take a
+To get started with #{product.fullname}, let's start the server and take a
 look at the web interface ...
 
 1. Open a console and navigate to the install directory.
 2. Start the server:
    * Windows: use bin\Neo4j.bat
    * Linux/Mac: use ./bin/neo4j console
-3. In a browser, open http://localhost:${org.neo4j.webserver.port}/
-4. From any REST client or browser, open http://localhost:${org.neo4j.webserver.port}/db/data
+3. In a browser, open http://localhost:#{org.neo4j.webserver.port}/
+4. From any REST client or browser, open http://localhost:#{org.neo4j.webserver.port}/db/data
    in order to get a REST starting point, e.g.
-   curl -v http://localhost:${org.neo4j.webserver.port}/db/data
+   curl -v http://localhost:#{org.neo4j.webserver.port}/db/data
 5. Shutdown the server by typing Ctrl-C in the console.
 
 Learn more
 ----------
 
-* ${neo4j-home.url.title}: ${neo4j-home.url}
-* ${getting-started.url.title}: ${getting-started.url}
-* ${neo4j-manual.title}: ${neo4j-manual.url}
+* #{neo4j-home.url.title}: #{neo4j-home.url}
+* #{getting-started.url.title}: #{getting-started.url}
+* #{neo4j-manual.title}: #{neo4j-manual.url}
 
 License(s)
 ----------

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/bin/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/bin/README.txt
@@ -1,5 +1,5 @@
-${product.fullname} Binaries
+#{product.fullname} Binaries
 =======================================
 
 This directory has scripts for running the applications
-distributed with ${product.fullname}.
+distributed with #{product.fullname}.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} Configuration
+#{product.fullname} Configuration
 =======================================
 
-${product.fullname} configuration files.
+#{product.fullname} configuration files.
 
 * neo4j-http-logging.xml             -- logging system configuration for the HTTP REST server
                                         using standard logback options

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j-server.properties - runtime operational settings
 #
@@ -10,7 +10,7 @@
 #***************************************************************
 
 # location of the database directory
-org.neo4j.server.database.location=${org.neo4j.database.location}
+org.neo4j.server.database.location=#{org.neo4j.database.location}
 
 # Low-level graph engine tuning file
 org.neo4j.server.db.tuning.properties=conf/neo4j.properties
@@ -21,41 +21,41 @@ org.neo4j.server.db.tuning.properties=conf/neo4j.properties
 #org.neo4j.server.webserver.address=0.0.0.0
 
 # Require (or disable the requirement of) auth to access Neo4j
-dbms.security.auth_enabled=${dbms.security.require_auth}
+dbms.security.auth_enabled=#{dbms.security.require_auth}
 
 #
 # HTTP Connector
 #
 
 # http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=${org.neo4j.webserver.port}
+org.neo4j.server.webserver.port=#{org.neo4j.webserver.port}
 
 #
 # HTTPS Connector
 #
 
 # Turn https-support on/off
-org.neo4j.server.webserver.https.enabled=${org.neo4j.server.webserver.https.enabled}
+org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enabled}
 
 # https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=${org.neo4j.webserver.https.port}
+org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=${org.neo4j.server.webserver.https.cert.location}
+org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=${org.neo4j.server.webserver.https.key.location}
+org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)
-org.neo4j.server.webserver.https.keystore.location=${org.neo4j.server.webserver.https.keystore.location}
+org.neo4j.server.webserver.https.keystore.location=#{org.neo4j.server.webserver.https.keystore.location}
 
 # Comma separated list of JAX-RS packages containing JAX-RS resources, one
 # package name for each mountpoint. The listed package names will be loaded
 # under the mountpoints specified. Uncomment this line to mount the
 # org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
 # neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
-# http://localhost:${org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
+# http://localhost:#{org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
 #org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
 
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -53,4 +53,4 @@ wrapper.user=
 #********************************************************************
 # Other Neo4j system properties
 #********************************************************************
-wrapper.java.additional=-Dneo4j.ext.udc.source=${neo4j.ext.udc.source}
+wrapper.java.additional=-Dneo4j.ext.udc.source=#{neo4j.ext.udc.source}

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j.properties - database tuning parameters
 #

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/data/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/data/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} Data
+#{product.fullname} Data
 =======================================
 
 This directory contains all live data managed by this server, including

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/data/log/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/data/log/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} Logs
+#{product.fullname} Logs
 =======================================
 
 Server logs, including:

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/system/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/system/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} System
+#{product.fullname} System
 =======================================
 
 The system directory contains runtime libraries and resources
-required by ${product.fullname}.
+required by #{product.fullname}.
 
 These are not the droids you're looking for.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/system/lib/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/system/lib/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} System Libraries
+#{product.fullname} System Libraries
 =======================================
 
 Nobody really knows what these things are for, but if anything

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -25,6 +25,9 @@
 	  <url>https://github.com/neo4j/neo4j/tree/master/packaging/standalone/standalone-enterprise</url>
   </scm>
 
+  <properties>
+    <neo4j.mainClass>org.neo4j.server.enterprise.EnterpriseBootstrapper</neo4j.mainClass>
+  </properties>
 
   <licenses>
     <license>
@@ -69,11 +72,17 @@ terms of the relevant Commercial Agreement.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.4</version>
         <configuration>
           <attach>false</attach>
           <finalName>${product.shortname}-enterprise-${project.version}</finalName>
           <appendAssemblyId>true</appendAssemblyId>
           <outputDirectory>${project.parent.build.directory}</outputDirectory>
+          <delimiters>
+            <!-- Because we are filtering shell scripts, which use '@' on windows and '${}' on *nix, change the
+                 parameter substitution pattern to not clash with those. -->
+            <delimiter>#{*}</delimiter>
+          </delimiters>
         </configuration>
         <executions>
           <execution>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -67,23 +67,9 @@
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
-        <exclude>bin/neo4j</exclude>
-        <exclude>bin/neo4j-*</exclude>
         <exclude>**/*.bat</exclude>
       </excludes>
       <filtered>true</filtered>
-    </fileSet>
-    <!-- treat the neo4j script as special so we don't filter shell variables -->
-    <fileSet>
-      <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
-      <lineEnding>unix</lineEnding>
-      <fileMode>0755</fileMode>
-      <includes>
-        <include>**/neo4j</include>
-        <include>**/neo4j-*</include>
-      </includes>
-      <filtered>false</filtered>
     </fileSet>
     <!--add MacOS *.plist installer files -->
     <fileSet>

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -1,4 +1,4 @@
-For Release Notes, see http://neo4j.com/release-notes/neo4j-${project.version}/
+For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
 2.3-M02
 -------

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/README.txt
@@ -1,14 +1,14 @@
-${product.fullname} ${neo4j.version}
+#{product.fullname} #{neo4j.version}
 =======================================
 
-Welcome to ${product.fullname} release ${neo4j.version}, a high-performance graph database.
-This is the enterprise distribution of ${product.fullname}, including everything you need to
+Welcome to #{product.fullname} release #{neo4j.version}, a high-performance graph database.
+This is the enterprise distribution of #{product.fullname}, including everything you need to
 start building applications that can model, persist and explore graph-like data.
 
 In the box
 ----------
 
-${product.fullname} runs as a server application, exposing a Web-based management
+#{product.fullname} runs as a server application, exposing a Web-based management
 interface and RESTful endpoints for data access, along with logging, capabilities
 for participating in a database cluster and JMX remote monitoring.
 
@@ -24,27 +24,27 @@ Here in the installation directory, you'll find:
 Make it go
 ----------
 
-For full instructions, see ${getting-started-server.url}
+For full instructions, see #{getting-started-server.url}
 
-To get started with ${product.fullname}, let's start the server and take a
+To get started with #{product.fullname}, let's start the server and take a
 look at the web interface ...
 
 1. Open a console and navigate to the install directory.
 2. Start the server:
    * Windows: use bin\Neo4j.bat
    * Linux/Mac: use ./bin/neo4j console
-3. In a browser, open http://localhost:${org.neo4j.webserver.port}/
-4. From any REST client or browser, open http://localhost:${org.neo4j.webserver.port}/db/data
+3. In a browser, open http://localhost:#{org.neo4j.webserver.port}/
+4. From any REST client or browser, open http://localhost:#{org.neo4j.webserver.port}/db/data
    in order to get a REST starting point, e.g.
-   curl -v http://localhost:${org.neo4j.webserver.port}/db/data
+   curl -v http://localhost:#{org.neo4j.webserver.port}/db/data
 5. Shutdown the server by typing Ctrl-C in the console.
 
 Learn more
 ----------
 
-* ${neo4j-home.url.title}: ${neo4j-home.url}
-* ${getting-started.url.title}: ${getting-started.url}
-* ${neo4j-manual.title}: ${neo4j-manual.url}
+* #{neo4j-home.url.title}: #{neo4j-home.url}
+* #{getting-started.url.title}: #{getting-started.url}
+* #{neo4j-manual.title}: #{neo4j-manual.url}
 
 License(s)
 ----------

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/bin/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/bin/README.txt
@@ -1,5 +1,5 @@
-${product.fullname} Binaries
+#{product.fullname} Binaries
 =======================================
 
 This directory has scripts for running the applications
-distributed with ${product.fullname}.
+distributed with #{product.fullname}.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} Configuration
+#{product.fullname} Configuration
 =======================================
 
-${product.fullname} configuration files.
+#{product.fullname} configuration files.
 
 * neo4j-http-logging.xml             -- logging system configuration for the HTTP REST server
                                         using standard logback options

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j-server.properties - runtime operational settings
 #
@@ -10,7 +10,7 @@
 #***************************************************************
 
 # location of the database directory
-org.neo4j.server.database.location=${org.neo4j.database.location}
+org.neo4j.server.database.location=#{org.neo4j.database.location}
 
 # Low-level graph engine tuning file
 org.neo4j.server.db.tuning.properties=conf/neo4j.properties
@@ -28,41 +28,41 @@ org.neo4j.server.db.tuning.properties=conf/neo4j.properties
 #org.neo4j.server.webserver.address=0.0.0.0
 
 # Require (or disable the requirement of) auth to access Neo4j
-dbms.security.auth_enabled=${dbms.security.require_auth}
+dbms.security.auth_enabled=#{dbms.security.require_auth}
 
 #
 # HTTP Connector
 #
 
 # http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=${org.neo4j.webserver.port}
+org.neo4j.server.webserver.port=#{org.neo4j.webserver.port}
 
 #
 # HTTPS Connector
 #
 
 # Turn https-support on/off
-org.neo4j.server.webserver.https.enabled=${org.neo4j.server.webserver.https.enabled}
+org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enabled}
 
 # https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=${org.neo4j.webserver.https.port}
+org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=${org.neo4j.server.webserver.https.cert.location}
+org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=${org.neo4j.server.webserver.https.key.location}
+org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)
-org.neo4j.server.webserver.https.keystore.location=${org.neo4j.server.webserver.https.keystore.location}
+org.neo4j.server.webserver.https.keystore.location=#{org.neo4j.server.webserver.https.keystore.location}
 
 # Comma separated list of JAX-RS packages containing JAX-RS resources, one
 # package name for each mountpoint. The listed package names will be loaded
 # under the mountpoints specified. Uncomment this line to mount the
 # org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
 # neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
-# http://localhost:${org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
+# http://localhost:#{org.neo4j.webserver.port}/examples/unmanaged/helloworld/{nodeId}
 #org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
 
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -70,4 +70,4 @@ wrapper.user=
 #********************************************************************
 # Other Neo4j system properties
 #********************************************************************
-wrapper.java.additional=-Dneo4j.ext.udc.source=${neo4j.ext.udc.source}
+wrapper.java.additional=-Dneo4j.ext.udc.source=#{neo4j.ext.udc.source}

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -1,5 +1,5 @@
 ################################################################
-# ${product.fullname}
+# #{product.fullname}
 #
 # neo4j.properties - database tuning parameters
 #
@@ -65,7 +65,7 @@ online_backup_server=127.0.0.1:6362
 
 # Uncomment and specify these lines for running Neo4j in High Availability mode.
 # See the High availability setup tutorial for more details on these settings
-# ${getting-started-ha.url}
+# #{getting-started-ha.url}
 
 # ha.server_id is the number of each instance in the HA cluster. It should be
 # an integer (e.g. 1), and should be unique for each cluster instance.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} Data
+#{product.fullname} Data
 =======================================
 
 This directory contains all live data managed by this server, including

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/log/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/log/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} Logs
+#{product.fullname} Logs
 =======================================
 
 Server logs, including:

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/system/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/system/README.txt
@@ -1,7 +1,7 @@
-${product.fullname} System
+#{product.fullname} System
 =======================================
 
 The system directory contains runtime libraries and resources
-required by ${product.fullname}. 
+required by #{product.fullname}.
 
 These are not the droids you're looking for.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/system/lib/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/system/lib/README.txt
@@ -1,4 +1,4 @@
-${product.fullname} System Libraries
+#{product.fullname} System Libraries
 =======================================
 
 Nobody really knows what these things are for, but if anything


### PR DESCRIPTION
First step of many to clean up server boot cycle. This replaces the 'most
derived bootstrapper' code with explicitly calling the bootstrapper we want
from the shell scripts.

It's a large commit, because the shell scripts use '@' and '${}', both of which
clash with maven property filtering. Property filtering has been swapped to
'#{}' for the packaging project, meaning all the assembly files in there had
to be changed.

Other than that, it's really just parameterizing per edition which bootstrapper
to call.
