### PR TITLE
Include generated source code in PlanDescription

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeGeneratorOption.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeGeneratorOption.java
@@ -22,4 +22,12 @@ package org.neo4j.codegen;
 public interface CodeGeneratorOption
 {
     void applyTo( Object target );
+
+    CodeGeneratorOption BLANK_OPTION = new CodeGeneratorOption()
+    {
+        @Override
+        public void applyTo( Object target )
+        {
+        }
+    };
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/InternalPlanDescription.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planDescription
 
-import org.neo4j.cypher.internal.compiler.v2_3.{ast, commands}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.{SeekArgs => PipeEntityByIdRhs}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments._
+import org.neo4j.cypher.internal.compiler.v2_3.{ast, commands}
 import org.neo4j.graphdb.Direction
 
 /**
@@ -104,6 +104,9 @@ object InternalPlanDescription {
       override def name = "runtime-impl"
     }
     case class ExpandExpression(from: String, relName: String, relTypes:Seq[String], to: String, direction: Direction, varLength: Boolean = false) extends Argument
+    case class SourceCode(className: String, sourceCode: String) extends Argument {
+      override def name = className
+    }
   }
 }
 
@@ -154,12 +157,19 @@ final case class PlanDescriptionImpl(id: Id,
 
   override def toString = {
     val NL = System.lineSeparator()
-    s"${renderAsTreeTable(this)}$NL${renderSummary(this)}"
+    s"${renderAsTreeTable(this)}$NL${renderSummary(this)}$renderSources"
   }
 
   def render( builder: StringBuilder, separator: String, levelSuffix: String ) { ??? }
 
   def render( builder: StringBuilder ) { ??? }
+
+  private def renderSources = {
+    arguments.flatMap {
+      case SourceCode(className, sourceCode) => Some(s"=== Compiled: $className ===\n$sourceCode")
+      case _ => None
+    }.mkString("\n","\n","")
+  }
 }
 
 final case class SingleRowPlanDescription(id: Id, arguments: Seq[Argument] = Seq.empty, identifiers: Set[String]) extends InternalPlanDescription {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -49,6 +49,7 @@ object PlanDescriptionArgumentSerializer {
       case Planner(planner) => planner
       case PlannerImpl(plannerName) => plannerName
       case Runtime(runtime) => runtime
+      case SourceCode(className, sourceCode) => sourceCode
       case RuntimeImpl(runtimeName) => runtimeName
       case ExpandExpression(from, rel, typeNames, to, dir: Direction, varLength) =>
         val left = if (dir == Direction.INCOMING) "<-" else "-"

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/renderAsTreeTable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/renderAsTreeTable.scala
@@ -132,6 +132,7 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
         !x.isInstanceOf[Planner] &&
         !x.isInstanceOf[PlannerImpl] &&
         !x.isInstanceOf[Runtime] &&
+        !x.isInstanceOf[SourceCode] &&
         !x.isInstanceOf[Time] &&
         !x.isInstanceOf[RuntimeImpl] &&
         !x.isInstanceOf[Version] => PlanDescriptionArgumentSerializer.serialize(x)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGeneratorTest.scala
@@ -80,6 +80,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Map("a" -> bNode),
       Map("a" -> cNode)
     ))
+    println(compiled.executionPlanDescription())
   }
 
   test("hash join of all nodes scans") { // MATCH a RETURN a

--- a/community/kernel/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
@@ -57,7 +57,7 @@ public interface ExecutionPlanDescription
     /**
      * @return the set of identifiers used in this execution step
      */
-    public Set<String> getIdentifiers();
+    Set<String> getIdentifiers();
 
     /**
      * Signifies that the query was profiled, and that statistics from the profiling can


### PR DESCRIPTION
Normally a PlanDescription would not include the source code, but for debugging purposes, viewing the source code generated by the query compiler can be incredibly helpful. For these purposes the system property `org.neo4j.cypher.codegen.IncludeSourcesInPlanDescription` is introduced. When this property is set to `true`, PlanDescriptions will include SourceCode argument objects, one for each class generated by the query compiler. These SourceCode objects are automatically included in the string representation of the PlanDescription.
