### PR TITLE
Only log fatal stack trace once in user log

### DIFF
--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/PackStreamMessageFormatV1.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/PackStreamMessageFormatV1.java
@@ -395,7 +395,7 @@ public class PackStreamMessageFormatV1 implements MessageFormat
             }
             else
             {
-                throw new RuntimeException( "Unpackable value " + obj + " of type " + obj.getClass().getName() );
+                throw new NDPIOException( Status.General.UnknownFailure, "Unpackable value " + obj + " of type " + obj.getClass().getName() );
             }
         }
     }
@@ -673,11 +673,11 @@ public class PackStreamMessageFormatV1 implements MessageFormat
                     return new ValuePath( entities );
                 }
                 default:
-                    throw new IOException( "Unknown struct type: " + signature );
+                    throw new NDPIOException( Status.Request.InvalidFormat, "Unknown struct type: " + signature );
                 }
             }
             default:
-                throw new IOException( "Unknown value type: " + valType );
+                throw new NDPIOException( Status.Request.InvalidFormat, "Unknown value type: " + valType );
             }
         }
 

--- a/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/ErrorTranslatorTest.java
+++ b/community/ndp/runtime/src/test/java/org/neo4j/ndp/runtime/internal/ErrorTranslatorTest.java
@@ -38,7 +38,7 @@ public class ErrorTranslatorTest
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();
         ErrorTranslator translator =
-                new ErrorTranslator( provider.getLog( "userlog" ), provider.getLog( "internallog" ) );
+                new ErrorTranslator( provider.getLog( "userlog" ) );
 
         Throwable cause = new Throwable( "This is not an error we know how to handle." );
 
@@ -50,8 +50,6 @@ public class ErrorTranslatorTest
         provider.assertExactly(
                 inLog( "userlog" )
                     .error( both(containsString( "START OF REPORT" ))
-                            .and(containsString( "END OF REPORT" )), equalTo( cause ) ),
-                inLog( "internallog" )
-                    .error( containsString( "Client triggered unexpected error, reference" ), equalTo( cause ) ) );
+                            .and(containsString( "END OF REPORT" )) ));
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
@@ -25,7 +25,7 @@ import org.neo4j.server.rest.dbms.UserService;
 import org.neo4j.server.rest.discovery.DiscoveryService;
 import org.neo4j.server.web.WebServer;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 /**
  * Mounts the DBMS REST API.
@@ -49,9 +49,9 @@ public class DBMSModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return listFrom(
+        return asList(
                 DiscoveryService.class.getName(),
-                UserService.class.getName());
+                UserService.class.getName() );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ManagementApiModule.java
@@ -29,7 +29,7 @@ import org.neo4j.server.rest.management.VersionAndEditionService;
 import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.server.web.WebServer;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 public class ManagementApiModule implements ServerModule
 {
@@ -51,7 +51,7 @@ public class ManagementApiModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return listFrom(
+        return asList(
                 JmxService.class.getName(),
                 RootService.class.getName(),
                 VersionAndEditionService.class.getName() );

--- a/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/RESTApiModule.java
@@ -46,7 +46,7 @@ import org.neo4j.server.web.WebServer;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 /**
  * Mounts the database REST API.
@@ -107,7 +107,7 @@ public class RESTApiModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return listFrom(
+        return asList(
                 RestfulGraphDatabase.class.getName(),
                 TransactionalService.class.getName(),
                 CypherService.class.getName(),

--- a/community/server/src/main/java/org/neo4j/server/modules/ThirdPartyJAXRSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ThirdPartyJAXRSModule.java
@@ -31,7 +31,7 @@ import org.neo4j.server.configuration.ThirdPartyJaxRsPackage;
 import org.neo4j.server.plugins.Injectable;
 import org.neo4j.server.web.WebServer;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 public class ThirdPartyJAXRSModule implements ServerModule
 {
@@ -66,7 +66,7 @@ public class ThirdPartyJAXRSModule implements ServerModule
 
     private List<String> packagesFor( ThirdPartyJaxRsPackage tpp )
     {
-        return listFrom( new String[] { tpp.getPackageName() } );
+        return asList( tpp.getPackageName() );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/modules/WebAdminModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/WebAdminModule.java
@@ -28,7 +28,7 @@ import org.neo4j.server.rest.management.console.ConsoleService;
 import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.server.web.WebServer;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 public class WebAdminModule implements ServerModule
 {
@@ -57,7 +57,7 @@ public class WebAdminModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return listFrom(
+        return asList(
                 MonitorService.class.getName(),
                 ConsoleService.class.getName() );
     }

--- a/community/server/src/main/java/org/neo4j/server/web/JaxRsServletHolderFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/web/JaxRsServletHolderFactory.java
@@ -19,21 +19,20 @@
  */
 package org.neo4j.server.web;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.sun.jersey.api.core.ClassNamesResourceConfig;
 import com.sun.jersey.api.core.PackagesResourceConfig;
 import com.sun.jersey.api.core.ResourceConfig;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.neo4j.server.database.InjectableProvider;
 import org.neo4j.server.modules.ServerModule;
 import org.neo4j.server.plugins.Injectable;
 import org.neo4j.server.rest.web.AllowAjaxFilter;
-import org.neo4j.server.rest.web.CollectUserAgentFilter;
 
 /**
  * Different {@link ServerModule}s can register services at the same mount point.
@@ -74,7 +73,7 @@ public abstract class JaxRsServletHolderFactory
     private String getRequestFilterConfig()
     {
         // Ordering of execution of filters goes from left to right
-        return XForwardFilter.class.getName() + "," + CollectUserAgentFilter.class.getName();
+        return XForwardFilter.class.getName();
     }
 
     protected abstract void configure( ServletHolder servletHolder, String commaSeparatedList );

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/MasterInfoServerModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/MasterInfoServerModule.java
@@ -29,7 +29,7 @@ import org.neo4j.server.modules.ServerModule;
 import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.server.web.WebServer;
 
-import static org.neo4j.server.JAXRSHelper.listFrom;
+import static java.util.Arrays.asList;
 
 public class MasterInfoServerModule implements ServerModule
 {
@@ -62,7 +62,7 @@ public class MasterInfoServerModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return listFrom( MasterInfoService.class.getName() );
+        return asList( MasterInfoService.class.getName() );
     }
 
     private URI managementApiUri()


### PR DESCRIPTION
Currently we print out a stack trace twice whenever a fatal error occurs in GAP. This cuts it down to one stack trace.
