### PR TITLE
Include NDP V1 into manual on ndp feature toggle.

### DIFF
--- a/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
@@ -370,13 +370,13 @@ DC 10 01 01  02 03 04 05  06 07 08 09  00 01 02 03
 ----
 
 [[ndp-value-structs]]
-==== Graph Type Stuctures
+=== Graph Type Stuctures
 
 A number of key Neo4j types are represented as <<ndp-packstream-structures,structures>>.
 These include _nodes_, _relationships_ and _paths_.
 
 [[ndp-value-nodestruct]]
-===== Node
+==== Node
 A Node represents a node from a Neo4j graph and consists of a unique identifier (within the scope of its origin graph), a list of labels and a map of properties. The general serialised structure is as follows:
 
 [source,ndp_value_struct]
@@ -389,7 +389,7 @@ Node (signature=0x4E) {             /* signature: 'N' */
 ----
 
 [[ndp-value-relstruct]]
-===== Relationship
+==== Relationship
 A Relationship represents a relationship from a Neo4j graph and consists of a unique identifier (within the scope of its origin graph), identifiers for the start and end nodes of that relationship, a type and a map of properties. The general serialised structure is as follows:
 
 [source,ndp_value_struct]
@@ -404,7 +404,7 @@ Relationship (signature=0x52) {    /* signature: 'R' */
 ----
 
 [[ndp-value-pathstruct]]
-===== Path
+==== Path
 A Path consists of a list of alternating nodes and relationships, always starting and ending with a node. The general serialised structure is as follows:
 
 [source,ndp_value_struct]

--- a/manual/contents/pom.xml
+++ b/manual/contents/pom.xml
@@ -24,6 +24,7 @@
     <neo4j.version>${project.version}</neo4j.version>
     <attach-docs-phase>none</attach-docs-phase>
     <attach-test-jar-phase>none</attach-test-jar-phase>
+    <additional-document-attributes>${ndp-attribute}</additional-document-attributes>
   </properties>
 
   <scm>
@@ -215,6 +216,13 @@
       <classifier>docs</classifier>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-ndp-v1-docs</artifactId>
+      <version>${neo4j.version}</version>
+      <classifier>docs</classifier>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -224,6 +232,8 @@
         <filtering>true</filtering>
         <includes>
           <include>version</include>
+          <!-- To allow injecting asciidoc attributes -->
+          <include>neo4j-manual.asciidoc</include>
         </includes>
       </resource>
       <resource>
@@ -231,6 +241,8 @@
         <filtering>false</filtering>
         <excludes>
           <exclude>version</exclude>
+          <!-- To allow injecting asciidoc attributes -->
+          <exclude>neo4j-manual.asciidoc</exclude>
         </excludes>
       </resource>
       <resource>
@@ -376,5 +388,19 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>feature-ndp</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property> <name>feature.ndp</name> </property>
+      </activation>
+      <properties>
+        <!-- Line break is intentional -->
+        <ndp-attribute>:feature-ndp:
+</ndp-attribute>
+      </properties>
+    </profile>
+  </profiles>
 </project>
 

--- a/manual/contents/src/neo4j-manual.asciidoc
+++ b/manual/contents/src/neo4j-manual.asciidoc
@@ -8,6 +8,8 @@
 :lucene-base-uri: http://lucene.apache.org/core/{lucene-version}
 :lucene-api-base-uri: {lucene-base-uri}/api/core
 
+${additional-document-attributes}
+
 :console: 0
 
 include::preface/preface.asciidoc[]

--- a/manual/contents/src/reference/index.asciidoc
+++ b/manual/contents/src/reference/index.asciidoc
@@ -27,6 +27,12 @@ include::{importdir}/neo4j-graph-algo-docs-jar/dev/index.asciidoc[]
 
 include::{importdir}/neo4j-server-docs-jar/dev/rest-api/index.asciidoc[]
 
+ifdef::feature-ndp[]
+:leveloffset: 1
+
+include::{importdir}/neo4j-ndp-v1-docs-docs-jar/dev/index.asciidoc[]
+endif::feature-ndp[]
+
 :leveloffset: 1
 
 include::deprecations.asciidoc[]


### PR DESCRIPTION
- Introduce feature toggle to docs build
- Modify serialization.asciidoc to not descend below max header level
- Images not yet getting pulled in

Run with `mvn clean package -DdocsBuild -Dfeature.ndp` to build manual with NDP docs.
