### PR TITLE
Fixed packaging of commons-lang3

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -111,6 +111,7 @@
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -135,6 +136,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
  </dependencySets>

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
@@ -91,6 +91,7 @@
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -113,6 +114,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -98,6 +98,7 @@
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -121,6 +122,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
  </dependencySets>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -90,6 +90,7 @@
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -111,6 +112,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -107,6 +107,7 @@
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -133,6 +134,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
  </dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -87,6 +87,7 @@
         <include>org.scala-lang:scala-library</include>
         <include>org.parboiled:*</include>
         <include>net.sf.opencsv:opencsv</include>
+        <include>org.apache.commons:commons-lang3</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -111,6 +112,7 @@
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
+        <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
This PR includes commons-lang3 in `./lib` directory because it is needed for compiled runtime.
