### PR TITLE
Changed how staleness of plans are calculated.

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
@@ -87,8 +87,8 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
 
     val frozen1 = snapshot1.freeze
     val frozen2 = snapshot2.freeze
-    val smallNumber = 1e-10
-    val bigNumber = 0.5
+    val smallNumber = 0.1
+    val bigNumber = 0.6
 
     frozen1.diverges(frozen2, smallNumber) should equal(true)
     frozen1.diverges(frozen2, bigNumber) should equal(false)

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,6 +1,7 @@
 2.2.4
 -----
 o Identifiers are properly exposed in nested foreach clauses
+o Better eviction policy for the plan cache
 
 2.2.3
 -----

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -1039,21 +1039,20 @@ order by a.COL1""")
     val planningListener = PlanningListener()
     kernelMonitors.addMonitorListener(planningListener)
 
-    createLabeledNode("Dog")
-    (0 until 50).foreach { _ => createLabeledNode("Person") }
+    (0 until 100).foreach { _ => createLabeledNode("Person") }
 
     // WHEN
-    eengine.execute(s"match (n:Person:Dog) return n").toList
+    eengine.execute(s"match (n:Person) return n").toList
     planningListener.planRequests.toSeq should equal(Seq(
-      s"match (n:Person:Dog) return n"
+      s"match (n:Person) return n"
     ))
-    (0 until 1000).foreach { _ => createLabeledNode("Dog") }
-    eengine.execute(s"match (n:Person:Dog) return n").toList
+    (0 until 50).foreach { _ => createLabeledNode("Person") }
+    eengine.execute(s"match (n:Person) return n").toList
 
     //THEN
     planningListener.planRequests.toSeq should equal (Seq(
-      s"match (n:Person:Dog) return n",
-      s"match (n:Person:Dog) return n"
+      s"match (n:Person) return n",
+      s"match (n:Person) return n"
     ))
   }
 
@@ -1062,19 +1061,18 @@ order by a.COL1""")
     val planningListener = PlanningListener()
     kernelMonitors.addMonitorListener(planningListener)
 
-    createLabeledNode("Dog")
-    (0 until 400).foreach { _ => createLabeledNode("Person") }
+    (0 until 100).foreach { _ => createLabeledNode("Person") }
     //WHEN
-    eengine.execute(s"match (n:Person:Dog) return n").toList
+    eengine.execute(s"match (n:Person) return n").toList
     planningListener.planRequests.toSeq should equal(Seq(
-      s"match (n:Person:Dog) return n"
+      s"match (n:Person) return n"
     ))
-    (0 until 500).foreach { _ => createLabeledNode("Dog") }
-    eengine.execute(s"match (n:Person:Dog) return n").toList
+    (0 until 9).foreach { _ => createLabeledNode("Dog") }
+    eengine.execute(s"match (n:Person) return n").toList
 
     //THEN
     planningListener.planRequests.toSeq should equal(Seq(
-      s"match (n:Person:Dog) return n"
+      s"match (n:Person) return n"
     ))
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
-import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, STATISTICS_DIVERGENCE_THRESHOLD}
+import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD}
 import org.neo4j.cypher.internal.compatibility.WrappedMonitors
 import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v2_2.{CostPlannerName, CypherCompilerFactory, InfoLogger}
@@ -170,7 +170,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
     CypherCompilerFactory.costBasedCompiler(
       graph = graph,
       queryCacheSize = 1,
-      statsDivergenceThreshold = STATISTICS_DIVERGENCE_THRESHOLD,
+      statsDivergenceThreshold = DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD,
       queryPlanTTL = DEFAULT_QUERY_PLAN_TTL,
       clock = CLOCK,
       monitors = new WrappedMonitors(kernelMonitors),

--- a/community/cypher/docs/cypher-docs/src/docs/dev/statistics.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/statistics.asciidoc
@@ -30,6 +30,11 @@ If background sampling is turned off, make sure to trigger manual sampling when 
 `index_sampling_update_percentage`::
 Controls how large portion of the index has to have been updated before a new sampling run is triggered.
 
+`dbms.cypher.statistics_divergence_threshold`::
+Controls how much the above statistical information is allowed to change before an execution plan is considered stale and has to be replanned.
+If the relative change in any of statistics is larger than this threshold, the plan will be thrown away and a new one will be created.
+A threshold of 0.0 means _always replan_, and a value of 1.0 means _never replan_.
+
 == Managing statistics from the shell
 
 Usage:

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.cache.MonitorGc;
 import static org.neo4j.helpers.Settings.ANY;
 import static org.neo4j.helpers.Settings.BOOLEAN;
 import static org.neo4j.helpers.Settings.BYTES;
+import static org.neo4j.helpers.Settings.DOUBLE;
 import static org.neo4j.helpers.Settings.DURATION;
 import static org.neo4j.helpers.Settings.FALSE;
 import static org.neo4j.helpers.Settings.INTEGER;
@@ -106,6 +107,12 @@ public abstract class GraphDatabaseSettings
 
     @Description( "The number of Cypher query execution plans that are cached." )
     public static Setting<Integer> query_cache_size = setting( "query_cache_size", INTEGER, "1000", min( 0 ) );
+
+    @Description( "The threshold when a plan is considered stale. If any of the underlying" +
+                  " statistics used to create the plan has changed more than this value, " +
+                  "the plan is considered stale and will be replanned. " +
+                  "A value of 0 means always replan, and 1 means never replan." )
+    public static Setting<Double> query_statistics_divergence_threshold = setting( "dbms.cypher.statistics_divergence_threshold", DOUBLE, "0.1", min( 0.0 ), max( 1.0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
     public static Setting<Long> cypher_min_replan_interval = setting( "dbms.cypher.min_replan_interval", DURATION, "1s" );


### PR DESCRIPTION
With this change a plan is considered stale if the relative difference in any
of the statistics (cardinalities and index selectivities) used in planning has changed more than a configurable threshold; by default a change in any of the statistics by more than ten percent will trigger a replanning.

There are several problems with the current existing implementation:
- Way too stale, small plans require changes by a factor of
  thousand and even worse for big plans.
- We don't consider that selectivity changes are in the range [0,1]
  whereas cardinality changes are unbounded. This means we will
  never consider changes to the index selectivity when checking if a plan is stale.
- Complicated, taking the cosine distance between the two vectors spanned by the
  statistical snapshots and then transforming it to a number in [0, 2] , is
  unnecessarily complicated.
- In general we need to replan more often since a plan only sees the statistics it
  used when it was planned; _e.g._ a plan that doesn't use an index will not see changes
  to index selectivity without actually replanning.
