### PR TITLE
Fix broken doc link

### DIFF
--- a/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/serialization.asciidoc
@@ -1,3 +1,4 @@
+[[ndp-serialization]]
 == Message Serialization
 === Overview
 


### PR DESCRIPTION
A silly tiny fix. A link in the NDP docs referred to this, but there was no anchor defined, so building the docs with link validation on fails, this fixes that.
