### PR TITLE
Make dbms.querylog.filename be null by default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -114,8 +114,6 @@ public abstract class GraphDatabaseSettings
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )
     public static Setting<Boolean> allow_file_urls = setting( "allow_file_urls", BOOLEAN, TRUE );
 
-
-
     // Store files
     @Description("The directory where the database files are located.")
     public static final Setting<File> store_dir = setting("store_dir", PATH, NO_DEFAULT );
@@ -390,7 +388,7 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> log_queries = setting("dbms.querylog.enabled", BOOLEAN, FALSE );
 
     @Description( "The file where queries will be recorded." )
-    public static final Setting<File> log_queries_filename = setting("dbms.querylog.filename", PATH, "queries.log", basePath(store_dir) );
+    public static final Setting<File> log_queries_filename = setting("dbms.querylog.filename", PATH, NO_DEFAULT );
 
     @Description("If the execution of query takes more time than this threshold, the query is logged - " +
             "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -265,6 +265,12 @@ public abstract class AbstractNeoServer implements NeoServer
         result.put( GraphDatabaseSettings.store_dir.name(), configurator.configuration()
                 .get( ServerInternalSettings.legacy_db_location ).getAbsolutePath() );
 
+        // make sure that the default in server for db_query_log_filename is "data/log/queries.log" instead of null
+        if ( dbConfig.get( GraphDatabaseSettings.log_queries_filename ) == null )
+        {
+            result.put( GraphDatabaseSettings.log_queries_filename.name(), "data/log/queries.log" );
+        }
+
         putIfAbsent( result, ShellSettings.remote_shell_enabled.name(), Settings.TRUE );
 
         dbConfig.applyChanges( result );


### PR DESCRIPTION
The idea is to force the user to specify an absolute path when using
embedded and to not log queries when the path is not specified.  This
solves the issue that queries have been logged in the store directory
and that behaviour was confusing for end users.

The null default value is overridden when using server and the queries
are logged by default into 'data/log/queries.log'.
