### PR TITLE
Fixed classpath of javac used in compiled runtime

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategy.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGenerationStrategy.java
@@ -26,7 +26,7 @@ import static org.neo4j.codegen.source.SourceCode.SOURCECODE;
 
 public abstract class CodeGenerationStrategy<Configuration> implements CodeGeneratorOption
 {
-    protected abstract Configuration createConfigurator();
+    protected abstract Configuration createConfigurator( ClassLoader loader );
 
     protected abstract CodeGenerator createCodeGenerator( ClassLoader loader, Configuration configuration );
 
@@ -46,7 +46,8 @@ public abstract class CodeGenerationStrategy<Configuration> implements CodeGener
 
     private CodeGenerator generateCode( ClassLoader loader, CodeGeneratorOption... options )
     {
-        return createCodeGenerator( loader, applyTo( createConfigurator(), options ) );
+        Configuration configurator = createConfigurator( loader );
+        return createCodeGenerator( loader, applyTo( configurator, options ) );
     }
 
     private static class Choice implements ByteCodeVisitor.Configurable

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/ClasspathHelper.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/ClasspathHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.codegen.source;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+final class ClasspathHelper
+{
+    private ClasspathHelper()
+    {
+        throw new AssertionError( "Not for instantiation!" );
+    }
+
+    static String javaClasspathString()
+    {
+        return System.getProperty( "java.class.path" );
+    }
+
+    static Set<String> javaClasspath()
+    {
+        String[] classpathElements = javaClasspathString().split( ":" );
+        Set<String> result = new LinkedHashSet<>();
+
+        for ( String element : classpathElements )
+        {
+            result.add( canonicalPath( element ) );
+        }
+
+        return result;
+    }
+
+    static String fullClasspathStringFor( ClassLoader classLoader )
+    {
+        Set<String> classpathElements = fullClasspathFor( classLoader );
+        return formClasspathString( classpathElements );
+    }
+
+    static Set<String> fullClasspathFor( ClassLoader classLoader )
+    {
+        Set<String> result = new LinkedHashSet<>();
+
+        result.addAll( javaClasspath() );
+
+        ClassLoader loader = classLoader;
+        while ( loader != null )
+        {
+            if ( loader instanceof URLClassLoader )
+            {
+                for ( URL url : ((URLClassLoader) loader).getURLs() )
+                {
+                    result.add( canonicalPath( url ) );
+                }
+            }
+            loader = loader.getParent();
+        }
+
+        return result;
+    }
+
+    private static String canonicalPath( URL url )
+    {
+        return canonicalPath( url.getPath() );
+    }
+
+    private static String canonicalPath( String path )
+    {
+        try
+        {
+            File file = new File( path );
+            return file.getCanonicalPath();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Failed to get canonical path for: '" + path + "'", e );
+        }
+    }
+
+    private static String formClasspathString( Set<String> classPathElements )
+    {
+        StringBuilder classpath = new StringBuilder();
+
+        Iterator<String> classPathElementsIterator = classPathElements.iterator();
+        while ( classPathElementsIterator.hasNext() )
+        {
+            classpath.append( classPathElementsIterator.next() );
+            if ( classPathElementsIterator.hasNext() )
+            {
+                classpath.append( File.pathSeparator );
+            }
+        }
+
+        return classpath.toString();
+    }
+}

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/FileManager.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/FileManager.java
@@ -22,11 +22,8 @@ package org.neo4j.codegen.source;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import javax.tools.FileObject;
@@ -39,13 +36,11 @@ import org.neo4j.codegen.ByteCodes;
 
 class FileManager extends ForwardingJavaFileManager<StandardJavaFileManager>
 {
-    private final ClassLoader classpathLoader;
     private final Map<String/*className*/, ClassFile> classes = new HashMap<>();
 
-    FileManager( StandardJavaFileManager fileManager, ClassLoader classpathLoader )
+    FileManager( StandardJavaFileManager fileManager )
     {
         super( fileManager );
-        this.classpathLoader = classpathLoader;
     }
 
     @Override
@@ -62,7 +57,7 @@ class FileManager extends ForwardingJavaFileManager<StandardJavaFileManager>
         return classes.values();
     }
 
-    static class ClassFile extends SimpleJavaFileObject implements ByteCodes
+    private static class ClassFile extends SimpleJavaFileObject implements ByteCodes
     {
         private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         private final String className;
@@ -89,18 +84,6 @@ class FileManager extends ForwardingJavaFileManager<StandardJavaFileManager>
         public ByteBuffer bytes()
         {
             return ByteBuffer.wrap( bytes.toByteArray() );
-        }
-    }
-
-    private static URL sourceUrl( Path sourceLocation )
-    {
-        try
-        {
-            return sourceLocation == null ? null : sourceLocation.toUri().toURL();
-        }
-        catch ( MalformedURLException e )
-        {
-            return null;
         }
     }
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
@@ -45,7 +45,7 @@ public enum SourceCode implements CodeGeneratorOption
     public static final CodeGeneratorOption SOURCECODE = new CodeGenerationStrategy<Configuration>()
     {
         @Override
-        protected Configuration createConfigurator()
+        protected Configuration createConfigurator( ClassLoader loader )
         {
             return new Configuration();
         }
@@ -80,7 +80,7 @@ public enum SourceCode implements CodeGeneratorOption
 
     private static CodeGeneratorOption printWarningsTo( PrintStream err )
     {
-        return new MyCodeGeneratorOption( err );
+        return new PrintWarningsOption( err );
     }
 
     public static CodeGeneratorOption annotationProcessor( Processor processor )
@@ -175,11 +175,11 @@ public enum SourceCode implements CodeGeneratorOption
         }
     }
 
-    private static class MyCodeGeneratorOption implements CodeGeneratorOption, WarningsHandler
+    private static class PrintWarningsOption implements CodeGeneratorOption, WarningsHandler
     {
         private final PrintStream target;
 
-        MyCodeGeneratorOption( PrintStream target )
+        PrintWarningsOption( PrintStream target )
         {
             this.target = target;
         }
@@ -189,7 +189,7 @@ public enum SourceCode implements CodeGeneratorOption
         {
             if ( target instanceof Configuration )
             {
-                ((Configuration) target).addWarningsHandler( this );
+                ((Configuration) target).withWarningsHandler( this );
             }
         }
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCode.java
@@ -30,14 +30,14 @@ import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
-import org.neo4j.codegen.TypeReference;
 import org.neo4j.codegen.CodeGenerationStrategy;
 import org.neo4j.codegen.CodeGenerator;
 import org.neo4j.codegen.CodeGeneratorOption;
+import org.neo4j.codegen.TypeReference;
 
 import static java.util.Objects.requireNonNull;
-
 import static org.neo4j.codegen.CompilationFailureException.format;
+import static org.neo4j.codegen.source.ClasspathHelper.fullClasspathStringFor;
 
 public enum SourceCode implements CodeGeneratorOption
 {
@@ -47,7 +47,7 @@ public enum SourceCode implements CodeGeneratorOption
         @Override
         protected Configuration createConfigurator( ClassLoader loader )
         {
-            return new Configuration();
+            return new Configuration().withOptions( "-classpath", fullClasspathStringFor( loader ) );
         }
 
         @Override

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceCodeGenerator.java
@@ -80,8 +80,7 @@ class SourceCodeGenerator extends CodeGenerator
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
 
         FileManager fileManager = new FileManager(
-                compiler.getStandardFileManager( diagnostics, configuration.locale(), configuration.chraset() ),
-                classpathLoader );
+                compiler.getStandardFileManager( diagnostics, configuration.locale(), configuration.chraset() ) );
 
         JavaCompiler.CompilationTask task = compiler.getTask(
                 configuration.errorWriter(), fileManager, diagnostics, configuration.options(), null, sourceFiles() );

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/SourceVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/SourceVisitor.java
@@ -30,7 +30,7 @@ public abstract class SourceVisitor implements CodeGeneratorOption
         if ( target instanceof Configuration )
         {
             Configuration configuration = (Configuration) target;
-            configuration.addSourceVisitor( this );
+            configuration.withSourceVisitor( this );
         }
     }
 

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -521,7 +521,7 @@ public class CodeGenerationTest
     }
 
     private static final String PACKAGE = "org.neo4j.codegen.test";
-    private final CodeGenerator generator = CodeGenerator.generateCode( SourceCode.PRINT_SOURCE );
+    private final CodeGenerator generator = CodeGenerator.generateCode( /*SourceCode.PRINT_SOURCE*/ );
 
     ClassGenerator generateClass( String name, Class<?> firstInterface, Class<?>... more )
     {

--- a/community/codegen/src/test/java/org/neo4j/codegen/source/ClasspathHelperTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/source/ClasspathHelperTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.codegen.source;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.codegen.source.ClasspathHelper.fullClasspathFor;
+import static org.neo4j.codegen.source.ClasspathHelper.fullClasspathStringFor;
+
+public class ClasspathHelperTest
+{
+    @Test
+    public void shouldNotFailForNullClassLoader()
+    {
+        assertThat( fullClasspathFor( null ), not( empty() ) );
+    }
+
+    @Test
+    public void shouldWorkForClassLoaderWithNoParent() throws MalformedURLException
+    {
+        // Given
+        ClassLoader loader = new URLClassLoader( urls( "file:///dev/null/file1", "file:///dev/null/file2" ), null );
+
+        // When
+        Set<String> elements = fullClasspathFor( loader );
+
+        // Then
+        assertThat( elements, hasItems( "/dev/null/file1", "/dev/null/file2" ) );
+    }
+
+    @Test
+    public void shouldWorkForClassLoaderWithSingleParent() throws MalformedURLException
+    {
+        // Given
+        ClassLoader parent = new URLClassLoader( urls( "file:///dev/null/file1", "file:///dev/null/file2" ), null );
+        ClassLoader child = new URLClassLoader( urls( "file:///dev/null/file3" ), parent );
+
+        // When
+        Set<String> elements = fullClasspathFor( child );
+
+        // Then
+        assertThat( elements, hasItems( "/dev/null/file1", "/dev/null/file2", "/dev/null/file3" ) );
+    }
+
+    @Test
+    public void shouldWorkForClassLoaderHierarchy() throws MalformedURLException
+    {
+        // Given
+        ClassLoader loader1 = new URLClassLoader( urls( "file:///dev/null/file1" ), null );
+        ClassLoader loader2 = new URLClassLoader( urls( "file:///dev/null/file2" ), loader1 );
+        ClassLoader loader3 = new URLClassLoader( urls( "file:///dev/null/file3" ), loader2 );
+        ClassLoader loader4 = new URLClassLoader( urls( "file:///dev/null/file4" ), loader3 );
+
+        // When
+        Set<String> elements = fullClasspathFor( loader4 );
+
+        // Then
+        assertThat( elements, hasItems( "/dev/null/file1", "/dev/null/file2", "/dev/null/file3", "/dev/null/file4" ) );
+    }
+
+    @Test
+    public void shouldReturnCorrectClasspathString() throws MalformedURLException
+    {
+        // Given
+        ClassLoader parent = new URLClassLoader( urls( "file:///dev/null/foo" ), null );
+        ClassLoader child = new URLClassLoader( urls( "file:///dev/null/bar" ), parent );
+
+        // When
+        String classpath = fullClasspathStringFor( child );
+
+        // Then
+        assertThat( classpath, containsString( "/dev/null/bar" + File.pathSeparator + "/dev/null/foo" ) );
+    }
+
+    private static URL[] urls( String... strings ) throws MalformedURLException
+    {
+        URL[] urls = new URL[strings.length];
+        for ( int i = 0; i < strings.length; i++ )
+        {
+            urls[i] = new URL( strings[i] );
+        }
+        return urls;
+    }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeStructure.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeStructure.scala
@@ -155,7 +155,7 @@ trait MethodStructure[E] {
 object CodeStructure {
   val __TODO__MOVE_IMPLEMENTATION = new CodeStructure[GeneratedQueryExecution] {
     override def generateQuery(packageName: String, className: String, columns: Seq[String], opIds: Seq[String])(block: MethodStructure[_] => Unit) = {
-      val generator: codegen.CodeGenerator = codegen.CodeGenerator.generateCode(/*SourceCode.PRINT_SOURCE*/)
+      val generator = codegen.CodeGenerator.generateCode(CodeStructure.getClass.getClassLoader/*, SourceCode.PRINT_SOURCE*/)
       using(generator.generateClass(packageName, className, typeRef[GeneratedQueryExecution], typeRef[SuccessfulCloseable])) { clazz =>
         // fields
         val fields = Fields(

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -78,7 +78,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
     //WHEN
     val result = profileWithAllPlannersAndRuntimes("match (n:A)-->(x:B) return *")
-    println(result.executionPlanDescription())
+
     //THEN
     assertRows(1)(result)("ProduceResults", "Projection", "Filter", "Expand(All)", "NodeByLabelScan")
     assertDbHits(0)(result)("ProduceResults", "Projection")


### PR DESCRIPTION
Incorrect classpath prevented queries from working after `mvn exec:java` in server directory.
Javac, used for compilation of generated classes, knew only about bootclasspath and thus was not able to locate any neo4j classes. Bootclasspath contained only some maven jars.
