### PR TITLE
Upgrade Scala to latest patch release

### DIFF
--- a/community/cypher/cypher-compiler-2.2_2.11/pom.xml
+++ b/community/cypher/cypher-compiler-2.2_2.11/pom.xml
@@ -22,7 +22,7 @@
 
   <properties>
     <version-package>cypher.internal.compiler.v2_2</version-package>
-    <scala.version>2.11.6</scala.version>
+    <scala.version>2.11.7</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 


### PR DESCRIPTION
From 2.11.6 to 2.11.7.
Announcement: http://www.scala-lang.org/news/2.11.7
