### PR TITLE
ha-robustness failure: "The lock session requested to start is already in use"

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -23,7 +23,6 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.function.LongPredicate;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.EntityOperations;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
@@ -117,6 +117,16 @@ public class TimedRepository<KEY, VALUE> implements Runnable
         }
     }
 
+    public void remove( KEY key )
+    {
+        Entry entry = repo.get( key );
+        if (entry == null)
+        {
+            return;
+        }
+        end0(key, entry.value);
+    }
+
     /**
      * End the life of a stored entry. If the entry is currently in use, it will be thrown out as soon as the other client
      * is done with it.
@@ -166,7 +176,7 @@ public class TimedRepository<KEY, VALUE> implements Runnable
     public VALUE acquire( KEY key ) throws NoSuchEntryException, ConcurrentAccessException
     {
         Entry entry = repo.get( key );
-        if(entry == null)
+        if ( entry == null )
         {
             throw new NoSuchEntryException( String.format("Cannot access '%s', no such entry exists.", key) );
         }
@@ -180,7 +190,7 @@ public class TimedRepository<KEY, VALUE> implements Runnable
     public void release( KEY key )
     {
         Entry entry = repo.get( key );
-        if(!entry.release())
+        if(entry != null && !entry.release())
         {
             // This happens when another client has asked that this entry be ended while we were using it, leaving us
             // a note to not release the object back to the public, and to end its life when we are done with it.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.util.diffsets;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/properties/DefinedPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/properties/DefinedPropertyTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api.properties;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
@@ -226,4 +226,19 @@ public class TimedRepositoryTest
         }
         assertThat(reapedValues, equalTo(asList(1l)));
     }
+
+    @Test
+    public void shouldAllowBeginWithSameKeyAfterSessionRemoval() throws Exception
+    {
+        // Given
+        repo.begin( 1l );
+        repo.acquire( 1l );
+
+        // when
+        repo.remove( 1l );
+
+        //then
+        repo.begin( 1l );
+        assertThat( reapedValues, equalTo( asList( 0l ) ) );
+    }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
@@ -81,7 +81,7 @@ public class MarshlandPool<T> implements Pool<T>
     public T acquire()
     {
         // Try and get it from the thread local
-        LocalSlot<T> localSlot = puddle.get();;
+        LocalSlot<T> localSlot = puddle.get();
 
         T object = localSlot.object;
         if(object != null)

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
@@ -89,7 +89,7 @@ class BackupServer extends Server<TheBackupInterface, Object>
     }
 
     @Override
-    protected void finishOffChannel( Channel channel, RequestContext context )
+    protected void cleanConversation( RequestContext context )
     {
     }
 }

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -103,7 +103,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
     }
 
     @Override
-    protected void finishOffChannel( Channel channel, RequestContext context )
+    protected void cleanConversation( RequestContext context )
     {
     }
 

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -123,7 +123,7 @@ public class ServerTest
             }
 
             @Override
-            protected void finishOffChannel( Channel channel, RequestContext context )
+            protected void cleanConversation( RequestContext context )
             {
             }
         };

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -84,7 +84,7 @@ public class HaSettings
     public static final Setting<TxPushStrategy> tx_push_strategy = setting( "ha.tx_push_strategy", options(
             TxPushStrategy.class ), "fixed" );
 
-    public static enum TxPushStrategy
+    public enum TxPushStrategy
     {
         @Description("Round robin")
         round_robin,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/ConversationSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/ConversationSPI.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+/**
+ * Conversation part of HA master SPI.
+ * Allows to hide dependencies from conversation management.
+ */
+public interface ConversationSPI
+{
+    Locks.Client acquireClient();
+
+    JobScheduler.JobHandle scheduleRecurringJob( JobScheduler.Group group, long interval, Runnable job );
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+/**
+ * Default implementation of {@link ConversationSPI} used on master in HA setup.
+ */
+public class DefaultConversationSPI implements ConversationSPI
+{
+    private Locks locks;
+    private JobScheduler jobScheduler;
+
+    public DefaultConversationSPI( Locks locks, JobScheduler jobScheduler )
+    {
+        this.locks = locks;
+        this.jobScheduler = jobScheduler;
+    }
+
+    @Override
+    public Locks.Client acquireClient()
+    {
+        return locks.newClient();
+    }
+
+    @Override
+    public JobScheduler.JobHandle scheduleRecurringJob( JobScheduler.Group group, long interval, Runnable job )
+    {
+        return jobScheduler.scheduleRecurring( group, job, interval, TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+
+import org.neo4j.kernel.impl.locking.Locks;
+
+/**
+ * Abstraction to hold all client related info on master side.
+ */
+public class Conversation implements AutoCloseable
+{
+    private Locks.Client locks;
+
+    public Conversation( Locks.Client locks )
+    {
+        this.locks = locks;
+    }
+
+    public Locks.Client getLocks()
+    {
+        return locks;
+    }
+
+    @Override
+    public void close()
+    {
+        locks.close();
+    }
+
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/ConversationManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/ConversationManager.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+import java.util.Set;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Factory;
+import org.neo4j.helpers.Clock;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.ha.cluster.ConversationSPI;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.collection.ConcurrentAccessException;
+import org.neo4j.kernel.impl.util.collection.NoSuchEntryException;
+import org.neo4j.kernel.impl.util.collection.TimedRepository;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.slaveLocksTimeout;
+
+/**
+ * Manages {@link Conversation} on master-side in HA.
+ * It's expected to have one instance of {@link ConversationManager} on master.
+ *
+ * Used for keeping and monitoring clients {@link Conversation} on master side.
+ */
+public class ConversationManager
+{
+    private static final int TX_TIMEOUT_ADDITION = 5 * 1000;
+    private static final int UNFINISHED_CONVERSATION_CLEANUP_DELAY = 1_000;
+
+    private final int activityCheckIntervalMillis;
+    private final Config config;
+    private final ConversationSPI spi;
+    private final Factory<Conversation> conversationFactory =  new Factory<Conversation>()
+    {
+        @Override
+        public Conversation newInstance()
+        {
+            return new Conversation( spi.acquireClient() );
+        }
+    };
+
+    TimedRepository<RequestContext,Conversation> conversations;
+    private JobScheduler.JobHandle staleReaperJob;
+
+    public ConversationManager( ConversationSPI spi, Config config )
+    {
+        this( spi, config, UNFINISHED_CONVERSATION_CLEANUP_DELAY );
+    }
+
+    public ConversationManager( ConversationSPI spi, Config config, int activityCheckIntervalMillis )
+    {
+        this.spi = spi;
+        this.config = config;
+        this.activityCheckIntervalMillis = activityCheckIntervalMillis;
+    }
+
+    public void start()
+    {
+        conversations = createConversationStore();
+
+        staleReaperJob = spi.scheduleRecurringJob( slaveLocksTimeout,
+                activityCheckIntervalMillis,
+                conversations );
+    }
+
+    public void stop()
+    {
+        staleReaperJob.cancel( false );
+        conversations = null;
+    }
+
+    public Conversation acquire( RequestContext context ) throws NoSuchEntryException, ConcurrentAccessException
+    {
+        return conversations.acquire( context );
+    }
+
+    public void release( RequestContext context )
+    {
+        conversations.release( context );
+    }
+
+    public void begin( RequestContext context ) throws ConcurrentAccessException
+    {
+        conversations.begin( context );
+    }
+
+    public void end( RequestContext context )
+    {
+        conversations.end( context );
+    }
+
+    public Set<RequestContext> getActiveContexts()
+    {
+        return conversations.keys();
+    }
+
+    public void remove( RequestContext context )
+    {
+        conversations.remove( context );
+    }
+
+    public Conversation acquire()
+    {
+        return conversationFactory.newInstance();
+    }
+
+    private TimedRepository<RequestContext,Conversation> createConversationStore()
+    {
+        return new TimedRepository<>( conversationFactory, new Consumer<Conversation>()
+        {
+            @Override
+            public void accept( Conversation conversation )
+            {
+                conversation.close();
+            }
+        }, config.get( HaSettings.lock_read_timeout ) + TX_TIMEOUT_ADDITION, Clock.SYSTEM_CLOCK );
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Master.java
@@ -80,4 +80,6 @@ public interface Master
     Response<LockResult> acquireExclusiveLock( RequestContext context, Locks.ResourceType type, long... resourceIds );
 
     Response<LockResult> acquireSharedLock( RequestContext context, Locks.ResourceType type, long... resourceIds );
+
+
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -117,9 +117,6 @@ public interface MasterClient extends Master
     @Override
     public Response<Long> commit( RequestContext context, final TransactionRepresentation channel );
 
-    @Override
-    public Response<Void> endLockSession( RequestContext context, final boolean success );
-
     public void rollbackOngoingTransactions( RequestContext context );
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.ha.com.slave;
 
-import org.jboss.netty.channel.Channel;
-
 import org.neo4j.com.ProtocolVersion;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.RequestType;
@@ -53,7 +51,7 @@ public class SlaveServer extends Server<Slave, Void>
     }
 
     @Override
-    protected void finishOffChannel( Channel channel, RequestContext context )
+    protected void cleanConversation( RequestContext context )
     {
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiLockManager.java
@@ -120,11 +120,12 @@ public class ForsetiLockManager extends LifecycleAdapter implements Locks
     @SuppressWarnings( "unchecked" )
     public ForsetiLockManager( ResourceType... resourceTypes )
     {
-        this.lockMaps = new ConcurrentMap[findMaxResourceId( resourceTypes )];
-        this.resourceTypes = new ResourceType[findMaxResourceId( resourceTypes )];
+        int maxResourceId = findMaxResourceId( resourceTypes );
+        this.lockMaps = new ConcurrentMap[maxResourceId];
+        this.resourceTypes = new ResourceType[maxResourceId];
 
         /* Wait strategies per resource type */
-        WaitStrategy<AcquireLockTimeoutException>[] waitStrategies = new WaitStrategy[findMaxResourceId( resourceTypes )];
+        WaitStrategy<AcquireLockTimeoutException>[] waitStrategies = new WaitStrategy[maxResourceId];
 
         for ( ResourceType type : resourceTypes )
         {

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -21,6 +21,7 @@ package org.neo4j.ha.upgrade;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.Random;
@@ -41,6 +42,7 @@ import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.MasterClient214;
+import org.neo4j.kernel.ha.com.master.ConversationManager;
 import org.neo4j.kernel.ha.com.master.MasterImpl;
 import org.neo4j.kernel.ha.com.master.MasterImpl.Monitor;
 import org.neo4j.kernel.ha.com.master.MasterImplTest;
@@ -96,6 +98,8 @@ public class MasterClientTest
 
     private static final int TX_LOG_COUNT = 10;
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
     @Rule
     public final CleanupRule cleanupRule = new CleanupRule();
     private final Monitors monitors = new Monitors();
@@ -170,14 +174,16 @@ public class MasterClientTest
 
     private MasterServer newMasterServer( MasterImpl.SPI masterImplSPI ) throws Throwable
     {
-        MasterImpl masterImpl = new MasterImpl( masterImplSPI, mock( Monitor.class ), masterConfig() );
+        MasterImpl masterImpl = new MasterImpl( masterImplSPI, mock(
+                ConversationManager.class ), mock( Monitor.class ), masterConfig() );
 
         return newMasterServer( masterImpl );
     }
 
     private static MasterImpl newMasterImpl( MasterImpl.SPI masterImplSPI )
     {
-        return new MasterImpl( masterImplSPI, mock( Monitor.class ), masterConfig() );
+        return new MasterImpl( masterImplSPI, mock(
+                ConversationManager.class ), mock( Monitor.class ), masterConfig() );
     }
 
     private MasterServer newMasterServer( MasterImpl masterImpl ) throws Throwable
@@ -186,7 +192,8 @@ public class MasterClientTest
                 masterServerConfiguration(),
                 mock( TxChecksumVerifier.class ),
                 monitors.newMonitor( ByteCounterMonitor.class, MasterClient.class ),
-                monitors.newMonitor( RequestMonitor.class, MasterClient.class ) ) );
+                monitors.newMonitor( RequestMonitor.class, MasterClient.class ), mock(
+                ConversationManager.class ) ) );
     }
 
     private MasterClient214 newMasterClient214( StoreId storeId ) throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MasterEpochTest.java
@@ -25,6 +25,7 @@ import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.com.RequestContext;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.com.master.ConversationManager;
 import org.neo4j.kernel.ha.com.master.HandshakeResult;
 import org.neo4j.kernel.ha.com.master.InvalidEpochException;
 import org.neo4j.kernel.ha.com.master.MasterImpl;
@@ -56,7 +57,7 @@ public class MasterEpochTest
         when( spi.getTransactionChecksum( anyLong() ) ).thenReturn( 10L );
         StoreId storeId = new StoreId();
         MasterImpl master = new MasterImpl( spi,
-                mock( MasterImpl.Monitor.class ),
+                mock( ConversationManager.class ), mock( MasterImpl.Monitor.class ),
                 new Config( stringMap( ClusterSettings.server_id.name(), "1" ) ) );
         HandshakeResult handshake = master.handshake( 1, storeId ).response();
         master.start();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith( MockitoJUnitRunner.class )
+public class DefaultConversationSPITest
+{
+
+    @Mock
+    private Locks locks;
+    @Mock
+    private JobScheduler jobScheduler;
+    @InjectMocks
+    private DefaultConversationSPI conversationSpi;
+
+    @Test
+    public void testAcquireClient() throws Exception
+    {
+        conversationSpi.acquireClient();
+
+        verify(locks).newClient();
+    }
+
+    @Test
+    public void testScheduleRecurringJob() throws Exception
+    {
+        Runnable job = mock( Runnable.class );
+        JobScheduler.Group group = mock( JobScheduler.Group.class );
+        conversationSpi.scheduleRecurringJob( group, 0, job );
+
+        verify( jobScheduler ).scheduleRecurring( group, job, 0, TimeUnit.MILLISECONDS );
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.ha.cluster.ConversationSPI;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.collection.TimedRepository;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith( MockitoJUnitRunner.class )
+public class ConversationManagerTest
+{
+
+    @Mock
+    private ConversationSPI conversationSPI;
+    @Mock
+    private Config config;
+    private ConversationManager conversationManager;
+
+    @Test
+    public void testStart() throws Exception
+    {
+        JobScheduler.JobHandle reaperJobHandle = mock( JobScheduler.JobHandle.class );
+        when( config.get( HaSettings.lock_read_timeout ) ).thenReturn( 1l );
+        when( conversationSPI.scheduleRecurringJob( any( JobScheduler.Group.class ), any( Long.class ),
+                any( Runnable.class ) ) ).thenReturn( reaperJobHandle );
+        conversationManager = getConversationManager();
+
+        conversationManager.start();
+
+        assertNotNull( conversationManager.conversations );
+        verify( conversationSPI ).scheduleRecurringJob(any( JobScheduler.Group.class ), any( Long.class ),
+                any( Runnable.class ) );
+    }
+
+    @Test
+    public void testStop() throws Exception
+    {
+        JobScheduler.JobHandle reaperJobHandle = mock( JobScheduler.JobHandle.class );
+        when( config.get( HaSettings.lock_read_timeout ) ).thenReturn( 1l );
+        when( conversationSPI.scheduleRecurringJob( any( JobScheduler.Group.class ), any( Long.class ),
+                any( Runnable.class ) ) ).thenReturn( reaperJobHandle );
+        conversationManager = getConversationManager();
+
+        conversationManager.start();
+        conversationManager.stop();
+
+        assertNull( conversationManager.conversations );
+        verify( reaperJobHandle ).cancel( false );
+    }
+
+    @Test
+    public void testConversationWorkflow() throws Exception
+    {
+        JobScheduler.JobHandle reaperJobHandle = mock( JobScheduler.JobHandle.class );
+        when( config.get( HaSettings.lock_read_timeout ) ).thenReturn( 1l );
+        when( conversationSPI.scheduleRecurringJob( any( JobScheduler.Group.class ), any( Long.class ),
+                any( Runnable.class ) ) ).thenReturn( reaperJobHandle );
+        RequestContext requestContext = getRequestContext();
+        conversationManager = getConversationManager();
+        TimedRepository conversationStorage = mock( TimedRepository.class );
+        conversationManager.conversations = conversationStorage;
+
+        conversationManager.begin( requestContext );
+        conversationManager.acquire( requestContext );
+        conversationManager.release( requestContext );
+        conversationManager.end( requestContext );
+
+        InOrder conversationOrder = inOrder( conversationStorage);
+        conversationOrder.verify(conversationStorage).begin( requestContext );
+        conversationOrder.verify(conversationStorage).acquire( requestContext );
+        conversationOrder.verify(conversationStorage).release( requestContext );
+        conversationOrder.verify(conversationStorage).end( requestContext );
+    }
+
+
+    @Test
+    public void testConversationClean()
+    {
+        RequestContext requestContext = getRequestContext();
+        conversationManager = getConversationManager();
+        TimedRepository conversationStorage = mock( TimedRepository.class );
+        conversationManager.conversations = conversationStorage;
+
+        conversationManager.remove( requestContext );
+
+        verify( conversationStorage ).remove( requestContext );
+    }
+
+    private RequestContext getRequestContext()
+    {
+        return new RequestContext( 1l, 1, 1, 1l, 1l );
+    }
+
+    private ConversationManager getConversationManager()
+    {
+        return new ConversationManager( conversationSPI, config, 1000 );
+    }
+
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.Server;
+import org.neo4j.com.TxChecksumVerifier;
+import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.kernel.monitoring.ByteCounterMonitor;
+import org.neo4j.logging.LogProvider;
+
+import static org.mockito.Mockito.*;
+
+
+public class MasterServerTest
+{
+    @Test
+    public void shouldCleanExistentLockSessionOnFinishOffChannel() throws Exception
+    {
+        Master master = mock( Master.class );
+        ConversationManager conversationManager = mock( ConversationManager.class );
+        MasterServer masterServer = new MasterServer( master, mock( LogProvider.class ),
+                mock(Server.Configuration.class ), mock( TxChecksumVerifier.class ),
+                mock( ByteCounterMonitor.class ), mock( RequestMonitor.class ), conversationManager );
+        RequestContext requestContext = new RequestContext( 1l, 1, 1, 0, 0l );
+
+        masterServer.cleanConversation( requestContext );
+
+        Mockito.verify( conversationManager ).remove( requestContext );
+    }
+}


### PR DESCRIPTION
Update dead client and idle channel reaper to cleanup clients locks session to prevent failure on next connection from the same client with same RequestContext.

Cleanup.
