### PR TITLE
Exception if accessing plan description before results are materialized

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
@@ -258,7 +258,10 @@ class CompiledExecutionResult(taskCloser: TaskCloser,
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]): Unit =
     compiledCode.accept(visitor)
 
-  override def executionPlanDescription(): InternalPlanDescription =
+  override def executionPlanDescription(): InternalPlanDescription = {
+    if (!taskCloser.isClosed) throw new ProfilerStatisticsNotReadyException
+
     compiledCode.executionPlanDescription()
+  }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineIT.scala
@@ -36,8 +36,8 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.2").newGraphDatabase()
 
     //when
-    val plan1 = db.execute("PROFILE MATCH (a) RETURN a").getExecutionPlanDescription
-    val plan2 = db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription
+    val plan1 = db.planDescriptionForQuery("PROFILE MATCH (a) RETURN a")
+    val plan2 = db.planDescriptionForQuery("PROFILE MATCH (a)-[:T*]-(a) RETURN a")
 
     //then
     plan1.getArguments.get("planner") should equal("COST")
@@ -51,8 +51,8 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.3").newGraphDatabase()
 
     //when
-    val plan1 = db.execute("PROFILE MATCH (a) RETURN a").getExecutionPlanDescription
-    val plan2 = db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription
+    val plan1 = db.planDescriptionForQuery("PROFILE MATCH (a) RETURN a")
+    val plan2 = db.planDescriptionForQuery("PROFILE MATCH (a)-[:T*]-(a) RETURN a")
 
     //then
     plan1.getArguments.get("planner") should equal("COST")
@@ -69,7 +69,7 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.2").newGraphDatabase()
 
     //when
-    val plan = db.execute("PROFILE MATCH (a) RETURN a").getExecutionPlanDescription
+    val plan = db.planDescriptionForQuery("PROFILE MATCH (a) RETURN a")
 
     //then
     plan.getArguments.get("planner") should equal("RULE")
@@ -83,7 +83,7 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.3").newGraphDatabase()
 
     //when
-    val plan = db.execute("PROFILE MATCH (a) RETURN a").getExecutionPlanDescription
+    val plan = db.planDescriptionForQuery("PROFILE MATCH (a) RETURN a")
 
     //then
     plan.getArguments.get("planner") should equal("RULE")
@@ -98,7 +98,7 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.2").newGraphDatabase()
 
     //when
-    val plan = db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription
+    val plan = db.planDescriptionForQuery("PROFILE MATCH (a)-[:T*]-(a) RETURN a")
 
     //then
     plan.getArguments.get("planner") should equal("COST")
@@ -113,7 +113,7 @@ class ExecutionEngineIT extends CypherFunSuite {
       .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.3").newGraphDatabase()
 
     //when
-    val plan = db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription
+    val plan = db.planDescriptionForQuery("PROFILE MATCH (a)-[:T*]-(a) RETURN a")
 
     //then
     plan.getArguments.get("planner") should equal("COST")
@@ -128,7 +128,7 @@ class ExecutionEngineIT extends CypherFunSuite {
         .setConfig(GraphDatabaseSettings.cypher_planner, "COST")
         .setConfig(GraphDatabaseSettings.cypher_parser_version, "2.0").newGraphDatabase()
 
-      db.execute("PROFILE MATCH (a)-[:T*]-(a) RETURN a").getExecutionPlanDescription
+      db.planDescriptionForQuery("PROFILE MATCH (a)-[:T*]-(a) RETURN a")
     }
   }
 
@@ -204,6 +204,15 @@ class ExecutionEngineIT extends CypherFunSuite {
     // then
     txBridge(db).hasTransaction shouldBe false
   }
+
+  private implicit class RichDb(db: GraphDatabaseService) {
+    def planDescriptionForQuery(query: String) = {
+      val res = db.execute(query)
+      res.resultAsString()
+      res.getExecutionPlanDescription
+    }
+  }
+
 
   private def txBridge(db: GraphDatabaseService) = {
     db.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -266,7 +266,9 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
   }
 
   test("reports COST planner when showing plan description") {
-    val executionPlanDescription = eengine.execute("CYPHER planner=cost match n return n").executionPlanDescription()
+    val result = eengine.execute("CYPHER planner=cost match n return n")
+    result.toList
+    val executionPlanDescription = result.executionPlanDescription()
     executionPlanDescription.toString should include("Planner COST" + System.lineSeparator())
   }
 
@@ -384,6 +386,13 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     // then
     assertDbHits(1)(result)("Projection")
     assertRows(1)(result)("Projection")
+  }
+
+  test("should throw if accessing profiled results before they have been materialized") {
+    createNode()
+    val res = eengine.execute("profile match n return n")
+    intercept[ProfilerStatisticsNotReadyException](res.executionPlanDescription())
+    res.close()
   }
 
   private def assertRows(expectedRows: Int)(result: InternalExecutionResult)(names: String*) {


### PR DESCRIPTION
Compiled plans should behave as interpreted plans and trow an exception
when trying to access the plan description before materializing the results.
