### PR TITLE
Documentation fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ out
 .scala_dependencies
 .factorypath
 .cache
+.cache-main
+.cache-tests
 *.iws
 *.ipr
 *.iml

--- a/community/cypher/docs/cypher-docs/src/docs/dev/execution-plan-groups/starting-query.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/execution-plan-groups/starting-query.asciidoc
@@ -1,8 +1,8 @@
 [[execution-plans-starting-query]]
 
-== Starting a query operators ==
+== Starting point operators ==
 
-These operators find parts of the graph from which to start a query.
+These operators find parts of the graph from which to start.
 
 :leveloffset: 2
 

--- a/community/cypher/docs/cypher-docs/src/docs/dev/general/updating.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/general/updating.asciidoc
@@ -1,51 +1,59 @@
 [[query-updating]]
-Updating the graph
-==================
+= Updating the graph
 
 Cypher can be used for both querying and updating your graph.
 
 [[query-updating-structure]]
 == The Structure of Updating Queries ==
 
-.Quick info
-***********
+[abstract]
 * A Cypher query part can't both match and update the graph at the same time.
 * Every part can either read and match on the graph, or make updates on it.
-***********
 
-If you read from the graph, and then update the graph, your query implicitly has two parts -- the reading is the first
-part, and the writing is the second. If your query is read-only, Cypher will be lazy, and not actually match the pattern
-until you ask for the results. In an updating query, the semantics are that _all_ the reading will be done before any
-writing actually happens.
-First reading, and then writing, is the only pattern where the query parts are implicit -- any other order and you
-have to be explicit about your query parts. The parts are separated using the `WITH` statement. `WITH` is like the event
-horizon -- it's a barrier between a plan and the finished execution of that plan.
+If you read from the graph and then update the graph, your query implicitly has two parts -- the reading is the first part, and the writing is the second part.
 
-When you want to filter using aggregated data, you have to chain together two reading query parts -- the first one does the
-aggregating, and the second query filters on the results coming from the first one.
+If your query only performs reads, Cypher will be lazy and not actually match the pattern until you ask for the results.
+In an updating query, the semantics are that _all_ the reading will be done before any writing actually happens.
+
+The only pattern where the query parts are implicit is when you first read and then write -- any other order and you have to be explicit about your query parts.
+The parts are separated using the `WITH` statement.
+`WITH` is like an event horizon -- it's a barrier between a plan and the finished execution of that plan.
+
+When you want to filter using aggregated data, you have to chain together two reading query parts -- the first one does the aggregating, and the second filters on the results coming from the first one.
 
 [source,cypher]
 ----
-MATCH (n {name: 'John'})-[:FRIEND]-friend
+MATCH (n {name: 'John'})-[:FRIEND]-(friend)
 WITH n, count(friend) as friendsCount
 WHERE friendsCount > 3
 RETURN n, friendsCount
 ----
 
-Using `WITH`, you specify how you want the aggregation to happen, and that the aggregation has to be finished before
-Cypher can start filtering.
+Using `WITH`, you specify how you want the aggregation to happen, and that the aggregation has to be finished before Cypher can start filtering.
 
-You can chain together as many query parts as you have JVM heap for.
+Here's an example of updating the graph, writing the aggregated data to the graph:
+
+[source,cypher]
+----
+MATCH (n {name: 'John'})-[:FRIEND]-(friend)
+WITH n, count(friend) as friendsCount
+SET n.friendCount = friendsCount
+RETURN n.friendsCount
+----
+
+You can chain together as many query parts as the available memory permits.
 
 [[query-updating-return]]
 == Returning data ==
 
-Any query can return data. If your query only reads, it has to return data -- it serves no purpose if it doesn't, and
- it is not a valid Cypher query. Queries that update the graph don't have to return anything, but they can.
+Any query can return data.
+If your query only reads, it has to return data -- it serves no purpose if it doesn't, and it is not a valid Cypher query.
+Queries that update the graph don't have to return anything, but they can.
 
-After all the parts of the query comes one final `RETURN` clause. `RETURN` is not part of any query part -- it
-is a period symbol at the end of a query. The `RETURN` clause has three sub-clauses that come with it `SKIP`/`LIMIT` and `ORDER BY`.
+After all the parts of the query comes one final `RETURN` clause.
+`RETURN` is not part of any query part -- it is a period symbol at the end of a query.
+The `RETURN` clause has three sub-clauses that come with it: `SKIP`/`LIMIT` and `ORDER BY`.
 
-If you return graph elements from a query that has just deleted them -- beware, you are holding a pointer that is no
- longer valid. Operations on that node might fail mysteriously and unpredictably.
+If you return graph elements from a query that has just deleted them -- beware, you are holding a pointer that is no longer valid.
+Operations on that node are undefined.
 

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/create/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/create/index.asciidoc
@@ -14,6 +14,8 @@ Read <<introduction-pattern>> for an introduction.
 
 include::create-single-node.asciidoc[]
 
+include::create-multiple-nodes.asciidoc[]
+
 include::create-a-node-with-a-label.asciidoc[]
 
 include::create-a-node-with-multiple-labels.asciidoc[]

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/periodic-commit/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/periodic-commit/index.asciidoc
@@ -3,19 +3,19 @@
 
 NOTE: See <<cypherdoc-importing-csv-files-with-cypher>> on how to import data from CSV files.
 
-Updating very large amounts of data (for example when importing) with a single Cypher query may fail due to memory constraints.
+Importing large amounts of data using `LOAD CSV` with a single Cypher query may fail due to memory constraints.
 This will manifest itself as an `OutOfMemoryError`.
 
-For this situation _only,_ Cypher provides the global `USING PERIODIC COMMIT` query hint for updating queries.
+For this situation _only,_ Cypher provides the global `USING PERIODIC COMMIT` query hint for updating queries using `LOAD CSV`.
 You can optionally set the limit for the number of rows per commit like so: `USING PERIODIC COMMIT 500`.
 
-Periodic Commit will process the rows until the number of rows reaches a limit.
+`PERIODIC COMMIT` will process the rows until the number of rows reaches a limit.
 Then the current transaction will be committed and replaced with a newly opened transaction.
 If no limit is set, a default value will be used.
 
 See <<load-csv-importing-large-amounts-of-data>> in <<query-load-csv>> for examples of `USING PERIODIC COMMIT` with and without setting the number of rows per commit.
 
 [IMPORTANT]
-Using periodic commit will prevent running out of memory when updating large amounts of data.
-However it will also break transactional isolation thus it should only be used where needed.
+Using periodic commit will prevent running out of memory when importing large amounts of data.
+However, it will also break transactional isolation and thus it should only be used where needed.
 

--- a/community/cypher/docs/cypher-docs/src/docs/dev/syntax/operators.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/syntax/operators.asciidoc
@@ -21,6 +21,7 @@ The boolean operators are `AND`, `OR`, `XOR`, `NOT`.
 == String operators ==
 
 Strings can be concatenated using the `+` operator.
+For regular expression matching the `=~` operator is used.
 
 [[query-operators-collection]]
 == Collection operators ==

--- a/community/cypher/docs/cypher-docs/src/docs/dev/syntax/values.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/syntax/values.asciidoc
@@ -2,7 +2,6 @@
 Values
 ======
 
-Cypher queries the graph by looking at nodes, relationships, properties and query parameters.
 All values that are handled by Cypher have a distinct type.
 The supported types of values are:
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
@@ -33,7 +33,16 @@ class CreateTest extends DocumentingTestBase with QueryStatisticsTestSupport {
       text = "Creating a single node is done by issuing the following query.",
       queryText = "create (n)",
       optionalResultExplanation = "Nothing is returned from this query, except the count of affected nodes.",
-      assertions = (p) => {})
+      assertions = (p) => assertStats(p, nodesCreated = 1))
+  }
+
+  @Test def create_multiple_nodes() {
+    testQuery(
+      title = "Create multiple nodes",
+      text = "Creating multiple nodes is done by separating them with a comma.",
+      queryText = "create (n), (m)",
+      optionalResultExplanation = "",
+      assertions = (p) => assertStats(p, nodesCreated = 2))
   }
 
   @Test def create_single_node_with_label() {

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigAsciiDocGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigAsciiDocGenerator.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.configuration;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -36,6 +37,9 @@ import org.neo4j.helpers.Triplet;
 public class ConfigAsciiDocGenerator
 {
     private static final Pattern CONFIG_SETTING_PATTERN = Pattern.compile( "[a-z0-9]+((\\.|_)[a-z0-9]+)+" );
+    private static final Pattern NUMBER_OR_IP = Pattern.compile( "[0-9\\.]+" );
+    private static final List<String> CONFIG_NAMES_BLACKLIST = Arrays.asList( "round_robin", "keep_all", "keep_last",
+            "keep_none" );
 
     public String generateDocsFor(
             Class<? extends SettingsResourceBundle> settingsResource )
@@ -185,6 +189,14 @@ public class ConfigAsciiDocGenerator
             {
                 // don't link to the settings we're describing
                 match = "`" + match + "`";
+            }
+            else if ( CONFIG_NAMES_BLACKLIST.contains( match ) )
+            {
+                // an option value; do nothing
+            }
+            else if ( NUMBER_OR_IP.matcher( match ).matches() )
+            {
+                // number or ip; do nothing
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
@@ -23,16 +23,13 @@ import java.util.Map;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
-import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
- * Provides instances of batch inserters.
- * <p>
- * A {@link BatchInserter} retrieved from the {@link #inserter(String)} or
- * {@link #inserter(String, Map)} methods is more performant while the
+ * Provides instances of {@link BatchInserter}.
  */
 public final class BatchInserters
 {

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -19,16 +19,16 @@
  */
 package examples;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicLabel;
@@ -38,11 +38,11 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.DefaultFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 
@@ -62,8 +62,7 @@ public class BatchInsertDocTest
         try
         {
             inserter = BatchInserters.inserter(
-                    new File( "target/batchinserter-example" ).getAbsolutePath(),
-                    fileSystem );
+                    new File( "target/batchinserter-example" ).getAbsolutePath() );
 
             Label personLabel = DynamicLabel.label( "Person" );
             inserter.createDeferredSchemaIndex( personLabel ).on( "name" ).create();
@@ -89,8 +88,9 @@ public class BatchInsertDocTest
         // END SNIPPET: insert
 
         // try it out from a normal db
-        GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fileSystem ).newImpermanentDatabase(
-                new File("target/batchinserter-example").getAbsolutePath() );
+        GraphDatabaseService db =
+                new GraphDatabaseFactory().newEmbeddedDatabase(
+                    new File("target/batchinserter-example").getAbsolutePath() );
         try ( Transaction tx = db.beginTx() )
         {
             Label personLabelForTesting = DynamicLabel.label( "Person" );
@@ -115,7 +115,7 @@ public class BatchInsertDocTest
         Map<String, String> config = new HashMap<>();
         config.put( "dbms.pagecache.memory", "512m" );
         BatchInserter inserter = BatchInserters.inserter(
-                new File("target/batchinserter-example-config").getAbsolutePath(), fileSystem, config );
+                new File( "target/batchinserter-example-config" ).getAbsolutePath(), config );
         // Insert data here ... and then shut down:
         inserter.shutdown();
         // END SNIPPET: configuredInsert
@@ -130,11 +130,11 @@ public class BatchInsertDocTest
         }
 
         // START SNIPPET: configFileInsert
-        try ( InputStream input = fileSystem.openAsInputStream( new File( "target/docs/batchinsert-config" ).getAbsoluteFile() ) )
+        try ( FileReader input = new FileReader( new File( "target/docs/batchinsert-config" ).getAbsoluteFile() ) )
         {
             Map<String, String> config = MapUtil.load( input );
             BatchInserter inserter = BatchInserters.inserter(
-                    "target/docs/batchinserter-example-config", fileSystem, config );
+                    "target/docs/batchinserter-example-config", config );
             // Insert data here ... and then shut down:
             inserter.shutdown();
         }

--- a/community/server/src/docs/dev/rest-api/batch-operations.asciidoc
+++ b/community/server/src/docs/dev/rest-api/batch-operations.asciidoc
@@ -1,7 +1,14 @@
 [[rest-api-batch-ops]]
 == Batch operations ==
 
-Note: You cannot use this resource to execute Cypher queries with +USING PERIODIC COMMIT+.
+[abstract]
+Batch operations lets you execute multiple API calls through a single HTTP call.
+This improves performance for large insert and update operations significantly.
+
+This service is _transactional._
+If any of the operations performed fails (returns a non-2xx HTTP status code), the transaction will be rolled back and no changes will be applied.
+
+IMPORTANT: You cannot use this resource to execute Cypher queries with +USING PERIODIC COMMIT+.
 
 include::execute-multiple-operations-in-batch.asciidoc[]
 

--- a/community/server/src/docs/dev/rest-api/transactional.asciidoc
+++ b/community/server/src/docs/dev/rest-api/transactional.asciidoc
@@ -9,7 +9,7 @@ Each HTTP request can include a list of statements, and for convenience you can 
 
 The server guards against orphaned transactions by using a timeout.
 If there are no requests for a given transaction within the timeout period, the server will roll it back.
-You can configure the timeout in the server configuration, by setting 'org.neo4j.server.transaction.timeout' to the number of seconds before timeout.
+You can configure the timeout in the server configuration, by setting `org.neo4j.server.transaction.timeout` to the number of seconds before timeout.
 The default timeout is 60 seconds.
 
 The key difference between the transactional HTTP endpoint for Cypher and the Cypher endpoint (see <<rest-api-cypher>>) is the ability to use the same transaction across multiple HTTP requests.
@@ -33,6 +33,8 @@ See <<cypher-parameters>> for more information.
 
 include::begin-and-commit-a-transaction-in-one-request.asciidoc[]
 
+include::execute-multiple-statements.asciidoc[]
+
 include::begin-a-transaction.asciidoc[]
 
 include::execute-statements-in-an-open-transaction.asciidoc[]
@@ -44,6 +46,8 @@ include::reset-transaction-timeout-of-an-open-transaction.asciidoc[]
 include::commit-an-open-transaction.asciidoc[]
 
 include::rollback-an-open-transaction.asciidoc[]
+
+include::include-query-statistics.asciidoc[]
 
 include::return-results-in-graph-format.asciidoc[]
 

--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -13,13 +13,13 @@ This is configured in the _conf/neo4j-server.properties_ file:
 # http port (for all data, administrative, and UI access)
 org.neo4j.server.webserver.port=7474
 
-#let the webserver only listen on the specified IP. Default
-#is localhost (only accept local connections). Uncomment to allow
-#any connection.
+# Let the webserver only listen on the specified IP. Default is localhost (only
+# accept local connections). Uncomment to allow any connection.
 #org.neo4j.server.webserver.address=0.0.0.0
 ----
 
-If you need to enable access from external hosts, configure the Web server in the _conf/neo4j-server.properties_ by setting the property +org.neo4j.server.webserver.address=0.0.0.0+ to enable access from any host.
+If you want the server to listen to external hosts, configure the Web server in the _conf/neo4j-server.properties_ by setting the property +org.neo4j.server.webserver.address=0.0.0.0+ which will cause the server to bind to all available network interfaces.
+Note that firewalls et cetera have to be configured accordingly as well.
 
 [[security-server-auth]]
 == Server authentication and authorization ==

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
@@ -50,17 +50,9 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
     /**
      * Execute multiple operations in batch.
      *
-     * This lets you execute multiple API calls through a single HTTP call,
-     * significantly improving performance for large insert and update
-     * operations.
-     *
      * The batch service expects an array of job descriptions as input, each job
      * description describing an action to be performed via the normal server
      * API.
-     *
-     * This service is transactional. If any of the operations performed fails
-     * (returns a non-2xx HTTP status code), the transaction will be rolled back
-     * and all changes will be undone.
      *
      * Each job description should contain a +to+ attribute, with a value
      * relative to the data API root (so http://localhost:7474/db/data/node becomes

--- a/manual/contents/src/reference/capabilities/cap-details.asciidoc
+++ b/manual/contents/src/reference/capabilities/cap-details.asciidoc
@@ -181,6 +181,6 @@ Currently, the address space is as follows:
 | nodes | 2^35^ (&#8764; 34 billion) 
 | relationships | 2^35^ (&#8764; 34 billion) 
 | properties | 2^36^ to 2^38^ depending on property types (maximum &#8764; 274 billion, always at least &#8764; 68 billion)
-| relationship types | 2^15^ (&#8764; 32 000)
+| relationship types | 2^16^ (&#8764; 65 000)
 |=========
 


### PR DESCRIPTION
- Removes references to test utils from batchinserter examples.
- Javadoc cleanup in BatchInserters.java.
- Better updating queries page.
- Fix for rendering of config attribute options.
- Make the scope of PERIODIC COMMIT clear.
- Correct max for relationship types.
- Add example creating multiple nodes.
- Add example sending multiple statements to tx endpoint.
- Add example for getting query stats from the tx endpoint.
- Add regex operator to the operators page.
