### PR TITLE
Correct error messages when using EXPLAIN and PROFILE

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -113,8 +113,14 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
     parsePreParsedQuery(preParseQuery(queryText))
 
   @throws(classOf[SyntaxException])
-  private def parsePreParsedQuery(preParsedQuery: PreParsedQuery): ParsedQuery =
-    parsedQueries.getOrElseUpdate(preParsedQuery.statementWithVersionAndPlanner, compiler.parseQuery(preParsedQuery))
+  private def parsePreParsedQuery(preParsedQuery: PreParsedQuery): ParsedQuery = {
+    parsedQueries.get(preParsedQuery.statementWithVersionAndPlanner).getOrElse {
+      val parsedQuery = compiler.parseQuery(preParsedQuery)
+      //don't cache failed queries
+      if (!parsedQuery.hasErrors) parsedQueries.put(preParsedQuery.statementWithVersionAndPlanner, parsedQuery)
+      parsedQuery
+    }
+  }
 
   @throws(classOf[SyntaxException])
   private def preParseQuery(queryText: String): PreParsedQuery =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
@@ -24,4 +24,5 @@ import org.neo4j.kernel.api.Statement
 trait ParsedQuery {
   def isPeriodicCommit: Boolean
   def plan(statement: Statement): (ExecutionPlan, Map[String, Any])
+  def hasErrors: Boolean
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
@@ -43,6 +43,9 @@ case class CompatibilityFor1_9(graph: GraphDatabaseService, queryCacheSize: Int,
     }
 
     def isPeriodicCommit = false
+
+    //we lack the knowledge whether or not this query is correct
+    def hasErrors = false
   }
 
   class ExecutionPlanWrapper(inner: ExecutionPlan_v1_9) extends ExecutionPlan {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_0.scala
@@ -44,6 +44,9 @@ case class CompatibilityFor2_0(graph: GraphDatabaseService, queryCacheSize: Int,
     }
 
     def isPeriodicCommit = false
+
+    //we lack the knowledge whether or not this query is correct
+    def hasErrors = false
   }
 
   class ExecutionPlanWrapper(inner: ExecutionPlan_v2_0) extends ExecutionPlan {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_1.scala
@@ -48,6 +48,8 @@ case class CompatibilityFor2_1(graph: GraphDatabaseService, queryCacheSize: Int,
     }
 
     def isPeriodicCommit = preparedQueryForV_2_1.map(_.isPeriodicCommit).getOrElse(false)
+
+    def hasErrors = preparedQueryForV_2_1.isFailure
   }
 
   class ExecutionPlanWrapper(inner: ExecutionPlan_v2_1) extends ExecutionPlan {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -161,6 +161,8 @@ trait CompatibilityFor2_2 {
       val (planImpl, extractedParameters) = compiler.planPreparedQuery(preparedQueryForV_2_2.get, planContext)
       (new ExecutionPlanWrapper(planImpl), extractedParameters)
     }
+
+    def hasErrors = preparedQueryForV_2_2.isFailure
   }
 
   class ExecutionPlanWrapper(inner: ExecutionPlan_v2_2) extends ExecutionPlan {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -151,8 +151,8 @@ trait CompatibilityFor2_2 {
 
   implicit val executionMonitor = kernelMonitors.newMonitor(classOf[QueryExecutionMonitor])
 
-  def produceParsedQuery(statementAsText: String, offset: InputPosition) = new ParsedQuery {
-    val preparedQueryForV_2_2 = Try(compiler.prepareQuery(statementAsText, Some(offset)))
+  def produceParsedQuery(statementAsText: String, rawStatement: String, offset: InputPosition) = new ParsedQuery {
+    val preparedQueryForV_2_2 = Try(compiler.prepareQuery(statementAsText, rawStatement, Some(offset)))
 
     def isPeriodicCommit = preparedQueryForV_2_2.map(_.isPeriodicCommit).getOrElse(false)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -511,6 +511,14 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     third should startWith(" "*33 + "^")
   }
 
+  test("positions should not be cached") {
+    executeAndEnsureError("EXPLAIN MATCH m, n RETURN m, n, o LIMIT 25",
+      "o not defined (line 1, column 33 (offset: 32))")
+    executeAndEnsureError("MATCH m, n RETURN m, n, o LIMIT 25",
+      "o not defined (line 1, column 25 (offset: 24))")
+
+  }
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.StringHelper._
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -501,6 +501,16 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
       s"$mess (line 1, column 55 (offset: 54))")
   }
 
+  test("error message should contain full query") {
+    val query = "EXPLAIN MATCH m, n RETURN m, n, o LIMIT 25"
+    val error = intercept[QueryExecutionException](graph.execute(query))
+
+    val first :: second :: third :: Nil = error.getMessage.lines.toList
+    first should equal("o not defined (line 1, column 33 (offset: 32))")
+    second should equal(s""""$query"""")
+    third should startWith(" "*33 + "^")
+  }
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.StringHelper._
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -152,7 +152,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
   def plan(query: String): (Double, Double) = {
     val compiler = createCurrentCompiler
-    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query))
+    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, query))
     val (planTime, _) = graph.inTx {
       measure(compiler.executionPlanBuilder.build(planContext, preparedQuery))
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -147,7 +147,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val compiler = createCompiler(queryPlanTTL = 0, clock = clock, logger = logger)
     compiler.monitors.addMonitorListener(counter)
     val query: String = "match (n:Person:Dog) return n"
-    val statement = compiler.prepareQuery(query).statement
+    val statement = compiler.prepareQuery(query, query).statement
 
     createLabeledNode("Dog")
     (0 until 50).foreach { _ => createLabeledNode("Person") }


### PR DESCRIPTION
Fixes include:
- Display error with the original query containing the Cypher options (`EXPLAIN`, `PROFILE`, and `CYPHER…`)
- Do not cache failed queries
