### PR TITLE
Increase park time to at least 10 ms

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1139,7 +1139,7 @@ public class NeoStoreDataSource implements NeoStoreSupplier, Lifecycle, IndexPro
     {
         while ( !neoStoreModule.neoStore().closedTransactionIdIsOnParWithOpenedTransactionId() )
         {
-            LockSupport.parkNanos( 1_000_000 ); // 1 ms
+            LockSupport.parkNanos( 10_000_000 ); // 10 ms
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/ParkStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/ParkStrategy.java
@@ -32,7 +32,7 @@ public interface ParkStrategy
 
     void unpark( Thread thread );
 
-    public static class Park implements ParkStrategy
+    class Park implements ParkStrategy
     {
         private final long nanos;
 


### PR DESCRIPTION
Necessary since waiting less than 10 milliseconds will change the
system-wide process scheduling quantum on Windows.
