### PR TITLE
Notify listener on log rotation failure

### DIFF
--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -154,15 +154,22 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
         synchronized (outRef)
         {
             closed.set( true );
-            outRef.get().close();
             for ( WeakReference<OutputStream> archivedStream : archivedStreams )
             {
                 OutputStream outputStream = archivedStream.get();
                 if ( outputStream != null )
                 {
-                    outputStream.close();
+                    try
+                    {
+                        outputStream.close();
+                    }
+                    catch ( Exception e )
+                    {
+                        // ignore
+                    }
                 }
             }
+            outRef.get().close();
         }
     }
 


### PR DESCRIPTION
Rather than directly executing. Also adds a test for the behaviour.
