### PR TITLE
Makes available relationship entity data in tx handler afterCommit

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/TransactionEventHandlers.java
@@ -125,7 +125,7 @@ public class TransactionEventHandlers
         }
 
         TransactionData txData = state == null ? EMPTY_DATA :
-                new TxStateTransactionDataSnapshot( state, nodeActions, storeReadLayer );
+                new TxStateTransactionDataSnapshot( state, nodeActions, relationshipActions, storeReadLayer );
 
         TransactionHandlerState handlerStates = new TransactionHandlerState( txData );
         for ( TransactionEventHandler<?> handler : this.transactionEventHandlers )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipDataExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RelationshipDataExtractor.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
-class RelationshipDataExtractor implements RelationshipVisitor<RuntimeException>
+public class RelationshipDataExtractor implements RelationshipVisitor<RuntimeException>
 {
     private int type;
     private long startNode;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
-import org.neo4j.function.Function;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -33,17 +32,20 @@ import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.ThisShouldNotHappenError;
-import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.txstate.ReadableTxState;
+import org.neo4j.kernel.impl.api.RelationshipDataExtractor;
 import org.neo4j.kernel.impl.api.state.NodeState;
 import org.neo4j.kernel.impl.api.state.RelationshipState;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
 import org.neo4j.kernel.impl.util.diffsets.ReadableDiffSets;
 
 /**
@@ -53,6 +55,8 @@ public class TxStateTransactionDataSnapshot implements TransactionData
 {
     private final ReadableTxState state;
     private final NodeProxy.NodeActions nodeActions;
+    private final RelationshipActions relationshipActions;
+    private final RelationshipDataExtractor relationshipData = new RelationshipDataExtractor();
 
     private final Collection<PropertyEntry<Node>> assignedNodeProperties = new ArrayList<>();
     private final Collection<PropertyEntry<Relationship>> assignedRelationshipProperties = new ArrayList<>();
@@ -62,13 +66,16 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     private final Collection<PropertyEntry<Relationship>> removedRelationshipProperties = new ArrayList<>();
     private final Collection<LabelEntry> removedLabels = new ArrayList<>();
 
-    public TxStateTransactionDataSnapshot(
-            ReadableTxState state, NodeProxy.NodeActions nodeActions, StoreReadLayer storeReadLayer )
+    public TxStateTransactionDataSnapshot( ReadableTxState state,
+            NodeProxy.NodeActions nodeActions, RelationshipProxy.RelationshipActions relationshipActions,
+            StoreReadLayer storeReadLayer )
     {
         this.state = state;
         this.nodeActions = nodeActions;
+        this.relationshipActions = relationshipActions;
 
-        // Load all changes eagerly, because we won't have access to the after state after the tx has been committed.
+        // Load changes that require store access eagerly, because we won't have access to the after-state
+        // after the tx has been committed.
         takeSnapshot( state, storeReadLayer );
     }
 
@@ -167,11 +174,12 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             }
             for ( Long relId : state.addedAndRemovedRelationships().getRemoved() )
             {
+                Relationship relationship = relationship( relId );
                 Iterator<DefinedProperty> props = storeReadLayer.relationshipGetAllProperties( relId );
-                while(props.hasNext())
+                while ( props.hasNext() )
                 {
                     DefinedProperty prop = props.next();
-                    removedRelationshipProperties.add( new RelationshipPropertyEntryView( relId,
+                    removedRelationshipProperties.add( new RelationshipPropertyEntryView( relationship,
                             storeReadLayer.propertyKeyGetName( prop.propertyKeyId() ), null, prop.value() ) );
                 }
             }
@@ -205,11 +213,12 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             }
             for ( RelationshipState relState : state.modifiedRelationships() )
             {
+                Relationship relationship = relationship( relState.getId() );
                 Iterator<DefinedProperty> added = relState.addedAndChangedProperties();
                 while ( added.hasNext()  )
                 {
                     DefinedProperty property = added.next();
-                    assignedRelationshipProperties.add( new RelationshipPropertyEntryView( relState.getId(),
+                    assignedRelationshipProperties.add( new RelationshipPropertyEntryView( relationship,
                             storeReadLayer.propertyKeyGetName( property.propertyKeyId() ), property.value(),
                             committedValue( storeReadLayer, relState, property.propertyKeyId() ) ) );
                 }
@@ -217,7 +226,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
                 while ( removed.hasNext()  )
                 {
                     Integer property = removed.next();
-                    removedRelationshipProperties.add( new RelationshipPropertyEntryView( relState.getId(),
+                    removedRelationshipProperties.add( new RelationshipPropertyEntryView( relationship,
                             storeReadLayer.propertyKeyGetName( property ), null,
                             committedValue( storeReadLayer, relState, property ) ) );
                 }
@@ -229,26 +238,35 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         }
     }
 
+    private Relationship relationship( long relId )
+    {
+        state.relationshipVisit( relId, relationshipData );
+        return new RelationshipProxy( relationshipActions, relId,
+                relationshipData.startNode(), relationshipData.type(), relationshipData.endNode() );
+    }
+
     private Iterable<Node> map2Nodes( Iterable<Long> added )
     {
-        return Iterables.map(new Function<Long, Node>(){
+        return new IterableWrapper<Node,Long>( added )
+        {
             @Override
-            public Node apply( Long id )
+            protected Node underlyingObjectToObject( Long id )
             {
                 return new NodeProxy( nodeActions, id );
             }
-        }, added);
+        };
     }
 
-    private Iterable<Relationship> map2Rels( Iterable<Long> added )
+    private Iterable<Relationship> map2Rels( Iterable<Long> ids )
     {
-        return Iterables.map(new Function<Long, Relationship>(){
+        return new IterableWrapper<Relationship,Long>( ids )
+        {
             @Override
-            public Relationship apply( Long id )
+            protected Relationship underlyingObjectToObject( Long id )
             {
-                return nodeActions.lazyRelationshipProxy( id );
+                return relationship( id );
             }
-        }, added);
+        };
     }
 
     private Object committedValue( StoreReadLayer storeReadLayer, NodeState nodeState, int property )
@@ -339,14 +357,15 @@ public class TxStateTransactionDataSnapshot implements TransactionData
 
     private class RelationshipPropertyEntryView implements PropertyEntry<Relationship>
     {
-        private final long relId;
+        private final Relationship relationship;
         private final String key;
         private final Object newValue;
         private final Object oldValue;
 
-        public RelationshipPropertyEntryView( long relId, String key, Object newValue, Object oldValue )
+        public RelationshipPropertyEntryView( Relationship relationship,
+                String key, Object newValue, Object oldValue )
         {
-            this.relId = relId;
+            this.relationship = relationship;
             this.key = key;
             this.newValue = newValue;
             this.oldValue = oldValue;
@@ -355,7 +374,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         @Override
         public Relationship entity()
         {
-            return nodeActions.lazyRelationshipProxy( relId );
+            return relationship;
         }
 
         @Override
@@ -384,7 +403,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         public String toString()
         {
             return "RelationshipPropertyEntryView{" +
-                    "relId=" + relId +
+                    "relId=" + relationship.getId() +
                     ", key='" + key + '\'' +
                     ", newValue=" + newValue +
                     ", oldValue=" + oldValue +

--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/LogbackService.java
@@ -19,24 +19,23 @@
  */
 package org.neo4j.kernel.logging;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
 import java.io.File;
 import java.net.URL;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Visitor;
-import org.neo4j.kernel.InternalAbstractGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.RestartOnChange;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.Monitors;
-
-import org.slf4j.Logger;
-import org.slf4j.Marker;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.core.joran.spi.JoranException;
 
 /**
  * Logging service that uses Logback as backend.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.impl.coreapi;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.graphdb.Node;
@@ -45,13 +45,13 @@ import org.neo4j.kernel.impl.core.NodeProxy;
 import org.neo4j.kernel.impl.core.RelationshipProxy;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 
-import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
 
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
@@ -291,6 +291,6 @@ public class TxStateTransactionDataViewTest
                 return new RelationshipProxy( relActions, (Long)invocation.getArguments()[0] );
             }
         } );
-        return new TxStateTransactionDataSnapshot( state, nodeActions, ops );
+        return new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops );
     }
 }


### PR DESCRIPTION
by collecting that information when making the tx data snapshot.
Relationship entity data means: type, start node and end node
