### PR TITLE
Stop sampling of indexes during database shutdown

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -315,6 +315,7 @@ public class IndexingService extends LifecycleAdapter
     public void stop()
     {
         state = State.STOPPED;
+        samplingController.stop();
         closeAllIndexes();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
@@ -19,19 +19,27 @@
  */
 package org.neo4j.kernel.impl.api.index.sampling;
 
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Test;
 
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.test.DoubleLatch;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -148,6 +156,189 @@ public class IndexSamplingJobTrackerTest
         while( ! jobTracker.canExecuteMoreSamplingJobs() )
         {
             Thread.yield();
+        }
+    }
+
+    @Test( timeout = 5_000 )
+    public void shouldAcceptNewJobWhenRunningJobFinishes() throws Throwable
+    {
+        // Given
+        when( config.jobLimit() ).thenReturn( 1 );
+
+        JobScheduler jobScheduler = new Neo4jJobScheduler();
+        jobScheduler.init();
+
+        final IndexSamplingJobTracker jobTracker = new IndexSamplingJobTracker( config, jobScheduler );
+
+        final DoubleLatch latch = new DoubleLatch();
+        final AtomicBoolean lastJobExecuted = new AtomicBoolean();
+
+        jobTracker.scheduleSamplingJob( new IndexSamplingJob()
+        {
+            @Override
+            public IndexDescriptor descriptor()
+            {
+                return new IndexDescriptor( 1, 1 );
+            }
+
+            @Override
+            public void run()
+            {
+                latch.awaitStart();
+            }
+        } );
+
+        // When
+        Executors.newSingleThreadExecutor().execute( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                jobTracker.waitUntilCanExecuteMoreSamplingJobs();
+                jobTracker.scheduleSamplingJob( new IndexSamplingJob()
+                {
+                    @Override
+                    public IndexDescriptor descriptor()
+                    {
+                        return new IndexDescriptor( 2, 2 );
+                    }
+
+                    @Override
+                    public void run()
+                    {
+                        lastJobExecuted.set( true );
+                        latch.finish();
+                    }
+                } );
+            }
+        } );
+
+        assertFalse( jobTracker.canExecuteMoreSamplingJobs() );
+        latch.start();
+        latch.awaitFinish();
+
+        // Then
+        assertTrue( lastJobExecuted.get() );
+    }
+
+    @Test( timeout = 5_000 )
+    public void shouldThrowWhenUsedAfterBeingStopped()
+    {
+        // Given
+        IndexSamplingJobTracker jobTracker = new IndexSamplingJobTracker( config, mock( JobScheduler.class ) );
+
+        // When
+        jobTracker.stopAndAwaitAllJobs();
+
+        // Then
+        try
+        {
+            jobTracker.scheduleSamplingJob( mock( IndexSamplingJob.class ) );
+            fail( "Exception expected: " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            assertThat( e.getMessage(), containsString( "stopped" ) );
+        }
+
+        try
+        {
+            jobTracker.waitUntilCanExecuteMoreSamplingJobs();
+            fail( "Exception expected: " + IllegalStateException.class.getSimpleName() );
+        }
+        catch ( IllegalStateException e )
+        {
+            assertThat( e.getMessage(), containsString( "stopped" ) );
+        }
+    }
+
+    @Test( timeout = 5_000 )
+    public void shouldNotAllowNewJobsAfterBeingStopped()
+    {
+        // Given
+        IndexSamplingJobTracker jobTracker = new IndexSamplingJobTracker( config, mock( JobScheduler.class ) );
+
+        // When
+        jobTracker.stopAndAwaitAllJobs();
+
+        // Then
+        assertFalse( jobTracker.canExecuteMoreSamplingJobs() );
+    }
+
+    @Test( timeout = 5_000 )
+    public void shouldStopAndWaitForAllJobsToFinish() throws Throwable
+    {
+        // Given
+        when( config.jobLimit() ).thenReturn( 2 );
+
+        JobScheduler jobScheduler = new Neo4jJobScheduler();
+        jobScheduler.init();
+
+        final IndexSamplingJobTracker jobTracker = new IndexSamplingJobTracker( config, jobScheduler );
+        final CountDownLatch latch1 = new CountDownLatch( 1 );
+        final CountDownLatch latch2 = new CountDownLatch( 1 );
+
+        WaitingIndexSamplingJob job1 = new WaitingIndexSamplingJob( new IndexDescriptor( 1, 1 ), latch1 );
+        WaitingIndexSamplingJob job2 = new WaitingIndexSamplingJob( new IndexDescriptor( 2, 2 ), latch1 );
+
+        jobTracker.scheduleSamplingJob( job1 );
+        jobTracker.scheduleSamplingJob( job2 );
+
+        Future<?> stopping = Executors.newSingleThreadExecutor().submit( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                latch2.countDown();
+                jobTracker.stopAndAwaitAllJobs();
+            }
+        } );
+
+        // When
+        latch2.await();
+        assertFalse( stopping.isDone() );
+        latch1.countDown();
+        stopping.get( 10, SECONDS );
+
+        // Then
+        assertTrue( stopping.isDone() );
+        assertNull( stopping.get() );
+        assertTrue( job1.executed );
+        assertTrue( job2.executed );
+    }
+
+    private static class WaitingIndexSamplingJob implements IndexSamplingJob
+    {
+        final IndexDescriptor descriptor;
+        final CountDownLatch latch;
+
+        volatile boolean executed;
+
+        WaitingIndexSamplingJob( IndexDescriptor descriptor, CountDownLatch latch )
+        {
+            this.descriptor = descriptor;
+            this.latch = latch;
+        }
+
+        @Override
+        public IndexDescriptor descriptor()
+        {
+            return descriptor;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                latch.await();
+                executed = true;
+            }
+            catch ( InterruptedException e )
+            {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException( e );
+            }
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.test;
 
+import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -87,7 +88,9 @@ public class NeoStoreDataSourceRule extends ExternalResource
         Caches caches = new DefaultCaches( StringLogger.DEV_NULL, new Monitors() );
         caches.configure( new NoCacheProvider(), config );
 
-        theDs = new NeoStoreDataSource( config, sf, StringLogger.DEV_NULL, mock( JobScheduler.class ),
+        JobScheduler jobScheduler = mock( JobScheduler.class, RETURNS_MOCKS );
+
+        theDs = new NeoStoreDataSource( config, sf, StringLogger.DEV_NULL, jobScheduler,
                 DevNullLoggingService.DEV_NULL, mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locks,


### PR DESCRIPTION
This PR makes database to wait for all ongoing index samplings to finish and not accept new ones during shutdown.
Previously index sampling was not stopped and could interfere with various other components while they
were in process of shutting down or already shut down.
