### PR TITLE
Initial work on making javadocs build on Java 8.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/DiffRecordAccess.java
@@ -28,11 +28,11 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 /**
  * A {@link RecordAccess} for use with incremental checking. Provides access to
- * <p/>
+ * <p>
  * {@link #previousNode(long) Node}, {@link #previousRelationship(long) Relationship}, and {@link
  * #previousProperty(long) Property} are the only record types one might need a previous version of when checking
  * another type of record.
- * <p/>
+ * <p>
  * Getting the new version of a record is an operation that can always be performed without any I/O, therefore these
  * return the records immediately, instead of returning {@link RecordReference} objects. New versions of records can be
  * retrieved for {@link #changedNode(long)} Node}, {@link #changedRelationship(long)} (long) Relationship}, {@link

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
@@ -30,7 +30,7 @@ import java.nio.CharBuffer;
  * every call. However {@link Reader#read(char[], int, int)} doesn't, and so leaves no garbage.
  *
  * The fact that this is a separate interface means that {@link Readable} instances need to be wrapped,
- * but that's fine since the buffer size should be reasonably big such that {@link #read(char[], int, int)}
+ * but that's fine since the buffer size should be reasonably big such that {@link #read(SectionedCharBuffer, int)}
  * isn't called too often. Therefore the wrapping overhead should not be noticeable at all.
  *
  * Also took the opportunity to let {@link CharReadable} extends {@link Closeable}, something that

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeeker.java
@@ -63,18 +63,18 @@ public interface CharSeeker extends Closeable, SourceTraceability
     boolean seek( Mark mark, int untilChar ) throws IOException;
 
     /**
-     * Extracts the value specified by the {@link Mark}, previously populated by a call to {@link #seek(Mark, int[])}.
+     * Extracts the value specified by the {@link Mark}, previously populated by a call to {@link #seek(Mark, int)}.
      * @param mark the {@link Mark} specifying which part of a bigger piece of data contains the found value.
      * @param extractor {@link Extractor} capable of extracting the value.
      * @return the supplied {@link Extractor}, which after the call carries the extracted value itself,
      * where either {@link Extractor#value()} or a more specific accessor method can be called to access the value.
-     * @throws IllegalStateException if the {@link Extractor#extract(char[], int, int) extraction}
+     * @throws IllegalStateException if the {@link Extractor#extract(char[], int, int, boolean) extraction}
      * returns {@code false}.
      */
     <EXTRACTOR extends Extractor<?>> EXTRACTOR extract( Mark mark, EXTRACTOR extractor );
 
     /**
-     * Extracts the value specified by the {@link Mark}, previously populated by a call to {@link #seek(Mark, int[])}.
+     * Extracts the value specified by the {@link Mark}, previously populated by a call to {@link #seek(Mark, int)}.
      * @param mark the {@link Mark} specifying which part of a bigger piece of data contains the found value.
      * @param extractor {@link Extractor} capable of extracting the value.
      * @return {@code true} if a value was extracted, otherwise {@code false}. Probably the only reason for

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
@@ -20,8 +20,8 @@
 package org.neo4j.csv.reader;
 
 /**
- * Extracts a value from a part of a {@code char[]} into any type of value, f.ex. a {@link Extractors#STRING string},
- * {@link Extractors#LONG long} or {@link Extractors#intArray()}.
+ * Extracts a value from a part of a {@code char[]} into any type of value, f.ex. a {@link Extractors#string()},
+ * {@link Extractors#long_() long} or {@link Extractors#intArray()}.
  *
  * An {@link Extractor} is mutable for the single purpose of ability to reuse its value instance. Consider extracting
  * a primitive int -

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -28,12 +28,12 @@ import static java.lang.reflect.Modifier.isStatic;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 
 /**
- * Common implementations of {@link Extractor}. Since array values can have a delimiter of user choice this isn't
+ * Common implementations of {@link Extractor}. Since array values can have a delimiter of user choice that isn't
  * an enum, but a regular class with a constructor where that delimiter can be specified.
  *
  * The common {@link Extractor extractors} can be accessed using the accessor methods, like {@link #string()},
  * {@link #long_()} and others. Specific classes are declared as return types for those providing additional
- * value accessors, f.ex {@link LongExtractor#primitive()}.
+ * value accessors, f.ex {@link LongExtractor#longValue()}.
  *
  * Typically an instance of {@link Extractors} would be instantiated along side a {@link BufferedCharSeeker},
  * assumed to be used by a single thread, since each {@link Extractor} it has is stateful. Example:

--- a/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/SectionedCharBuffer.java
@@ -88,14 +88,14 @@ public class SectionedCharBuffer
      * <pre>
      * pivot (i.e. effective buffer size) = 16
      * buffer A
-     * <------ back ------> <------ front ----->
+     * &lt;------ back ------&gt; &lt;------ front -----&gt;
      * [    .    .    .    |abcd.efgh.ijkl.mnop]
      *                                 ^ = 25
      *
      * A.compactInto( B, 25 )
      *
      * buffer B
-     * <------ back ------> <------ front ----->
+     * &lt;------ back ------&gt; &lt;------ front -----&gt;
      * [    .    . jkl.mnop|    .    .    .    ]
      * </pre>
      *

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -24,7 +24,7 @@ import java.nio.CharBuffer;
 
 /**
  * Like an ordinary {@link CharReadable}, it's just that the reading happens in a separate thread, so when
- * a consumer wants to {@link #read(CharBuffer)} more data it's already available, merely a memcopy away.
+ * a consumer wants to {@link #read(SectionedCharBuffer, int)} more data it's already available, merely a memcopy away.
  */
 public class ThreadAheadReadable extends ThreadAhead implements CharReadable
 {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/stress/PageCacheStressTest.java
@@ -120,15 +120,15 @@ public class PageCacheStressTest
      * Target page size is 8192 which is what the product uses by default
      *
      * 8 threads => 8*8 bytes for counters + 8 bytes for checksum = 72 bytes per record
-     * <p/>
+     * <p>
      * 8192 bytes per page / 72 bytes per record = 113 records per page
-     * <p/>
+     * <p>
      * 8192 bytes per page - 72 bytes per record * 113 records per page =
      * 8192 bytes per page - 8136 bytes for the records in the page =
      * 56 bytes padding
-     * <p/>
+     * <p>
      * 8136 bytes per page * 100,000 pages = 776 MB for the whole file
-     * <p/>
+     * <p>
      * 8192 bytes per page * 10,000 pages = 78 MB cache in memory
      *
      * 8 threads * 1 counter per thread per record * 100,000 pages * 113 records per page * 8 bytes per counter =

--- a/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -35,17 +35,17 @@ import org.neo4j.tooling.GlobalGraphOperations;
  * implementation is the {@link EmbeddedGraphDatabase} class, which is used to
  * embed Neo4j in an application. Typically, you would create an
  * <code>EmbeddedGraphDatabase</code> instance as follows:
- * <p/>
+ * <p>
  * <pre>
  * <code>GraphDatabaseService graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( "var/graphDb" );
  * // ... use Neo4j
  * graphDb.{@link #shutdown() shutdown()};</code>
  * </pre>
- * <p/>
+ * <p>
  * GraphDatabaseService provides operations to {@link #createNode() create
  * nodes}, {@link #getNodeById(long) get nodes given an id} and ultimately {@link #shutdown()
  * shutdown Neo4j}.
- * <p/>
+ * <p>
  * Please note that all operations on the graph must be invoked in a
  * {@link Transaction transactional context}. Failure to do so will result in a
  * {@link NotInTransactionException} being thrown.
@@ -102,17 +102,17 @@ public interface GraphDatabaseService
      * Returns all nodes having the label, and the wanted property value.
      * If an online index is found, it will be used to look up the requested
      * nodes.
-     * <p/>
+     * <p>
      * If no indexes exist for the label/property combination, the database will
      * scan all labeled nodes looking for the property value.
-     * <p/>
+     * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
      * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
-     * <p/>
+     * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
-     * <p/>
+     * <p>
      * Finally - arrays also follow these rules. An int[] {1,2,3} is equal to a double[] {1.0, 2.0, 3.0}
-     * <p/>
+     * <p>
      * Please ensure that the returned {@link ResourceIterator} is closed correctly and as soon as possible
      * inside your transaction to avoid potential blocking of write operations.
      *
@@ -125,7 +125,7 @@ public interface GraphDatabaseService
 
     /**
      * Equivalent to {@link #findNodes(Label, String, Object)}, however it must find no more than one
-     * @{link Node node} or it will throw an exception.
+     * {@link Node node} or it will throw an exception.
      *
      * @param label consider nodes with this label
      * @param key   required property key
@@ -150,17 +150,17 @@ public interface GraphDatabaseService
      * Returns all nodes having the label, and the wanted property value.
      * If an online index is found, it will be used to look up the requested
      * nodes.
-     * <p/>
+     * <p>
      * If no indexes exist for the label/property combination, the database will
      * scan all labeled nodes looking for the property value.
-     * <p/>
+     * <p>
      * Note that equality for values do not follow the rules of Java. This means that the number 42 is equals to all
      * other 42 numbers, indifferently of if they are encoded as Integer, Long, Float, Short, Byte or Double.
-     * <p/>
+     * <p>
      * Same rules follow Character and String - the Character 'A' is equal to the String 'A'.
-     * <p/>
+     * <p>
      * Finally - arrays also follow these rules. An int[] {1,2,3} is equal to a double[] {1.0, 2.0, 3.0}
-     * <p/>
+     * <p>
      * Please ensure that the returned {@link ResourceIterable} is closed correctly and as soon as possible
      * inside your transaction to avoid potential blocking of write operations.
      *
@@ -206,12 +206,12 @@ public interface GraphDatabaseService
 
     /**
      * Starts a new {@link Transaction transaction} and associates it with the current thread.
-     * <p/>
+     * <p>
      * <em>All database operations must be wrapped in a transaction.</em>
-     * <p/>
+     * <p>
      * If you attempt to access the graph outside of a transaction, those operations will throw
      * {@link NotInTransactionException}.
-     * <p/>
+     * <p>
      * Please ensure that any returned {@link ResourceIterable} is closed correctly and as soon as possible
      * inside your transaction to avoid potential blocking of write operations.
      *

--- a/community/kernel/src/main/java/org/neo4j/graphdb/PathExpanderBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/PathExpanderBuilder.java
@@ -25,7 +25,7 @@ import static org.neo4j.graphdb.Direction.BOTH;
 
 /**
  * A fluent builder for creating specialized {@link PathExpander path expanders}.
- * <p/>
+ * <p>
  * See {@link PathExpanders} for a catalog of common expanders.
  */
 public class PathExpanderBuilder
@@ -80,7 +80,7 @@ public class PathExpanderBuilder
 
     /**
      * Remove expansion of {@code type} in any direction from the PathExpander configuration.
-     * <p/>
+     * <p>
      * Example: {@code PathExpanderBuilder.allTypesAndDirections().remove(type).add(type, Direction.INCOMING)}
      * would restrict the {@link PathExpander} to only follow {@code Direction.INCOMING} relationships for {@code
      * type} while following any other relationship type in either direction.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/QueryExecutionType.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/QueryExecutionType.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Signifies how a query is executed, as well as what side effects and results could be expected from the query.
- * <p/>
+ * <p>
  * In Cypher there are three different modes of execution:
  * <ul>
  * <li>Normal execution,</li>
@@ -36,12 +36,12 @@ import static java.util.Objects.requireNonNull;
  * It also contains information about what effects the query could have, and whether it could yield any results, in
  * form
  * of the {@link QueryType QueryType enum}.
- * <p/>
+ * <p>
  * Queries executed with the {@code PROFILE} directive can have side effects and produce results in the same way as a
  * normally executed method. The difference being that the user has expressed an interest in seeing the plan used to
  * execute the query, and that this plan will (after execution completes) be annotated with
  * {@linkplain ExecutionPlanDescription#getProfilerStatistics() profiling information} from the execution of the query.
- * <p/>
+ * <p>
  * Queries executed with the {@code EXPLAIN} directive never have any side effects, nor do they ever yield any rows in
  * the results, the sole purpose of this mode of execution is to
  * {@linkplain Result#getExecutionPlanDescription() get a description of the plan} that <i>would</i> be executed

--- a/community/kernel/src/main/java/org/neo4j/graphdb/RelationshipType.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/RelationshipType.java
@@ -76,12 +76,15 @@ package org.neo4j.graphdb;
  * <p>
  * However, you usually want to check whether a specific relationship
  * <i>instance</i> is of a certain type. That is best achieved with the
- * {@link Relationship#isType Relationship.isType} method, such as: <code><pre>
+ * {@link Relationship#isType Relationship.isType} method, such as:
+ * <pre>
+ * <code>
  * if ( rel.isType( MyRelationshipTypes.CONTAINED_IN ) )
  * {
  *     ...
  * }
- * </pre></code>
+ * </code>
+ * </pre>
  */
 public interface RelationshipType
 {

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Result.java
@@ -25,18 +25,18 @@ import java.util.Map;
 
 /**
  * Represents the result of {@link GraphDatabaseService#execute(String, java.util.Map) executing} a query.
- * <p/>
+ * <p>
  * The result is comprised of a number of rows, potentially computed lazily, with this result object being an iterator
  * over those rows. Each row is represented as a <code>{@link Map}&lt;{@link String}, {@link Object}&gt;</code>, the
  * keys in this map are the names of the columns in the row, as specified by the {@code return} clause of the query,
  * and the values of the map is the corresponding computed value of the expression in the {@code return} clause. Each
  * row will thus have the same set of keys, and these keys can be retrieved using the
  * {@linkplain #columns() columns-method}.
- * <p/>
+ * <p>
  * To ensure that any resource, including transactions bound to the query, are properly freed, the result must either
  * be fully exhausted, by means of the {@linkplain java.util.Iterator iterator protocol}, or the result has to be
  * explicitly closed, by invoking the {@linkplain #close() close-method}.
- * <p/>
+ * <p>
  * Idiomatic use of the Result object would look like this:
  * <pre><code>
  * try ( Result result = graphDatabase.execute( query, parameters ) )
@@ -56,13 +56,13 @@ import java.util.Map;
  * should be noted that this iterator consumes the rows of the result in the same way as invoking {@link #next()} on
  * this object would, and that the {@link #close() close-method} on either iterator has the same effect. It is thus
  * safe to either close the projected column iterator, or this iterator, or both if all rows have not been consumed.
- * <p/>
+ * <p>
  * In addition to the {@link #next() iteration methods} on this interface, {@link #close()}, and the
  * {@link #columnAs(String) column projection method}, there are two methods for getting a string representation of the
  * result that also consumes the entire result if invoked. {@link #resultAsString()} returns a single string
  * representation of all (remaining) rows in the result, and {@link #writeAsStringTo(PrintWriter)} does the same, but
  * streams the result to the provided {@link PrintWriter} instead, without allocating large string objects.
- * <p/>
+ * <p>
  * The methods that do not consume any rows from the result, or in other ways alter the state of the result are safe to
  * invoke at any time, even after the result has been {@linkplain #close() closed} or fully exhausted. These methods
  * are:
@@ -72,7 +72,7 @@ import java.util.Map;
  * <li>{@link #getQueryExecutionType()}</li>
  * <li>{@link #getExecutionPlanDescription()}</li>
  * </ul>
- * <p/>
+ * <p>
  * Not all queries produce an actual result, and some queries that do might yield an empty result set. In order to
  * distinguish between these cases the {@link QueryExecutionType} {@linkplain #getQueryExecutionType() of this result}
  * can be queried.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/StopEvaluator.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/StopEvaluator.java
@@ -54,7 +54,7 @@ import org.neo4j.kernel.Traversal;
  *         }
  *         {@link Node} node = position.{@link TraversalPosition#currentNode() currentNode}();
  *         Object someProp = node.{@link Node#getProperty(String, Object) getProperty}( "key", null );
- *         return someProp instanceof String &&
+ *         return someProp instanceof String &amp;&amp;
  *             ((String) someProp).equals( "someValue" );
  *     }
  * };

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -34,7 +34,7 @@ import static java.util.Arrays.asList;
 
 /**
  * Creates a {@link org.neo4j.graphdb.GraphDatabaseService}.
- * <p/>
+ * <p>
  * Use {@link #newEmbeddedDatabase(String)} or
  * {@link #newEmbeddedDatabaseBuilder(String)} to create a database instance.
  */

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/SettingsResourceBundle.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/SettingsResourceBundle.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.IllegalResourceException;
 
 /**
  * ResourceBundle for classes that use GraphDatabaseSetting, which use reflection to find its values.
- * <p/>
+ * <p>
  * This allows us to keep the descriptions in the Java code, so they are available in JavaDoc.
  */
 public class SettingsResourceBundle

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexHits.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexHits.java
@@ -42,6 +42,7 @@ import org.neo4j.graphdb.Transaction;
  * entirely closes automatically. Typical use:
  * 
  * <pre>
+ * <code>
  * IndexHits<Node> hits = index.get( "key", "value" );
  * try
  * {
@@ -54,7 +55,8 @@ import org.neo4j.graphdb.Transaction;
  * {
  *     hits.close();
  * }
- * </pre> 
+ * </code>
+ * </pre>
  * 
  * @param <T> the type of items in the Iterator.
  */

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexManager.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexManager.java
@@ -74,7 +74,7 @@ public interface IndexManager
      *
      * @param indexName the name of the index to create.
      * @param customConfiguration configuration for the index being created.
-     * Use the <bold>provider</bold> key to control which index implementation,
+     * Use the <b>provider</b> key to control which index implementation,
      * i.e. the {@link IndexImplementation} to use for this index if it's created. The
      * value represents the service name corresponding to the {@link IndexImplementation}.
      * Other options can f.ex. say that the index will be a fulltext index and that it
@@ -126,7 +126,7 @@ public interface IndexManager
      *
      * @param indexName the name of the index to create.
      * @param customConfiguration configuration for the index being created.
-     * Use the <bold>provider</bold> key to control which index implementation,
+     * Use the <b>provider</b> key to control which index implementation,
      * i.e. the {@link IndexImplementation} to use for this index if it's created. The
      * value represents the service name corresponding to the {@link IndexImplementation}.
      * Other options can f.ex. say that the index will be a fulltext index and that it

--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/package-info.java
@@ -19,7 +19,7 @@
  */
 /**
  * Integrated API for node and relationship indexing.
- * <p/>
+ * <p>
  * A concrete implementation like the neo4j-lucene-index component must be available
  * on the classpath for indexing to work.
  */

--- a/community/kernel/src/main/java/org/neo4j/graphdb/schema/package-info.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/schema/package-info.java
@@ -19,7 +19,7 @@
  */
 /**
  * Optional graph schema including indexes and constraints.
- * <p/>
+ * <p>
  * Use indexes to find nodes with specific property values.
  * Use constraints to enforce rules in the graph.
  * Both indexes and constraints are configured based on node {@linkplain org.neo4j.graphdb.Label labels}.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Evaluators.java
@@ -232,7 +232,7 @@ public abstract class Evaluators
      *                          it's considered a match.
      * @return an {@link Evaluator} which compares the type of the last relationship
      *         in a {@link Path} to a given set of relationship types.
-     * @see #lastRelationshipTypeIs(Evaluation, Evaluation, RelationshipType, RelationshipType...).
+     * @see #lastRelationshipTypeIs(Evaluation, Evaluation, RelationshipType, RelationshipType...)
      *      Uses {@link Evaluation#INCLUDE_AND_CONTINUE} for {@code evaluationIfMatch}
      *      and {@link Evaluation#EXCLUDE_AND_CONTINUE} for {@code evaluationIfNoMatch}.
      */
@@ -251,7 +251,7 @@ public abstract class Evaluators
      *                          it's considered a match.
      * @return an {@link Evaluator} which compares the type of the last relationship
      *         in a {@link Path} to a given set of relationship types.
-     * @see #lastRelationshipTypeIs(Evaluation, Evaluation, RelationshipType, RelationshipType...).
+     * @see #lastRelationshipTypeIs(Evaluation, Evaluation, RelationshipType, RelationshipType...)
      *      Uses {@link Evaluation#INCLUDE_AND_PRUNE} for {@code evaluationIfMatch}
      *      and {@link Evaluation#INCLUDE_AND_CONTINUE} for {@code evaluationIfNoMatch}.
      */

--- a/community/kernel/src/main/java/org/neo4j/helpers/Function.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Function.java
@@ -21,7 +21,7 @@ package org.neo4j.helpers;
 
 /**
  * Generic function interface to map from one type to another.
- * <p/>
+ * <p>
  * This can be used with the Iterables methods to transform lists of objects.
  *
  * This is deprecated, use {@link org.neo4j.function.Function} instead.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Service.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Service.java
@@ -42,10 +42,10 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
  * <code>ServiceLoader</code> if available, but backports the functionality to
  * previous Java versions and adds some error handling to ignore misconfigured
  * service implementations.
- * <p/>
+ * <p>
  * Additionally this class can be used as a base class for implementing services
  * that are differentiated by a String key. An example implementation might be:
- * <p/>
+ * <p>
  * <pre>
  * <code>
  * public abstract class StringConverter extends org.neo4j.commons.Service
@@ -64,9 +64,9 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
  * }
  * </code>
  * </pre>
- * <p/>
+ * <p>
  * With for example these implementations:
- * <p/>
+ * <p>
  * <pre>
  * <code>
  * public final class UppercaseConverter extends StringConverter
@@ -103,9 +103,9 @@ import org.neo4j.helpers.collection.PrefetchingIterator;
  * }
  * </code>
  * </pre>
- * <p/>
+ * <p>
  * This would then be used as:
- * <p/>
+ * <p>
  * <pre>
  * <code>
  * String atad = StringConverter.load( "reverse" ).convert( "data" );
@@ -125,7 +125,7 @@ public abstract class Service
     /**
      * Designates that a class implements the specified service and should be
      * added to the services listings file (META-INF/services/[service-name]).
-     * <p/>
+     * <p>
      * The annotation in itself does not provide any functionality for adding
      * the implementation class to the services listings file. But it serves as
      * a handle for an Annotation Processing Tool to utilize for performing that

--- a/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Settings.java
@@ -482,11 +482,11 @@ public final class Settings
     /**
      * For values such as:
      * <ul>
-     *   <li>100M</li>   ==> 100 * 1024 * 1024
-     *   <li>37261</li>  ==> 37261
-     *   <li>2g</li>     ==> 2 * 1024 * 1024 * 1024
-     *   <li>50m</li>    ==> 50 * 1024 * 1024
-     *   <li>10k</li>    ==> 10 * 1024
+     *   <li>100M</li>   ==&gt; 100 * 1024 * 1024
+     *   <li>37261</li>  ==&gt; 37261
+     *   <li>2g</li>     ==&gt; 2 * 1024 * 1024 * 1024
+     *   <li>50m</li>    ==&gt; 50 * 1024 * 1024
+     *   <li>10k</li>    ==&gt; 10 * 1024
      * </ul>
      */
     public static final Function<String, Long> LONG_WITH_OPTIONAL_UNIT = new Function<String, Long>()

--- a/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
@@ -34,10 +34,10 @@ import static org.neo4j.helpers.Predicates.or;
  * Neo4j transaction template that automates the retry-on-exception logic. It uses the builder
  * pattern for configuration, with copy-semantics, so you can iteratively build up instances for
  * different scenarios.
- * <p/>
+ * <p>
  * First instantiate and configure the template using the fluent API methods, and then
  * invoke execute which will begin/commit transactions in a loop for the specified number of times.
- * <p/>
+ * <p>
  * By default all exceptions (except Errors and TransactionTerminatedException) cause a retry, and the monitor does nothing, but these can be overridden
  * with
  * custom behaviour.

--- a/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/progress/ProgressListener.java
@@ -21,7 +21,7 @@ package org.neo4j.helpers.progress;
 
 /**
  * A Progress object is an object through which a process can report its progress.
- * <p/>
+ * <p>
  * Progress objects are not thread safe, and are to be used by a single thread only. Each Progress object from a {@link
  * ProgressMonitorFactory.MultiPartBuilder} can be used from different threads.
  *

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -35,7 +35,7 @@ import static org.neo4j.helpers.collection.Iterables.join;
 /**
  * The availability guard is what ensures that the database will only take calls when it is in an ok state. It allows
  * query handling to easily determine if it is ok to call the database by calling {@link #isAvailable(long)}.
- * <p/>
+ * <p>
  * The implementation uses an atomic integer that is initialized to the nr of conditions that must be met for the
  * database to be available. Each such condition will then call grant/deny accordingly,
  * and if the integer becomes 0 access is granted.

--- a/community/kernel/src/main/java/org/neo4j/kernel/EmbeddedGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/EmbeddedGraphDatabase.java
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
  * An implementation of {@link GraphDatabaseService} that is used to embed Neo4j
  * in an application. You typically instantiate it by using
  * {@link org.neo4j.graphdb.factory.GraphDatabaseFactory} like so:
- * <p/>
+ * <p>
  *
  * <pre>
  * <code>
@@ -38,7 +38,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
  * graphDb.shutdown();
  * </code>
  * </pre>
- * <p/>
+ * <p>
  * For more information, see {@link GraphDatabaseService}.
  *
  * @deprecated This will be moved to internal packages in the next major release.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -337,12 +337,12 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
      * {@link Properties#load}). Any parameter that exist in the config file
      * and in the map passed into this constructor will take the value from the
      * map.
-     * <p/>
+     * <p>
      * If <CODE>config</CODE> parameter is set but file doesn't exist an
      * <CODE>IOException</CODE> is thrown. If any problem is found with that
      * configuration file or Neo4j store can't be loaded an <CODE>IOException is
      * thrown</CODE>.
-     * <p/>
+     * <p>
      * Note that the tremendous number of dependencies for this class, clearly, is an architecture smell. It is part
      * of the ongoing work on introducing the Kernel API, where components that were previously spread throughout the
      * core API are now slowly accumulating in the Kernel implementation. Over time, these components should be

--- a/community/kernel/src/main/java/org/neo4j/kernel/StoreLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/StoreLocker.java
@@ -47,7 +47,7 @@ public class StoreLocker
 
     /**
      * Obtains lock on store file so that we can ensure the store is not shared between database instances
-     * <p/>
+     * <p>
      * Creates store dir if necessary, creates store lock file if necessary
      *
      * @throws StoreLockException if lock could not be acquired

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDescriptor.java
@@ -25,7 +25,7 @@ import static java.lang.String.format;
 
 /**
  * Description of a single index as needed by the {@link org.neo4j.kernel.impl.api.index.IndexProxy} cake
- * <p/>
+ * <p>
  * This is a IndexContext cake level representation of {@link org.neo4j.kernel.impl.store.record.IndexRule}
  */
 public class IndexDescriptor

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -44,10 +44,10 @@ import static java.util.Collections.emptyList;
 /**
  * This class holds the overall configuration of a Neo4j database instance. Use the accessors
  * to convert the internal key-value settings to other types.
- * <p/>
+ * <p>
  * Users can assume that old settings have been migrated to their new counterparts, and that defaults
  * have been applied.
- * <p/>
+ * <p>
  * UI's can change configuration by calling applyChanges. Any listener, such as services that use
  * this configuration, can be notified of changes by implementing the {@link ConfigurationChangeListener} interface.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/RestartOnChange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/RestartOnChange.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 
 /**
  * When a specified change happens, restart the given LifeSupport instance.
- * <p/>
+ * <p>
  * Typically, provide a specification for the settings that a service uses, and then set it to restart
  * an internal LifeSupport instance when any of those settings change.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -55,7 +55,7 @@ import static java.util.Collections.newSetFromMap;
 
 /**
  * Central source of transactions in the database.
- * <p/>
+ * <p>
  * This class maintains references to all transactions, a pool of passive kernel transactions, and provides
  * capabilities
  * for enumerating all running transactions. During normal operation, acquiring new transactions and enumerating live
@@ -91,12 +91,12 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
 
     /**
      * Used to enumerate all transactions in the system, active and idle ones.
-     * <p/>
+     * <p>
      * This data structure is *only* updated when brand-new transactions are created, or when transactions are disposed
      * of. During normal operation (where all transactions come from and are returned to the pool), this will be left
      * in peace, working solely as a collection of references to all transaction objects (idle and active) in the
      * database.
-     * <p/>
+     * <p>
      * As such, it provides a good mechanism for listing all transactions without requiring synchronization when
      * starting and committing transactions.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -77,13 +77,13 @@ import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
  * transactionality. Each index has an {@link org.neo4j.kernel.impl.store.record.IndexRule}, which it uses to filter
  * changes that come into the database. Changes that apply to the the rule are indexed. This way, "normal" changes to
  * the database can be replayed to perform recovery after a crash.
- * <p/>
+ * <p>
  * <h3>Recovery procedure</h3>
- * <p/>
+ * <p>
  * Each index has a state, as defined in {@link org.neo4j.kernel.api.index.InternalIndexState}, which is used during
  * recovery. If an index is anything but {@link org.neo4j.kernel.api.index.InternalIndexState#ONLINE}, it will simply be
  * destroyed and re-created.
- * <p/>
+ * <p>
  * If, however, it is {@link org.neo4j.kernel.api.index.InternalIndexState#ONLINE}, the index provider is required to
  * also guarantee that the index had been flushed to disk.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ValidatedIndexUpdates.java
@@ -28,11 +28,11 @@ import org.neo4j.kernel.api.index.IndexEntryConflictException;
  * This class represents validated and prepared index updates that are ready to be flushed.
  * Flushing is performed with {@link ValidatedIndexUpdates#flush()} method.
  * Releasing of resources is performed with {@link ValidatedIndexUpdates#close()} method.
- * <p/>
+ * <p>
  * Notion of being 'prepared' indicates that index updates are placed in internal data structures and no
  * pre-processing before {@link ValidatedIndexUpdates#flush()} is needed. Such data structure might represent simply
  * a mapping 'Index -> [set of updates]'.
- * <p/>
+ * <p>
  * Notion of being 'validated' indicates that all updates in this batch can be consumed by corresponding indexes.
  * This mostly mean that index size permit new insertions {@see IndexCapacityExceededException}.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
@@ -28,13 +28,13 @@ import org.neo4j.helpers.collection.Iterables;
 /**
  * Utility for {@linkplain #get(TxState, Object) retrieving} and
  * {@linkplain #getOrCreate(TxState, Object) initializing} lazy state held in maps in {@link TxState}.
- * <p/>
+ * <p>
  * {@linkplain #get(TxState, Object) Retrieving} state only guarantees that a readable object is returned, it does not
  * guarantee a writable version. This allows us to return a read-only default value if the state has not been
  * initialized. Only when invoking {@link #getOrCreate(TxState, Object)} do we need to return a writable version, and
  * at this point the state is initialized, if it has not been before, by creating a new instance and putting it in the
  * map.
- * <p/>
+ * <p>
  * There are two categories of methods in this class, one category concerns the value type, and the other concerns the
  * {@linkplain TxState value holder}. Implementations for methods of these two categories are preferably provided in
  * two stages, as to have each of those participating types contribute their part to the final implementation.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PersistenceCache.java
@@ -66,7 +66,7 @@ import static org.neo4j.kernel.impl.api.store.CacheUpdateListener.NO_UPDATES;
  * NodeImpl/RelationshipImpl manages caching, locking and transaction state merging. In the future
  * they might disappear and split up into {@link CacheLayer},
  * {@link org.neo4j.kernel.impl.api.LockingStatementOperations} and {@link org.neo4j.kernel.impl.api.StateHandlingStatementOperations}.
- * <p/>
+ * <p>
  * The point is that we need a cache and the implementation is a bit temporary, but might end
  * up being the cache to replace the data within NodeImpl/RelationshipImpl.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/LruCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/LruCache.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Simple implementation of Least-recently-used cache.
- * <p/>
+ * <p>
  * The cache has a <CODE>maxSize</CODE> set and when the number of cached
  * elements exceeds that limit the least recently used element will be removed.
  */
@@ -148,12 +148,12 @@ public class LruCache<K, E>
      * greater then <CODE>maxSize()</CODE> next invoke to <CODE>maxSize()</CODE>
      * will return <CODE>newMaxSize</CODE> and the entries in cache will not
      * be modified.
-     * <p/>
+     * <p>
      * If <CODE>newMaxSize</CODE> is less then <CODE>size()</CODE>
      * the cache will shrink itself removing least recently used element until
      * <CODE>size()</CODE> equals <CODE>newMaxSize</CODE>. For each element
      * removed the {@link #elementCleaned} method is invoked.
-     * <p/>
+     * <p>
      * If <CODE>newMaxSize</CODE> is less then <CODE>1</CODE> an
      * {@link IllegalArgumentException} is thrown.
      *

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenHolder.java
@@ -30,12 +30,12 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 /**
  * Exists:
  * get from map
- * <p/>
+ * <p>
  * Previously when it doesn't exist:
  * tokenCreator.create
  * record changes
  * command execution
- * <p/>
+ * <p>
  * Doesn't exist:
  * tokenCreator.create( name, id )
  * new kernel transaction

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -49,17 +49,17 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
  * An abstract representation of a dynamic store. The difference between a
  * normal {@link AbstractStore} and a <CODE>AbstractDynamicStore</CODE> is
  * that the size of a record/entry can be dynamic.
- * <p/>
+ * <p>
  * Instead of a fixed record this class uses blocks to store a record. If a
  * record size is greater than the block size the record will use one or more
  * blocks to store its data.
- * <p/>
+ * <p>
  * A dynamic store don't have a {@link IdGenerator} because the position of a
  * record can't be calculated just by knowing the id. Instead one should use a
  * {@link AbstractStore} and store the start block of the record located in the
  * dynamic store. Note: This class makes use of an id generator internally for
  * managing free and non free blocks.
- * <p/>
+ * <p>
  * Note, the first block of a dynamic store is reserved and contains information
  * about the store.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractStore.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.impl.util.StringLogger;
  * records. Each record has a fixed size (<CODE>getRecordSize()</CODE>) so
  * the position for a record can be calculated by
  * <CODE>id * getRecordSize()</CODE>.
- * <p/>
+ * <p>
  * A store has an {@link IdGenerator} managing the records that are free or in
  * use.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -81,12 +81,12 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
      * Opens and validates the store contained in <CODE>fileName</CODE>
      * loading any configuration defined in <CODE>config</CODE>. After
      * validation the <CODE>initStorage</CODE> method is called.
-     * <p/>
+     * <p>
      * If the store had a clean shutdown it will be marked as <CODE>ok</CODE>
      * and the {@link #getStoreOk()} method will return true.
      * If a problem was found when opening the store the {@link #makeStoreOk()}
      * must be invoked.
-     * <p/>
+     * <p>
      * throws IOException if the unable to open the storage or if the
      * <CODE>initStorage</CODE> method fails
      *
@@ -204,7 +204,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
     /**
      * Should do first validation on store validating stuff like version and id
      * generator. This method is called by constructors.
-     * <p/>
+     * <p>
      * Note: This method will map the file with the page cache. The store file must not
      * be accessed directly until it has been unmapped - the store file must only be
      * accessed through the page cache.
@@ -332,7 +332,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
 
     /**
      * Should rebuild the id generator from scratch.
-     * <p/>
+     * <p>
      * Note: This method may be called both while the store has the store file mapped in the
      * page cache, and while the store file is not mapped. Implementers must therefore
      * map their own temporary PagedFile for the store file, and do their file IO through that,
@@ -454,9 +454,9 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
      * This method should close/release all resources that the implementation of
      * this store has allocated and is called just before the <CODE>close()</CODE>
      * method returns. Override this method to clean up stuff the constructor.
-     * <p/>
+     * <p>
      * This default implementation does nothing.
-     * <p/>
+     * <p>
      * Note: This method runs before the store file is unmapped from the page cache,
      * and is therefore not allowed to operate on the store files directly.
      */
@@ -586,7 +586,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
 
     /**
      * Opens the {@link IdGenerator} used by this store.
-     * <p/>
+     * <p>
      * Note: This method may be called both while the store has the store file mapped in the
      * page cache, and while the store file is not mapped. Implementers must therefore
      * map their own temporary PagedFile for the store file, and do their file IO through that,
@@ -599,7 +599,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
 
     /**
      * Opens the {@link IdGenerator} given by the fileName.
-     * <p/>
+     * <p>
      * Note: This method may be called both while the store has the store file mapped in the
      * page cache, and while the store file is not mapped. Implementers must therefore
      * map their own temporary PagedFile for the store file, and do their file IO through that,
@@ -692,7 +692,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
      * Closes this store. This will cause all buffers and channels to be closed.
      * Requesting an operation from after this method has been invoked is
      * illegal and an exception will be thrown.
-     * <p/>
+     * <p>
      * This method will start by invoking the {@link #closeStorage} method
      * giving the implementing store way to do anything that it needs to do
      * before the fileChannel is closed.
@@ -776,7 +776,7 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
      * Returns a <CODE>StoreChannel</CODE> to this storage's file. If
      * <CODE>close()</CODE> method has been invoked <CODE>null</CODE> will be
      * returned.
-     * <p/>
+     * <p>
      * Note: You can only operate directly on the StoreChannel while the file
      * is not mapped in the page cache.
      *

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
@@ -24,11 +24,11 @@ import org.neo4j.kernel.impl.store.record.NodeRecord;
 /**
  * Logic for parsing and constructing {@link NodeRecord#getLabelField()} and dynamic label
  * records in {@link NodeRecord#getDynamicLabelRecords()} from label ids.
- * <p/>
+ * <p>
  * Each node has a label field of 5 bytes, where labels will be stored, if sufficient space
  * (max bits required for storing each label id is considered). If not then the field will
  * point to a dynamic record where the labels will be stored in the format of an array property.
- * <p/>
+ * <p>
  * [hhhh,bbbb][bbbb,bbbb][bbbb,bbbb][bbbb,bbbb][bbbb,bbbb]
  * h: header
  * - 0x0<=h<=0x7 (leaving high bit reserved): number of in-lined labels in the body

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -503,7 +503,7 @@ public class StoreFactory
      * reserved (contains info about the block size). There will be an overhead
      * for each block of <CODE>AbstractDynamicStore.BLOCK_HEADER_SIZE</CODE>
      * bytes.
-     * <p/>
+     * <p>
      * This method will create a empty store with descriptor returned by the
      * {@link CommonAbstractStore#getTypeDescriptor()}. The internal id generator used by
      * this store will also be created.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFile.java
@@ -145,7 +145,7 @@ public class KeyValueStoreFile implements Closeable
     private final int totalEntries;
     /**
      * The page catalogue is used to find the appropriate (first) page without having to do I/O.
-     * <p/>
+     * <p>
      * <b>Content:</b> {@code (minKey, maxKey)+}, one entry (at {@code 2 x} {@link #keySize}) for each page.
      */
     private final byte[] pageCatalogue;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -107,10 +107,10 @@ import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.wit
 
 /**
  * Migrates a neo4j kernel database from one version to the next.
- * <p/>
+ * <p>
  * Since only one store migration is supported at any given version (migration from the previous store version)
  * the migration code is specific for the current upgrade and changes with each store format version.
- * <p/>
+ * <p>
  * Just one out of many potential participants in a {@link StoreUpgrader migration}.
  *
  * @see StoreUpgrader

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -43,7 +43,7 @@ import org.neo4j.kernel.logging.Logging;
  * The migration will happen to a separate, isolated directory so that an incomplete migration will not affect
  * the original database. Only when a successful migration has taken place the migrated store will replace
  * the original database.
- * <p/>
+ * <p>
  * Migration process at a glance:
  * <ol>
  * <li>Participants are asked whether or not there's a need for migration</li>
@@ -54,7 +54,7 @@ import org.neo4j.kernel.logging.Logging;
  * replacing only the existing files, so that if only some store files needed migration the others are left intact</li>
  * <li>Migration is completed and participant resources are closed</li>
  * </ol>
- * <p/>
+ * <p>
  * TODO walk through crash scenarios and how they are handled.
  *
  * @see StoreMigrationParticipant

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v19/Legacy19Store.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v19/Legacy19Store.java
@@ -46,10 +46,10 @@ import static org.neo4j.kernel.impl.store.CommonAbstractStore.buildTypeDescripto
 
 /**
  * Reader for a database in an older store format version.
- * <p/>
+ * <p>
  * Since only one store migration is supported at any given version (migration from the previous store version)
  * the reader code is specific for the current upgrade and changes with each store format version.
- * <p/>
+ * <p>
  * {@link #LEGACY_VERSION} marks which version it's able to read.
  */
 public class Legacy19Store implements LegacyStore

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/Legacy21Store.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/Legacy21Store.java
@@ -31,10 +31,10 @@ import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
 
 /**
  * Reader for a database in an older store format version.
- * <p/>
+ * <p>
  * Since only one store migration is supported at any given version (migration from the previous store version)
  * the reader code is specific for the current upgrade and changes with each store format version.
- * <p/>
+ * <p>
  * {@link #LEGACY_VERSION} marks which version it's able to read.
  */
 public class Legacy21Store implements LegacyStore

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoCommandHandler.java
@@ -46,14 +46,14 @@ import org.neo4j.kernel.impl.transaction.command.Command.SchemaRuleCommand;
  * Implementations need to provide all these methods of course, but it is expected that they will delegate
  * the actual work to implementations that hold related functionality together, using a Facade pattern.
  * For example, it is conceivable that a CommandWriterHandler would use a NeoCommandHandler and a SchemaCommandHandler.
- * <p/>
+ * <p>
  * The order in which the methods of a NeoCommandHandler is expected to be called is this:
  * <ol>
  * <li>zero or more calls to visit??? methods</li>
  * <li>{@link #apply()}</li>
  * <li>{@link #close()}</li>
  * </ol>
- * <p/>
+ * <p>
  * The boolean returned from visit methods is false for continuing traversal, and true for breaking traversal.
  */
 public interface NeoCommandHandler extends AutoCloseable

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
  * Visits commands targeted towards the {@link NeoStore} and update corresponding stores.
  * What happens in here is what will happen in a "internal" transaction, i.e. a transaction that has been
  * forged in this database, with transaction state, a KernelTransaction and all that and is now committing.
- * <p/>
+ * <p>
  * For other modes of application, like recovery or external there are other, added functionality, decorated
  * outside this applier.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReaderFactory.java
@@ -29,11 +29,11 @@ import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LO
 
 /**
  * Version aware factory of LogEntryReaders
- * <p/>
+ * <p>
  * Starting with Neo4j version 2.2, we can read older format log versions at runtime. Support for this comes from
  * {@link org.neo4j.kernel.impl.transaction.xaframework.log.entry.LogEntryParserFactory} which can provide different
  * parsers for the log entries.
- * <p/>
+ * <p>
  * Starting with Neo4j version 2.1, log entries are prefixed with a version. This allows for Neo4j instances of
  * different versions to exchange transaction data, either directly or via logical logs. This implementation of
  * LogEntryReader makes use of the version information to deserialize command entries that hold commands created

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StringLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StringLogger.java
@@ -711,7 +711,7 @@ public abstract class StringLogger
          * Will move:
          * messages.log.1 -> messages.log.2
          * messages.log   -> messages.log.1
-         * <p/>
+         * <p>
          * Will delete (if exists):
          * messages.log.2
          */

--- a/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -29,10 +29,10 @@ import org.neo4j.kernel.impl.util.StringLogger;
 
 /**
  * Support class for handling collections of Lifecycle instances. Manages the transitions from one state to another.
- * <p/>
+ * <p>
  * To use this, first add instances to it that implement the Lifecycle interface. When lifecycle methods on this
  * class are called it will try to invoke the same methods on the registered instances.
- * <p/>
+ * <p>
  * Components that internally owns other components that has a lifecycle can use this to control them as well.
  */
 public class LifeSupport
@@ -55,7 +55,7 @@ public class LifeSupport
 
     /**
      * Initialize all registered instances, transitioning from status NONE to STOPPED.
-     * <p/>
+     * <p>
      * If transition fails, then it goes to STOPPED and then SHUTDOWN, so it cannot be restarted again.
      */
     @Override
@@ -91,9 +91,9 @@ public class LifeSupport
 
     /**
      * Start all registered instances, transitioning from STOPPED to STARTED.
-     * <p/>
+     * <p>
      * If it was previously not initialized, it will be initialized first.
-     * <p/>
+     * <p>
      * If any instance fails to start, the already started instances will be stopped, so
      * that the overall status is STOPPED.
      *
@@ -135,7 +135,7 @@ public class LifeSupport
 
     /**
      * Stop all registered instances, transitioning from STARTED to STOPPED.
-     * <p/>
+     * <p>
      * If any instance fails to stop, the rest of the instances will still be stopped,
      * so that the overall status is STOPPED.
      */
@@ -171,7 +171,7 @@ public class LifeSupport
 
     /**
      * Shutdown all registered instances, transitioning from either STARTED or STOPPED to SHUTDOWN.
-     * <p/>
+     * <p>
      * If any instance fails to shutdown, the rest of the instances will still be shut down,
      * so that the overall status is SHUTDOWN.
      */

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -62,7 +62,7 @@ import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.wit
  * {@link BatchImporter} which tries to exercise as much of the available resources to gain performance.
  * Or rather ensure that the slowest resource (usually I/O) is fully saturated and that enough work is
  * being performed to keep that slowest resource saturated all the time.
- * <p/>
+ * <p>
  * Overall goals: split up processing cost by parallelizing. Keep CPUs busy, keep I/O busy and writing sequentially.
  * I/O is only allowed to be read to and written from sequentially, any random access drastically reduces performance.
  * Goes through multiple stages where each stage has one or more steps executing in parallel, passing

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -56,7 +56,7 @@ public class KernelIT extends KernelIntegrationTest
     /**
      * While we transition ownership from the Beans API to the Kernel API for core database
      * interactions, there will be a bit of a mess. Our first goal is an architecture like this:
-     * <p/>
+     * <p>
      * Users
      * /    \
      * Beans API   Cypher
@@ -64,9 +64,9 @@ public class KernelIT extends KernelIntegrationTest
      * Kernel API
      * |
      * Kernel Implementation
-     * <p/>
+     * <p>
      * But our current intermediate architecture looks like this:
-     * <p/>
+     * <p>
      * Users
      * /        \
      * Beans API <--- Cypher
@@ -74,17 +74,17 @@ public class KernelIT extends KernelIntegrationTest
      * |  Kernel API
      * |      |
      * Kernel Implementation
-     * <p/>
+     * <p>
      * Meaning Kernel API and Beans API both manipulate the underlying kernel, causing lots of corner cases. Most
      * notably, those corner cases are related to Transactions, and the interplay between three transaction APIs:
      * - The Beans API
      * - The JTA Transaction Manager API
      * - The Kernel TransactionContext API
-     * <p/>
+     * <p>
      * In the long term, the goal is for JTA compliant stuff to live outside of the kernel, as an addon. The Kernel
      * API will rule supreme over the land of transactions. We are a long way away from there, however, so as a first
      * intermediary step, the JTA transaction manager rules supreme, and the Kernel API piggybacks on it.
-     * <p/>
+     * <p>
      * This test shows us how to use both the Kernel API and the Beans API together in the same transaction,
      * during the transition phase.
      */

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
@@ -22,7 +22,7 @@ package org.neo4j.collection.primitive;
 import static java.util.Arrays.copyOf;
 
 /**
- * Like a {@link Stack<Integer>} but for primitive ints. Virtually GC free in that it has an {@code int[]}
+ * Like a {@code Stack<Integer>} but for primitive ints. Virtually GC free in that it has an {@code int[]}
  * and merely moves a cursor where to {@link #push(int)} and {@link #poll()} values to and from.
  * If many items goes in the stack the {@code int[]} will grow to accomodate all of them, but not shrink again.
  */

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Work.java
@@ -29,17 +29,17 @@ package org.neo4j.concurrent;
  * </p>
  * <ul>
  *     <li>
- *         <strong>Commutativity</strong><br/>
+ *         <strong>Commutativity</strong><br>
  *         The order of operands must not matter:
  *         <code>a.combine(b)  =  b.combine(a)</code>
  *     </li>
  *     <li>
- *         <strong>Associativity</strong><br/>
+ *         <strong>Associativity</strong><br>
  *         The order of operations must not matter:
  *         <code>a.combine(b.combine(c))  =  a.combine(b).combine(c)</code>
  *     </li>
  *     <li>
- *         <strong>Effect Transitivity</strong><br/>
+ *         <strong>Effect Transitivity</strong><br>
  *         Work-combining must not change work outcome:
  *         <code>a.combine(b).apply(m)  =  { a.apply(m) ; b.apply(m) }</code>
  *     </li>

--- a/community/primitive-collections/src/main/java/org/neo4j/function/RawFunction.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/function/RawFunction.java
@@ -21,7 +21,7 @@ package org.neo4j.function;
 
 /**
  * Generic function interface to map from one type to another.
- * <p/>
+ * <p>
  * This can be used with the Iterables methods to transform lists of objects.
  */
 public interface RawFunction<FROM,TO,EXCEPTION extends Exception>
@@ -31,7 +31,7 @@ public interface RawFunction<FROM,TO,EXCEPTION extends Exception>
      *
      * @param from the input item
      * @return the mapped item
-     * @throws an exception if the function fails.
+     * @throws EXCEPTION if the function fails.
      */
     TO apply( FROM from ) throws EXCEPTION;
 }

--- a/community/server-api/src/main/java/org/neo4j/server/plugins/ServerPlugin.java
+++ b/community/server-api/src/main/java/org/neo4j/server/plugins/ServerPlugin.java
@@ -30,7 +30,7 @@ import org.neo4j.helpers.Service;
 
 /**
  * API for creating extensions for the Neo4j server.
- * <p/>
+ * <p>
  * Extensions are created by creating a subclass of this class. The subclass
  * should have a public no-argument constructor (or no constructor at all).
  * Then place this class in a jar-file that contains a file called
@@ -42,7 +42,7 @@ import org.neo4j.helpers.Service;
  * extension classes, each class name on its own line in the file. When the jar
  * file is placed on the class path of the server, it will be loaded
  * automatically when the server starts.
- * <p/>
+ * <p>
  * The easiest way to implement Neo4j server extensions is by defining public
  * methods on the extension class annotated with
  * <code>@{@link PluginTarget}</code>. The parameter for the
@@ -75,7 +75,7 @@ import org.neo4j.helpers.Service;
  * <li>{@link java.util.List lists}, {@link java.util.Set sets} or arrays of any
  * of the above types.</li>
  * </ul>
- * <p/>
+ * <p>
  * All exceptions thrown by an {@link PluginTarget} method are treated as
  * server errors, unless the method has declared the ability to throw such an
  * exception, in that case the exception is treated as a bad request and

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigurator.java
@@ -36,18 +36,18 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 /**
  * Used by the {@link WrappingNeoServerBootstrapper}, passing the minimum amount
  * of required configuration on to the neo4j server.
- * <p/>
+ * <p>
  * If you want to change configuration for your
  * {@link WrappingNeoServerBootstrapper}, create an instance of this class, and
  * add configuration like so:
- * <p/>
+ * <p>
  * <pre>
  * {
  *     &#064;code ServerConfigurator conf = new ServerConfigurator( myDb );
  *     conf.setProperty( ServerSettings.webserver_port.name(), "8080" );
  * }
  * </pre>
- * <p/>
+ * <p>
  * See the neo4j manual for information about what configuration directives the
  * server takes, or take a look at the settings in {@link ServerSettings}.
  */

--- a/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
@@ -47,7 +47,7 @@ public interface SecurityRule
      *         '/' character), meaning <code>/myExtension/*</code> is not the
      *         same as <code>/myExtension*</code> and implementers should take
      *         care to ensure their implementations are tested accordingly.
-     *         <p/>
+     *         <p>
      *         Final note: the only wildcard supported is '*' and there is no
      *         support for regular expression syntax.
      */

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -51,7 +51,7 @@ import static org.neo4j.server.rest.domain.JsonHelper.writeValue;
  * <li>{@link #transactionStatus(long expiryDate)}{@code ?}</li>
  * <li>{@link #finish() finish}</li>
  * </ul>
- * <p/>
+ * <p>
  * Where {@code ?} means invoke at most once, and {@code *} means invoke zero or more times.
  */
 public class ExecutionResultSerializer

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -32,9 +32,9 @@ import org.neo4j.server.rest.web.TransactionUriScheme;
 /**
  * Transactional actions contains the business logic for executing statements against Neo4j across long-running
  * transactions.
- * <p/>
+ * <p>
  * The idiom for the public methods here is:
- * <p/>
+ * <p>
  * response.begin()
  * try {
  * // Do internal calls, saving errors into a common error list
@@ -45,7 +45,7 @@ import org.neo4j.server.rest.web.TransactionUriScheme;
  * {
  * response.finish(errors)
  * }
- * <p/>
+ * <p>
  * This is done to ensure we stick to the contract of the response handler, which is important, because if we skimp on
  * it, clients may be left waiting for results that never arrive.
  */

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/error/Neo4jError.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/error/Neo4jError.java
@@ -28,11 +28,11 @@ import org.neo4j.kernel.api.exceptions.Status;
 /**
  * This is an initial move towards unified errors - it should not live here in the server, but should probably
  * exist in the kernel or similar, where it can be shared across surfaces other than the server.
- * <p/>
+ * <p>
  * It's put in place here in order to enforce that the {@link org.neo4j.server.rest.web.TransactionalService}
  * is strictly tied down towards what errors it handles and returns to the client, to create a waterproof abstraction
  * between the runtime-exception landscape that lives below, and the errors we send to the user.
- * <p/>
+ * <p>
  * This way, we make it easy to transition this service over to a unified error code based error scheme.
  */
 public class Neo4jError

--- a/community/server/src/main/java/org/neo4j/server/security/auth/AuthManager.java
+++ b/community/server/src/main/java/org/neo4j/server/security/auth/AuthManager.java
@@ -28,7 +28,7 @@ import org.neo4j.server.security.auth.exception.IllegalUsernameException;
 
 /**
  * Manages server authentication and authorization.
- * <p/>
+ * <p>
  * Through the AuthManager you can create, update and delete users, and authenticate using credentials.
  */
 public class AuthManager extends LifecycleAdapter

--- a/community/server/src/main/java/org/neo4j/server/web/XForwardFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/XForwardFilter.java
@@ -30,7 +30,7 @@ import static org.neo4j.server.web.XForwardUtil.X_FORWARD_PROTO_HEADER_KEY;
 /**
  * Changes the value of the base and request URIs to match the provided
  * X-Forwarded-Host and X-Forwarded-Proto header values.
- * <p/>
+ * <p>
  * In doing so, it means Neo4j server can use those URIs as if they were the
  * actual request URIs.
  */

--- a/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/TransactionWrappedDatabaseActions.java
@@ -41,7 +41,7 @@ import org.neo4j.server.rest.repr.RelationshipRepresentation;
 
 /**
  * A class that is helpful when testing DatabaseActions. The alternative would be to writ tx-scaffolding in each test.
- * <p/>
+ * <p>
  * Some methods are _not_ wrapped: those are the ones that return a representation which is later serialised,
  * as that requires a transaction. For those, the test have scaffolding added.
  */

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtension.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  * Kernel extension for UDC, the Usage Data Collector. The UDC runs as a background
  * daemon, waking up once a day to collect basic usage information about a long
  * running graph database.
- * <p/>
+ * <p>
  * The first update is delayed to avoid needless activity during integration
  * testing and short-run applications. Subsequent updates are made at regular
  * intervals. Both times are specified in milliseconds.

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  * Kernel extension for UDC, the Usage Data Collector. The UDC runs as a background
  * daemon, waking up once a day to collect basic usage information about a long
  * running graph database.
- * <p/>
+ * <p>
  * The first update is delayed to avoid needless activity during integration
  * testing and short-run applications. Subsequent updates are made at regular
  * intervals. Both times are specified in milliseconds.

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterJoin.java
@@ -46,7 +46,7 @@ import static java.lang.String.format;
 
 /**
  * This service starts quite late, and is available for the instance to join as a member in the cluster.
- * <p/>
+ * <p>
  * It can either use manual listing of hosts, or auto discovery protocols.
  */
 public class ClusterJoin

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 /**
  * Message for state machines which can be sent out to instances in the cluster as well.
- * <p/>
+ * <p>
  * These are typically produced and consumed by a {@link org.neo4j.cluster.statemachine.StateMachine}.
  */
 public class Message<MESSAGETYPE extends MessageType>

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/ClusterMemberListener.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.impl.store.StoreId;
 
 /**
  * A HighAvailabilityListener is listening for events from elections and availability state.
- * <p/>
+ * <p>
  * These are invoked by translating atomic broadcast messages to methods on this interface.
  */
 public interface ClusterMemberListener

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
@@ -40,7 +40,7 @@ import org.neo4j.kernel.logging.Logging;
 
 /**
  * Context that implements all the context interfaces used by the Paxos state machines.
- * <p/>
+ * <p>
  * The design here is that all shared state is handled in a common class, {@link CommonContextState}, while all
  * state specific to some single context is contained within the specific context classes.
  */

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/State.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/State.java
@@ -27,7 +27,7 @@ import org.neo4j.cluster.com.message.MessageType;
  * Implemented by states in a state machine. Each state must
  * implement the handle method, to perform different things depending
  * on the message that comes in. This should only be implemented as enums.
- * <p/>
+ * <p>
  * A state is guaranteed to only have one handle at a time, i.e. access is serialized.
  */
 public interface State<CONTEXT, MESSAGETYPE extends MessageType>

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineConversations.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineConversations.java
@@ -25,7 +25,7 @@ import org.neo4j.cluster.InstanceId;
 
 /**
  * Generate id's for state machine conversations. This should be shared between all state machines in a server.
- * <p/>
+ * <p>
  * These conversation id's can be used to uniquely identify conversations between distributed state machines.
  */
 public class StateMachineConversations

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/statemachine/StateMachineProxyFactory.java
@@ -37,7 +37,7 @@ import org.neo4j.cluster.com.message.MessageType;
 /**
  * Used to generate dynamic proxies whose methods are backed by a {@link StateMachine}. Method
  * calls will be translated to the corresponding message, and the parameters are set as payload.
- * <p/>
+ * <p>
  * Methods in the interface to be proxied can either return void or Future<T>. If a method returns
  * a future, then the value of it will be set when a message named nameResponse or nameFailure is created,
  * where "name" corresponds to the name of the method.

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -76,7 +76,7 @@ import static org.neo4j.helpers.NamedThreadFactory.named;
 /**
  * Receives requests from {@link Client clients}. Delegates actual work to an instance
  * of a specified communication interface, injected in the constructor.
- * <p/>
+ * <p>
  * frameLength vs. chunkSize: frameLength is the maximum and hardcoded size in each
  * Netty buffer created by this server and handed off to a {@link Client}. If the
  * client has got a smaller frameLength than this server it will fail on reading a frame

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -52,7 +52,7 @@ import static org.neo4j.kernel.impl.api.TransactionApplicationMode.EXTERNAL;
  * {@link TransactionStream transaction streams} are {@link TransactionRepresentationStoreApplier applied to the
  * store},
  * in batches.
- * <p/>
+ * <p>
  * It is assumed that any {@link TransactionStreamResponse response carrying transaction data} comes from the one
  * and same thread.
  */

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -732,7 +732,7 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
 
     /**
      * At end of startup, wait for instance to become either master or slave.
-     * <p/>
+     * <p>
      * This helps users who expect to be able to access the instance after
      * the constructor is run.
      */

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
@@ -31,7 +31,7 @@ public enum HighAvailabilityMemberState
 {
     /**
      * This state is the initial state, and is also the state used when leaving the cluster.
-     * <p/>
+     * <p>
      * Here we are waiting for events that transitions this member either to becoming a master or slave.
      */
     PENDING

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterManager.java
@@ -917,7 +917,7 @@ public class ClusterManager
 
         /**
          * WARNING: beware of hacks.
-         * <p/>
+         * <p>
          * Fails a member of this cluster by making it not respond to heart beats.
          * A {@link RepairKit} is returned which is able to repair the instance
          * (i.e start the network) again.

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
@@ -52,7 +52,7 @@ import static org.neo4j.server.configuration.Configurator.NEO_SERVER_CONFIG_FILE
  * Wrapper around a {@link ClusterClient} to fit the environment of the Neo4j server,
  * mostly regarding the use of the server config file passed in from the script starting
  * this class. That server config file will be parsed and necessary parts passed on.
- * <p/>
+ * <p>
  * Configuration of the cluster client can be specified by
  * <ol>
  * <li>reading from a db tuning file (neo4j.properties) appointed by the neo4j server configuration file,

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ServerClassNameTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ServerClassNameTest.java
@@ -30,12 +30,12 @@ import static org.junit.Assert.assertEquals;
 /**
  * The classes that extend AbstractNeoServer are currently known to be:
  * CommunityNeoServer, AdvancedNeoServer, and EnterpriseNeoServer
- * <p/>
+ * <p>
  * This test asserts that those names won't change, for example during an
  * otherwise perfectly reasonable refactoring. Changing those names will cause
  * problems for the server which relies on those names to yield the correct
  * Neo4j edition (community, advanced, enterprise) to the Web UI and other clients.
- * <p/>
+ * <p>
  * Although this test asserts naming against classes in other modules (neo4j,
  * neo4j-advanced) it lives in neo4j-enterprise because otherwise the CommunityNeoServer
  * and AdvancedNeoServer would not be visible.

--- a/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
@@ -75,7 +75,7 @@ import static org.neo4j.ext.udc.UdcConstants.VERSION;
 
 /**
  * Unit testing for the UDC kernel extension.
- * <p/>
+ * <p>
  * The UdcExtensionImpl is loaded when a new
  * GraphDatabase is instantiated, as part of
  * {@link org.neo4j.helpers.Service#load}.


### PR DESCRIPTION
Java 8 treats certain problems with javadoc as errors, which were warnings prior to Java 8. A full build of Neo4j using Java 8 thus fails with a lot of javadoc errors. This PR fixes the javadoc of a bunch of modules (needed something to distract me).
Not sure when or if I'll pick this up again, so I'm putting this up to be merged. Shouldn't be a problem, since this can nicely be done iteratively.
There are some classes of errors remaining where an email is provided like "@author Name <email>", where the <> characters need to be escaped. I was wondering whether they're worth being fixed, can be dropped or should be replaced by the GH handle?
Overall, I only tended to errors, not warnings. There's a _"screw this, just ignore the errors"_-flag, but it's unknown to JDK7, so using it would make the build work _only_ on JDK8. The question I'm asking (myself, and now you guys) is what value lies in javadocs and how much effort should be put into this?
