### PR TITLE
Use GraphDatabaseSettings.log_queries_filename as a file not as a directory

### DIFF
--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -24,6 +24,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -32,11 +38,6 @@ import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -74,7 +75,7 @@ public class QueryLoggerIT
 
         db.shutdown();
 
-        File logfile = new File( "target/test-data/impermanent-db/queries.log/messages.log" );
+        File logfile = new File( "target/test-data/impermanent-db/queries.log" );
         List<String> logLines = new ArrayList<>();
         try ( BufferedReader reader = new BufferedReader( fs.get().openAsReader( logfile, "UTF-8" ) ) )
         {


### PR DESCRIPTION
Problem was query logging was using `query.log/messages.log` as file
for logging slow queries instead of `query.log`.
