### PR TITLE
Errors in generated hash join code

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
@@ -32,15 +32,13 @@ import scala.collection.mutable
 
 case class Variable(name: String, cypherType: CypherType, nullable: Boolean = false)
 
-class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, Id]) {
+class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, Id], val namer: Namer = Namer()) {
 
   private val variables: mutable.Map[String, Variable] = mutable.Map()
   private val projections: mutable.Map[String, CodeGenExpression] = mutable.Map()
   private val probeTables: mutable.Map[CodeGenPlan, JoinData] = mutable.Map()
   private val parents: mutable.Stack[CodeGenPlan] = mutable.Stack()
   val operatorIds: mutable.Map[Id, String] = mutable.Map()
-
-  val namer = Namer()
 
   def addVariable(name: String, variable: Variable) {
     variables.put(name, variable)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/LogicalPlanConverter.scala
@@ -115,12 +115,12 @@ object LogicalPlanConverter {
       else if (child.logicalPlan eq logicalPlan.rhs.get) {
 
         val nodeId = context.getVariable(logicalPlan.nodes.head.name)
-        val thunk = context.getProbeTable(this)
-        thunk.vars foreach { case (name, symbol) => context.addVariable(name, symbol) }
+        val joinData = context.getProbeTable(this)
+        joinData.vars foreach { case (_, symbol) => context.addVariable(symbol.identifier, symbol.outgoing) }
 
         val (methodHandle, actions) = context.popParent().consume(context, this)
 
-        (methodHandle, GetMatchesFromProbeTable(nodeId, thunk, actions))
+        (methodHandle, GetMatchesFromProbeTable(nodeId, joinData, actions))
       }
       else {
         throw new InternalException(s"Unexpected consume call by $child")

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/Namer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/Namer.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.codegen
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class Namer(classNameCounter: AtomicInteger) {
+class Namer(classNameCounter: AtomicInteger, varPrefix: String = "v", methodPrefix: String = "m", operationPrefix: String = "OP") {
 
   private var methodNameCounter = 0
   private var varNameCounter = 0
@@ -29,17 +29,17 @@ class Namer(classNameCounter: AtomicInteger) {
 
   def newMethodName(): String = {
     methodNameCounter += 1
-    s"m$methodNameCounter"
+    s"$methodPrefix$methodNameCounter"
   }
 
   def newVarName(): String = {
     varNameCounter += 1
-    s"v$varNameCounter"
+    s"$varPrefix$varNameCounter"
   }
 
   def newOpName(planName: String): String = {
     opNameCounter += 1
-    s"OP${opNameCounter}_$planName"
+    s"$operationPrefix${opNameCounter}_$planName"
   }
 }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/GetMatchesFromProbeTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/GetMatchesFromProbeTable.scala
@@ -31,5 +31,8 @@ case class GetMatchesFromProbeTable(key: Variable, code: JoinData, action: Instr
       }
     }
 
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
+    action.init(generator)
+
   override def children = Seq(action)
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/Instruction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/Instruction.scala
@@ -48,5 +48,6 @@ object Instruction {
 
     override protected def children = Seq.empty
 
+    override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/TracingInstruction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/TracingInstruction.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.codegen.{CodeGenContext, MethodSt
 
 case class TracingInstruction(id: String, instruction: Instruction) extends Instruction {
 
-  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = super.init(generator)
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
     generator.trace(operatorId.get) { body =>


### PR DESCRIPTION
- `opIds` must be unique
- variable names for hash join must be unique
- `TracingInstruction` was shadowing `init`
- use generated names instead of identifiers for `ValueType` fields
