### PR TITLE
Add an (initially undocumented) toggle to disable webadmin and rrd4j.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -110,7 +110,7 @@ public class CommunityNeoServer extends AbstractNeoServer
                 new RESTApiModule( webServer, database, configurator.configuration(), logging ),
                 new ManagementApiModule( webServer, configurator.configuration() ),
                 new ThirdPartyJAXRSModule( webServer, configurator.configuration(), logging, this ),
-                new WebAdminModule( webServer ),
+                new WebAdminModule( webServer, configurator.configuration() ),
                 new Neo4jBrowserModule( webServer ),
                 new AuthorizationModule( webServer, authManager, configurator.configuration(), logging ),
                 new SecurityRulesModule( webServer, configurator.configuration(), logging ) );

--- a/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
@@ -23,13 +23,11 @@ import java.net.URI;
 import java.util.List;
 
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.server.web.ServerInternalSettings;
-import org.neo4j.server.web.WebServer;
 import org.neo4j.server.rest.management.JmxService;
-import org.neo4j.server.rest.management.MonitorService;
 import org.neo4j.server.rest.management.RootService;
 import org.neo4j.server.rest.management.VersionAndEditionService;
-import org.neo4j.server.rest.management.console.ConsoleService;
+import org.neo4j.server.web.ServerInternalSettings;
+import org.neo4j.server.web.WebServer;
 
 import static org.neo4j.server.JAXRSHelper.listFrom;
 
@@ -55,9 +53,7 @@ public class ManagementApiModule implements ServerModule
     {
         return listFrom(
                 JmxService.class.getName(),
-                MonitorService.class.getName(),
                 RootService.class.getName(),
-                ConsoleService.class.getName(),
                 VersionAndEditionService.class.getName() );
     }
 

--- a/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
@@ -84,4 +84,6 @@ public class ServerInternalSettings
             PATH, File.separator + "etc" + File.separator + "neo" + File.separator + ServerInternalSettings.DB_TUNING_CONFIG_FILE_NAME );
 
     public static final Setting<String> legacy_db_mode = setting( "org.neo4j.server.database.mode", STRING, "SINGLE" );
+
+    public static final Setting<Boolean> webadmin_enabled = setting( "dbms.webadmin.enabled", BOOLEAN, TRUE );
 }


### PR DESCRIPTION
- This allows running Neo4j on certain VMs that don't support memory mapping,
  since RRD4j has hard-coded requirements for memory mapping.
- Also acts as a dry-run for removing webadmin.
