### PR TITLE
Mapping Non-Existing Files with the Page Cache

### DIFF
--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -444,7 +444,7 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
     setupConstraintQueries.foreach(engine.execute)
 
     db.inTx {
-      db.schema().awaitIndexesOnline(1, TimeUnit.SECONDS)
+      db.schema().awaitIndexesOnline(10, TimeUnit.SECONDS)
 
       nodeIndex = db.index().forNodes("nodes")
       relIndex = db.index().forRelationships("rels")

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 
 /**
  * A page caching mechanism that allows caching multiple files and accessing their data
@@ -38,8 +39,19 @@ public interface PageCache extends AutoCloseable
      * Note that this currently asks for the pageSize to use, which is an artifact or records being
      * of varying size in the stores. This should be consolidated to use a standard page size for the
      * whole cache, with records aligning on those page boundaries.
+     *
+     * @param file The file to map.
+     * @param pageSize The file page size to use for this mapping. If the file is already mapped with a different page
+     * size, an exception will be thrown.
+     * @param openOptions The set of open options to use for mapping this file. The
+     * {@link java.nio.file.StandardOpenOption#READ} and {@link java.nio.file.StandardOpenOption#WRITE} options always
+     * implicitly specified. The only supported option is {@link java.nio.file.StandardOpenOption#CREATE}, and
+     * all other options are either silently ignored, or will cause an exception to be thrown.
+     * @throws java.nio.file.NoSuchFileException if the given file does not exist, and the
+     * {@link java.nio.file.StandardOpenOption#CREATE} option was not specified.
+     * @throws IOException if the file could otherwise not be mapped.
      */
-    PagedFile map( File file, int pageSize ) throws IOException;
+    PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException;
 
     /** Flush all dirty pages */
     void flushAndForce() throws IOException;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -91,4 +91,16 @@ public interface PageSwapper
      * Get the filePageId of the last page in the concrete file.
      */
     long getLastPageId() throws IOException;
+
+    /**
+     * Truncate the file represented by this PageSwapper, so the size of the file is zero and
+     * {@link #getLastPageId()} returns -1.
+     *
+     * Truncation may occur concurrently with writes, in which case both operations will appear to be atomic, such that
+     * either the write happens before the truncation and is lost, or the file is truncated and the write then extends
+     * the file with any zero padding and the written data.
+     *
+     * @throws IOException
+     */
+    void truncate() throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -64,14 +64,17 @@ public interface PageSwapperFactory
      *                     multiple of some record size.
      * @param onEviction The PageSwapper will be told about evictions, and has
      *                   the responsibility of informing the PagedFile via this callback.
+     * @param createIfNotExist When true, creates the given file if it does not exist, instead of throwing an exception.
      * @return A working PageSwapper instance for the given file.
      * @throws IOException If the PageSwapper could not be created, for
-     * instance if the underlying file could not be opened.
+     * instance if the underlying file could not be opened, or the given file does not exist and createIfNotExist is
+     * false.
      */
     PageSwapper createPageSwapper(
             File file,
             int filePageSize,
-            PageEvictionCallback onEviction ) throws IOException;
+            PageEvictionCallback onEviction,
+            boolean createIfNotExist ) throws IOException;
 
     /**
      * Forces all prior writes made through all non-closed PageSwappers that this factory has created, to all the

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -63,7 +63,7 @@ public interface PagedFile extends AutoCloseable
     /**
      * Do not update page access statistics.
      */
-    int PF_TRANSIENT = 1 << 5;
+    int PF_TRANSIENT = 1 << 5; // TBD
 
     /**
      * Initiate an IO interaction with the contents of the paged file.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageEvictionCallback;
@@ -46,8 +47,20 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
     public PageSwapper createPageSwapper(
             File file,
             int filePageSize,
-            PageEvictionCallback onEviction ) throws IOException
+            PageEvictionCallback onEviction,
+            boolean createIfNotExist ) throws IOException
     {
+        if ( !fs.fileExists( file ) )
+        {
+            if ( createIfNotExist )
+            {
+                fs.create( file ).close();
+            }
+            else
+            {
+                throw new NoSuchFileException( file.getPath(), null, "Cannot map non-existing file" );
+            }
+        }
         return new SingleFilePageSwapper( file, fs, filePageSize, onEviction );
     }
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -21,6 +21,10 @@ package org.neo4j.io.pagecache.impl.muninn;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +135,7 @@ public class MuninnPageCache implements PageCache
             "org.neo4j.io.pagecache.impl.muninn.backgroundFlushLongBreak", 1000 );
 
     // This is a pre-allocated constant, so we can throw it without allocating any objects:
+    @SuppressWarnings( "ThrowableInstanceNeverThrown" )
     private static final IOException oomException = new IOException(
             "OutOfMemoryError encountered in the page cache background eviction thread" );
 
@@ -154,6 +159,9 @@ public class MuninnPageCache implements PageCache
     // highly troublesome for our use case; caller-runs, bounded submission queues, bounded thread count, non-daemon
     // thread factories, etc.
     private static final Executor backgroundThreadExecutor = BackgroundThreadExecutor.INSTANCE;
+
+    private static final List<OpenOption> ignoredOpenOptions = Arrays.asList( (OpenOption) StandardOpenOption.APPEND,
+            StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.SPARSE );
 
     private final int pageCacheId;
     private final PageSwapperFactory swapperFactory;
@@ -285,7 +293,7 @@ public class MuninnPageCache implements PageCache
     }
 
     @Override
-    public synchronized PagedFile map( File file, int filePageSize ) throws IOException
+    public synchronized PagedFile map( File file, int filePageSize, OpenOption... openOptions ) throws IOException
     {
         assertHealthy();
         ensureThreadsInitialised();
@@ -294,6 +302,18 @@ public class MuninnPageCache implements PageCache
             throw new IllegalArgumentException( "Cannot map files with a filePageSize (" +
                     filePageSize + ") that is greater than the cachePageSize (" +
                     cachePageSize + ")" );
+        }
+        boolean createIfNotExists = false;
+        for ( OpenOption option : openOptions )
+        {
+            if ( option.equals( StandardOpenOption.CREATE ) )
+            {
+                createIfNotExists = true;
+            }
+            else if ( !ignoredOpenOptions.contains( option ) )
+            {
+                throw new UnsupportedOperationException( "Unsupported OpenOption: " + option );
+            }
         }
 
         FileMapping current = mappedFiles;
@@ -326,7 +346,8 @@ public class MuninnPageCache implements PageCache
                 filePageSize,
                 swapperFactory,
                 cursorPool,
-                tracer );
+                tracer,
+                createIfNotExists );
         pagedFile.incrementRefCount();
         current = new FileMapping( file, pagedFile );
         current.next = mappedFiles;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -304,11 +304,16 @@ public class MuninnPageCache implements PageCache
                     cachePageSize + ")" );
         }
         boolean createIfNotExists = false;
+        boolean truncateExisting = false;
         for ( OpenOption option : openOptions )
         {
             if ( option.equals( StandardOpenOption.CREATE ) )
             {
                 createIfNotExists = true;
+            }
+            else if ( option.equals( StandardOpenOption.TRUNCATE_EXISTING ) )
+            {
+                truncateExisting = true;
             }
             else if ( !ignoredOpenOptions.contains( option ) )
             {
@@ -333,6 +338,10 @@ public class MuninnPageCache implements PageCache
                             " bytes.";
                     throw new IllegalArgumentException( msg );
                 }
+                if ( truncateExisting )
+                {
+                    throw new UnsupportedOperationException( "Cannot truncate a file that is already mapped" );
+                }
                 pagedFile.incrementRefCount();
                 return pagedFile;
             }
@@ -347,7 +356,8 @@ public class MuninnPageCache implements PageCache
                 swapperFactory,
                 cursorPool,
                 tracer,
-                createIfNotExists );
+                createIfNotExists,
+                truncateExisting );
         pagedFile.incrementRefCount();
         current = new FileMapping( file, pagedFile );
         current.next = mappedFiles;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -69,7 +69,8 @@ final class MuninnPagedFile implements PagedFile
             int filePageSize,
             PageSwapperFactory swapperFactory,
             CursorPool cursorPool,
-            PageCacheTracer tracer ) throws IOException
+            PageCacheTracer tracer,
+            boolean createIfNotExists ) throws IOException
     {
         this.pageCache = pageCache;
         this.filePageSize = filePageSize;
@@ -89,7 +90,7 @@ final class MuninnPagedFile implements PagedFile
         // the remaining outer array slots with more inner arrays, and then finally assigns the new outer array to
         // the translationTable field and releases the resize lock.
         PageEvictionCallback onEviction = new MuninnPageEvictionCallback( this );
-        swapper = swapperFactory.createPageSwapper( file, filePageSize, onEviction );
+        swapper = swapperFactory.createPageSwapper( file, filePageSize, onEviction, createIfNotExists );
         long lastPageId = swapper.getLastPageId();
 
         int initialChunks = 1 + computeChunkId( lastPageId );

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -70,7 +70,8 @@ final class MuninnPagedFile implements PagedFile
             PageSwapperFactory swapperFactory,
             CursorPool cursorPool,
             PageCacheTracer tracer,
-            boolean createIfNotExists ) throws IOException
+            boolean createIfNotExists,
+            boolean truncateExisting ) throws IOException
     {
         this.pageCache = pageCache;
         this.filePageSize = filePageSize;
@@ -91,6 +92,10 @@ final class MuninnPagedFile implements PagedFile
         // the translationTable field and releases the resize lock.
         PageEvictionCallback onEviction = new MuninnPageEvictionCallback( this );
         swapper = swapperFactory.createPageSwapper( file, filePageSize, onEviction, createIfNotExists );
+        if ( truncateExisting )
+        {
+            swapper.truncate();
+        }
         long lastPageId = swapper.getLastPageId();
 
         int initialChunks = 1 + computeChunkId( lastPageId );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
@@ -70,4 +70,9 @@ public class DelegatingPageSwapper implements PageSwapper
     {
         return delegate.getLastPageId();
     }
+
+    public void truncate() throws IOException
+    {
+        delegate.truncate();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -35,6 +35,9 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -169,10 +172,23 @@ public abstract class PageCacheTest<T extends PageCache>
     }
 
     @Before
-    public void setUp()
+    public void setUp() throws IOException
     {
         Thread.interrupted(); // Clear stray interrupts
         fs = new EphemeralFileSystemAbstraction();
+        ensureExists( PageCacheTest.file );
+    }
+
+    private void ensureExists( File file ) throws IOException
+    {
+        fs.create( file ).close();
+    }
+
+    private File existingFile( String name ) throws IOException
+    {
+        File file = new File( name );
+        ensureExists( file );
+        return file;
     }
 
     @After
@@ -513,8 +529,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000 )
     public void writesToPagesMustNotBleedIntoAdjacentPages() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         // Write the pageId+1 to every byte in the file
@@ -578,8 +592,8 @@ public abstract class PageCacheTest<T extends PageCache>
 
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
-        try ( PagedFile pagedFileA = pageCache.map( new File( "a" ), filePageSize );
-              PagedFile pagedFileB = pageCache.map( new File( "b" ), filePageSize ) )
+        try ( PagedFile pagedFileA = pageCache.map( existingFile( "a" ), filePageSize );
+              PagedFile pagedFileB = pageCache.map( existingFile( "b" ), filePageSize ) )
         {
             try ( PageCursor cursor = pagedFileA.io( 0, PF_EXCLUSIVE_LOCK ) )
             {
@@ -1890,11 +1904,9 @@ public abstract class PageCacheTest<T extends PageCache>
     public void mustThrowWhenClaimingExclusivelyMoreThanOneCursorFromSamePageCacheButDifferentPagedFiles() throws Exception
     {
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
 
-        try ( PagedFile pfA = pageCache.map( fileA, filePageSize );
-              PagedFile pfB = pageCache.map( fileB, filePageSize );
+        try ( PagedFile pfA = pageCache.map( existingFile( "a" ), filePageSize );
+              PagedFile pfB = pageCache.map( existingFile( "b" ), filePageSize );
               PageCursor a = pfA.io( 0, PF_EXCLUSIVE_LOCK );
               PageCursor b = pfB.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
@@ -1919,11 +1931,9 @@ public abstract class PageCacheTest<T extends PageCache>
     public void mustThrowWhenClaimingSharinglyMoreThanOneCursorFromSamePageCacheButDifferentPagedFiles() throws Exception
     {
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
 
-        try ( PagedFile pfA = pageCache.map( fileA, filePageSize );
-              PagedFile pfB = pageCache.map( fileB, filePageSize );
+        try ( PagedFile pfA = pageCache.map( existingFile( "a" ), filePageSize );
+              PagedFile pfB = pageCache.map( existingFile( "b" ), filePageSize );
               PageCursor a = pfA.io( 0, PF_SHARED_LOCK );
               PageCursor b = pfB.io( 0, PF_SHARED_LOCK ) )
         {
@@ -1935,11 +1945,9 @@ public abstract class PageCacheTest<T extends PageCache>
     public void mustThrowWhenClaimingReadCursorWhileHavingWriteCursor() throws Exception
     {
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
 
-        try ( PagedFile pfA = pageCache.map( fileA, filePageSize );
-              PagedFile pfB = pageCache.map( fileB, filePageSize );
+        try ( PagedFile pfA = pageCache.map( existingFile( "a" ), filePageSize );
+              PagedFile pfB = pageCache.map( existingFile( "b" ), filePageSize );
               PageCursor a = pfA.io( 0, PF_EXCLUSIVE_LOCK );
               PageCursor b = pfB.io( 0, PF_SHARED_LOCK ) )
         {
@@ -1951,11 +1959,9 @@ public abstract class PageCacheTest<T extends PageCache>
     public void mustThrowWhenClaimingWriteCursorWhileHavingReadCursor() throws Exception
     {
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
 
-        try ( PagedFile pfA = pageCache.map( fileA, filePageSize );
-              PagedFile pfB = pageCache.map( fileB, filePageSize );
+        try ( PagedFile pfA = pageCache.map( existingFile( "a" ), filePageSize );
+              PagedFile pfB = pageCache.map( existingFile( "b" ), filePageSize );
               PageCursor a = pfA.io( 0, PF_SHARED_LOCK );
               PageCursor b = pfB.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
@@ -2164,7 +2170,6 @@ public abstract class PageCacheTest<T extends PageCache>
     {
         long pagesToGenerate = 142;
         DefaultPageCacheTracer tracer = new DefaultPageCacheTracer();
-        fs.create( file ).close();
 
         getPageCache( fs, maxPages, pageCachePageSize, tracer );
 
@@ -2259,8 +2264,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test
     public void lastPageIdOfEmptyFileIsMinusOne() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         try ( PagedFile pagedFile = pageCache.map( file, filePageSize ) )
@@ -2414,8 +2417,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test
     public void cursorOffsetMustBeUpdatedReadAndWrite() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         try ( PagedFile pagedFile = pageCache.map( file, filePageSize ) )
@@ -2482,8 +2483,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test
     public void cursorCanReadUnsignedIntGreaterThanMaxInt() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         try ( PagedFile pagedFile = pageCache.map( file, filePageSize );
@@ -2501,8 +2500,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000, expected = IllegalStateException.class )
     public void pageCacheCloseMustThrowIfFilesAreStillMapped() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         try ( PagedFile ignore = pageCache.map( file, filePageSize ) )
@@ -2514,8 +2511,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000, expected = IllegalStateException.class )
     public void pagedFileIoMustThrowIfFileIsUnmapped() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         PagedFile pagedFile = pageCache.map( file, filePageSize );
@@ -2527,8 +2522,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000, expected = IllegalStateException.class )
     public void writeLockedPageCursorNextMustThrowIfFileIsUnmapped() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         PagedFile pagedFile = pageCache.map( file, filePageSize );
@@ -2541,8 +2534,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000, expected = IllegalStateException.class )
     public void writeLockedPageCursorNextWithIdMustThrowIfFileIsUnmapped() throws IOException
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         PagedFile pagedFile = pageCache.map( file, filePageSize );
@@ -2583,8 +2574,6 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 1000 )
     public void writeLockedPageMustBlockFileUnmapping() throws Exception
     {
-        fs.create( file ).close();
-
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         PagedFile pagedFile = pageCache.map( file, filePageSize );
@@ -3137,17 +3126,14 @@ public abstract class PageCacheTest<T extends PageCache>
         // Furthermore, our writes to the B-pages do not overwrite the entire page.
         // In those cases, the bytes not written to must be zeros.
 
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
-        fs.create( fileA ).close();
-        fs.create( fileB ).close();
+        File fileB = existingFile( "b" );
         int filePageSizeA = pageCachePageSize - 2;
         int filePageSizeB = pageCachePageSize - 6;
         int pagesToWriteA = 100;
         int pagesToWriteB = 3;
 
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        PagedFile pagedFileA = pageCache.map( fileA, filePageSizeA );
+        PagedFile pagedFileA = pageCache.map( existingFile( "a" ), filePageSizeA );
 
         try ( PageCursor cursor = pagedFileA.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
@@ -3197,14 +3183,11 @@ public abstract class PageCacheTest<T extends PageCache>
     @Test( timeout = 10000 )
     public void freshlyCreatedPagesMustContainAllZeros() throws IOException
     {
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
-        fs.create( fileA ).close();
         ThreadLocalRandom rng = ThreadLocalRandom.current();
 
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
-        try ( PagedFile pagedFile = pageCache.map( fileA, filePageSize );
+        try ( PagedFile pagedFile = pageCache.map( existingFile( "a" ), filePageSize );
               PageCursor cursor = pagedFile.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
             for ( int i = 0; i < 100; i++ )
@@ -3223,7 +3206,7 @@ public abstract class PageCacheTest<T extends PageCache>
 
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
-        try ( PagedFile pagedFile = pageCache.map( fileB, filePageSize );
+        try ( PagedFile pagedFile = pageCache.map( existingFile( "b" ), filePageSize );
               PageCursor cursor = pagedFile.io( 0, PF_EXCLUSIVE_LOCK ) )
         {
             for ( int i = 0; i < 100; i++ )
@@ -3242,11 +3225,9 @@ public abstract class PageCacheTest<T extends PageCache>
     {
         final byte a = 'a';
         final byte b = 'b';
-        final File fileA = new File( "a" );
-        final File fileB = new File( "b" );
+        final File fileA = existingFile( "a" );
+        final File fileB = existingFile( "b" );
 
-        fs.create( fileA ).close();
-        fs.create( fileB ).close();
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
 
         final PagedFile pagedFileA = pageCache.map( fileA, filePageSize );
@@ -3536,8 +3517,6 @@ public abstract class PageCacheTest<T extends PageCache>
         RandomAdversary adversary = new RandomAdversary( 0.5, 0.2, 0.2 );
         adversary.setProbabilityFactor( 0.0 );
         FileSystemAbstraction fs = new AdversarialFileSystemAbstraction( adversary, this.fs );
-        File fileA = new File( "a" );
-        File fileB = new File( "b" );
         ThreadLocalRandom rng = ThreadLocalRandom.current();
 
         // Because our test failures are non-deterministic, we use this tracer to capture a full history of the
@@ -3545,8 +3524,8 @@ public abstract class PageCacheTest<T extends PageCache>
         LinearHistoryPageCacheTracer tracer = new LinearHistoryPageCacheTracer();
         getPageCache( fs, maxPages, pageCachePageSize, tracer );
 
-        PagedFile pfA = pageCache.map( fileA, filePageSize );
-        PagedFile pfB = pageCache.map( fileB, filePageSize / 2 + 1 );
+        PagedFile pfA = pageCache.map( existingFile( "a" ), filePageSize );
+        PagedFile pfB = pageCache.map( existingFile( "b" ), filePageSize / 2 + 1 );
         adversary.setProbabilityFactor( 1.0 );
 
         for ( int i = 0; i < 1000; i++ )
@@ -3739,10 +3718,10 @@ public abstract class PageCacheTest<T extends PageCache>
         PageSwapperFactory swapperFactory = new SingleFilePageSwapperFactory()
         {
             @Override
-            public PageSwapper createPageSwapper( File file, int filePageSize, PageEvictionCallback onEviction )
-                    throws IOException
+            public PageSwapper createPageSwapper(
+                    File file, int filePageSize, PageEvictionCallback onEviction, boolean createIfNotExist ) throws IOException
             {
-                PageSwapper delegate = super.createPageSwapper( file, filePageSize, onEviction );
+                PageSwapper delegate = super.createPageSwapper( file, filePageSize, onEviction, createIfNotExist );
                 return new DelegatingPageSwapper( delegate )
                 {
                     @Override
@@ -3837,10 +3816,11 @@ public abstract class PageCacheTest<T extends PageCache>
             }
 
             @Override
-            public PageSwapper createPageSwapper( File file, int filePageSize, PageEvictionCallback onEviction )
-                    throws IOException
+            public PageSwapper createPageSwapper(
+                    File file, int filePageSize, PageEvictionCallback onEviction, boolean createIfNotExist ) throws IOException
             {
-                return new DelegatingPageSwapper( super.createPageSwapper( file, filePageSize, onEviction ) )
+                PageSwapper delegate = super.createPageSwapper( file, filePageSize, onEviction, createIfNotExist );
+                return new DelegatingPageSwapper( delegate )
                 {
                     @Override
                     public void force() throws IOException
@@ -3855,10 +3835,11 @@ public abstract class PageCacheTest<T extends PageCache>
         return factory;
     }
 
-    private <T> Queue<T> queue( T... items )
+    @SafeVarargs
+    private static <E> Queue<E> queue( E... items )
     {
-        Queue<T> queue = new ConcurrentLinkedQueue<>();
-        for ( T item : items )
+        Queue<E> queue = new ConcurrentLinkedQueue<>();
+        for ( E item : items )
         {
             queue.offer( item );
         }
@@ -3875,8 +3856,8 @@ public abstract class PageCacheTest<T extends PageCache>
                 1, 2 ); // closing+forcing the files one by one, we get 2 more `syncDevice`
         PageSwapperFactory factory = factoryCountingSyncDevice( syncDeviceCounter, expectedCountsInForce );
         try ( PageCache cache = createPageCache( factory, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-              PagedFile p1 = cache.map( new File( "a" ), filePageSize );
-              PagedFile p2 = cache.map( new File( "b" ), filePageSize ) )
+              PagedFile p1 = cache.map( existingFile( "a" ), filePageSize );
+              PagedFile p2 = cache.map( existingFile( "b" ), filePageSize ) )
         {
             try ( PageCursor cursor = p1.io( 0, PF_EXCLUSIVE_LOCK ) )
             {
@@ -3903,8 +3884,8 @@ public abstract class PageCacheTest<T extends PageCache>
                 1, 2 ); // after test, files are closed+forced one by one
         PageSwapperFactory factory = factoryCountingSyncDevice( syncDeviceCounter, expectedCountsInForce );
         try ( PageCache cache = createPageCache( factory, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-              PagedFile p1 = cache.map( new File( "a" ), filePageSize );
-              PagedFile p2 = cache.map( new File( "b" ), filePageSize ) )
+              PagedFile p1 = cache.map( existingFile( "a" ), filePageSize );
+              PagedFile p2 = cache.map( existingFile( "b" ), filePageSize ) )
         {
             try ( PageCursor cursor = p1.io( 0, PF_EXCLUSIVE_LOCK ) )
             {
@@ -3918,6 +3899,80 @@ public abstract class PageCacheTest<T extends PageCache>
             cache.flushAndForce();
             expectedCountInForce.set( 1 );
             assertThat( syncDeviceCounter.get(), is( 1 ) );
+        }
+    }
+
+    @Test(expected = NoSuchFileException.class)
+    public void mustThrowWhenMappingNonExistingFile() throws Exception
+    {
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        pageCache.map( new File( "does not exist" ), filePageSize );
+    }
+
+    @Test
+    public void mustCreateNonExistingFileWithCreateOption() throws Exception
+    {
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( new File( "does not exist" ), filePageSize, StandardOpenOption.CREATE );
+              PageCursor cursor = pf.io( 0, PF_EXCLUSIVE_LOCK ))
+        {
+            assertTrue( cursor.next() );
+        }
+    }
+
+    @Test
+    public void mustIgnoreCreateOptionIfFileAlreadyExists() throws Exception
+    {
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize, StandardOpenOption.CREATE );
+              PageCursor cursor = pf.io( 0, PF_EXCLUSIVE_LOCK ))
+        {
+            assertTrue( cursor.next() );
+        }
+    }
+
+    @Test
+    public void mustIgnoreCertainOpenOptions() throws Exception
+    {
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize,
+                StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.APPEND,
+                StandardOpenOption.SPARSE );
+              PageCursor cursor = pf.io( 0, PF_EXCLUSIVE_LOCK ))
+        {
+            assertTrue( cursor.next() );
+        }
+    }
+
+    @Test
+    public void mustThrowOnUnsupportedOpenOptions() throws Exception
+    {
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        verifyMappingWithOpenOptionThrows( StandardOpenOption.TRUNCATE_EXISTING );
+        verifyMappingWithOpenOptionThrows( StandardOpenOption.CREATE_NEW );
+        verifyMappingWithOpenOptionThrows( StandardOpenOption.DELETE_ON_CLOSE );
+        verifyMappingWithOpenOptionThrows( StandardOpenOption.SYNC );
+        verifyMappingWithOpenOptionThrows( StandardOpenOption.DSYNC );
+        verifyMappingWithOpenOptionThrows( new OpenOption()
+        {
+            @Override
+            public String toString()
+            {
+                return "NonStandardOpenOption";
+            }
+        } );
+    }
+
+    private void verifyMappingWithOpenOptionThrows( OpenOption option ) throws IOException
+    {
+        try
+        {
+            pageCache.map( file, filePageSize, option );
+            fail( "Expected PageCache.map() to throw when given the OpenOption " + option );
+        }
+        catch ( IllegalArgumentException | UnsupportedOperationException e )
+        {
+            // good
         }
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
@@ -69,7 +69,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         channel.close();
 
         PageSwapperFactory factory = swapperFactory();
-        PageSwapper swapper = factory.createPageSwapper( file, 4, null );
+        PageSwapper swapper = factory.createPageSwapper( file, 4, null, false );
         ByteBuffer target = ByteBuffer.allocateDirect( 4 );
         ByteBufferPage page = new ByteBufferPage( target );
         swapper.read( 0, page );
@@ -91,7 +91,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         channel.close();
 
         PageSwapperFactory factory = swapperFactory();
-        PageSwapper swapper = factory.createPageSwapper( file, 4, null );
+        PageSwapper swapper = factory.createPageSwapper( file, 4, null, false );
         ByteBuffer target = ByteBuffer.allocateDirect( 4 );
         ByteBufferPage page = new ByteBufferPage( target );
         swapper.read( 1, page );
@@ -108,7 +108,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         ByteBufferPage page = new ByteBufferPage( wrap( expected ) );
 
         PageSwapperFactory factory = swapperFactory();
-        PageSwapper swapper = factory.createPageSwapper( file, 4, null );
+        PageSwapper swapper = factory.createPageSwapper( file, 4, null, false );
         swapper.write( 0, page );
 
         InputStream stream = fs.openAsInputStream( file );
@@ -145,7 +145,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         ByteBufferPage page = new ByteBufferPage( wrap( change ) );
 
         PageSwapperFactory factory = swapperFactory();
-        PageSwapper swapper = factory.createPageSwapper( file, 4, null );
+        PageSwapper swapper = factory.createPageSwapper( file, 4, null, false );
         swapper.write( 1, page );
 
         InputStream stream = fs.openAsInputStream( file );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
@@ -73,4 +73,9 @@ public class DummyPageSwapper implements PageSwapper
     {
         return 0;
     }
+
+    @Override
+    public void truncate() throws IOException
+    {
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPageCache.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.nio.file.OpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -131,8 +132,12 @@ public class BatchingPageCache implements PageCache
     }
 
     @Override
-    public PagedFile map( final File file, int pageSize ) throws IOException
+    public PagedFile map( final File file, int pageSize, OpenOption... openOptions ) throws IOException
     {
+        if ( openOptions.length != 0 )
+        {
+            throw new UnsupportedOperationException( "BatchingPageCache does not support any OpenOptions" );
+        }
         StoreChannel channel = fs.open( file, "rw" );
         // This is a hack necessary to make sure that we write to disk immediately the changes to the
         // counts store since we circumvent the page cache to read the counts

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/v2_2/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/v2_2/RecordFormatTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
@@ -65,8 +66,11 @@ public abstract class RecordFormatTest<FORMAT extends StoreFormat<RECORD, CURSOR
     {
         int pageSize = 1024;
         pageCursor = new StubPageCursor( 0l, pageSize );
-        pageCache = pageCacheRule.getPageCache( fsRule.get() );
-        pagedFile = pageCache.map( new File("store"), 1024 );
+        EphemeralFileSystemAbstraction fs = fsRule.get();
+        pageCache = pageCacheRule.getPageCache( fs );
+        File store = new File( "store" );
+        fs.create( store ).close();
+        pagedFile = pageCache.map( store, 1024 );
         storeToolkit = new StoreToolkit( format.recordSize( null ), pageSize, 0, null, null );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -21,6 +21,7 @@ package org.neo4j.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -161,9 +162,9 @@ public class PageCacheRule extends ExternalResource
         }
 
         @Override
-        public PagedFile map( File file, int pageSize ) throws IOException
+        public PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException
         {
-            PagedFile pagedFile = pageCache.map( file, pageSize );
+            PagedFile pagedFile = pageCache.map( file, pageSize, openOptions );
             return new PossiblyInconsistentPagedFile( pagedFile, decision );
         }
 

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -400,6 +400,11 @@ public final class UnsafeUtil
         unsafe.putLong( obj, offset, value );
     }
 
+    public static void putLongVolatile( Object obj, long offset, long value )
+    {
+        unsafe.putLongVolatile( obj, offset, value );
+    }
+
     public static long getLongVolatile( Object obj, long offset )
     {
         return unsafe.getLongVolatile( obj, offset );

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -21,6 +21,7 @@ package org.neo4j.com.storecopy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 import java.util.Map;
 
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -58,9 +59,9 @@ public class ExternallyManagedPageCache implements PageCache
     }
 
     @Override
-    public PagedFile map( File file, int pageSize ) throws IOException
+    public PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException
     {
-        return delegate.map( file, pageSize );
+        return delegate.map( file, pageSize, openOptions );
     }
 
     @Override


### PR DESCRIPTION
The `PageCache.map` method now takes an array of `OpenOptions`, and now throws an exception if the given files does not exist, unless the `StandardOpenOption.CREATE` option was specified.
