### PR TITLE
Implemented the cypher parts of mandatory property constraints

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalQueryStatistics.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalQueryStatistics.scala
@@ -28,8 +28,10 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
                            labelsRemoved: Int = 0,
                            indexesAdded: Int = 0,
                            indexesRemoved: Int = 0,
-                           constraintsAdded: Int = 0,
-                           constraintsRemoved: Int = 0) {
+                           uniqueConstraintsAdded: Int = 0,
+                           uniqueConstraintsRemoved: Int = 0,
+                           mandatoryConstraintsAdded: Int = 0,
+                           mandatoryConstraintsRemoved: Int = 0) {
   def containsUpdates =
     nodesCreated > 0 ||
       relationshipsCreated > 0 ||
@@ -40,8 +42,10 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
       labelsRemoved > 0 ||
       indexesAdded > 0 ||
       indexesRemoved > 0 ||
-      constraintsAdded > 0 ||
-      constraintsRemoved > 0
+      uniqueConstraintsAdded > 0 ||
+      uniqueConstraintsRemoved > 0||
+      mandatoryConstraintsAdded > 0 ||
+      mandatoryConstraintsRemoved > 0
 
   override def toString = {
     val builder = new StringBuilder
@@ -55,8 +59,10 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
     includeIfNonZero(builder, "Labels removed: ", labelsRemoved)
     includeIfNonZero(builder, "Indexes added: ", indexesAdded)
     includeIfNonZero(builder, "Indexes removed: ", indexesRemoved)
-    includeIfNonZero(builder, "Constraints added: ", constraintsAdded)
-    includeIfNonZero(builder, "Constraints removed: ", constraintsRemoved)
+    includeIfNonZero(builder, "Unique constraints added: ", uniqueConstraintsAdded)
+    includeIfNonZero(builder, "Unique constraints removed: ", uniqueConstraintsRemoved)
+    includeIfNonZero(builder, "Mandatory property constraints added: ", mandatoryConstraintsAdded)
+    includeIfNonZero(builder, "Mandatory property constraints removed: ", mandatoryConstraintsRemoved)
 
     val result = builder.toString()
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/Command.scala
@@ -32,7 +32,7 @@ case class DropIndex(label: LabelName, property: PropertyKeyName)(val position: 
   def semanticCheck = Seq()
 }
 
-trait UniqueConstraintCommand extends Command with SemanticChecking {
+trait PropertyConstraintCommand extends Command with SemanticChecking {
   def identifier: Identifier
   def label: LabelName
   def property: Property
@@ -45,6 +45,11 @@ trait UniqueConstraintCommand extends Command with SemanticChecking {
     }
 }
 
-case class CreateUniqueConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends UniqueConstraintCommand
+case class CreateUniquePropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends PropertyConstraintCommand
 
-case class DropUniqueConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends UniqueConstraintCommand
+case class DropUniquePropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends PropertyConstraintCommand
+
+case class CreateMandatoryPropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends PropertyConstraintCommand
+
+case class DropMandatoryPropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends PropertyConstraintCommand
+

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
@@ -39,14 +39,26 @@ object StatementConverters {
         commands.CreateIndex(s.label.name, Seq(s.property.name))
       case s: ast.DropIndex =>
         commands.DropIndex(s.label.name, Seq(s.property.name))
-      case s: ast.CreateUniqueConstraint =>
+      case s: ast.CreateUniquePropertyConstraint =>
         commands.CreateUniqueConstraint(
           id = s.identifier.name,
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.DropUniqueConstraint =>
+      case s: ast.DropUniquePropertyConstraint =>
         commands.DropUniqueConstraint(
+          id = s.identifier.name,
+          label = s.label.name,
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
+      case s: ast.CreateMandatoryPropertyConstraint =>
+        commands.CreateMandatoryPropertyConstraint(
+          id = s.identifier.name,
+          label = s.label.name,
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
+      case s: ast.DropMandatoryPropertyConstraint =>
+        commands.DropMandatoryPropertyConstraint(
           id = s.identifier.name,
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
@@ -32,7 +32,7 @@ final case class DropIndex(label: String, propertyKeys: Seq[String], queryString
   def setQueryText(t: String): DropIndex = copy(queryString = QueryString(t))
 }
 
-sealed abstract class UniqueConstraintOperation(_id: String, _label: String, _idForProperty: String, _propertyKey: String,
+sealed abstract class PropertyConstraintOperation(_id: String, _label: String, _idForProperty: String, _propertyKey: String,
     _queryString: QueryString = QueryString.empty) extends AbstractQuery {
   def id:String
   def label: String
@@ -41,11 +41,21 @@ sealed abstract class UniqueConstraintOperation(_id: String, _label: String, _id
 }
 
 final case class CreateUniqueConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-    queryString: QueryString = QueryString.empty) extends UniqueConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+    queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
   def setQueryText(t: String): CreateUniqueConstraint = copy(queryString = QueryString(t))
 }
 
 final case class DropUniqueConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-    queryString: QueryString = QueryString.empty) extends UniqueConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+    queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
   def setQueryText(t: String): DropUniqueConstraint = copy(queryString = QueryString(t))
+}
+
+final case class CreateMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
+                                        queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+  def setQueryText(t: String): CreateMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+}
+
+final case class DropMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
+                                      queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+  def setQueryText(t: String): DropMandatoryPropertyConstraint = copy(queryString = QueryString(t))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
@@ -54,7 +54,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String
       case q: IndexOperation =>
         buildIndexQuery(q)
 
-      case q: UniqueConstraintOperation =>
+      case q: PropertyConstraintOperation =>
         buildConstraintQuery(q)
 
       case q: Union =>
@@ -70,7 +70,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String
 
   private def buildIndexQuery(op: IndexOperation): PipeInfo = PipeInfo(new IndexOperationPipe(op), updating = true, plannerUsed = RulePlannerName)
 
-  private def buildConstraintQuery(op: UniqueConstraintOperation): PipeInfo = {
+  private def buildConstraintQuery(op: PropertyConstraintOperation): PipeInfo = {
     val label = KeyToken.Unresolved(op.label, TokenType.Label)
     val propertyKey = KeyToken.Unresolved(op.propertyKey, TokenType.PropertyKey)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
@@ -29,8 +29,10 @@ trait Command extends Parser
 
   def Command: Rule1[ast.Command] = rule(
     CreateUniqueConstraint
+      | CreateMandatoryConstraint
       | CreateIndex
       | DropUniqueConstraint
+      | DropMandatoryConstraint
       | DropIndex
   )
 
@@ -42,14 +44,25 @@ trait Command extends Parser
     group(keyword("DROP INDEX ON") ~~ NodeLabel ~~ "(" ~~ PropertyKeyName ~~ ")") ~~>> (ast.DropIndex(_, _))
   }
 
-  def CreateUniqueConstraint: Rule1[ast.CreateUniqueConstraint] = rule {
-    group(keyword("CREATE") ~~ ConstraintSyntax) ~~>> (ast.CreateUniqueConstraint(_, _, _))
+  def CreateUniqueConstraint: Rule1[ast.CreateUniquePropertyConstraint] = rule {
+    group(keyword("CREATE") ~~ UniqueConstraintSyntax) ~~>> (ast.CreateUniquePropertyConstraint(_, _, _))
   }
 
-  def DropUniqueConstraint: Rule1[ast.DropUniqueConstraint] = rule {
-    group(keyword("DROP") ~~ ConstraintSyntax) ~~>> (ast.DropUniqueConstraint(_, _, _))
+  def CreateMandatoryConstraint: Rule1[ast.CreateMandatoryPropertyConstraint] = rule {
+    group(keyword("CREATE") ~~ MandatoryConstraintSyntax) ~~>> (ast.CreateMandatoryPropertyConstraint(_, _, _))
   }
 
-  private def ConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
+  def DropUniqueConstraint: Rule1[ast.DropUniquePropertyConstraint] = rule {
+    group(keyword("DROP") ~~ UniqueConstraintSyntax) ~~>> (ast.DropUniquePropertyConstraint(_, _, _))
+  }
+
+  def DropMandatoryConstraint: Rule1[ast.DropMandatoryPropertyConstraint] = rule {
+    group(keyword("DROP") ~~ MandatoryConstraintSyntax) ~~>> (ast.DropMandatoryPropertyConstraint(_, _, _))
+  }
+
+  private def UniqueConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
     optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS UNIQUE")
+
+  private def MandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
+    optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS NOT NULL")
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 
-class ConstraintOperationPipe(op: UniqueConstraintOperation, label: KeyToken, propertyKey: KeyToken)
+class ConstraintOperationPipe(op: PropertyConstraintOperation, label: KeyToken, propertyKey: KeyToken)
                              (implicit val monitor: PipeMonitor) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val labelId = label.getOrCreateId(state.query)
@@ -35,6 +35,8 @@ class ConstraintOperationPipe(op: UniqueConstraintOperation, label: KeyToken, pr
     op match {
       case _: CreateUniqueConstraint => state.query.createUniqueConstraint(labelId, propertyKeyId)
       case _: DropUniqueConstraint   => state.query.dropUniqueConstraint(labelId, propertyKeyId)
+      case _: CreateMandatoryPropertyConstraint => state.query.createMandatoryConstraint(labelId, propertyKeyId)
+      case _: DropMandatoryPropertyConstraint => state.query.dropMandatoryConstraint(labelId, propertyKeyId)
     }
 
     Iterator.empty

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -95,6 +95,10 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropUniqueConstraint(labelId, propertyKeyId))
 
+  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.createMandatoryConstraint(labelId, propertyKeyId))
+
+  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropMandatoryConstraint(labelId, propertyKeyId))
+
   def withAnyOpenQueryContext[T](work: (QueryContext) => T): T = inner.withAnyOpenQueryContext(work)
 
   def exactUniqueIndexSearch(index: IndexDescriptor, value: Any): Option[Node] = singleDbHit(inner.exactUniqueIndexSearch(index, value))

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -95,6 +95,10 @@ trait QueryContext extends TokenContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int)
 
+  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint]//TODO add MandatoryConstraint when doing kernel work
+
+  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int)
+
   def getOptStatistics: Option[InternalQueryStatistics] = None
 
   def hasLocalFileAccess: Boolean = false

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
@@ -34,8 +34,10 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
   private val labelsRemoved = new Counter
   private val indexesAdded = new Counter
   private val indexesRemoved = new Counter
-  private val constraintsAdded = new Counter
-  private val constraintsRemoved = new Counter
+  private val uniqueConstraintsAdded = new Counter
+  private val uniqueConstraintsRemoved = new Counter
+  private val mandatoryConstraintsAdded = new Counter
+  private val mandatoryConstraintsRemoved = new Counter
 
   def getStatistics = InternalQueryStatistics(
     nodesCreated = nodesCreated.count,
@@ -47,8 +49,10 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     relationshipsDeleted = relationshipsDeleted.count,
     indexesAdded = indexesAdded.count,
     indexesRemoved = indexesRemoved.count,
-    constraintsAdded = constraintsAdded.count,
-    constraintsRemoved = constraintsRemoved.count)
+    uniqueConstraintsAdded = uniqueConstraintsAdded.count,
+    uniqueConstraintsRemoved = uniqueConstraintsRemoved.count,
+    mandatoryConstraintsAdded = mandatoryConstraintsAdded.count,
+    mandatoryConstraintsRemoved = mandatoryConstraintsRemoved.count)
 
   override def getOptStatistics = Some(getStatistics)
 
@@ -92,13 +96,24 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
 
   override def createUniqueConstraint(labelId: Int, propertyKeyId: Int) = {
     val result = inner.createUniqueConstraint(labelId, propertyKeyId)
-    result.ifCreated { constraintsAdded.increase() }
+    result.ifCreated { uniqueConstraintsAdded.increase() }
     result
   }
 
   override def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) {
     inner.dropUniqueConstraint(labelId, propertyKeyId)
-    constraintsRemoved.increase()
+    uniqueConstraintsRemoved.increase()
+  }
+
+  override def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) = {
+    val result = inner.createMandatoryConstraint(labelId, propertyKeyId)
+    result.ifCreated { mandatoryConstraintsAdded.increase() }
+    result
+  }
+
+  override def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) {
+    inner.dropMandatoryConstraint(labelId, propertyKeyId)
+    mandatoryConstraintsRemoved.increase()
   }
 
   override def nodeGetDegree(node: Long, dir: Direction): Int = super.nodeGetDegree(node, dir)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -2880,6 +2880,20 @@ class CypherParserTest extends CypherFunSuite {
     )
   }
 
+  test("mandatory property constraint creation") {
+    expectQuery(
+      "CREATE CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      CreateMandatoryPropertyConstraint("id", "Label", "id", "property")
+    )
+  }
+
+  test("mandatory property constraint deletion") {
+    expectQuery(
+      "DROP CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      DropMandatoryPropertyConstraint("id", "Label", "id", "property")
+    )
+  }
+
   test("named path with variable length path and named relationships collection") {
     expectQuery(
       "match p = (a)-[r*]->(b) return p",

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
@@ -60,6 +60,9 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   when( inner.createUniqueConstraint(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[UniquenessConstraint]))
 
+  when( inner.createMandatoryConstraint(anyInt(), anyInt()) )
+    .thenReturn(IdempotentResult(mock[UniquenessConstraint]))
+
   when( inner.addIndexRule(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[IndexDescriptor]))
 
@@ -145,12 +148,24 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   test("create_unique_constraint") {
     context.createUniqueConstraint(0, 1)
 
-    context.getStatistics should equal(InternalQueryStatistics(constraintsAdded = 1))
+    context.getStatistics should equal(InternalQueryStatistics(uniqueConstraintsAdded = 1))
   }
 
   test("constraint_dropped") {
     context.dropUniqueConstraint(0, 42)
 
-    context.getStatistics should equal(InternalQueryStatistics(constraintsRemoved = 1))
+    context.getStatistics should equal(InternalQueryStatistics(uniqueConstraintsRemoved = 1))
+  }
+
+  test("create mandatory constraint") {
+    context.createMandatoryConstraint(0, 1)
+
+    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsAdded = 1))
+  }
+
+  test("drop mandatory constraint") {
+    context.dropMandatoryConstraint(0, 42)
+
+    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsRemoved = 1))
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -245,8 +245,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       labelsRemoved = i.labelsRemoved,
       indexesAdded = i.indexesAdded,
       indexesRemoved = i.indexesRemoved,
-      constraintsAdded = i.constraintsAdded,
-      constraintsRemoved = i.constraintsRemoved)
+      constraintsAdded = i.uniqueConstraintsAdded,
+      constraintsRemoved = i.uniqueConstraintsRemoved)
   }
 
   def dumpToString(writer: PrintWriter) = exceptionHandlerFor2_3.runSafely{inner.dumpToString(writer)}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -112,6 +112,12 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
   override def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     translateException(super.dropUniqueConstraint(labelId, propertyKeyId))
 
+  override def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.createMandatoryConstraint(labelId, propertyKeyId))
+
+  override def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.dropMandatoryConstraint(labelId, propertyKeyId))
+
   override def withAnyOpenQueryContext[T](work: (QueryContext) => T): T =
     super.withAnyOpenQueryContext(qc =>
       translateException(

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -321,6 +321,12 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
 
+  //TODO implement
+  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = ???
+
+  //TODO implement
+  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) = ???
+
   override def hasLocalFileAccess: Boolean = graph match {
     case db: GraphDatabaseAPI => db.getDependencyResolver.resolveDependency(classOf[Config]).get(GraphDatabaseSettings.allow_file_urls)
     case _ => true

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -118,8 +118,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
     val result = execute("create constraint on (n:Person) assert n.name is unique")
     val stats  = result.queryStatistics()
 
-    assert(stats.constraintsAdded === 1)
-    assert(stats.constraintsRemoved === 0)
+    assert(stats.uniqueConstraintsAdded === 1)
+    assert(stats.uniqueConstraintsRemoved === 0)
   }
 
   test("correctConstraintStatisticsForUniquenessConstraintAddedTwice") {
@@ -128,7 +128,48 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
     val result = execute("create constraint on (n:Person) assert n.name is unique")
     val stats  = result.queryStatistics()
 
-    assert(stats.constraintsAdded === 0)
-    assert(stats.constraintsRemoved === 0)
+    assert(stats.uniqueConstraintsAdded === 0)
+    assert(stats.uniqueConstraintsRemoved === 0)
   }
+
+  //TODO unignore when implemented spi
+  ignore("correct statistics for mandatory constraint added ") {
+    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    val stats  = result.queryStatistics()
+
+    assert(stats.mandatoryConstraintsAdded === 1)
+    assert(stats.mandatoryConstraintsRemoved === 0)
+  }
+
+  //TODO unignore when implemented spi
+  ignore("correct statistics for mandatory constraint added twice") {
+    execute("create constraint on (n:Person) assert n.name is not null")
+    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    val stats  = result.queryStatistics()
+
+    assert(stats.mandatoryConstraintsAdded === 0)
+    assert(stats.mandatoryConstraintsRemoved === 0)
+  }
+
+    //TODO unignore when implemented spi
+    ignore("correct statistics for mandatory constraint dropped") {
+      execute("create constraint on (n:Person) assert n.name is not null")
+      val result = execute("drop constraint on (n:Person) assert n.name is not null")
+      val stats  = result.queryStatistics()
+
+      assert(stats.mandatoryConstraintsAdded === 0)
+      assert(stats.mandatoryConstraintsRemoved === 1)
+    }
+
+    //TODO unignore when implemented spi
+    ignore("correct statistics for mandatory constraint dropped twice") {
+      execute("create constraint on (n:Person) assert n.name is not null")
+      execute("drop constraint on (n:Person) assert n.name is not null")
+      val result = execute("drop constraint on (n:Person) assert n.name is not null")
+      val stats  = result.queryStatistics()
+
+      assert(stats.mandatoryConstraintsAdded === 0)
+      assert(stats.mandatoryConstraintsRemoved === 0)
+    }
+
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -139,6 +139,10 @@ class SnitchingQueryContext extends QueryContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) {???}
 
+  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = ???
+
+  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) {???}
+
   def getLabelId(labelName: String): Int = ???
 
   def getPropertyKeyName(id: Int): String = ???

--- a/community/cypher/docs/cypher-docs/src/docs/dev/tutorials/gists/cypher/labels.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/tutorials/gists/cypher/labels.asciidoc
@@ -13,7 +13,7 @@ CREATE CONSTRAINT ON (movie:Movie) ASSERT movie.title IS UNIQUE
 
 [source,querytest]
 ----
-Constraints added: 1
+Unique constraints added: 1
 ----
 
 // console

--- a/community/cypher/docs/cypher-docs/src/docs/graphgists/intro/labels.adoc
+++ b/community/cypher/docs/cypher-docs/src/docs/graphgists/intro/labels.adoc
@@ -19,7 +19,7 @@ CREATE CONSTRAINT ON (movie:Movie) ASSERT movie.title IS UNIQUE
 
 [source,querytest]
 ----
-Constraints added: 1
+Unique constraints added: 1
 ----
 
 // console


### PR DESCRIPTION
Implementing the necessary cypher infrastructure for creating and dropping mandatory
property constraints. Note that nothing is yet implemented on the kernel side so at the moment
using the feature will end up in a `NotImplementedError`. Also note that syntax is not yet final,
however the implementation is not expected to change much due to syntax changes.
