### PR TITLE
Fixed generation of tracing id for recording probe table

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTable.scala
@@ -55,6 +55,8 @@ case class BuildRecordingProbeTable(id:String, name: String, node: String, value
     generator.updateProbeTable(valueTypeStructure, name, node, value)
   }
 
+  override protected def operatorId = Some(id)
+
   private val valueTypeField2VarName = valueSymbols.map {
     case (fieldName, symbol) => fieldName -> context.namer.newVarName()
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir
+
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.neo4j.collection.primitive.PrimitiveLongIterator
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.{CodeGenContext, JoinTableMethod}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.SemanticTable
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.{GraphDatabaseService, Node}
+import org.neo4j.kernel.api.{ReadOperations, Statement}
+
+import scala.collection.mutable
+
+class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
+
+  private val tableVarName = "probeTable"
+  private val tableKeyVarName = "nodeId"
+  private val buildTableMethodName = "buildProbeTable"
+  private val probeKeyVarName = "probeKey"
+  private val resultRowKey = "resultKey"
+
+  private val db = mock[GraphDatabaseService]
+  private val statement = mock[Statement]
+  private val readOps = mock[ReadOperations]
+  private val allNodeIds = mutable.ArrayBuffer[Long]()
+
+  // used by instructions that generate probe tables
+  private implicit val codeGenContext = new CodeGenContext(SemanticTable(), Map.empty)
+
+  when(statement.readOperations()).thenReturn(readOps)
+  when(readOps.nodesGetAll()).then(new Answer[PrimitiveLongIterator] {
+    def answer(invocation: InvocationOnMock) = allNodeIdsIterator()
+  })
+
+  override protected def beforeEach() = allNodeIds.clear()
+
+  test("should generate correct code for simple counting probe table") {
+    // Given
+    setUpNodeMocks(1, 2, 42)
+
+    val buildInstruction = BuildCountingProbeTable(id = "countingTable",
+                                                   name = tableVarName,
+                                                   node = tableKeyVarName)
+
+    // When
+    val results = runTest(buildInstruction)
+
+    // Then
+    results should have size 3
+    val (a :: b :: c :: Nil) = results
+    checkNodeResult(1, a)
+    checkNodeResult(2, b)
+    checkNodeResult(42, c)
+  }
+
+  test("should generate correct code for simple recording probe table") {
+    // Given
+    setUpNodeMocks(42, 4242)
+
+    val buildInstruction = BuildRecordingProbeTable(id = "recordingTable",
+                                                    name = tableVarName,
+                                                    node = tableKeyVarName,
+                                                    valueSymbols = Map(tableKeyVarName -> tableKeyVarName))
+
+    // When
+    val results = runTest(buildInstruction)
+
+    // Then
+    results should have size 2
+    val (a :: b :: Nil) = results
+    checkNodeResult(42, a)
+    checkNodeResult(4242, b)
+  }
+
+  private def setUpNodeMocks(ids: Long*): Unit = {
+    ids.foreach { id =>
+      val nodeMock = mock[Node]
+      when(nodeMock.getId).thenReturn(id)
+      when(db.getNodeById(id)).thenReturn(nodeMock)
+      allNodeIds += id
+    }
+  }
+
+  private def checkNodeResult(id: Long, res: Map[String, Object]): Unit = {
+    res.size shouldEqual 1
+    val node = res(resultRowKey).asInstanceOf[Node]
+    node.getId shouldEqual id
+  }
+
+  private def allNodeIdsIterator() = new PrimitiveLongIterator {
+    val inner = allNodeIds.iterator
+
+    override def hasNext = inner.hasNext
+
+    override def next() = inner.next()
+  }
+
+  private def runTest(buildInstruction: BuildProbeTable): List[Map[String, Object]] = {
+    val instructions = buildProbeTableWithTwoAllNodeScans(buildInstruction)
+    evaluate(instructions, statement, db, Map.empty[String, Object])
+  }
+
+  private def buildProbeTableWithTwoAllNodeScans(buildInstruction: BuildProbeTable): Seq[Instruction] = {
+    val buildWhileLoop = WhileLoop(tableKeyVarName, ScanAllNodes("scanOp1"), buildInstruction)
+
+    val buildProbeTableMethod = MethodInvocation(operatorId = None,
+                                                 symbol = JoinTableMethod(tableVarName, buildInstruction.tableType),
+                                                 methodName = buildTableMethodName,
+                                                 statements = Seq(buildWhileLoop))
+
+
+    val acceptVisitor = AcceptVisitor("visitorOp", Map(resultRowKey -> expressions.Node(probeKeyVarName)))
+
+    val probeTheTable = GetMatchesFromProbeTable(key = probeKeyVarName,
+                                                 code = buildInstruction.joinData,
+                                                 action = acceptVisitor)
+
+    val probeTheTableWhileLoop = WhileLoop(id = probeKeyVarName,
+                                           producer = ScanAllNodes("scanOp2"),
+                                           action = probeTheTable)
+
+    Seq(buildProbeTableMethod, probeTheTableWhileLoop)
+  }
+
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenExpressionCompilationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenExpressionCompilationTest.scala
@@ -27,7 +27,8 @@ import org.scalatest._
 class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with CodeGenSugar {
   // addition
 
-  { // literal + literal
+  {
+    // literal + literal
     def adding(lhs: CodeGenExpression, rhs: CodeGenExpression) = {
       val addition = add(lhs, rhs)
       evaluate(
@@ -39,21 +40,24 @@ class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with
     })
   }
 
-  { // parameter + parameter
+  {
+    // parameter + parameter
     val addition: CodeGenExpression = add(parameter("lhs"), parameter("rhs"))
-    val clazz = compile(Project("X", Seq(addition), AcceptVisitor("id", Map("result" -> addition))))
+    val instructions = Seq(Project("X", Seq(addition), AcceptVisitor("id", Map("result" -> addition))))
 
-    def adding(lhs: Any, rhs: Any) = evaluate(newInstance(clazz, params = Map("lhs" -> lhs, "rhs" -> rhs)))
+    def adding(lhs: Any, rhs: Any) = evaluate(instructions, params = Map("lhs" -> lhs, "rhs" -> rhs))
 
     verifyAddition(adding, new SimpleOperands[Any]("parameter") {
       override def value(value: Any) = value
     })
   }
 
-  { // literal + parameter
+  {
+    // literal + parameter
     def adding(lhs: CodeGenExpression, rhs: Any) = {
       val addition: CodeGenExpression = add(lhs, parameter("rhs"))
-      evaluate(newInstance(compile(Project("X", Seq(addition), AcceptVisitor("id", Map("result" -> addition)))), params = Map("rhs" -> rhs)))
+      val instructions = Seq(Project("X", Seq(addition), AcceptVisitor("id", Map("result" -> addition))))
+      evaluate(instructions, params = Map("rhs" -> rhs))
 
     }
 
@@ -64,11 +68,12 @@ class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with
     })
   }
 
-  { // parameter + literal
+  {
+    // parameter + literal
     def adding(lhs: Any, rhs: CodeGenExpression) = {
       val addition: CodeGenExpression = add(parameter("lhs"), rhs)
-      evaluate(newInstance(compile(Project("X", Seq(addition),
-        AcceptVisitor("id", Map("result" -> addition)))), params = Map("lhs" -> lhs)))
+      val instructions = Seq(Project("X", Seq(addition), AcceptVisitor("id", Map("result" -> addition))))
+      evaluate(instructions, params = Map("lhs" -> lhs))
     }
 
     verifyAddition(adding, new Operands[Any, CodeGenExpression]("parameter", "literal") {
@@ -80,34 +85,36 @@ class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with
 
   // subtraction
 
-  { // literal - literal
+  {
+    // literal - literal
     def subtracting(lhs: CodeGenExpression, rhs: CodeGenExpression) = {
-    val subtraction = sub(lhs, rhs)
-    evaluate(
-      Project("X", Seq.empty, AcceptVisitor("id", Map("result" -> subtraction))))
-  }
+      val subtraction = sub(lhs, rhs)
+      evaluate(
+        Project("X", Seq.empty, AcceptVisitor("id", Map("result" -> subtraction))))
+    }
 
     verifySubtraction(subtracting, new SimpleOperands[CodeGenExpression]("literal") {
       override def value(value: Any) = literal(value)
     })
   }
 
-  { // parameter - parameter
+  {
+    // parameter - parameter
     val subtraction: CodeGenExpression = sub(parameter("lhs"), parameter("rhs"))
-    val clazz = compile(Project("X", Seq(subtraction), AcceptVisitor("id", Map("result" -> subtraction))))
-    def subtracting(lhs: Any, rhs: Any) = evaluate(newInstance(clazz, params = Map("lhs" -> lhs, "rhs" -> rhs)))
+    val instructions = Seq(Project("X", Seq(subtraction), AcceptVisitor("id", Map("result" -> subtraction))))
+    def subtracting(lhs: Any, rhs: Any) = evaluate(instructions, params = Map("lhs" -> lhs, "rhs" -> rhs))
 
     verifySubtraction(subtracting, new SimpleOperands[Any]("parameter") {
       override def value(value: Any) = value
     })
   }
 
-  { // literal - parameter
+  {
+    // literal - parameter
     def subtracting(lhs: CodeGenExpression, rhs: Any) = {
       val subtraction: CodeGenExpression = sub(lhs, parameter("rhs"))
-      evaluate(newInstance(compile(Project("X", Seq(subtraction),
-        AcceptVisitor("id", Map("result" ->  subtraction)))), params = Map("rhs" -> rhs)))
-
+      val instructions = Seq(Project("X", Seq(subtraction), AcceptVisitor("id", Map("result" -> subtraction))))
+      evaluate(instructions, params = Map("rhs" -> rhs))
     }
 
     verifySubtraction(subtracting, new Operands[CodeGenExpression, Any]("literal", "parameter") {
@@ -117,11 +124,12 @@ class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with
     })
   }
 
-  { // parameter - literal
+  {
+    // parameter - literal
     def subtracting(lhs: Any, rhs: CodeGenExpression) = {
       val subtraction: CodeGenExpression = sub(parameter("lhs"), rhs)
-      evaluate(newInstance(compile(Project("X", Seq(subtraction),
-        AcceptVisitor("id", Map("result" ->  subtraction)))), params = Map("lhs" -> lhs)))
+      val instructions = Seq(Project("X", Seq(subtraction), AcceptVisitor("id", Map("result" -> subtraction))))
+      evaluate(instructions, params = Map("lhs" -> lhs))
     }
 
     verifySubtraction(subtracting, new Operands[Any, CodeGenExpression]("parameter", "literal") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenSugar.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenSugar.scala
@@ -76,6 +76,15 @@ trait CodeGenSugar extends MockitoSugar {
     evaluate(newInstance(compile(instructions: _*)))
   }
 
+  def evaluate(instructions: Seq[Instruction],
+               stmt: Statement = mock[Statement],
+               db: GraphDatabaseService = null,
+               params: Map[String, Any] = Map.empty): List[Map[String, Object]] = {
+    val clazz = compile(instructions: _*)
+    val result = newInstance(clazz, statement = stmt, graphdb = db, params = params)
+    evaluate(result)
+  }
+
   def evaluate(result: InternalExecutionResult): List[Map[String, Object]] = {
     var rows = List.empty[Map[String, Object]]
     val columns: List[String] = result.columns


### PR DESCRIPTION
Currently static field with tracing id for recording probe table is not generated.
Generated java code does not compile.
This PR fixes such behaviour: adds proper override of `BuildRecordingProbeTable#operatorId`.
