### PR TITLE
2.2 - legacy index modification constraint and some logging additions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -511,7 +511,10 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                     kernelModule );
         }
         catch ( Throwable e )
-        { // Something unexpected happened during startup
+        {
+            // Something unexpected happened during startup
+            msgLog.logMessage( "Exception occurred while setting up store modules. Attempting to close things down.",
+                    e, true);
             try
             { // Close the neostore, so that locks are released properly
                 neoStoreModule.neoStore().close();
@@ -528,8 +531,10 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
             life.start();
         }
         catch ( Throwable e )
-        { // Something unexpected happened during startup
-
+        {
+            // Something unexpected happened during startup
+            msgLog.logMessage( "Exception occurred while starting the datasource. Attempting to close things down.",
+                    e, true);
             try
             { // Close the neostore, so that locks are released properly
                 neoStoreModule.neoStore().close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
@@ -110,19 +110,19 @@ public class IndexDefineCommand extends Command
         Byte id = stringToId.get( string );
         if ( id != null )
         {
-            return id.byteValue();
+            return id;
         }
 
         int nextIdInt = nextId.incrementAndGet();
-        id = (byte) nextIdInt;
-        if ( nextIdInt != id )
+        if ( nextIdInt > 63 )
         {
-            throw new IllegalArgumentException( "Too many names " + nextIdInt );
+            throw new IllegalStateException( "Modifying more than 63 indexes in a single transaction is not supported" );
         }
+        id = (byte) nextIdInt;
 
         stringToId.put( string, id );
         idToString.put( id, string );
-        return id.byteValue();
+        return id;
     }
 
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexDefineCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/IndexDefineCommandTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class IndexDefineCommandTest
+{
+    @Test
+    public void testIndexCommandCreationEnforcesLimit() throws Exception
+    {
+        // Given
+        IndexDefineCommand idc = new IndexDefineCommand();
+
+        // When
+        // 63 keys are used, it should be fine
+        for ( int i = 0; i < 63; i++ )
+        {
+            idc.getOrAssignKeyId( "index" + i );
+        }
+
+        // Then
+        // it should break on the 64th
+        try
+        {
+            idc.getOrAssignKeyId( "index63" );
+            fail("IndexDefineCommand should not allow more than 63 indexes per transaction");
+        }
+        catch( IllegalStateException e )
+        {
+            // wonderful
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogNeoCommandReaderV2Test.java
@@ -66,4 +66,46 @@ public class PhysicalLogNeoCommandReaderV2Test
         assertEquals( startNode, readCommand.getStartNode() );
         assertEquals( endNode, readCommand.getEndNode() );
     }
+
+    @Test
+    public void shouldProperlyMaskIndexIdFieldInIndexHeader() throws Exception
+    {
+        /* This is how the index command header is laid out
+         * [x   ,    ] start node needs long
+         * [ x  ,    ] end node needs long
+         * [  xx,xxxx] index name id
+         * This means that the index name id can be in the range of 0 to 63. This test verifies that
+         * this constraint is actually respected
+         */
+
+        // GIVEN
+        PhysicalLogNeoCommandReaderV2 reader = new PhysicalLogNeoCommandReaderV2();
+        InMemoryLogChannel data = new InMemoryLogChannel();
+        CommandWriter writer = new CommandWriter( data );
+        // Here we take advantage of the fact that all index commands have the same header written out
+        AddRelationshipCommand command = new AddRelationshipCommand();
+        long entityId = 123;
+        byte keyId = (byte)1;
+        Object value = "test value";
+        long startNode = 14;
+        long endNode = 15;
+
+        for ( byte indexByteId = 0; indexByteId < 63; indexByteId++ )
+        {
+            // WHEN
+            command.init( indexByteId, entityId, keyId, value, startNode, endNode );
+            writer.visitIndexAddRelationshipCommand( command );
+
+            // THEN
+            AddRelationshipCommand readCommand = (AddRelationshipCommand) reader.read( data );
+            assertEquals( indexByteId, readCommand.getIndexNameId() );
+            assertEquals( entityId, readCommand.getEntityId() );
+            assertEquals( keyId, readCommand.getKeyId() );
+            assertEquals( value, readCommand.getValue() );
+            assertEquals( startNode, readCommand.getStartNode() );
+            assertEquals( endNode, readCommand.getEndNode() );
+
+            data.reset();
+        }
+    }
 }

--- a/community/neo4j/src/test/java/org/neo4j/index/TestSingleTransactionLegacyIndexConstraints.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/TestSingleTransactionLegacyIndexConstraints.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+public class TestSingleTransactionLegacyIndexConstraints
+{
+    @Test
+    public void alteringMoreThan63IndexesInASingleTransactionShouldLeadToIllegalStateException() throws Exception
+    {
+        // Given
+        // A database with at least 64 indexes
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 64; i++ )
+            {
+                db.index().forNodes( "foo" + i );
+            }
+            tx.success();
+        }
+
+        // When
+        // We try to alter 64 of them in a single tx
+        try( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 63; i++ )
+            {
+                db.index().forNodes( "foo" + i ).add( db.createNode(), "aKey", "aValue" );
+            }
+
+            // Then
+            // it should lead to an IllegalStateException
+            try
+            {
+                db.index().forNodes( "foo" + 63 ).add( db.createNode(), "aKey", "aValue" );
+                fail( "Altering more than 63 legacy indexes in a single tx should not be allowed" );
+            }
+            catch( IllegalStateException e )
+            {
+                // fantastic
+            }
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
This adds enforcing of 63 or less legacy index alterations in the same transaction. It also adds some logging in the NSDS startup cycle.
