### PR TITLE
Transient errors cause transaction rollback.

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,3 +1,9 @@
+2.3.0-SNAPSHOT
+--------------
+o Status codes of the 'transient' classification now cause transactions to be rolled back. This resolves several
+  outstanding issues where deadlocks, network errors and other similar problems required clients to manually roll back
+  transactions. Only ClientError and ClientNotification classified status codes leave open transactions running.
+
 2.3.0-M01
 ---------
 o Object cache (i.e. node/relationship/property data cached as java objects in heap) has been removed.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -66,7 +66,7 @@ public interface Status
             return code;
         }
 
-        private Network( Classification classification, String description )
+        Network( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -86,7 +86,7 @@ public interface Status
             return code;
         }
 
-        private Request( Classification classification, String description )
+        Request( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -132,7 +132,7 @@ public interface Status
             return code;
         }
 
-        private Transaction( Classification classification, String description )
+        Transaction( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -172,7 +172,7 @@ public interface Status
             return code;
         }
 
-        private Statement( Classification classification, String description )
+        Statement( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -224,7 +224,7 @@ public interface Status
             return code;
         }
 
-        private Schema( Classification classification, String description )
+        Schema( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -244,7 +244,7 @@ public interface Status
             return code;
         }
 
-        private LegacyIndex( Classification classification, String description )
+        LegacyIndex( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -266,7 +266,7 @@ public interface Status
             return code;
         }
 
-        private Security( Classification classification, String description )
+        Security( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -293,7 +293,7 @@ public interface Status
             return code;
         }
 
-        private General( Classification classification, String description )
+        General( Classification classification, String description )
         {
             this.code = new Code( classification, this, description );
         }
@@ -413,7 +413,7 @@ public interface Status
         DatabaseError( TransactionEffect.ROLLBACK,
                 "The database failed to service the request. " ),
         /** The database cannot service the request right now, retrying later might yield a successful outcome. */
-        TransientError( TransactionEffect.NONE,
+        TransientError( TransactionEffect.ROLLBACK,
                 "The database cannot service the request right now, retrying later might yield a successful outcome. "),
         ;
 

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/SessionState.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/SessionState.java
@@ -22,7 +22,8 @@ package org.neo4j.ndp.runtime.internal;
 import org.neo4j.kernel.api.Statement;
 
 /**
- * Exposes the ability to manipulate the state of a running session in various ways.
+ * Exposes the ability to manipulate the state of a running session in various ways. This is the interface Tank
+ * uses to manipulate the session.
  */
 public interface SessionState
 {
@@ -47,6 +48,4 @@ public interface SessionState
     /** Rollback the current explicit transaction associated with this session. */
     void rollbackTransaction();
 
-    /** Get or create a new statement object, to execute operations against the database */
-    Statement statement();
 }

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/RecordingCallback.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/integration/RecordingCallback.java
@@ -40,7 +40,7 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
 
     public Call next() throws InterruptedException
     {
-        Call msg = calls.poll( 10, TimeUnit.SECONDS );
+        Call msg = calls.poll( 10000, TimeUnit.SECONDS );
         if ( msg == null )
         {
             throw new RuntimeException( "Waited 10 seconds for message, but no message arrived." );

--- a/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
+++ b/community/ndp/v1-docs/src/docs/dev/messaging.asciidoc
@@ -262,6 +262,12 @@ FailureMessage (signature=0x7F) {
 `FAILURE` messages contain metadata providing details regarding the primary failure that has occurred.
 This metadata is a simple map containing a code and a message. These codes map to the standard Neo4j status codes.
 
+When a `FAILURE` occurs, in most cases any open transaction will be rolled back.
+However, if the `FAILURE` is classified as a `client error`, the transaction will be left open and can be used again
+after the `FAILURE` has been acknowledged.
+This is mainly to support user-driven queries, where a database administrator may have built up a large transaction, and
+we do not want a simple spelling mistake to roll it all back.
+
 .Example
 [source,ndp_packstream_type]
 ----


### PR DESCRIPTION
- Mark transient errors as causing roll backs, this was a mistake in the original
  implementatiation.
- NDP now honors the transaction effects of neo4j status codes.
