### PR TITLE
Add syncDevice to PageSwapperFactory

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -76,8 +76,14 @@ public interface PageSwapper
     void close() throws IOException;
 
     /**
-     * Synchronise all writes done by this PageSwapper, with the underlying
-     * storage device.
+     * Forces all writes done by this PageSwapper to the underlying storage device, such that the writes are durable
+     * when this call returns.
+     *
+     * This method has no effect if the {@link PageSwapperFactory#syncDevice()} method forces the writes for all
+     * non-closed PageSwappers created through the given <code>PageSwapperFactory</code>.
+     * The {@link PageCache#flushAndForce()} method will first call <code>force</code> on the PageSwappers for all
+     * mapped files, then call <code>syncDevice</code> on the PageSwapperFactory. This way, the writes are always made
+     * durable regardless of which method that does the forcing.
      */
     void force() throws IOException;
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -72,4 +72,15 @@ public interface PageSwapperFactory
             File file,
             int filePageSize,
             PageEvictionCallback onEviction ) throws IOException;
+
+    /**
+     * Forces all prior writes made through all non-closed PageSwappers that this factory has created, to all the
+     * relevant devices, such that the writes are durable when this call returns.
+     *
+     * This method has no effect if the {@link PageSwapper#force()} method forces the writes for the individual file.
+     * The {@link PageCache#flushAndForce()} method will first call <code>force</code> on the PageSwappers for all
+     * mapped files, then call <code>syncDevice</code> on the PageSwapperFactory. This way, the writes are always made
+     * durable regardless of which method that does the forcing.
+     */
+    void syncDevice() throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -147,11 +147,6 @@ public interface PagedFile extends AutoCloseable
     void flushAndForce() throws IOException;
 
     /**
-     * Force all changes to this file handle down to disk. Does not flush dirty pages.
-     */
-    void force() throws IOException;
-
-    /**
      * Get the file-page-id of the last page in the file.
      *
      * This will return -1 if the file is completely empty.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -52,6 +52,12 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
     }
 
     @Override
+    public void syncDevice()
+    {
+        // Nothing do to, since we `fsync` files individually in `force()`.
+    }
+
+    @Override
     public String implementationName()
     {
         return "striped";

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -32,8 +32,6 @@ import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 import static java.lang.String.format;
-import static org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.allowUnalignedMemoryAccess;
-import static org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.storeByteOrderIsNative;
 
 final class MuninnPage extends StampedLock implements Page
 {
@@ -51,6 +49,7 @@ final class MuninnPage extends StampedLock implements Page
 
     // Optimistically incremented; occasionally truncated to a max of 4.
     // accessed through unsafe
+    @SuppressWarnings( "unused" )
     private volatile byte usageStamp;
 
     // Next pointer in the freelist of available pages. This is either a
@@ -152,10 +151,10 @@ final class MuninnPage extends StampedLock implements Page
     public long getLong( int offset )
     {
         checkBounds( offset + 8 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             long x = UnsafeUtil.getLong( pointer + offset );
-            return storeByteOrderIsNative ? x : Long.reverseBytes( x );
+            return UnsafeUtil.storeByteOrderIsNative ? x : Long.reverseBytes( x );
         }
         return getLongBigEndian( offset );
     }
@@ -177,10 +176,10 @@ final class MuninnPage extends StampedLock implements Page
     public void putLong( long value, int offset )
     {
         checkBounds( offset + 8 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             long p = pointer + offset;
-            UnsafeUtil.putLong( p, storeByteOrderIsNative ? value : Long.reverseBytes( value ) );
+            UnsafeUtil.putLong( p, UnsafeUtil.storeByteOrderIsNative ? value : Long.reverseBytes( value ) );
         }
         else
         {
@@ -204,10 +203,10 @@ final class MuninnPage extends StampedLock implements Page
     public int getInt( int offset )
     {
         checkBounds( offset + 4 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             int x = UnsafeUtil.getInt( pointer + offset );
-            return storeByteOrderIsNative ? x : Integer.reverseBytes( x );
+            return UnsafeUtil.storeByteOrderIsNative ? x : Integer.reverseBytes( x );
         }
         return getIntBigEndian( offset );
     }
@@ -225,10 +224,10 @@ final class MuninnPage extends StampedLock implements Page
     public void putInt( int value, int offset )
     {
         checkBounds( offset + 4 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             long p = pointer + offset;
-            UnsafeUtil.putInt( p, storeByteOrderIsNative ? value : Integer.reverseBytes( value ) );
+            UnsafeUtil.putInt( p, UnsafeUtil.storeByteOrderIsNative ? value : Integer.reverseBytes( value ) );
         }
         else
         {
@@ -248,10 +247,10 @@ final class MuninnPage extends StampedLock implements Page
     public short getShort( int offset )
     {
         checkBounds( offset + 2 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             short x = UnsafeUtil.getShort( pointer + offset );
-            return storeByteOrderIsNative ? x : Short.reverseBytes( x );
+            return UnsafeUtil.storeByteOrderIsNative ? x : Short.reverseBytes( x );
         }
         return getShortBigEndian( offset );
     }
@@ -267,10 +266,10 @@ final class MuninnPage extends StampedLock implements Page
     public void putShort( short value, int offset )
     {
         checkBounds( offset + 2 );
-        if ( allowUnalignedMemoryAccess )
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             long p = pointer + offset;
-            UnsafeUtil.putShort( p, storeByteOrderIsNative ? value : Short.reverseBytes( value ) );
+            UnsafeUtil.putShort( p, UnsafeUtil.storeByteOrderIsNative ? value : Short.reverseBytes( value ) );
         }
         else
         {
@@ -301,10 +300,9 @@ final class MuninnPage extends StampedLock implements Page
     {
         checkBounds( offset + data.length );
         long address = pointer + offset;
-        int length = data.length;
-        for ( int i = 0; i < length; i++ )
+        for ( byte b : data )
         {
-            UnsafeUtil.putByte( address, data[i] );
+            UnsafeUtil.putByte( address, b );
             address++;
         }
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -451,7 +451,13 @@ public class MuninnPageCache implements PageCache
                 fileMapping.pagedFile.flushAndForceInternal( flushOpportunity );
                 fileMapping = fileMapping.next;
             }
+            syncDevice();
         }
+    }
+
+    void syncDevice() throws IOException
+    {
+        swapperFactory.syncDevice();
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -171,6 +171,7 @@ final class MuninnPagedFile implements PagedFile
         try ( MajorFlushEvent flushEvent = tracer.beginFileFlush( swapper ) )
         {
             flushAndForceInternal( flushEvent.flushEventOpportunity() );
+            syncDevice();
         }
     }
 
@@ -205,6 +206,11 @@ final class MuninnPagedFile implements PagedFile
         {
             pageCache.unpauseBackgroundFlushTask();
         }
+    }
+
+    private void syncDevice() throws IOException
+    {
+        pageCache.syncDevice();
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -58,8 +58,9 @@ final class MuninnPagedFile implements PagedFile
     final PageSwapper swapper;
     private final CursorPool cursorPool;
 
-    // Accessed via Unsafe
+    @SuppressWarnings( "unused" ) // Accessed via Unsafe
     private volatile int referenceCounter;
+    @SuppressWarnings( "unused" ) // Accessed via Unsafe
     private volatile long lastPageId;
 
     MuninnPagedFile(

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -197,18 +197,13 @@ final class MuninnPagedFile implements PagedFile
                     }
                 }
             }
-            force();
+
+            swapper.force();
         }
         finally
         {
             pageCache.unpauseBackgroundFlushTask();
         }
-    }
-
-    @Override
-    public void force() throws IOException
-    {
-        swapper.force();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
@@ -280,11 +280,6 @@ public class BatchingPageCache implements PageCache
         }
 
         @Override
-        public void force() throws IOException
-        {   // no-op
-        }
-
-        @Override
         public long getLastPageId() throws IOException
         {
             return max( cursors[PF_SHARED_LOCK].highestKnownPageId(), cursors[PF_EXCLUSIVE_LOCK].highestKnownPageId );

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -234,12 +234,6 @@ public class PageCacheRule extends ExternalResource
         }
 
         @Override
-        public void force() throws IOException
-        {
-            pagedFile.force();
-        }
-
-        @Override
         public long getLastPageId() throws IOException
         {
             return pagedFile.getLastPageId();


### PR DESCRIPTION
This allows the page cache to force all writes to a storage device in one go, instead of fsync'ing files one by one.

This can be more performant when the page cache is directly attached to a block device, instead of going through the normal file system and the operating system, where a device sync can be extremely costly.

Also include a bit of clean-up.
