### PR TITLE
GH#4790 - StandardBranchCollisionDetector memory footprint enhancement

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/matching/BidirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/matching/BidirectionalTraversalMatcher.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes.matching
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
+import org.neo4j.function.Predicate
 import pipes.{EntityProducer, QueryState}
 import org.neo4j.graphdb.{Node, Path}
 import org.neo4j.graphdb.traversal._
@@ -111,7 +112,10 @@ class BidirectionalTraversalMatcher(steps: ExpanderStep,
       include
     }
 
+    override def create(evaluator: Evaluator, pathPredicate: Predicate[Path]) = new StepCollisionDetector
+
     def create(evaluator: Evaluator) = new StepCollisionDetector
+
   }
 
   def arguments: Seq[Argument] = Seq.empty // TODO: Remove this class. This is wrong. But not worth fixing plans for.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/AbstractUniquenessFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/AbstractUniquenessFilter.java
@@ -30,6 +30,6 @@ abstract class AbstractUniquenessFilter implements BidirectionalUniquenessFilter
 
     public boolean checkFirst( TraversalBranch branch )
     {
-        return type == PrimitiveTypeFetcher.RELATIONSHIP ? true : check( branch );
+        return type == PrimitiveTypeFetcher.RELATIONSHIP || check( branch );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionDetector.java
@@ -45,7 +45,7 @@ public interface BranchCollisionDetector
      * from the start side of this bidirectional traversal, or {@link Direction#INCOMING}
      * for the end side.
      * @return new paths formed if this branch collided with other branches,
-     * or {@code null} if no collision occured.
+     * or {@code null} if no collision occurred.
      */
     Iterable<Path> evaluate( TraversalBranch branch, Direction direction );
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicies.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicies.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.graphdb.traversal;
 
+import org.neo4j.function.Predicate;
+import org.neo4j.function.Predicates;
+import org.neo4j.graphdb.Path;
 import org.neo4j.kernel.ShortestPathsBranchCollisionDetector;
 import org.neo4j.kernel.StandardBranchCollisionDetector;
 
@@ -32,17 +35,32 @@ public enum BranchCollisionPolicies implements BranchCollisionPolicy
     STANDARD
     {
         @Override
+        @Deprecated
         public BranchCollisionDetector create( Evaluator evaluator )
         {
             return new StandardBranchCollisionDetector( evaluator );
+        }
+
+        @Override
+        public BranchCollisionDetector create( Evaluator evaluator, Predicate<Path> pathPredicate )
+        {
+            return new StandardBranchCollisionDetector( evaluator, pathPredicate );
         }
     },
     SHORTEST_PATH
     {
         @Override
+        @Deprecated
         public BranchCollisionDetector create( Evaluator evaluator )
         {
             return new ShortestPathsBranchCollisionDetector( evaluator );
         }
-    };
+
+        @Override
+        public BranchCollisionDetector create( Evaluator evaluator, Predicate<Path> pathPredicate )
+        {
+            return new ShortestPathsBranchCollisionDetector( evaluator, pathPredicate );
+        }
+    }
 }
+

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicy.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/BranchCollisionPolicy.java
@@ -19,10 +19,37 @@
  */
 package org.neo4j.graphdb.traversal;
 
+import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.Path;
+
 /**
  * Copied from kernel package so that we can hide kernel from the public API.
  */
 public interface BranchCollisionPolicy
 {
+    @Deprecated
     BranchCollisionDetector create( Evaluator evaluator );
+
+    BranchCollisionDetector create( Evaluator evaluator, Predicate<Path> pathPredicate );
+
+    class CollisionPolicyAdapter implements BranchCollisionPolicy
+    {
+        private BranchCollisionPolicy policy;
+
+        public CollisionPolicyAdapter( BranchCollisionPolicy policy )
+        {
+            this.policy = policy;
+        }
+
+        @Override
+        public BranchCollisionDetector create( Evaluator evaluator )
+        {
+            return policy.create( evaluator );
+        }
+
+        public BranchCollisionDetector create( Evaluator evaluator, Predicate<Path> pathPredicate )
+        {
+            return create( evaluator );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/BidirectionalTraversalBranchPath.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/BidirectionalTraversalBranchPath.java
@@ -90,7 +90,7 @@ public class BidirectionalTraversalBranchPath implements Path
     private LinkedList<Relationship> gatherRelationships( TraversalBranch first, TraversalBranch then )
     {
         // TODO Don't loop through them all up front
-        LinkedList<Relationship> relationships = new LinkedList<Relationship>();
+        LinkedList<Relationship> relationships = new LinkedList<>();
         TraversalBranch branch = first;
         while ( branch.length() > 0 )
         {
@@ -98,16 +98,20 @@ public class BidirectionalTraversalBranchPath implements Path
             branch = branch.parent();
         }
         // We can might as well cache start node since we're right now there anyway
-        if ( cachedStartNode == null && first == start )
+        if ( cachedStartNode == null && first == start && branch.length() >= 0)
+        {
             cachedStartNode = branch.endNode();
+        }
         branch = then;
         while ( branch.length() > 0 )
         {
             relationships.add( branch.lastRelationship() );
             branch = branch.parent();
         }
-        if ( cachedStartNode == null && then == start )
+        if ( cachedStartNode == null && then == start && branch.length() >= 0 )
+        {
             cachedStartNode = branch.endNode();
+        }
         return relationships;
     }
     
@@ -126,15 +130,17 @@ public class BidirectionalTraversalBranchPath implements Path
     private Iterable<Node> gatherNodes( TraversalBranch first, TraversalBranch then )
     {
         // TODO Don't loop through them all up front
-        LinkedList<Node> nodes = new LinkedList<Node>();
+        LinkedList<Node> nodes = new LinkedList<>();
         TraversalBranch branch = first;
         while ( branch.length() > 0 )
         {
             nodes.addFirst( branch.endNode() );
             branch = branch.parent();
         }
-        if ( cachedStartNode == null && first == start )
+        if ( cachedStartNode == null && first == start && branch.length() >= 0)
+        {
             cachedStartNode = branch.endNode();
+        }
         nodes.addFirst( branch.endNode() );
         branch = then.parent();
         if ( branch != null )
@@ -149,8 +155,10 @@ public class BidirectionalTraversalBranchPath implements Path
                 nodes.add( branch.endNode() );
             }
         }
-        if ( cachedStartNode == null && then == start )
+        if ( cachedStartNode == null && then == start && branch.length() >= 0)
+        {
             cachedStartNode = branch.endNode();
+        }
         return nodes;
     }
     
@@ -164,7 +172,7 @@ public class BidirectionalTraversalBranchPath implements Path
     public Iterator<PropertyContainer> iterator()
     {
         // TODO Don't loop through them all up front
-        LinkedList<PropertyContainer> entities = new LinkedList<PropertyContainer>();
+        LinkedList<PropertyContainer> entities = new LinkedList<>();
         TraversalBranch branch = start;
         while ( branch.length() > 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/ShortestPathsBranchCollisionDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/ShortestPathsBranchCollisionDetector.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.function.Predicate;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.TraversalBranch;
@@ -26,10 +27,16 @@ import org.neo4j.graphdb.traversal.TraversalBranch;
 public class ShortestPathsBranchCollisionDetector extends StandardBranchCollisionDetector
 {
     private int depth = -1;
-    
-    public ShortestPathsBranchCollisionDetector( Evaluator evaluator )
+
+    @Deprecated
+    public ShortestPathsBranchCollisionDetector( Evaluator evaluator)
     {
         super( evaluator );
+    }
+
+    public ShortestPathsBranchCollisionDetector( Evaluator evaluator, Predicate<Path> pathPredicate )
+    {
+        super( evaluator, pathPredicate );
     }
     
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Traversal.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Expander;
 import org.neo4j.graphdb.Node;
@@ -484,7 +485,8 @@ public class Traversal
     @Deprecated
     public static BranchCollisionDetector shortestPathsCollisionDetector( int maxDepth )
     {
-        return new ShortestPathsBranchCollisionDetector( Evaluators.toDepth( maxDepth ) );
+        return new ShortestPathsBranchCollisionDetector( Evaluators.toDepth( maxDepth ),
+                                                         Predicates.<Path>alwaysTrue() );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
@@ -25,6 +25,7 @@ import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
+import org.neo4j.graphdb.traversal.BranchCollisionPolicy.CollisionPolicyAdapter;
 import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.PathEvaluator;
@@ -51,7 +52,8 @@ public class BidirectionalTraversalDescriptionImpl implements BidirectionalTrave
 
     private BidirectionalTraversalDescriptionImpl( MonoDirectionalTraversalDescription start,
                                                    MonoDirectionalTraversalDescription end,
-                                                   org.neo4j.graphdb.traversal.BranchCollisionPolicy collisionPolicy,
+                                                   org.neo4j.graphdb.traversal.BranchCollisionPolicy
+                                                           collisionPolicy,
                                                    PathEvaluator collisionEvaluator, SideSelectorPolicy sideSelector,
                                                    Supplier<? extends Resource> statementFactory, int maxDepth )
     {
@@ -67,8 +69,10 @@ public class BidirectionalTraversalDescriptionImpl implements BidirectionalTrave
     public BidirectionalTraversalDescriptionImpl(Supplier<? extends Resource> statementFactory)
     {
         // TODO Proper defaults.
-        this( new MonoDirectionalTraversalDescription(), new MonoDirectionalTraversalDescription(), STANDARD, Evaluators.all(), ALTERNATING,
-              statementFactory, Integer.MAX_VALUE );
+        this( new MonoDirectionalTraversalDescription(), new MonoDirectionalTraversalDescription(),
+                STANDARD,
+                Evaluators.all(), ALTERNATING,
+                statementFactory, Integer.MAX_VALUE );
     }
 
     public BidirectionalTraversalDescriptionImpl()
@@ -107,15 +111,15 @@ public class BidirectionalTraversalDescriptionImpl implements BidirectionalTrave
     @Override
     public BidirectionalTraversalDescription collisionPolicy( org.neo4j.graphdb.traversal.BranchCollisionPolicy collisionPolicy )
     {
-        return new BidirectionalTraversalDescriptionImpl( this.start, this.end,
-                collisionPolicy, this.collisionEvaluator, this.sideSelector, statementFactory, this.maxDepth );
+        return new BidirectionalTraversalDescriptionImpl( this.start, this.end, collisionPolicy,
+                this.collisionEvaluator, this.sideSelector, statementFactory, this.maxDepth );
     }
 
     @Override
     public BidirectionalTraversalDescription collisionPolicy( BranchCollisionPolicy collisionPolicy )
     {
-        return new BidirectionalTraversalDescriptionImpl( this.start, this.end,
-                collisionPolicy, this.collisionEvaluator, this.sideSelector, statementFactory, this.maxDepth );
+        return new BidirectionalTraversalDescriptionImpl( this.start, this.end, new CollisionPolicyAdapter(collisionPolicy),
+                this.collisionEvaluator, this.sideSelector, statementFactory, this.maxDepth );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BranchCollisionPolicies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BranchCollisionPolicies.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.traversal;
 
+import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.traversal.BranchCollisionDetector;
 import org.neo4j.graphdb.traversal.Evaluator;
 
@@ -33,8 +35,16 @@ public enum BranchCollisionPolicies implements BranchCollisionPolicy
     STANDARD;
 
     @Override
+    @Deprecated
     public BranchCollisionDetector create( Evaluator evaluator )
     {
         return org.neo4j.graphdb.traversal.BranchCollisionPolicies.STANDARD.create( evaluator );
     }
+
+    @Override
+    public BranchCollisionDetector create( Evaluator evaluator, Predicate< Path > pathPredicate )
+    {
+        return org.neo4j.graphdb.traversal.BranchCollisionPolicies.STANDARD.create( evaluator, pathPredicate );
+    }
+
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/StandardBranchCollisionDetectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/StandardBranchCollisionDetectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import com.google.common.collect.Iterators;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collection;
+
+import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.traversal.Evaluation;
+import org.neo4j.graphdb.traversal.Evaluator;
+import org.neo4j.graphdb.traversal.TraversalBranch;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StandardBranchCollisionDetectorTest
+{
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testFilteredPathEvaluation()
+    {
+        final PropertyContainer endNode = mock( Node.class );
+        final PropertyContainer alternativeEndNode = mock( Node.class );
+        final Node startNode = mock( Node.class );
+        Evaluator evaluator = mock( Evaluator.class );
+        TraversalBranch branch = mock( TraversalBranch.class );
+        TraversalBranch alternativeBranch = mock( TraversalBranch.class );
+
+        when( branch.iterator() ).thenAnswer( new IteratorAnswer( endNode ) );
+        when( alternativeBranch.iterator() ).thenAnswer( new IteratorAnswer( alternativeEndNode ) );
+        when( alternativeBranch.startNode() ).thenReturn( startNode );
+        when( evaluator.evaluate( Mockito.any( Path.class ) ) ).thenReturn( Evaluation.INCLUDE_AND_CONTINUE );
+        StandardBranchCollisionDetector collisionDetector = new StandardBranchCollisionDetector( evaluator,
+                new Predicate<Path>()
+                {
+                    @Override
+                    public boolean test( Path path )
+                    {
+                        return alternativeEndNode.equals( path.endNode() ) && startNode.equals( path.startNode() );
+                    }
+                } );
+
+        Collection<Path> incoming = collisionDetector.evaluate( branch, Direction.INCOMING );
+        Collection<Path> outgoing = collisionDetector.evaluate( branch, Direction.OUTGOING );
+        Collection<Path> alternativeIncoming = collisionDetector.evaluate( alternativeBranch, Direction.INCOMING );
+        Collection<Path> alternativeOutgoing = collisionDetector.evaluate( alternativeBranch, Direction.OUTGOING );
+
+        assertThat( incoming, nullValue() );
+        assertThat( outgoing, nullValue() );
+        assertThat( alternativeIncoming, nullValue() );
+        assertThat( alternativeOutgoing, hasSize( 1 ) );
+    }
+
+    private static class IteratorAnswer implements Answer<Object>
+    {
+        private final PropertyContainer endNode;
+
+        public IteratorAnswer( PropertyContainer endNode )
+        {
+            this.endNode = endNode;
+        }
+
+        @Override
+        public Object answer( InvocationOnMock invocation ) throws Throwable
+        {
+            return Iterators.singletonIterator( endNode );
+        }
+    }
+}


### PR DESCRIPTION
Enhance StandardBranchCollisionDetector to be able to filter paths before considering them using user supplied filter to decrease memory footprint.

Introduce Filterable interface to be able to provide filters to classes without interface changes.
