### PR TITLE
Introduces specification of tx application mode per commit

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -361,14 +361,13 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
                             dependencyResolver.resolveDependency( KernelHealth.class ),
                             dependencyResolver.resolveDependency( NeoStoreProvider.class ).evaluate(),
                             dependencyResolver.resolveDependency( TransactionRepresentationStoreApplier.class ),
-                            dependencyResolver.resolveDependency( IndexUpdatesValidator.class ),
-                            TransactionApplicationMode.EXTERNAL );
+                            dependencyResolver.resolveDependency( IndexUpdatesValidator.class ) );
             TransactionIdStore transactionIdStore = database.getDependencyResolver().resolveDependency(
                     TransactionIdStore.class );
             NodeStore nodes = database.getDependencyResolver().resolveDependency( NeoStore.class ).getNodeStore();
             commitProcess.commit( transaction.representation( idGenerator(), masterId(), myId(),
-                    transactionIdStore.getLastCommittedTransactionId(), nodes ), locks,
-                    CommitEvent.NULL );
+                    transactionIdStore.getLastCommittedTransactionId(), nodes ), locks, CommitEvent.NULL,
+                    TransactionApplicationMode.EXTERNAL );
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -230,8 +230,7 @@ public abstract class InternalAbstractGraphDatabase
                                                 KernelHealth kernelHealth, NeoStore neoStore,
                                                 TransactionRepresentationStoreApplier storeApplier,
                                                 NeoStoreInjectedTransactionValidator txValidator,
-                                                IndexUpdatesValidator indexUpdatesValidator,
-                                                TransactionApplicationMode mode, Config config )
+                                                IndexUpdatesValidator indexUpdatesValidator, Config config )
         {
             if ( config.get( GraphDatabaseSettings.read_only ) )
             {
@@ -240,7 +239,7 @@ public abstract class InternalAbstractGraphDatabase
             else
             {
                 return new TransactionRepresentationCommitProcess( logicalTransactionStore, kernelHealth,
-                        neoStore, storeApplier, indexUpdatesValidator, mode );
+                        neoStore, storeApplier, indexUpdatesValidator );
             }
         }
     };

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -62,7 +62,6 @@ import org.neo4j.kernel.impl.api.SchemaStateConcern;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StateHandlingStatementOperations;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
@@ -981,8 +980,7 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
     {
         final TransactionCommitProcess transactionCommitProcess =
                 commitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore, storeApplier,
-                        new NeoStoreInjectedTransactionValidator( integrityValidator ), indexUpdatesValidator,
-                        TransactionApplicationMode.INTERNAL, config );
+                        new NeoStoreInjectedTransactionValidator( integrityValidator ), indexUpdatesValidator, config );
 
         /*
          * This is used by legacy indexes and constraint indexes whenever a transaction is to be spawned

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommitProcessFactory.java
@@ -31,6 +31,5 @@ public interface CommitProcessFactory
     TransactionCommitProcess create( LogicalTransactionStore logicalTransactionStore, KernelHealth kernelHealth,
                                      NeoStore neoStore, TransactionRepresentationStoreApplier storeApplier,
                                      NeoStoreInjectedTransactionValidator txValidator,
-                                     IndexUpdatesValidator indexUpdatesValidator, TransactionApplicationMode mode,
-                                     Config config );
+                                     IndexUpdatesValidator indexUpdatesValidator, Config config );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -71,6 +71,7 @@ import org.neo4j.kernel.impl.util.collection.ArrayCollection;
 
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
 
 /**
  * This class should replace the {@link org.neo4j.kernel.api.KernelTransaction} interface, and take its name, as soon
@@ -498,7 +499,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                 locks.getLockSessionId() );
 
                         // Commit the transaction
-                        commitProcess.commit( transactionRepresentation, lockGroup, commitEvent );
+                        commitProcess.commit( transactionRepresentation, lockGroup, commitEvent, INTERNAL );
                     }
 
                     if ( hasTxStateWithChanges() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyTransactionCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ReadOnlyTransactionCommitProcess.java
@@ -29,11 +29,11 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
  * For databases in read_only mode, the implementation of {@link org.neo4j.kernel.impl.api.TransactionCommitProcess}
  * will simply always throw an exception on commit, to ensure that no changes are made.
  */
-public class ReadOnlyTransactionCommitProcess
-        implements TransactionCommitProcess
+public class ReadOnlyTransactionCommitProcess implements TransactionCommitProcess
 {
     @Override
-    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                        TransactionApplicationMode mode ) throws TransactionFailureException
     {
         throw new ReadOnlyDbException();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionCommitProcess.java
@@ -25,14 +25,28 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 
 /*
- * This interface represents the contract for committing a transaction. It's quite
- * straightforward - you pass in a TransactionRepresentation and that's it. A simple
- * implementation of this would be to append to a log and then apply the
+ * This interface represents the contract for committing a transaction. While the concept of a transaction is
+ * captured in {@link TransactionRepresentation}, commit requires some more information to proceed, since a transaction
+ * can come from various sources (normal commit, recovery etc) each of which can be committed but requires special
+ * handling.
+ *
+ * A simple implementation of this would be to append to a log and then apply the
  * commands of the representation to the store that generated them. Another could
  * instead of appending to a log, write the transaction over the network to another
  * machine.
  */
 public interface TransactionCommitProcess
 {
-    long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent ) throws TransactionFailureException;
+    /**
+     * The main work method.
+     * @param representation The {@link TransactionRepresentation} to commit
+     * @param locks the {@link LockGroup} to add locks to while committing the transaction. This lock group is expected
+     *              to be managed by the caller - implementations should not attempt to close it.
+     * @param commitEvent A tracer for the commit process
+     * @param mode The {@link TransactionApplicationMode} to use
+     * @return The transaction id assigned to the transaction as part of the commit
+     * @throws TransactionFailureException If the commit process fails
+     */
+    long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                 TransactionApplicationMode mode ) throws TransactionFailureException;
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.RecordStateForCacheAccessor;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
@@ -387,7 +388,8 @@ public class KernelTransactionImplementationTest
         private TransactionRepresentation transaction;
 
         @Override
-        public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent ) throws TransactionFailureException
+        public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                            TransactionApplicationMode mode ) throws TransactionFailureException
         {
             assert transaction == null : "Designed to only allow one transaction";
             transaction = representation;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -147,7 +147,8 @@ public class KernelTransactionsTest
         TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
 
         when( commitProcess.commit(
-                any( TransactionRepresentation.class ), any( LockGroup.class ), any( CommitEvent.class ) ) )
+                any( TransactionRepresentation.class ), any( LockGroup.class ), any( CommitEvent.class ),
+                any( TransactionApplicationMode.class ) ) )
                 .then( new Answer<Long>()
                 {
                     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
@@ -73,12 +73,12 @@ public class TransactionRepresentationCommitProcessTest
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         TransactionRepresentationStoreApplier storeApplier = mock( TransactionRepresentationStoreApplier.class );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( logicalTransactionStore,
-                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator(), INTERNAL );
+                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator() );
 
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess.commit( mockedTransaction(), locks, commitEvent );
+            commitProcess.commit( mockedTransaction(), locks, commitEvent, INTERNAL );
             fail( "Should have failed, something is wrong with the mocking in this test" );
         }
         catch ( TransactionFailureException e )
@@ -107,13 +107,13 @@ public class TransactionRepresentationCommitProcessTest
         doThrow( new IOException( rootCause ) ).when( storeApplier ).apply( any( TransactionRepresentation.class ),
                 any( ValidatedIndexUpdates.class ), any( LockGroup.class ), eq( txId ), eq( INTERNAL ) );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( logicalTransactionStore,
-                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator(), INTERNAL );
+                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator() );
         TransactionRepresentation transaction = mockedTransaction();
 
         // WHEN
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess.commit( transaction, locks, commitEvent );
+            commitProcess.commit( transaction, locks, commitEvent, INTERNAL );
         }
         catch ( TransactionFailureException e )
         {
@@ -138,12 +138,12 @@ public class TransactionRepresentationCommitProcessTest
 
         TransactionRepresentationCommitProcess commitProcess = new TransactionRepresentationCommitProcess(
                 mock( LogicalTransactionStore.class ), mock( KernelHealth.class ), mock( TransactionIdStore.class ),
-                mock( TransactionRepresentationStoreApplier.class ), indexUpdatesValidator, INTERNAL );
+                mock( TransactionRepresentationStoreApplier.class ), indexUpdatesValidator );
 
         try ( LockGroup lockGroup = new LockGroup() )
         {
             // When
-            commitProcess.commit( mock( TransactionRepresentation.class ), lockGroup, CommitEvent.NULL );
+            commitProcess.commit( mock( TransactionRepresentation.class ), lockGroup, CommitEvent.NULL, INTERNAL );
             fail( "Should have thrown " + TransactionFailureException.class.getSimpleName() );
         }
         catch ( TransactionFailureException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogRotationDeadlockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogRotationDeadlockTest.java
@@ -32,7 +32,6 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.LogRotationImpl;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
@@ -52,6 +51,7 @@ import org.neo4j.test.OtherThreadRule;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
 
 public class LogRotationDeadlockTest
 {
@@ -103,7 +103,7 @@ public class LogRotationDeadlockTest
         when( txStore.getAppender() ).thenReturn( appender );
         TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( txStore,
                 health, txIdStore, mock( TransactionRepresentationStoreApplier.class ),
-                mock( IndexUpdatesValidator.class ), TransactionApplicationMode.INTERNAL );
+                mock( IndexUpdatesValidator.class ) );
 
         // WHEN
         // trapping an appender in between having its transaction committed and closed
@@ -130,7 +130,7 @@ public class LogRotationDeadlockTest
             @Override
             public Void doWork( Void state ) throws Exception
             {
-                commitProcess.commit( arbitraryTransaction(), new LockGroup(), CommitEvent.NULL );
+                commitProcess.commit( arbitraryTransaction(), new LockGroup(), CommitEvent.NULL, INTERNAL );
                 return null;
             }
         };

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -250,7 +250,7 @@ public class NeoStoreTransactionTest
         writeTransaction.createSchemaRule( schemaRule );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -284,7 +284,7 @@ public class NeoStoreTransactionTest
         writeTransaction.dropSchemaRule( rule );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -312,7 +312,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
 
@@ -327,7 +327,7 @@ public class NeoStoreTransactionTest
 
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -373,7 +373,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -391,7 +391,7 @@ public class NeoStoreTransactionTest
 
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         final AtomicBoolean nodeCommandsExist = new AtomicBoolean( false );
@@ -485,7 +485,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -510,7 +510,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -522,7 +522,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -549,7 +549,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -560,7 +560,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -586,7 +586,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -596,7 +596,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -621,7 +621,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -632,7 +632,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -659,7 +659,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -669,7 +669,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -696,7 +696,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -707,7 +707,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -733,7 +733,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionCommands, locks, commitEvent );
+            commitProcess().commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -744,7 +744,7 @@ public class NeoStoreTransactionTest
         transactionCommands = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent );
+            commitProcess( indexingService ).commit( transactionCommands, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -856,7 +856,7 @@ public class NeoStoreTransactionTest
         tx.nodeAddProperty( nodeId, index, string( 70 ) ); // will require a block of size 1
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
 
         // WHEN
@@ -889,7 +889,7 @@ public class NeoStoreTransactionTest
         representation.accept( verifier );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( representation, locks, commitEvent );
+            commitProcess().commit( representation, locks, commitEvent, INTERNAL );
         }
     }
 
@@ -912,7 +912,7 @@ public class NeoStoreTransactionTest
         tx.createSchemaRule( rule );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
 
         // -- and a tx creating a node with that label and property key
@@ -927,7 +927,7 @@ public class NeoStoreTransactionTest
         representation.accept( recoverer );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( representation, locks, commitEvent );
+            commitProcess().commit( representation, locks, commitEvent, INTERNAL );
         }
         verify( mockIndexing, times( 1 ) ).validate( any( Iterable.class ) );
         indexUpdates.assertContent( expectedUpdate );
@@ -967,7 +967,7 @@ public class NeoStoreTransactionTest
             }
             tx.nodeAddProperty( nodes[3], 0, "old" );
             tx.nodeAddProperty( nodes[4], 0, "old" );
-            commitProcess().commit( transactionRepresentationOf( tx ), lockGroup, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), lockGroup, commitEvent, INTERNAL );
             reset( locks ); // reset the lock counts
         }
 
@@ -987,7 +987,7 @@ public class NeoStoreTransactionTest
         // when
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
 
         // then
@@ -1223,7 +1223,7 @@ public class NeoStoreTransactionTest
 
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( writeTransaction ), locks, commitEvent, INTERNAL );
         }
         writeTransaction = newWriteTransaction().first();
 
@@ -1242,7 +1242,7 @@ public class NeoStoreTransactionTest
         PhysicalTransactionRepresentation tx = transactionRepresentationOf( writeTransaction );
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess().commit( tx, locks, commitEvent );
+            commitProcess().commit( tx, locks, commitEvent, INTERNAL );
         }
 
         // THEN
@@ -1287,7 +1287,7 @@ public class NeoStoreTransactionTest
             tx.createRelationshipTypeToken( "5", type5 );
             tx.createRelationshipTypeToken( "10", type10 );
             tx.createRelationshipTypeToken( "15", type15 );
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
         long nodeId = neoStore.getNodeStore().nextId();
         try ( LockGroup locks = new LockGroup() )
@@ -1301,7 +1301,7 @@ public class NeoStoreTransactionTest
             tx.relCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode1Id );
             // This relationship will cause the switch to dense
             tx.relCreate( neoStore.getRelationshipStore().nextId(), type10, nodeId, otherNode2Id );
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
             // Just a little validation of assumptions
             assertRelationshipGroupsInOrder( nodeId, type10 );
         }
@@ -1313,7 +1313,7 @@ public class NeoStoreTransactionTest
             long otherNodeId = neoStore.getNodeStore().nextId();
             tx.nodeCreate( otherNodeId );
             tx.relCreate( neoStore.getRelationshipStore().nextId(), type5, nodeId, otherNodeId );
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
 
         // THEN that group should end up first in the chain
@@ -1326,7 +1326,7 @@ public class NeoStoreTransactionTest
             long otherNodeId = neoStore.getNodeStore().nextId();
             tx.nodeCreate( otherNodeId );
             tx.relCreate( neoStore.getRelationshipStore().nextId(), type15, nodeId, otherNodeId );
-            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent );
+            commitProcess().commit( transactionRepresentationOf( tx ), locks, commitEvent, INTERNAL );
         }
 
         // THEN that group should end up last in the chain
@@ -1451,11 +1451,6 @@ public class NeoStoreTransactionTest
         return commitProcess( mockIndexing );
     }
 
-    private TransactionRepresentationCommitProcess commitProcess(TransactionApplicationMode mode) throws IOException
-    {
-        return commitProcess( mockIndexing, mode );
-    }
-
     private TransactionRepresentationCommitProcess commitProcess( IndexingService indexing) throws IOException
     {
         return commitProcess(indexing, INTERNAL);
@@ -1483,7 +1478,7 @@ public class NeoStoreTransactionTest
         PropertyLoader propertyLoader = new PropertyLoader( neoStore );
 
         return new TransactionRepresentationCommitProcess( txStoreMock, mock( KernelHealth.class ),
-                neoStore, applier, new IndexUpdatesValidator( neoStore, propertyLoader, indexing ), mode );
+                neoStore, applier, new IndexUpdatesValidator( neoStore, propertyLoader, indexing ) );
     }
 
     @After
@@ -1529,7 +1524,7 @@ public class NeoStoreTransactionTest
 
         try ( LockGroup locks = new LockGroup() )
         {
-            commitProcess( mode ).commit( recoveredTx, locks, CommitEvent.NULL );
+            commitProcess().commit( recoveredTx, locks, CommitEvent.NULL, mode );
         }
     }
 

--- a/enterprise/ha/CHANGES.txt
+++ b/enterprise/ha/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.3
+-----
+o Transactions executed on slaves will now properly invalidate the master's cache on commit
+
 2.2.2
 -----
 o Fixes an issue in the high-performance cache, HPC, where the array would be much bigger than intended

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -90,7 +90,6 @@ import org.neo4j.kernel.ha.transaction.CommitPusher;
 import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.ha.transaction.TransactionPropagator;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
@@ -447,20 +446,19 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                                                     KernelHealth kernelHealth, NeoStore neoStore,
                                                     TransactionRepresentationStoreApplier storeApplier,
                                                     NeoStoreInjectedTransactionValidator txValidator,
-                                                    IndexUpdatesValidator indexUpdatesValidator,
-                                                    TransactionApplicationMode mode, Config config )
+                                                    IndexUpdatesValidator indexUpdatesValidator, Config config )
             {
                 if ( config.get( GraphDatabaseSettings.read_only ) )
                 {
                     return defaultCommitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore,
-                            storeApplier, txValidator, indexUpdatesValidator, mode, config );
+                            storeApplier, txValidator, indexUpdatesValidator, config );
                 }
                 else
                 {
 
                     TransactionCommitProcess inner =
                             defaultCommitProcessFactory.create( logicalTransactionStore, kernelHealth, neoStore,
-                                    storeApplier, txValidator, indexUpdatesValidator, mode, config );
+                                    storeApplier, txValidator, indexUpdatesValidator, config );
                     new CommitProcessSwitcher( pusher, master, commitProcessDelegate, requestContextFactory,
                             memberStateMachine, txValidator, inner );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterTransactionCommitProcess.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.ha;
 
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.transaction.TransactionPropagator;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
@@ -47,11 +48,12 @@ public class MasterTransactionCommitProcess implements TransactionCommitProcess
     }
 
     @Override
-    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                        TransactionApplicationMode mode ) throws TransactionFailureException
     {
         validator.assertInjectionAllowed( representation.getLatestCommittedTxWhenStarted() );
 
-        long result = inner.commit( representation, locks, commitEvent );
+        long result = inner.commit( representation, locks, commitEvent, mode );
 
         pusher.committed( result, representation.getAuthorId() );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcess.java
@@ -26,6 +26,7 @@ import org.neo4j.com.Response;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
@@ -33,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 
 /**
  * Commit process on slaves in HA. Transactions aren't committed here, but sent to the master, committed
- * there and streamed back.
+ * there and streamed back. Look at {@link org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker}
  */
 public class SlaveTransactionCommitProcess implements TransactionCommitProcess
 {
@@ -47,7 +48,8 @@ public class SlaveTransactionCommitProcess implements TransactionCommitProcess
     }
 
     @Override
-    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent ) throws TransactionFailureException
+    public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                        TransactionApplicationMode mode ) throws TransactionFailureException
     {
         try
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.TransactionChecksumLookup;
 import org.neo4j.kernel.ha.com.master.MasterImpl;
 import org.neo4j.kernel.ha.id.IdAllocation;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
@@ -142,7 +143,8 @@ class DefaultMasterImplSPI implements MasterImpl.SPI
             TransactionCommitProcess txCommitProcess = dependencyResolver
                     .resolveDependency( NeoStoreDataSource.class )
                     .getDependencyResolver().resolveDependency( TransactionCommitProcess.class );
-            return txCommitProcess.commit( preparedTransaction, locks, CommitEvent.NULL );
+            return txCommitProcess.commit( preparedTransaction, locks, CommitEvent.NULL,
+                    TransactionApplicationMode.EXTERNAL );
         }
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
@@ -27,6 +27,7 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
@@ -58,7 +59,7 @@ public class SlaveTransactionCommitProcessTest
         tx.setHeader(new byte[]{}, 1, 1, 1, 1, 1, 1337);
 
         // When
-        process.commit(tx , new LockGroup(), CommitEvent.NULL );
+        process.commit(tx , new LockGroup(), CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
 
         // Then
         verify( reqFactory ).newRequestContext( 1337 );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestBasicHaOperations.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestBasicHaOperations.java
@@ -37,6 +37,7 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
 
+
 public class TestBasicHaOperations
 {
     @Rule
@@ -97,31 +98,50 @@ public class TestBasicHaOperations
     public void testBasicPropagationFromSlaveToMaster() throws Throwable
     {
         // given
+        // a cluster of 2
         clusterManager = new ClusterManager( clusterOfSize( 2 ), dir.cleanDirectory( "propagation" ),
-                stringMap( tx_push_factor.name(), "1" ) );
+                stringMap(HaSettings.tx_push_factor.name(), "1" ) );
         clusterManager.start();
         ClusterManager.ManagedCluster cluster = clusterManager.getDefaultCluster();
 
         cluster.await( ClusterManager.allSeesAllAsAvailable() );
 
-        long nodeId = 0;
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
         HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+        long nodeId;
 
-        try ( Transaction tx = slave.beginTx() )
+        // a node with a property
+        try( Transaction tx = master.beginTx() )
         {
-            Node node = slave.createNode();
-            node.setProperty( "Hello", "World" );
+            Node node = master.createNode();
             nodeId = node.getId();
-
+            node.setProperty( "foo", "bar" );
             tx.success();
         }
 
-        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        try( Transaction tx = master.beginTx() )
+        {
+            // make sure it's in the cache
+            master.getNodeById( nodeId ).getProperty( "foo" );
+            tx.success();
+        }
+
+        // which has propagated to the slaves
+        slave.getDependencyResolver().resolveDependency( UpdatePullerClient.class ).pullUpdates();
+
+        // when
+        // the slave does a change
+        try ( Transaction tx = slave.beginTx() )
+        {
+            slave.getNodeById( nodeId ).setProperty( "foo", "bar2" );
+            tx.success();
+        }
+
+        // then
+        // the master must pick up the change
         try ( Transaction tx = master.beginTx() )
         {
-            String value = master.getNodeById( nodeId ).getProperty( "Hello" ).toString();
-            logger.getLogger().info( "Hello=" + value );
-            assertEquals( "World", value );
+            assertEquals( "bar2", master.getNodeById( nodeId ).getProperty( "foo" ) );
             tx.success();
         }
     }

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -9,6 +9,9 @@ o Fixes #4758 - OPTIONAL MATCH when either side is null
 o Fixes problem with projection of named paths
 o Identifiers in scope of ORDER BY are no longer lost in rewriting
 
+HA:
+o Transactions executed on slaves will now properly invalidate the master's cache on commit
+
 2.2.2
 -----
 General:


### PR DESCRIPTION
So far the TransactionApplicationMode was specified on the transaction
 commit process level. That was not granular enough since the master
 in an HA cluster needs to commit transactions coming from slaves in
 the EXTERNAL TAM. This patch removes the setting of the TAM from the
 TACP and adds it as an argument in the commit() call.
Tests and documentation updates are forthcoming.
