### PR TITLE
Test IDP for optional shortest path with apply/args

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -67,6 +67,21 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
 
+  test("apply-arguments with optional shortest path should be plannable in IDP") {
+    /*
+       a-b-c-d
+       b-d
+     */
+    relate(nodeA, nodeB)
+    relate(nodeB, nodeC)
+    relate(nodeC, nodeD)
+    relate(nodeB, nodeD)
+
+    val result = executeWithAllPlanners("MATCH (a:A), (d:D) OPTIONAL MATCH p = shortestPath((a)-[*]->(d)) RETURN nodes(p) AS nodes").toList
+
+    result should equal(List(Map("nodes" -> List(nodeA, nodeB, nodeD))))
+  }
+
   test("returns null when no shortest path is found") {
     val result = executeWithAllPlanners("MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
 


### PR DESCRIPTION
Ported test from 2.2 that confirms that IDP can handle planning optional shortest path with apply/arguments.
