### PR TITLE
Change cartesian product notification input position

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
@@ -25,7 +25,10 @@ class SemanticChecker {
   def check(queryText: String, statement: Statement, notificationLogger: InternalNotificationLogger = devNullLogger,
             mkException: (String, InputPosition) => CypherException): SemanticState = {
 
-    val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean.withNotificationLogger(notificationLogger))
+    val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean)
+
+    // TODO: Actually replace this mutable-state logger with an immutable structure
+    semanticState.notifications.foreach(notificationLogger += _)
 
     val scopeTreeIssues = ScopeTreeVerifier.verify(semanticState.scopeTree)
     if (scopeTreeIssues.nonEmpty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticState.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticState.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3
 
 import org.neo4j.cypher.internal.compiler.v2_3.ast.{ASTAnnotationMap, Identifier}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{TreeElem, TreeZipper}
+import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
 import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 
 import scala.collection.immutable.HashMap
@@ -186,7 +187,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.SemanticState.ScopeLocation
 case class SemanticState(currentScope: ScopeLocation,
                          typeTable: ASTAnnotationMap[ast.Expression, ExpressionTypeInfo],
                          recordedScopes: ASTAnnotationMap[ast.ASTNode, Scope],
-                         notificationLogger: InternalNotificationLogger = devNullLogger) {
+                         notifications: Set[InternalNotification] = Set.empty) {
   def scopeTree = currentScope.rootScope
 
   def newChildScope = copy(currentScope = currentScope.newChildScope)
@@ -210,7 +211,7 @@ case class SemanticState(currentScope: ScopeLocation,
         Left(SemanticError(s"${identifier.name} already declared", identifier.position, symbol.positions.toSeq: _*))
     }
 
-  def withNotificationLogger(notificationLogger: InternalNotificationLogger) = copy(notificationLogger = notificationLogger)
+  def addNotification(notification: InternalNotification) = copy(notifications = notifications + notification)
 
   def implicitIdentifier(identifier: ast.Identifier, possibleTypes: TypeSpec): Either[SemanticError, SemanticState] =
     this.symbol(identifier.name) match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/notification/InternalNotification.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.InputPosition
  */
 sealed trait InternalNotification
 
-case class CartesianProductNotification(position: InputPosition) extends InternalNotification
+case class CartesianProductNotification(position: InputPosition, isolatedIdentifiers: Set[String]) extends InternalNotification
 
 case class LengthOnNonPathNotification(position: InputPosition) extends InternalNotification
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -24,8 +24,8 @@ import org.mockito.Mockito.{verify, _}
 import org.neo4j.cypher.internal.compatibility.{StringInfoLogger2_3, WrappedMonitors2_3}
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.notification.CartesianProductNotification
-import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.helpers.Clock
 import org.neo4j.logging.NullLog
 
@@ -35,13 +35,14 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
     //given
     val logger = mock[InternalNotificationLogger]
     val compiler = createCompiler()
-    val executionMode = NormalMode
 
     //when
-    graph.inTx(compiler.planQuery("MATCH (a)-->(b), (c)-->(d) RETURN *", planContext, logger))
+    graph.inTx {
+      compiler.planQuery("MATCH (a)-->(b), (c)-->(d) RETURN *", planContext, logger)
+    }
 
     //then
-    verify(logger, times(1)) += CartesianProductNotification(InputPosition( 7, 1, 8 ))
+    verify(logger, times(1)) += CartesianProductNotification(InputPosition(0, 1, 1), Set("c", "d"))
   }
 
   test("should not warn when connected patterns") {
@@ -60,13 +61,14 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
     //given
     val logger = mock[InternalNotificationLogger]
     val compiler = createCompiler()
-    val executionMode = NormalMode
 
     //when
-    graph.inTx(compiler.planQuery("MATCH (a)-->(b), (b)-->(c), (x)-->(y), (c)-->(d), (d)-->(e) RETURN *", planContext, logger))
+    graph.inTx {
+      compiler.planQuery("MATCH (a)-->(b), (b)-->(c), (x)-->(y), (c)-->(d), (d)-->(e) RETURN *", planContext, logger)
+    }
 
     //then
-    verify(logger, times(1)) += CartesianProductNotification(InputPosition(29, 1, 30))
+    verify(logger, times(1)) += CartesianProductNotification(InputPosition(0, 1, 1), Set("x", "y"))
   }
 
   test("should not warn when disconnected patterns in multiple match clauses") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -27,19 +27,20 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   test("Warn for cartesian product") {
     val result = executeWithAllPlanners("explain match (a)-->(b), (c)-->(d) return *")
 
-    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(7, 1, 8))))
+    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(0, 1, 1), Set("c", "d"))))
   }
 
   test("Warn for cartesian product with runtime=compiled") {
     val result = innerExecute("explain cypher runtime=compiled match (a)-->(b), (c)-->(d) return *")
 
-    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(7, 1, 8)), RuntimeUnsupportedNotification))
+    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(0, 1, 1), Set("c", "d")),
+                                                  RuntimeUnsupportedNotification))
   }
 
   test("Warn for cartesian product with runtime=interpreted") {
     val result = executeWithAllPlanners("explain cypher runtime=interpreted match (a)-->(b), (c)-->(d) return *")
 
-    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(7, 1, 8))))
+    result.notifications.toList should equal(List(CartesianProductNotification(InputPosition(0, 1, 1), Set("c", "d"))))
   }
 
   test("Don't warn for cartesian product when not using explain") {

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.graphdb.impl.notification;
 
+import java.util.Set;
+
 public interface NotificationDetail
 {
     String name();
@@ -27,12 +29,30 @@ public interface NotificationDetail
 
     public final static class Factory
     {
-        public static NotificationDetail index( final String name, final String labelName, final String propertyKeyName )
+        public static NotificationDetail index( final String labelName, final String propertyKeyName )
         {
-            return createNotificationDetail( name, String.format( "index on :%s(%s)", labelName, propertyKeyName ) );
+            return createNotificationDetail( "hinted index",
+                    String.format( "index on :%s(%s)", labelName, propertyKeyName ), true );
         }
 
-        private static NotificationDetail createNotificationDetail( final String name, final String value )
+        public static NotificationDetail cartesianProduct( Set<String> identifiers )
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.append( "(" );
+            String separator = "";
+            for ( String identifier : identifiers )
+            {
+                builder.append( separator );
+                builder.append( identifier );
+                separator = ", ";
+            }
+            builder.append( ")" );
+            boolean singular = identifiers.size() == 1;
+            return createNotificationDetail( singular ? "identifier" : "identifiers", builder.toString(), singular );
+        }
+
+        private static NotificationDetail createNotificationDetail( final String name, final String value,
+                final boolean singular )
         {
             return new NotificationDetail()
             {
@@ -51,7 +71,7 @@ public interface NotificationDetail
                 @Override
                 public String toString()
                 {
-                    return String.format( "%s is %s", name, value );
+                    return String.format( "%s %s %s", name, singular ? "is" : "are:", value );
                 }
             };
         }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationDetailTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/impl/notification/NotificationDetailTest.java
@@ -21,6 +21,9 @@ package org.neo4j.graphdb.impl.notification;
 
 import org.junit.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -29,10 +32,35 @@ public class NotificationDetailTest
     @Test
     public void shouldConstructIndexDetails()
     {
-        NotificationDetail detail = NotificationDetail.Factory.index( "hinted index", "Person", "name" );
+        NotificationDetail detail = NotificationDetail.Factory.index( "Person", "name" );
 
         assertThat( detail.name(), equalTo( "hinted index" ) );
         assertThat( detail.value(), equalTo( "index on :Person(name)" ) );
         assertThat( detail.toString(), equalTo( "hinted index is index on :Person(name)" ) );
+    }
+
+    @Test
+    public void shouldConstructCartesianProductDetailsSingular()
+    {
+        Set<String> idents = new HashSet<>();
+        idents.add( "n" );
+        NotificationDetail detail = NotificationDetail.Factory.cartesianProduct( idents );
+
+        assertThat( detail.name(), equalTo( "identifier" ) );
+        assertThat( detail.value(), equalTo( "(n)" ) );
+        assertThat( detail.toString(), equalTo( "identifier is (n)" ) );
+    }
+
+    @Test
+    public void shouldConstructCartesianProductDetails()
+    {
+        Set<String> idents = new HashSet<>();
+        idents.add( "n" );
+        idents.add( "node2" );
+        NotificationDetail detail = NotificationDetail.Factory.cartesianProduct( idents );
+
+        assertThat( detail.name(), equalTo( "identifiers" ) );
+        assertThat( detail.value(), equalTo( "(n, node2)" ) );
+        assertThat( detail.toString(), equalTo( "identifiers are: (n, node2)" ) );
     }
 }


### PR DESCRIPTION
A cartesian product notification will now use the input position of its
wrapping clause (eg, a MATCH) as well as point to the identifiers that are involved
in causing the cartesian product to happen in its description.
