### PR TITLE
Further StoreLogService creation simplification. Remove factory methods that return Builder from StoreLogService

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -208,7 +208,8 @@ public class PlatformModule
         int internalLogMaxArchives = config.get( GraphDatabaseSettings.store_internal_log_max_archives );
 
         final StoreLogService.Builder builder =
-                StoreLogService.withRotation( internalLogRotationThreshold, internalLogRotationDelay, internalLogMaxArchives, jobScheduler );
+                StoreLogService.withRotation( internalLogRotationThreshold, internalLogRotationDelay,
+                        internalLogMaxArchives, jobScheduler );
 
         if ( userLogProvider != null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -50,6 +50,10 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
         private int maxInternalLogArchives = 0;
         private Consumer<LogProvider> rotationListener = Consumers.noop();
 
+        private Builder()
+        {
+        }
+
         public Builder withUserLogProvider( LogProvider userLogProvider )
         {
             this.userLogProvider = userLogProvider;

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLog.java
@@ -79,6 +79,10 @@ public class FormattedLog extends AbstractLog
         private Level level = Level.INFO;
         private boolean autoFlush = true;
 
+        private Builder()
+        {
+        }
+
         /**
          * Set the timezone for datestamps in the log
          *

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
@@ -50,6 +50,10 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
         private Level level = Level.INFO;
         private boolean autoFlush = true;
 
+        private Builder()
+        {
+        }
+
         /**
          * Disable rendering of the context (or class name) in each output line.
          *

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/util/Configuration.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/util/Configuration.java
@@ -103,12 +103,13 @@ public abstract class Configuration
 
     public static final class Builder
     {
-        public Configuration build()
-        {
-            return fromMap( new HashMap<String, String>( config ) );
-        }
 
         private final Map<String, String> config;
+
+        public Configuration build()
+        {
+            return fromMap( new HashMap<>( config ) );
+        }
 
         private Builder( HashMap<String, String> config )
         {


### PR DESCRIPTION
Switch to StoreLogService builder creation in cases where factory methods from StoreLogService with builder as result where used before.
