### PR TITLE
Prefix search fixes

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LikeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LikeAcceptanceTest.scala
@@ -135,6 +135,7 @@ class LikeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTes
 
     val result = executeWithCostPlannerOnly("MATCH (a:Address) WHERE a.prop LIKE 'ww_' RETURN a")
 
+    result.executionPlanDescription().toString should include("Filter")
     result.executionPlanDescription().toString should include("NodeIndexRangeSeek")
     result.toList should equal(List(Map("a" -> a2)))
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
@@ -25,9 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.PatternConve
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression => CommandExpression, ProjectedPath}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.TokenType._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.UnresolvedRelType
-import org.neo4j.cypher.internal.compiler.v2_3.commands.{Predicate => CommandPredicate, StringSeekRange, expressions => commandexpressions, values => commandvalues}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.{Predicate => CommandPredicate, expressions => commandexpressions, values => commandvalues}
 import org.neo4j.cypher.internal.compiler.v2_3.parser.{LikePatternParser, convertLikePatternToRegex}
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{AsStringRangeSeekable, StringRangeSeekable, LowerBounded}
 import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.ThisShouldNotHappenError
 
@@ -108,7 +107,7 @@ object ExpressionConverters {
 
   implicit class StringSeekRangeConverter(val original: ast.StringSeekRange) extends AnyVal {
     def asCommandStringSeekRange = {
-      commands.StringSeekRange(original.range)
+      commands.expressions.StringSeekRange(original.range)
     }
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/Predicate.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/Predicate.scala
@@ -252,19 +252,6 @@ case class PropertyExists(identifier: Expression, propertyKey: KeyToken) extends
   override def localEffects(symbols: SymbolTable) = Effects.propertyRead(identifier, symbols)(propertyKey.name)
 }
 
-case class StringSeekRange(range: SeekRange[String])(implicit converter: String => String = identity) extends Expression {
-
-  override def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = throw new InternalException("This should never be called")
-
-  override def rewrite(f: (Expression) => Expression): Expression = f(this)
-
-  override def arguments: Seq[Expression] = Seq.empty
-
-  override protected def calculateType(symbols: SymbolTable): CypherType = CTCollection(CTNode)
-
-  override def symbolTableDependencies: Set[String] = Set.empty
-}
-
 case class LiteralRegularExpression(lhsExpr: Expression, regexExpr: Literal)(implicit converter: String => String = identity) extends Predicate {
   lazy val pattern = converter(regexExpr.v.asInstanceOf[String]).r.pattern
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/StringSeekRange.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/StringSeekRange.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
+
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.SeekRange
+import org.neo4j.cypher.internal.compiler.v2_3.symbols._
+import org.neo4j.cypher.internal.compiler.v2_3.{ExecutionContext, InternalException}
+
+case class StringSeekRange(range: SeekRange[String])(implicit converter: String => String = identity)
+  extends Expression {
+
+  override def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = throw new
+      InternalException("This should never be called")
+
+  override def rewrite(f: (Expression) => Expression): Expression = f(this)
+
+  override def arguments: Seq[Expression] = Seq.empty
+
+  override protected def calculateType(symbols: SymbolTable): CypherType = CTCollection(CTNode)
+
+  override def symbolTableDependencies: Set[String] = Set.empty
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
@@ -21,8 +21,8 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.{LabelToken, PropertyKeyToken}
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
-import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQueryExpression, StringSeekRange, indexQuery}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{StringSeekRange, Expression}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQueryExpression, indexQuery}
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel, ReadsNodeProperty, ReadsNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Index, RangeIndex}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -81,7 +81,7 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def exactIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = manyDbHits(inner.exactIndexSearch(index, value))
 
-  override def rangeIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = manyDbHits(inner.rangeIndexSearch(index, value))
+  def rangeIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = manyDbHits(inner.rangeIndexSearch(index, value))
 
   def indexScan(index: IndexDescriptor): Iterator[Node] = manyDbHits(inner.indexScan(index))
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -77,7 +77,7 @@ trait QueryContext extends TokenContext {
 
   def exactIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node]
 
-  def rangeIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = Iterator.empty
+  def rangeIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node]
 
   def indexScan(index: IndexDescriptor): Iterator[Node]
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipeTest.scala
@@ -64,7 +64,7 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
   }
 
   test("should produce the correct plan description for unique range seek based on query expression") {
-    val queryExpression: QueryExpression[Expression] = RangeQueryExpression(commands.StringSeekRange(LowerBounded(InclusiveBound("prefix")))(InputPosition.NONE))
+    val queryExpression: QueryExpression[Expression] = RangeQueryExpression(commands.expressions.StringSeekRange(LowerBounded(InclusiveBound("prefix")))(InputPosition.NONE))
     val pipe = NodeIndexSeekPipe("a", label, propertyKey, queryExpression, UniqueIndexRangeSeek)()
 
     pipe.planDescriptionWithoutCardinality.toString should equal("""+---------------------------+-------------+---------------------------------------+
@@ -80,7 +80,7 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
   }
 
   test("should produce the correct plan description for nonunique range seek based on query expression") {
-    val queryExpression: QueryExpression[Expression] = RangeQueryExpression(commands.StringSeekRange(LowerBounded(InclusiveBound("prefix")))(InputPosition.NONE))
+    val queryExpression: QueryExpression[Expression] = RangeQueryExpression(commands.expressions.StringSeekRange(LowerBounded(InclusiveBound("prefix")))(InputPosition.NONE))
     val pipe = NodeIndexSeekPipe("a", label, propertyKey, queryExpression, NonUniqueIndexRangeSeek)()
 
     pipe.planDescriptionWithoutCardinality.toString should equal("""+---------------------+-------------+---------------------------------------+

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -131,9 +131,6 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def exactIndexSearch(index: IndexDescriptor, value: Any) =
     mapToScala(statement.readOperations().nodesGetFromIndexLookup(index, value))(nodeOps.getById)
 
-  def indexScan(index: IndexDescriptor) =
-    mapToScala(statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
-
   def exactUniqueIndexSearch(index: IndexDescriptor, value: Any): Option[Node] = {
     val nodeId: Long = statement.readOperations().nodeGetUniqueFromIndexLookup(index, value)
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -20,10 +20,10 @@
 package org.neo4j.cypher.internal.spi.v2_3
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator
-import org.neo4j.cypher.internal.compiler.v2_3.commands.StringSeekRange
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.{BeansAPIRelationshipIterator, JavaConversionSupport}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.StringSeekRange
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LowerBounded
+import org.neo4j.cypher.internal.compiler.v2_3.helpers.{BeansAPIRelationshipIterator, JavaConversionSupport}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{Between, LowerBounded}
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.compiler.v2_3.{EntityNotFoundException, FailedIndexException}
 import org.neo4j.graphdb.DynamicRelationshipType._
@@ -32,7 +32,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.helpers.collection.IteratorUtil
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api._
-import org.neo4j.kernel.api.properties._
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -123,6 +123,8 @@ class SnitchingQueryContext extends QueryContext {
 
   def exactIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = ???
 
+  def rangeIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node] = ???
+
   def indexScan(index: IndexDescriptor): Iterator[Node] = ???
 
   def getNodesByLabel(id: Int): Iterator[Node] = ???

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/DataReadCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/DataReadCursors.java
@@ -45,6 +45,9 @@ public interface DataReadCursors
     NodeCursor nodeCursorGetFromIndexLookup( IndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
+    NodeCursor nodeCursorGetFromIndexByPrefixSearch( IndexDescriptor index, String prefix )
+            throws IndexNotFoundKernelException;
+
     NodeCursor nodeGetFromIndexScan( IndexDescriptor index )
             throws IndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralNumberProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/IntegralNumberProperty.java
@@ -81,7 +81,7 @@ abstract class IntegralNumberProperty extends NumberProperty implements DefinedP
         if ( other instanceof IntegralNumberProperty )
         {
             IntegralNumberProperty that = (IntegralNumberProperty) other;
-            return (int) (this.longValue() - that.longValue());
+            return Long.compare( this.longValue(), that.longValue() );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/properties/NumberProperty.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/properties/NumberProperty.java
@@ -37,7 +37,7 @@ public abstract class NumberProperty extends DefinedProperty implements DefinedP
         if ( other instanceof WithDoubleValue )
         {
             WithDoubleValue that = (WithDoubleValue) other;
-            return (int) (this.doubleValue() - that.doubleValue());
+            return Double.compare( this.doubleValue(), that.doubleValue() );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -175,6 +175,13 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
+    public NodeCursor nodeCursorGetFromIndexByPrefixSearch( IndexDescriptor index, String prefix )
+            throws IndexNotFoundKernelException
+    {
+        return statement.acquireNodeCursor().init( statement.getStoreStatement().acquireIteratorNodeCursor().init( nodesGetFromIndexByPrefixSearch( index, prefix ) ) );
+    }
+
+    @Override
     public NodeCursor nodeGetFromIndexScan( IndexDescriptor index ) throws IndexNotFoundKernelException
     {
         return statement.acquireNodeCursor().init( statement.getStoreStatement().acquireIteratorNodeCursor().init( nodesGetFromIndexScan(


### PR DESCRIPTION
These changes will hook up the kernel/lucene support for prefix searches with Cypher, which is used when performing a query such as `MATCH (n:Label) WHERE n.property LIKE 'prefix%' RETURN n`, assuming an index `:Label(property)` exists.
