### PR TITLE
Make planning favor the longest prefix when using multiple LIKE patterns

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/InternalPlanDescription.scala
@@ -83,6 +83,7 @@ object InternalPlanDescription {
     case class UpdateActionName(value: String) extends Argument
     case class LegacyIndex(value: String) extends Argument
     case class Index(label: String, propertyKey: String) extends Argument
+    case class RangeIndex(label: String, propertyKey: String, prefix: String) extends Argument
     case class LabelName(label: String) extends Argument
     case class KeyNames(keys: Seq[String]) extends Argument
     case class KeyExpressions(expressions: Seq[commands.expressions.Expression]) extends Argument

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -37,6 +37,7 @@ object PlanDescriptionArgumentSerializer {
       case UpdateActionName(action) => action
       case LegacyIndex(index) => index
       case Index(label, property) => s":$label($property)"
+      case RangeIndex(label, property, likePrefix) => s":$label($property LIKE $likePrefix%)"
       case LabelName(label) => s":$label"
       case KeyNames(keys) => keys.map(removeGeneratedNames).mkString(SEPARATOR)
       case KeyExpressions(expressions) => expressions.mkString(SEPARATOR)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/GraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/GraphStatistics.scala
@@ -30,7 +30,7 @@ object GraphStatistics {
   val DEFAULT_NUMBER_OF_ID_LOOKUPS       = Cardinality(25)
   val DEFAULT_NUMBER_OF_INDEX_LOOKUPS    = Cardinality(25)
   val DEFAULT_REL_UNIQUENESS_SELECTIVITY = Selectivity(1.0 - 1 / 100 /*rel-cardinality*/)
-  val DEFAULT_RANGE_SEEK_FACTOR          = 0.01
+  val DEFAULT_RANGE_SEEK_FACTOR          = 0.03
 }
 
 trait GraphStatistics {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CardinalitySupport.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CardinalitySupport.scala
@@ -32,6 +32,6 @@ object CardinalitySupport {
       case _ => false
     }
 
-    private def tolerance(a: Cardinality) = Math.max(0.1, a.amount * 0.1) // 10% off is acceptable
+    private def tolerance(a: Cardinality) = Math.max(5e-3, a.amount * 5e-3) // .5% off is acceptable
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.cardinality
 
 import org.mockito.Mockito
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.Selectivity
-import org.neo4j.cypher.internal.compiler.v2_3.{PropertyKeyId, LabelId}
+import org.neo4j.cypher.internal.compiler.v2_3.{InputPosition, PropertyKeyId, LabelId}
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.IdName
 import org.neo4j.cypher.internal.compiler.v2_3.planner.{Predicate, Selections, SemanticTable}
@@ -62,5 +62,31 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
     val result = calculator(PartialPredicate.ifNotEqual[HasLabels](HasLabels(ident("n"), Seq(LabelName("Page")_))_, mock[HasLabels]))
 
     result.factor should equal(0.5)
+  }
+
+  test("should optimize selectivity with respect to prefix length for LIKE predicates") {
+    implicit val semanticTable = SemanticTable()
+    semanticTable.resolvedLabelIds.put("A", LabelId(0))
+    semanticTable.resolvedPropertyKeyNames.put("prop", PropertyKeyId(0))
+
+    implicit val selections = mock[Selections]
+    val label = LabelName("A")(InputPosition.NONE)
+    val propKey = PropertyKeyName("prop")(InputPosition.NONE)
+    Mockito.when(selections.labelsOnNode(IdName("a"))).thenReturn(Set(label))
+
+    val stats = mock[GraphStatistics]
+    Mockito.when(stats.indexSelectivity(LabelId(0), PropertyKeyId(0))).thenReturn(Some(Selectivity(.01)))
+    val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
+
+    val prefixes = Map(StringLiteral("p%")(InputPosition.NONE)          -> 0.24551328138282763,
+                       StringLiteral("p2%")(InputPosition.NONE)         -> 0.23384596099184043,
+                       StringLiteral("p33%")(InputPosition.NONE)        -> 0.2299568541948447,
+                       StringLiteral("p5555%")(InputPosition.NONE)      -> 0.22684556875724812,
+                       StringLiteral("reallylong%")(InputPosition.NONE) -> 0.22451210467905067)
+
+    prefixes.foreach { entry =>
+      calculator(Like(Property(Identifier("a") _, propKey) _, LikePattern(entry._1)) _) should equal(
+        Selectivity(entry._2))
+    }
   }
 }


### PR DESCRIPTION
`MATCH (p:Person) where p.name LIKE 'M%' AND p.name LIKE 'Petr%'` should choose to do a prefix search on the second LIKE pattern.
