### PR TITLE
Fixes a legacy index recovery issue

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -20,7 +20,6 @@
 package org.neo4j.csv.reader;
 
 import java.io.IOException;
-import java.nio.CharBuffer;
 
 /**
  * Like an ordinary {@link CharReadable}, it's just that the reading happens in a separate thread, so when

--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -85,7 +85,6 @@ import org.neo4j.kernel.impl.api.CommitProcessFactory;
 import org.neo4j.kernel.impl.api.NonTransactionalTokenNameLookup;
 import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
-import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/RecoveryLegacyIndexApplierLookup.java
@@ -62,7 +62,10 @@ public class RecoveryLegacyIndexApplierLookup implements LegacyIndexApplierLooku
     {
         for ( RecoveryCommandHandler applier : appliers.values() )
         {
-            applier.applyForReal();
+            try ( RecoveryCommandHandler closeThisPlease = applier )
+            {
+                applier.applyForReal();
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
@@ -21,7 +21,6 @@ package org.neo4j.unsafe.batchinsert;
 
 import java.util.Map;
 
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.extension.KernelExtensionFactory;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.unsafe.batchinsert;
 
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
@@ -114,7 +114,6 @@ public class LuceneCommandApplier extends NeoCommandHandler.Adapter
     public boolean visitIndexDefineCommand( IndexDefineCommand indexDefineCommand ) throws IOException
     {
         definitions = indexDefineCommand;
-        dataSource.getWriteLock();
         return false;
     }
 
@@ -123,13 +122,17 @@ public class LuceneCommandApplier extends NeoCommandHandler.Adapter
     {
         try
         {
-            for ( CommitContext context : nodeContexts.values() )
+            if ( definitions != null )
             {
-                context.close();
-            }
-            for ( CommitContext context : relationshipContexts.values() )
-            {
-                context.close();
+                dataSource.getWriteLock();
+                for ( CommitContext context : nodeContexts.values() )
+                {
+                    context.close();
+                }
+                for ( CommitContext context : relationshipContexts.values() )
+                {
+                    context.close();
+                }
             }
         }
         catch ( IOException e )

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.cluster.com.NetworkReceiver;
 import org.neo4j.cluster.com.NetworkSender;
-import org.neo4j.cluster.protocol.atomicbroadcast.AtomicBroadcastSerializer;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceStore;


### PR DESCRIPTION
where recovery would see a scew of amount of LuceneDataSource write lock
acquires compared to releases. This would have future updates to any
lucene legacy index block indefinitely.
