### PR TITLE
Do not rotate the log on shutdown if the kernel is unhealthy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/KernelHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/KernelHealth.java
@@ -50,12 +50,11 @@ public class KernelHealth
      * @param panicDisguise the cause of the unhealthy state wrapped in an exception of this type.
      * @throws EXCEPTION exception type to wrap cause in.
      */
-    public <EXCEPTION extends Throwable> void assertHealthy( Class<EXCEPTION> panicDisguise )
-            throws EXCEPTION
+    public <EXCEPTION extends Throwable> void assertHealthy( Class<EXCEPTION> panicDisguise ) throws EXCEPTION
     {
         if ( !tmOk )
         {
-            EXCEPTION exception = null;
+            EXCEPTION exception;
             try
             {
                 try
@@ -94,6 +93,11 @@ public class KernelHealth
         // Keeps the "setting TM not OK string for grep:ability
         log.error( "setting TM not OK. " + panicMessage, cause );
         kpe.generateEvent( ErrorState.TX_MANAGER_NOT_OK, causeOfPanic );
+    }
+
+    public boolean isHealthy()
+    {
+        return tmOk;
     }
 
     public void healed()

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1140,11 +1140,16 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 // Force all pending store changes to disk.
                 logRotationControl.forceEverything();
 
-                // We simply increment the version, essentially "rotating" away
-                // the current active log file, to avoid having a recovery on
-                // next startup. Not necessary, simply speeds up the startup
-                // process.
-                neoStoreModule.neoStore().incrementAndGetVersion();
+                // Rotate away the latest log only if the kernel is healthy.
+                // We cannot throw here since we need to shutdown without exceptions.
+                if ( kernelHealth.isHealthy() )
+                {
+                    // We simply increment the version, essentially "rotating" away
+                    // the current active log file, to avoid having a recovery on
+                    // next startup. Not necessary, simply speeds up the startup
+                    // process.
+                    neoStoreModule.neoStore().incrementAndGetVersion();
+                }
 
                 // Shut down all services in here, effectively making the database unusable for anyone who tries.
                 life.shutdown();

--- a/community/kernel/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileSystemGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileSystemGraphDatabase.java
@@ -22,10 +22,14 @@ package org.neo4j.graphdb.mockfs;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.ImpermanentGraphDatabase;
 
-@SuppressWarnings("deprecation")
 public class LimitedFileSystemGraphDatabase extends ImpermanentGraphDatabase
 {
     private LimitedFilesystemAbstraction fs;
+
+    public LimitedFileSystemGraphDatabase( String storeDir )
+    {
+        super( storeDir );
+    }
 
     @Override
     protected FileSystemAbstraction createFileSystemAbstraction()
@@ -41,5 +45,10 @@ public class LimitedFileSystemGraphDatabase extends ImpermanentGraphDatabase
     public void somehowGainMoreDiskSpace()
     {
         this.fs.runOutOfDiskSpace( false );
+    }
+
+    public LimitedFilesystemAbstraction getFileSystem()
+    {
+        return fs;
     }
 }


### PR DESCRIPTION
NSDS always bumps the log version in the neo store on shutdown and in
such way it behaves differently wrt LogRotationImpl that avoids to
rotate logs in case the kernel is not healthy. This fix tries to unify
the log rotation behavior by avoiding to bump the log version when
shutting down NSDS if the kernel is unhealthy.

Notice that we don't throw exception from NSDS when shutting down
since we assume that the shutdown is always possible without causing
exceptions.
