### PR TITLE
Do not accept plans with joins on multiple nodes.

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/LogicalPlanConverter.scala
@@ -122,6 +122,9 @@ object LogicalPlanConverter {
 
   private implicit class NodeHashJoinCodeGen(val logicalPlan: NodeHashJoin) extends CodeGenPlan {
 
+    if (logicalPlan.nodes.size > 1)
+      throw new CantCompileQueryException("Joining on multiple nodes is not yet supported in compiled runtim")
+
     override def produce(context: CodeGenContext): (Option[JoinTableMethod], Seq[Instruction]) = {
       context.pushParent(this)
       val (Some(symbol), leftInstructions) = logicalPlan.lhs.get.asCodeGenPlan.produce(context)


### PR DESCRIPTION
The compiled runtime was accepting plans with joins on multiple nodes without
that feature being implemented yet leading to incorrect results. We should throw
a `CantCompileQueryException` until the feature is properly supported.
