### PR TITLE
Remove as many unncessary usages of DependencyResolver as possible, r…

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/DependencyResolver.java
@@ -21,6 +21,8 @@ package org.neo4j.graphdb;
 
 import java.util.Iterator;
 
+import org.neo4j.function.Supplier;
+
 /**
  * Find a dependency given a type. This can be the exact type or a super type of
  * the actual dependency.
@@ -48,6 +50,11 @@ public interface DependencyResolver
      * @throws IllegalArgumentException if no matching dependency was found.
      */
     <T> T resolveDependency( Class<T> type, SelectionStrategy selector ) throws IllegalArgumentException;
+
+    <T> Supplier<T> provideDependency( final Class<T> type, final SelectionStrategy selector);
+
+    <T> Supplier<T> provideDependency( final Class<T> type );
+
 
     /**
      * Responsible for making the choice between available candidates.
@@ -91,6 +98,30 @@ public interface DependencyResolver
         public <T> T resolveDependency( Class<T> type ) throws IllegalArgumentException
         {
             return resolveDependency( type, FIRST );
+        }
+
+        public <T> Supplier<T> provideDependency( final Class<T> type, final SelectionStrategy selector)
+        {
+            return new Supplier<T>()
+            {
+                @Override
+                public T get()
+                {
+                    return resolveDependency( type, selector );
+                }
+            };
+        }
+
+        public <T> Supplier<T> provideDependency( final Class<T> type )
+        {
+            return new Supplier<T>()
+            {
+                @Override
+                public T get()
+                {
+                    return resolveDependency( type );
+                }
+            };
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -81,10 +81,8 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.execution_guard_enabled;
 
 /**
- * Datasource module for {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory}. This implements all the
- * remaining
- * services not yet created by either the {@link org.neo4j.kernel.impl.factory.PlatformModule} or {@link org.neo4j
- * .kernel.impl.factory.EditionModule}.
+ * Datasource module for {@link GraphDatabaseFacadeFactory}. This implements all the
+ * remaining services not yet created by either the {@link PlatformModule} or {@link EditionModule}.
  * <p/>
  * When creating new services, this would be the default place to put them, unless they need to go into the other
  * modules for any reason.
@@ -139,8 +137,7 @@ public class DataSourceModule
         transactionEventHandlers = new TransactionEventHandlers( nodeActions, relationshipActions,
                 threadToTransactionBridge );
 
-        IndexConfigStore indexStore = life.add(
-                deps.satisfyDependency( new IndexConfigStore( storeDir, fileSystem ) ) );
+        IndexConfigStore indexStore = life.add( deps.satisfyDependency( new IndexConfigStore( storeDir, fileSystem ) ) );
 
         diagnosticsManager.prependProvider( config );
 
@@ -274,13 +271,10 @@ public class DataSourceModule
         };
     }
 
-    protected RelationshipProxy.RelationshipActions createRelationshipActions( final GraphDatabaseService
-                                                                                       graphDatabaseService,
-                                                                               final ThreadToStatementContextBridge
-                                                                                       threadToStatementContextBridge,
+    protected RelationshipProxy.RelationshipActions createRelationshipActions( final GraphDatabaseService graphDatabaseService,
+                                                                               final ThreadToStatementContextBridge threadToStatementContextBridge,
                                                                                final NodeManager nodeManager,
-                                                                               final RelationshipTypeTokenHolder
-                                                                                       relationshipTypeTokenHolder )
+                                                                               final RelationshipTypeTokenHolder relationshipTypeTokenHolder )
     {
         return new RelationshipProxy.RelationshipActions()
         {
@@ -331,8 +325,7 @@ public class DataSourceModule
     }
 
     protected NodeProxy.NodeActions createNodeActions( final GraphDatabaseService graphDatabaseService,
-                                                       final ThreadToStatementContextBridge
-                                                               threadToStatementContextBridge,
+                                                       final ThreadToStatementContextBridge threadToStatementContextBridge,
                                                        final NodeManager nodeManager )
     {
         return new NodeProxy.NodeActions()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -128,9 +128,9 @@ public abstract class GraphDatabaseFacadeFactory
         Throwable error = null;
         try
         {
-            enableAvailabilityLogging( platform.availabilityGuard, platform.logging.getInternalLog( getClass() )
-                    .infoLogger() ); // Done after create to avoid a redundant
+            // Done after create to avoid a redundant
             // "database is now unavailable"
+            enableAvailabilityLogging( platform.availabilityGuard, platform.logging.getInternalLog( getClass() ).infoLogger() );
 
             platform.life.start();
         }
@@ -193,8 +193,8 @@ public abstract class GraphDatabaseFacadeFactory
      * @param editionModule
      * @return
      */
-    protected DataSourceModule createDataSource( final Dependencies dependencies, final PlatformModule
-            platformModule, EditionModule editionModule )
+    protected DataSourceModule createDataSource( final Dependencies dependencies,
+                                                 final PlatformModule platformModule, EditionModule editionModule )
     {
         return new DataSourceModule( dependencies, platformModule, editionModule );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -37,9 +37,8 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 /**
  * Not thread safe (since DiffRecordStore is not thread safe), intended for
@@ -75,7 +74,7 @@ public class StoreAccess
     @SuppressWarnings( "deprecation" )
     private static NeoStore getNeoStoreFrom( GraphDatabaseAPI graphdb )
     {
-        return graphdb.getDependencyResolver().resolveDependency( NeoStoreSupplier.class ).get();
+        return graphdb.getDependencyResolver().resolveDependency( NeoStore.class );
     }
 
     public StoreAccess( NeoStore store )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DependenciesProxy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.DependencyResolver;
+
+/**
+ * Used to create dynamic proxies that implement dependency interfaces. Each method should have no arguments
+ * and return the type of the dependency desired. It will be mapped to a lookup in the provided {@link DependencyResolver}.
+ * Methods may also use a {@link Supplier} type for deferred lookups.
+ *
+ */
+public class DependenciesProxy
+{
+    /**
+     * Create a dynamic proxy that implements the given interface and backs invocation with lookups into the given
+     * dependency resolver.
+     *
+     * @param dependencyResolver
+     * @param dependenciesInterface
+     * @param <T>
+     * @return
+     */
+    public static <T> T dependencies(DependencyResolver dependencyResolver, Class<T> dependenciesInterface)
+    {
+        return (T) Proxy.newProxyInstance( dependenciesInterface.getClassLoader(), new Class[]{dependenciesInterface},
+                new ProxyHandler(dependencyResolver) );
+    }
+
+
+    private static class ProxyHandler
+            implements InvocationHandler
+    {
+        private DependencyResolver dependencyResolver;
+
+        public ProxyHandler( DependencyResolver dependencyResolver )
+        {
+            this.dependencyResolver = dependencyResolver;
+        }
+
+        @Override
+        public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
+        {
+            try
+            {
+                if (method.getReturnType().equals( Supplier.class ))
+                {
+                    return dependencyResolver.provideDependency( (Class)((ParameterizedType) method.getGenericReturnType()).getActualTypeArguments()[0] );
+                } else
+                {
+                    return dependencyResolver.resolveDependency( method.getReturnType() );
+                }
+            }
+            catch ( IllegalArgumentException e )
+            {
+                throw new UnsatisfiedDependencyException( e );
+            }
+        }
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DummyExtensionFactory.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -30,6 +31,8 @@ public class DummyExtensionFactory extends KernelExtensionFactory<DummyExtension
         Config getConfig();
 
         KernelData getKernel();
+
+        Supplier<NeoStoreDataSource> getNeoStoreDataSource();
     }
 
     static final String EXTENSION_ID = "dummy";

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
@@ -75,6 +75,9 @@ public final class TestKernelExtension extends KernelExtensionFactoryContractTes
             assertEquals( graphdb.getDependencyResolver().resolveDependency( Config.class ),
                     graphdb.getDependencyResolver().resolveDependency( KernelExtensions.class ).resolveDependency(
                             DummyExtension.class ).getDependencies().getConfig() );
+            assertEquals( graphdb.getDependencyResolver().resolveDependency( NeoStoreDataSource.class ),
+                    graphdb.getDependencyResolver().resolveDependency( KernelExtensions.class ).resolveDependency(
+                            DummyExtension.class ).getDependencies().getNeoStoreDataSource().get() );
         }
         finally
         {

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -191,8 +191,9 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
 
     protected static class ImpermanentPlatformModule extends PlatformModule
     {
-        public ImpermanentPlatformModule( File storeDir, Map<String, String> params, GraphDatabaseFacadeFactory.Dependencies
-                dependencies, GraphDatabaseFacade graphDatabaseFacade )
+        public ImpermanentPlatformModule( File storeDir, Map<String, String> params,
+                                          GraphDatabaseFacadeFactory.Dependencies dependencies,
+                                          GraphDatabaseFacade graphDatabaseFacade )
         {
             super( storeDir, withForcedInMemoryConfiguration(params), dependencies, graphDatabaseFacade );
         }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -62,6 +62,7 @@ import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -309,7 +310,8 @@ class BackupService
         DependencyResolver resolver = targetDb.getDependencyResolver();
 
         ProgressTxHandler handler = new ProgressTxHandler();
-        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker( resolver );
+        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker(
+                DependenciesProxy.dependencies(resolver, TransactionCommittingResponseUnpacker.Dependencies.class) );
 
         Monitors monitors = resolver.resolveDependency( Monitors.class );
         LogProvider logProvider = resolver.resolveDependency( LogService.class ).getInternalLogProvider();

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -19,12 +19,18 @@
  */
 package org.neo4j.backup;
 
+import org.neo4j.function.Supplier;
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotationControl;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -37,14 +43,23 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
     {
         Config getConfig();
 
-
         GraphDatabaseAPI getGraphDatabaseAPI();
 
         LogService logService();
 
-        KernelPanicEventGenerator kpeg();
-
         Monitors monitors();
+
+        NeoStoreDataSource neoStoreDataSource();
+
+        Supplier<LogRotationControl> logRotationControlSupplier();
+
+        Supplier<TransactionIdStore> transactionIdStoreSupplier();
+
+        Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier();
+
+        Supplier<LogFileInformation> logFileInformationSupplier();
+
+        FileSystemAbstraction fileSystemAbstraction();
     }
 
     public OnlineBackupExtensionFactory()
@@ -62,6 +77,12 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
     public Lifecycle newKernelExtension( Dependencies dependencies ) throws Throwable
     {
         return new OnlineBackupKernelExtension( dependencies.getConfig(), dependencies.getGraphDatabaseAPI(),
-                dependencies.kpeg(), dependencies.logService().getInternalLogProvider(), dependencies.monitors() );
+                dependencies.logService().getInternalLogProvider(), dependencies.monitors(),
+                dependencies.neoStoreDataSource(),
+                dependencies.logRotationControlSupplier(),
+                dependencies.transactionIdStoreSupplier(),
+                dependencies.logicalTransactionStoreSupplier(),
+                dependencies.logFileInformationSupplier(),
+                dependencies.fileSystemAbstraction());
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -33,21 +33,19 @@ import org.neo4j.com.ServerUtil;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.function.Supplier;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotationControl;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.backup.OnlineBackupSettings.online_backup_server;
 
@@ -75,26 +73,29 @@ public class OnlineBackupKernelExtension implements Lifecycle
     private final BackupProvider backupProvider;
     private volatile URI me;
 
-    public OnlineBackupKernelExtension( Config config, final GraphDatabaseAPI graphDatabaseAPI,
-                                        final KernelPanicEventGenerator kpeg, final LogProvider logProvider,
-                                        final Monitors monitors )
+    public OnlineBackupKernelExtension( Config config, final GraphDatabaseAPI graphDatabaseAPI, final LogProvider logProvider,
+                                        final Monitors monitors, final NeoStoreDataSource neoStoreDataSource,
+                                        final Supplier<LogRotationControl> logRotationControlSupplier,
+                                        final Supplier<TransactionIdStore> transactionIdStoreSupplier,
+                                        final Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier,
+                                        final Supplier<LogFileInformation> logFileInformationSupplier,
+                                        final FileSystemAbstraction fileSystemAbstraction)
     {
         this( config, graphDatabaseAPI, new BackupProvider()
         {
             @Override
             public TheBackupInterface newBackup()
             {
-                DependencyResolver resolver = graphDatabaseAPI.getDependencyResolver();
-                TransactionIdStore transactionIdStore = resolver.resolveDependency( TransactionIdStore.class );
+                TransactionIdStore transactionIdStore = transactionIdStoreSupplier.get();
                 StoreCopyServer copier = new StoreCopyServer(
                         transactionIdStore,
-                        resolver.resolveDependency( DataSourceManager.class ).getDataSource(),
-                        resolver.resolveDependency( LogRotationControl.class ),
-                        resolver.resolveDependency( FileSystemAbstraction.class ),
+                        neoStoreDataSource,
+                        logRotationControlSupplier.get(),
+                        fileSystemAbstraction,
                         new File( graphDatabaseAPI.getStoreDir() ),
                         monitors.newMonitor( StoreCopyServer.Monitor.class ) );
-                LogicalTransactionStore logicalTransactionStore = resolver.resolveDependency( LogicalTransactionStore.class );
-                LogFileInformation logFileInformation = resolver.resolveDependency( LogFileInformation.class );
+                LogicalTransactionStore logicalTransactionStore = logicalTransactionStoreSupplier.get();
+                LogFileInformation logFileInformation = logFileInformationSupplier.get();
                 return new BackupImpl( copier, monitors,
                         logicalTransactionStore, transactionIdStore, logFileInformation, new Supplier<StoreId>()
                         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -31,14 +31,14 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
 import org.neo4j.com.Server;
 import org.neo4j.com.ServerUtil;
-import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
-import org.neo4j.com.storecopy.TransactionObligationFulfiller;
+import org.neo4j.function.Factory;
+import org.neo4j.function.Function;
+import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.CancellationRequest;
-import org.neo4j.helpers.HostnamePort;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -63,7 +63,6 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.ha.com.slave.MasterClient;
 import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
-import org.neo4j.kernel.ha.com.slave.SlaveImpl;
 import org.neo4j.kernel.ha.com.slave.SlaveServer;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.ha.store.ForeignStoreException;
@@ -78,12 +77,10 @@ import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.logging.Log;
-import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.first;
@@ -121,8 +118,17 @@ public class SwitchToSlave
     private static final int VERSION_CHECK_TIMEOUT = 10;
 
     private final LogService logService;
-    private final FileSystemAbstraction fs;
     private final File storeDir;
+    private final Supplier<NeoStoreDataSource> neoDataSourceSupplier;
+    private final FileSystemAbstraction fileSystemAbstraction;
+    private final ClusterMembers clusterMembers;
+    private Supplier<TransactionIdStore> transactionIdStoreSupplier;
+    private final Factory<Slave> slaveFactory;
+    private final Function<Slave, SlaveServer> slaveServerFactory;
+    private final UpdatePuller updatePuller;
+    private final PageCache pageCache;
+    private final Monitors monitors;
+
     private final Log userLog;
     private final Log msgLog;
     private final Config config;
@@ -133,23 +139,33 @@ public class SwitchToSlave
     private final RequestContextFactory requestContextFactory;
     private final Iterable<KernelExtensionFactory<?>> kernelExtensions;
     private final MasterClientResolver masterClientResolver;
-    private final ByteCounterMonitor byteCounterMonitor;
-    private final RequestMonitor requestMonitor;
     private final StoreCopyClient.Monitor storeCopyMonitor;
     private final Monitor monitor;
 
-    public SwitchToSlave( LogService logService, FileSystemAbstraction fs, File storeDir, Config config, DependencyResolver resolver,
-            HaIdGeneratorFactory idGeneratorFactory,
-            DelegateInvocationHandler<Master> masterDelegateHandler,
-            ClusterMemberAvailability clusterMemberAvailability,
-            RequestContextFactory requestContextFactory,
-            Iterable<KernelExtensionFactory<?>> kernelExtensions, MasterClientResolver masterClientResolver,
-            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor, Monitor monitor,
-            StoreCopyClient.Monitor storeCopyMonitor )
+    public SwitchToSlave( File storeDir, LogService logService, FileSystemAbstraction fileSystemAbstraction,
+            ClusterMembers clusterMembers, Config config, DependencyResolver resolver,
+                          HaIdGeneratorFactory idGeneratorFactory,
+                          DelegateInvocationHandler<Master> masterDelegateHandler,
+                          ClusterMemberAvailability clusterMemberAvailability,
+                          RequestContextFactory requestContextFactory,
+                          Iterable<KernelExtensionFactory<?>> kernelExtensions, MasterClientResolver masterClientResolver,
+                          Monitor monitor,
+                          StoreCopyClient.Monitor storeCopyMonitor,
+                          Supplier<NeoStoreDataSource> neoDataSourceSupplier,
+                          Supplier<TransactionIdStore> transactionIdStoreSupplier,
+                          Factory<Slave> slaveFactory, Function<Slave, SlaveServer> slaveServerFactory, UpdatePuller updatePuller, PageCache pageCache, Monitors monitors )
     {
         this.logService = logService;
+        this.fileSystemAbstraction = fileSystemAbstraction;
+        this.clusterMembers = clusterMembers;
+        this.neoDataSourceSupplier = neoDataSourceSupplier;
+        this.transactionIdStoreSupplier = transactionIdStoreSupplier;
+        this.slaveFactory = slaveFactory;
+        this.slaveServerFactory = slaveServerFactory;
+        this.updatePuller = updatePuller;
+        this.pageCache = pageCache;
+        this.monitors = monitors;
         this.userLog = logService.getUserLog( getClass() );
-        this.fs = fs;
         this.storeDir = storeDir;
         this.config = config;
         this.resolver = resolver;
@@ -157,8 +173,6 @@ public class SwitchToSlave
         this.clusterMemberAvailability = clusterMemberAvailability;
         this.requestContextFactory = requestContextFactory;
         this.kernelExtensions = kernelExtensions;
-        this.byteCounterMonitor = byteCounterMonitor;
-        this.requestMonitor = requestMonitor;
         this.storeCopyMonitor = storeCopyMonitor;
         this.msgLog = logService.getInternalLog( getClass() );
         this.masterDelegateHandler = masterDelegateHandler;
@@ -214,12 +228,12 @@ public class SwitchToSlave
              * start the ds or we already had a store, so we have already started the ds. Either way,
              * make sure it's there.
              */
-            NeoStoreDataSource nioneoDataSource = resolver.resolveDependency( NeoStoreDataSource.class );
+            NeoStoreDataSource nioneoDataSource = neoDataSourceSupplier.get();
             nioneoDataSource.afterModeSwitch();
             StoreId myStoreId = nioneoDataSource.getStoreId();
 
             boolean consistencyChecksExecutedSuccessfully = executeConsistencyChecks(
-                    myId, masterUri, nioneoDataSource, cancellationRequest );
+                    myId, transactionIdStoreSupplier.get(), masterUri, myStoreId, cancellationRequest );
 
             if ( !consistencyChecksExecutedSuccessfully )
             {
@@ -249,7 +263,7 @@ public class SwitchToSlave
 
     private void copyStoreFromMasterIfNeeded( URI masterUri, CancellationRequest cancellationRequest ) throws Throwable
     {
-        if ( !isStorePresent( fs, storeDir ) )
+        if ( !isStorePresent( fileSystemAbstraction, storeDir ) )
         {
             boolean success = false;
             monitor.storeCopyStarted();
@@ -279,25 +293,22 @@ public class SwitchToSlave
         }
     }
 
-    private boolean executeConsistencyChecks( InstanceId myId, URI masterUri, NeoStoreDataSource nioneoDataSource,
+    private boolean executeConsistencyChecks( InstanceId myId, TransactionIdStore txIdStore, URI masterUri, StoreId storeId,
                                               CancellationRequest cancellationRequest ) throws Throwable
     {
         LifeSupport consistencyCheckLife = new LifeSupport();
         try
         {
-            StoreId myStoreId = nioneoDataSource.getStoreId();
-
-            MasterClient masterClient = newMasterClient( masterUri, myStoreId, consistencyCheckLife );
+            MasterClient masterClient = newMasterClient( masterUri, storeId, consistencyCheckLife );
             consistencyCheckLife.start();
 
             boolean masterIsOld = MasterClient.CURRENT.compareTo( masterClient.getProtocolVersion() ) > 0;
 
             if ( masterIsOld )
             {
-                ClusterMembers members = resolver.resolveDependency( ClusterMembers.class );
-                ClusterMemberVersionCheck checker = new ClusterMemberVersionCheck( members, myId, SYSTEM_CLOCK );
+                ClusterMemberVersionCheck checker = new ClusterMemberVersionCheck( clusterMembers, myId, SYSTEM_CLOCK );
 
-                Outcome outcome = checker.doVersionCheck( myStoreId, VERSION_CHECK_TIMEOUT, SECONDS );
+                Outcome outcome = checker.doVersionCheck( storeId, VERSION_CHECK_TIMEOUT, SECONDS );
                 msgLog.info( "Cluster members version  checked: " + outcome );
 
                 if ( outcome.hasUnavailable() )
@@ -306,7 +317,7 @@ public class SwitchToSlave
                 }
                 if ( outcome.hasMismatched() )
                 {
-                    throw new InconsistentlyUpgradedClusterException( myStoreId, outcome.getMismatched() );
+                    throw new InconsistentlyUpgradedClusterException( storeId, outcome.getMismatched() );
                 }
             }
 
@@ -315,7 +326,7 @@ public class SwitchToSlave
                 return false;
             }
 
-            checkDataConsistency( masterClient, nioneoDataSource, masterUri, masterIsOld );
+            checkDataConsistency( masterClient, txIdStore, storeId, masterUri, masterIsOld );
         }
         finally
         {
@@ -324,15 +335,14 @@ public class SwitchToSlave
         return true;
     }
 
-    void checkDataConsistency( MasterClient masterClient, NeoStoreDataSource neoDataSource, URI masterUri,
+    void checkDataConsistency( MasterClient masterClient, TransactionIdStore txIdStore, StoreId storeId, URI masterUri,
             boolean masterIsOld ) throws Throwable
     {
-        TransactionIdStore txIdStore = neoDataSource.getDependencyResolver().resolveDependency( TransactionIdStore.class );
         try
         {
             userLog.info( "Checking store consistency with master" );
-            checkMyStoreIdAndMastersStoreId( neoDataSource, masterIsOld );
-            checkDataConsistencyWithMaster( masterUri, masterClient, neoDataSource, txIdStore );
+            checkMyStoreIdAndMastersStoreId( storeId, masterIsOld );
+            checkDataConsistencyWithMaster( masterUri, masterClient, storeId, txIdStore );
             userLog.info( "Store is consistent" );
         }
         catch ( StoreUnableToParticipateInClusterException upe )
@@ -365,13 +375,10 @@ public class SwitchToSlave
         }
     }
 
-    private void checkMyStoreIdAndMastersStoreId( NeoStoreDataSource neoDataSource, boolean masterIsOld )
+    private void checkMyStoreIdAndMastersStoreId( StoreId myStoreId, boolean masterIsOld )
     {
         if ( !masterIsOld )
         {
-            StoreId myStoreId = neoDataSource.getStoreId();
-
-            ClusterMembers clusterMembers = resolver.resolveDependency( ClusterMembers.class );
             ClusterMember master = first( filter( inRole( MASTER ), clusterMembers.getMembers() ) );
             StoreId masterStoreId = master.getStoreId();
 
@@ -392,9 +399,11 @@ public class SwitchToSlave
     {
         MasterClient master = newMasterClient( masterUri, neoDataSource.getStoreId(), haCommunicationLife );
 
-        Slave slaveImpl = new SlaveImpl( resolver.resolveDependency( TransactionObligationFulfiller.class ) );
+        Slave slaveImpl = slaveFactory.newInstance();
 
-        SlaveServer server = new SlaveServer( slaveImpl, serverConfig(), logService.getInternalLogProvider(), byteCounterMonitor, requestMonitor);
+        SlaveServer server = slaveServerFactory.apply(slaveImpl);
+
+        ;
 
         masterDelegateHandler.setDelegate( master );
 
@@ -421,42 +430,11 @@ public class SwitchToSlave
         userLog.info( "Catching up with master. I'm at %s", catchUpRequestContext );
 
         // Unpause the update puller, because we know that we are a slave that just started communication with master.
-        UpdatePuller updatePuller = resolver.resolveDependency( UpdatePuller.class );
         updatePuller.unpause();
         updatePuller.await( UpdatePuller.NEXT_TICKET, true );
 
         userLog.info( "Now caught up with master" );
         monitor.catchupCompleted();
-    }
-
-    private Server.Configuration serverConfig()
-    {
-        return new Server.Configuration()
-        {
-            @Override
-            public long getOldChannelThreshold()
-            {
-                return config.get( HaSettings.lock_read_timeout );
-            }
-
-            @Override
-            public int getMaxConcurrentTransactions()
-            {
-                return config.get( HaSettings.max_concurrent_channels_per_slave );
-            }
-
-            @Override
-            public int getChunkSize()
-            {
-                return config.get( HaSettings.com_chunk_size ).intValue();
-            }
-
-            @Override
-            public HostnamePort getServerAddress()
-            {
-                return config.get( HaSettings.ha_server );
-            }
-        };
     }
 
     private URI createHaURI( URI me, Server<?, ?> server )
@@ -471,12 +449,10 @@ public class SwitchToSlave
     private void copyStoreFromMaster( final MasterClient masterClient,
                                       CancellationRequest cancellationRequest ) throws Throwable
     {
-        FileSystemAbstraction fs = resolver.resolveDependency( FileSystemAbstraction.class );
-        PageCache pageCache = resolver.resolveDependency( PageCache.class );
-
         // This will move the copied db to the graphdb location
         userLog.info( "Copying store from master" );
-        new StoreCopyClient( storeDir, config, kernelExtensions, logService.getUserLogProvider(), fs, pageCache, storeCopyMonitor ).copyStore(
+        new StoreCopyClient( storeDir, config, kernelExtensions, logService.getUserLogProvider(),
+                fileSystemAbstraction, pageCache, storeCopyMonitor ).copyStore(
                 new StoreCopyClient.StoreCopyRequester()
                 {
                     @Override
@@ -499,7 +475,7 @@ public class SwitchToSlave
     private MasterClient newMasterClient( URI masterUri, StoreId storeId, LifeSupport life )
     {
         MasterClient masterClient = masterClientResolver.instantiate( masterUri.getHost(), masterUri.getPort(),
-                resolver.resolveDependency( Monitors.class ), storeId, life );
+                monitors, storeId, life );
         if ( masterClient.getProtocolVersion().compareTo( MasterClient210.PROTOCOL_VERSION ) < 0 )
         {
             idGeneratorFactory.enableCompatibilityMode();
@@ -527,13 +503,13 @@ public class SwitchToSlave
     }
 
     private void checkDataConsistencyWithMaster( URI availableMasterId, Master master,
-                                                 NeoStoreDataSource neoDataSource,
+                                                 StoreId storeId,
                                                  TransactionIdStore transactionIdStore )
     {
         long[] myLastCommittedTxData = transactionIdStore.getLastCommittedTransaction();
         long myLastCommittedTx = myLastCommittedTxData[0];
         HandshakeResult handshake;
-        try ( Response<HandshakeResult> response = master.handshake( myLastCommittedTx, neoDataSource.getStoreId() ) )
+        try ( Response<HandshakeResult> response = master.handshake( myLastCommittedTx, storeId ) )
         {
             handshake = response.response();
             requestContextFactory.setEpoch( handshake.epoch() );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/RequestContextFactory.java
@@ -20,8 +20,7 @@
 package org.neo4j.kernel.ha.com;
 
 import org.neo4j.com.RequestContext;
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
@@ -29,15 +28,15 @@ public class RequestContextFactory extends LifecycleAdapter
 {
     private long epoch;
     private final int serverId;
-    private final DependencyResolver resolver;
+    private final Supplier<TransactionIdStore> txIdStoreSupplier;
     private TransactionIdStore txIdStore;
 
     public static final int VOID_EVENT_IDENTIFIER = -3;
     public static final int DEFAULT_EVENT_IDENTIFIER = -1;
 
-    public RequestContextFactory( int serverId, DependencyResolver resolver )
+    public RequestContextFactory( int serverId, Supplier<TransactionIdStore> txIdStoreSupplier)
     {
-        this.resolver = resolver;
+        this.txIdStoreSupplier = txIdStoreSupplier;
         this.epoch = -1;
         this.serverId = serverId;
     }
@@ -45,7 +44,7 @@ public class RequestContextFactory extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        this.txIdStore = resolver.resolveDependency( NeoStoreDataSource.class ).getDependencyResolver().resolveDependency( TransactionIdStore.class );
+        this.txIdStore = txIdStoreSupplier.get();
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/HighAvailabilityBean.java
@@ -130,8 +130,7 @@ public final class HighAvailabilityBean extends ManagementBeanProvider
             long time = System.currentTimeMillis();
             try
             {
-                kernelData.graphDatabase().getDependencyResolver().resolveDependency(
-                        UpdatePullerClient.class ).pullUpdates();
+                kernelData.graphDatabase().getDependencyResolver().resolveDependency(UpdatePullerClient.class ).pullUpdates();
             }
             catch ( Exception e )
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
@@ -19,19 +19,18 @@
  */
 package org.neo4j.kernel.ha.transaction;
 
-import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.function.Supplier;
 import org.neo4j.kernel.impl.core.LastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
 
 public class OnDiskLastTxIdGetter implements LastTxIdGetter
 {
-    private final GraphDatabaseAPI graphdb;
+    private final Supplier<NeoStore> neoStoreSupplier;
 
-    public OnDiskLastTxIdGetter( GraphDatabaseAPI graphdb )
+    public OnDiskLastTxIdGetter( Supplier<NeoStore> neoStoreSupplier )
     {
-        this.graphdb = graphdb;
+        this.neoStoreSupplier = neoStoreSupplier;
     }
 
     @Override
@@ -50,8 +49,6 @@ public class OnDiskLastTxIdGetter implements LastTxIdGetter
         // if we cache it.
         // We avoid this problem by simply not caching it, and instead looking it up
         // every time.
-        NeoStoreSupplier neoStoreSupplier =
-                graphdb.getDependencyResolver().resolveDependency( NeoStoreSupplier.class );
         return neoStoreSupplier.get();
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
@@ -21,8 +21,6 @@ package org.neo4j.kernel.ha;
 
 import org.junit.Test;
 
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
@@ -38,16 +36,12 @@ public class OnDiskLastTxIdGetterTest
     {
         // This is a sign that we have some bad coupling on our hands.
         // We currently have to do this because of our lifecycle and construction ordering.
-        GraphDatabaseAPI graphdb = mock( GraphDatabaseAPI.class );
-        DependencyResolver resolver = mock( DependencyResolver.class );
         NeoStoreSupplier supplier = mock( NeoStoreSupplier.class );
         NeoStore neoStore = mock( NeoStore.class );
-        when( graphdb.getDependencyResolver() ).thenReturn( resolver );
-        when( resolver.resolveDependency( NeoStoreSupplier.class ) ).thenReturn( supplier );
         when( supplier.get() ).thenReturn( neoStore );
         when( neoStore.getLastCommittedTransactionId() ).thenReturn( 13L );
 
-        OnDiskLastTxIdGetter getter = new OnDiskLastTxIdGetter( graphdb );
+        OnDiskLastTxIdGetter getter = new OnDiskLastTxIdGetter( supplier );
         assertEquals( 13L, getter.getLastTxId() );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -21,15 +21,20 @@ package org.neo4j.kernel.ha.cluster;
 
 import org.junit.Test;
 
+import java.io.File;
+
 import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.Response;
-import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
+import org.neo4j.function.Factory;
+import org.neo4j.function.Function;
+import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.StoreLockerLifecycleAdapter;
 import org.neo4j.kernel.configuration.Config;
@@ -38,12 +43,15 @@ import org.neo4j.kernel.ha.BranchedDataException;
 import org.neo4j.kernel.ha.BranchedDataPolicy;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.kernel.ha.cluster.member.ClusterMember;
 import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
+import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.ha.com.slave.MasterClient;
 import org.neo4j.kernel.ha.com.slave.MasterClientResolver;
+import org.neo4j.kernel.ha.com.slave.SlaveServer;
 import org.neo4j.kernel.ha.id.HaIdGeneratorFactory;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.logging.NullLogService;
@@ -51,12 +59,9 @@ import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.kernel.monitoring.ByteCounterMonitor;
-
-import java.io.File;
+import org.neo4j.kernel.monitoring.Monitors;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -81,13 +86,16 @@ public class SwitchToSlaveTest
         when( response.response() ).thenReturn( new HandshakeResult( 1, 2 ) );
         when( masterClient.handshake( anyLong(), any( StoreId.class ) ) ).thenReturn( response );
 
-        NeoStoreDataSource dataSource = dataSourceMock();
-        when( dataSource.getStoreId() ).thenReturn( new StoreId( 1, 2, 3, 4 ) );
+        StoreId storeId = new StoreId( 1, 2, 3, 4 );
+
+        TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+        when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new long[]{42, 42} );
+        when( transactionIdStore.getLastCommittedTransactionId() ).thenReturn( TransactionIdStore.BASE_TX_ID );
 
         // When
         try
         {
-            switchToSlave.checkDataConsistency( masterClient, dataSource, null, false );
+            switchToSlave.checkDataConsistency( masterClient, transactionIdStore, storeId, null, false );
             fail( "Should have thrown " + MismatchingStoreIdException.class.getSimpleName() + " exception" );
         }
         catch ( MismatchingStoreIdException e )
@@ -108,10 +116,14 @@ public class SwitchToSlaveTest
         MasterClient masterClient = mock( MasterClient.class );
         when( masterClient.handshake( anyLong(), any( StoreId.class ) ) ).thenThrow( new BranchedDataException( "" ) );
 
+        TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+        when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new long[]{42, 42} );
+        when( transactionIdStore.getLastCommittedTransactionId() ).thenReturn( TransactionIdStore.BASE_TX_ID );
+
         // When
         try
         {
-            switchToSlave.checkDataConsistency( masterClient, dataSourceMock(), null, true );
+            switchToSlave.checkDataConsistency( masterClient, transactionIdStore, null, null, true );
             fail( "Should have thrown " + BranchedDataException.class.getSimpleName() + " exception" );
         }
         catch ( BranchedDataException e )
@@ -126,21 +138,46 @@ public class SwitchToSlaveTest
     @SuppressWarnings( "unchecked" )
     private static SwitchToSlave newSwitchToSlaveSpy()
     {
-        return spy( new SwitchToSlave( NullLogService.getInstance(), mock( FileSystemAbstraction.class ), mock( File.class ), configMock(), dependencyResolverMock(),
+        ClusterMembers clusterMembers = mock( ClusterMembers.class );
+        ClusterMember master = mock( ClusterMember.class );
+        when( master.getStoreId() ).thenReturn( new StoreId( 42, 42, 42, 42 ) );
+        when( master.getHARole() ).thenReturn( HighAvailabilityModeSwitcher.MASTER );
+        when( master.hasRole( eq( HighAvailabilityModeSwitcher.MASTER ) ) ).thenReturn( true );
+        when( clusterMembers.getMembers() ).thenReturn( asList( master ) );
+
+        DependencyResolver resolver = mock(DependencyResolver.class);
+        when(resolver.resolveDependency( any( Class.class ) )).thenReturn( mock( Lifecycle.class ) );
+
+        NeoStoreDataSource dataSource = mock( NeoStoreDataSource.class );
+        when(dataSource.getStoreId()).thenReturn( new StoreId( 42, 42, 42, 42 ) );
+
+        return spy( new SwitchToSlave(  mock( File.class ), NullLogService.getInstance(),
+                mock( FileSystemAbstraction.class ),
+                clusterMembers,
+                configMock(), resolver,
                 mock( HaIdGeneratorFactory.class ),
                 mock( DelegateInvocationHandler.class ),
                 mock( ClusterMemberAvailability.class ), mock( RequestContextFactory.class ),
                 Iterables.<KernelExtensionFactory<?>>empty(), mock( MasterClientResolver.class ),
-                ByteCounterMonitor.NULL, mock( RequestMonitor.class ), mock( SwitchToSlave.Monitor.class ),
-                new StoreCopyClient.Monitor.Adapter() ) );
-    }
-
-    private static NeoStoreDataSource dataSourceMock()
-    {
-        NeoStoreDataSource dataSource = mock( NeoStoreDataSource.class );
-        DependencyResolver dependencyResolver = dependencyResolverMock();
-        when( dataSource.getDependencyResolver() ).thenReturn( dependencyResolver );
-        return dataSource;
+                mock( SwitchToSlave.Monitor.class ),
+                new StoreCopyClient.Monitor.Adapter(),
+                Suppliers.singleton( dataSource ),
+                Suppliers.singleton( mock(TransactionIdStore.class) ),
+                new Factory<Slave>()
+        {
+            @Override
+            public Slave newInstance()
+            {
+                return mock( Slave.class );
+            }
+        }, new Function<Slave, SlaveServer>()
+        {
+            @Override
+            public SlaveServer apply( Slave slave ) throws RuntimeException
+            {
+                return mock(SlaveServer.class);
+            }
+        }, mock(UpdatePuller.class), mock(PageCache.class), mock(Monitors.class) ) );
     }
 
     private static Config configMock()


### PR DESCRIPTION
…eplacing with either constructor dependency, supplier constructor dependency, or dependency interfaces backed by DependenciesProxy

Ability to create dependency interfaces extracted from KernelExtensions into DependenciesProxy, so can be used elsewhere as well.
Formatting cleanup
