### PR TITLE
Introduce security policies in the browser.

### DIFF
--- a/community/browser/app/scripts/controllers/Auth.coffee
+++ b/community/browser/app/scripts/controllers/Auth.coffee
@@ -27,13 +27,38 @@ angular.module('neo4jApp.controllers')
     'ConnectionStatusService'
     'Frame'
     'Settings'
-    ($scope, AuthService, ConnectionStatusService, Frame, Settings) ->
+    '$timeout'
+    ($scope, AuthService, ConnectionStatusService, Frame, Settings, $timeout) ->
       $scope.username = 'neo4j'
       $scope.password = ''
       $scope.current_password = ''
       $scope.connection_summary = ConnectionStatusService.getConnectionStatusSummary()
       $scope.static_user = $scope.connection_summary.user
       $scope.static_is_authenticated = $scope.connection_summary.is_connected
+      $scope.policy_message = ''
+
+      setPolicyMessage = ->
+        return unless $scope.static_is_authenticated
+        _connection_summary = ConnectionStatusService.getConnectionStatusSummary()
+        if _connection_summary.credential_timeout is null
+          $timeout(->
+            setPolicyMessage()
+          , 1000)
+          return
+        msg = ""
+        if _connection_summary.store_credentials
+          msg += "Connection credentials are stored in your web browsers localstorage"
+        else
+          msg += "Connection credentials are not stored in your web browsers localstorage"
+        if _connection_summary.credential_timeout > 0
+          msg += " and your credential timeout is #{_connection_summary.credential_timeout} seconds. "
+          msg += "You have #{_connection_summary.credential_timeout - _connection_summary.connection_age} seconds "
+          msg += " until you are disconnected."
+        else
+          msg += "."
+        $scope.$evalAsync(->
+          $scope.policy_message = msg
+        )
 
       $scope.authenticate = ->
         $scope.frame.resetError()
@@ -50,7 +75,7 @@ angular.module('neo4jApp.controllers')
             $scope.connection_summary = ConnectionStatusService.getConnectionStatusSummary()
             $scope.static_user = $scope.connection_summary.user
             $scope.static_is_authenticated = $scope.connection_summary.is_connected
-
+            setPolicyMessage()
             Frame.create({input:"#{Settings.initCmd}"})
             $scope.focusEditor()
           ,
@@ -67,4 +92,6 @@ angular.module('neo4jApp.controllers')
           $scope.static_user = ConnectionStatusService.connectedAsUser()
           $scope.static_is_authenticated = ConnectionStatusService.isConnected()
         )
+
+      setPolicyMessage()
   ]

--- a/community/browser/app/scripts/controllers/Main.coffee
+++ b/community/browser/app/scripts/controllers/Main.coffee
@@ -28,10 +28,11 @@ angular.module('neo4jApp.controllers')
       'Server'
       'Frame'
       'AuthService'
+      'ConnectionStatusService'
       'Settings'
       'motdService'
       'UsageDataCollectionService'
-      ($scope, $window, Server, Frame, AuthService, Settings, motdService, UDC) ->
+      ($scope, $window, Server, Frame, AuthService, ConnectionStatusService, Settings, motdService, UDC) ->
         refresh = ->
           return '' if $scope.unauthorized || $scope.offline
 
@@ -39,6 +40,7 @@ angular.module('neo4jApp.controllers')
           $scope.relationships = Server.relationships()
           $scope.propertyKeys = Server.propertyKeys()
           $scope.server = Server.info()
+          $scope.version = Server.version()
           $scope.host = $window.location.host
           $scope.kernel = {}
           # gather info from jmx
@@ -53,7 +55,13 @@ angular.module('neo4jApp.controllers')
                   $scope.kernel[a.name] = a.value
               UDC.set('store_id',   $scope.kernel['StoreId'])
               UDC.set('neo4j_version', $scope.server.neo4j_version)
+              refreshPolicies $scope.kernel['dbms.browser.storeCredentials'], $scope.kernel['dbms.browser.credentialTimeout']
             ).error((r)-> $scope.kernel = {})
+
+        refreshPolicies = (storeCredentials = yes, credentialTimeout = 0) ->
+          storeCredentials = [no, 'false', 'no'].indexOf(storeCredentials) < 0 ? yes : no
+          credentialTimeout = parseInt credentialTimeout
+          ConnectionStatusService.setAuthPolicies {storeCredentials, credentialTimeout}
 
         $scope.identity = angular.identity
 
@@ -64,7 +72,8 @@ angular.module('neo4jApp.controllers')
           license =
             type: "GPLv3"
             url: "http://www.gnu.org/licenses/gpl.html"
-            edition: "Enterprise" # TODO: determine edition via REST
+            edition: 'community'
+            enterpriseEdition: no
 
         $scope.$on 'db:changed:labels', refresh
 
@@ -85,8 +94,10 @@ angular.module('neo4jApp.controllers')
         $scope.$watch 'unauthorized', (isUnauthorized) ->
           refresh()
 
-        $scope.$on 'auth:status_updated', () ->
+        $scope.$on 'auth:status_updated', (e, is_connected) ->
           $scope.check()
+          if is_connected
+            ConnectionStatusService.setSessionStartTimer new Date()
 
         # Authorization
         AuthService.hasValidAuthorization().then(
@@ -100,11 +111,15 @@ angular.module('neo4jApp.controllers')
               Frame.createOne({input:"#{Settings.cmdchar}server connect"})
         )
 
-        $scope.$watch 'server', (val) ->
+        $scope.$watch 'version', (val) ->
           return '' if not val
-          $scope.neo4j.version = val.neo4j_version
 
-          if val.neo4j_version then $scope.motd.setCallToActionVersion(val.neo4j_version)
+          $scope.neo4j.version = val.version
+          $scope.neo4j.edition = val.edition
+          $scope.neo4j.enterpriseEdition = val.edition is 'enterprise'
+          $scope.$emit 'db:updated:edition', val.edition
+
+          if val.version then $scope.motd.setCallToActionVersion(val.version)
         , true
 
         refresh()

--- a/community/browser/app/scripts/services/AuthData.coffee
+++ b/community/browser/app/scripts/services/AuthData.coffee
@@ -26,18 +26,35 @@ angular.module('neo4jApp.services')
   '$base64'
   (localStorageService, $base64) ->
     cached_authorization_data = localStorageService.get('authorization_data') || ''
+    cached_store_credentials = null
+    cached_credential_timeout = null
     @setAuthData = (authdata) ->
       return unless authdata
       encoded = $base64.encode(authdata)
       cached_authorization_data = encoded
-      localStorageService.set('authorization_data', encoded)
+      if @getPolicies().storeCredentials isnt no
+        localStorageService.set('authorization_data', encoded)
+    @persistCachedAuthData = ->
+      if @getPolicies().storeCredentials isnt no
+        localStorageService.set('authorization_data', cached_authorization_data)
     @clearAuthData = ->
       localStorageService.remove('authorization_data')
       cached_authorization_data = null
+    @clearPersistentAuthData = ->
+      localStorageService.remove('authorization_data')
     @getAuthData = ->
       return cached_authorization_data || localStorageService.get('authorization_data') || ''
     @getPlainAuthData = ->
-      data = (cached_authorization_data || localStorageService.get('authorization_data'))
+      data = @getAuthData()
       if data then $base64.decode(data) else ''
+    @setStoreCredentials = (storeCredentials) ->
+      cached_store_credentials = storeCredentials
+    @setCredentialTimeout = (credentialTimeout) ->
+      cached_credential_timeout = credentialTimeout
+    @getPolicies = ->
+      return {storeCredentials: cached_store_credentials, credentialTimeout: cached_credential_timeout}
+    @clearPolicies = ->
+      cached_store_credentials = null
+      cached_credential_timeout = null
     @
 ]

--- a/community/browser/app/scripts/services/RequestInterceptor.coffee
+++ b/community/browser/app/scripts/services/RequestInterceptor.coffee
@@ -26,7 +26,13 @@ angular.module('neo4jApp.services')
     (AuthDataService) ->
       interceptor =
         request: (config) ->
-          return config if config.skipAuthHeader
+          isLocalRequest = yes
+          if /^https?:/.test config.url
+            url = document.location.origin || window.location.protocol + "//" + window.location.host
+            if config.url.indexOf url < 0
+              isLocalRequest = no
+
+          return config if config.skipAuthHeader or not isLocalRequest
           header = AuthDataService.getAuthData()
           if header then config.headers['Authorization'] = "Basic #{header}"
           config

--- a/community/browser/app/scripts/services/Server.coffee
+++ b/community/browser/app/scripts/services/Server.coffee
@@ -120,6 +120,9 @@ angular.module('neo4jApp.services')
         info: ->
           returnAndUpdateObject @get Settings.endpoint.rest + '/'
 
+        version: ->
+          returnAndUpdateObject @get Settings.endpoint.version + '/'
+
         status: (params = '')->
           # User a smaller timeout for status requests so IE10 detects when the
           # server goes down faster.

--- a/community/browser/app/scripts/settings.coffee
+++ b/community/browser/app/scripts/settings.coffee
@@ -27,6 +27,7 @@ angular.module('neo4jApp.settings', ['neo4jApp.utils'])
     cmdchar: ':'
     endpoint:
       console: "#{baseURL}/db/manage/server/console"
+      version: "#{baseURL}/db/manage/server/version"
       jmx: "#{baseURL}/db/manage/server/jmx/query"
       rest: restAPI
       cypher: "#{restAPI}/cypher"
@@ -49,11 +50,12 @@ angular.module('neo4jApp.settings', ['neo4jApp.utils'])
     initCmd: ":play start"
     refreshInterval: 10 # in seconds
     userName: "Graph Friend"
+    storeCredentials: yes
   })
 
 angular.module('neo4jApp.settings')
-.service('SettingsStore', ['localStorageService','Settings', 'Utils'
-  (localStorageService, Settings, Utils) ->
+.service('SettingsStore', ['$rootScope', 'localStorageService','Settings', 'Utils'
+  ($rootScope, localStorageService, Settings, Utils) ->
     originalSettings = angular.copy(Settings)
     load: ->
       settings = localStorageService.get('settings')
@@ -66,6 +68,7 @@ angular.module('neo4jApp.settings')
 
     save: ->
       localStorageService.set('settings', angular.copy(Settings))
+      $rootScope.$emit('settings:saved')
 
 ])
 

--- a/community/browser/app/views/frame-connect.jade
+++ b/community/browser/app/views/frame-connect.jade
@@ -54,6 +54,8 @@ div(ng-controller="AuthCtrl")
                       | You are connected as user:&nbsp;
                     code
                       | {{static_user}}
+                  li
+                    p.lead {{policy_message}}
       .view-result.fade(ng-show="password_change_required")
         include partials/frame-change-password
       .status-bar(ng-class='{error: frame.detailedErrorText, loading: frame.isLoading}')

--- a/community/browser/app/views/frame-server-status.jade
+++ b/community/browser/app/views/frame-server-status.jade
@@ -19,6 +19,8 @@ div(ng-controller="AuthCtrl")
                       | You are connected as user:&nbsp;
                     code
                       | {{connection_summary.user}}
+                  li
+                    p.lead {{policy_message}}
               .details.col-sm-9(ng-show="!connection_summary.is_connected")
                 p You are not connected to the server.
               .details.col-sm-9(ng-show="!connection_summary.authorization_required")


### PR DESCRIPTION
- Follow server config policies for storing credentials and credential timeout on enterprise.
- Disconnect user on hit of credentials timeout.
- `:config storeCredentials:true/false` toggles credentials in local storage in browser.
- Credentials will be stored if `server.storeCredentials AND client.storeCredentials`.
- Display policies on `:server connect` and `:server status` frames
  when connected.
