### PR TITLE
Fix test failure on windows caused by file path separator

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
@@ -21,6 +21,8 @@ package org.neo4j.server.configuration;
 
 import org.junit.Test;
 
+import java.io.File;
+
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
 
@@ -44,8 +46,8 @@ public class ServerSettingsTest
         config.setLogger( logging.getLog( "config" ) );
 
         // Then
-        assertEquals( "whatever/cert", config.get( ServerSettings.tls_certificate_file ).getPath() );
-        assertEquals( "whatever/key", config.get( ServerSettings.tls_key_file ).getPath() );
+        assertEquals( new File( "whatever/cert" ).getPath(), config.get( ServerSettings.tls_certificate_file ).getPath() );
+        assertEquals( new File( "whatever/key" ).getPath(), config.get( ServerSettings.tls_key_file ).getPath() );
         logging.assertContainsMessageContaining(
                 "The TLS certificate configuration you are using, 'org.neo4j.server.webserver.https.cert.location' " +
                 "is deprecated. Please use 'dbms.security.tls_certificate_file' instead." );


### PR DESCRIPTION
Windows build is unhappy about hard-coded file path separator '/'
