### PR TITLE
Improve precision when calculating selectivities

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/Metrics.scala
@@ -158,7 +158,13 @@ case class Selectivity(factor: Double) extends Ordered[Selectivity] {
   def *(other: Selectivity): Selectivity = other.factor * factor
   def *(other: Multiplier): Selectivity = factor * other.coefficient
   def ^(a: Int): Selectivity = Math.pow(factor, a)
-  def negate: Selectivity = 1 - factor
+  def negate: Selectivity = {
+    val f = 1.0 - factor
+    if (factor == 0 || f < 1)
+      f
+    else
+      Selectivity.CLOSEST_TO_ONE
+  }
 
   def compare(that: Selectivity) = factor.compare(that.factor)
 }
@@ -168,6 +174,7 @@ object Selectivity {
 
   val ZERO = Selectivity(0.0d)
   val ONE = Selectivity(1.0d)
+  val CLOSEST_TO_ONE = Selectivity(1 - 5.56e-17)    // we can get closer, but this is close enough
 
   implicit def lift(amount: Double): Selectivity = Selectivity(amount)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombiner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombiner.scala
@@ -19,44 +19,52 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality
 
+import java.math
+
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Selectivity
 
 trait SelectivityCombiner {
+
   def andTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity]
 
   // A ∪ B = ¬ ( ¬ A ∩ ¬ B )
-  def orTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity] = {
-    val inverses = selectivities.map(_.negate)
-    andTogetherSelectivities(inverses).
-      map(_.negate)
-  }
+  def orTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity]
 }
 
 case object IndependenceCombiner extends SelectivityCombiner {
+
   // This is the simple and straight forward way of combining two statistically independent probabilities
   //P(A ∪ B) = P(A) * P(B)
-  def andTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity] =
-    selectivities.reduceOption(_ * _)
+  def andTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity] = {
+    BigDecimalCombiner.andTogetherBigDecimals(toBigDecimals(selectivities)).map(fromBigDecimal)
+  }
+
+  // A ∪ B = ¬ ( ¬ A ∩ ¬ B )
+  override def orTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity] = {
+    BigDecimalCombiner.orTogetherBigDecimals(toBigDecimals(selectivities)).map(fromBigDecimal)
+  }
+
+  private def toBigDecimals(selectivities: Seq[Selectivity]): Seq[math.BigDecimal] = {
+    selectivities.map(s => math.BigDecimal.valueOf(s.factor))
+  }
+
+  private def fromBigDecimal(bigDecimal: math.BigDecimal): Selectivity = {
+    Selectivity(bigDecimal.doubleValue())
+  }
 }
 
-// The estimate is computed the most selective predicate multiplied by the table cardinality, multiplied by the
-// square root of the next most selective predicate, and so on with each new selectivity gaining an additional
-// square root.
-// Recalling that selectivity is a number between 0 and 1, it is clear that applying a square root moves the number
-// closer to 1. The effect is to take account of all predicates in the final estimate, but to reduce the impact of
-// the less selective predicates exponentially.
-// For the ones that need visual aids to grokk it: http://i.imgur.com/V4Fs7AC.png
-case object ExponentialBackOff extends SelectivityCombiner {
-  def andTogetherSelectivities(selectivities: Seq[Selectivity]): Option[Selectivity] =
-    if (selectivities.isEmpty)
-      None
-    else {
-      val newSelectivity = (selectivities.sorted zipWithIndex).foldLeft(1.0) {
-        // P(A ∪ B ∪ C) = P(A) * SQRT(P(B)) * SQRT(SQRT(P(C)))
-        // This is encoded using the fact that SQRT(x) is equal to x to the power of 1/2.
-        case (acc, (sel, idx)) => acc * Math.pow(sel.factor, 1.0 / Math.pow(2, idx))
-      }
+object BigDecimalCombiner {
 
-      Some(Selectivity(newSelectivity))
-    }
+  def orTogetherBigDecimals(bigDecimals: Seq[math.BigDecimal]): Option[math.BigDecimal] = {
+    val inverses = bigDecimals.map(negate)
+    andTogetherBigDecimals(inverses).map(negate)
+  }
+
+  def andTogetherBigDecimals(bigDecimals: Seq[math.BigDecimal]): Option[math.BigDecimal] = {
+    bigDecimals.reduceOption(_ multiply _)
+  }
+
+  private def negate(bigDecimal: math.BigDecimal): math.BigDecimal = {
+    math.BigDecimal.ONE.subtract(bigDecimal)
+  }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/MetricsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/MetricsTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner.logical
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+
+class MetricsTest extends CypherFunSuite {
+
+  test("negating a selectivity behaves as expected") {
+    Selectivity(.1).negate should not equal Selectivity.ONE
+    Selectivity(5.6e-17).negate should not equal Selectivity.ONE
+    Selectivity(1e-300).negate should not equal Selectivity.ONE
+
+    Selectivity.ZERO.negate should equal(Selectivity.ONE)
+    Selectivity(0).negate should equal(Selectivity.ONE)
+
+    Selectivity.ONE.negate should equal(Selectivity.ZERO)
+    Selectivity(1).negate should equal(Selectivity.ZERO)
+
+    Selectivity.CLOSEST_TO_ONE.negate should not equal Selectivity.ONE
+  }
+
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.planner.logical.cardinality
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Selectivity
+
+class SelectivityCombinerTest extends CypherFunSuite {
+
+  test("should not lose precision for intermediate numbers") {
+    val selectivities = Seq(Selectivity(1e-10), Selectivity(2e-10))
+
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity(0)
+  }
+
+  test("should not lose precision for small numbers") {
+    val selectivities = Seq(Selectivity(1e-100), Selectivity(2e-100), Selectivity(1e-300))
+
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity(0)
+  }
+
+  test("ANDing together works as expected") {
+    val selectivities = Seq(Selectivity(.1), Selectivity(.2), Selectivity.ONE)
+
+    IndependenceCombiner.andTogetherSelectivities(selectivities).get should equal(Selectivity(0.02))
+  }
+
+  test("ORing together works as expected") {
+    val selectivities = Seq(Selectivity(.1), Selectivity(.2))
+
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should equal(Selectivity(0.28))
+  }
+
+}


### PR DESCRIPTION
The negate function lost precision when the operand was a value smaller than
~5.56e-17, causing the negation of the result to be zero.
