### PR TITLE
Handle EntityNotFoundException insted of re-throwing

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -85,10 +85,9 @@ public class LookupFilter
             {
                 return nodeProperty( nodeId, propertyKeyId ).valueEquals( value );
             }
-            catch ( EntityNotFoundException e )
+            catch ( EntityNotFoundException ignored )
             {
-                throw new ThisShouldNotHappenError( "Chris", "An index claims a node by id " + nodeId
-                        + " has the value. However, it looks like that node does not exist.", e );
+                return false;
             }
         }
 


### PR DESCRIPTION
If nodes have been concurrently deleted since the index thought they had the
correct value, simply drop them from the returned nodes
