### PR TITLE
Fix #4829: Behaviour of Path.lastRelationship.

### DIFF
--- a/community/cypher/src/main/scala/org/neo4j/cypher/PathImpl.scala
+++ b/community/cypher/src/main/scala/org/neo4j/cypher/PathImpl.scala
@@ -60,7 +60,7 @@ case class PathImpl(pathEntities: PropertyContainer*)
 
   def endNode(): Node = nodeList.last
 
-  def lastRelationship(): Relationship = if (relList.isEmpty) null else relList.head
+  def lastRelationship(): Relationship = if (relList.isEmpty) null else relList.last
 
   def relationships(): JavaIterable[Relationship] = relList.asJava
 

--- a/community/cypher/src/test/scala/org/neo4j/cypher/PathImplTest.scala
+++ b/community/cypher/src/test/scala/org/neo4j/cypher/PathImplTest.scala
@@ -71,6 +71,18 @@ class PathImplTest extends Spec {
     badPaths.foreach(p => intercept[IllegalArgumentException](new PathImpl(p:_*)))
   }
 
+  @Test def retrieveLastRelationshipOnLongPath() {
+    val nodA = new FakeNode
+    val nodB = new FakeNode
+    val nodC = new FakeNode
+    val rel1 = new FakeRel(nodA, nodB, typ)
+    val rel2 = new FakeRel(nodB, nodC, typ)
+    val path = new PathImpl(nodA, rel1, nodB, rel2, nodC)
+
+    assert(path.lastRelationship() == rel2)
+  }
+
+
   class FakeRel(start: Node, end: Node, typ: RelationshipType) extends Relationship {
     def getId: Long = 0L
 


### PR DESCRIPTION
This reverts the behaviour of Path.lastRelationship, which was
accidentially changed to return the first, not the last relationship
during a refactoring: 92ab0c60ffd11f3494235ec2d64341392cc30060

1.9-maint version
