### PR TITLE
Iterative qsort and more informed pivot selection in ParallelSort

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -173,6 +173,7 @@ import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
+
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
 import static org.neo4j.helpers.Settings.ANY;
 import static org.neo4j.helpers.Settings.NO_DEFAULT;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -128,6 +128,7 @@ public class EncodingIdMapper implements IdMapper
     private final Encoder encoder;
     private final Radix radix;
     private final int processorsForSorting;
+    private final Comparator comparator;
 
     private final List<Object> collisionValues = new ArrayList<>();
     private final LongArray collisionNodeIdCache;
@@ -142,20 +143,21 @@ public class EncodingIdMapper implements IdMapper
     private IdGroup[] idGroups = new IdGroup[10];
     private IdGroup currentIdGroup;
     private final Monitor monitor;
-    private final int chunkSize;
     private final Factory<Radix> radixFactory;
 
-    public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory, Monitor monitor )
+    public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
+            Monitor monitor )
     {
-        this( cacheFactory, encoder, radixFactory, monitor, DEFAULT_CACHE_CHUNK_SIZE, Runtime.getRuntime().availableProcessors() - 1 );
+        this( cacheFactory, encoder, radixFactory, monitor, DEFAULT_CACHE_CHUNK_SIZE,
+                Runtime.getRuntime().availableProcessors() - 1, DEFAULT );
     }
 
     public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
-            Monitor monitor, int chunkSize, int processorsForSorting )
+            Monitor monitor, int chunkSize, int processorsForSorting, Comparator comparator )
     {
         this.monitor = monitor;
         this.cacheFactory = cacheFactory;
-        this.chunkSize = chunkSize;
+        this.comparator = comparator;
         this.processorsForSorting = max( processorsForSorting, 1 );
         this.dataCache = cacheFactory.newDynamicLongArray( chunkSize, GAP_VALUE );
         this.encoder = encoder;
@@ -265,7 +267,7 @@ public class EncodingIdMapper implements IdMapper
         try
         {
             sortBuckets = new ParallelSort( radix, dataCache, highestSetIndex, trackerCache,
-                    processorsForSorting, progress, DEFAULT ).run();
+                    processorsForSorting, progress, comparator ).run();
 
             int numberOfCollisions = detectAndMarkCollisions( progress );
             if ( numberOfCollisions > 0 )
@@ -378,8 +380,8 @@ public class EncodingIdMapper implements IdMapper
 
                 switch ( unsignedDifference( eIdA, eIdB ) )
                 {
-                case GT: throw new IllegalStateException( "Failure:[" + i + "] " +
-                            Long.toHexString( eIdA ) + ":" + Long.toHexString( eIdB ) + " | " +
+                case GT: throw new IllegalStateException( "Unsorted data, a > b Failure:[" + i + "] " +
+                            Long.toHexString( eIdA ) + " > " + Long.toHexString( eIdB ) + " | " +
                             radixOf( eIdA ) + ":" + radixOf( eIdB ) );
                 case EQ:
                     // Here we have two equal encoded values. First let's check if they are in the same id space.
@@ -495,14 +497,14 @@ public class EncodingIdMapper implements IdMapper
         // comparison based on dataIndex is done if it's comparing two equal eIds. We do this so that
         // stretches of multiple equal eIds are sorted by dataIndex order, to be able to write an efficient
         // duplication scanning below and to have deterministic duplication reporting.
-        Comparator comparator = new Comparator()
+        Comparator duplicateComparator = new Comparator()
         {
             @Override
             public boolean lt( long left, long pivot )
             {
                 long leftEId = dataCache.get( left );
                 long pivotEId = dataCache.get( pivot );
-                if ( DEFAULT.lt( leftEId, pivotEId ) )
+                if ( comparator.lt( leftEId, pivotEId ) )
                 {
                     return true;
                 }
@@ -518,7 +520,7 @@ public class EncodingIdMapper implements IdMapper
             {
                 long rightEId = dataCache.get( right );
                 long pivotEId = dataCache.get( pivot );
-                if ( DEFAULT.ge( rightEId, pivotEId ) )
+                if ( comparator.ge( rightEId, pivotEId ) )
                 {
                     return rightEId == pivotEId ? right > pivot : true;
                 }
@@ -527,7 +529,7 @@ public class EncodingIdMapper implements IdMapper
         };
 
         new ParallelSort( radix, collisionNodeIdCache, numberOfCollisions-1,
-                collisionTrackerCache, processorsForSorting, ProgressListener.NONE, comparator ).run();
+                collisionTrackerCache, processorsForSorting, ProgressListener.NONE, duplicateComparator ).run();
         // Here we have a populated C
         // We want to detect duplicate input ids within the
         long previousEid = 0;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -47,6 +47,7 @@ import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.Monitor;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.ParallelSort.Comparator;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
@@ -548,9 +549,19 @@ public class EncodingIdMapperTest
         }
     }
 
+    private List<Object> ids( Object... ids )
+    {
+        return Arrays.asList( ids );
+    }
+
     private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor )
     {
-        return new EncodingIdMapper( NumberArrayFactory.HEAP, encoder, radix, monitor, 1_000, processors );
+        return mapper( encoder, radix, monitor, ParallelSort.DEFAULT );
+    }
+
+    private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor, Comparator comparator )
+    {
+        return new EncodingIdMapper( NumberArrayFactory.HEAP, encoder, radix, monitor, 1_000, processors, comparator );
     }
 
     private class ValueGenerator implements InputIterable<Object>
@@ -733,6 +744,6 @@ public class EncodingIdMapperTest
         abstract Factory<Object> data( Random random );
     }
 
-    public final @Rule RandomRule random = new RandomRule();
+    public final @Rule RandomRule random = new RandomRule().withSeed( 1436724681847L );
     public final @Rule RepeatRule repeater = new RepeatRule();
 }


### PR DESCRIPTION
Problem being that the qsort algorithm, which is implemented with
recursion, may be extremely unlucky and hit StackOverflowError before
reaching the leaves to start sorting.

Pivot base is (and was) selected at random. In addition to that this
commit adds so that 10 surrounding items are looked at and the mean
of those selected as the pivot to use. This should result in a better
worst-case.

The qsort is changed from being implemented using recursion to using
an iterative approach with a stack to push partitions instead, this to
remove chance of StackOverflowError being thrown for unlucky cases.

When reading this commit it may look like much have chanced. That's
because a couple of methods have been moved into SortWorker where they
belong. The important change is the added qsort and removed
recursiveQsort and of course the added informedPivot method.
